### PR TITLE
Fix missing argument in getClassFromConstantPool

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1026,10 +1026,11 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          break;
       case J9ServerMessageType::ResolvedMethod_getClassFromConstantPool:
          {
-         auto recv = client->getRecvData<TR_ResolvedJ9Method *, uint32_t>();
+         auto recv = client->getRecvData<TR_ResolvedJ9Method *, uint32_t, bool>();
          TR_ResolvedJ9Method *method = std::get<0>(recv);
          uint32_t cpIndex = std::get<1>(recv);
-         client->write(method->getClassFromConstantPool(comp, cpIndex));
+         bool returnClassForAOT = std::get<2>(recv);
+         client->write(method->getClassFromConstantPool(comp, cpIndex, returnClassForAOT));
          }
          break;
       case J9ServerMessageType::ResolvedMethod_getDeclaringClassFromFieldOrStatic:

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -148,7 +148,7 @@ TR_ResolvedJ9JITaaSServerMethod::staticAttributes(TR::Compilation * comp, I_32 c
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp, uint32_t cpIndex, bool)
+TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp, uint32_t cpIndex, bool returnClassForAOT)
    {
    if (cpIndex == -1)
       return nullptr;
@@ -169,7 +169,7 @@ TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp
             return it->second;
          }
       }
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getClassFromConstantPool, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getClassFromConstantPool, _remoteMirror, cpIndex, returnClassForAOT);
    TR_OpaqueClassBlock *resolvedClass = std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
    if (resolvedClass)
       {
@@ -1783,7 +1783,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compila
    {
    if (returnClassForAOT || comp->getOption(TR_UseSymbolValidationManager))
       {
-      TR_OpaqueClassBlock * resolvedClass = TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(comp, cpIndex);
+      TR_OpaqueClassBlock * resolvedClass = TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(comp, cpIndex, returnClassForAOT);
       if (resolvedClass &&
          validateClassFromConstantPool(comp, (J9Class *)resolvedClass, cpIndex))
          {


### PR DESCRIPTION
[skip ci]
`returnClassForAOT` optional argument was missing in JITaaS
implementation of
`TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool`.