### PR TITLE
Increase JVM_INTERFACE_VERSION to 6 for JDK11+

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5578,19 +5578,20 @@ JVM_GetClassName(JNIEnv *env, jclass theClass)
 
 /**
  * Return the JVM_INTERFACE_VERSION. This function should not lock, gc or throw exception.
- * @return JVM_INTERFACE_VERSION, current value is 4
+ * @return JVM_INTERFACE_VERSION, JDK8 - 4, JDK11+ - 6.
  */
 jint JNICALL
 JVM_GetInterfaceVersion(void)
 {
-	jint result = 4;
-	UDATA j2seVersion = getVersionFromPropertiesFile();
-
-	if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_19) {
-		result = 5;
-	}
+	jint result = 4;	/* JDK8 */
+	UDATA j2seVersion = 0;
 
 	Trc_SC_GetInterfaceVersion_Entry();
+
+	j2seVersion = getVersionFromPropertiesFile();
+	if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_V11) {
+		result = 6; /* JDK11+ */
+	}
 
 	Trc_SC_GetInterfaceVersion_Exit(result);
 


### PR DESCRIPTION
Increase `JVM_INTERFACE_VERSION` to `6` for `JDK11+`

This is required by `JCL` extension changes. In addition, minor refactoring to make `Trc_SC_GetInterfaceVersion_Entry` first call.
Note: changed `J2SE_19` to `J2SE_V11` since Java `9/10` is out of service.

Manually verified that `JDK11` builds with this PR.
```
openjdk version "11.0.2-internal" 2019-01-15
OpenJDK Runtime Environment (build 11.0.2-internal+0-adhoc.jason.openj9-openjdk-jdk11)
Eclipse OpenJ9 VM (build master-7d048d4, JRE 11 Linux amd64-64-Bit Compressed References 20190219_000000 (JIT enabled, AOT enabled)
OpenJ9   - 7d048d4
OMR      - 6e7568d
JCL      - 455c2c3 based on jdk-11.0.2+9)
```

related: #4770 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>