### PR TITLE
Remove unnecessary findHelperTrampoline API

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -722,10 +722,3 @@ J9::CodeCacheManager::printOccupancyStats()
       codeCache->printOccupancyStats();
       }
    }
-
-
-intptrj_t
-J9::CodeCacheManager::findHelperTrampoline(int32_t helperIndex, void *callSite)
-   {
-   return (intptrj_t)OMR::CodeCacheManagerConnector::findHelperTrampoline(helperIndex, callSite);
-   }

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -151,13 +151,6 @@ public:
     */
    void printOccupancyStats();
 
-   /**
-    * @brief A temporary function to assist with changing the return type of
-    *        findHelperTrampoline.  It simply redirects to the original version
-    *        and will be removed once the OMR API has changed.
-    */
-   intptrj_t findHelperTrampoline(int32_t helperIndex, void *callSite);
-
 private :
    TR_FrontEnd *_fe;
    static TR::CodeCacheManager *_codeCacheManager;


### PR DESCRIPTION
An equivalent method has been provided in OMR.  No need for the
project specific version any longer.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>