### PR TITLE
Adding dependency for XML Parser on the Dockerfiles

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -43,7 +43,9 @@ RUN yum -y update \
     cups-devel \
     cmake \
     cpio \
+    curl-devel `# This is being used for git` \
     elfutils-libelf-devel \
+    expat-devel `# This is being used for the xml parser and git` \
     file-devel \
     file-libs \
     flex \
@@ -51,6 +53,7 @@ RUN yum -y update \
     fontconfig-devel \
     freetype-devel \
     gettext \
+    gettext-devel `# This is being used for git` \
     glibc \
     glibc-common \
     glibc-devel \
@@ -69,12 +72,13 @@ RUN yum -y update \
     mpfr-devel \
     numactl-devel \
     ntp \
-    openssl-devel \
+    openssl-devel `# This is being used in git` \
     openssh-server \
     openssh-clients \
     perl-CPAN \
     perl-DBI \
     perl-devel \
+    perl-ExtUtils-MakeMaker `# This is being used for git` \
     perl-GD \
     perl-libwww-perl \
     perl-Time-HiRes \
@@ -84,6 +88,7 @@ RUN yum -y update \
     xorg-x11-server-Xvfb \
     xz \
     zip \
+    zlib-devel `# This is being used for git` \
     libdwarf-devel \
   && yum clean all
 
@@ -119,16 +124,7 @@ RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
   && cpanm XML::Parser
   
 #Building and setting up git version 2.5.3
-RUN yum -y update \
-  && yum -y install \
-    curl-devel \
-    expat-devel \
-    gettext-devel \
-    openssl-devel \
-    zlib-devel \
-    perl-ExtUtils-MakeMaker \
-  && yum clean all \
-  && cd /usr/src \
+RUN cd /usr/src \
   && wget https://www.kernel.org/pub/software/scm/git/git-2.5.3.tar.gz \
   && tar xzf git-2.5.3.tar.gz \
   && rm git-2.5.3.tar.gz \

--- a/buildenv/jenkins/docker-slaves/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/ubuntu16/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
+    libexpat1-dev `# This is being used for the xml parser` \
     g++-7 \
     gcc-7 \
     gdb \

--- a/buildenv/jenkins/docker-slaves/ppc64le/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/ubuntu18/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
+    libexpat1-dev `# This is being used for the xml parser` \
     g++-7 \
     gcc-7 \
     gdb \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
     cmake \
     cpio \
     curl \
+    libexpat1-dev `# This is being used for the xml parser` \
     file \
     gdb \
     git \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu18/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
+    libexpat1-dev `# This is being used for the xml parser` \
     g++-7 \
     gcc-7 \
     gdb \

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     cmake \
     cpio \
     curl \
+    libexpat1-dev `# This is being used for the xml parser` \
     file \
     g++-7 \
     gcc-7 \

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
+    libexpat1-dev `# This is being used for the xml parser` \
     g++-7 \
     gcc-7 \
     gdb \


### PR DESCRIPTION
Missing expat library caused some of the containers to fail their build
Also moved the dependencies for git to the top and identified them

[skip ci]
Related #4870
Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>