### PR TITLE
Load the zip native library earlier on Windows

### DIFF
--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -137,16 +137,6 @@ standardInit( J9JavaVM *vm, char *dllName)
 		goto _fail;
 	}
 
-	vmFuncs->internalAcquireVMAccess(vmThread);
-	result = (jint)initializeRequiredClasses(vmThread, dllName);
-
-	if (0 == result) {
-		result = vmFuncs->initializeHeapOOMMessage(vmThread);
-	}
-
-	/* CANNOT hold VM Access while calling registerBootstrapLibrary */
-	vmFuncs->internalReleaseVMAccess(vmThread);
-
 	/* Add the correct "zip" natives to the path:
 	 * Configuration	Load Zip
 	 *  Java_6			yes
@@ -155,62 +145,74 @@ standardInit( J9JavaVM *vm, char *dllName)
 	 */
 #ifdef J9VM_OPT_SIDECAR
 #if !defined(J9VM_INTERP_MINIMAL_JCL)
-	if (result == 0) {
+	{
 		UDATA handle = 0;
 		result = (jint)vmFuncs->registerBootstrapLibrary(vm->mainThread, "zip", (J9NativeLibrary **)&handle, FALSE);
 	}
 #endif /* !J9VM_INTERP_MINIMAL_JCL */
 #endif /* J9VM_OPT_SIDECAR */
 
-	vmFuncs->internalAcquireVMAccess(vmThread);
-
-	if (result == 0) {
-		U_32 runtimeFlags = computeJCLRuntimeFlags(vm);
-		result = initializeKnownClasses(vm, runtimeFlags);
-	}
-
-	if (result == 0) {
-		IDATA continueInitialization = TRUE;
-		/* Must do this before initializeAttachedThread */
-		vmFuncs->internalReleaseVMAccess(vmThread);
-
-		TRIGGER_J9HOOK_VM_INITIALIZE_REQUIRED_CLASSES_DONE(vm->hookInterface, vmThread, continueInitialization);
-		if (!continueInitialization) {
-			goto _fail;
-		}
-
-		result = (jint)initializeSystemThreadGroup(vm, (JNIEnv *)vmThread);
-		if (result != JNI_OK) goto _fail;
-
-#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
-		vmFuncs->internalEnterVMFromJNI(vmThread);
-		vmFuncs->internalReleaseVMAccess(vmThread);
-#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-		vmFuncs->initializeAttachedThread(vmThread, threadName, (j9object_t *)threadGroup, FALSE, vmThread);
-
+	if (JNI_OK == result) {
 		vmFuncs->internalAcquireVMAccess(vmThread);
+		
+		result = (jint)initializeRequiredClasses(vmThread, dllName);
+		
+		if (JNI_OK == result) {
+			result = vmFuncs->initializeHeapOOMMessage(vmThread);
+		}
+		
+		if (JNI_OK == result) {
+			U_32 runtimeFlags = computeJCLRuntimeFlags(vm);
+			result = initializeKnownClasses(vm, runtimeFlags);
+		}
+		
+		if (JNI_OK == result) {
+			IDATA continueInitialization = TRUE;
+			/* Must do this before initializeAttachedThread */
+			vmFuncs->internalReleaseVMAccess(vmThread);
 
-		if ((vmThread->currentException != NULL) || (vmThread->threadObject == NULL)) {
-			result = JNI_ERR;
-		} else {
-			vmFuncs->internalFindKnownClass(vmThread,
-				J9VMCONSTANTPOOL_JAVALANGTHREADDEATH,
-				J9_FINDKNOWNCLASS_FLAG_INITIALIZE | J9_FINDKNOWNCLASS_FLAG_NON_FATAL);
-			if (vmThread->currentException) {
+			TRIGGER_J9HOOK_VM_INITIALIZE_REQUIRED_CLASSES_DONE(vm->hookInterface, vmThread, continueInitialization);
+			if (!continueInitialization) {
+				goto _fail;
+			}
+
+			result = (jint)initializeSystemThreadGroup(vm, (JNIEnv *)vmThread);
+			if (JNI_OK != result) {
+				goto _fail;
+			}
+
+	#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+			vmFuncs->internalEnterVMFromJNI(vmThread);
+			vmFuncs->internalReleaseVMAccess(vmThread);
+	#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+			vmFuncs->initializeAttachedThread(vmThread, threadName, (j9object_t *)threadGroup, FALSE, vmThread);
+
+			vmFuncs->internalAcquireVMAccess(vmThread);
+
+			if ((NULL != vmThread->currentException) || (NULL == vmThread->threadObject)) {
 				result = JNI_ERR;
+			} else {
+				vmFuncs->internalFindKnownClass(vmThread,
+					J9VMCONSTANTPOOL_JAVALANGTHREADDEATH,
+					J9_FINDKNOWNCLASS_FLAG_INITIALIZE | J9_FINDKNOWNCLASS_FLAG_NON_FATAL);
+				if (vmThread->currentException) {
+					result = JNI_ERR;
+				}
 			}
 		}
+		vmFuncs->internalReleaseVMAccess(vmThread);
 	}
-	vmFuncs->internalReleaseVMAccess(vmThread);
-
-	if (result != JNI_OK) goto _fail;
+	
+	if (JNI_OK != result) {
+		goto _fail;
+	}
 
 	internalInitializeJavaLangClassLoader((JNIEnv*)vmThread);
 	if (vmThread->currentException) goto _fail;
 
 	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		result = registerJdkInternalReflectConstantPoolNatives((JNIEnv*)vmThread);
-		if (0 != result) {
+		if (JNI_OK != result) {
 			fprintf(stderr, "Failed to register natives for jdk.internal.reflect.ConstantPool\n");
 			goto _fail;
 		}
@@ -256,7 +258,9 @@ standardInit( J9JavaVM *vm, char *dllName)
 
 #ifdef J9VM_INTERP_SIG_QUIT_THREAD
 	result = J9SigQuitStartup(vm);
-	if (result != JNI_OK) goto _fail;
+	if (JNI_OK != result) {
+		goto _fail;
+	}
 #endif
 
 	/*


### PR DESCRIPTION
The change is to get zip.dll loaded earlier
after successfully loading jimage.dll before
invoking GetModuleHandle on Windows

Close: #4098

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>