### PR TITLE
Remove unused method index from various functions

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -4631,7 +4631,7 @@ void TR_IProfiler::dumpIPBCDataCallGraph(J9VMThread* vmThread)
             J9ROMClass * romClass = vmFunctions->findROMClassFromPC(vmThread, (UDATA)pc, &loader);
             if (romClass)
                {
-               //J9ROMMethod * romMethod = vmFunctions->findROMMethodInROMClass(vmThread, romClass, (UDATA)pc, NULL);
+               //J9ROMMethod * romMethod = vmFunctions->findROMMethodInROMClass(vmThread, romClass, (UDATA)pc);
                J9ROMMethod *currentMethod = J9ROMCLASS_ROMMETHODS(romClass);
                J9ROMMethod *desiredMethod = NULL;
                //fprintf(stderr, "Scanning %u romMethods...\n", romClass->romMethodCount);

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -171,7 +171,7 @@ Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 
 			result = vmFuncs->j9jni_createLocalRef(env, frame);
 			UDATA bytecodeOffset = walkState->bytecodePCOffset;  /* need this for StackFrame */
-			UDATA lineNumber = getLineNumberForROMClassFromROMMethod(vm, romMethod, romClass, 0, classLoader, bytecodeOffset);
+			UDATA lineNumber = getLineNumberForROMClassFromROMMethod(vm, romMethod, romClass, classLoader, bytecodeOffset);
 			PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, frame);
 
 			/* set the class object if requested */

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1299,14 +1299,13 @@ void validateLibrary(J9JavaVM *javaVM, J9NativeLibrary *library);
 * @param *vm
 * @param *romMethod
 * @param *romClass
-* @param offset
 * @param *classLoader
 * @param relativePC
 * @param *romClass
 * @return UDATA
 */
 UDATA
-getLineNumberForROMClassFromROMMethod(J9JavaVM *vm, J9ROMMethod *romMethod, J9ROMClass *romClass, UDATA offset, J9ClassLoader *classLoader, UDATA relativePC);
+getLineNumberForROMClassFromROMMethod(J9JavaVM *vm, J9ROMMethod *romMethod, J9ROMClass *romClass, J9ClassLoader *classLoader, UDATA relativePC);
 
 /**
 * @brief

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3843,13 +3843,12 @@ J9ROMClass *
 * @param vmThread
 * @param romClass
 * @param methodPC
-* @param offset
 * @return J9ROMMethod
 *
 * Returns the method, or NULL on failure.
 */
 J9ROMMethod * 
-	findROMMethodInROMClass(J9VMThread *vmThread, J9ROMClass *romClass, UDATA methodPC, UDATA *offset);
+	findROMMethodInROMClass(J9VMThread *vmThread, J9ROMClass *romClass, UDATA methodPC);
 
 /**
 * @brief Finds the rom class given a PC.  Also returns the classloader it belongs to.

--- a/runtime/util/optinfo.c
+++ b/runtime/util/optinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -695,7 +695,7 @@ getSimpleNameForROMClass(J9JavaVM *vm, J9ClassLoader *classLoader, J9ROMClass *r
 }
 
 UDATA
-getLineNumberForROMClassFromROMMethod(J9JavaVM *vm, J9ROMMethod *romMethod, J9ROMClass *romClass, UDATA offset, J9ClassLoader *classLoader, UDATA relativePC)
+getLineNumberForROMClassFromROMMethod(J9JavaVM *vm, J9ROMMethod *romMethod, J9ROMClass *romClass, J9ClassLoader *classLoader, UDATA relativePC)
 {
 	UDATA bytecodeSize = J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod);
 	UDATA number = (UDATA)-1;

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -280,7 +280,6 @@ iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t 
 			UDATA lineNumber = 0;
 			J9UTF8 * fileName = NULL;
 			J9ClassLoader *classLoader = NULL;
-			UDATA offset = 0;
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 			J9JITExceptionTable * metaData = NULL;
 			UDATA inlineDepth = 0;
@@ -340,14 +339,12 @@ inlinedEntry:
 					ramClass = J9_CLASS_FROM_CP(J9_CP_FROM_METHOD(ramMethod));
 					romClass = ramClass->romClass;
 					classLoader = ramClass->classLoader;
-
-					offset = getMethodIndexUnchecked(ramMethod);
 				} else {
 					pruneConstructors = FALSE;
 #endif
 					romClass = findROMClassFromPC(vmThread, methodPC, &classLoader);
 					if(romClass) {
-						romMethod = findROMMethodInROMClass(vmThread, romClass, methodPC, &offset);
+						romMethod = findROMMethodInROMClass(vmThread, romClass, methodPC);
 						if (romMethod != NULL) {
 							methodPC -= (UDATA) J9_BYTECODE_START_FROM_ROM_METHOD(romMethod);
 						}
@@ -358,7 +355,7 @@ inlinedEntry:
 
 #ifdef J9VM_OPT_DEBUG_INFO_SERVER
 				if (romMethod != NULL) {
-					lineNumber = getLineNumberForROMClassFromROMMethod(vm, romMethod, romClass, offset, classLoader, methodPC);
+					lineNumber = getLineNumberForROMClassFromROMMethod(vm, romMethod, romClass, classLoader, methodPC);
 					fileName = getSourceFileNameForROMClass(vm, classLoader, romClass);
 				}
 #endif

--- a/runtime/vm/findmethod.c
+++ b/runtime/vm/findmethod.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,7 @@ findROMClassInSegment(J9VMThread *vmThread, J9MemorySegment *memorySegment, UDAT
 }
 
 J9ROMMethod * 
-findROMMethodInROMClass(J9VMThread *vmThread, J9ROMClass *romClass, UDATA methodPC, UDATA *offset)
+findROMMethodInROMClass(J9VMThread *vmThread, J9ROMClass *romClass, UDATA methodPC)
 {
 	J9ROMMethod *currentMethod = J9ROMCLASS_ROMMETHODS(romClass);
 	U_32 i;
@@ -59,9 +59,6 @@ findROMMethodInROMClass(J9VMThread *vmThread, J9ROMClass *romClass, UDATA method
 	for (i = 0; i < romClass->romMethodCount; i++) {
 		if ((methodPC >= (UDATA)currentMethod) && (methodPC < (UDATA)J9_BYTECODE_END_FROM_ROM_METHOD(currentMethod))) {
 			 /* found the method */
-			if (offset != NULL) {
-				*offset = i;
-			}
 			return currentMethod;
 		}
 		currentMethod = nextROMMethod(currentMethod);


### PR DESCRIPTION
Method index is computed inaccurately in exception printing code (HCR
issue to be addressed in a later PR) and is unused, so just remove it.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>