### PR TITLE
Add option to skip resolver nameserver request

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -437,6 +437,9 @@ enum INIT_STAGE {
 #define VMOPT_XXUSECONTAINERSUPPORT "-XX:+UseContainerSupport"
 #define VMOPT_XXNOUSECONTAINERSUPPORT "-XX:-UseContainerSupport"
 
+#define VMOPT_XXREADIPINFOFORRAS "-XX:+ReadIPInfoForRAS"
+#define VMOPT_XXNOREADIPINFOFORRAS "-XX:-ReadIPInfoForRAS"
+
 #define MAPOPT_AGENTLIB_JDWP_EQUALS "-agentlib:jdwp="
 
 #define MAPOPT_XCOMP "-Xcomp"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2056,7 +2056,14 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			 * defer initialization of network data until after heap allocated, since the intialization
 			 * can initiate DLL loads which prevent allocation of large heaps.
 			 */
-			populateRASNetData(vm, vm->j9ras);
+			argIndex = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXREADIPINFOFORRAS, NULL);
+			argIndex2 = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOREADIPINFOFORRAS, NULL);
+			if (argIndex >= argIndex2) {
+				JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "\t\tenabled network query to determine host name and IP address for RAS.\n");
+				populateRASNetData(vm, vm->j9ras);
+			} else {
+				JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "\t\tdisabled network query to determine host name and IP address for RAS.\n");
+			}
 #endif
 			consumeVMArgs(vm, vm->vmArgsArray);
 			if (FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXALLOWVMSHUTDOWN, NULL) >= 0) {

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
@@ -25,7 +25,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Command-Line Option Tests" timeout="180">
-    
+    <variable name="READIPINFOFORRAS" value="-XX:+ReadIPInfoForRAS"/>
+    <variable name="NOREADIPINFOFORRAS" value="-XX:-ReadIPInfoForRAS"/>
+    <variable name="READIPINFOFORRAS_MESSAGE" value="enabled network query to determine host name and IP address for RAS."/>
+    <variable name="NOREADIPINFOFORRAS_MESSAGE" value="disabled network query to determine host name and IP address for RAS."/>
+
     <test id="Verify Generate a javacore to STDOUT">
         <command>$EXE$ -Xdump:java:events=vmstart,file=/STDOUT/</command>
         <output type="success" caseSensitive="yes" regex="no">TITLE subcomponent dump routine</output>
@@ -44,5 +48,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
         <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
     </test>
 
+    <test id="test -XX:-ReadIPInfoForRAS -XX:+ReadIPInfoForRAS">
+        <command>$EXE$ $NOREADIPINFOFORRAS$ $READIPINFOFORRAS$ -verbose:init -version</command>
+        <output type="success" caseSensitive="yes" regex="no">$READIPINFOFORRAS_MESSAGE$</output>
+        <output type="failure" caseSensitive="yes" regex="no">$NOREADIPINFOFORRAS_MESSAGE$</output>
+    </test>
+
+    <test id="test -XX:+ReadIPInfoForRAS -XX:-ReadIPInfoForRAS">
+        <command>$EXE$ $READIPINFOFORRAS$ $NOREADIPINFOFORRAS$ -verbose:init -version</command>
+        <output type="success" caseSensitive="yes" regex="no">$NOREADIPINFOFORRAS_MESSAGE$</output>
+        <output type="failure" caseSensitive="yes" regex="no">$READIPINFOFORRAS_MESSAGE$</output>
+    </test>
 </suite>
 


### PR DESCRIPTION
Java programs run on z/OS are hanging when the resolver cannot contact any of the nameservers. The programs hang until the resolver times out, which is ~60 seconds. By skipping the nameserver request, this situation can be avoided.

Fixes: #4540
Documentation Issue: https://github.com/eclipse/openj9-docs/issues/226

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>