### PR TITLE
AArch64: Add initial version of some JIT files

### DIFF
--- a/runtime/compiler/aarch64/codegen/CMakeLists.txt
+++ b/runtime/compiler/aarch64/codegen/CMakeLists.txt
@@ -1,0 +1,29 @@
+################################################################################
+# Copyright (c) 2019, 2019 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
+
+j9jit_files(
+	aarch64/codegen/J9ARM64Snippet.cpp
+	aarch64/codegen/J9CodeGenerator.cpp
+	aarch64/codegen/J9TreeEvaluator.cpp
+	aarch64/codegen/J9UnresolvedDataSnippet.cpp
+	aarch64/codegen/StackCheckFailureSnippet.cpp
+)

--- a/runtime/compiler/aarch64/codegen/J9ARM64Snippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9ARM64Snippet.cpp
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/J9ARM64Snippet.hpp"
+
+TR::ARM64MonitorEnterSnippet::ARM64MonitorEnterSnippet(
+   TR::CodeGenerator *codeGen,
+   TR::Node *monitorNode,
+   int32_t lwOffset,
+   TR::LabelSymbol *incLabel,
+   TR::LabelSymbol *callLabel,
+   TR::LabelSymbol *restartLabel)
+   : _incLabel(incLabel),
+     _lwOffset(lwOffset),
+     TR::ARM64HelperCallSnippet(codeGen, monitorNode, callLabel, monitorNode->getSymbolReference(), restartLabel)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+uint8_t *
+TR::ARM64MonitorEnterSnippet::emitSnippetBody()
+   {
+   TR_UNIMPLEMENTED();
+
+   uint8_t *buffer = cg()->getBinaryBufferCursor();
+   return buffer;
+   }
+
+void
+TR::ARM64MonitorEnterSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+uint32_t TR::ARM64MonitorEnterSnippet::getLength(int32_t estimatedSnippetStart)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }
+
+int32_t TR::ARM64MonitorEnterSnippet::setEstimatedCodeLocation(int32_t estimatedSnippetStart)
+   {
+   TR_UNIMPLEMENTED();
+   return estimatedSnippetStart;
+   }
+
+
+TR::ARM64MonitorExitSnippet::ARM64MonitorExitSnippet(
+   TR::CodeGenerator *codeGen,
+   TR::Node *monitorNode,
+   int32_t lwOffset,
+   TR::LabelSymbol *decLabel,
+   TR::LabelSymbol *callLabel,
+   TR::LabelSymbol *restartLabel)
+   : _decLabel(decLabel),
+     _lwOffset(lwOffset),
+     TR::ARM64HelperCallSnippet(codeGen, monitorNode, callLabel, monitorNode->getSymbolReference(), restartLabel)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+uint8_t *
+TR::ARM64MonitorExitSnippet::emitSnippetBody()
+   {
+   TR_UNIMPLEMENTED();
+
+   uint8_t *buffer = cg()->getBinaryBufferCursor();
+   return buffer;
+   }
+
+void
+TR::ARM64MonitorExitSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+uint32_t
+TR::ARM64MonitorExitSnippet::getLength(int32_t estimatedSnippetStart)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }
+
+int32_t TR::ARM64MonitorExitSnippet::setEstimatedCodeLocation(int32_t estimatedSnippetStart)
+   {
+   TR_UNIMPLEMENTED();
+   return estimatedSnippetStart;
+   }

--- a/runtime/compiler/aarch64/codegen/J9ARM64Snippet.hpp
+++ b/runtime/compiler/aarch64/codegen/J9ARM64Snippet.hpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9ARM64SNIPPET_INCL
+#define J9ARM64SNIPPET_INCL
+
+#include "codegen/Snippet.hpp"
+#include "codegen/ARM64HelperCallSnippet.hpp"
+#include "j9cfg.h"
+
+namespace TR {
+
+class ARM64MonitorEnterSnippet : public TR::ARM64HelperCallSnippet
+   {
+   TR::LabelSymbol *_incLabel;
+   int32_t _lwOffset;
+
+   public:
+
+   /**
+    * @brief Constructor
+    */
+   ARM64MonitorEnterSnippet(TR::CodeGenerator *codeGen,
+                            TR::Node *monitorNode,
+                            int32_t lwOffset,
+                            TR::LabelSymbol *incLabel,
+                            TR::LabelSymbol *callLabel,
+                            TR::LabelSymbol *restartLabel);
+
+   /**
+    * @brief Answers the Snippet kind
+    * @return Snippet kind
+    */
+   virtual Kind getKind() { return IsMonitorEnter; }
+
+   /**
+    * @brief Emits the Snippet body
+    * @return instruction cursor
+    */
+   virtual uint8_t *emitSnippetBody();
+
+   /**
+    * @brief Prints the Snippet
+    */
+   virtual void print(TR::FILE *, TR_Debug *);
+
+   /**
+    * @brief Answers the Snippet length
+    * @return Snippet length
+    */
+   virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+   /**
+    * @brief Sets estimated binary location
+    * @return estimated binary location
+    */
+   virtual int32_t setEstimatedCodeLocation(int32_t p);
+
+   /**
+    * @brief Answers the incLabel
+    * @return incLabel
+    */
+   TR::LabelSymbol * getIncLabel() { return _incLabel; };
+
+   /**
+    * @brief Answers the lock-word offset
+    * @return lock-word offset
+    */
+   int32_t getLockWordOffset() { return _lwOffset; }
+   };
+
+class ARM64MonitorExitSnippet : public TR::ARM64HelperCallSnippet
+   {
+   TR::LabelSymbol *_decLabel;
+   int32_t _lwOffset;
+
+   public:
+
+   /**
+    * @brief Constructor
+    */
+   ARM64MonitorExitSnippet(TR::CodeGenerator *codeGen,
+                           TR::Node *monitorNode,
+                           int32_t lwOffset,
+                           TR::LabelSymbol *decLabel,
+                           TR::LabelSymbol *callLabel,
+                           TR::LabelSymbol *restartLabel);
+
+   /**
+    * @brief Answers the Snippet kind
+    * @return Snippet kind
+    */
+   virtual Kind getKind() { return IsMonitorExit; }
+
+   /**
+    * @brief Emits the Snippet body
+    * @return instruction cursor
+    */
+   virtual uint8_t *emitSnippetBody();
+
+   /**
+    * @brief Prints the Snippet
+    */
+   virtual void print(TR::FILE *, TR_Debug *);
+
+   /**
+    * @brief Answers the Snippet length
+    * @return Snippet length
+    */
+   virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+   /**
+    * @brief Sets estimated binary location
+    * @return estimated binary location
+    */
+   virtual int32_t setEstimatedCodeLocation(int32_t p);
+
+   /**
+    * @brief Answers the decLabel
+    * @return decLabel
+    */
+   TR::LabelSymbol * getDecLabel() { return _decLabel; }
+
+   /**
+    * @brief Answers the lock-word offset
+    * @return lock-word offset
+    */
+   int32_t getLockWordOffset() { return _lwOffset; }
+   };
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/CodeGenerator.hpp"
+
+J9::ARM64::CodeGenerator::CodeGenerator() :
+      J9::CodeGenerator()
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+TR::Linkage *
+J9::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+TR::Recompilation *
+J9::ARM64::CodeGenerator::allocateRecompilationInfo()
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_J9_ARM64_CODEGENERATORBASE_INCL
+#define TR_J9_ARM64_CODEGENERATORBASE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef TRJ9_CODEGENERATORBASE_CONNECTOR
+#define TRJ9_CODEGENERATORBASE_CONNECTOR
+
+namespace J9 { namespace ARM64 { class CodeGenerator; } }
+namespace J9 { typedef J9::ARM64::CodeGenerator CodeGeneratorConnector; }
+#else
+#error J9::ARM64::CodeGenerator expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9CodeGenerator.hpp"
+#include "codegen/LinkageConventionsEnum.hpp"
+
+namespace TR { class Recompilation; }
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
+   {
+   public:
+
+   /**
+    * @brief Constructor
+    */
+   CodeGenerator();
+
+   /**
+    * @brief Allocates recompilation information
+    */
+   TR::Recompilation *allocateRecompilationInfo();
+
+   /**
+    * @brief Gets or creates a TR::Linkage object
+    * @param[in] lc : linkage convention
+    * @return created linkage object
+    */
+   TR::Linkage *createLinkage(TR_LinkageConventions lc);
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/TreeEvaluator.hpp"
+

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_ARM64_TREE_EVALUATOR_INCL
+#define J9_ARM64_TREE_EVALUATOR_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_TREE_EVALUATOR_CONNECTOR
+#define J9_TREE_EVALUATOR_CONNECTOR
+namespace J9 { namespace ARM64 { class TreeEvaluator; } }
+namespace J9 { typedef J9::ARM64::TreeEvaluator TreeEvaluatorConnector; }
+#else
+#error J9::ARM64::TreeEvaluator expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+
+#include "compiler/codegen/J9TreeEvaluator.hpp"  // include parent
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
+   {
+   public:
+
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/UnresolvedDataSnippet.hpp"
+
+uint8_t *
+J9::ARM64::UnresolvedDataSnippet::emitSnippetBody()
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+uint32_t
+J9::ARM64::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }

--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.hpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_ARM64_UNRESOLVEDDATASNIPPET_INCL
+#define J9_ARM64_UNRESOLVEDDATASNIPPET_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_UNRESOLVEDDATASNIPPET_CONNECTOR
+#define J9_UNRESOLVEDDATASNIPPET_CONNECTOR
+namespace J9 { namespace ARM64 { class UnresolvedDataSnippet; } }
+namespace J9 { typedef J9::ARM64::UnresolvedDataSnippet UnresolvedDataSnippetConnector; }
+#else
+#error J9::ARM64::UnresolvedDataSnippet expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9UnresolvedDataSnippet.hpp"
+
+#include "il/SymbolReference.hpp"
+
+namespace TR { class MemoryReference; }
+namespace TR { class Symbol; }
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
+   {
+
+   TR::MemoryReference  *_memoryReference;
+
+   public:
+
+   /**
+    * @brief Constructor
+    */
+   UnresolvedDataSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, bool isStore, bool isGCSafePoint) :
+      J9::UnresolvedDataSnippet(cg, node, symRef, isStore, isGCSafePoint),
+      _memoryReference(NULL)
+      {
+      }
+
+   /**
+    * @brief Answers the Snippet kind
+    * @return Snippet kind
+    */
+   virtual Kind getKind() { return IsUnresolvedData; }
+
+   /**
+    * @brief Answers the DataSymbol
+    * @return DataSymbol
+    */
+   TR::Symbol *getDataSymbol() { return getDataSymbolReference()->getSymbol(); }
+
+   /**
+    * @brief Answers the MemoryReference
+    * @return MemoryReference
+    */
+   TR::MemoryReference *getMemoryReference() { return _memoryReference; }
+   /**
+    * @brief Sets the MemoryReference
+    * @return MemoryReference
+    */
+   TR::MemoryReference *setMemoryReference(TR::MemoryReference *mr) { return (_memoryReference = mr); }
+
+   /**
+    * @brief Emits the Snippet body
+    * @return instruction cursor
+    */
+   virtual uint8_t *emitSnippetBody();
+
+   /**
+    * @brief Answers the Snippet length
+    * @return Snippet length
+    */
+   virtual uint32_t getLength(int32_t estimatedSnippetStart);
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/StackCheckFailureSnippet.hpp"
+
+#include "codegen/CodeGenerator.hpp"
+
+uint8_t *
+TR::ARM64StackCheckFailureSnippet::emitSnippetBody()
+   {
+   TR_UNIMPLEMENTED();
+
+   uint8_t *buffer = cg()->getBinaryBufferCursor();
+   return buffer;
+   }
+
+uint32_t
+TR::ARM64StackCheckFailureSnippet::getLength(int32_t estimatedSnippetStart)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }

--- a/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.hpp
+++ b/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ARM64STACKCHECKFAILURESNIPPET_INCL
+#define ARM64STACKCHECKFAILURESNIPPET_INCL
+
+#include "codegen/Snippet.hpp"
+
+#include <stdint.h>
+
+namespace TR { class CodeGenerator; }
+namespace TR { class LabelSymbol; }
+namespace TR { class Node; }
+
+namespace TR {
+
+class ARM64StackCheckFailureSnippet : public TR::Snippet
+   {
+   TR::LabelSymbol *reStartLabel;
+
+   public:
+
+   ARM64StackCheckFailureSnippet(TR::CodeGenerator *cg,
+                                 TR::Node *node,
+                                 TR::LabelSymbol *restartlab,
+                                 TR::LabelSymbol *snippetlab)
+      : TR::Snippet(cg, node, snippetlab), reStartLabel(restartlab)
+      {
+      }
+
+   /**
+    * @brief Answers the Snippet kind
+    * @return Snippet kind
+    */
+   virtual Kind getKind() { return IsStackCheckFailure; }
+
+   /**
+    * @brief Answers the restart label
+    * @return restart label
+    */
+   TR::LabelSymbol *getReStartLabel() { return reStartLabel; }
+   /**
+    * @brief Sets the restart label
+    * @return restart label
+    */
+   TR::LabelSymbol *setReStartLabel(TR::LabelSymbol *l) { return (reStartLabel = l); }
+
+   /**
+    * @brief Emits the Snippet body
+    * @return instruction cursor
+    */
+   virtual uint8_t *emitSnippetBody();
+
+   /**
+    * @brief Answers the Snippet length
+    * @return Snippet length
+    */
+   virtual uint32_t getLength(int32_t estimatedSnippetStart);
+   };
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/env/CMakeLists.txt
+++ b/runtime/compiler/aarch64/env/CMakeLists.txt
@@ -1,0 +1,25 @@
+################################################################################
+# Copyright (c) 2019, 2019 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
+
+j9jit_files(
+	aarch64/env/J9CPU.cpp
+)

--- a/runtime/compiler/aarch64/env/J9CPU.cpp
+++ b/runtime/compiler/aarch64/env/J9CPU.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "env/CompilerEnv.hpp"
+#include "env/CPU.hpp"
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+TR_ProcessorFeatureFlags
+CPU::getProcessorFeatureFlags()
+   {
+   TR_ProcessorFeatureFlags processorFeatureFlags = { {0} };
+   return processorFeatureFlags;
+   }
+
+bool
+CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+   {
+   return self()->is(processorSignature);
+   }
+
+}
+
+}

--- a/runtime/compiler/aarch64/env/J9CPU.hpp
+++ b/runtime/compiler/aarch64/env/J9CPU.hpp
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_ARM64_CPU_INCL
+#define J9_ARM64_CPU_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_CPU_CONNECTOR
+#define J9_CPU_CONNECTOR
+namespace J9 { namespace ARM64 { class CPU; } }
+namespace J9 { typedef J9::ARM64::CPU CPUConnector; }
+#else
+#error J9::ARM64::CPU expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/env/J9CPU.hpp"
+#include "env/ProcessorInfo.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PROCESSOR_FEATURES_SIZE 1
+typedef struct TR_ProcessorFeatureFlags {
+  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
+} TR_ProcessorFeatureFlags;
+
+#ifdef __cplusplus
+}
+#endif
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+class CPU : public J9::CPU
+   {
+protected:
+
+   CPU() :
+         J9::CPU()
+      {}
+
+public:
+
+   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
+   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+
+   };
+
+}
+
+}
+
+#endif


### PR DESCRIPTION
This commit adds the initial version of some JIT files for aarch64,
such as J9CodeGenerator, J9TreeEvaluator, and J9CPU.
Mostly declarations only in this PR except for trivial functions.

Signed-off-by: knn-k <konno@jp.ibm.com>