### PR TITLE
Implement TR_J9JITaaSServerSharedCache

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2621,7 +2621,7 @@ J9::CodeGenerator::processRelocations()
 
    if (self()->comp()->compileRelocatableCode() || isJITaaSMode)
       {
-      if (!isJITaaSMode)
+      if (self()->comp()->compileRelocatableCode())
          {
          uint32_t inlinedCallSize = self()->comp()->getNumInlinedCallSites();
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8703,7 +8703,8 @@ TR::CompilationInfoPerThreadBase::compile(
                TR_ASSERT_FATAL(false, "alwaysFatalAssert set");
             }
 
-            if (vm.isAOT_DEPRECATED_DO_NOT_USE())
+            if (vm.isAOT_DEPRECATED_DO_NOT_USE() &&
+               compiler->getOption(TR_UseSymbolValidationManager))
                compiler->getSymbolValidationManager()->populateWellKnownClasses();
 
             rtn = compiler->compile();

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -88,6 +88,7 @@ class ClientSessionData
       int32_t _arrayletLeafSize;
       uint64_t _overflowSafeAllocSize;
       int32_t _compressedReferenceShift;
+      UDATA _cacheStartAddress;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -34,6 +34,7 @@
 class TR_J9VMBase;
 class TR_ResolvedMethod;
 namespace TR { class CompilationInfo; }
+namespace JITaaS { class J9ServerStream; }
 
 class TR_J9SharedCache : public TR_SharedCache
    {
@@ -80,8 +81,6 @@ public:
       }
 
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *chainData, void *classLoader);
-
-   virtual uintptrj_t lookupClassChainOffsetInSharedCacheFromClass(TR_OpaqueClassBlock *clazz);
 
    virtual bool isPointerInSharedCache(void *ptr, void * & cacheOffset);
 
@@ -178,13 +177,10 @@ public:
    virtual void addHint(TR_ResolvedMethod *, TR_SharedCacheHint) override { TR_ASSERT(false, "called"); }
    virtual bool isMostlyFull() override { TR_ASSERT(false, "called"); return false;}
 
-   virtual void *pointerFromOffsetInSharedCache(void *offset) override { TR_ASSERT(false, "called"); return NULL;}
-   virtual void *offsetInSharedCacheFromPointer(void *ptr) override { TR_ASSERT(false, "called"); return NULL;}
+   virtual void *pointerFromOffsetInSharedCache(void *offset) override;
+   virtual void *offsetInSharedCacheFromPointer(void *ptr) override;
 
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp) override { TR_ASSERT(false, "called"); }
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp) override { TR_ASSERT(false, "called"); }
-
-   virtual UDATA *rememberClass(J9Class *clazz, bool create=true) override { TR_ASSERT(false, "called"); return NULL;}
+   virtual UDATA *rememberClass(J9Class *clazz, bool create=true) override;
 
    virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT(false, "called"); return NULL;}
    virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT(false, "called"); return NULL;}
@@ -192,8 +188,6 @@ public:
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL) override { TR_ASSERT(false, "called"); return false;}
 
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *chainData, void *classLoader) override { TR_ASSERT(false, "called"); return NULL;}
-
-   virtual uintptrj_t lookupClassChainOffsetInSharedCacheFromClass(TR_OpaqueClassBlock *clazz) override { TR_ASSERT(false, "called"); return NULL;}
 
    virtual bool isPointerInSharedCache(void *ptr, void * & cacheOffset) override { TR_ASSERT(false, "called"); return false;}
 
@@ -203,7 +197,13 @@ public:
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo) { TR_ASSERT(false, "called"); return TR_no;}
    static void setStoreSharedDataFailedLength(UDATA length) { TR_ASSERT(false, "called"); }
    
-   virtual UDATA getCacheStartAddress() override { TR_ASSERT(false, "called"); return NULL; }
+   virtual UDATA getCacheStartAddress() override;
+
+   virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
+
+private:
+   JITaaS::J9ServerStream *_stream;
+
    };
 
 #endif

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -47,7 +47,6 @@ public:
    virtual bool isPointerInSharedCache(void *ptr, void * & cacheOffset) { return false; }
 
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *cinaData, void *loader) { return NULL; }
-   virtual uintptrj_t lookupClassChainOffsetInSharedCacheFromClass(TR_OpaqueClassBlock *clazz) { return 0; }
 
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) { return 0; }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -735,9 +735,14 @@ TR_J9VMBase::TR_J9VMBase(
          }
 
    _sharedCache = NULL;
-   if (TR::Options::sharedClassCache())        // shared classes and AOT must be enabled
+   if (TR::Options::sharedClassCache() ||
+       (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE && feGetEnv("TR_EnableJITaaSRemoteAOT")))
+      // shared classes and AOT must be enabled, or we should be on the JITaaS server with remote AOT enabled
       {
-      _sharedCache = new (PERSISTENT_NEW) TR_J9SharedCache(this);
+      if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+         _sharedCache = new (PERSISTENT_NEW) TR_J9JITaaSServerSharedCache(this);
+      else
+         _sharedCache = new (PERSISTENT_NEW) TR_J9SharedCache(this);
       if (!_sharedCache)
          {
          TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1447,8 +1447,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::TR_ResolvedRelocatableJ9JITaaSServer
    TR::Compilation *comp = fej9->_compInfoPT->getCompilation();
    if (comp && this->TR_ResolvedMethod::getRecognizedMethod() != TR::unknownMethod)
       {
-      // TODO: replace with fe->canRememberClass(containingClass()) after rebase
-      if (fej9->sharedCache()->rememberClass(containingClass()))
+      if (fej9->canRememberClass(containingClass()))
          {
          if (comp->getOption(TR_UseSymbolValidationManager))
             {

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -240,6 +240,7 @@ enum J9ServerMessageType
 
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetInSharedCache = 600;
+   SharedCache_rememberClass = 601;
 
    // For runFEMacro
    runFEMacro_invokeCollectHandleNumArgsToCollect = 700;
@@ -273,6 +274,7 @@ enum J9ServerMessageType
    IProfiler_searchForMethodSample = 901;
    IProfiler_getMaxCallCount = 902;
    IProfiler_setCallCount = 903;
+   IProfiler_persistIprofileInfo = 904;
 
    Recompilation_getExistingMethodInfo = 1000;
    Recompilation_getJittedBodyInfoFromPC = 1001;

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -518,7 +518,7 @@ public:
    /* 
    leave the TR_ResolvedMethodSymbol argument for debugging purpose when called from Ilgen
    */
-   void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp);
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp); // JITaaS: mark virtual
 
    void checkMethodHashTable();
 

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 #include "ilgen/J9ByteCodeIterator.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "bcnames.h"
+#include "env/j9methodServer.hpp"
 
 TR_JITaaSIProfiler *
 TR_JITaaSIProfiler::allocate(J9JITConfig *jitConfig)
@@ -754,4 +755,14 @@ TR_JITaaSIProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, 
       stream->write(JITaaS::J9ServerMessageType::IProfiler_setCallCount, method, bcIndex, count);
       stream->read<JITaaS::Void>();
       }
+   }
+
+void 
+TR_JITaaSIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp)
+   {
+   // resolvedMethodSymbol is only used for debugging on the client, so we don't have to send it
+   auto serverMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method);
+   auto stream = TR::CompilationInfo::getStream();
+   stream->write(JITaaS::J9ServerMessageType::IProfiler_persistIprofileInfo, serverMethod->getRemoteMirror());
+   auto recv = stream->read<JITaaS::Void>();
    }

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,8 @@ public:
 
    virtual int32_t getMaxCallCount() override;
    virtual void setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *) override;
+   
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp) override;
 
    TR_IPBytecodeHashTableEntry *ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptrj_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
    TR_IPMethodHashTableEntry *deserializeMethodEntry(TR_ContiguousIPMethodHashTableEntry *serialEntry, TR_Memory *trMemory);

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -178,7 +178,7 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          TR_OpaqueMethodBlock *j9method = (TR_OpaqueMethodBlock *) aconstNode->getAddress();
          TR_OpaqueClassBlock *j9class = fej9->getClassFromMethodBlock(j9method);
 
-         uintptrj_t classChainOffsetInSharedCache = sharedCache->lookupClassChainOffsetInSharedCacheFromClass(j9class);
+         uintptrj_t classChainOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
          *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
          cursor += SIZEPOINTER;
 
@@ -199,7 +199,7 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          cursor += SIZEPOINTER;
 
          TR_OpaqueClassBlock *j9class = (TR_OpaqueClassBlock *) aconstNode->getAddress();
-         uintptrj_t classChainOffsetInSharedCache = sharedCache->lookupClassChainOffsetInSharedCacheFromClass(j9class);
+         uintptrj_t classChainOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
          *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
          cursor += SIZEPOINTER;
 


### PR DESCRIPTION
- Initialize TR_J9JITaaSServerSharedCache on the server when
    `TR_EnableJITaaSRemoteAOT` environment variable is set.
    It will be used to make remote calls/cache information to/from
    shared class cache on the client.

 - Implement most methods that are used by shared cache on the server:
    pointerFromOffsetInSharedCache
    offsetInSharedCacheFromPointer
    persistIprofileInfo (dummy implementation, does nothing)
    rememberClass
    getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache

- Enable AOT-specific relocations that require shared cache access