### PR TITLE
Run the CryptoTest on AIX for jdk11 and later

### DIFF
--- a/test/functional/cmdLineTests/openssl/playlist.xml
+++ b/test/functional/cmdLineTests/openssl/playlist.xml
@@ -25,7 +25,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>cmdLineTester_CryptoTest</testCaseName>
+		<testCaseName>cmdLineTester_CryptoTest_8</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -45,5 +45,33 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_CryptoTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)openssl.xml$(Q) \
+		-verbose -explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
+	</test>
+
 </playlist>


### PR DESCRIPTION
Depends on
https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/139
https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/19

[ci skip]
