### PR TITLE
Tgc root scan for Metronome

### DIFF
--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -275,10 +275,15 @@ public:
 
 	virtual CompletePhaseCode scanWeakReferencesComplete(MM_EnvironmentBase *envBase) {
 		MM_EnvironmentRealtime *env = MM_EnvironmentRealtime::getEnvironment(envBase);
+		reportScanningStarted(RootScannerEntity_WeakReferenceObjectsComplete);
+
 		if (env->_currentTask->synchronizeGCThreadsAndReleaseMaster(env, UNIQUE_ID)) {
 			env->_cycleState->_referenceObjectOptions |= MM_CycleState::references_clear_weak;
 			env->_currentTask->releaseSynchronizedGCThreads(env);
 		}
+
+		reportScanningEnded(RootScannerEntity_WeakReferenceObjectsComplete);
+
 		return complete_phase_OK;
 	}
 

--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -713,9 +713,7 @@ MM_Scheduler::condYieldFromGC(MM_EnvironmentBase *envBase, U_64 timeSlack)
 		return false;
 	}
 
-	env->reportScanningSuspended();
 	yieldFromGC(env, true);
-	env->reportScanningResumed();
 
 	env->resetCurrentDistanceToYieldTimeCheck();
 
@@ -739,9 +737,11 @@ void MM_Scheduler::yieldFromGC(MM_EnvironmentRealtime *env, bool distanceChecked
 			startGCTime(env, true);
 		} else {
 			reportStopGCIncrement(env);
+			env->reportScanningSuspended();
 			Assert_MM_true(isGCOn());
 			restartMutatorsAndWait(env);
 			waitForMutatorsToStop(env);
+			env->reportScanningResumed();
 			reportStartGCIncrement(env);
 			_shouldGCYield = false;
 		}
@@ -752,7 +752,9 @@ void MM_Scheduler::yieldFromGC(MM_EnvironmentRealtime *env, bool distanceChecked
 		
 	} else {
 		/* Slave only running here. _yieldCollaborator instance exists for sure */
+		env->reportScanningSuspended();
 		_yieldCollaborator->yield(env);
+		env->reportScanningResumed();
 	}
 }
 

--- a/runtime/gc_realtime/WorkPacketsRealtime.cpp
+++ b/runtime/gc_realtime/WorkPacketsRealtime.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,8 +103,9 @@ MM_WorkPacketsRealtime::createOverflowHandler(MM_EnvironmentBase *env, MM_WorkPa
  * @return Pointer to an input packet
  */
 MM_Packet *
-MM_WorkPacketsRealtime::getInputPacket(MM_EnvironmentBase *env)
+MM_WorkPacketsRealtime::getInputPacket(MM_EnvironmentBase *envBase)
 {
+	MM_EnvironmentRealtime *env = (MM_EnvironmentRealtime *)envBase;
 	MM_Packet *packet = NULL;
 	bool doneFlag = false;
 	volatile UDATA doneIndex = _inputListDoneIndex;
@@ -163,7 +164,9 @@ MM_WorkPacketsRealtime::getInputPacket(MM_EnvironmentBase *env)
 					 * (We may be overly cautious here, since we are not that sure that overlap between iterations may even happen)
 					 */
 					do {
+						env->reportScanningSuspended();
 						omrthread_monitor_wait(_inputListMonitor);
+						env->reportScanningResumed();
 					} while ((_inputListDoneIndex == doneIndex) && !env->isMasterThread() && ((_yieldCollaborator.getResumeEvent() == MM_YieldCollaborator::notifyMaster) || (_yieldCollaborator.getResumeEvent() == MM_YieldCollaborator::fromYield)));
 				}
 			}

--- a/runtime/gc_trace/TgcRootScanner.cpp
+++ b/runtime/gc_trace/TgcRootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ static void tgcHookGCEnd(J9HookInterface** hook, UDATA eventNumber, void* eventD
  * @ref RootScannerEntity
  */
 const static char *attributeNames[] = {
-	"none", /* RootScannerEntity_None */
+	"unknown", /* RootScannerEntity_None */
 	"scavengerememberedset", /* RootScannerEntity_ScavengeRememberedSet */
 	"classes", /* RootScannerEntity_Classes */
 	"vmclassslots",	/* RootScannerEntity_VMClassSlots */


### PR DESCRIPTION
Miscellaneous improvements for TGC root scan times for Metronome:

1) add suspend/resume pair (for tracking increment durations per thread)
to the slave wait point in getPacket (the logic is identical to the wait
point in synchronization barriers, which already have suspent/resume)

2) suspend/resume pair in yield point is brought down to more specific
points for master and slave points separately. This is to avoid
reporting a false increment end when we decide to for example double
beat.

3) report 'unknown' root entity. These are typically synchronization
points not residing with existing known root entities, but somewhere
between them. Or anything else that we miss to reported as a known
entity.

4) report start/end scanWeakReferencesComplete to avoid reporting it as
unknown (an example of one that we miss to properly report).


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>