### PR TITLE
VarargsCollectorHandle.asType throws WrongMethodTypeException

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1266,6 +1266,7 @@ K0677=Module '{0}' no access to: package '{1}' which is not exported by module '
 K0678=Class '{0}' no access to: '{1}'
 K0679=Module '{0}' no access to: package '{1}' because module '{0}' can't read module '{2}'
 K0680=Class '{0}' no access to: class '{1}'
+K0681=Failed to build collector
 
 #java.lang.StackWalker
 K0639="Stack walker not configured with RETAIN_CLASS_REFERENCE"

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarargsCollectorHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarargsCollectorHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -140,6 +140,11 @@ final class VarargsCollectorHandle extends MethodHandle {
 	
 	private CollectHandle previousCollector = null;
 	
+	private WrongMethodTypeException throwNewWMTE(IllegalArgumentException iae) {
+		/*[MSG "K0681", "Failed to build collector"]*/
+		throw new WrongMethodTypeException(com.ibm.oti.util.Msg.getString("K0681"), iae); //$NON-NLS-1$
+	}
+	
 	@Override
 	public MethodHandle asType(MethodType newType) throws ClassCastException {
 		if (type == newType)  {
@@ -170,7 +175,11 @@ final class VarargsCollectorHandle extends MethodHandle {
 		}
 		CollectHandle collector = previousCollector;
 		if ((collector == null) || (collector.collectArraySize != collectCount)) {
-			collector = (CollectHandle) next.asCollector(arrayType, collectCount);
+			try {
+				collector = (CollectHandle) next.asCollector(arrayType, collectCount);
+			} catch (IllegalArgumentException iae) {
+				throw throwNewWMTE(iae);
+			}
 			// update cached collector handle
 			previousCollector = collector;
 		}


### PR DESCRIPTION
`VarargsCollectorHandle.asType()` throws `WrongMethodTypeException`

Convert `IllegalArgumentException` to `WrongMethodTypeException` within `VarargsCollectorHandle.asType()`.

This PR passes the test within https://github.com/eclipse/openj9/issues/4937.

Note: [Java doc](http://cr.openjdk.java.net/~iris/se/12/build/latest/api/java.base/java/lang/invoke/MethodHandle.html#asType(java.lang.invoke.MethodType)) states that `java.lang.invoke.MethodHandle` can throws `NullPointerException` if newType is a `null` reference or `WrongMethodTypeException` if the conversion cannot be made. There is no `IllegalArgumentException` thrown.
It appears there are other cases that `IllegalArgumentException` might be thrown. I would like to leave it as is for now since no test complains or another PR if required.

closes: #4937 

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>