### PR TITLE
Prevent crash trying to access module in JDK 8

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -887,6 +887,8 @@ resolveInstanceFieldRefInto(J9VMThread *vmStruct, J9Method *method, J9ConstantPo
 			targetClass = resolvedClass;
 			goto illegalAccess;
 		}
+		/* Reset checkResult to the default error case */
+		checkResult = J9_VISIBILITY_NON_MODULE_ACCESS_ERROR;
 
 		/* Get the field address. */
 		nameAndSig = J9ROMFIELDREF_NAMEANDSIGNATURE(romFieldRef);


### PR DESCRIPTION
There is a path through `resolveInstanceFieldRefInto` that can end up
calling `illegalAccessMessage()` and passing `J9_VISIBILITY_ALLOWED`
which results in attempting to dereference modules.

This resets the default value of the `checkResult` local variable
to error case after its first use.

Native stack trace from the crash:
```
#13 <signal handler called>
#14 0x00007fa6e992d030 in getModuleNameUTF () at lookupmethod.c:1007
#15 illegalAccessMessage () at lookupmethod.c:1140
#16 0x00007fa6e99369cc in resolveInstanceFieldRefInto () at resolvesupport.cpp:935
#17 0x00007fa6e99369f8 in resolveInstanceFieldRef () at resolvesupport.cpp:1005
#18 0x00007fa6e98b2d53 in getfieldLogic () at BytecodeInterpreter.hpp:6344
#19 getfield () at BytecodeInterpreter.hpp:6408
#20 VM_BytecodeInterpreter::run () at BytecodeInterpreter.hpp:9904
```

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>