### PR TITLE
JDK12 equals() & hashCode() can't be final methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -342,7 +342,7 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return true if the specified object is equal to this VarHandle, false otherwise
 	 */
 	@Override
-	public final boolean equals(Object obj) {
+	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;
 		}
@@ -387,7 +387,7 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return a hash for this VarHandle
 	 */
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		if (hashCode == 0) {
 			hashCode = fieldType.hashCode();
 			for (Class<?> c : coordinateTypes) {


### PR DESCRIPTION
`JDK12` `equals()` & `hashCode()` can't be `final` methods

Remove `final` modifier from `equals()` & `hashCode()` methods which is required by Java specification.

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>