### PR TITLE
Disable HPR support in prepration for removal

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1879,6 +1879,16 @@ J9::Options::fePreProcess(void * base)
       {
       self()->setOption(TR_InlineVeryLargeCompiledMethods);
       }
+
+   // Disable HPR support in preparation for it's removal. After nearly a decade of struggles we are ready to give up
+   // on this feature due to being unable to mould it into a state where it provides general benefit. See issue #4609
+   // for a detailed justification and disucssion on this topic.
+   // 
+   // In preparation for codebase-wide deprecation of this feature, which has founds it's way into many locations, we
+   // first disable the support here such that the mere act of cleanup does not introduce unwanted problems.
+   self()->setOption(TR_DisableHighWordRA);
+   self()->setOption(TR_DisableHPRSpill);
+   self()->setOption(TR_DisableHPRUpgrade);
 #endif
 
    // On big machines we can afford to spend more time compiling

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -200,7 +200,6 @@ TR::S390PrivateLinkage::initS390RealRegisterLinkage()
       freeingSSPDisabled = false;
 
    if (freeingSSPDisabled || disableFreeJITSSP != NULL ||
-       (TR::Compiler->target.is32Bit() && !cg()->supportsHighWordFacility()) ||   // Cannot use FreeSSP on 31-bit without highword tracking
        comp()->getOption(TR_Randomize))                                   // We can generate code for different hardware targets, which are incompatiable.
       {
       sspReal->setState(TR::RealRegister::Locked);


### PR DESCRIPTION
Disable HPR support at the option level in preparation for the
codebase-wide removal of the feature. Disabling support early fixes
several HPR related issues which have been propping up over the last
few months since some initial refactoring was checked in which enabled
fatal assertions which are now catching pre-existing HPR bugs which
have been lurking in the codebase causing runtime issues.

As a tactical fix, disabling HPRs will "fix" all of these problems. A
subsequent PR will perform the codebase-wide cleanup which will enable
us to greatly simplify and make sense of the register allocator on Z.

Fixes: #4526
Fixes: #4747
Issue: #4609

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>