### PR TITLE
Remove the unneeded if statement in ObjectMonitor.cpp::spinOnFlatLock

### DIFF
--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -407,13 +407,11 @@ spinOnFlatLock(J9VMThread *currentThread, j9objectmonitor_t volatile *lwEA, j9ob
 			{
 				if (nestedPath) {
 					VM_AtomicSupport::yieldCPU();
-					if (0 != spinCount1) {
-						VM_AtomicSupport::dropSMTThreadPriority();
-						for (UDATA _spinCount1 = spinCount1; _spinCount1 > 0; _spinCount1--) {
-							VM_AtomicSupport::nop();
-						} /* end tight loop */
-						VM_AtomicSupport::restoreSMTThreadPriority();
-					}
+					VM_AtomicSupport::dropSMTThreadPriority();
+					for (UDATA _spinCount1 = spinCount1; _spinCount1 > 0; _spinCount1--) {
+						VM_AtomicSupport::nop();
+					} /* end tight loop */
+					VM_AtomicSupport::restoreSMTThreadPriority();
 				}
 			} else {
 				goto done;


### PR DESCRIPTION
**Referring to [runtime/vm/vmthread.c#L516-L521](https://github.com/eclipse/openj9/blob/master/runtime/vm/vmthread.c#L516-L521):**
> In `ObjectMonitor.cpp:objectMonitorEnterNonBlocking`, we converted "goto
statements" into "three nested for loops". Due to this change, we can no
longer let spin counts be set to 0. With spin counts set to zero, there will
be no attempts to acquire a lock. To allow atleast one attempt to
acquire a lock, minimum value of spin counts is set to 1.

So, `spinCount1`/`thrMaxSpins1BeforeBlocking` won't be set to 0. Thus, the
unneeded if statement, `(0 != spinCount1)`, is removed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>