### PR TITLE
Use a class annotation to prevent instrumentation

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -556,7 +556,7 @@ public class J9BCUtil {
 
 		out.append(String.format("Sun Access Flags (0x%s): ", Long.toHexString(romClass.modifiers().longValue())));
 		dumpModifiers(out, romClass.modifiers().longValue(), MODIFIERSOURCE_CLASS, ONLY_SPEC_MODIFIERS);
-		
+		out.append(nl);
 		out.append(String.format("J9  Access Flags (0x%s): ", Long.toHexString(romClass.extraModifiers().longValue())));
 		dumpClassJ9ExtraModifiers(out, romClass.extraModifiers().longValue());
 		out.append(nl);
@@ -708,6 +708,8 @@ public class J9BCUtil {
 			out.append("(preverified) ");
 		if ((accessFlags & J9JavaAccessFlags.J9AccClassAnonClass) != 0)
 			out.append("(anonClass) ");
+		if ((accessFlags & J9JavaAccessFlags.J9AccClassIsUnmodifiable) != 0)
+			out.append("(unmodifiable) ");
 	}
 
 	private static void dumpEnclosingMethod(PrintStream out, J9ROMClassPointer romClass, long flags) throws CorruptDataException {

--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -3,7 +3,7 @@
 package com.ibm.jit;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@ package com.ibm.jit;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+import com.ibm.oti.vm.J9UnmodifiableClass;
 import java.lang.reflect.Field;
 import java.lang.reflect.Array;
 import com.ibm.oti.vm.VM;
@@ -41,6 +42,7 @@ import sun.reflect.CallerSensitive;
  * The <code>JITHelpers</code> class contains methods used by the JIT to optimize certain primitive operations.
  */
 @SuppressWarnings("javadoc")
+@J9UnmodifiableClass
 public final class JITHelpers {
 
 	private static final JITHelpers helpers;

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/J9UnmodifiableClass.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/J9UnmodifiableClass.java
@@ -1,0 +1,41 @@
+/*[INCLUDE-IF Sidecar17]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.oti.vm;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+
+// WARNING: Do not rename or repackage this class without changing
+// J9_UNMODIFIABLE_CLASS_ANNOTATION in j9.h to match. Under no
+// circumstances include any character whose ASCII value is
+// less than that of '/' (see canClassBeInstrumented in jvmtiHook.c).
+
+public @interface J9UnmodifiableClass {
+}
+

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -2,6 +2,7 @@
 
 package java.lang;
 
+import com.ibm.oti.vm.J9UnmodifiableClass;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.*;
 import java.security.AccessController;
@@ -30,7 +31,7 @@ import com.ibm.oti.util.Msg;
 
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +52,7 @@ import com.ibm.oti.util.Msg;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+@J9UnmodifiableClass
 final class J9VMInternals {
 	/*[PR VMDESIGN 1891] Move j9Version and j9Config from Class to J9VMInternals */
 	/*[IF]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInternal.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInternal.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,9 @@
  *******************************************************************************/
 package java.lang.invoke;
 
+import com.ibm.oti.vm.J9UnmodifiableClass;
+
+@J9UnmodifiableClass
 class VarHandleInternal {
 	/*[IF ]*/
 	/* Methods with VarHandle send target 

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -907,6 +907,7 @@ class NameAndTypeIterator
 	bool hasEmptyFinalizeMethod() const { return _hasEmptyFinalizeMethod; }
 	bool hasFinalFields() const { return _hasFinalFields; }
 	bool isClassContended() const { return _isClassContended; }
+	bool isClassUnmodifiable() const { return _isClassUnmodifiable; }
 	bool hasNonStaticNonAbstractMethods() const { return _hasNonStaticNonAbstractMethods; }
 	bool hasFinalizeMethod() const { return _hasFinalizeMethod; }
 	bool isCloneable() const { return _isCloneable; }
@@ -949,6 +950,7 @@ private:
 		JDK_INTERNAL_REFLECT_CALLERSENSITIVE_ANNOTATION,
 		JAVA8_CONTENDED_ANNOTATION,
 		CONTENDED_ANNOTATION,
+		UNMODIFIABLE_ANNOTATION,
 		KNOWN_ANNOTATION_COUNT
 	};
 
@@ -988,6 +990,7 @@ private:
 	bool _isSerializable;
 	bool _isSynthetic;
 	bool _isClassContended;
+	bool _isClassUnmodifiable;
 	bool _hasVerifyExcludeAttribute;
 	bool _hasFrameIteratorSkipAnnotation;
 	bool _hasClinit;

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1064,7 +1064,7 @@ ROMClassBuilder::finishPrepareAndLaydown(
  *                             + UNUSED
  *                            + UNUSED
  *                           + UNUSED
- *                          + AccClassAnonClass;
+ *                          + AccClassAnonClass
  *
  *                        + AccSynthetic (matches Oracle modifier position)
  *                       + AccClassUseBisectionSearch
@@ -1078,10 +1078,10 @@ ROMClassBuilder::finishPrepareAndLaydown(
  *
  *              + AccClassBytecodesModified
  *             + AccClassHasEmptyFinalize
- *            + UNUSED
+ *            + AccClassIsUnmodifiable
  *           + AccClassHasVerifyData
  *
- *         + J9AccClassIsContended
+ *         + AccClassIsContended
  *        + AccClassHasFinalFields
  *       + AccClassHasClinit
  *      + AccClassHasNonStaticNonAbstractMethods
@@ -1125,6 +1125,10 @@ ROMClassBuilder::computeExtraModifiers(ClassFileOracle *classFileOracle, ROMClas
 
 	if ( classFileOracle->isClassContended() ) {
 		modifiers |= J9AccClassIsContended;
+	}
+
+	if ( classFileOracle->isClassUnmodifiable() ) {
+		modifiers |= J9AccClassIsUnmodifiable;
 	}
 
 	U_32 classNameindex = classFileOracle->getClassNameIndex();

--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -222,6 +222,21 @@ public:
 	bool isClassUnsafe() const { return J9_FINDCLASS_FLAG_UNSAFE == (_findClassFlags & J9_FINDCLASS_FLAG_UNSAFE); }
 	bool isClassAnon() const { return J9_FINDCLASS_FLAG_ANON == (_findClassFlags & J9_FINDCLASS_FLAG_ANON); }
 	bool alwaysSplitBytecodes() const { return J9_ARE_ANY_BITS_SET(_bctFlags, BCT_AlwaysSplitBytecodes); }
+
+	bool isClassUnmodifiable() const {
+		bool unmodifiable = false;
+		if (NULL != _javaVM) {
+			if ((J2SE_VERSION(_javaVM) >= J2SE_V11) && isClassAnon()) {
+				unmodifiable = true;
+			} else if (NULL == J9VMJAVALANGOBJECT_OR_NULL(_javaVM)) {
+				/* Object is currently only allowed to be redefined in fast HCR */
+				if (areExtensionsEnabled(_javaVM)) {
+					unmodifiable = true;
+				}
+			}
+		}
+		return unmodifiable;
+	}
 
 	bool isIntermediateClassDataShareable() const {
 		bool shareable = false;

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -338,4 +338,26 @@ static const struct { \
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) FALSE
 #endif /* defined(OPENJ9_BUILD) */
 
+/* Annotation name which indicates that a class is not allowed to be modified by
+ * JVMTI ClassFileLoadHook or RedefineClasses.
+ */
+#define J9_UNMODIFIABLE_CLASS_ANNOTATION "Lcom/ibm/oti/vm/J9UnmodifiableClass;"
+
+typedef struct {
+	char tag;
+	char zero;
+	char size;
+	char data[LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION)];
+} J9_UNMODIFIABLE_CLASS_ANNOTATION_DATA;
+
+#if defined(__cplusplus)
+static_assert((sizeof(J9_UNMODIFIABLE_CLASS_ANNOTATION_DATA) == (3 + LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION))), "Annotation structure is not packed correctly");
+/* '/' is the lowest numbered character which appears in the annotation name (assume
+ * that no '$' exists in there). The name length must be smaller than '/' in order
+ * to ensure that there are no overlapping substrings which would mandate a more
+ * complex matching algorithm.
+ */
+static_assert((LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION) < (size_t)'/'), "Annotation contains invalid characters");
+#endif /* __cplusplus */
+
 #endif /* J9_H */

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -47,6 +47,7 @@
 #define J9AccClassHasBeenOverridden 0x100000
 #define J9AccClassHasClinit 0x4000000
 #define J9AccClassHasEmptyFinalize 0x200000
+#define J9AccClassIsUnmodifiable 0x400000
 #define J9AccClassHasFinalFields 0x2000000
 #define J9AccClassHasJDBCNatives 0x400000
 #define J9AccClassHasNonStaticNonAbstractMethods 0x8000000

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -64,6 +64,7 @@
 #define J9ROMCLASS_FINALIZE_NEEDED(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassFinalizeNeeded)
 #define J9ROMCLASS_IS_CLONEABLE(romClass)		_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassCloneable)
 #define J9ROMCLASS_ANNOTATION_REFERS_DOUBLE_SLOT_ENTRY(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassAnnnotionRefersDoubleSlotEntry)
+#define J9ROMCLASS_IS_UNMODIFIABLE(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassIsUnmodifiable)
 
 /* 
  * Note that resolvefield ignores this flag if the cache line size cannot be determined.

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3232,25 +3232,7 @@ verifyClassesCanBeReplaced(J9VMThread * currentThread, jint class_count, const j
 jboolean
 classIsModifiable(J9JavaVM * vm, J9Class * clazz)
 {
-	jboolean rc = JNI_TRUE;
-
-	if (J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(clazz->romClass)) {
-		rc = JNI_FALSE;
-	} else if (clazz == J9VMJAVALANGJ9VMINTERNALS_OR_NULL(vm)) {
-		rc = JNI_FALSE;
-	} else if ((J2SE_VERSION(vm) >= J2SE_V11) && J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsAnonymous)) {
-		rc = JNI_FALSE;
-	}
-
-	/* Object is currently only allowed to be redefined in fast HCR */
-	if (areExtensionsEnabled(vm)) {
-		if (0 == J9CLASS_DEPTH(clazz)) {
-			/* clazz is Object */
-			rc = JNI_FALSE;
-		}
-	}
-
-	return rc;
+	return !J9ROMCLASS_IS_UNMODIFIABLE(clazz->romClass);
 }
 
 jvmtiError

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1316,6 +1316,13 @@ j9_printClassExtraModifiers(J9PortLibrary *portLib, U_32 modifiers)
 	{
 		j9tty_printf(PORTLIB, "(preverified)");
 		modifiers &= ~CFR_ACC_HAS_VERIFY_DATA;
+		if(modifiers) j9tty_printf(PORTLIB, " ");
+	}
+
+	if(modifiers & J9AccClassIsUnmodifiable)
+	{
+		j9tty_printf(PORTLIB, "(unmodifiable)");
+		modifiers &= ~J9AccClassIsUnmodifiable;
 		if(modifiers) j9tty_printf(PORTLIB, " ");
 	}
 }

--- a/runtime/vm/romclasses.c
+++ b/runtime/vm/romclasses.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -127,7 +127,7 @@ initializeArrayROMClass(J9ROMArrayClass *romClass, J9UTF8 *className, U_32 array
 	NNSRP_SET(romClass->className, className);
 	NNSRP_SET(romClass->superclassName, &arrayROMClasses.objectClassName);
 	romClass->modifiers = J9AccFinal | J9AccPublic | J9AccClassArray | J9AccAbstract;
-	romClass->extraModifiers = J9AccClassCloneable;
+	romClass->extraModifiers = J9AccClassCloneable | J9AccClassIsUnmodifiable;
 	romClass->interfaceCount = sizeof(arrayROMClasses.interfaceClasses) / sizeof(J9SRP);
 	NNSRP_SET(romClass->interfaces, &arrayROMClasses.interfaceClasses);
 	romClass->arrayShape = arrayShape;
@@ -150,6 +150,7 @@ initializeBaseTypeROMClass(J9ROMReflectClass *romClass, J9UTF8 *className, U_32 
 	romClass->romSize = size;
 	NNSRP_SET(romClass->className, className);
 	romClass->modifiers = J9AccFinal | J9AccPublic | J9AccClassInternalPrimitiveType | J9AccAbstract;
+	romClass->extraModifiers = J9AccClassIsUnmodifiable;
 	romClass->reflectTypeCode = typeCode;
 	romClass->instanceShape = instanceShape;
 	romClass->elementSize = elementSize;


### PR DESCRIPTION
New annotation: com.ibm.oti.vm.J9UnmodifiableClass

Rather than using a hard-coded (and inconsistent!) list of classes which
are not allowed to be modified by the JVMTI ClassFileLoadHook or
Re[define/transform]Classes APIs, annotate the classes which are private
to the VM implementation.

For performance, only classes loaded by the bootstrap loader will be
scanned for the annotation before ClassFileLoadHook (and that scan is
optimistic - any class file containing the bytes representing a constant
pool entry UTF8 matching the annotation signature will be tagged). This
is safe because the VM is largely in control of the boot path (it's
beyond unlikely that this pattern could match accidentally in classes
added to the boot path by the application).

Any class with access to com.ibm.oti.vm may use the annotation to prevent being redefined. This prevents application classes from using the annotation.

This also fixes the fact that we were not reporting ClassFileLoadHook for any class that was not explicitly-named in the defineClass call.

Fixes: #2768

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>