### PR TITLE
Function implemented for TR_ResolvedRelocatableJ9JITaaSServerMethod

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -137,7 +137,7 @@ static TR::DataType decodeType(U_32 inType)
       }
    }
 
-static inline UDATA getFieldType(J9ROMConstantPoolItem * cp, I_32 cpIndex)
+UDATA getFieldType(J9ROMConstantPoolItem * cp, I_32 cpIndex)
    {
    J9ROMFieldRef * ref = (J9ROMFieldRef *) (&cp[cpIndex]);
    J9ROMNameAndSignature * nameAndSignature = J9ROMFIELDREF_NAMEANDSIGNATURE(ref);

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -73,6 +73,7 @@ static bool supportsFastJNI(TR_FrontEnd *fe)
 #endif
    }
 
+UDATA getFieldType(J9ROMConstantPoolItem * cp, I_32 cpIndex);
 inline char *nextSignatureArgument(char *currentArgument)
    {
    char *result = currentArgument;
@@ -596,6 +597,7 @@ public:
 
    virtual bool                  storeValidationRecordIfNecessary(TR::Compilation * comp, J9ConstantPool *constantPool, int32_t cpIndex, TR_ExternalRelocationTargetKind reloKind, J9Method *ramMethod, J9Class *definingClass=0);
 
+   static void                   setAttributeResult(bool, bool, uintptr_t, int32_t, int32_t, int32_t, TR::DataType *, bool *, bool *, bool *, void ** );
 protected:
    virtual TR_ResolvedMethod *   createResolvedMethodFromJ9Method(TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats);
 
@@ -607,7 +609,6 @@ protected:
 
    bool                          unresolvedFieldAttributes (int32_t cpIndex, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate);
    bool                          unresolvedStaticAttributes(int32_t cpIndex, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate);
-   void                          setAttributeResult(bool, bool, uintptr_t, int32_t, int32_t, int32_t, TR::DataType *, bool *, bool *, bool *, void ** );
    virtual char *                fieldOrStaticNameChars(int32_t cpIndex, int32_t & len);
 
    J9ExceptionHandler * exceptionHandler();

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -263,14 +263,17 @@ class TR_ResolvedRelocatableJ9JITaaSServerMethod : public TR_ResolvedJ9JITaaSSer
    virtual bool                  isUnresolvedMethodType(int32_t cpIndex) override;
    virtual void *                methodHandleConstant(int32_t cpIndex) override;
    virtual bool                  isUnresolvedMethodHandle(int32_t cpIndex) override;
-   /* No need to override the stringConstant, fieldAttributes and staticAttributes method as the parent method will be sufficient */
    virtual TR_OpaqueClassBlock * classOfStatic(int32_t cpIndex, bool returnClassForAOT = false) override;
    virtual TR_ResolvedMethod *   getResolvedPossiblyPrivateVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP) override;
    virtual bool                  getUnresolvedFieldInCP(I_32 cpIndex) override;
    virtual bool                  getUnresolvedStaticMethodInCP(int32_t cpIndex) override;
    virtual bool                  getUnresolvedSpecialMethodInCP(I_32 cpIndex) override;
    virtual bool                  getUnresolvedVirtualMethodInCP(int32_t cpIndex) override;
-   virtual TR_ResolvedMethod *   getResolvedImproperInterfaceMethod(TR::Compilation * comp, I_32 cpIndex) override { TR_ASSERT(0, "called");  return NULL; }
+   /* No need to override the stringConstant method as the parent method will be sufficient */
+   virtual bool                  fieldAttributes(TR::Compilation * comp, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation) override;
+   virtual bool                  staticAttributes(TR::Compilation * comp, int32_t cpIndex, void * * address,TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation);
+   virtual TR_ResolvedMethod *   getResolvedImproperInterfaceMethod(TR::Compilation * comp, I_32 cpIndex) override;
+
    virtual TR_OpaqueMethodBlock *getNonPersistentIdentifier() override;
    virtual uint8_t *             allocateException(uint32_t, TR::Compilation*) override;
    virtual TR_OpaqueClassBlock  *getDeclaringClassFromFieldOrStatic( TR::Compilation *comp, int32_t cpIndex) override;
@@ -279,10 +282,10 @@ class TR_ResolvedRelocatableJ9JITaaSServerMethod : public TR_ResolvedJ9JITaaSSer
 protected:
    virtual TR_ResolvedMethod *   createResolvedMethodFromJ9Method(TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats) override;
    virtual TR_ResolvedMethod * createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo) override;
-
-   virtual void                  handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override { TR_ASSERT(0, "called");  return; }
-   virtual void                  handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override { TR_ASSERT(0, "called");  return; }
-   virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override { TR_ASSERT(0, "called");  return; }
+   virtual void                  handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
+   virtual void                  handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
+   virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual char *                fieldOrStaticNameChars(int32_t cpIndex, int32_t & len) override;
+   UDATA getFieldType(J9ROMConstantPoolItem * CP, int32_t cpIndex);
    };
 #endif // J9METHODSERVER_H

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -105,7 +105,9 @@ enum J9ServerMessageType
 
    ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 150;
    ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 151;
-
+   ResolvedRelocatableMethod_fieldAttributes = 152;
+   ResolvedRelocatableMethod_staticAttributes = 153;
+   ResolvedRelocatableMethod_getFieldType = 154;
    // For TR_J9ServerVM methods
    VM_isClassLibraryClass = 200;
    VM_isClassLibraryMethod = 201;


### PR DESCRIPTION
Functions implemented
1. getResolvedImproperInterfaceMethod
2. handleUnresolvedStaticMethodInCP
3. handleUnresolvedSpecialMethodInCP
4. handleUnresolvedVirtualMethodInCP
5. fieldAttributes
6. staticAttributes

small bugfix in the TR_ResolvedJ9JITaaSServerMethod::
getResolvedImproperInterfaceMethod

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>