### PR TITLE
Revert "Add FileSystemImpl.isSecuritySupported0()"

### DIFF
--- a/runtime/mgmt/mgmtinit.c
+++ b/runtime/mgmt/mgmtinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,16 +20,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(WIN32)
-#include <windows.h>
-#endif /* defined(WIN32) */
-
 #include "jni.h"
 #include "j9port.h"
 #include "jclprots.h"
 
 /*
  * Invoked immediately after this shared library has been loaded.
+ * The shared library is currenly only a stub: simply return.
  */
 jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -37,36 +34,43 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
 	return JNI_VERSION_1_8;
 }
 
-/* Convert a modified UTF8 path to the given encoding.
- *
- * The caller must free the returned memory.
+/* Convert path to platform encoding.
+ * It is the callers responsibility for freeing the returned memory.
  *
  * @return NULL on error, otherwise return converted string
  */
-static char *
-convertPath(JNIEnv *env, const char *pathUTF, int32_t toCode)
+static const char*
+translatePathToPlatform(JNIEnv *env, const char* pathUTF)
 {
-	PORT_ACCESS_FROM_ENV(env);
 	char *result = NULL;
-	const uintptr_t pathUTFSize = strlen(pathUTF);
-	const int32_t resultSize = j9str_convert(J9STR_CODE_MUTF8, toCode, pathUTF, pathUTFSize, NULL, 0);
+	int32_t bufferLength = 0;
+	uintptr_t pathUTFSize = strlen(pathUTF);
 
-	if (resultSize >= 0) {
-		const int32_t spaceRequired = resultSize + MAX_STRING_TERMINATOR_LENGTH;
-		result = (char *)j9mem_allocate_memory(spaceRequired, OMRMEM_CATEGORY_PORT_LIBRARY);
-		if (NULL != result) {
-			if (resultSize != j9str_convert(J9STR_CODE_MUTF8, toCode,
-					pathUTF, pathUTFSize, result, spaceRequired)) {
+	PORT_ACCESS_FROM_ENV(env);
+
+	bufferLength = 	j9str_convert(J9STR_CODE_MUTF8, J9STR_CODE_PLATFORM_OMR_INTERNAL, pathUTF, pathUTFSize, NULL, 0);
+
+	if (bufferLength >= 0) {
+		bufferLength += MAX_STRING_TERMINATOR_LENGTH;
+
+		result = (char*)j9mem_allocate_memory(bufferLength, OMRMEM_CATEGORY_PORT_LIBRARY);
+		if (NULL != result)  {
+			int32_t resultLength = j9str_convert(J9STR_CODE_MUTF8, J9STR_CODE_PLATFORM_OMR_INTERNAL, pathUTF, pathUTFSize, result, bufferLength);
+			if ((resultLength < 0) ||  (resultLength + MAX_STRING_TERMINATOR_LENGTH != bufferLength)) {
 				j9mem_free_memory(result);
 				result = NULL; /* error occured */
+			} else {
+				/* add terminator */
+				memset(result + resultLength, 0, MAX_STRING_TERMINATOR_LENGTH);
 			}
 		}
 	}
 
-	return result;
+	return (const char*)result;
+
 }
 
-/*
+/**
  * Determines whether file path has user permissions only.
  *
  * @param path file path
@@ -75,27 +79,29 @@ convertPath(JNIEnv *env, const char *pathUTF, int32_t toCode)
  *
  * Note: Windows permission bits are not set to differentiate between users.
  */
-jboolean JNICALL
+JNIEXPORT jboolean JNICALL 
 Java_sun_management_FileSystemImpl_isAccessUserOnly0(JNIEnv *env, jclass c, jstring path)
 {
-	PORT_ACCESS_FROM_ENV(env);
+	const char* pathUTF = NULL;
 	jboolean result = JNI_FALSE;
-	const char *pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
 
+	PORT_ACCESS_FROM_ENV(env);
+
+	pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
 	if (NULL == pathUTF) {
 		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 	} else {
 		struct J9FileStat buf;
 		I_32 status = -1;
-#if defined(WIN32)
-		const char *pathConvert = pathUTF;
-#else
-		const char *pathConvert = convertPath(env, pathUTF, J9STR_CODE_PLATFORM_OMR_INTERNAL);
+		const char* pathConvert = pathUTF;
+#if !defined(WIN32) && !defined(WIN64)
+		pathConvert = (char*)translatePathToPlatform(env, pathUTF);
 		if (NULL == pathConvert) {
 			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
-			goto done;
+			(*env)->ReleaseStringUTFChars(env, path, pathUTF);
+			return result;
 		}
-#endif /* !defined(WIN32) */
+#endif /* skip on windows */
 		/* retrieve file information */
 		status = j9file_stat(pathConvert, 0, &buf);
 
@@ -109,65 +115,19 @@ Java_sun_management_FileSystemImpl_isAccessUserOnly0(JNIEnv *env, jclass c, jstr
 			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNewJavaIoIOException(env, NULL);
 		}
 
-#if !defined(WIN32)
-		j9mem_free_memory(pathConvert);
-done:
-#endif /* !defined(WIN32) */
+		if (pathConvert != pathUTF) {
+			j9mem_free_memory((void*)pathConvert);
+		}
 		(*env)->ReleaseStringUTFChars(env, path, pathUTF);
 	}
 
 	return result;
 }
 
-#if defined(WIN32)
-
-void JNICALL
+#if defined(WIN32) || defined(WIN64)
+JNIEXPORT void JNICALL 
 Java_sun_management_FileSystemImpl_init0(JNIEnv *env, jclass c)
 {
-	/* stub method, no implementation required */
+	/* stub method, no implementation required */ 
 }
-
-/*
- * Determines whether the file system addressed by the given absolute path suports security.
- *
- * @param path file path
- * @return Returns true if the referenced file system suports security, false otherwise.
- */
-jboolean JNICALL
-Java_sun_management_FileSystemImpl_isSecuritySupported0(JNIEnv *env, jclass c, jstring path)
-{
-	jboolean result = JNI_FALSE;
-	const char *pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
-
-	if (NULL == pathUTF) {
-		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
-	} else {
-		PORT_ACCESS_FROM_ENV(env);
-		void *pathWide = convertPath(env, pathUTF, J9STR_CODE_WIDE);
-
-		if (NULL == pathWide) {
-			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
-		} else {
-			DWORD fileSystemFlags = 0;
-			wchar_t volumePath[EsMaxPath];
-
-			if (GetVolumePathNameW((wchar_t *)pathWide, volumePath, EsMaxPath)
-					&& GetVolumeInformationW(volumePath, NULL, 0, NULL, NULL, &fileSystemFlags, NULL, 0)) {
-				if (0 != (fileSystemFlags & FILE_PERSISTENT_ACLS)) {
-					result = JNI_TRUE;
-				}
-			} else {
-				/* failed to retrieve information */
-				((J9VMThread *)env)->javaVM->internalVMFunctions->throwNewJavaIoIOException(env, NULL);
-			}
-
-			j9mem_free_memory(pathWide);
-		}
-
-		(*env)->ReleaseStringUTFChars(env, path, pathUTF);
-	}
-
-	return result;
-}
-
-#endif /* defined(WIN32) */
+#endif /* defined(WIN32) || defined(WIN64) */

--- a/runtime/mgmt/module.xml
+++ b/runtime/mgmt/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2019 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,11 +25,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<exports group="all">
 		<export name="JNI_OnLoad" />
 		<export name="Java_sun_management_FileSystemImpl_isAccessUserOnly0" />
-	</exports>
-
-	<exports group="windows">
-		<export name="Java_sun_management_FileSystemImpl_init0" />
-		<export name="Java_sun_management_FileSystemImpl_isSecuritySupported0" />
+		<export name="Java_sun_management_FileSystemImpl_init0">
+			<include-if condition="spec.win_x86.*" />
+		</export>
 	</exports>
 
 	<artifact type="shared" name="management" loadgroup="" appendrelease="false">
@@ -41,9 +39,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 		<exports>
 			<group name="all" />
-			<group name="windows">
-				<include-if condition="spec.win_x86.*" />
-			</group>
 		</exports>
 
 		<includes>


### PR DESCRIPTION
Reverts eclipse/openj9#4808

The change doesn't compile on some platforms
`"mgmtinit.c", line 113.35: 1506-280 (W) Function argument assignment between types "void*" and "const char*" is not allowed.`