### PR TITLE
Revert "Clean up jpp_configurations.xml"

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -109,10 +109,122 @@
 	</configuration>
 
 	<configuration
+		  label="SIDECAR19-SE-B148"
+		  outputpath="SIDECAR19-SE-B148/src"
+		  flags="Sidecar19-SE, DAA, Open-Module-Support"
+		  dependencies="SIDECAR18-SE"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
+		  label="SIDECAR19-SE-B136"
+		  outputpath="SIDECAR19-SE-B136/src"
+		  flags="Sidecar19-SE, DAA"
+		  dependencies="SIDECAR18-SE"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
+		  label="SIDECAR19-SE-OPENJ9"
+		  outputpath="SIDECAR19-SE-OpenJ9/src"
+		  flags="Sidecar18-SE-OpenJ9,Sidecar19-SE-OpenJ9"
+		  dependencies="SIDECAR19-SE-B148"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190b174.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
+		  label="JAVA10"
+		  outputpath="JAVA10/src"
+		  flags="Java10"
+		  dependencies="SIDECAR19-SE-OPENJ9"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava10.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
 		  label="JAVA11"
 		  outputpath="JAVA11/src"
-		  flags="Sidecar18-SE-OpenJ9, DAA, Open-Module-Support,Sidecar19-SE,Sidecar19-SE-OpenJ9,Java10,Java11"
-		  dependencies="SIDECAR18-SE"
+		  flags="Java11"
+		  dependencies="JAVA10"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
@@ -196,7 +308,7 @@
 		  label="PANAMA"
 		  outputpath="PANAMA/src"
 		  flags="Panama"
-		  dependencies="JAVA12"
+		  dependencies="SIDECAR19-SE-B136"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
@@ -217,6 +329,31 @@
 		<source path="src"/>
 		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
+		  label="SIDECAR19-SE_RAWPLUSJ9"
+		  outputpath="SIDECAR19-SE_RAWPLUSJ9/src"
+		  flags="Sidecar19-SE_RAWPLUSJ9"
+		  dependencies="SIDECAR19-SE-B136"
+		  jdkcompliance="1.8">
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190RawPlusJ9.jar"/>
+		<source path="src/java.base/share/classes"/>
+		<source path="src/java.desktop/share/classes"/>
+		<source path="src/java.management/share/classes"/>
+		<source path="src/jdk.management/share/classes"/>
+		<source path="src/jdk.attach/share/classes"/>
+		<source path="src/jdk.jcmd/share/classes"/>
+		<source path="src/openj9.jvm/share/classes"/>
+		<source path="src/openj9.dataaccess/share/classes"/>
+		<source path="src/openj9.sharedclasses/share/classes"/>
+		<source path="src/openj9.zosconditionhandling/share/classes"/>
+		<source path="src/openj9.gpu/share/classes"/>
+		<source path="src/openj9.cuda/share/classes"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
 


### PR DESCRIPTION
Reverts eclipse/openj9#4867

I suspect this was causing failures in the builds like the following
```
Creating images/lib/ext/dtfj.jar
13:24:15  'u' flag requires manifest, 'e' flag or input files to be specified!
13:24:15  Usage: jar {ctxui}[vfmn0PMe] [jar-file] [manifest-file] [entry-point] [-C dir] files ...
13:24:15  Options:
13:24:15      -c  create new archive
13:24:15      -t  list table of contents for archive
13:24:15      -x  extract named (or all) files from archive
13:24:15      -u  update existing archive
13:24:15      -v  generate verbose output on standard output
13:24:15      -f  specify archive file name
13:24:15      -m  include manifest information from specified manifest file
13:24:15      -n  perform Pack200 normalization after creating a new archive
13:24:15      -e  specify application entry point for stand-alone application 
13:24:15          bundled into an executable jar file
13:24:15      -0  store only; use no ZIP compression
13:24:15      -P  preserve leading '/' (absolute path) and ".." (parent directory) components from file names
13:24:15      -M  do not create a manifest file for the entries
13:24:15      -i  generate index information for the specified jar files
13:24:15      -C  change to the specified directory and include the following file
13:24:15  If any file is a directory then it is processed recursively.
13:24:15  The manifest file name, the archive file name and the entry point name are
13:24:15  specified in the same order as the 'm', 'f' and 'e' flags.
13:24:15  
13:24:15  Example 1: to archive two class files into an archive called classes.jar: 
13:24:15         jar cvf classes.jar Foo.class Bar.class 
13:24:15  Example 2: use an existing manifest file 'mymanifest' and archive all the
13:24:15             files in the foo/ directory into 'classes.jar': 
13:24:15         jar cvfm classes.jar mymanifest -C foo/ .
13:24:15  
13:24:15  make[2]: *** [/Users/jenkins/workspace/PullRequest-Sanity-JDK8-osx_x86-64_cmprssptrs-OpenJ9/build/macosx-x86_64-normal-server-release/images/lib/ext/dtfj.jar] Error 1
13:24:15  make[2]: *** Waiting for unfinished jobs....
13:24:19  make[1]: *** [images] Error 2
13:24:19  make: *** [images-only] Error 2
```