### PR TITLE
WIP: Marshal relo data

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -101,6 +101,21 @@ void J9::ARM::AheadOfTimeCompile::processRelocations()
       }
    }
 
+void
+J9::ARM::AheadOfTimeCompile::marshalReloData(TR::IteratedExternalRelocation *relocation, J9::MarshalledReloData &marshalledReloData)
+   {
+   TR_ExternalRelocationTargetKind kind = relocation->getTargetKind();
+
+   switch (kind)
+      {
+      default:
+         {
+         marshalledReloData.data1 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress());
+         marshalledReloData.data2 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress2());
+         }
+      }
+   }
+
 uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR::Compilation* comp = TR::comp();

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
@@ -54,6 +54,8 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
 public:
    AheadOfTimeCompile(TR::CodeGenerator *cg);
 
+   virtual void marshalReloData(TR::IteratedExternalRelocation *relocation, MarshalledReloData &marshalledReloData);
+
    virtual void     processRelocations();
    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -164,6 +164,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
    TR_ExternalRelocationTargetKind kind = relocation->getTargetKind();
 
+   J9::MarshalledReloData marshalledReloData;
+   self()->marshalReloData(relocation, marshalledReloData);
+
    // initializeCommonAOTRelocationHeader is currently in the process
    // of becoming the canonical place to initialize the platform agnostic
    // relocation headers; new relocation records' header should be
@@ -175,15 +178,15 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          {
          TR_RelocationRecordConstantPool * cpRecord = reinterpret_cast<TR_RelocationRecordConstantPool *>(reloRecord);
 
-         cpRecord->setConstantPool(reloTarget, reinterpret_cast<uintptrj_t>(relocation->getTargetAddress()));
-         cpRecord->setInlinedSiteIndex(reloTarget, reinterpret_cast<uintptrj_t>(relocation->getTargetAddress2()));
+         cpRecord->setConstantPool(reloTarget, reinterpret_cast<uintptrj_t>(marshalledReloData.data1));
+         cpRecord->setInlinedSiteIndex(reloTarget, reinterpret_cast<uintptrj_t>(marshalledReloData.data2));
          }
          break;
 
       case TR_HelperAddress:
          {
          TR_RelocationRecordHelperAddress *haRecord = reinterpret_cast<TR_RelocationRecordHelperAddress *>(reloRecord);
-         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(relocation->getTargetAddress());
+         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(marshalledReloData.data1);
 
          haRecord->setEipRelative(reloTarget);
          haRecord->setHelperID(reloTarget, static_cast<uint32_t>(symRef->getReferenceNumber()));
@@ -210,14 +213,14 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_RelocationRecordMethodCallAddress *mcaRecord = reinterpret_cast<TR_RelocationRecordMethodCallAddress *>(reloRecord);
 
          mcaRecord->setEipRelative(reloTarget);
-         mcaRecord->setAddress(reloTarget, relocation->getTargetAddress());
+         mcaRecord->setAddress(reloTarget, marshalledReloData.data1);
          }
          break;
 
       case TR_AbsoluteHelperAddress:
          {
          TR_RelocationRecordAbsoluteHelperAddress *ahaRecord = reinterpret_cast<TR_RelocationRecordAbsoluteHelperAddress *>(reloRecord);
-         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(relocation->getTargetAddress());
+         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(marshalledReloData.data1);
 
          ahaRecord->setHelperID(reloTarget, static_cast<uint32_t>(symRef->getReferenceNumber()));
          }
@@ -228,8 +231,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
       case TR_StaticRamMethodConst:
          {
          TR_RelocationRecordConstantPoolWithIndex *cpiRecord = reinterpret_cast<TR_RelocationRecordConstantPoolWithIndex *>(reloRecord);
-         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(relocation->getTargetAddress());
-         uintptrj_t inlinedSiteIndex = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress2());
+         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(marshalledReloData.data1);
+         uintptrj_t inlinedSiteIndex = reinterpret_cast<uintptrj_t>(marshalledReloData.data2);
 
          void *constantPool = symRef->getOwningMethod(comp)->constantPool();
          inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(constantPool, inlinedSiteIndex);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -40,6 +40,22 @@ namespace TR { class Compilation; }
 namespace J9
 {
 
+struct MarshalledReloData
+   {
+   uintptrj_t data1;
+   uintptrj_t data2;
+
+   /* We need to set these fields to 0 so that if they are
+    * unused in a particular platform, they don't cause any
+    * issues because of the random value they may take on
+    * due to being uninitialized (eg, relo flags)
+    */
+   MarshalledReloData()
+      : data1(0),
+        data2(0)
+      {}
+   };
+
 class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnector
    {
    public:
@@ -49,6 +65,8 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
       OMR::AheadOfTimeCompileConnector(headerSizeMap, c)
       {
       }
+
+   virtual void marshalReloData(TR::IteratedExternalRelocation *relocation, MarshalledReloData &marshalledReloData) = 0;
 
    uint8_t* emitClassChainOffset(uint8_t* cursor, TR_OpaqueClassBlock* classToRemember);
    uintptr_t findCorrectInlinedSiteIndex(void *constantPool, uintptr_t currentInlinedSiteIndex);

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -111,6 +111,21 @@ void J9::Power::AheadOfTimeCompile::processRelocations()
       }
    }
 
+void
+J9::Power::AheadOfTimeCompile::marshalReloData(TR::IteratedExternalRelocation *relocation, J9::MarshalledReloData &marshalledReloData)
+   {
+   TR_ExternalRelocationTargetKind kind = relocation->getTargetKind();
+
+   switch (kind)
+      {
+      default:
+         {
+         marshalledReloData.data1 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress());
+         marshalledReloData.data2 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress2());
+         }
+      }
+   }
+
 uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR::Compilation* comp = TR::comp();

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
@@ -52,6 +52,8 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
    public:
    AheadOfTimeCompile(TR::CodeGenerator *cg);
 
+   virtual void marshalReloData(TR::IteratedExternalRelocation *relocation, MarshalledReloData &marshalledReloData);
+
    virtual void     processRelocations();
    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -117,6 +117,21 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
       }
    }
 
+void
+J9::X86::AheadOfTimeCompile::marshalReloData(TR::IteratedExternalRelocation *relocation, J9::MarshalledReloData &marshalledReloData)
+   {
+   TR_ExternalRelocationTargetKind kind = relocation->getTargetKind();
+
+   switch (kind)
+      {
+      default:
+         {
+         marshalledReloData.data1 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress());
+         marshalledReloData.data2 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress2());
+         }
+      }
+   }
+
 uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.hpp
@@ -50,6 +50,8 @@ class OMR_EXTENSIBLE AheadOfTimeCompile  : public J9::AheadOfTimeCompile
       {
       }
 
+   virtual void marshalReloData(TR::IteratedExternalRelocation *relocation, MarshalledReloData &marshalledReloData);
+
    virtual void     processRelocations();
    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -122,6 +122,21 @@ void J9::Z::AheadOfTimeCompile::processRelocations()
       }
    }
 
+void
+J9::Z::AheadOfTimeCompile::marshalReloData(TR::IteratedExternalRelocation *relocation, J9::MarshalledReloData &marshalledReloData)
+   {
+   TR_ExternalRelocationTargetKind kind = relocation->getTargetKind();
+
+   switch (kind)
+      {
+      default:
+         {
+         marshalledReloData.data1 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress());
+         marshalledReloData.data2 = reinterpret_cast<uintptrj_t>(relocation->getTargetAddress2());
+         }
+      }
+   }
+
 uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.hpp
@@ -47,6 +47,8 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
    public:
      AheadOfTimeCompile(TR::CodeGenerator *cg);
 
+    virtual void marshalReloData(TR::IteratedExternalRelocation *relocation, MarshalledReloData &marshalledReloData);
+
     virtual void     processRelocations();
     virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 


### PR DESCRIPTION
The data that is stored in the `_targetAddress`/`_targetAddress2` may be
different on different platforms. However, relocation header data that
is stored to to the SCC is common across platforms. In order to fully
consolidate the code that writes the header information, this PR
introduces a method that has to be implemented on each platform that is
used to demarshal the platform specific data from the
`TR::IteratedExternalRelocation` object and marshal it into the platform
agnostic form that is used to write out the header information.
