### PR TITLE
Fix rev-parse to a length of 8 to account for different versions of git

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/omrMirror
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ pipeline {
                             currentBuild.description = "${LAST_COMMIT}"
 
                             current_sha = sh (
-                                    script: 'git rev-parse --short HEAD',
+                                    script: 'git rev-parse --short=8 HEAD',
                                     returnStdout: true
                                 ).trim()
                         }


### PR DESCRIPTION
* [skip ci]
* fixes #4813

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>