### PR TITLE
JDK12 JVM_INTERFACE_VERSION workaround

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5590,7 +5590,11 @@ JVM_GetInterfaceVersion(void)
 
 	j2seVersion = getVersionFromPropertiesFile();
 	if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_V11) {
-		result = 6; /* JDK11+ */
+		if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) == J2SE_V12) {
+			result = 5; /* JDK12 hasn't got same update as JDK11 & HEAD */
+		} else {
+			result = 6; /* JDK11 & HEAD */
+		}
 	}
 
 	Trc_SC_GetInterfaceVersion_Exit(result);


### PR DESCRIPTION
JDK12 `JVM_INTERFACE_VERSION` workaround


Returns `JVM_INTERFACE_VERSION 5` for `JDK12` before it gets same updates as `JDK11 & HEAD`.

As per https://github.com/eclipse/openj9/issues/4770#issuecomment-465323032, this PR allows `JDK12` builds before `OpenJDK` releases `JVM_INTERFACE_VERSION 6` changes to `JDK12` branch.

Related: #4770

Reviewer: @DanHeidinga 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>