### PR TITLE
Implement new JDK12 method java.lang.String.indent(int)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -8299,10 +8299,15 @@ written authorization of the copyright holder.
 
 /*[IF Java12]*/
 	/**
-	 * Apply a function to this string. The function expects a single String input and returns an R.
+	 * Apply a function to this string. The function expects a single String input
+	 * and returns an R.
 	 * 
-	 * @param f - the functional interface to be applied
+	 * @param f 
+	 *			  the functional interface to be applied
+	 *
 	 * @return the result of application of the function to this string
+	 * 
+	 * @since 12
 	 */
 	public <R> R transform(Function<? super String, ? extends R> f) {
 		return f.apply(this);
@@ -8313,20 +8318,75 @@ written authorization of the copyright holder.
 	 * if construction is not possible.
 	 * 
 	 * @return Optional with nominal descriptor of String instance
+	 * 
+	 * @since 12
 	 */
 	public Optional<String> describeConstable() {
 		return Optional.of(this);
 	}
 
 	/**
-	 * Resolves this ConstantDesc instance
+	 * Resolves this ConstantDesc instance.
 	 * 
-	 * @param lookup parameter is ignored
+	 * @param lookup 
+	 *			  parameter is ignored
 	 * 
 	 * @return the resolved Constable value
+	 * 
+	 * @since 12
 	 */
 	public String resolveConstantDesc(MethodHandles.Lookup lookup) {
 		return this;
 	}
+
+	/**
+	 * Indents each line of the string depending on the value of n, and normalizes
+	 * line terminators to the newline character "\n".
+	 * 
+	 * @param n 
+	 *			  the number of spaces to indent the string
+	 *
+	 * @return the indented string with normalized line terminators
+	 * 
+	 * @since 12
+	 */
+	public String indent(int n) {
+		Stream<String> lines = lines();
+		Iterator<String> iter = lines.iterator();
+		StringBuilder builder = new StringBuilder();
+
+		String spaces = n > 0 ? " ".repeat(n) : null;
+		int absN = Math.abs(n);
+
+		while (iter.hasNext()) {
+			String currentLine = iter.next();
+
+			if (n > 0) {
+				builder.append(spaces);
+			} else if (n < 0) {
+				int start = 0;
+
+				while ((currentLine.length() > start) 
+					&& (Character.isWhitespace(currentLine.charAt(start)))
+				) {
+					start++;
+
+					if (start >= absN) {
+						break;
+					}
+				}
+				currentLine = currentLine.substring(start);
+			}
+
+			/**
+			 * Line terminators are removed when lines() is called. A newline character is
+			 * added to the end of each line, to normalize line terminators.
+			 */
+			builder.append(currentLine);
+			builder.append("\n");
+		}
+
+		return builder.toString();
+	}	
 /*[ENDIF] Java12 */
 }

--- a/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java12andUp/playlist.xml
+++ b/test/functional/Java12andUp/playlist.xml
@@ -45,4 +45,27 @@
                   <subset>12+</subset>
           </subsets>
   </test>
+
+  <test>
+          <testCaseName>StringIndentTests</testCaseName>
+          <variations>
+                  <variation>NoOptions</variation>
+          </variations>
+          <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+                  -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+                  org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames StringIndentTests \
+                  -groups $(TEST_GROUP) \
+                  -excludegroups $(DEFAULT_EXCLUDE); \
+                  $(TEST_STATUS)
+          </command>
+          <levels>
+                  <level>sanity</level>
+          </levels>
+          <groups>
+                  <group>functional</group>
+          </groups>
+          <subsets>
+                  <subset>12+</subset>
+          </subsets>
+  </test>
 </playlist>

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -82,5 +82,4 @@ public class Test_String {
 		String resolvedTest2 = test.resolveConstantDesc(null);
 		Assert.assertTrue(test.equals(resolvedTest2));
 	}
-	 
 }

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_StringIndent.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_StringIndent.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/**
+ * This tests Java.lang.String API added in Java 12 and later versions.
+ *
+ */
+public class Test_StringIndent {
+	public static Logger logger = Logger.getLogger(Test_String.class);
+
+	private String empty = "";
+	private String allWhiteSpace = "   ";
+	private String latin1 = "abc123";
+	private String emptyWithTerm = "\n";
+
+	/*
+	 * Test Java 12 API String.indent
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testIndent() {
+		// Empty ""
+		logger.debug("testIndent: test with string: " + empty);
+		verifyIndentSingleLine(empty, empty, 0);
+		verifyIndentSingleLine(empty, empty, 1);
+		verifyIndentSingleLine(empty, empty, -1);
+
+		// Newline Only "\n"
+		logger.debug("testIndent: test with string: " + emptyWithTerm);
+		verifyIndentSingleLine(emptyWithTerm, emptyWithTerm, 0);
+		verifyIndentSingleLine(emptyWithTerm, " " + emptyWithTerm, 1);
+		verifyIndentSingleLine(emptyWithTerm, emptyWithTerm, -1);
+
+		// // Whitespace " "
+		logger.debug("testIndent: test with string: " + allWhiteSpace);
+		verifyIndentSingleLine(allWhiteSpace, allWhiteSpace, 0);
+		verifyIndentSingleLine(allWhiteSpace, " " + allWhiteSpace, 1);
+		verifyIndentSingleLine(allWhiteSpace, allWhiteSpace.substring(1), -1);
+		verifyIndentSingleLine(allWhiteSpace, "", -3);
+		verifyIndentSingleLine(allWhiteSpace, "", -4);
+
+		// Whitespace with tab "\t "
+		String tabAllWhiteSpace = "\t" + allWhiteSpace;
+		logger.debug("testIndent: test with string: " + tabAllWhiteSpace);
+		verifyIndentSingleLine(tabAllWhiteSpace, tabAllWhiteSpace, 0);
+		verifyIndentSingleLine(tabAllWhiteSpace, " " + tabAllWhiteSpace, 1);
+		verifyIndentSingleLine(tabAllWhiteSpace, allWhiteSpace, -1);
+
+		// Single-line "abc123"
+		logger.debug("testIndent: test with string: " + latin1);
+		verifyIndentSingleLine(latin1, latin1, 0);
+		verifyIndentSingleLine(latin1, " " + latin1, 1);
+		verifyIndentSingleLine(latin1, latin1, -1);
+
+		// Single-line with leading whitespace " abc123"
+		String whiteSpaceLatin1 = allWhiteSpace + latin1;
+		logger.debug("testIndent: test with string: " + whiteSpaceLatin1);
+		verifyIndentSingleLine(whiteSpaceLatin1, whiteSpaceLatin1, 0);
+		verifyIndentSingleLine(whiteSpaceLatin1, "  " + whiteSpaceLatin1, 2);
+		verifyIndentSingleLine(whiteSpaceLatin1, whiteSpaceLatin1.substring(1), -1);
+		verifyIndentSingleLine(whiteSpaceLatin1, whiteSpaceLatin1.substring(3), -3);
+		verifyIndentSingleLine(whiteSpaceLatin1, whiteSpaceLatin1.substring(3), -4);
+
+		// Single-line with leading whitespace and terminator " abc123\n"
+		String whiteSpaceLatin1Term = allWhiteSpace + latin1 + emptyWithTerm;
+		logger.debug("testIndent: test with string: " + whiteSpaceLatin1Term);
+		verifyIndentSingleLine(whiteSpaceLatin1Term, whiteSpaceLatin1, 0);
+		verifyIndentSingleLine(whiteSpaceLatin1Term, "  " + whiteSpaceLatin1, 2);
+		verifyIndentSingleLine(whiteSpaceLatin1Term, whiteSpaceLatin1.substring(1), -1);
+		verifyIndentSingleLine(whiteSpaceLatin1Term, whiteSpaceLatin1.substring(3), -3);
+		verifyIndentSingleLine(whiteSpaceLatin1Term, whiteSpaceLatin1.substring(3), -4);
+
+		// Multi-line with leading whitespace
+		String multiLine = " \tabc\r\n    def\t\n";
+		logger.debug("testIndent: test with string: " + multiLine);
+		String firstLine = " \tabc";
+		String secondLine = "    def\t";
+		String[] multiLineArray;
+
+		multiLineArray = new String[] { firstLine, secondLine };
+		verifyIndentMultiLine(multiLine, multiLineArray, 0);
+
+		multiLineArray = new String[] { " " + firstLine, " " + secondLine };
+		verifyIndentMultiLine(multiLine, multiLineArray, 1);
+
+		multiLineArray = new String[] { firstLine.substring(1), secondLine.substring(1) };
+		verifyIndentMultiLine(multiLine, multiLineArray, -1);
+
+		multiLineArray = new String[] { firstLine.substring(2), secondLine.substring(2) };
+		verifyIndentMultiLine(multiLine, multiLineArray, -2);
+
+		multiLineArray = new String[] { firstLine.stripLeading(), secondLine.stripLeading() };
+		verifyIndentMultiLine(multiLine, multiLineArray, -5);
+	}
+
+	/*
+	 * Test Java 12 API String.indent Helper Function
+	 * 
+	 * Verifies indent for a multi-line string.
+	 */
+	public void verifyIndentMultiLine(String input, String[] expected, int n) {
+		String expectedResult = String.join("\n", expected);
+		verifyIndentSingleLine(input, expectedResult, n);
+	}
+
+	/*
+	 * Test Java 12 API String.indent Helper Function
+	 * 
+	 * Verifies indent for a single-line string.
+	 */
+	public void verifyIndentSingleLine(String input, String expected, int n) {
+		String indentResult = input.indent(n);
+		String expectedResult;
+
+		if (input.equals(empty) || input.equals(emptyWithTerm)) {
+			expectedResult = expected;
+		} else {
+			expectedResult = expected + emptyWithTerm;
+		}
+
+		Assert.assertEquals(indentResult, expectedResult,
+				"indent: failed to indent " + n + " spaces - failed to produce " + expectedResult);
+	}
+}

--- a/test/functional/Java12andUp/testng.xml
+++ b/test/functional/Java12andUp/testng.xml
@@ -31,4 +31,10 @@
 		</classes>
 	</test>
 
+	<test name="StringIndentTests">
+		<classes>
+			<class name="org.openj9.test.java_lang.Test_StringIndent" />
+		</classes>
+	</test>
+
 </suite>


### PR DESCRIPTION
Fixes: #3850.

Dependent on: #4105 test framework commit - sanity test for indent(int) will be moved to Java12andUp once it is available.

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>