### PR TITLE
Remove definition and uses of J9VM_JAVA9_BUILD

### DIFF
--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,16 +42,6 @@ extern "C" {
 #define EsExtraVersionString ""
 
 #define JAVA_SPEC_VERSION ${uma.spec.properties.JAVA_SPEC_VERSION.value}
-
-#if defined(J9VM_JAVA9_BUILD)
-#  error J9VM_JAVA9_BUILD is already defined
-#elif (JAVA_SPEC_VERSION >= 10) || ((JAVA_SPEC_VERSION == 9) && defined(OPENJ9_BUILD))
-#  define J9VM_JAVA9_BUILD 181
-#elif JAVA_SPEC_VERSION == 9
-#  define J9VM_JAVA9_BUILD 148
-#else
-#  define J9VM_JAVA9_BUILD 0
-#endif
 
 /*  Note: The following defines record flags used to build VM.  */
 /*  Changing them here does not remove the feature and may cause linking problems. */

--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,15 +43,6 @@ extern "C" {
 #define EsExtraVersionString ""
 
 #define JAVA_SPEC_VERSION ${JAVA_SPEC_VERSION}
-
-#if defined(J9VM_JAVA9_BUILD)
-#  error J9VM_JAVA9_BUILD is already defined
-#elif JAVA_SPEC_VERSION >= 9
-/* Cmake-enabled builds only work with the latest of each Java version: For Java 9 that means b165. */
-#  define J9VM_JAVA9_BUILD 165
-#else
-#  define J9VM_JAVA9_BUILD 0
-#endif
 
 /* Note: The following defines record flags used to build the VM. */
 /* Changing them here does not remove the feature and may cause linking problems. */

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -291,7 +291,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_IsVMGeneratedMethodIx@12"/>
 		<export name="JVM_GetTemporaryDirectory"/>
 		<export name="_JVM_CopySwapMemory@44"/>
+	</exports>
 
+	<exports group="jdk11">
 		<!-- Additions for Java 9 (Modularity) -->
 		<export name="JVM_DefineModule"/>
 		<export name="JVM_AddModuleExports"/>
@@ -325,9 +327,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 		<!-- Additions for Java 9 (General) -->
 		<export name="_JVM_GetNanoTimeAdjustment@16"/>
-	</exports>
 
-	<exports group="jdk11">
+		<!-- Additions for Java 11 (General) -->
 		<export name="JVM_BeforeHalt"/>
 		<export name="JVM_GetNestHost"/>
 		<export name="JVM_GetNestMembers"/>

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -55,7 +55,6 @@
  * a) If VMAccess is required, it assumes the caller has already done so
  * b) If performing a hash operation, it assumes the caller has already locked vm->classLoaderModuleAndLocationMutex
  */
-#if J9VM_JAVA9_BUILD >= 156
 static UDATA hashPackageTableDelete(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName);
 static J9Package * createPackage(J9VMThread * currentThread, J9Module * fromModule, const char *package);
 static void freePackageDefinition(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName);
@@ -74,26 +73,6 @@ static void trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module
 static void trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fromModule, const char *package);
 static void trcModulesAddModuleExports(J9VMThread * currentThread, J9Module * fromModule, const char *package, J9Module * toModule);
 static void trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, const char *package);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-static UDATA hashPackageTableDelete(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName);
-static J9Package * createPackage(J9VMThread * currentThread, J9Module * fromModule, j9object_t package);
-static void freePackageDefinition(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName);
-static BOOLEAN removePackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object_t packageName);
-static BOOLEAN addPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object_t package);
-static UDATA addMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, jobjectArray packages);
-static void removeMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, jobjectArray packages, U_32 packagesIndex);
-static UDATA addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, jobjectArray packages, jstring version);
-static BOOLEAN isPackageDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName);
-static BOOLEAN areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, jobjectArray packages);
-static UDATA exportPackageToAll(J9VMThread * currentThread, J9Module * fromModule, jstring package);
-static UDATA exportPackageToAllUnamed(J9VMThread * currentThread, J9Module * fromModule, jstring package);
-static UDATA exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, jstring package, J9Module * toModule);
-static void trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9object_t package);
-static void trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModule, jstring package);
-static void trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fromModule, jstring package);
-static void trcModulesAddModuleExports(J9VMThread * currentThread, J9Module * fromModule, jstring package, J9Module * toModule);
-static void trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring package);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 static UDATA hashTableAtPut(J9HashTable * table, void * value, BOOLEAN collisionIsFailure);
 static void throwExceptionHelper(J9VMThread * currentThread, UDATA errCode);
 static void freePackage(J9VMThread * currentThread, J9Package * j9package);
@@ -140,11 +119,7 @@ hashTableAtPut(J9HashTable * table, void * value, BOOLEAN collisionIsFailure)
 }
 
 static UDATA
-#if J9VM_JAVA9_BUILD >= 156
 hashPackageTableDelete(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-hashPackageTableDelete(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9HashTable * table = classLoader->packageHashTable;
 	J9Package package = {0};
@@ -212,11 +187,7 @@ freePackage(J9VMThread * currentThread, J9Package * j9package)
 }
 
 static J9Package *
-#if J9VM_JAVA9_BUILD >= 156
 createPackage(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-createPackage(J9VMThread * currentThread, J9Module * fromModule, j9object_t package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9JavaVM * const vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
@@ -317,11 +288,7 @@ createModule(J9VMThread * currentThread, j9object_t moduleObject, J9ClassLoader 
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 freePackageDefinition(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-freePackageDefinition(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9Package * j9package = hashPackageTableAt(currentThread, classLoader, packageName);
 
@@ -331,11 +298,7 @@ freePackageDefinition(J9VMThread * currentThread, J9ClassLoader * classLoader, j
 }
 
 static BOOLEAN
-#if J9VM_JAVA9_BUILD >= 156
 removePackageDefinition(J9VMThread * currentThread, J9Module * fromModule, const char *packageName)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-removePackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object_t packageName)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9ClassLoader * const classLoader = fromModule->classLoader;
 
@@ -347,40 +310,19 @@ removePackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9obj
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9object_t package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
-#if J9VM_JAVA9_BUILD < 156
-	char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-	char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, package, J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
-#endif /* J9VM_JAVA9_BUILD < 156 */
 
 	if (NULL != moduleNameUTF) {
 		if (0 == strcmp(moduleNameUTF, JAVA_BASE_MODULE)) {
-#if J9VM_JAVA9_BUILD >= 156
 			Trc_MODULE_creation_package(currentThread, package, "java.base");
-#else
-			if (NULL != packageNameUTF) {
-				Trc_MODULE_creation_package(currentThread, packageNameUTF, "java.base");
-			}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		} else {
-#if J9VM_JAVA9_BUILD >= 156
 			Trc_MODULE_creation_package(currentThread, package, moduleNameUTF);
-#else
-			if (NULL != packageNameUTF) {
-				Trc_MODULE_creation_package(currentThread, packageNameUTF, moduleNameUTF);
-			}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		}
 		if (moduleNameBuf != moduleNameUTF) {
 			j9mem_free_memory(moduleNameUTF);
@@ -388,20 +330,10 @@ trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9o
 	} else {
 		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 	}
-
-#if J9VM_JAVA9_BUILD < 156
-	if (packageNameBuf != packageNameUTF) {
-		j9mem_free_memory(packageNameUTF);
-	}
-#endif /* J9VM_JAVA9_BUILD < 156 */
 }
 
 static BOOLEAN
-#if J9VM_JAVA9_BUILD >= 156
 addPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-addPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object_t package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9ClassLoader * const classLoader = fromModule->classLoader;
 
@@ -425,21 +357,13 @@ addPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 removeMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, const char* const* packages, U_32 packagesIndex)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-removeMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, jobjectArray packages, U_32 packagesIndex)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	BOOLEAN stopLoop = FALSE;
 	U_32 i = packagesIndex;
 
 	while (!stopLoop) {
-#if J9VM_JAVA9_BUILD >= 156
 		const char *packageName = packages[i];
-#else /* J9VM_JAVA9_BUILD >= 156 */
-		j9object_t packageName = J9JAVAARRAYOFOBJECT_LOAD(currentThread, J9_JNI_UNWRAP_REFERENCE(packages), i);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 
 		Assert_SC_true(removePackageDefinition(currentThread, fromModule, packageName));
 
@@ -449,30 +373,17 @@ removeMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, j
 }
 
 static UDATA
-#if J9VM_JAVA9_BUILD >= 156
 addMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, const char* const* packages, U_32 numPackages)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-addMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, jobjectArray packages)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	UDATA retval = ERRCODE_SUCCESS;
 
 	if (NULL != packages) {
-#if J9VM_JAVA9_BUILD >= 156
 		U_32 const arrayLength = numPackages;
-#else /* J9VM_JAVA9_BUILD >= 156 */
-		j9object_t packageArray = J9_JNI_UNWRAP_REFERENCE(packages);
-		U_32 const arrayLength = J9INDEXABLEOBJECT_SIZE(currentThread, packageArray);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		if (0 != arrayLength) {
 			U_32 i = 0;
 
 			for (i = 0; i < arrayLength; i++) {
-#if J9VM_JAVA9_BUILD >= 156
 				const char *packageName = packages[i];
-#else /* J9VM_JAVA9_BUILD >= 156 */
-				j9object_t packageName = J9JAVAARRAYOFOBJECT_LOAD(currentThread, packageArray, i);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 				if (!addPackageDefinition(currentThread, fromModule, packageName)) {
 					J9ClassLoader * const classLoader = fromModule->classLoader;
 
@@ -499,29 +410,17 @@ addMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, jobj
 }
 
 static UDATA
-#if J9VM_JAVA9_BUILD >= 156
 addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, const char* const* packages, U_32 numPackages, jstring version)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, jobjectArray packages, jstring version)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9ClassLoader * const classLoader = fromModule->classLoader;
 
 	UDATA retval = ERRCODE_GENERAL_FAILURE;
-#if J9VM_JAVA9_BUILD >= 156
 	if (!areNoPackagesDefined(currentThread, classLoader, packages, numPackages)) {
-#else /* J9VM_JAVA9_BUILD >= 156 */
-	if (!areNoPackagesDefined(currentThread, classLoader, packages)) {
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		retval = ERRCODE_PACKAGE_ALREADY_DEFINED;
 	} else if (isModuleDefined(currentThread, fromModule)) {
 		retval = ERRCODE_MODULE_ALREADY_DEFINED;
 	} else {
-#if J9VM_JAVA9_BUILD >= 156
 		retval = addMulPackageDefinitions(currentThread, fromModule, packages, numPackages);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-		retval = addMulPackageDefinitions(currentThread, fromModule, packages);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		if (ERRCODE_SUCCESS == retval) {
 			BOOLEAN const success = (0 == hashTableAtPut(classLoader->moduleHashTable, (void*)&fromModule, TRUE));
 			if (NULL != version) {
@@ -530,12 +429,7 @@ addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, jobjectAr
 			if (!success) {
 				/* If we failed to add the module to the hash table */
 				if (NULL != packages) {
-#if J9VM_JAVA9_BUILD >= 156
 					removeMulPackageDefinitions(currentThread, fromModule, packages, numPackages);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-					U_32 const arrayLength = J9INDEXABLEOBJECT_SIZE(currentThread, J9_JNI_UNWRAP_REFERENCE(packages));
-					removeMulPackageDefinitions(currentThread, fromModule, packages, arrayLength);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 				}
 
 				retval = ERRCODE_HASHTABLE_OPERATION_FAILED;
@@ -547,11 +441,7 @@ addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, jobjectAr
 }
 
 static BOOLEAN
-#if J9VM_JAVA9_BUILD >= 156
 isPackageDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-isPackageDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9Package const * target = NULL;
 
@@ -561,29 +451,16 @@ isPackageDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, j9obje
 }
 
 static BOOLEAN
-#if J9VM_JAVA9_BUILD >= 156
 areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char* const* packages, U_32 numPackages)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, jobjectArray packages)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	BOOLEAN success = TRUE;
 
 	if (NULL != packages) {
-#if J9VM_JAVA9_BUILD >= 156
 		U_32 const arrayLength = numPackages;
-#else /* J9VM_JAVA9_BUILD >= 156 */
-		j9object_t packageArray = J9_JNI_UNWRAP_REFERENCE(packages);
-		U_32 const arrayLength = J9INDEXABLEOBJECT_SIZE(currentThread, packageArray);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		if (0 != arrayLength) {
 			U_32 i = 0;
 			for (i = 0; i < arrayLength; i++) {
-#if J9VM_JAVA9_BUILD >= 156
 				const char *packageName = packages[i];
-#else /* J9VM_JAVA9_BUILD >= 156 */
-				j9object_t packageName = J9JAVAARRAYOFOBJECT_LOAD(currentThread, packageArray, i);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 				if (isPackageDefined(currentThread, classLoader, packageName)) {
 					success = FALSE;
 					break;
@@ -596,11 +473,7 @@ areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, jo
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModule, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
@@ -608,19 +481,7 @@ trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModul
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
-#if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all(currentThread, package, fromModuleNameUTF);
-#else
-		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
-		if (NULL != packageNameUTF) {
-			Trc_MODULE_add_module_exports_to_all(currentThread, packageNameUTF, fromModuleNameUTF);
-			if (packageNameBuf != packageNameUTF) {
-				j9mem_free_memory(packageNameUTF);
-			}
-		}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		if (fromModuleNameBuf != fromModuleNameUTF) {
 			j9mem_free_memory(fromModuleNameUTF);
 		}
@@ -628,18 +489,10 @@ trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModul
 }
 
 static UDATA
-#if J9VM_JAVA9_BUILD >= 156
 exportPackageToAll(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-exportPackageToAll(J9VMThread * currentThread, J9Module * fromModule, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	UDATA retval = ERRCODE_GENERAL_FAILURE;
-#if J9VM_JAVA9_BUILD >= 156
 	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, package, &retval);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, J9_JNI_UNWRAP_REFERENCE(package), &retval);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 	if (NULL != j9package) {
 		j9package->exportToAll = TRUE;
 		if (TrcEnabled_Trc_MODULE_add_module_exports_to_all) {
@@ -651,11 +504,7 @@ exportPackageToAll(J9VMThread * currentThread, J9Module * fromModule, jstring pa
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fromModule, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
@@ -663,19 +512,7 @@ trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fr
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
-#if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, package, fromModuleNameUTF);
-#else
-		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
-		if (NULL != packageNameUTF) {
-			Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, packageNameUTF, fromModuleNameUTF);
-			if (packageNameBuf != packageNameUTF) {
-				j9mem_free_memory(packageNameUTF);
-			}
-		}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		if (fromModuleNameBuf != fromModuleNameUTF) {
 			j9mem_free_memory(fromModuleNameUTF);
 		}
@@ -683,18 +520,10 @@ trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fr
 }
 
 static UDATA
-#if J9VM_JAVA9_BUILD >= 156
 exportPackageToAllUnamed(J9VMThread * currentThread, J9Module * fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-exportPackageToAllUnamed(J9VMThread * currentThread, J9Module * fromModule, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	UDATA retval = ERRCODE_GENERAL_FAILURE;
-#if J9VM_JAVA9_BUILD >= 156
 	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, package, &retval);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, J9_JNI_UNWRAP_REFERENCE(package), &retval);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 	if (NULL != j9package) {
 		j9package->exportToAllUnnamed = TRUE;
 		if (TrcEnabled_Trc_MODULE_add_module_exports_to_all_unnamed) {
@@ -746,11 +575,7 @@ isModuleNameValid(j9object_t moduleName)
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, const char *package, J9Module *toModule)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, jstring package, J9Module *toModule)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
@@ -761,19 +586,7 @@ trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, jstr
 	char *toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, toModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if ((NULL != fromModuleNameUTF) && (NULL != toModuleNameUTF)) {
-#if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports(currentThread, package, fromModuleNameUTF, toModuleNameUTF);
-#else
-		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
-		if (NULL != packageNameUTF) {
-			Trc_MODULE_add_module_exports(currentThread, packageNameUTF, fromModuleNameUTF, toModuleNameUTF);
-			if (packageNameBuf != packageNameUTF) {
-				j9mem_free_memory(packageNameUTF);
-			}
-		}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 	}
 	if (fromModuleNameBuf != fromModuleNameUTF) {
 		j9mem_free_memory(fromModuleNameUTF);
@@ -784,18 +597,10 @@ trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, jstr
 }
 
 static UDATA
-#if J9VM_JAVA9_BUILD >= 156
 exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, const char *package, J9Module * toModule)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, jstring package, J9Module * toModule)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	UDATA retval = ERRCODE_GENERAL_FAILURE;
-#if J9VM_JAVA9_BUILD >= 156
 	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, package, &retval);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, J9_JNI_UNWRAP_REFERENCE(package), &retval);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 	if (NULL != j9package) {
 		if (isModuleDefined(currentThread, toModule)) {
 			if (0 == hashTableAtPut(j9package->exportsHashTable, (void*)&toModule, FALSE)) {
@@ -898,13 +703,7 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
  * @return If successful, returns a java.lang.reflect.Module object. Otherwise, returns NULL.
  */
 jobject JNICALL
-#if J9VM_JAVA9_BUILD >= 156
 JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version, jstring location, const char* const* packages, jsize numPackages)
-#elif J9VM_JAVA9_BUILD >= 148 /* J9VM_JAVA9_BUILD >= 156 */
-JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version, jstring location, jobjectArray packages)
-#else /* J9VM_JAVA9_BUILD >= 148 */
-JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location, jobjectArray packages)
-#endif /* J9VM_JAVA9_BUILD >= 148 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM * vm = currentThread->javaVM;
@@ -924,7 +723,6 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 		J9ClassLoader * const classLoader = getModuleObjectClassLoader(currentThread, modObj);
 		j9object_t moduleName = J9VMJAVALANGMODULE_NAME(currentThread, modObj);
 
-#if J9VM_JAVA9_BUILD >= 156
 		if ((classLoader != vm->systemClassLoader) && (classLoader != vm->platformClassLoader)) {
 			jsize pkgIndex = 0;
 			for (pkgIndex = 0; pkgIndex < numPackages; pkgIndex++) {
@@ -941,7 +739,6 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 #undef JAVADOT
 			}
 		}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 
 		if (NULL == moduleName) {
 			vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, J9NLS_VM_MODULE_IS_UNNAMED);
@@ -965,17 +762,8 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 				J9Module *j9mod = createModule(currentThread, modObj, classLoader, moduleName);
 				if (NULL != j9mod) {
 					BOOLEAN success = FALSE;
-					UDATA rc = ERRCODE_GENERAL_FAILURE;
-#if J9VM_JAVA9_BUILD >= 156
-					rc = addModuleDefinition(currentThread, j9mod, packages, (U_32) numPackages, version);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-					rc = addModuleDefinition(currentThread, j9mod, packages, version);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
-#if J9VM_JAVA9_BUILD >= 148
+					UDATA rc = addModuleDefinition(currentThread, j9mod, packages, (U_32) numPackages, version);
 					j9mod->isOpen = isOpen;
-#else /* J9VM_JAVA9_BUILD >= 148 */
-					j9mod->isOpen = FALSE;
-#endif /* J9VM_JAVA9_BUILD >= 148 */
 					success = (ERRCODE_SUCCESS == rc);
 					if (success) {
 						/* For "java.base" module setting of jrt URL and patch paths is already done during startup. Avoid doing it here. */
@@ -1054,11 +842,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
  * 5) Package is not in module fromModule.
  */
 void JNICALL
-#if J9VM_JAVA9_BUILD >= 156
 JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobject toModule)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-JVM_AddModuleExports(JNIEnv * env, jobject fromModule, jstring package, jobject toModule)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;
@@ -1105,11 +889,7 @@ JVM_AddModuleExports(JNIEnv * env, jobject fromModule, jstring package, jobject 
  * 4) Package is not in module fromModule.
  */
 void JNICALL
-#if J9VM_JAVA9_BUILD >= 156
 JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;
@@ -1273,11 +1053,7 @@ JVM_CanReadModule(JNIEnv * env, jobject askModule, jobject srcModule)
 }
 
 static void
-#if J9VM_JAVA9_BUILD >= 156
 trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
@@ -1285,19 +1061,7 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring p
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, j9mod->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
-#if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_package(currentThread, package, moduleNameUTF);
-#else
-		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
-		if (NULL != packageNameUTF) {
-			Trc_MODULE_add_module_package(currentThread, packageNameUTF, moduleNameUTF);
-			if (packageNameBuf != packageNameUTF) {
-				j9mem_free_memory(packageNameUTF);
-			}
-		}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 		if (moduleNameBuf != moduleNameUTF) {
 			j9mem_free_memory(moduleNameUTF);
 		}
@@ -1313,11 +1077,7 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring p
  * 4) Package is already defined for module's class loader.
  */
 void JNICALL
-#if J9VM_JAVA9_BUILD >= 156
 JVM_AddModulePackage(JNIEnv * env, jobject module, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-JVM_AddModulePackage(JNIEnv * env, jobject module, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;
@@ -1330,15 +1090,8 @@ JVM_AddModulePackage(JNIEnv * env, jobject module, jstring package)
 	f_monitorEnter(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
 	{
-		UDATA rc = ERRCODE_GENERAL_FAILURE;
-
 		J9Module * const j9mod = getJ9Module(currentThread, module);
-
-#if J9VM_JAVA9_BUILD >= 156
-		rc = addPackageDefinition(currentThread, j9mod, package);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-		rc = addPackageDefinition(currentThread, j9mod, J9_JNI_UNWRAP_REFERENCE(package));
-#endif /* J9VM_JAVA9_BUILD >= 156 */
+		UDATA rc = addPackageDefinition(currentThread, j9mod, package);
 		if (ERRCODE_SUCCESS != rc) {
 			throwExceptionHelper(currentThread, rc);
 		} else {
@@ -1365,11 +1118,7 @@ JVM_AddModulePackage(JNIEnv * env, jobject module, jstring package)
  * 3) package is not in module
  */
 void JNICALL
-#if J9VM_JAVA9_BUILD >= 156
 JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, const char *package)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, jstring package)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -977,18 +977,14 @@ getj9bin()
 #endif
 
 /* We use forward slashes here because J9VM_LIB_ARCH_DIR is not used on Windows. */
-#if (J9VM_JAVA9_BUILD >= 150) || defined(OSX)
-/* On OSX, <arch> doesn't exist. So, JVM_ARCH_DIR shouldn't be appended to
- * J9VM_LIB_ARCH_DIR on OSX.
- */
+#if (JAVA_SPEC_VERSION >= 9) || defined(OSX)
+/* On OSX, <arch> doesn't exist, so JVM_ARCH_DIR shouldn't be included in J9VM_LIB_ARCH_DIR. */
 #define J9VM_LIB_ARCH_DIR "/lib/"
-#elif defined(JVM_ARCH_DIR) /* (J9VM_JAVA9_BUILD >= 150) || defined(OSX) */
+#else /* (JAVA_SPEC_VERSION >= 9) || defined(OSX) */
 #define J9VM_LIB_ARCH_DIR "/lib/" JVM_ARCH_DIR "/"
-#else /* (J9VM_JAVA9_BUILD >= 150) || defined(OSX) */
-#error "No matching ARCH found"
-#endif /* (J9VM_JAVA9_BUILD >= 150) || defined(OSX) */
+#endif /* (JAVA_SPEC_VERSION >= 9) || defined(OSX) */
 
-#if J9VM_JAVA9_BUILD < 150
+#if JAVA_SPEC_VERSION == 8
 /*
  * Remove the suffix from string if present.
  */
@@ -1006,7 +1002,7 @@ removeSuffix(char *string, const char *suffix)
 		}
 	}
 }
-#endif /* J9VM_JAVA9_BUILD < 150 */
+#endif /* JAVA_SPEC_VERSION == 8 */
 
 #if defined(J9UNIX) || defined(J9ZOS390)
 static BOOLEAN 
@@ -1060,10 +1056,10 @@ preloadLibraries(void)
 	if (0 == strcmp(lastDirName + 1, "classic")) {
 		truncatePath(jvmBufferData(j9binBuffer)); /* at jre/bin or jre/lib/<arch> */
 		truncatePath(jvmBufferData(j9binBuffer)); /* at jre     or jre/lib        */
-#if J9VM_JAVA9_BUILD < 150
+#if JAVA_SPEC_VERSION == 8
 		/* remove /lib if present */
 		removeSuffix(jvmBufferData(j9binBuffer), "/lib"); /* at jre */
-#endif /* J9VM_JAVA9_BUILD < 150 */
+#endif /* JAVA_SPEC_VERSION == 8 */
 		j9binBuffer = jvmBufferCat(j9binBuffer, J9VM_LIB_ARCH_DIR "j9vm/");
 		if (-1 != stat(jvmBufferData(j9binBuffer), &statBuf)) {
 			/* does exist, carry on */
@@ -1105,10 +1101,10 @@ preloadLibraries(void)
 	/* <arch> directory doesn't exist on OSX so j9libBuffer shouldn't
 	 * be truncated on OSX for removing <arch>.
 	 */
-#if (J9VM_JAVA9_BUILD < 150)
+#if JAVA_SPEC_VERSION == 8
 	/* Remove <arch> */
 	truncatePath(jvmBufferData(j9libBuffer));
-#endif /* (J9VM_JAVA9_BUILD < 150) */
+#endif /* JAVA_SPEC_VERSION == 8 */
 #endif /* !defined(OSX) */
 	j9libvmBuffer = jvmBufferCat(NULL, jvmBufferData(j9binBuffer));
 	j9Buffer = jvmBufferCat(NULL, jvmBufferData(jrebinBuffer));

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2654,11 +2654,7 @@ isPackageExportedToModuleWithName(J9VMThread *currentThread, J9Module *fromModul
  * @return the package definition
  */
 J9Package*
-#if J9VM_JAVA9_BUILD >= 156
 getPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, const char *packageName, UDATA * errCode);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-getPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object_t packageName, UDATA * errCode);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 /**
  * Get a pointer to J9Package structure associated with incoming classloader and package name
  *
@@ -2669,11 +2665,7 @@ getPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, j9object
  * @return a pointer to J9Package structure associated with incoming classloader and package name
  */
 J9Package*
-#if J9VM_JAVA9_BUILD >= 156
 hashPackageTableAt(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-hashPackageTableAt(J9VMThread * currentThread, J9ClassLoader * classLoader, j9object_t packageName);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 /**
  * Add UTF package name to construct a J9Package for hashtable query
  *
@@ -2686,12 +2678,7 @@ hashPackageTableAt(J9VMThread * currentThread, J9ClassLoader * classLoader, j9ob
  * @return true if finished successfully, false if NativeOutOfMemoryError occurred
  */
 BOOLEAN
-#if J9VM_JAVA9_BUILD >= 156
 addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, const char *packageName, U_8 *buf, UDATA bufLen);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t packageName, U_8 *buf, UDATA bufLen);
-#endif /* J9VM_JAVA9_BUILD >= 156 */
-
 
 /**
  * Find the J9Package with given package name. Caller needs to hold the

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -269,30 +269,18 @@ _X(JVM_PrintStackTrace,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2)
 _X(JVM_SetField,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2, jint arg3)
 _X(JVM_SetPrimitiveField,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5)
 _X(JVM_SetNativeThreadName,JNICALL,true,void ,jint arg0, jobject arg1, jstring arg2)
-_IF([J9VM_JAVA9_BUILD < 148],
-	[_X(JVM_DefineModule,JNICALL,false,jobject ,JNIEnv arg0, jobject arg1, jstring arg2, jstring arg3, jobjectArray arg4)])
-_IF([(148 <= J9VM_JAVA9_BUILD) && (J9VM_JAVA9_BUILD < 156)],
-	[_X(JVM_DefineModule,JNICALL,false,jobject ,JNIEnv arg0, jobject arg1, jboolean arg2, jstring arg3, jstring arg4, jobjectArray arg5)])
-_IF([J9VM_JAVA9_BUILD >= 156],
-	[_X(JVM_DefineModule,JNICALL,false,jobject ,JNIEnv arg0, jobject arg1, jboolean arg2, jstring arg3, jstring arg4, const char* const* arg5, jsize arg6)])
-_IF([J9VM_JAVA9_BUILD < 156],
-	[_X(JVM_AddModuleExports,JNICALL,false,void ,JNIEnv arg0, jobject arg1, jstring arg2, jobject arg3)])
-_IF([J9VM_JAVA9_BUILD >= 156],
-	[_X(JVM_AddModuleExports,JNICALL,false,void ,JNIEnv arg0, jobject arg1, const char *arg2, jobject arg3)])
-_IF([J9VM_JAVA9_BUILD < 156],
-	[_X(JVM_AddModuleExportsToAll,JNICALL,false,void ,JNIEnv arg0, jobject arg1, jstring arg2, jobject arg3)])
-_IF([J9VM_JAVA9_BUILD >= 156],
-	[_X(JVM_AddModuleExportsToAll,JNICALL,false,void ,JNIEnv arg0, jobject arg1, const char *arg2, jobject arg3)])
+_IF([JAVA_SPEC_VERSION >= 9],
+	[_X(JVM_DefineModule,JNICALL,false,jobject,JNIEnv arg0, jobject arg1, jboolean arg2, jstring arg3, jstring arg4, const char* const* arg5, jsize arg6)])
+_IF([JAVA_SPEC_VERSION >= 9],
+	[_X(JVM_AddModuleExports,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2, jobject arg3)])
+_IF([JAVA_SPEC_VERSION >= 9],
+	[_X(JVM_AddModuleExportsToAll,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2, jobject arg3)])
 _X(JVM_AddReadsModule,JNICALL,false,void ,JNIEnv arg0, jobject arg1, jobject arg2)
 _X(JVM_CanReadModule,JNICALL,false,jboolean ,JNIEnv arg0, jobject arg1, jobject arg2)
-_IF([J9VM_JAVA9_BUILD < 156],
-	[_X(JVM_AddModulePackage,JNICALL,false,void ,JNIEnv arg0, jobject arg1, jstring arg2)])
-_IF([J9VM_JAVA9_BUILD >= 156],
-	[_X(JVM_AddModulePackage,JNICALL,false,void ,JNIEnv arg0, jobject arg1, const char *arg2)])
-_IF([J9VM_JAVA9_BUILD < 156],
-	[_X(JVM_AddModuleExportsToAllUnnamed,JNICALL,false,void ,JNIEnv arg0, jobject arg1, jstring arg2)])
-_IF([J9VM_JAVA9_BUILD >= 156],
-	[_X(JVM_AddModuleExportsToAllUnnamed,JNICALL,false,void ,JNIEnv arg0, jobject arg1, const char *arg2)])
+_IF([JAVA_SPEC_VERSION >= 9],
+	[_X(JVM_AddModulePackage,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2)])
+_IF([JAVA_SPEC_VERSION >= 9],
+	[_X(JVM_AddModuleExportsToAllUnnamed,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2)])
 _X(JVM_GetSimpleBinaryName,JNICALL,false,jstring ,JNIEnv arg0, jclass arg1)
 _X(JVM_SetMethodInfo,JNICALL,false,void ,JNIEnv arg0, jobject arg1)
 _X(JVM_ConstantPoolGetNameAndTypeRefIndexAt,JNICALL,false,jint ,JNIEnv arg0, jobject arg1, jobject arg2, jint arg3)
@@ -313,7 +301,8 @@ _X(JVM_InitStackTraceElement,JNICALL,false,void ,JNIEnv *env, jobject arg1, jobj
 _X(JVM_GetAndClearReferencePendingList,JNICALL,false,jobject ,JNIEnv *env)
 _X(JVM_HasReferencePendingList,JNICALL,false,jboolean ,JNIEnv *env)
 _X(JVM_WaitForReferencePendingList,JNICALL,false,void ,JNIEnv *env)
-_X(JVM_GetNanoTimeAdjustment,JNICALL,true,jlong ,JNIEnv *env, jclass clazz, jlong offsetSeconds)
+_IF([JAVA_SPEC_VERSION >= 9],
+	[_X(JVM_GetNanoTimeAdjustment,JNICALL,true,jlong ,JNIEnv *env, jclass clazz, jlong offsetSeconds)])
 _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_BeforeHalt,JNICALL,false,void,void)])
 _IF([JAVA_SPEC_VERSION >= 11],

--- a/runtime/tests/j9vm/jvmjni.c
+++ b/runtime/tests/j9vm/jvmjni.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2016 IBM Corp. and others
+ * Copyright (c) 2002, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -360,10 +360,10 @@ Java_com_ibm_oti_jvmtests_SupportJVM_ArrayCopy(JNIEnv * env, jclass unused, jobj
 	JVM_ArrayCopy(env, unused, src, src_pos, dst, dst_pos, length);
 }
 
+#if JAVA_SPEC_VERSION >= 9
 jlong JNICALL
 Java_com_ibm_oti_jvmtests_SupportJVM_GetNanoTimeAdjustment(JNIEnv *env, jclass clazz, jlong offset_seconds)
 {
 	return JVM_GetNanoTimeAdjustment(env, clazz, offset_seconds);
 }
-
-
+#endif /* JAVA_SPEC_VERSION >= 9 */

--- a/runtime/tests/j9vm/module.xml
+++ b/runtime/tests/j9vm/module.xml
@@ -1,55 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2009, 2018 IBM Corp. and others
+Copyright (c) 2009, 2019 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <module>
-        
 	<exports group="all">
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetSystemPackage"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetSystemPackages"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GCNoCompact"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_MaxObjectInspectionAge"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetArrayLength"/>
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetArrayElement"/> 
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetArrayElement"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetPrimitiveArrayElementWCodeParam"/>
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetShortArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetIntArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetLongArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetByteArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetCharArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetFloatArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetDoubleArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetBooleanArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetPrimitiveArrayElementWCodeParam"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetShortArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetIntArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetLongArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetByteArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetCharArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetFloatArrayElement"/> 
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetDoubleArrayElement"/> 
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetShortArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetIntArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetLongArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetByteArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetCharArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetFloatArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetDoubleArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetBooleanArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetPrimitiveArrayElementWCodeParam"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetShortArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetIntArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetLongArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetByteArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetCharArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetFloatArrayElement"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetDoubleArrayElement"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_SetBooleanArrayElement"/>
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_ArrayCopy"/>
-		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetNanoTimeAdjustment"/>
+		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetNanoTimeAdjustment">
+			<include-if condition="spec.java11"/>
+		</export>
 	</exports>
 
 	<artifact type="shared" name="j9vmtest" appendrelease="false">
@@ -69,7 +70,7 @@
 		<includes>
 			<include path="j9include"/>
 			<include path="j9oti"/>
-		</includes>		
+		</includes>
 		<makefilestubs>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 		</makefilestubs>

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -86,11 +86,7 @@ isAllowedReadAccessToModule(J9VMThread *currentThread, J9Module *fromModule, J9M
 }
 
 J9Package *
-#if J9VM_JAVA9_BUILD >= 156
 getPackageDefinition(J9VMThread *currentThread, J9Module *fromModule, const char *packageName, UDATA *errCode)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-getPackageDefinition(J9VMThread *currentThread, J9Module *fromModule, j9object_t packageName, UDATA *errCode)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9Package *retval = NULL;
 	if (isModuleDefined(currentThread, fromModule)) {
@@ -107,11 +103,7 @@ getPackageDefinition(J9VMThread *currentThread, J9Module *fromModule, j9object_t
 }
 
 J9Package*
-#if J9VM_JAVA9_BUILD >= 156
 hashPackageTableAt(J9VMThread *currentThread, J9ClassLoader *classLoader, const char *packageName)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-hashPackageTableAt(J9VMThread *currentThread, J9ClassLoader *classLoader, j9object_t packageName)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9Package package = {0};
 	J9Package *packagePtr = &package;
@@ -132,18 +124,13 @@ hashPackageTableAt(J9VMThread *currentThread, J9ClassLoader *classLoader, j9obje
 }
 
 BOOLEAN
-#if J9VM_JAVA9_BUILD >= 156
 addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, const char *packageName, U_8 *buf, UDATA bufLen)
-#else /* J9VM_JAVA9_BUILD >= 156 */
-addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t packageName, U_8 *buf, UDATA bufLen)
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 {
 	J9JavaVM * const vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
 	UDATA packageNameLength = 0;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
-#if J9VM_JAVA9_BUILD >= 156
 	j9package->packageName = (J9UTF8*)buf;
 	packageNameLength = (UDATA) strlen(packageName);
 	if ((NULL == j9package->packageName) || ((packageNameLength + sizeof(j9package->packageName->length) + 1) > bufLen)) {
@@ -157,13 +144,6 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t 
 	memcpy(J9UTF8_DATA(j9package->packageName), (void *)packageName, packageNameLength);
 	J9UTF8_DATA(j9package->packageName)[packageNameLength] = '\0';
 	J9UTF8_SET_LENGTH(j9package->packageName, (U_16)packageNameLength);
-#else /* J9VM_JAVA9_BUILD >= 156 */
-	j9package->packageName = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, packageName, J9_STR_NULL_TERMINATE_RESULT, "", 0, (char*)buf, bufLen);
-	if (NULL == j9package->packageName) {
-		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
-		return FALSE;
-	}
-#endif /* J9VM_JAVA9_BUILD >= 156 */
 
 	return TRUE;
 }


### PR DESCRIPTION
J9VM_JAVA9_BUILD was used to distinguish among intermediate versions of Java 9. Those distinctions are no longer relevant as Java 9 is out of support. This removes dead code that was added during Java 9 development and is not used in Java 11 or later versions.