### PR TITLE
Remove TR::X86UnresolvedVirtualCallSnippet print

### DIFF
--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -39,10 +39,6 @@
 #include "il/symbol/StaticSymbol.hpp"
 #include "x/codegen/X86PrivateLinkage.hpp"
 
-// TODO: Delete this forward declaration along with the corresponding
-// TR_Debug::print overload.
-namespace TR { class X86UnresolvedVirtualCallSnippet; }
-
 bool TR::X86PicDataSnippet::shouldEmitJ2IThunkPointer()
    {
    if (!TR::Compiler->target.is64Bit())
@@ -1133,11 +1129,4 @@ uint32_t TR::X86CallSnippet::getLength(int32_t estimatedSnippetStart)
       }
 
    return length;
-   }
-
-// TODO: Delete this once the (dead) call site is deleted from omr.
-void
-TR_Debug::print(TR::FILE *pOutFile, TR::X86UnresolvedVirtualCallSnippet *snippet)
-   {
-   TR_ASSERT_FATAL(false, "stub for staged deletion");
    }


### PR DESCRIPTION
`TR::X86UnresolvedVirtualCallSnippet` itself has already been removed, and the definition of `print` is only here to prevent linker errors. Now that the only (dead) call site has been removed from OMR, this definition is unreferenced and can be deleted.