### PR TITLE
Move auto slot poisoning function to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -453,6 +453,19 @@ public:
       uint8_t **coldCode,
       bool isMethodHeaderNeeded);
 
+
+   /**
+    * \brief Store a poison value in an auto slot that should have gone dead.  Used for debugging.
+    *
+    * \param[in] currentBlock : block in which the auto slot appears
+    * \param[in] liveAutoSymRef : SymbolReference of auto slot to poison
+    *
+    * \return poisoned store node
+    */
+   TR::Node *generatePoisonNode(
+      TR::Block *currentBlock,
+      TR::SymbolReference *liveAutoSymRef);
+
 private:
 
    enum // Flags


### PR DESCRIPTION
Auto slot poisoning is only used in specialized contexts in OpenJ9.
Add some documentation to the function.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>