### PR TITLE
 Use standardized branch range queries on Power

### DIFF
--- a/runtime/compiler/p/codegen/InterfaceCastSnippet.cpp
+++ b/runtime/compiler/p/codegen/InterfaceCastSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,14 +116,16 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
          opcode.setOpCodeValue(TR::InstOpCode::b);
          cursor = opcode.copyBinaryToBuffer(cursor);
          branchDistance = (intptrj_t)getReStartLabel()->getCodeLocation() - (intptrj_t)cursor;
-         TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+         TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)getReStartLabel()->getCodeLocation(), (intptrj_t)cursor),
+                   "backward jump in Interface Cache is too long\n");
          *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
          cursor += PPC_INSTRUCTION_LENGTH;
 
          opcode.setOpCodeValue(TR::InstOpCode::b);
          cursor = opcode.copyBinaryToBuffer(cursor);
          branchDistance = (intptrj_t)_doneLabel->getCodeLocation() - (intptrj_t)cursor;
-         TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+         TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_doneLabel->getCodeLocation(), (intptrj_t)cursor),
+                   "backward jump in Interface Cache is too long\n");
          *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
          cursor += PPC_INSTRUCTION_LENGTH;
          }
@@ -139,14 +141,16 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
          opcode.setOpCodeValue(TR::InstOpCode::b);
          cursor = opcode.copyBinaryToBuffer(cursor);
          branchDistance = (intptrj_t)getDoneLabel()->getCodeLocation() - (intptrj_t)cursor;
-         TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+         TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)getDoneLabel()->getCodeLocation(), (intptrj_t)cursor),
+                   "backward jump in Interface Cache is too long\n");
          *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
          cursor += PPC_INSTRUCTION_LENGTH;
 
          opcode.setOpCodeValue(TR::InstOpCode::b);
          cursor = opcode.copyBinaryToBuffer(cursor);
          branchDistance = (intptrj_t)_callLabel->getCodeLocation() - (intptrj_t)cursor;
-         TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+         TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_callLabel->getCodeLocation(), (intptrj_t)cursor),
+                   "backward jump in Interface Cache is too long\n");
          *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
          cursor += PPC_INSTRUCTION_LENGTH;
          }
@@ -256,7 +260,8 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
          opcode.setOpCodeValue(TR::InstOpCode::b);
          cursor = opcode.copyBinaryToBuffer(cursor);
          branchDistance = (intptrj_t)getReStartLabel()->getCodeLocation() - (intptrj_t)cursor;
-         TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+         TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)getReStartLabel()->getCodeLocation(), (intptrj_t)cursor),
+                   "backward jump in Interface Cache is too long\n");
          *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
          cursor += PPC_INSTRUCTION_LENGTH;
       }
@@ -272,7 +277,8 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
          opcode.setOpCodeValue(TR::InstOpCode::b);
          cursor = opcode.copyBinaryToBuffer(cursor);
          branchDistance = (intptrj_t)_callLabel->getCodeLocation() - (intptrj_t)cursor;
-         TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+         TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_callLabel->getCodeLocation(), (intptrj_t)cursor),
+                   "backward jump in Interface Cache is too long\n");
          *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
          cursor += PPC_INSTRUCTION_LENGTH;
       }
@@ -312,14 +318,16 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
             opcode.setOpCodeValue(TR::InstOpCode::b);
             cursor = opcode.copyBinaryToBuffer(cursor);
             branchDistance = (intptrj_t)_trueLabel->getCodeLocation() - (intptrj_t)cursor;
-            TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+            TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_trueLabel->getCodeLocation(), (intptrj_t)cursor),
+                      "backward jump in Interface Cache is too long\n");
             *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
             cursor += PPC_INSTRUCTION_LENGTH;
 
             opcode.setOpCodeValue(TR::InstOpCode::b);
             cursor = opcode.copyBinaryToBuffer(cursor);
             branchDistance = (intptrj_t)_falseLabel->getCodeLocation() - (intptrj_t)cursor;
-            TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+            TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_falseLabel->getCodeLocation(), (intptrj_t)cursor),
+                      "backward jump in Interface Cache is too long\n");
             *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
             cursor += PPC_INSTRUCTION_LENGTH;
             }
@@ -328,7 +336,8 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
             opcode.setOpCodeValue(TR::InstOpCode::b);
             cursor = opcode.copyBinaryToBuffer(cursor);
             branchDistance = (intptrj_t)_doneLabel->getCodeLocation() - (intptrj_t)cursor;
-            TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+            TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_doneLabel->getCodeLocation(), (intptrj_t)cursor),
+                      "backward jump in Interface Cache is too long\n");
             *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
             cursor += PPC_INSTRUCTION_LENGTH;
             }
@@ -361,14 +370,16 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
             opcode.setOpCodeValue(TR::InstOpCode::b);
             cursor = opcode.copyBinaryToBuffer(cursor);
             branchDistance = (intptrj_t)_trueLabel->getCodeLocation() - (intptrj_t)cursor;
-            TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+            TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_trueLabel->getCodeLocation(), (intptrj_t)cursor),
+                      "backward jump in Interface Cache is too long\n");
             *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
             cursor += PPC_INSTRUCTION_LENGTH;
 
             opcode.setOpCodeValue(TR::InstOpCode::b);
             cursor = opcode.copyBinaryToBuffer(cursor);
             branchDistance = (intptrj_t)_falseLabel->getCodeLocation() - (intptrj_t)cursor;
-            TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+            TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_falseLabel->getCodeLocation(), (intptrj_t)cursor),
+                      "backward jump in Interface Cache is too long\n");
             *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
             cursor += PPC_INSTRUCTION_LENGTH;
             }
@@ -377,7 +388,8 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
             opcode.setOpCodeValue(TR::InstOpCode::b);
             cursor = opcode.copyBinaryToBuffer(cursor);
             branchDistance = (intptrj_t)_doneLabel->getCodeLocation() - (intptrj_t)cursor;
-            TR_ASSERT(branchDistance>=BRANCH_BACKWARD_LIMIT, "backward jump in Interface Cache is too long\n");
+            TR_ASSERT(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)_doneLabel->getCodeLocation(), (intptrj_t)cursor),
+                      "backward jump in Interface Cache is too long\n");
             *(int32_t *)cursor |= (branchDistance & 0x03fffffc);
             cursor += PPC_INSTRUCTION_LENGTH;
             }

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -322,7 +322,9 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
 
 bool TR_PPCRelocationTarget::useTrampoline(uint8_t * helperAddress, uint8_t *baseLocation)
    {
-   return !(((IDATA)(helperAddress - baseLocation) <=BRANCH_FORWARD_LIMIT) && ((IDATA)(helperAddress - baseLocation) >=BRANCH_BACKWARD_LIMIT));
+   return
+      !TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)helperAddress, (intptrj_t)baseLocation) ||
+      TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines);
    }
 
 uint8_t *

--- a/runtime/compiler/p/runtime/Recomp.cpp
+++ b/runtime/compiler/p/runtime/Recomp.cpp
@@ -130,7 +130,6 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
    TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
    int32_t   bytesToSaveAtStart = 0;
    int32_t   *patchAddr, newInstr;
-   intptrj_t distance;
 
    if (linkageInfo->isCountingMethodBody())
       {
@@ -139,15 +138,16 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
       // which expects the new startPC.
 
       patchAddr = (int32_t *)((uint8_t *)oldStartPC + getJitEntryOffset(linkageInfo) + OFFSET_COUNTING_BRANCH_FROM_JITENTRY - 4);
-      distance  = (uint8_t *)runtimeHelperValue(TR_PPCcountingPatchCallSite) - (uint8_t *)patchAddr;
-      if (!(distance<=BRANCH_FORWARD_LIMIT && distance>=BRANCH_BACKWARD_LIMIT))
+      intptrj_t helperAddress = (intptrj_t)runtimeHelperValue(TR_PPCcountingPatchCallSite);
+      if (!TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(helperAddress, (intptrj_t)patchAddr) ||
+          TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines))
 	 {
-         distance = TR::CodeCacheManager::instance()->findHelperTrampoline(TR_PPCcountingPatchCallSite, (void *)patchAddr) - (intptrj_t)patchAddr;
-         TR_ASSERT(distance<=BRANCH_FORWARD_LIMIT && distance>=BRANCH_BACKWARD_LIMIT,
-                "CodeCache is more than 32MB.\n");
+         helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(TR_PPCcountingPatchCallSite, (void *)patchAddr);
+         TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(helperAddress, (intptrj_t)patchAddr),
+                         "Helper address is out of range");
 	 }
 
-      newInstr = 0x48000001 | (distance & 0x03FFFFFC);
+      newInstr = 0x48000001 | ((helperAddress - (intptrj_t)patchAddr) & 0x03FFFFFC);
       *patchAddr = newInstr;
       ppcCodeSync((uint8_t *)patchAddr, 4);
       bytesToSaveAtStart = getJitEntryOffset(linkageInfo) + OFFSET_COUNTING_BRANCH_FROM_JITENTRY;
@@ -157,15 +157,16 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
       // Turn the call to samplingMethodRecompile into a call to samplingPatchCallSite
 
       patchAddr = (int32_t *)((uint8_t *)oldStartPC + OFFSET_SAMPLING_BRANCH_FROM_STARTPC);
-      distance  = (uint8_t *)runtimeHelperValue(TR_PPCsamplingPatchCallSite) - (uint8_t *)patchAddr;
-      if (!(distance<=BRANCH_FORWARD_LIMIT && distance>=BRANCH_BACKWARD_LIMIT))
+      intptrj_t helperAddress = (intptrj_t)runtimeHelperValue(TR_PPCsamplingPatchCallSite);
+      if (!TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(helperAddress, (intptrj_t)patchAddr) ||
+          TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines))
 	 {
-         distance = TR::CodeCacheManager::instance()->findHelperTrampoline(TR_PPCsamplingPatchCallSite, (void *)patchAddr) - (intptrj_t)patchAddr;
-         TR_ASSERT(distance<=BRANCH_FORWARD_LIMIT && distance>=BRANCH_BACKWARD_LIMIT,
-                "CodeCache is more than 32MB.\n");
+         helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(TR_PPCsamplingPatchCallSite, (void *)patchAddr);
+         TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(helperAddress, (intptrj_t)patchAddr),
+                         "Helper address is out of range");
 	 }
 
-      newInstr = 0x48000001 | (distance & 0x03FFFFFC);
+      newInstr = 0x48000001 | ((helperAddress - (intptrj_t)patchAddr) & 0x03FFFFFC);
       *patchAddr = newInstr;
       ppcCodeSync((uint8_t *)patchAddr, 4);
 
@@ -181,7 +182,7 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
    bool codeMemoryWasAlreadyReleased = linkageInfo->hasBeenRecompiled(); // HCR - can recompile the same body twice
    linkageInfo->setHasBeenRecompiled();
 
-   // asheikh 2005-05-05: Code Cache Reclamation does not work on ppc
+   // Code Cache Reclamation does not work on ppc
    // without counting method bodies.  _countingPatchCallSite still refers
    // to the methodInfo poitner in the snippet area.
    if (linkageInfo->isSamplingMethodBody() && !codeMemoryWasAlreadyReleased)

--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,9 +42,6 @@
 #define TRAMPOLINE_SIZE       16
 #define OFFSET_IPIC_TO_CALL   32
 #endif
-
-#define BRANCH_FORWARD_LIMIT      (0x01fffffc)
-#define BRANCH_BACKWARD_LIMIT     ((int32_t)0xfe000000)
 
 extern TR_Processor portLibCall_getProcessorType();
 
@@ -323,7 +320,8 @@ bool ppcCodePatching(void *method, void *callSite, void *currentPC, void *curren
       distance = entryAddress - (uint8_t *)callSite;
       currentDistance = ((oldBits << 6) >> 6) & 0xfffffffc;
       oldBits &= 0xfc000003;
-      if (TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines) || distance>BRANCH_FORWARD_LIMIT || distance<BRANCH_BACKWARD_LIMIT)
+      if (TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines) ||
+          !TR::Compiler->target.cpu.isTargetWithinIFormBranchRange((intptrj_t)entryAddress, (intptrj_t)callSite))
          {
          if (currentPC == newPC)
             {
@@ -495,8 +493,6 @@ void ppcCodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *
    }
 
 #undef TRAMPOLINE_SIZE
-#undef BRANCH_FORWARD_LIMIT
-#undef BRANCH_BACKWARD_LIMIT
 
 #endif /*(TR_TARGET_POWER)*/
 
@@ -933,7 +929,7 @@ void s390zOS64CreateHelperTrampoline(void *trampPtr, int32_t numHelpers)
 
       static bool enableIIHF = (feGetEnv("TR_IIHF") != NULL);
 
-      if (!enableIIHF) 
+      if (!enableIIHF)
          {
          // Trampoline Code:
          // zOS Linkage rEP = r15.
@@ -1111,7 +1107,7 @@ bool s390zOS64CodePatching(void *method, void *callSite, void *currentPC, void *
             s390zOS64CreateMethodTrampoline(newTramp, newPC, method);
             }
          else
-            {  
+            {
             // Patch the existing trampoline.
             // Should not require Self-loops in patching since trampolines addresses
             // should be aligned by 8-bytes, and STG is atomic.
@@ -1228,7 +1224,7 @@ void s390zLinux64CreateHelperTrampoline(void *trampPtr, int32_t numHelpers)
 
       if (enableIIHF)
          {
-         //Alternative Trampoline code 
+         //Alternative Trampoline code
          // IIHF rEP addr
          // IILF rEP addr
          // BRC  rEP
@@ -1236,7 +1232,7 @@ void s390zLinux64CreateHelperTrampoline(void *trampPtr, int32_t numHelpers)
          uint32_t low = (uint32_t)helperAddr;
          uint32_t high = (uint32_t)(helperAddr >> 32);
 
-         // IIHF rEP, mAddr;	  
+         // IIHF rEP, mAddr;
          *(int16_t *)buffer = 0xC008 + (rEP << 4);
          buffer += sizeof(int16_t);
          *(int32_t *)buffer = 0x00000000 + high;
@@ -1299,7 +1295,7 @@ void s390zLinux64CreateMethodTrampoline(void *trampPtr, void *startPC, void *met
    intptrj_t dispatcher = (intptrj_t)((uint8_t *) startPC + linkInfo->getReservedWord());
 
    static bool enableIIHF = (feGetEnv("TR_IIHF") != NULL);
-  
+
    if (enableIIHF)
       {
       //Alternative Trampoline code
@@ -1355,7 +1351,7 @@ void s390zLinux64CreateMethodTrampoline(void *trampPtr, void *startPC, void *met
       // DC mAddr
       *(intptrj_t *)buffer = dispatcher;
       buffer += sizeof(intptrj_t);
-      }   
+      }
    }
 
 // zLinux64 Code Patching.


### PR DESCRIPTION
* Use the standard CodeGenerator query `directCallRequiresTrampolines` to
determine the need for trampolines for direct calls and helpers.

* Use platform-specific CPU queries to test call or branch instruction ranges
when a CodeGenerator object is not available.

* Remove forward and backward branch range macros

Signed-off-by: Daryl Maier <maier@ca.ibm.com>