### PR TITLE
Add ValueType support to the MonitorEnter and MonitorExit  bytecodes

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1870,4 +1870,13 @@ J9NLS_VM_ERROR_BYTECODE_OBJECTREF_MUST_BE_VALUE_TYPE.sample_input_2=Foo
 J9NLS_VM_ERROR_BYTECODE_OBJECTREF_MUST_BE_VALUE_TYPE.explanation=The class has specified a bytecode operation that can only be performed on a value type but the object on stack is not a value type.
 J9NLS_VM_ERROR_BYTECODE_OBJECTREF_MUST_BE_VALUE_TYPE.system_action=The JVM will throw a IncompatibleClassChangeError.
 J9NLS_VM_ERROR_BYTECODE_OBJECTREF_MUST_BE_VALUE_TYPE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE=bad object type %2$.*1$s: object that is synchronized is a value type
+# START NON-TRANSLATABLE
+J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE.sample_input_1=3
+J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE.sample_input_2=Foo
+J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE.explanation=The class has specified the bytecode monitorenter or monitorexit operation which cannot be performed on a value type but the object on stack is a value type.
+J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE.system_action=The JVM will throw an IllegalMonitorStateException.
+J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -93,6 +93,9 @@ public class ValueTypeGenerator extends ClassLoader {
 			testWithFieldOnNonValueType(cw, className, fields);
 			testWithFieldOnNull(cw, className, fields);
 			testWithFieldOnNonExistentClass(cw, className, fields);
+			testMonitorEnterOnObject(cw, className, fields);
+			testMonitorExitOnObject(cw, className, fields);
+			testMonitorEnterAndExitWithRefType(cw, className, fields);
 		} else {
 			makeValue(cw, className, makeValueSig, fields, makeMaxLocal);
 			if (!isVerifiable) {
@@ -174,7 +177,53 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitMaxs(1, 2);
 		mv.visitEnd();
 	}
-	
+
+	 /* 
+	  * This function should only be called in the
+	  * TestMonitorEnterOnValueType test and 
+	  * TestMonitorEnterWithRefType test
+	  */
+	private static void testMonitorEnterOnObject(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testMonitorEnterOnObject", "(Ljava/lang/Object;)V", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ALOAD, 0);
+		mv.visitInsn(MONITORENTER);
+		mv.visitInsn(RETURN);
+		mv.visitMaxs(1, 1);
+		mv.visitEnd();
+	}
+
+	 /* 
+	  * This function should only be called in the
+	  * TestMonitorExitOnValueType test and
+	  * TestMonitorExitWithRefType test
+	  */
+	private static void testMonitorExitOnObject(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testMonitorExitOnObject", "(Ljava/lang/Object;)V", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ALOAD, 0);
+		mv.visitInsn(MONITOREXIT);
+		mv.visitInsn(RETURN);
+		mv.visitMaxs(1, 1);
+		mv.visitEnd();
+	}
+
+	 /* 
+	  * This function should only be called in the
+	  * TestMonitorEnterAndExitWithRefType test
+	  */
+	private static void testMonitorEnterAndExitWithRefType(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testMonitorEnterAndExitWithRefType", "(Ljava/lang/Object;)V", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ALOAD, 0);
+		mv.visitInsn(DUP);
+		mv.visitInsn(MONITORENTER);
+		mv.visitInsn(MONITOREXIT);
+		mv.visitInsn(RETURN);
+		mv.visitMaxs(2,1);
+		mv.visitEnd();
+	}
+
 	private static void makeValue(ClassWriter cw, String valueName, String makeValueSig, String[] fields, int makeMaxLocal) {
 		boolean doubleDetected = false;
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "makeValue", "(" + makeValueSig + ")L" + valueName + ";", null, null);

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -397,7 +397,116 @@ public class ValueTypeTests {
 	 *
 	 *	Assert.assertFalse((refType != refType), "An identity (!=) comparison on the same refType should always return false");
 	 *	}
-	 */	
+	 */
+
+    /*    
+	 * Test monitorEnter on valueType
+	 * 
+	 * class TestMonitorEnterOnValueType {
+	 *  long longField
+	 * }
+	 */
+	@Test(priority=2)
+	static public void testMonitorEnterOnValueType() throws Throwable {
+		int x = 0;
+		int y = 0;
+		Object valueType = makePoint2D.invoke(x, y);
+
+		String fields[] = {"longField:J"};
+		Class<?> testMonitorEnterOnValueType = ValueTypeGenerator.generateRefClass("TestMonitorEnterOnValueType", fields);
+		MethodHandle monitorEnterOnValueType = lookup.findStatic(testMonitorEnterOnValueType, "testMonitorEnterOnObject", MethodType.methodType(void.class, Object.class));
+		try {
+			monitorEnterOnValueType.invoke(valueType);
+			Assert.fail("should throw exception. MonitorEnter cannot be used with ValueType");
+		} catch (IllegalMonitorStateException e) {}
+	}
+
+	/*
+	 * Test monitorExit on valueType
+	 * 
+	 * class TestMonitorExitOnValueType {
+	 *  long longField
+	 * }
+	 */
+	@Test(priority=2)
+	static public void testMonitorExitOnValueType() throws Throwable {
+		int x = 1;
+		int y = 1;
+		Object valueType = makePoint2D.invoke(x, y);
+
+		String fields[] = {"longField:J"};
+		Class<?> testMonitorExitOnValueType = ValueTypeGenerator.generateRefClass("TestMonitorExitOnValueType", fields);
+		MethodHandle monitorExitOnValueType = lookup.findStatic(testMonitorExitOnValueType, "testMonitorExitOnObject", MethodType.methodType(void.class, Object.class));
+		try {
+			monitorExitOnValueType.invoke(valueType);
+			Assert.fail("should throw exception. MonitorExit cannot be used with ValueType");
+		} catch (IllegalMonitorStateException e) {}
+	}
+
+	/*
+	 * Test monitorEnter with refType
+	 * 
+	 * class TestMonitorEnterWithRefType {
+	 *  long longField
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testMonitorEnterWithRefType() throws Throwable {
+		int x = 0;
+		Object refType = (Object) x;
+		
+		String fields[] = {"longField:J"};
+		Class<?> testMonitorEnterWithRefType = ValueTypeGenerator.generateRefClass("TestMonitorEnterWithRefType", fields);
+		MethodHandle monitorEnterWithRefType = lookup.findStatic(testMonitorEnterWithRefType, "testMonitorEnterOnObject", MethodType.methodType(void.class, Object.class));
+		try {
+			monitorEnterWithRefType.invoke(refType);
+		} catch (IllegalMonitorStateException e) { 
+			Assert.fail("shouldn't throw exception. MonitorEnter should be used with refType");
+		}
+	}
+
+	/*
+	 * Test monitorExit with refType
+	 * 
+	 * class TestMonitorExitWithRefType {
+	 *  long longField
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testMonitorExitWithRefType() throws Throwable {
+		int x = 1;
+		Object refType = (Object) x;
+		
+		String fields[] = {"longField:J"};
+		Class<?> testMonitorExitWithRefType = ValueTypeGenerator.generateRefClass("TestMonitorExitWithRefType", fields);
+		MethodHandle monitorExitWithRefType = lookup.findStatic(testMonitorExitWithRefType, "testMonitorExitOnObject", MethodType.methodType(void.class, Object.class));
+		try {
+			monitorExitWithRefType.invoke(refType);
+			Assert.fail("should throw exception. MonitorExit doesn't have a matching MonitorEnter");
+		} catch (IllegalMonitorStateException e) {}
+	}
+
+	/*
+	 * Test monitorEnterAndExit with refType
+	 * 
+	 * class TestMonitorEnterAndExitWithRefType {
+	 *  long longField
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testMonitorEnterAndExitWithRefType() throws Throwable {
+		int x = 2;
+		Object refType = (Object) x;
+		
+		String fields[] = {"longField:J"};
+		Class<?> testMonitorEnterAndExitWithRefType = ValueTypeGenerator.generateRefClass("TestMonitorEnterAndExitWithRefType", fields);
+		MethodHandle monitorEnterAndExitWithRefType = lookup.findStatic(testMonitorEnterAndExitWithRefType, "testMonitorEnterAndExitWithRefType", MethodType.methodType(void.class, Object.class));
+		try {
+			monitorEnterAndExitWithRefType.invoke(refType);
+		} catch (IllegalMonitorStateException e) {
+			Assert.fail("shouldn't throw exception. MonitorEnter and MonitorExit should be used with refType");
+		}
+	}
 	
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {
 		try {


### PR DESCRIPTION
we need to modify the behaviour of these two bytecodes when value types are involved:

- These two bytecodes should throw illegalMonitorStateException when they are used on valueTypes
- others remain the same for nonValueType object
- new nls message are added for the exception when these bytecodes are used on valuetypes
- new tests are added: monitorenter on valuetypes, monitorexit on valuetypes, monitorenter on nonvaluetypes, monitorexit on nonvaluetypes, and monitorenterandmonitorexit on nonvaluetypes

Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>