### PR TITLE
Fix code cache issues with remote AOT

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2386,9 +2386,17 @@ remoteCompilationEnd(
       {
       compInfoPT->reloRuntime()->setReloStartTime(compInfoPT->getTimeWhenCompStarted());
 
-      relocatedMetaData = compInfoPT->reloRuntime()->prepareRelocateJITCodeAndData(vmThread, fe,
-            comp->cg()->getCodeCache(), (uint8_t *)&codeCacheStr[0], (J9JITDataCacheHeader *)&dataCacheStr[0],
-            method, false, TR::comp()->getOptions(), TR::comp(), compilee);
+      relocatedMetaData = compInfoPT->reloRuntime()->prepareRelocateAOTCodeAndData(
+         vmThread,
+         fe,
+         comp->cg()->getCodeCache(),
+         (J9JITDataCacheHeader *)&dataCacheStr[0],
+         method,
+         false,
+         comp->getOptions(),
+         comp,
+         compilee,
+         (uint8_t *)&codeCacheStr[0]);
 
       if (!relocatedMetaData)
          {
@@ -2552,7 +2560,8 @@ remoteCompilationEnd(
                false,
                comp->getOptions(),
                comp,
-               compilee
+               compilee,
+               (uint8_t *)&codeCacheStr[0]
                );
             returnCode = entry->_compInfoPT->reloRuntime()->returnCode();
             }

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -181,18 +181,8 @@ class TR_RelocationRuntime {
                                                          bool shouldUseCompiledCopy,
                                                          TR::Options *options,
                                                          TR::Compilation *compilation,
-                                                         TR_ResolvedMethod *resolvedMethod);
-
-      J9JITExceptionTable *prepareRelocateJITCodeAndData(J9VMThread* vmThread,
-                                                         TR_FrontEnd *fe,
-                                                         TR::CodeCache *cc,
-                                                         uint8_t *code,
-                                                         const J9JITDataCacheHeader *cacheEntry,
-                                                         J9Method *theMethod,
-                                                         bool shouldUseCompiledCopy,
-                                                         TR::Options *options,
-                                                         TR::Compilation *compilation,
-                                                         TR_ResolvedMethod *resolvedMethod);
+                                                         TR_ResolvedMethod *resolvedMethod,
+                                                         uint8_t *existingCode = NULL);
 
       virtual bool storeAOTHeader(J9JavaVM *javaVM, TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(J9JavaVM *javaVM, TR_FrontEnd *fe);
@@ -415,8 +405,6 @@ private:
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize);
       virtual uint8_t * allocateSpaceInDataCache(UDATA metaDataSize, UDATA type);
       virtual void initializeCacheDeltas();
-// The following private APIs should not be used with this class
-      virtual void initializeAotRuntimeInfo()  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!");  return; }
-
+      virtual void initializeAotRuntimeInfo() override { _classReloAmount = 1; }
 };
 #endif   // RELOCATION_RUNTIME_INCL


### PR DESCRIPTION
- Use `prepareRelocateJITCodeAndData` instead of `prepareRelocateAOTCodeAndData`,
even in remote AOT mode. This is because both methods do the same thing, except
the former is passed a code cache string received from the server, while the latter
assumes that code cache is contiguously allocated right after data cache.
For JITaaS, that assumption is incorrect and we always need to use code cache from the server.

- Tell `prepareRelocateJITCodeAndData` to allocate code cache by passing
`shouldUseCompiledCopy=false`. In a local compilation, code cache is allocated during codegen,
so it can be later accessed when relocating code. In JITaaS, however, we allocate code cache on the
server and need to allocate it on the client right before relocating.
