### PR TITLE
Remove Java 9/10 native supports

### DIFF
--- a/runtime/bcutil/bcutil.c
+++ b/runtime/bcutil/bcutil.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,7 +134,7 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 		/* Note that verbose support should have already been initialized in an earlier stage */
 		case BUFFERS_ALLOC_STAGE :
 			loadInfo = FIND_DLL_TABLE_ENTRY( THIS_DLL_NAME );
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				rc = initJImageIntf(&jimageIntf, vm, PORTLIB);
 				if (J9JIMAGE_NO_ERROR != rc) {
 					loadInfo->fatalErrorStr = "failed to initialize JImage interface";

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1608,7 +1608,8 @@ checkMethods(J9CfrClassFile* classfile, U_8* segment, U_32 vmVersionShifted, U_3
 				method->accessFlags |= CFR_ACC_STATIC;
 
 			/* Leave this here to find usages of the following check:
-			 * if (J2SE_VERSION(vm) >= J2SE_19) { 
+			 * J2SE_19 has been deprecated and replaced with J2SE_V11
+			 * if (J2SE_VERSION(vm) >= J2SE_V11) { 
 			 */
 			} else if (vmVersionShifted >= BCT_Java9MajorVersionShifted) {
 				if (J9_ARE_NO_BITS_SET(method->accessFlags, CFR_ACC_STATIC)) {

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,7 +144,7 @@ internalDefineClass(
 		/* Host class can only be set for anonymous classes, which are defined by Unsafe.defineAnonymousClass.
 		 * For other cases, host class is set to NULL.
 		 */
-		if ((NULL != hostClass) && (J2SE_VERSION(vm) >= J2SE_19)) {
+		if ((NULL != hostClass) && (J2SE_VERSION(vm) >= J2SE_V11)) {
 			J9ROMClass *hostROMClass = hostClass->romClass;
 			/* This error-check should only be done for anonymous classes. */
 			Trc_BCU_Assert_True(isAnonFlagSet);
@@ -536,10 +536,6 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 		translationFlags |= BCT_Java12MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_V11) {
 		translationFlags |= BCT_Java11MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_V10) {
-		translationFlags |= BCT_Java10MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_19) {
-		translationFlags |= BCT_Java9MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_18) {
 		translationFlags |= BCT_Java8MajorVersionShifted;
 	}
@@ -749,10 +745,9 @@ callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediat
 			localBuffer);
 
 	/* The module of a class transformed by a JVMTI agent needs access to unnamed modules */
-	if (
-			(J2SE_VERSION(vm) >= J2SE_19)
-			&& (classFileBytesReplacedByRIA || classFileBytesReplacedByRCA)
-			&& (NULL != loadData->romClass)
+	if ((J2SE_VERSION(vm) >= J2SE_V11)
+		&& (classFileBytesReplacedByRIA || classFileBytesReplacedByRCA)
+		&& (NULL != loadData->romClass)
 	) {
 		J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
 		J9Module *module = vm->internalVMFunctions->findModuleForPackage(currentThread, loadData->classLoader,

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,7 +102,7 @@ findLocallyDefinedClass(J9VMThread * vmThread, J9Module * j9module, U_8 * classN
 	Trc_BCU_findLocallyDefinedClass_Entry(mbString, classPathEntryCount);
 	
 	/* Search patch path of the module before looking up in bootclasspath */
-	if (J2SE_VERSION(javaVM) >= J2SE_19) {
+	if (J2SE_VERSION(javaVM) >= J2SE_V11) {
 		if (NULL == module) {
 			if (J9_ARE_NO_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
 				module = javaVM->javaBaseModule;

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1821,9 +1821,10 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 		 * In a class file whose version number is 51.0 or above, the method
 		 * has its ACC_STATIC flag set and takes no arguments.
 		 */
-                 /* Leave this here to find usages of the following check:
-                  * if (J2SE_VERSION(vm) >= J2SE_19) {
-                  */
+		/* Leave this here to find usages of the following check:
+		 * J2SE_19 has been deprecated and replaced with J2SE_V11
+		 * if (J2SE_VERSION(vm) >= J2SE_V11) {
+		 */
 		if (vmVersionShifted >= BCT_Java9MajorVersionShifted) {
 			if (classfile->majorVersion >= 51) {
 				if ((CFR_METHOD_NAME_CLINIT == isInit) 

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -237,7 +237,7 @@ MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
 	}
 
 #if defined(OMR_ENV_DATA64)
-	if (J2SE_VERSION((J9JavaVM *)getOmrVM()->_language_vm) >= J2SE_19) {
+	if (J2SE_VERSION((J9JavaVM *)getOmrVM()->_language_vm) >= J2SE_V11) {
 		/* extend java default max memory to 25% of usable RAM */
 		memoryMax = OMR_MAX(memoryMax, usablePhysicalMemory / 4);
 	}

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -644,13 +644,13 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 
 		if (IS_STRING_COMPRESSION_ENABLED_VM(vm)) {
 			if (isCompressable) {
-				if (J2SE_VERSION(vm) >= J2SE_19) {
+				if (J2SE_VERSION(vm) >= J2SE_V11) {
 					J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 0);
 				} else {
 					J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32)unicodeLength);
 				}
 			} else {
-				if (J2SE_VERSION(vm) >= J2SE_19) {
+				if (J2SE_VERSION(vm) >= J2SE_V11) {
 					J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 1);
 				} else {
 					J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32)unicodeLength | (I_32)0x80000000);
@@ -677,7 +677,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 				}
 			}
 		} else {
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 1);
 			} else {
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32)unicodeLength);
@@ -765,7 +765,7 @@ setupCharArray(J9VMThread *vmThread, j9object_t sourceString, j9object_t newStri
 
 		J9VMJAVALANGSTRING_SET_VALUE(vmThread, newString, newChars);
 
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			J9VMJAVALANGSTRING_SET_CODER(vmThread, newString, J9VMJAVALANGSTRING_CODER(vmThread, sourceString));
 		} else {
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, newString, J9VMJAVALANGSTRING_COUNT(vmThread, sourceString));
@@ -917,13 +917,13 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 
 	if (IS_STRING_COMPRESSION_ENABLED_VM(vm)) {
 		if (isCompressable) {
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 0);
 			} else {
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength);
 			}
 		} else {
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 1);
 			} else {
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength | (I_32)0x80000000);
@@ -950,7 +950,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 			}
 		}
 	} else {
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 1);
 		} else {
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength);

--- a/runtime/gc_vlhgc/RuntimeExecManager.cpp
+++ b/runtime/gc_vlhgc/RuntimeExecManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,7 +107,7 @@ MM_RuntimeExecManager::jniNativeBindHook(J9HookInterface** hook, UDATA eventNum,
 			/* Assuming J2SE_18, no other lower level supported */
 			literalCheck = J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(classNameUTF8), J9UTF8_LENGTH(classNameUTF8), CLASS_NAME1);
 		} else {
-			/* J2SE_19 and beyond */
+			/* J2SE_V11 and beyond */
 			literalCheck = J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(classNameUTF8), J9UTF8_LENGTH(classNameUTF8), CLASS_NAME2);
 		}
 

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1312,8 +1312,7 @@ static const VersionSetting SHAPE_SETTINGS[] = {
  * Table to map textual props file entries to numeric constants.
  */
 static const VersionSetting VERSION_SETTINGS[] = {
-		{"1.8", J2SE_18},
-		{"1.9", J2SE_19}
+		{"1.8", J2SE_18}
 };
 #define NUM_VERSION_SETTINGS (sizeof(VERSION_SETTINGS) / sizeof(VersionSetting))
 
@@ -1441,16 +1440,12 @@ bail:
  * Attempt loading 'release' file, and get Java version info.
  * If the file is found, 'JAVA_VERSION' value is retrieved and decoded as following:
  * "1.8.0_xxx" --- Java 8, 'J2SE_18 | J2SE_SHAPE_OPENJDK';
- * "9[.x.x]"   --- Java 9, 'J2SE_19 | J2SE_SHAPE_V9';
- * "10[.x.x]"  --- Java 10, 'J2SE_V10 | J2SE_SHAPE_V10';
  * "11[.x.x]"  --- Java 11, 'J2SE_V11 | J2SE_SHAPE_V11';
  * "12[.x.x]"  --- Java 12, 'J2SE_V12 | J2SE_SHAPE_V12';
  * Others      --- Latest Java, 'J2SE_LATEST | J2SE_SHAPE_LATEST'.
  * Otherwise, 0 is returned.
  *
  * @return 'J2SE_18 | J2SE_SHAPE_OPENJDK',
- *         'J2SE_19 | J2SE_SHAPE_V9',
- *         'J2SE_V10 | J2SE_SHAPE_V10',
  *         'J2SE_V11 | J2SE_SHAPE_V11',
  *         'J2SE_V12 | J2SE_SHAPE_V12',
  *         'J2SE_LATEST | J2SE_SHAPE_LATEST'
@@ -1477,14 +1472,6 @@ getVersionFromReleaseFile(void)
 			if (!strncmp(version, JAVA_VERSION_8, sizeof(JAVA_VERSION_8) - 1)) {
 #undef   JAVA_VERSION_8
 				finalVersion = J2SE_18 | J2SE_SHAPE_OPENJDK;
-#define	 JAVA_VERSION_9 "\"9" /* its usual format is "9[.x.x]" */
-			} else if (!strncmp(version, JAVA_VERSION_9, sizeof(JAVA_VERSION_9) - 1)) {
-#undef   JAVA_VERSION_9
-				finalVersion = J2SE_19 | J2SE_SHAPE_V9;
-#define	 JAVA_VERSION_10 "\"10" /* its usual format is "10[.x.x]" */
-			} else if (!strncmp(version, JAVA_VERSION_10, sizeof(JAVA_VERSION_10) - 1)) {
-#undef   JAVA_VERSION_10			
-				finalVersion = J2SE_V10 | J2SE_SHAPE_V10;
 #define	 JAVA_VERSION_11 "\"11" /* its usual format is "11[.x.x]" */
 			} else if (!strncmp(version, JAVA_VERSION_11, sizeof(JAVA_VERSION_11) - 1)) {
 #undef   JAVA_VERSION_11
@@ -1657,7 +1644,7 @@ setNLSCatalog(struct J9PortLibrary* portLib, UDATA j2seVersion)
 	const char *nlsSearchPaths = NULL;
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_19) {
+	if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_V11) {
 		/*
 		 * j9libBuffer doesn't end in a slash, but j9nls_set_catalog ignores everything after
 		 * the last slash. Append a slash to our local copy of j9libBuffer
@@ -1757,7 +1744,7 @@ static jint initializeReflectionGlobals(JNIEnv * env, BOOLEAN includeAccessors) 
 	}
 
 	if (includeAccessors) {
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			clazzConstructorAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/ConstructorAccessorImpl");
 			clazzMethodAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/MethodAccessorImpl");
 		} else {
@@ -2107,7 +2094,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 			zipFuncs = (J9ZipFunctionTable*) J9_GetInterface(IF_ZIPSUP, &j9portLibrary, j9binBuffer);
 #endif /* CALL_BUNDLED_FUNCTIONS_DIRECTLY */
 		}
-		if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_19) {
+		if ((j2seVersion & J2SE_SERVICE_RELEASE_MASK) >= J2SE_V11) {
 			optionsDefaultFileLocation = jvmBufferData(j9libBuffer);
 		} else {
 			optionsDefaultFileLocation = jvmBufferData(j9binBuffer);

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -102,20 +102,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 			j2se_version_info = "1.8.?";
 		}
 		break;
-	case J2SE_19:
-		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_19) {
-			j2se_version_info = "9";
-		} else {
-			j2se_version_info = "9.?";
-		}
-		break;
-	case J2SE_V10:
-		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V10) {
-			j2se_version_info = "10";
-		} else {
-			j2se_version_info = "10.?";
-		}
-		break;
 	case J2SE_V11:
 		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V11) {
 			j2se_version_info = "11";
@@ -574,7 +560,7 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	};
 
 	/* Determine java/lang/String.value signature before any required class is initialized */
-	if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 	   vm->runtimeFlags |= J9_RUNTIME_STRING_BYTE_ARRAY;
 	}
 

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -122,7 +122,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 			PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, element);
 
 			/* Fill in module name and version */
-			if (j2seVersion >= J2SE_19) {
+			if (j2seVersion >= J2SE_V11) {
 				J9Module *module = NULL;
 				U_8 *classNameUTF = NULL;
 				UDATA length = 0;

--- a/runtime/jcl/common/jniidcacheinit.c
+++ b/runtime/jcl/common/jniidcacheinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,7 @@ initializeSunReflectConstantPoolIDCache(JNIEnv* env)
 	if (!isClassIDAlreadyCached) {	
 
 		/* Load sun/reflect/ConstantPool */
-		if (J2SE_VERSION(javaVM) >= J2SE_19) {
+		if (J2SE_VERSION(javaVM) >= J2SE_V11) {
 			sunReflectConstantPool = (*env)->FindClass(env, "jdk/internal/reflect/ConstantPool");
 		} else {
 			sunReflectConstantPool = (*env)->FindClass(env, "sun/reflect/ConstantPool");

--- a/runtime/jcl/common/mgmtruntime.c
+++ b/runtime/jcl/common/mgmtruntime.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,7 @@ jboolean JNICALL
 Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_isBootClassPathSupportedImpl(JNIEnv *env, jobject beanInstance)
 {
 	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
-	if (J2SE_VERSION(javaVM) < J2SE_19) {
+	if (J2SE_VERSION(javaVM) < J2SE_V11) {
 		return JNI_TRUE;
 	} else {
 		return JNI_FALSE;

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -80,7 +80,7 @@ computeJCLRuntimeFlags(J9JavaVM *vm)
 #endif
 
 #ifdef J9VM_OPT_MODULE
-	if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		flags |= JCL_RTFLAG_OPT_MODULE;
 	}
 #endif
@@ -100,11 +100,10 @@ standardInit( J9JavaVM *vm, char *dllName)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9ConstantPool *jclConstantPool = (J9ConstantPool *) vm->jclConstantPool;
 	extern J9ROMClass *jclROMClass;
-	jclass clazz;
+	jclass clazz = NULL;
 	J9NativeLibrary *javaLibHandle = NULL;
 	char *threadName = NULL;
 	jobject threadGroup = NULL;
-	UDATA j2seVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
 
 	/* Register this module with trace */
 	UT_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(vm));
@@ -117,7 +116,7 @@ standardInit( J9JavaVM *vm, char *dllName)
 	jclConstantPool->romConstantPool = J9_ROM_CP_FROM_ROM_CLASS(jclROMClass);
 
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
-	if (j2seVersion < J2SE_19) {
+	if (J2SE_VERSION(vm) < J2SE_V11) {
 		/* Process the command-line bootpath additions/modifications */
 		if (computeFinalBootstrapClassPath(vm)) {
 			goto _fail;
@@ -209,7 +208,7 @@ standardInit( J9JavaVM *vm, char *dllName)
 	internalInitializeJavaLangClassLoader((JNIEnv*)vmThread);
 	if (vmThread->currentException) goto _fail;
 
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		result = registerJdkInternalReflectConstantPoolNatives((JNIEnv*)vmThread);
 		if (0 != result) {
 			fprintf(stderr, "Failed to register natives for jdk.internal.reflect.ConstantPool\n");
@@ -294,7 +293,7 @@ standardPreconfigure(JavaVM *jvm)
 	J9JavaVM* vm = (J9JavaVM*)jvm;
 
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
-	if (J2SE_VERSION(vm) < J2SE_19) {
+	if (J2SE_VERSION(vm) < J2SE_V11) {
 		/* Now, based on java.home we can compute the default bootpath */
 		if (initializeBootClassPathSystemProperty(vm)) {
 			goto _fail;
@@ -525,7 +524,7 @@ initializeBootstrapClassPath(J9JavaVM *vm)
 	BOOLEAN initClassPathEntry = FALSE;
 
 	/* Get the BP from the VM sysprop */
-	if ((J2SE_VERSION(vm) & J2SE_VERSION_MASK) < J2SE_19) {
+	if (J2SE_VERSION(vm) < J2SE_V11) {
 		(*VMI)->GetSystemProperty(VMI, BOOT_PATH_SYS_PROP, &path);
 	} else {
 		(*VMI)->GetSystemProperty(VMI, BOOT_CLASS_PATH_APPEND_PROP, &path);

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -929,7 +929,7 @@ Java_jdk_internal_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 
 	Java_sun_misc_Unsafe_registerNatives(env, clazz);
 	registerJdkInternalMiscUnsafeNativesCommon(env, clazz);
-	if (J2SE_SHAPE(currentThread->javaVM) >= J2SE_SHAPE_V10) {
+	if (J2SE_VERSION(currentThread->javaVM) >= J2SE_V11) {
 		registerJdkInternalMiscUnsafeNativesJava10(env, clazz);
 	}
 }

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -521,7 +521,7 @@ Java_java_lang_System_startSNMPAgent(JNIEnv *env, jclass jlClass)
 		jclass smAClass = NULL;
 		jmethodID startAgent = NULL;
 		
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			smAClass = (*env)->FindClass(env, "jdk/internal/agent/Agent");
 		} else {
 			smAClass = (*env)->FindClass(env, "sun/management/Agent");

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -278,7 +278,6 @@ scarInit(J9JavaVM * vm)
 #if defined(WIN32) && !defined(OPENJ9_BUILD)
 	switch (jclVersion) {
 	case J2SE_18:
-	case J2SE_19:	/* This will need to be modified when the JCL team provides a dbgwrapper90 */
 		dbgwrapperStr = "dbgwrapper80";
 		break;
 	default:
@@ -448,7 +447,7 @@ scarPreconfigure(J9JavaVM * vm)
 		return JNI_ERR;
 	}
 
-	if (J2SE_VERSION(vm) < J2SE_19) {
+	if (J2SE_VERSION(vm) < J2SE_V11) {
 		char *vmSpecificDirectoryPath = "jclSC180";
 
 		rc = addVMSpecificDirectories(vm, &i, vmSpecificDirectoryPath);

--- a/runtime/jcl/win32/syshelp.c
+++ b/runtime/jcl/win32/syshelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -218,7 +218,7 @@ char* getPlatformFileEncoding(JNIEnv *env, char *codepage, int size, int encodin
 	if (GetCPInfo(cp, &cpInfo) && cpInfo.MaxCharSize > 1) {
 		if (cp == 936) {
 			J9JavaVM* vm = ((J9VMThread *)env)->javaVM;
-			if (J2SE_VERSION(vm) < J2SE_19) {
+			if (J2SE_VERSION(vm) < J2SE_V11) {
 				if (IsValidCodePage(54936)) {
 					return "GB18030";
 				}

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -185,7 +185,7 @@ jvmtiGetVersionNumber(jvmtiEnv* env,
 
 	ENSURE_NON_NULL(version_ptr);
 
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		rv_version = JVMTI_VERSION_9_0;
 	}
 

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -587,7 +587,7 @@ jvmtiHookVMStarted(J9HookInterface** hook, UDATA eventNum, void* eventData, void
 		UDATA javaOffloadOldState = 0;
 		BOOLEAN reportEvent = TRUE;
 
-	 	if (J2SE_VERSION(vm) >= J2SE_19) {
+	 	if (J2SE_VERSION(vm) >= J2SE_V11) {
 	 		if (j9env->capabilities.can_generate_early_vmstart == 0) {
 	 			reportEvent = FALSE;
 	 		}
@@ -614,7 +614,7 @@ jvmtiHookModuleSystemStarted(J9HookInterface** hook, UDATA eventNum, void* event
 	Trc_JVMTI_jvmtiHookModuleSystemStarted_Entry();
 
 	Assert_JVMTI_true(J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED));
-	Assert_JVMTI_true(J2SE_VERSION(vm) >= J2SE_19);
+	Assert_JVMTI_true(J2SE_VERSION(vm) >= J2SE_V11);
 
 	/*
 	 * In Java9 the VMStart event can be triggered from either the J9HOOK_VM_STARTED
@@ -2248,7 +2248,7 @@ jvmtiHookClassFileLoadHook(J9HookInterface** hook, UDATA eventNum, void* eventDa
 
 	Trc_JVMTI_jvmtiHookClassFileLoadHook_Entry();
 
-	if ((J2SE_VERSION(vm) >= J2SE_19)
+	if ((J2SE_VERSION(vm) >= J2SE_V11)
 		&& (j9env->capabilities.can_generate_early_class_hook_events == 0)
 	) {
 		ENSURE_EVENT_PHASE_START_OR_LIVE(jvmtiHookClassFileLoadHook, j9env);

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -33,8 +33,6 @@
  *       nor release file presents.
  */
 #define J2SE_18   0x0800
-#define J2SE_19   0x0900
-#define J2SE_V10  0x0A00            /* This refers Java 10 */
 #define J2SE_V11  0x0B00            /* This refers Java 11 */
 #define J2SE_V12  0x0C00            /* This refers Java 12 */
 /* Shared class cache is using JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) to get the Java version.
@@ -43,10 +41,6 @@
 
 #if JAVA_SPEC_VERSION == 8
 	#define J2SE_LATEST  J2SE_18
-#elif JAVA_SPEC_VERSION == 9
-	#define J2SE_LATEST  J2SE_19
-#elif JAVA_SPEC_VERSION == 10
-	#define J2SE_LATEST  J2SE_V10
 #elif JAVA_SPEC_VERSION == 11
 	#define J2SE_LATEST  J2SE_V11
 #else
@@ -72,10 +66,6 @@
  */
 #if JAVA_SPEC_VERSION == 8
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_OPENJDK
-#elif JAVA_SPEC_VERSION == 9
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V9
-#elif JAVA_SPEC_VERSION == 10
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V10
 #elif JAVA_SPEC_VERSION == 11
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V11
 #elif JAVA_SPEC_VERSION == 12
@@ -84,8 +74,6 @@
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V12
 #endif
 #define J2SE_SHAPE_OPENJDK 		0x10000
-#define J2SE_SHAPE_V9           0x60000
-#define J2SE_SHAPE_V10			0x70000
 #define J2SE_SHAPE_V11			0x80000
 #define J2SE_SHAPE_V12			0x90000
 #define J2SE_SHAPE_RAWPLUSJ9	0xA0000

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -130,33 +130,33 @@ typedef struct J9ClassLoaderWalkState {
 
 #define IS_STRING_COMPRESSED(vmThread, object) \
 	(IS_STRING_COMPRESSION_ENABLED(vmThread) ? \
-		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_19 ? \
+		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_V11 ? \
 			(((I_32) J9VMJAVALANGSTRING_CODER(vmThread, object)) == 0) : \
 			(((I_32) J9VMJAVALANGSTRING_COUNT(vmThread, object)) >= 0)) : \
 		FALSE)
 
 #define IS_STRING_COMPRESSED_VM(javaVM, object) \
 	(IS_STRING_COMPRESSION_ENABLED_VM(javaVM) ? \
-		(J2SE_VERSION(javaVM) >= J2SE_19 ? \
+		(J2SE_VERSION(javaVM) >= J2SE_V11 ? \
 			(((I_32) J9VMJAVALANGSTRING_CODER_VM(javaVM, object)) == 0) : \
 			(((I_32) J9VMJAVALANGSTRING_COUNT_VM(javaVM, object)) >= 0)) : \
 		FALSE)
 
 #define J9VMJAVALANGSTRING_LENGTH(vmThread, object) \
 	(IS_STRING_COMPRESSION_ENABLED(vmThread) ? \
-		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_19 ? \
+		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE(vmThread, J9VMJAVALANGSTRING_VALUE(vmThread, object)) >> ((I_32) J9VMJAVALANGSTRING_CODER(vmThread, object))) : \
 			(J9VMJAVALANGSTRING_COUNT(vmThread, object) & 0x7FFFFFFF)) : \
-		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_19 ? \
+		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE(vmThread, J9VMJAVALANGSTRING_VALUE(vmThread, object)) >> 1) : \
 			(J9VMJAVALANGSTRING_COUNT(vmThread, object))))
 
 #define J9VMJAVALANGSTRING_LENGTH_VM(javaVM, object) \
 	(IS_STRING_COMPRESSION_ENABLED_VM(javaVM) ? \
-		(J2SE_VERSION(javaVM) >= J2SE_19 ? \
+		(J2SE_VERSION(javaVM) >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE_VM(javaVM, J9VMJAVALANGSTRING_VALUE_VM(javaVM, object)) >> ((I_32) J9VMJAVALANGSTRING_CODER_VM(javaVM, object))) : \
 			(J9VMJAVALANGSTRING_COUNT_VM(javaVM, object) & 0x7FFFFFFF)) : \
-		(J2SE_VERSION(javaVM) >= J2SE_19 ? \
+		(J2SE_VERSION(javaVM) >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE_VM(javaVM, J9VMJAVALANGSTRING_VALUE_VM(javaVM, object)) >> 1) : \
 			(J9VMJAVALANGSTRING_COUNT_VM(javaVM, object))))
 
@@ -290,7 +290,7 @@ static const struct { \
 
 #define J9_IS_J9MODULE_OPEN(module) (TRUE == module->isOpen)
 
-#define J9_ARE_MODULES_ENABLED(vm) (J2SE_VERSION(vm) >= J2SE_19)
+#define J9_ARE_MODULES_ENABLED(vm) (J2SE_VERSION(vm) >= J2SE_V11)
 
 /* Macro for VM internalVMFunctions */
 #if defined(J9_INTERNAL_TO_VM)

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,7 +169,7 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 #if defined(OPENJ9_BUILD)
 	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
 #endif /* OPENJ9_BUILD */

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,7 +155,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 #if defined(OPENJ9_BUILD)
 	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
 #endif /* OPENJ9_BUILD */

--- a/runtime/shared_common/SCImplementedAPI.cpp
+++ b/runtime/shared_common/SCImplementedAPI.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -473,7 +473,7 @@ j9shr_classStoreTransaction_start(void * tobj, J9VMThread* currentThread, J9Clas
 		IDATA helperID = 0;
 		U_16 cpType = CP_TYPE_CLASSPATH;
 
-		if ((J2SE_VERSION(vm) >= J2SE_19)
+		if ((J2SE_VERSION(vm) >= J2SE_V11)
 			|| ((NULL != classPathEntries) && (-1 != obj->entryIndex))
 		) {
 			/* For class loaded from modules that entryIndex is -1. classPathEntries can be NULL. */
@@ -489,7 +489,7 @@ j9shr_classStoreTransaction_start(void * tobj, J9VMThread* currentThread, J9Clas
 			if (!classpath && !infoFound) {
 				UDATA pathEntryCount = cpEntryCount;
 
-				if (J2SE_VERSION(vm) >= J2SE_19) {
+				if (J2SE_VERSION(vm) >= J2SE_V11) {
 					if (classloader == vm->systemClassLoader) {
 						if (J9_ARE_NO_BITS_SET(localRuntimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHEBOOTCLASSES)) {
 							/* User specified noBootclasspath - do not continue */

--- a/runtime/shared_common/hookhelpers.cpp
+++ b/runtime/shared_common/hookhelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ makeClasspathItems(J9JavaVM* vm, J9ClassPathEntry* classPathEntries, I_16 entryC
 	bool ret = true;
 	bool ignoreStateChange = false;
 
-	if (bootstrap && (J2SE_VERSION(vm) >= J2SE_19)) {
+	if (bootstrap && (J2SE_VERSION(vm) >= J2SE_V11)) {
 		J9ClassPathEntry* modulePath = vm->modulesPathEntry;
 		if (CPE_TYPE_JIMAGE == modulePath->type) {
 			prototype = PROTO_JIMAGE;
@@ -226,7 +226,7 @@ createClasspath(J9VMThread* currentThread, J9ClassPathEntry* classPathEntries, U
 
 	I_16 supportedEntries = (I_16)entryCount;
 	
-	if (!infoFound && J2SE_VERSION(currentThread->javaVM) >= J2SE_19) {
+	if (!infoFound && J2SE_VERSION(currentThread->javaVM) >= J2SE_V11) {
 		/* Add module entry */
 		supportedEntries += 1;
 	}
@@ -258,7 +258,7 @@ createClasspath(J9VMThread* currentThread, J9ClassPathEntry* classPathEntries, U
 		if (vm->sharedClassConfig->bootstrapCPI) {
 			j9mem_free_memory(vm->sharedClassConfig->bootstrapCPI);
 		}
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			vm->sharedClassConfig->lastBootstrapCPE = vm->modulesPathEntry;
 		} else {
 			vm->sharedClassConfig->lastBootstrapCPE = classPathEntries;

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1345,7 +1345,7 @@ hookFindSharedClass(J9HookInterface** hookInterface, UDATA eventNum, void* voidD
 	}
 
 	J9Module* module = eventData->j9module;
-	if ((J2SE_VERSION(vm) >= J2SE_19)
+	if ((J2SE_VERSION(vm) >= J2SE_V11)
 		&& (NULL == module)
 	) {
 		module = getModule(currentThread, (U_8*)eventData->className, realClassNameLength, eventData->classloader);
@@ -1394,7 +1394,7 @@ hookFindSharedClass(J9HookInterface** hookInterface, UDATA eventNum, void* voidD
 	if (!classpath && !infoFound) {
 		UDATA pathEntryCount = eventData->entryCount;
 
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			if (eventData->classloader == vm->systemClassLoader) {
 				isBootLoader = true;
 				pathEntryCount += 1;
@@ -2726,7 +2726,7 @@ ensureCorrectCacheSizes(J9JavaVM *vm, J9PortLibrary* portlib, U_64 runtimeFlags,
 #if defined(OPENJ9_BUILD)
 	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
 #endif /* OPENJ9_BUILD */

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -94,7 +94,7 @@ latestUserDefinedLoaderIterator(J9VMThread * currentThread, J9StackWalkState * w
 	 * In Java 9+, vm->extensionClassLoader is the PlatformClassLoader.
 	 */
 	BOOLEAN isPlatformClassLoader = FALSE;
-	if ((J2SE_VERSION(vm) >= J2SE_19) && (classLoader == vm->extensionClassLoader)) {
+	if ((J2SE_VERSION(vm) >= J2SE_V11) && (classLoader == vm->extensionClassLoader)) {
 		isPlatformClassLoader = TRUE;
 	}
 
@@ -424,7 +424,7 @@ initializeReflectionGlobals(JNIEnv * env,BOOLEAN includeAccessors) {
 	}
 #endif
 	
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		clazzConstructorAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/ConstructorAccessorImpl");
 		clazzMethodAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/MethodAccessorImpl");
 	} else {
@@ -734,7 +734,7 @@ JVM_GetSystemPackages_Impl(JNIEnv* env)
 						 * java.lang.Package.getSystemPackages() expects a trailing slash in Java 8
 						 * but no trailing slash in Java 9.
 						 */
-						if (J2SE_VERSION(vm) >= J2SE_19) {
+						if (J2SE_VERSION(vm) >= J2SE_V11) {
 							packageString = vm->memoryManagerFunctions->j9gc_createJavaLangString(vmThread,
 									(U_8*) packageName, packageNameLength, 0);
 						} else {

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -880,7 +880,7 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 #if defined(OPENJ9_BUILD)
 			defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 			}
 #endif /* OPENJ9_BUILD */

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3232,7 +3232,7 @@ classIsModifiable(J9JavaVM * vm, J9Class * clazz)
 		rc = JNI_FALSE;
 	} else if (clazz == J9VMJAVALANGJ9VMINTERNALS_OR_NULL(vm)) {
 		rc = JNI_FALSE;
-	} else if ((J2SE_VERSION(vm) >= J2SE_19) && J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsAnonymous)) {
+	} else if ((J2SE_VERSION(vm) >= J2SE_V11) && J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsAnonymous)) {
 		rc = JNI_FALSE;
 	}
 

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -168,9 +168,6 @@ getShcModlevelForJCL(uintptr_t j2seVersion)
 	switch (j2seVersion) {
 	case J2SE_18 :
 		modLevel = J9SH_MODLEVEL_JAVA8;
-		break;
-	case J2SE_19 :
-		modLevel = J9SH_MODLEVEL_JAVA9;
 		break;
 	default: 
 		modLevel = JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion);

--- a/runtime/vm/classloadersearch.c
+++ b/runtime/vm/classloadersearch.c
@@ -57,7 +57,7 @@ addToBootstrapClassLoaderSearch(J9JavaVM * vm, const char * pathSegment,
 	}
 
 	if (classLoaderType & CLS_TYPE_ADD_TO_SYSTEM_PROPERTY) {
-		if ((J2SE_VERSION(vm) & J2SE_VERSION_MASK) < J2SE_19) {
+		if (J2SE_VERSION(vm) < J2SE_V11) {
 			rc = addToSystemProperty(vm, BOOT_PATH_SYS_PROP, pathSegment);
 		} else {
 			rc = addToSystemProperty(vm, BOOT_CLASS_PATH_APPEND_PROP, pathSegment);
@@ -182,7 +182,7 @@ addZipToLoader(J9JavaVM * vm, const char * filename, J9ClassLoader * classLoader
 		zip_releaseZipFile(vm->portLibrary, &zipFile);
 	}
 
-	if ((classLoader == vm->systemClassLoader) && (J2SE_VERSION(vm) >= J2SE_19)) {
+	if ((classLoader == vm->systemClassLoader) && (J2SE_VERSION(vm) >= J2SE_V11)) {
 		if (0 == addJarToSystemClassLoaderClassPathEntries(vm, filename)) {
 			rc = CLS_ERROR_OUT_OF_MEMORY;
 		}
@@ -196,7 +196,7 @@ addZipToLoader(J9JavaVM * vm, const char * filename, J9ClassLoader * classLoader
 			jclass classLoaderClass = NULL;
 			jmethodID mid = NULL;
 
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				jclass jimModules = getJimModules(currentThread);
 				jstring moduleNameString = NULL;
 				jobject vmModule = NULL;

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -520,7 +520,7 @@ callFindLocallyDefinedClass(J9VMThread* vmThread, J9Module *j9module, U_8* class
 			}
 		} else {
 			/* The class is found in shared class cache. */
-			if (J2SE_VERSION(vmThread->javaVM) >= J2SE_19) {
+			if (J2SE_VERSION(vmThread->javaVM) >= J2SE_V11) {
 				if (localBuffer->entryIndex >= 0) {
 					localBuffer->loadLocationType = LOAD_LOCATION_CLASSPATH;
 				} else {
@@ -558,7 +558,7 @@ attemptDynamicClassLoad(J9VMThread* vmThread, J9Module *j9module, U_8* className
 	Trc_VM_internalFindClass_attemptDynamicClassLoad_entry(vmThread, classLoader->classLoaderObject, classNameLength, className);
 
 	/* try to load classes from system class loader */
-	if ((J2SE_VERSION(vmThread->javaVM) >= J2SE_19)
+	if ((J2SE_VERSION(vmThread->javaVM) >= J2SE_V11)
 		|| ((NULL != classLoader->classPathEntries) && (classLoader == vmThread->javaVM->systemClassLoader))
 	) {
 		IDATA findResult = -1;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2721,7 +2721,7 @@ fail:
 					omrthread_monitor_exit(javaVM->classLoaderModuleAndLocationMutex);
 				}
 			}
-			if ((J2SE_VERSION(javaVM) >= J2SE_19) && (NULL == classBeingRedefined)) {
+			if ((J2SE_VERSION(javaVM) >= J2SE_V11) && (NULL == classBeingRedefined)) {
 				ramClass->module = module;
 				if (TrcEnabled_Trc_MODULE_setting_package) {
 					trcModulesSettingPackage(vmThread, ramClass, classLoader, className);
@@ -2837,7 +2837,7 @@ retry:
 	/* To prevent deadlock, release the classTableMutex before loading the classes required for the new class. */
 	omrthread_monitor_exit(javaVM->classTableMutex);
 
-	if (J2SE_VERSION(javaVM) >= J2SE_19) {
+	if (J2SE_VERSION(javaVM) >= J2SE_V11) {
 		if (NULL == classBeingRedefined) {
 			if (J9ROMCLASS_IS_ARRAY(romClass)) {
 				/* At this point the elementClass has been loaded. No

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -124,7 +124,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *rom
 		BOOLEAN freeModuleVersion = FALSE;
 		UDATA j2seVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
 
-		if (j2seVersion >= J2SE_19) {
+		if (j2seVersion >= J2SE_V11) {
 			moduleNameUTF = JAVA_BASE_MODULE;
 			moduleVersionUTF = JAVA_MODULE_VERSION;
 

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -394,13 +394,8 @@ getObjectClass(JNIEnv *env, jobject obj)
 jint JNICALL
 getVersion(JNIEnv *env)
 {
-	J9VMThread *currentThread = (J9VMThread*)env;
-	J9JavaVM *vm = currentThread->javaVM;
-
-	if (J2SE_VERSION(vm) >= J2SE_V10) {
+	if (J2SE_VERSION(((J9VMThread*)env)->javaVM) >= J2SE_V11) {
 		return JNI_VERSION_10;
-	} else if (J2SE_VERSION(vm) == J2SE_19) {
-		return JNI_VERSION_9;
 	} else {
 		return JNI_VERSION_1_8;
 	}

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1358,7 +1358,7 @@ initializeClassPathEntry (J9JavaVM * javaVM, J9ClassPathEntry *cpEntry)
 		return CPE_TYPE_DIRECTORY;
 	}
 
-	if ((EsIsFile == attr) && (J2SE_VERSION(javaVM) >= J2SE_19)) {
+	if ((EsIsFile == attr) && (J2SE_VERSION(javaVM) >= J2SE_V11)) {
 		J9JImageIntf *jimageIntf = javaVM->jimageIntf;
 		if (NULL != jimageIntf) {
 			UDATA jimageHandle = 0;
@@ -1850,7 +1850,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 					enableGcOnIdle = TRUE;
 				} else if (-1 == argIndexGcOnIdleDisable) {
 					if (inContainer
-					|| ((J2SE_VERSION(vm) >= J2SE_19) && J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_TUNE_VIRTUALIZED))
+						|| ((J2SE_VERSION(vm) >= J2SE_V11) && J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_TUNE_VIRTUALIZED))
 					) {
 						enableGcOnIdle = TRUE;
 					}
@@ -2042,7 +2042,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 
 			if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
 				goto _error;
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				vm->modularityPool = pool_new(OMR_MAX(sizeof(J9Package),sizeof(J9Module)),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_MODULES, POOL_FOR_PORT(vm->portLibrary));
 				if (NULL == vm->modularityPool) {
 					goto _error;
@@ -2154,7 +2154,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			break;
 
 		case BYTECODE_TABLE_SET:
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				rc = initializeModulesPath(vm);
 				if (0 != rc) {
 					loadInfo = FIND_DLL_TABLE_ENTRY( FUNCTION_VM_INIT );
@@ -2173,7 +2173,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				goto _error;
 			}
 
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				BOOLEAN patchPathResult = FALSE;
 
 				vm->javaBaseModule = pool_newElement(vm->modularityPool);
@@ -2464,7 +2464,7 @@ static void consumeVMArgs(J9JavaVM* vm, J9VMInitArgs* j9vm_args) {
 	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XNOJIT, NULL, TRUE);
 	findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XRUN, NULL, TRUE);
 
-	if ((J2SE_VERSION(vm) & J2SE_VERSION_MASK) < J2SE_19) {
+	if (J2SE_VERSION(vm) < J2SE_V11) {
 		findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XBOOTCLASSPATH_COLON, NULL, TRUE);
 		findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XBOOTCLASSPATH_P_COLON, NULL, TRUE);
 	}
@@ -2880,7 +2880,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 	vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_CLASSLOADER_LOCKING_ENABLED | J9_EXTENDED_RUNTIME_REDUCE_CPU_MONITOR_OVERHEAD; /* enabled by default */
 	vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_ENABLE_CPU_MONITOR; /* Cpu monitoring is enabled by default */
 	vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_ALLOW_CONTENDED_FIELDS; /* Allow contended fields on bootstrap classes */
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_RESTRICT_IFA; /* Enable zAAP switching for Registered Natives and JVMTI callbacks by default in Java 9 and later. */
 	}
 	vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_OSR_SAFE_POINT; /* Enable OSR safe point by default */
@@ -2998,7 +2998,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 			vm->extendedRuntimeFlags &= ~(UDATA)J9_EXTENDED_RUNTIME_POSITIVE_HASHCODE;
 		}
 		/* -Xbootclasspath and -Xbootclasspath/p are not supported from Java 9 onwards */
-		if (J2SE_VERSION(vm) >= J2SE_19) {
+		if (J2SE_VERSION(vm) >= J2SE_V11) {
 			const I_32 xbootClasspathLen = sizeof(VMOPT_XBOOTCLASSPATH_COLON) - 1;
 			const I_32 xbootClasspathPLen = sizeof(VMOPT_XBOOTCLASSPATH_P_COLON) - 1;
 			PORT_ACCESS_FROM_JAVAVM(vm);
@@ -3446,7 +3446,7 @@ zeroInitStages(J9JavaVM* vm, IDATA stage, void* reserved)
 	switch(stage) {
 		case PORT_LIBRARY_GUARANTEED :
 			/* -Xzero option is removed from Java 9 */
-			if (J2SE_VERSION(vm) >= J2SE_19) {
+			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				vm->zeroOptions = 0;
 			} else {
 				vm->zeroOptions = J9VM_ZERO_SHAREBOOTZIPCACHE;
@@ -6314,7 +6314,7 @@ signalDispatch(J9VMThread *vmThread, I_32 signal)
 
 	enterVMFromJNI(vmThread);
 
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		runStaticMethod(vmThread, (U_8 *)"jdk/internal/misc/Signal", &nas, 1, (UDATA *)args);
 	} else {
 		runStaticMethod(vmThread, (U_8 *)"sun/misc/Signal", &nas, 1, (UDATA *)args);
@@ -6435,7 +6435,7 @@ initializeDDR(J9JavaVM * vm)
 
 #if defined(J9VM_OPT_SIDECAR)
 	/* Append the VM path to the filename if it's available */
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		j9ddrDatDir = vm->j9libvmDirectory;
 	} else {
 		j9ddrDatDir = vm->j2seRootDirectory;

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -386,10 +386,6 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 
 	if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_18) {
 		javaVersion = "JRE 1.8.0";
-	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_19) {
-		javaVersion = "JRE 9";
-	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V10) {
-		javaVersion = "JRE 10";
 	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V11) {
 		javaVersion = "JRE 11";
 	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V12) {

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -148,7 +148,7 @@ BOOLEAN
 requirePackageAccessCheck(J9JavaVM *vm, J9ClassLoader *srcClassLoader, J9Module *srcModule, J9Class *targetClass)
 {
 	BOOLEAN checkFlag = TRUE;
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		if (srcModule == targetClass->module) {
 			if (NULL != srcModule) {
 				/* same named module */
@@ -489,7 +489,7 @@ tryAgain:
 		cpClass = J9_CLASS_FROM_CP(ramCP);
 		lookupOptions |= J9_LOOK_CLCONSTRAINTS;
 
-		if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_19) {
+		if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_V11) {
 			/* This check is only required in Java9 and there have been applications that
 			 * fail when this check is enabled on Java8.
 			 */
@@ -1191,7 +1191,7 @@ resolveSpecialMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 		lookupOptions |= J9_LOOK_CLCONSTRAINTS;
 	}
 
-	if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_19) {
+	if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_V11) {
 		/* This check is only required in Java9 and there have been applications that
 		 * fail when this check is enabled on Java8.
 		 */

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,7 +101,7 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 		if ( modifiers & J9AccPublic ) {
 			/* Public */
 			if ((sourceClass != destClass)
-				&& (J2SE_VERSION(vm) >= J2SE_19) 
+				&& (J2SE_VERSION(vm) >= J2SE_V11) 
 				&& J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)
 				&& !J9ROMCLASS_IS_PRIMITIVE_TYPE(destClass->romClass)
 			) {

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -536,7 +536,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	jint i = 0;
 	JavaVMInitArgs *initArgs = NULL;
 	char *jclName = J9_DEFAULT_JCL_DLL_NAME;
-	UDATA j2seVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
+	UDATA j2seVersion = J2SE_VERSION(vm);
 	const char* propValue = NULL;
 	UDATA rc = J9SYSPROP_ERROR_NONE;
 
@@ -565,7 +565,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		return J9SYSPROP_ERROR_OUT_OF_MEMORY;
 	}
 
-	if (j2seVersion >= J2SE_19) {
+	if (j2seVersion >= J2SE_V11) {
 		rc = addModularitySystemProperties(vm);
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
@@ -583,14 +583,6 @@ initializeSystemProperties(J9JavaVM * vm)
 		case J2SE_18:
 			classVersion = "52.0";
 			specificationVersion = "1.8";
-			break;
-		case J2SE_19:
-			classVersion = "53.0";
-			specificationVersion = "9";
-			break;
-		case J2SE_V10:
-			classVersion = "54.0";
-			specificationVersion = "10";
 			break;
 		case J2SE_V11:
 		default:
@@ -710,7 +702,7 @@ initializeSystemProperties(J9JavaVM * vm)
 
 	/* We don't have enough information yet. Put in placeholders. */
 #if defined(J9VM_OPT_SIDECAR)
-	if (j2seVersion < J2SE_19) {
+	if (j2seVersion < J2SE_V11) {
 		rc = addSystemProperty(vm, BOOT_PATH_SYS_PROP, "", J9SYSPROP_FLAG_WRITEABLE);
 	} else {
 		rc = addSystemProperty(vm, BOOT_CLASS_PATH_APPEND_PROP, "", J9SYSPROP_FLAG_WRITEABLE);
@@ -750,7 +742,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	}
 
 	/* -Xzero option is removed from Java 9 */
-	if (j2seVersion < J2SE_19) {
+	if (j2seVersion < J2SE_V11) {
 		rc = addSystemProperty(vm, "com.ibm.zero.version", "2", 0);
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
@@ -854,7 +846,7 @@ initializeSystemProperties(J9JavaVM * vm)
 					goto fail;
 				}
 			}
-			if (j2seVersion >= J2SE_19) {
+			if (j2seVersion >= J2SE_V11) {
 				if ('\0' != propValue[0]) {
 					/* Support for java.endorsed.dirs and java.ext.dirs is disabled in Java 9+. */
 					if (0 == strncmp(JAVA_ENDORSED_DIRS, propNameCopy, sizeof(JAVA_ENDORSED_DIRS))) {
@@ -895,7 +887,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		}
 	}
 	
-	if (j2seVersion >= J2SE_19) {
+	if (j2seVersion >= J2SE_V11) {
 		/* On Java 9 support for java.endorsed.dirs is disabled. If java.home/lib/endorsed dir is found, JVM fails to startup. *
 		 * Similarly, support for java.ext.dirs is disabled. If java.home/lib/ext dir is found, JVM fails to startup.
 		 */

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@
 #include "j2sever.h"
 
 /* processReferenceMonitor is only used for Java 9 and later */
-#define J9_IS_PROCESS_REFERENCE_MONITOR_ENABLED(vm) ((J2SE_VERSION(vm) & J2SE_VERSION_MASK) >= J2SE_19)
+#define J9_IS_PROCESS_REFERENCE_MONITOR_ENABLED(vm) (J2SE_VERSION(vm) >= J2SE_V11)
 
 UDATA initializeVMThreading(J9JavaVM *vm)
 {


### PR DESCRIPTION
Remove `Java 9/10` native supports

Replaced `J2SE_19` with `J2SE_V11`;
Removed redundant `J2SE_VERSION(vm) &` with `J2SE_RELEASE_MASK` or `J2SE_VERSION_MASK`.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>