### PR TITLE
Add AOT upgrades based on SCC hints to the LPQ

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6635,8 +6635,19 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
             // Now let's see if we need to schedule an AOT upgrade
             if (hints)
                {
-               entry->_newStartPC = startPC; // must do this before calling queueForcedAOTUpgrade
-               _compInfo.queueForcedAOTUpgrade(entry, hints, _vm);
+               // must do this before queueing for an upgrade
+               entry->_newStartPC = startPC;
+
+               static char *disableQueueLPQAOTUpgrade = feGetEnv("TR_DisableQueueLPQAOTUpgrade");
+               if (TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableSymbolValidationManager)
+                   && !disableQueueLPQAOTUpgrade)
+                  {
+                  _compInfo.getLowPriorityCompQueue().addUpgradeReqToLPQ(getMethodBeingCompiled());
+                  }
+               else
+                  {
+                  _compInfo.queueForcedAOTUpgrade(entry, hints, _vm);
+                  }
                }
             }
          }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2446,6 +2446,17 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       self()->setOption(TR_DisableIntrinsics);
       }
 
+   /* Temporary (until SVM is the default)
+    *
+    * If the SVM is not enabled, use the old _coldUpgradeSampleThreshold
+    * for AGGRESSIVE_AOT
+    */
+   if (!self()->getOption(TR_EnableSymbolValidationManager)
+       && TR::Options::_aggressivenessLevel == TR::Options::AGGRESSIVE_AOT)
+      {
+      TR::Options::_coldUpgradeSampleThreshold = 10;
+      }
+
    return true;
    }
 


### PR DESCRIPTION
Forced AOT upgrades are recompilations that are based on hints stored in
the SCC. These hints are used to identify methods that were AOT compiled
(or loaded), but were recompiled because the sampling mechanism
determined that they were important methods. However, these upgrades are
added immediately to the queue when the method is loaded from the SCC,
which can potentially impact an application's rampup phase.

This PR defers these upgrades until free cycles are available by adding them to
the low priority queue.