### PR TITLE
Enable Symbol Validation Manager on Power

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1947,7 +1947,7 @@ J9::Options::fePreProcess(void * base)
          }
       }
 
-#if (defined(TR_HOST_X86) || defined(TR_HOST_S390)) && defined(TR_TARGET_64BIT)
+#if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_POWER)) && defined(TR_TARGET_64BIT)
    self()->setOption(TR_EnableSymbolValidationManager);
 #endif
 


### PR DESCRIPTION
Enable use of the Symbol Validation Manager by default for AOT compiles
on 64-bit Power.

Signed-off-by: Ben Thomas <ben@benthomas.ca>