### PR TITLE
Add FileSystemImpl.isSecuritySupported0()

### DIFF
--- a/runtime/mgmt/mgmtinit.c
+++ b/runtime/mgmt/mgmtinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,13 +20,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#if defined(WIN32)
+#include <windows.h>
+#endif /* defined(WIN32) */
+
 #include "jni.h"
 #include "j9port.h"
 #include "jclprots.h"
 
 /*
  * Invoked immediately after this shared library has been loaded.
- * The shared library is currenly only a stub: simply return.
  */
 jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -34,43 +37,36 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
 	return JNI_VERSION_1_8;
 }
 
-/* Convert path to platform encoding.
- * It is the callers responsibility for freeing the returned memory.
+/* Convert a modified UTF8 path to the given encoding.
+ *
+ * The caller must free the returned memory.
  *
  * @return NULL on error, otherwise return converted string
  */
-static const char*
-translatePathToPlatform(JNIEnv *env, const char* pathUTF)
+static char *
+convertPath(JNIEnv *env, const char *pathUTF, int32_t toCode)
 {
-	char *result = NULL;
-	int32_t bufferLength = 0;
-	uintptr_t pathUTFSize = strlen(pathUTF);
-
 	PORT_ACCESS_FROM_ENV(env);
+	char *result = NULL;
+	const uintptr_t pathUTFSize = strlen(pathUTF);
+	const int32_t resultSize = j9str_convert(J9STR_CODE_MUTF8, toCode, pathUTF, pathUTFSize, NULL, 0);
 
-	bufferLength = 	j9str_convert(J9STR_CODE_MUTF8, J9STR_CODE_PLATFORM_OMR_INTERNAL, pathUTF, pathUTFSize, NULL, 0);
-
-	if (bufferLength >= 0) {
-		bufferLength += MAX_STRING_TERMINATOR_LENGTH;
-
-		result = (char*)j9mem_allocate_memory(bufferLength, OMRMEM_CATEGORY_PORT_LIBRARY);
-		if (NULL != result)  {
-			int32_t resultLength = j9str_convert(J9STR_CODE_MUTF8, J9STR_CODE_PLATFORM_OMR_INTERNAL, pathUTF, pathUTFSize, result, bufferLength);
-			if ((resultLength < 0) ||  (resultLength + MAX_STRING_TERMINATOR_LENGTH != bufferLength)) {
+	if (resultSize >= 0) {
+		const int32_t spaceRequired = resultSize + MAX_STRING_TERMINATOR_LENGTH;
+		result = (char *)j9mem_allocate_memory(spaceRequired, OMRMEM_CATEGORY_PORT_LIBRARY);
+		if (NULL != result) {
+			if (resultSize != j9str_convert(J9STR_CODE_MUTF8, toCode,
+					pathUTF, pathUTFSize, result, spaceRequired)) {
 				j9mem_free_memory(result);
 				result = NULL; /* error occured */
-			} else {
-				/* add terminator */
-				memset(result + resultLength, 0, MAX_STRING_TERMINATOR_LENGTH);
 			}
 		}
 	}
 
-	return (const char*)result;
-
+	return result;
 }
 
-/**
+/*
  * Determines whether file path has user permissions only.
  *
  * @param path file path
@@ -79,29 +75,27 @@ translatePathToPlatform(JNIEnv *env, const char* pathUTF)
  *
  * Note: Windows permission bits are not set to differentiate between users.
  */
-JNIEXPORT jboolean JNICALL 
+jboolean JNICALL
 Java_sun_management_FileSystemImpl_isAccessUserOnly0(JNIEnv *env, jclass c, jstring path)
 {
-	const char* pathUTF = NULL;
-	jboolean result = JNI_FALSE;
-
 	PORT_ACCESS_FROM_ENV(env);
+	jboolean result = JNI_FALSE;
+	const char *pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
 
-	pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
 	if (NULL == pathUTF) {
 		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 	} else {
 		struct J9FileStat buf;
 		I_32 status = -1;
-		const char* pathConvert = pathUTF;
-#if !defined(WIN32) && !defined(WIN64)
-		pathConvert = (char*)translatePathToPlatform(env, pathUTF);
+#if defined(WIN32)
+		const char *pathConvert = pathUTF;
+#else
+		char *pathConvert = convertPath(env, pathUTF, J9STR_CODE_PLATFORM_OMR_INTERNAL);
 		if (NULL == pathConvert) {
 			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
-			(*env)->ReleaseStringUTFChars(env, path, pathUTF);
-			return result;
+			goto done;
 		}
-#endif /* skip on windows */
+#endif /* !defined(WIN32) */
 		/* retrieve file information */
 		status = j9file_stat(pathConvert, 0, &buf);
 
@@ -115,19 +109,63 @@ Java_sun_management_FileSystemImpl_isAccessUserOnly0(JNIEnv *env, jclass c, jstr
 			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNewJavaIoIOException(env, NULL);
 		}
 
-		if (pathConvert != pathUTF) {
-			j9mem_free_memory((void*)pathConvert);
-		}
+#if !defined(WIN32)
+		j9mem_free_memory(pathConvert);
+done:
+#endif /* !defined(WIN32) */
 		(*env)->ReleaseStringUTFChars(env, path, pathUTF);
 	}
 
 	return result;
 }
 
-#if defined(WIN32) || defined(WIN64)
-JNIEXPORT void JNICALL 
+#if defined(WIN32)
+
+void JNICALL
 Java_sun_management_FileSystemImpl_init0(JNIEnv *env, jclass c)
 {
-	/* stub method, no implementation required */ 
+	/* stub method, no implementation required */
 }
-#endif /* defined(WIN32) || defined(WIN64) */
+
+/*
+ * Determines whether the file system addressed by the given absolute path suports security.
+ *
+ * @param path file path
+ * @return Returns true if the referenced file system suports security, false otherwise.
+ */
+jboolean JNICALL
+Java_sun_management_FileSystemImpl_isSecuritySupported0(JNIEnv *env, jclass c, jstring path)
+{
+	jboolean result = JNI_FALSE;
+	const char *pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
+
+	if (NULL == pathUTF) {
+		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
+	} else {
+		PORT_ACCESS_FROM_ENV(env);
+		void *pathWide = convertPath(env, pathUTF, J9STR_CODE_WIDE);
+
+		if (NULL == pathWide) {
+			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
+		} else {
+			DWORD fileSystemFlags = 0;
+			wchar_t volumePath[EsMaxPath];
+
+			if (!GetVolumePathNameW((wchar_t *)pathWide, volumePath, EsMaxPath) ||
+				!GetVolumeInformationW(volumePath, NULL, 0, NULL, NULL, &fileSystemFlags, NULL, 0)) {
+				/* failed to retrieve information */
+				((J9VMThread *)env)->javaVM->internalVMFunctions->throwNewJavaIoIOException(env, NULL);
+			} else if (0 != (fileSystemFlags & FILE_PERSISTENT_ACLS)) {
+				result = JNI_TRUE;
+			}
+
+			j9mem_free_memory(pathWide);
+		}
+
+		(*env)->ReleaseStringUTFChars(env, path, pathUTF);
+	}
+
+	return result;
+}
+
+#endif /* defined(WIN32) */

--- a/runtime/mgmt/module.xml
+++ b/runtime/mgmt/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2018 IBM Corp. and others
+Copyright (c) 2017, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<exports group="all">
 		<export name="JNI_OnLoad" />
 		<export name="Java_sun_management_FileSystemImpl_isAccessUserOnly0" />
-		<export name="Java_sun_management_FileSystemImpl_init0">
-			<include-if condition="spec.win_x86.*" />
-		</export>
+	</exports>
+
+	<exports group="windows">
+		<export name="Java_sun_management_FileSystemImpl_init0" />
+		<export name="Java_sun_management_FileSystemImpl_isSecuritySupported0" />
 	</exports>
 
 	<artifact type="shared" name="management" loadgroup="" appendrelease="false">
@@ -39,6 +41,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 		<exports>
 			<group name="all" />
+			<group name="windows">
+				<include-if condition="spec.win_x86.*" />
+			</group>
 		</exports>
 
 		<includes>


### PR DESCRIPTION
* generalize translatePathToPlatform() as convertPath()
* remove redundant uses of JNIEXPORT and WIN64

This is a replay of #4808 (without the compile error).
Fixes: #4776.