### PR TITLE
Do not force code cache contiguous allocation at the JITaaS client

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4755,10 +4755,7 @@ J9::CodeGenerator::allocateCodeMemoryInner(
    bool hadClassUnloadMonitor;
    bool hadVMAccess = self()->fej9()->releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(comp, &hadClassUnloadMonitor);
 
-   // Override contiguous allocation for the JITaaS client                                                                                                                                          
-   // JITaaS FIXME: why do we need contiguous allocation at the client?                                                                                                                             
    bool useContiguousAllocation = self()->fej9()->needsContiguousAllocation();                                                                                                                                      
-   useContiguousAllocation |= comp->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE;
 
    uint8_t *warmCode = TR::CodeCacheManager::instance()->allocateCodeMemory(
          warmCodeSizeInBytes,


### PR DESCRIPTION
Obsolete code from a previous prototype required a contiguous
code cache allocation at the JITaaS client. This is no longer
needed, so the code should be removed.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>