### PR TITLE
AArch64: Add #if defined(TR_HOST_ARM64)

### DIFF
--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -322,7 +322,7 @@ class TR_PersistentJittedBodyInfo
    friend class J9::Options;
    friend class TR_DebugExt;
 
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || (defined(TR_HOST_ARM))
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
    friend void fixPersistentMethodInfo(void *table);
 #endif
 

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -88,7 +88,7 @@ inline uint32_t getJitEntryOffset(TR_LinkageInfo *linkageInfo)
 #endif
 
 /* Functions used by AOT runtime to fixup recompilation info for AOT */
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || (defined(TR_HOST_ARM))
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
 uint32_t *getLinkageInfo(void * startPC);
 uint32_t isRecompMethBody(void *li);
 void fixPersistentMethodInfo(void *table);

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -59,7 +59,7 @@
 #include "runtime/IProfiler.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM)
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
 #include "codegen/PicHelpers.hpp"
 #include "control/Recompilation.hpp"
 #endif
@@ -1309,7 +1309,7 @@ void platformUnlock(uint32_t *ptr)
    }
 }
 
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || (defined(TR_HOST_ARM))
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
 uint32_t *getLinkageInfo(void *startPC)
    {
    return (uint32_t *)TR_LinkageInfo::get(startPC);


### PR DESCRIPTION
This commit adds `defined(TR_HOST_ARM64)` to `#if` lines so that
the JIT files can be compiled for AArch64.

Signed-off-by: knn-k <konno@jp.ibm.com>