### PR TITLE
AArch64: Add rules for JIT assembler files

### DIFF
--- a/runtime/compiler/build/rules/gnu/filetypes.mk
+++ b/runtime/compiler/build/rules/gnu/filetypes.mk
@@ -212,3 +212,26 @@ RULE.spp=$(eval $(DEF_RULE.spp))
 
 endif # ($(HOST_ARCH),arm)
 ##### END ARM SPECIFIC RULES #####
+
+##### START AARCH64 SPECIFIC RULES #####
+ifeq ($(HOST_ARCH),aarch64)
+
+#
+# Preprocess .spp file into .s file
+#
+define DEF_RULE.spp
+$(1).s: $(2) | jit_createdirs
+	$$(SPP_CMD) $$(SPP_FLAGS) $$(patsubst %,-D%,$$(SPP_DEFINES)) $$(patsubst %,-I'%',$$(SPP_INCLUDES)) -o $$@ -x assembler-with-cpp -E -P $$<
+
+JIT_DIR_LIST+=$(dir $(1))
+
+jit_cleanobjs::
+	rm -f $(1).s
+
+$(call RULE.s,$(1),$(1).s)
+endef # DEF_RULE.spp
+
+RULE.spp=$(eval $(DEF_RULE.spp))
+
+endif # ($(HOST_ARCH),aarch64)
+##### END AARCH64 SPECIFIC RULES #####

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -392,7 +392,29 @@ ifeq ($(HOST_ARCH),arm)
 
     SPP_DEFINES+=$(SPP_DEFINES_EXTRA)
     SPP_FLAGS+=$(SPP_FLAGS_EXTRA)
-endif
+endif # HOST_ARCH == arm
+
+#
+# Setup CPP to preprocess AArch64 Assembly Files
+#
+ifeq ($(HOST_ARCH),aarch64)
+    SPP_CMD=$(CC)
+
+    SPP_INCLUDES=$(PRODUCT_INCLUDES)
+    SPP_DEFINES+=$(CX_DEFINES)
+    SPP_FLAGS+=$(CX_FLAGS)
+
+    ifeq ($(BUILD_CONFIG),debug)
+        SPP_FLAGS+=$(SPP_FLAGS_DEBUG)
+    endif
+
+    ifeq ($(BUILD_CONFIG),prod)
+        SPP_FLAGS+=$(SPP_FLAGS_PROD)
+    endif
+
+    SPP_DEFINES+=$(SPP_DEFINES_EXTRA)
+    SPP_FLAGS+=$(SPP_FLAGS_EXTRA)
+endif # HOST_ARCH == aarch64
 
 #
 # Finally setup the linker


### PR DESCRIPTION
This commit adds rules for JIT assembler files for aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>