### PR TITLE
Assume J9VM_TASUKI_LOCKS_SINGLE_SLOT is always defined

### DIFF
--- a/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,6 @@
  *******************************************************************************/
 
 #include "j9.h"
-#ifdef J9VM_TASUKI_LOCKS_SINGLE_SLOT
 
 #include "arm/codegen/J9ARMSnippet.hpp"
 
@@ -220,11 +219,6 @@ TR::ARMMonitorExitSnippet::ARMMonitorExitSnippet(
 
 uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
    {
-
-//#if !defined(J9VM_TASUKI_LOCKS_SINGLE_SLOT)
-//   TR_ASSERT(0, "Tasuki double slot lock exit snippet not implemented");
-//#endif
-
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
 
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
@@ -515,5 +509,3 @@ int32_t TR::ARMMonitorExitSnippet::setEstimatedCodeLocation(int32_t estimatedSni
    getSnippetLabel()->setEstimatedCodeLocation(estimatedSnippetStart+len);
    return(estimatedSnippetStart);
    }
-
-#endif

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -80,9 +80,6 @@ uint8_t *TR::PPCMonitorEnterSnippet::emitSnippetBody()
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg()->fe());
 
-#if !defined(J9VM_TASUKI_LOCKS_SINGLE_SLOT)
-   TR_ASSERT(0, "Tasuki double slot lock enter snippet not implemented");
-#endif
    // The 32-bit code for the snippet looks like:
    // incLabel:
    //    rlwinm  threadReg, monitorReg, 0, LOCK_THREAD_PTR_AND_UPPER_COUNT_BIT_MASK
@@ -362,10 +359,6 @@ uint8_t *TR::PPCMonitorExitSnippet::emitSnippetBody()
    {
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg()->fe());
-
-#if !defined(J9VM_TASUKI_LOCKS_SINGLE_SLOT)
-   TR_ASSERT(0, "Tasuki double slot lock exit snippet not implemented");
-#endif
 
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -5516,9 +5516,7 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
          lockSize = 4;
          }
       generateTrg1MemInstruction(cg, opCode, node, monitorReg, new (cg->trHeapMemory()) TR::MemoryReference(baseReg, moffset, lockSize, cg));
-#if defined(J9VM_TASUKI_LOCKS_SINGLE_SLOT)
       generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, ctempReg, 0);
-#endif
       generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmp, node, condReg, monitorReg, metaReg);
 
       if (TR::Compiler->target.cpu.id() >= TR_PPCgp)

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -5522,9 +5522,6 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
 
    if (!node->isReadMonitor() && !reservingLock)
       {
-#ifdef J9VM_TASUKI_LOCKS_DOUBLE_SLOT
-      TR_ASSERT(TR::Compiler->target.is32Bit(), "This code-piece should never be reached");
-#endif
       if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);

--- a/runtime/oti/j9cfg_builder.h
+++ b/runtime/oti/j9cfg_builder.h
@@ -25,9 +25,6 @@
 
 #include "j9cfg.h"
 
-/* The following define specifies what type of locks are used by this VM */
-#define J9VM_TASUKI_LOCKS_SINGLE_SLOT
-
 /* The following define specifies whether or not an instruction to sample the CPU timestamp is supported */
 #if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER)
 #define J9VM_CPU_TIMESTAMP_SUPPORT


### PR DESCRIPTION
This has been true on all platforms for at least 15 years.  There
is no alternative on many platforms, and certainly no means of
testing it.  Fold code assuming it is always defined.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>