### PR TITLE
Update assertion error message for JVM_EnqueueOperation()

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2709,7 +2709,7 @@ JVM_DefineClassWithSourceCond(jint arg0, jint arg1, jint arg2, jint arg3, jint a
 jobject JNICALL
 JVM_EnqueueOperation(jint arg0, jint arg1, jint arg2, jint arg3, jint arg4)
 {
-	assert(!"JVM_EnqueueOperation() stubbed!");
+	assert(!"A HotSpot VM Attach API is attempting to connect to an OpenJ9 VM. This is not supported.");
 	return NULL;
 }
 


### PR DESCRIPTION
Fixes: #4465. 
Related: #3441. 

The existing assertion error message does not indicate the likely cause of the error.
The cause of the error is likely due to the use of an OpenJDK+Hotspot/Oracle VM Attach API to connect to an OpenJ9 VM, which is not supported.

Suggestions on the wording of the message are welcomed!

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>