### PR TITLE
Exclude tests for JDK12+

### DIFF
--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -150,7 +150,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
 		</subsets>
 	</test>
 
@@ -175,7 +175,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
 		</subsets>
 	</test>
 


### PR DESCRIPTION
Exclude tests for `JDK12+`

Excluding following tests:
```
TestRefreshGCSpecialClassesCache_BCI_EXTENDED_HCR - UnsupportedOperationException: This feature requires ASM7
TestGCClassWithStaticRetransformInGencon - UnsupportedOperationException: This feature requires ASM5
```

Related: #4663 

Reviewer: @smlambert 
FYI: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>