### PR TITLE
Reenable disableDeferredWipeout also add deleteDirs

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -367,8 +367,8 @@ def build_all() {
                 archive()
             }
         } finally {
-            // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
-            cleanWs notFailBuild: true, disableDeferredWipeout: false
+            // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
+            cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
         }
     }
 }

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,8 +120,8 @@ def test_all() {
             test()
             publish()
         } finally {
-            // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
-            cleanWs notFailBuild: true, disableDeferredWipeout: false
+            // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
+            cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
         }
     }
 }

--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -44,8 +44,8 @@ timeout(time: 10, unit: 'HOURS') {
 
                 buildFile = load 'buildenv/jenkins/common/build'
             } finally {
-                // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
-                cleanWs notFailBuild: true, disableDeferredWipeout: false
+                // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
+                cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
             }
         }
     }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -184,8 +184,8 @@ timeout(time: 12, unit: 'HOURS') {
                     }
                 }
             } finally {
-                // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
-                cleanWs notFailBuild: true, disableDeferredWipeout: false
+                // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
+                cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
             }
         }
         try {

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -43,8 +43,8 @@ timestamps {
                 variableFile.create_job(BUILD_NAME, SDK_VERSION, SPEC, 'build')
             }
         } finally {
-            // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
-            cleanWs notFailBuild: true, disableDeferredWipeout: false
+            // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
+            cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
         }
     }
 


### PR DESCRIPTION
- This will force the job to wait for the WS to be
  deleted rather than let it execute asynchronously.
- Asynchronous delete often leaves the WS not completely
  removed in a folder called JOB_NAME_ws-cleanup_TIMESTAMP.
  Particularily bad on Windows. This has caused us to
  create a cleanup job to the remove all workspaces on
  all nodes. Hopefully this change will elimiate the
  lingering workspaces.

[JENKINS-54225](https://issues.jenkins-ci.org/browse/JENKINS-54225)
Related #3510 #3309
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>