### PR TITLE
Remove TR_J9VMBase::traceAssumeFailure

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5439,13 +5439,6 @@ TR_J9VMBase::reportPrexInvalidation(void * startPC)
    }
 
 
-void
-TR_J9VMBase::traceAssumeFailure(int32_t line, const char * file)
-   {
-   //Trc_JIT_assumeFailure(vmThread(), line, file);
-   }
-
-
 // Multiple codeCache support
 
 void

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -772,7 +772,6 @@ public:
    virtual void restoreCompilationPhase(int32_t phase);
 
    virtual void reportPrexInvalidation(void * startPC);
-   virtual void traceAssumeFailure(int32_t line, const char * file);
 
    virtual bool compilationShouldBeInterrupted( TR::Compilation *, TR_CallingContext);
    bool checkForExclusiveAcquireAccessRequest( TR::Compilation *);


### PR DESCRIPTION
This function is disabled, and has no callsites in J9. In OMR, there is
one remaining call inside the implemention of TR_ASSERT. Once this call
is removed in eclipse/omr#3613, this function can be deleted.

Signed-off-by: Robert Young <rwy0717@gmail.com>