### PR TITLE
Decorate Jenkins Pipeline-Build-Test-Any-Platform

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -342,7 +342,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
     if (TESTS_TARGETS.trim() != "none") {
         def testjobs = [:]
-        def TARGET_NAMES = []
+        def TARGET_NAMES = get_test_target_names()
 
         if (SHAS['VENDOR_TEST']) {
             // the downstream job is expecting comma separated SHAs
@@ -351,20 +351,6 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
         }
 
         echo "Using VENDOR_TEST_REPOS = ${VENDOR_TEST_REPOS}, VENDOR_TEST_BRANCHES = ${VENDOR_TEST_BRANCHES}, VENDOR_TEST_SHAS = ${VENDOR_TEST_SHAS}, VENDOR_TEST_DIRS = ${VENDOR_TEST_DIRS}, BUILD_LIST = ${BUILD_LIST}" 
-
-        def targets = TESTS_TARGETS.split(",")
-        targets.each { target ->
-            switch (target.trim().toLowerCase()) {
-                case "_sanity":
-                    TARGET_NAMES.addAll(["sanity.functional", "sanity.system"])
-                    break
-                case "_extended":
-                    TARGET_NAMES.addAll(["extended.functional", "extended.system"])
-                    break
-                default:
-                    TARGET_NAMES.add(target.trim())
-            }
-        }
 
         // Determine if Build job archived to Artifactory
         def BUILD_JOB_ENV = jobs["build"].getBuildVariables()
@@ -384,7 +370,8 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                 name -= '+jitaas'
                 TEST_FLAG = 'JITAAS'
             }
-            def TEST_JOB_NAME = "Test-${name}-JDK${SDK_VERSION}-${SPEC}"
+            def TEST_JOB_NAME = get_test_job_name(name, SPEC, SDK_VERSION)
+
             testjobs["${TEST_JOB_NAME}"] = {
                 if (ARTIFACTORY_CREDS) {
                     jobs["${TEST_JOB_NAME}"] = build_with_artifactory(TEST_JOB_NAME, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST, CUSTOMIZED_SDK_URL, ARTIFACTORY_SERVER, ARTIFACTORY_CREDS, TEST_FLAG, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH)
@@ -398,6 +385,83 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
     // return jobs for further reference
     return jobs
+}
+
+def get_test_target_names() {
+    def targetNames = []
+    def targets = TESTS_TARGETS.split(",")
+
+    targets.each { target ->
+        switch (target.trim().toLowerCase()) {
+            case "_sanity":
+                targetNames.addAll(["sanity.functional", "sanity.system"])
+                break
+            case "_extended":
+                targetNames.addAll(["extended.functional", "extended.system"])
+                break
+            default:
+                targetNames.add(target.trim())
+        }
+    }
+
+    return targetNames
+}
+
+def get_build_job_name(spec, version) {
+    return "Build-JDK${version}-${spec}"
+}
+
+def get_test_job_name(targetName, spec, version) {
+    return "Test-${targetName}-JDK${version}-${spec}"
+}
+
+/*
+* Finds the downstream builds of a build.
+* Limits the search only to the downstream builds with given names.
+* Returns a map of builds.
+*/
+def get_downstream_builds(upstreamBuild, downstreamJobNames) {
+    def downstreamBuilds = [:]
+    def pattern = /.*${upstreamBuild.projectName}.*${upstreamBuild.number}.*/
+    def startTime = System.currentTimeMillis()
+
+    for (name in downstreamJobNames.sort()) {
+        def job = Jenkins.getInstance().getItemByFullName(name)
+        if (job) {
+            def builds = [:]
+            //find downstream jobs
+            for (build in job.getBuilds().byTimestamp(upstreamBuild.startTimeInMillis, System.currentTimeMillis())) {
+                if ((build && build.getCause(hudson.model.Cause.UpstreamCause) && build.getCause(hudson.model.Cause.UpstreamCause).upstreamRun)
+                    && (build.getCause(hudson.model.Cause.UpstreamCause).upstreamRun==~pattern)) {
+                        // cache all builds (in case of multiple runs)
+                        builds.put(build.getNumber(), build)
+                }
+            }
+
+            // fetch last build
+            if (!builds.isEmpty()) {
+                lastBuildId = builds.keySet().max()
+                downstreamBuilds.put(name, builds.get(lastBuildId))
+            }
+        }
+    }
+
+    elapsedTime = (System.currentTimeMillis() - startTime)/1000
+    echo "Time spent fetching downstream jobs: ${elapsedTime} seconds"
+
+    return downstreamBuilds
+}
+
+/*
+* Returns the build status icon.
+* Requires Embeddable Build Status plugin.
+*/
+def get_build_embedded_status_link(build) {
+    if (build) {
+        def buildLink = "${JENKINS_URL}${build.getUrl()}"
+        return "<a href=\"${buildLink}\"><img src=\"${buildLink}badge/icon\"></a>"
+    }
+    return ''
 }
 
 return this

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -31,13 +31,14 @@ def BUILD_NAME = 'Build-JDK'
 timestamps {
     node(SETUP_LABEL) {
         try{
+            currentBuild.description = "<a href=\"${RUN_DISPLAY_URL}\">Blue Ocean</a>"
             checkout scm
             variableFile = load 'buildenv/jenkins/common/variables-functions'
             variableFile.set_job_variables('pipeline')
 
             buildFile = load 'buildenv/jenkins/common/pipeline-functions'
             SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_SHAS_MAP)
-            BUILD_NAME="Build-JDK${SDK_VERSION}-${SPEC}"
+            BUILD_NAME = buildFile.get_build_job_name(SPEC, SDK_VERSION)
             if (params.AUTOMATIC_GENERATION != 'false'){
                 variableFile.create_job(BUILD_NAME, SDK_VERSION, SPEC, 'build')
             }
@@ -46,5 +47,79 @@ timestamps {
             cleanWs notFailBuild: true, disableDeferredWipeout: false
         }
     }
-    jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_DIRS_MAP, USER_CREDENTIALS_ID, BUILD_LIST, SETUP_LABEL, ghprbGhRepository, ghprbActualCommit, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, BUILD_NAME)
+
+    try {
+        jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_DIRS_MAP, USER_CREDENTIALS_ID, BUILD_LIST, SETUP_LABEL, ghprbGhRepository, ghprbActualCommit, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, BUILD_NAME)
+    } finally {
+        //display the build status of the downstream jobs
+        def downstreamBuilds = buildFile.get_downstream_builds(currentBuild, get_downstream_job_names(SPEC, SDK_VERSION))
+        add_badges(downstreamBuilds)
+        add_summary_badge(downstreamBuilds)
+    }
+}
+
+/*
+* Returns the list of the downstream jobs.
+*/
+def get_downstream_job_names(spec, version) {
+    downstreamJobNames = []
+    downstreamJobNames.add(buildFile.get_build_job_name(spec, version))
+
+    for (target in buildFile.get_test_target_names()) {
+        downstreamJobNames.add(buildFile.get_test_job_name(target, spec, version))
+    }
+
+    return downstreamJobNames
+}
+
+/*
+* Adds status badges for the given downstream build.
+*/
+def add_badges(downstreamBuilds) {
+    downstreamBuilds.entrySet().each { entry ->
+        def build = entry.value
+
+        switch(build.getResult()){
+            case "SUCCESS":
+                icon = "/images/16x16/accept.png"
+                break
+            case "UNSTABLE":
+                icon = "/images/16x16/yellow.png"
+                break
+            case "FAILURE":
+                icon = "/images/16x16/error.png"
+                break
+            case "ABORTED":
+                icon = "/images/16x16/aborted.png"
+                break
+            default:
+                icon = "/images/16x16/grey.png"
+        }
+
+        addBadge icon: "${icon}",
+                 id: "", 
+                 link: "${JENKINS_URL}${build.getUrl()}",
+                 text: "${entry.key} - #${build.getNumber()}"
+    }
+}
+
+/*
+* Adds a summary badge.
+* Requires Groovy Postbuild plugin.
+*/
+def add_summary_badge(downstreamBuilds) {
+    def summaryText = "Downstream Jobs Status:<br/>"
+    summaryText += "<table>"
+
+    downstreamBuilds.entrySet().each { entry ->
+        def buildLink = buildFile.get_build_embedded_status_link(entry.value)
+        Job job = entry.value.getParent()
+        def blueLink = "<a href=\"${JENKINS_URL}blue/organizations/jenkins/${job.getFullName()}/detail/${entry.key}/${entry.value.getNumber()}/pipeline\">${entry.key}</a>"
+        summaryText += "<tr><td>${blueLink}</td><td>${buildLink}</td></tr>"
+    }
+
+    summaryText += "</table>"
+
+    // add summary badge
+    manager.createSummary("plugin.png").appendText(summaryText)
 }


### PR DESCRIPTION
- add downstream builds badges (shown in the Build History panel)
- add summary badge to display the embeddable build status for the
downstream jobs

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>