### PR TITLE
JDK13 bringup - adding pConfig JAVA13

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -1047,6 +1047,10 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 		<description>Controls if the VM includes support for romImageLoad and romImageUnload</description>
 		<ifRemoved>No facility for installing jxes or romImages</ifRemoved>
 	</flag>
+	<flag id="ive_rawBuild">
+		<description>Pure OpenJDK Java code without any OpenJ9 modifications</description>
+		<ifRemoved>No raw builds</ifRemoved>
+	</flag>
 	<flag id="jit_32bitUses64bitRegisters">
 		<description>Allow the 32 bit JIT to use the 64 bit registers</description>
 		<ifRemoved></ifRemoved>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -165,6 +165,34 @@
 	</configuration>
 
 	<configuration
+		  label="JAVA13"
+		  outputpath="JAVA13/src"
+		  flags="Java13"
+		  dependencies="JAVA12"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava12.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
 		  label="OPENJ9-RAWBUILD"
 		  outputpath="OPENJ9-RAWBUILD/src"
 		  flags="OpenJ9-RawBuild"
@@ -196,7 +224,7 @@
 		  label="PANAMA"
 		  outputpath="PANAMA/src"
 		  flags="Panama"
-		  dependencies="JAVA12"
+		  dependencies="JAVA13"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,9 @@ package java.lang.invoke;
  */
 
 class InvokerBytecodeGenerator {
+/*[IF Java13]*/
+	static final String HIDDEN_SIG = null;
+/*[ENDIF] Java13 */
 	static boolean isStaticallyInvocable(MemberName mn) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -532,7 +532,9 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 
 	/* Determine allowed class file version */
 #ifdef J9VM_OPT_SIDECAR
-	if (J2SE_VERSION(vm) >= J2SE_V12) {
+	if (J2SE_VERSION(vm) >= J2SE_V13) {
+		translationFlags |= BCT_Java13MajorVersionShifted;
+	} else if (J2SE_VERSION(vm) >= J2SE_V12) {
 		translationFlags |= BCT_Java12MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_V11) {
 		translationFlags |= BCT_Java11MajorVersionShifted;

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -116,6 +116,13 @@ jint computeFullVersionString(J9JavaVM* vm)
 			j2se_version_info = "12.?";
 		}
 		break;
+	case J2SE_V13:
+		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V13) {
+			j2se_version_info = "13";
+		} else {
+			j2se_version_info = "13.?";
+		}
+		break;
 	default:
 		j2se_version_info = "?.?.?";
 	}

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -227,31 +227,30 @@ standardInit( J9JavaVM *vm, char *dllName)
 		vm->jlrMethodInvoke = ((J9JNIMethodID *) invokeMethod)->method;
 		(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
 
-		if (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW) {
-			/* JSR 292-related class */
-			clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "com/ibm/oti/lang/ArgumentHelper");
-			if (!clazz) goto _fail;
-			vm->jliArgumentHelper = (*(JNIEnv*)vmThread)->NewGlobalRef((JNIEnv*)vmThread, clazz);
-			if (!vm->jliArgumentHelper) goto _fail;
-			(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
+#ifndef J9VM_IVE_RAW_BUILD /* J9VM_IVE_RAW_BUILD is not enabled by default */
+		/* JSR 292-related class */
+		clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "com/ibm/oti/lang/ArgumentHelper");
+		if (!clazz) goto _fail;
+		vm->jliArgumentHelper = (*(JNIEnv*)vmThread)->NewGlobalRef((JNIEnv*)vmThread, clazz);
+		if (!vm->jliArgumentHelper) goto _fail;
+		(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
 
-			clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "java/lang/invoke/MethodHandle");
-			if (!clazz) goto _fail;
-			invokeMethod = (*(JNIEnv*)vmThread)->GetMethodID((JNIEnv*)vmThread, clazz, "invokeWithArguments", "([Ljava/lang/Object;)Ljava/lang/Object;");
-			if (!invokeMethod) goto _fail;
-			vm->jliMethodHandleInvokeWithArgs = ((J9JNIMethodID *) invokeMethod)->method;
-			invokeMethod = (*(JNIEnv*)vmThread)->GetMethodID((JNIEnv*)vmThread, clazz, "invokeWithArguments", "(Ljava/util/List;)Ljava/lang/Object;");
-			if (!invokeMethod) goto _fail;
-			vm->jliMethodHandleInvokeWithArgsList = ((J9JNIMethodID *) invokeMethod)->method;
+		clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "java/lang/invoke/MethodHandle");
+		if (!clazz) goto _fail;
+		invokeMethod = (*(JNIEnv*)vmThread)->GetMethodID((JNIEnv*)vmThread, clazz, "invokeWithArguments", "([Ljava/lang/Object;)Ljava/lang/Object;");
+		if (!invokeMethod) goto _fail;
+		vm->jliMethodHandleInvokeWithArgs = ((J9JNIMethodID *) invokeMethod)->method;
+		invokeMethod = (*(JNIEnv*)vmThread)->GetMethodID((JNIEnv*)vmThread, clazz, "invokeWithArguments", "(Ljava/util/List;)Ljava/lang/Object;");
+		if (!invokeMethod) goto _fail;
+		vm->jliMethodHandleInvokeWithArgsList = ((J9JNIMethodID *) invokeMethod)->method;
+		(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
+		clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "com/ibm/jit/JITHelpers");
+		if (NULL != clazz) {
+			/* Force class initialization */
+			(void)(*(JNIEnv*)vmThread)->GetStaticFieldID((JNIEnv*)vmThread, clazz, "helpers", "Lcom/ibm/jit/JITHelpers;");
 			(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
-
-			clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "com/ibm/jit/JITHelpers");
-			if (NULL != clazz) {
-				/* Force class initialization */
-				(void)(*(JNIEnv*)vmThread)->GetStaticFieldID((JNIEnv*)vmThread, clazz, "helpers", "Lcom/ibm/jit/JITHelpers;");
-				(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
-			}
 		}
+#endif /* !J9VM_IVE_RAW_BUILD */
 	}
 #endif
 

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -27,25 +27,13 @@
 /**
  * Constants for supported J2SE versions.
  */
-/*
- * Note: J2SE_LATEST is the highest Java version supported by VM for a JCL level.
- *       This allows JVM operates with latest version when neither classlib.properties
- *       nor release file presents.
- */
 #define J2SE_18   0x0800
 #define J2SE_V11  0x0B00            /* This refers Java 11 */
 #define J2SE_V12  0x0C00            /* This refers Java 12 */
+#define J2SE_V13  0x0D00            /* This refers Java 13 */
 /* Shared class cache is using JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) to get the Java version.
  * So bits 9 to 16 of the J2SE constant should match the java version number.
  */
-
-#if JAVA_SPEC_VERSION == 8
-	#define J2SE_LATEST  J2SE_18
-#elif JAVA_SPEC_VERSION == 11
-	#define J2SE_LATEST  J2SE_V11
-#else
-	#define J2SE_LATEST  J2SE_V12
-#endif
 
 /**
  * Masks for extracting major and full versions.
@@ -54,33 +42,9 @@
 #define J2SE_RELEASE_MASK 0xFFF0
 #define J2SE_SERVICE_RELEASE_MASK 0xFFFF
 
-/**
- * Masks and constants for describing J2SE shapes.
- *  J2SE_SHAPE_OPENJDK = OpenJDK core libraries (aka J9 'sidecar', OpenJDK code + J9 kernel)
- *  J2SE_SHAPE_RAW = Pure Oracle code without any IBM modifications
- */
-/*
- * Note: J2SE_SHAPE_LATEST is the highest JCL level supported by VM for a JCL level.
- *       This allows JVM operates with latest level when neither classlib.properties
- *       nor release file presents.
- */
-#if JAVA_SPEC_VERSION == 8
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_OPENJDK
-#elif JAVA_SPEC_VERSION == 11
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V11
-#elif JAVA_SPEC_VERSION == 12
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V12
-#else
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V12
-#endif
-#define J2SE_SHAPE_OPENJDK 		0x10000
-#define J2SE_SHAPE_V11			0x80000
-#define J2SE_SHAPE_V12			0x90000
-#define J2SE_SHAPE_RAWPLUSJ9	0xA0000
-#define J2SE_SHAPE_RAW	 		0xB0000
-#define J2SE_SHAPE_MASK 		0xF0000
-#define J2SE_SHAPE_SHIFT		16
 #define J2SE_JAVA_SPEC_VERSION_SHIFT 8
+/* J2SE_CURRENT_VERSION is the current Java version supported by VM for a JCL level. */
+#define J2SE_CURRENT_VERSION (JAVA_SPEC_VERSION << J2SE_JAVA_SPEC_VERSION_SHIFT)
 
 /**
  * Masks and constants for describing J2SE shapes.
@@ -98,16 +62,6 @@
  * Macro to extract J2SE version given a JNIEnv.
  */
 #define J2SE_VERSION_FROM_ENV(env) J2SE_VERSION(((J9VMThread*)env)->javaVM)
-
-/**
- * Macro to extract the shape portion of the J2SE flags.
- */
-#define J2SE_SHAPE(javaVM) 	((javaVM)->j2seVersion & J2SE_SHAPE_MASK)
-
-/**
- * Macro to extract J2SE shape given a JNIEnv.
- */
-#define J2SE_SHAPE_FROM_ENV(env) J2SE_SHAPE(((J9VMThread*)env)->javaVM)
 
 /**
  * Macro to extract java spec version from J2SE version.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1985,7 +1985,8 @@ typedef struct J9BCTranslationData {
 #define BCT_Java10MajorVersionShifted 0x36000000
 #define BCT_Java11MajorVersionShifted 0x37000000
 #define BCT_Java12MajorVersionShifted 0x38000000
-#define BCT_JavaMaxMajorVersionShifted BCT_Java12MajorVersionShifted
+#define BCT_Java13MajorVersionShifted 0x39000000
+#define BCT_JavaMaxMajorVersionShifted BCT_Java13MajorVersionShifted
 
 typedef struct J9RAMClassFreeListBlock {
 	UDATA size;

--- a/runtime/tests/shared/OSCacheTestMmap.cpp
+++ b/runtime/tests/shared/OSCacheTestMmap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,7 @@ SH_OSCacheTestMmap::testBasic(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 	
 	rc = j9shmem_getDir(NULL, flags, cacheDir, J9SH_MAXPATH);
@@ -146,7 +146,7 @@ SH_OSCacheTestMmap::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	rc = j9shmem_getDir(NULL, flags, cacheDir, J9SH_MAXPATH);
@@ -218,7 +218,7 @@ SH_OSCacheTestMmap::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -317,7 +317,7 @@ SH_OSCacheTestMmap::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -451,7 +451,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if(NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -498,7 +498,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat != NULL) {
 		numCacheBeforeTest += pool_numElements(cacheStat);
@@ -520,7 +520,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
 	if(cacheStat == NULL) {
 		j9tty_printf(PORTLIB, "testGetAllCacheStatistics: failed to get cache statistics - there should be at least one cache!\n");
 		goto cleanup;
@@ -574,7 +574,7 @@ SH_OSCacheTestMmap::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (osc = (SH_OSCachemmap *)j9mem_allocate_memory(SH_OSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
@@ -667,7 +667,7 @@ SH_OSCacheTestMmap::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -761,7 +761,7 @@ SH_OSCacheTestMmap::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -60,7 +60,7 @@ SH_OSCacheTestSysv::testBasic(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	rc = j9shmem_getDir(NULL, flags, cacheDir, J9SH_MAXPATH);
@@ -189,7 +189,7 @@ SH_OSCacheTestSysv::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /*  defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 	
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -325,7 +325,7 @@ SH_OSCacheTestSysv::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /*  defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -409,7 +409,7 @@ SH_OSCacheTestSysv::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -491,7 +491,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	J9PortShcVersion versionData;
 	U_32 flags = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if(NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -541,7 +541,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat != NULL) {
 		numCacheBeforeTest += pool_numElements(cacheStat);
@@ -565,7 +565,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	}
 
 	/* Search for caches in "/tmp/javasharedresources". */
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat == NULL) {
 		j9tty_printf(PORTLIB, "testGetAllCacheStatistics: failed to get cache statistics - there should be at least one cache!\n");
@@ -618,7 +618,7 @@ SH_OSCacheTestSysv::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 #if	defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (osc = (SH_OSCachesysv *)j9mem_allocate_memory(SH_OSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
@@ -713,7 +713,7 @@ SH_OSCacheTestSysv::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -806,7 +806,7 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -962,7 +962,7 @@ SH_OSCacheTestSysv::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
+	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -677,9 +677,9 @@ addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2s
 	J9JavaVMArgInfo *optArg = NULL;
 	
 	PORT_ACCESS_FROM_PORT(portLib);
-	if (J2SE_SHAPE_RAW == (j2seVersion & J2SE_SHAPE_MASK)) {
-		Assert_Util_unreachable();
-	}
+#ifdef J9VM_IVE_RAW_BUILD /* J9VM_IVE_RAW_BUILD is not enabled by default */
+	Assert_Util_unreachable();
+#endif /* J9VM_IVE_RAW_BUILD */
 
 	argumentLength = sizeof(VMOPT_XJCL_COLON) + dllNameLength - 1; /* sizeof called twice, each includes the \0 */
 	argString = j9mem_allocate_memory(argumentLength, OMRMEM_CATEGORY_VM);

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -536,20 +536,20 @@ oom:
 				}
 				j9object_t threadGroup = (NULL == group) ? NULL : *group;
 				*--currentThread->sp = (UDATA)threadObject;
-				if (J2SE_SHAPE(vm) == J2SE_SHAPE_RAW) {
-					/* Oracle constructor takes thread group, thread name */
-					J9VMJAVALANGTHREAD_SET_PRIORITY(currentThread, threadObject, priority);
-					J9VMJAVALANGTHREAD_SET_ISDAEMON(currentThread, threadObject, (I_32)daemon);
-					*--currentThread->sp = (UDATA)threadGroup;
-					*--currentThread->sp = (UDATA)threadName;
-				} else {
-					/* J9 constructor takes thread name, thread group, priority and isDaemon */
-					J9VMJAVALANGTHREAD_SET_STARTED(currentThread, threadObject, JNI_TRUE);
-					*--currentThread->sp = (UDATA)threadName;
-					*--currentThread->sp = (UDATA)threadGroup;
-					*(I_32*)--currentThread->sp = priority;
-					*(I_32*)--currentThread->sp = (I_32)daemon;
-				}
+#ifdef J9VM_IVE_RAW_BUILD /* J9VM_IVE_RAW_BUILD is not enabled by default */
+				/* Oracle constructor takes thread group, thread name */
+				J9VMJAVALANGTHREAD_SET_PRIORITY(currentThread, threadObject, priority);
+				J9VMJAVALANGTHREAD_SET_ISDAEMON(currentThread, threadObject, (I_32)daemon);
+				*--currentThread->sp = (UDATA)threadGroup;
+				*--currentThread->sp = (UDATA)threadName;
+#else /* J9VM_IVE_RAW_BUILD */
+				/* J9 constructor takes thread name, thread group, priority and isDaemon */
+				J9VMJAVALANGTHREAD_SET_STARTED(currentThread, threadObject, JNI_TRUE);
+				*--currentThread->sp = (UDATA)threadName;
+				*--currentThread->sp = (UDATA)threadGroup;
+				*(I_32*)--currentThread->sp = priority;
+				*(I_32*)--currentThread->sp = (I_32)daemon;
+#endif /* J9VM_IVE_RAW_BUILD */
 				currentThread->returnValue = J9_BCLOOP_RUN_METHOD;
 				currentThread->returnValue2 = (UDATA)J9VMJAVALANGTHREAD_INIT_METHOD(vm);
 				c_cInterpreter(currentThread);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1823,13 +1823,13 @@ nativeOOM:
 
 		/* Initialize class object and link the object and the J9Class. */
 		if (state->classObject != NULL) {
-			if (J2SE_SHAPE_RAW != J2SE_SHAPE(javaVM)) {
-				j9object_t protectionDomain = NULL;
+#ifndef J9VM_IVE_RAW_BUILD /* J9VM_IVE_RAW_BUILD is not enabled by default */
+			j9object_t protectionDomain = NULL;
 
-				J9VMJAVALANGCLASS_SET_CLASSLOADER(vmThread, state->classObject, classLoader->classLoaderObject);
-				protectionDomain = (j9object_t)PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0);
-				J9VMJAVALANGCLASS_SET_PROTECTIONDOMAIN(vmThread, state->classObject, protectionDomain);
-			}
+			J9VMJAVALANGCLASS_SET_CLASSLOADER(vmThread, state->classObject, classLoader->classLoaderObject);
+			protectionDomain = (j9object_t)PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0);
+			J9VMJAVALANGCLASS_SET_PROTECTIONDOMAIN(vmThread, state->classObject, protectionDomain);
+#endif /* !J9VM_IVE_RAW_BUILD */
 
 			/* Link J9Class and object after possible access barrier failures. */
 			J9VMJAVALANGCLASS_SET_VMREF(vmThread, state->classObject, state->ramClass);

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -390,6 +390,8 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 		javaVersion = "JRE 11";
 	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V12) {
 		javaVersion = "JRE 12";
+	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V13) {
+		javaVersion = "JRE 13";
 	} else {
 		javaVersion = "UNKNOWN";
 	}

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -209,10 +209,10 @@ findFieldInClass(J9VMThread *vmStruct, J9Class *clazz, U_8 *fieldName, UDATA fie
 	if (NULL == shape){
 		U_32 walkFlags = J9VM_FIELD_OFFSET_WALK_INCLUDE_STATIC | J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE;
 
+#ifdef J9VM_IVE_RAW_BUILD /* J9VM_IVE_RAW_BUILD is not enabled by default */
 		/* temporary workaround to allow access to vm-inserted hidden fields, needed for constant pool resolution */
-		if (J2SE_SHAPE_RAW == J2SE_SHAPE(javaVM)) {
-			walkFlags |= J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN;
-		}
+		walkFlags |= J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN;
+#endif /* J9VM_IVE_RAW_BUILD */
 
 		/* walk all instance and static fields */
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)


### PR DESCRIPTION
`JDK13` bringup - adding `pConfig JAVA13`

1. added `pConfig JAVA13` along with flag `Java13`;
2. added a field `java.lang.invoke.InvokerBytecodeGenerator.HIDDEN_SIG` for `JDK13`;
3. added a build flag `ive_rawBuild` which is not enabled;
4. removed `J2SE_SHAPE` related code;
5. use `ifdef J9VM_IVE_RAW_BUILD` in place of `J2SE_SHAPE(vm) == J2SE_SHAPE_RAW`.

Manually verified that `JDK13` can be built and `-version` output is:
```
openjdk version "13-internal" 2019-09-17
OpenJDK Runtime Environment (build 13-internal+0-adhoc.jason.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build master-9d606fc, JRE 13 Linux amd64-64-Bit Compressed References 20190225_000000 (JIT enabled, AOT enabled)
OpenJ9   - 9d606fc
OMR      - e6c6285
JCL      - b0f7ca0 based on jdk-13+6)
```

related: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/81, https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/273
closes: https://github.com/eclipse/openj9/issues/4857

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>