### PR TITLE
Temporarily blacklist OMRs SwitchAnalyzer.cpp

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -131,6 +131,7 @@ set(REMOVED_OMR_FILES
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineRegister.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineRegisterInStruct.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineState.cpp
+	${omr_SOURCE_DIR}/compiler/optimizer/SwitchAnalyzer.cpp
 )
 
 # Extra defines not provided by the create_omr_compiler_library call


### PR DESCRIPTION
The SwitchAnalyzer optimization is being moved from OpenJ9 to OMR.
While it is being moved it will be in both repos at the same time.
For now blacklist the OMR one in OpenJ9 so that it does not find
duplicate symbols. Once a newer OMR has been accepted into OpenJ9
the OMR copy should be used and the OpenJ9 copy should be deleted.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>