### PR TITLE
Specifying nasm version on x86 centos Dockerfile

### DIFF
--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -126,6 +126,16 @@ RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
   && cpanm Text::CSV \
   && cpanm JSON \
   && cpanm XML::Parser
+  
+# Install nasm-2.13.03
+RUN cd /tmp \
+  && wget https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.gz \
+  && tar xzf nasm-2.13.03.tar.gz \
+  && rm /tmp/nasm-2.13.03.tar.gz \
+  && cd /tmp/nasm-2.13.03 \
+  && ./configure -prefix=/usr/local \
+  && make install \
+  && rm -rf /tmp/nasm-2.13.03
 
 #Building and setting up git version 2.5.3
 RUN cd /usr/src \


### PR DESCRIPTION
The default version of nasm on the Docker container is too low
This will bring it up to the minimum requirement

[skip ci]

Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>