### PR TITLE
Rationalize allocation macros

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -437,7 +437,7 @@ fast_jitNewObjectImpl(J9VMThread *currentThread, J9Class *objectClass, bool chec
 			goto slow;
 		}
 	}
-	if (J9_UNEXPECTED(J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(objectClass->romClass))) {
+	if (J9_UNEXPECTED(!J9ROMCLASS_ALLOCATES_VIA_NEW(objectClass->romClass))) {
 		goto slow;
 	}
 	{
@@ -471,7 +471,7 @@ slow_jitNewObjectImpl(J9VMThread *currentThread, bool checkClassInit, bool nonZe
 	if (nonZeroTLH) {
 		allocationFlags |= J9_GC_ALLOCATE_OBJECT_NON_ZERO_TLH;
 	}
-	if (J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(objectClass->romClass)) {
+	if (!J9ROMCLASS_ALLOCATES_VIA_NEW(objectClass->romClass)) {
 		buildJITResolveFrameForRuntimeHelper(currentThread, parmCount);
 		addr = setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGINSTANTIATIONERROR | J9_EX_CTOR_CLASS, J9VM_J9CLASS_TO_HEAPCLASS(objectClass));
 		goto done;

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -100,8 +100,13 @@
 #define J9ROMMETHOD_IS_NON_EMPTY_OBJECT_CONSTRUCTOR(romMethod) \
 	((((romMethod)->modifiers) & (J9AccMethodObjectConstructor | J9AccEmptyMethod)) == J9AccMethodObjectConstructor)
 
-#define J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(romClass) \
-	J9_ARE_ANY_BITS_SET((romClass)->modifiers, J9AccAbstract | J9AccInterface)
+/* Class instances are allocated via the new bytecode */
+#define J9ROMCLASS_ALLOCATES_VIA_NEW(romClass) \
+	J9_ARE_NO_BITS_SET((romClass)->modifiers, J9AccAbstract | J9AccInterface | J9AccClassArray | J9AccValueType)
+
+/* Class instances are allocated via J9RAMClass->totalInstanceSize */
+#define J9ROMCLASS_ALLOCATE_USES_TOTALINSTANCESIZE(romClass) \
+	J9_ARE_NO_BITS_SET((romClass)->modifiers, J9AccAbstract | J9AccInterface | J9AccClassArray)
 
 /* Only public vTable methods go into the iTable */
 #define J9ROMMETHOD_IN_ITABLE(romMethod) \

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2034,7 +2034,7 @@ copyPreservedValues(J9VMThread * currentThread, J9HashTable * classPairs, UDATA 
 			 * Do not do this for abstract or interface classes, which can not be
 			 * instantiated (and hence may reuse the totalInstanceSize field as something else).
 			 */
-			if (!J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(originalRAMClass->romClass)) {
+			if (J9ROMCLASS_ALLOCATE_USES_TOTALINSTANCESIZE(originalRAMClass->romClass)) {
 				originalRAMClass->totalInstanceSize = (UDATA)-256;
 			}
 		}

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7241,7 +7241,7 @@ retry:
 		J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);
 		J9RAMClassRef *ramCPEntry = ((J9RAMClassRef*)ramConstantPool) + index;
 		J9Class* volatile resolvedClass = ramCPEntry->value;
-		if ((NULL != resolvedClass) && !J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(resolvedClass->romClass)) {
+		if ((NULL != resolvedClass) && J9ROMCLASS_ALLOCATES_VIA_NEW(resolvedClass->romClass)) {
 			if (!VM_VMHelpers::classRequiresInitialization(_currentThread, resolvedClass)) {
 				j9object_t instance = _objectAllocate.inlineAllocateObject(_currentThread, resolvedClass);
 				if (NULL == instance) {

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -259,7 +259,7 @@ tryAgain:
 	ramClassRefWrapper = (J9RAMClassRef *)&ramCP[cpIndex];
 	resolvedClass = ramClassRefWrapper->value;
 	/* If resolving for "new", check if the class is instantiable */
-	if ((NULL != resolvedClass) && (J9_ARE_NO_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_INSTANTIABLE) || !J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(resolvedClass->romClass))) {
+	if ((NULL != resolvedClass) && (J9_ARE_NO_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_INSTANTIABLE) || J9ROMCLASS_ALLOCATES_VIA_NEW(resolvedClass->romClass))) {
 		/* ensure that the caller can safely read the modifiers field if it so desires */
 		issueReadBarrier();
 		goto done;
@@ -398,7 +398,7 @@ tryAgain:
 
 	accessModifiers = resolvedClass->romClass->modifiers;
 	if (J9_ARE_ANY_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_INSTANTIABLE)) {
-		if (J9_ARE_ANY_BITS_SET(accessModifiers, J9AccAbstract | J9AccInterface)) {
+		if (!J9ROMCLASS_ALLOCATES_VIA_NEW(resolvedClass->romClass)) {
 			if (canRunJavaCode) {
 				setCurrentException(vmStruct, J9_EX_CTOR_CLASS + J9VMCONSTANTPOOL_JAVALANGINSTANTIATIONERROR,
 						(UDATA *)resolvedClass->classObject);


### PR DESCRIPTION
Provide macros which describe their purpose rather than their literal
function (i.e. primitive or array). Add/rename macros to test for:

- class uses totalInstanceSize for allocation

In this case, HCR slams the old class with a size which prevents any
possible allocation.

- class can be allocated via the new bytecode

Value types are added to the mask preventing allocation via new.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>