### PR TITLE
AArch64: Add entries of helper functions to Runtime.cpp

### DIFF
--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -21,6 +21,7 @@
 ################################################################################
 
 j9jit_files(
+	aarch64/runtime/PicBuilder.spp
 	aarch64/runtime/Recomp.cpp
 	aarch64/runtime/Recompilation.spp
 )

--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+#include "jilconsts.inc"
+
+	.globl	_interpreterUnresolvedStaticGlue
+	.globl	_interpreterUnresolvedSpecialGlue
+	.globl	_interpreterUnresolvedDirectVirtualGlue
+	.globl	_interpreterUnresolvedClassGlue
+	.globl	_interpreterUnresolvedClassGlue2
+	.globl	_interpreterUnresolvedStringGlue
+	.globl	_interpreterUnresolvedStaticDataGlue
+	.globl	_interpreterUnresolvedStaticDataStoreGlue
+	.globl	_interpreterUnresolvedInstanceDataGlue
+	.globl	_interpreterUnresolvedInstanceDataStoreGlue
+	.globl	_virtualUnresolvedHelper
+	.globl	_interfaceCallHelper
+	.globl	_interpreterVoidStaticGlue
+	.globl	_interpreterSyncVoidStaticGlue
+	.globl	_interpreterIntStaticGlue
+	.globl	_interpreterSyncIntStaticGlue
+	.globl	_interpreterLongStaticGlue
+	.globl	_interpreterSyncLongStaticGlue
+	.globl	_interpreterFloatStaticGlue
+	.globl	_interpreterSyncFloatStaticGlue
+	.globl	_interpreterDoubleStaticGlue
+	.globl	_interpreterSyncDoubleStaticGlue
+	.globl	_nativeStaticHelper
+
+#define SETVAL(A,B) .set A, B
+#include "runtime/Helpers.inc"
+#undef SETVAL
+
+	.text
+	.align 2
+
+_interpreterUnresolvedStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedSpecialGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedDirectVirtualGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedClassGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedClassGlue2:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedStringGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedStaticDataGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedStaticDataStoreGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedInstanceDataGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedInstanceDataStoreGlue:
+	hlt	#0	// Not implemented yet
+
+_virtualUnresolvedHelper:
+	hlt	#0	// Not implemented yet
+
+_interfaceCallHelper:
+	hlt	#0	// Not implemented yet
+
+_interpreterVoidStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncVoidStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterIntStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncIntStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterLongStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncLongStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterFloatStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncFloatStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterDoubleStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncDoubleStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_nativeStaticHelper:
+	hlt	#0	// Not implemented yet

--- a/runtime/compiler/build/files/host/aarch64.mk
+++ b/runtime/compiler/build/files/host/aarch64.mk
@@ -22,5 +22,6 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/runtime/CodeSync.cpp
 
 JIT_PRODUCT_SOURCE_FILES+= \
+    compiler/aarch64/runtime/PicBuilder.spp \
     compiler/aarch64/runtime/Recomp.cpp \
     compiler/aarch64/runtime/Recompilation.spp

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1136,6 +1136,9 @@ JIT_HELPER(_countingRecompileMethod);
 JIT_HELPER(_induceRecompilation);
 JIT_HELPER(_revertToInterpreterGlue);
 
+#elif defined(TR_HOST_ARM64)
+JIT_HELPER(_revertToInterpreterGlue);
+
 #elif defined(TR_HOST_S390)
 
 JIT_HELPER(_countingRecompileMethod);
@@ -1238,6 +1241,9 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_ARMcountingPatchCallSite,             (void *)_countingPatchCallSite,   TR_Helper);
    SET(TR_ARMinduceRecompilation,               (void *)_induceRecompilation,     TR_Helper);
    SET(TR_ARMrevertToInterpreterGlue,           (void *)_revertToInterpreterGlue, TR_Helper);
+
+#elif defined(TR_HOST_ARM64)
+   SET(TR_ARM64revertToInterpreterGlue,           (void *)_revertToInterpreterGlue, TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390samplingRecompileMethod,          (void *)_samplingRecompileMethod,   TR_Helper);

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -576,6 +576,37 @@ JIT_HELPER(icallVMprJavaSendStaticSync1);
 JIT_HELPER(icallVMprJavaSendStaticSyncJ);
 JIT_HELPER(icallVMprJavaSendStaticSyncF);
 JIT_HELPER(icallVMprJavaSendStaticSyncD);
+
+#elif defined(TR_HOST_ARM64)
+JIT_HELPER(_interpreterUnresolvedStaticGlue);
+JIT_HELPER(_interpreterUnresolvedSpecialGlue);
+JIT_HELPER(_interpreterUnresolvedDirectVirtualGlue);
+JIT_HELPER(_interpreterUnresolvedClassGlue);
+JIT_HELPER(_interpreterUnresolvedClassGlue2);
+JIT_HELPER(_interpreterUnresolvedStringGlue);
+JIT_HELPER(_interpreterUnresolvedStaticDataGlue);
+JIT_HELPER(_interpreterUnresolvedStaticDataStoreGlue);
+JIT_HELPER(_interpreterUnresolvedInstanceDataGlue);
+JIT_HELPER(_interpreterUnresolvedInstanceDataStoreGlue);
+JIT_HELPER(_virtualUnresolvedHelper);
+JIT_HELPER(_interfaceCallHelper);
+JIT_HELPER(icallVMprJavaSendVirtual0);
+JIT_HELPER(icallVMprJavaSendVirtual1);
+JIT_HELPER(icallVMprJavaSendVirtualJ);
+JIT_HELPER(icallVMprJavaSendVirtualF);
+JIT_HELPER(icallVMprJavaSendVirtualD);
+JIT_HELPER(_interpreterVoidStaticGlue);
+JIT_HELPER(_interpreterSyncVoidStaticGlue);
+JIT_HELPER(_interpreterIntStaticGlue);
+JIT_HELPER(_interpreterSyncIntStaticGlue);
+JIT_HELPER(_interpreterLongStaticGlue);
+JIT_HELPER(_interpreterSyncLongStaticGlue);
+JIT_HELPER(_interpreterFloatStaticGlue);
+JIT_HELPER(_interpreterSyncFloatStaticGlue);
+JIT_HELPER(_interpreterDoubleStaticGlue);
+JIT_HELPER(_interpreterSyncDoubleStaticGlue);
+JIT_HELPER(_nativeStaticHelper);
+
 #elif defined(TR_HOST_S390)
 JIT_HELPER(outlinedNewObject);
 JIT_HELPER(outlinedNewArray);
@@ -1519,6 +1550,36 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARMjitMathHelperDoubleCompareGE,      (void *) jitMathHelperDoubleCompareGE,  TR_Helper);
    SET(TR_ARMjitMathHelperDoubleCompareGEU,     (void *) jitMathHelperDoubleCompareGEU, TR_Helper);
    SET(TR_ARMjitCollapseJNIReferenceFrame,      (void *) jitCollapseJNIReferenceFrame,  TR_Helper);
+
+#elif defined(TR_HOST_ARM64)
+   SET(TR_ARM64interpreterUnresolvedStaticGlue,            (void *) _interpreterUnresolvedStaticGlue,               TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedSpecialGlue,           (void *) _interpreterUnresolvedSpecialGlue,              TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedDirectVirtualGlue,     (void *) _interpreterUnresolvedDirectVirtualGlue,        TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedClassGlue,             (void *) _interpreterUnresolvedClassGlue,                TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedClassGlue2,            (void *) _interpreterUnresolvedClassGlue2,               TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedStringGlue,            (void *) _interpreterUnresolvedStringGlue,               TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedStaticDataGlue,        (void *) _interpreterUnresolvedStaticDataGlue,           TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedStaticDataStoreGlue,   (void *) _interpreterUnresolvedStaticDataStoreGlue,      TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedInstanceDataGlue,      (void *) _interpreterUnresolvedInstanceDataGlue,         TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedInstanceDataStoreGlue, (void *) _interpreterUnresolvedInstanceDataStoreGlue,    TR_Helper);
+   SET(TR_ARM64virtualUnresolvedHelper,                    (void *) _virtualUnresolvedHelper,                       TR_Helper);
+   SET(TR_ARM64interfaceCallHelper,                        (void *) _interfaceCallHelper,                           TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtual0,         (void *) icallVMprJavaSendVirtual0,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtual1,         (void *) icallVMprJavaSendVirtual1,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtualJ,         (void *) icallVMprJavaSendVirtualJ,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtualF,         (void *) icallVMprJavaSendVirtualF,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtualD,         (void *) icallVMprJavaSendVirtualD,        TR_Helper);
+   SET(TR_ARM64interpreterVoidStaticGlue,         (void *) _interpreterVoidStaticGlue,       TR_Helper);
+   SET(TR_ARM64interpreterSyncVoidStaticGlue,     (void *) _interpreterSyncVoidStaticGlue,   TR_Helper);
+   SET(TR_ARM64interpreterIntStaticGlue,          (void *) _interpreterIntStaticGlue,        TR_Helper);
+   SET(TR_ARM64interpreterSyncIntStaticGlue,      (void *) _interpreterSyncIntStaticGlue,    TR_Helper);
+   SET(TR_ARM64interpreterLongStaticGlue,         (void *) _interpreterLongStaticGlue,       TR_Helper);
+   SET(TR_ARM64interpreterSyncLongStaticGlue,     (void *) _interpreterSyncLongStaticGlue,   TR_Helper);
+   SET(TR_ARM64interpreterFloatStaticGlue,        (void *) _interpreterFloatStaticGlue,      TR_Helper);
+   SET(TR_ARM64interpreterSyncFloatStaticGlue,    (void *) _interpreterSyncFloatStaticGlue,  TR_Helper);
+   SET(TR_ARM64interpreterDoubleStaticGlue,       (void *) _interpreterDoubleStaticGlue,     TR_Helper);
+   SET(TR_ARM64interpreterSyncDoubleStaticGlue,   (void *) _interpreterSyncDoubleStaticGlue, TR_Helper);
+   SET(TR_ARM64nativeStaticHelper,                (void *) _nativeStaticHelper,              TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390double2Long,                                (void *) 0,                                              TR_Helper);


### PR DESCRIPTION
This commit adds entries of helper functions for aarch64 to Runtime.cpp
and JitRuntime.cpp.
It also declares some of those helper functions in PicBuilder.spp.

Signed-off-by: knn-k <konno@jp.ibm.com>