### PR TITLE
Fix crash in AOT during field iteration

### DIFF
--- a/runtime/compiler/env/j9fieldsInfo.cpp
+++ b/runtime/compiler/env/j9fieldsInfo.cpp
@@ -154,7 +154,17 @@ TR_VMFieldsInfo::TR_VMFieldsInfo(TR::Compilation * comp, J9Class *aClazz, int bu
    for (i=numSupClasses-1; i>=0; i--)
       {
       supClass = (J9Class*)comp->fej9()->getSuperClass((TR_OpaqueClassBlock*)supClass);
-      TR_ASSERT(supClass, "Found NULL supClass in inheritance chain");
+
+      if (comp->compileRelocatableCode())
+         {
+         if (!supClass)
+            comp->failCompilation<J9::AOTNoSupportForAOTFailure>("Found NULL supClass in inheritance chain");
+         }
+      else
+         {
+         TR_ASSERT_FATAL(supClass, "Found NULL supClass in inheritance chain");
+         }
+
       romCl = supClass->romClass;
 
       // iterate through the fields creating TR_VMField and inserting them into a List


### PR DESCRIPTION
The code in the constructor for TR_VMFieldsInfo was making the
assumption that the superclass for a class can always be found. While
this is always true when JIT compiling a method, it is possible under
certain rare circumstances for this to fail during an AOT compilation.
For instance, this can fail under SVM if the SCC runs out of space
while trying to store the class chain for the parent class.

When an unexpected failure was encountered, this would then cause the
JVM to crash. This has now been fixed so that under AOT this will cause
the compilation to fail instead of crashing the JVM.

Fixes: #4751
Signed-off-by: Ben Thomas <ben@benthomas.ca>