### PR TITLE
Use client's ROM class pointer in a front-end query

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3204,6 +3204,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct.totalInstanceSize = std::get<16>(classInfo);
    classInfoStruct._classOfStaticCache = nullptr;
    classInfoStruct._constantClassPoolCache = nullptr;
+   classInfoStruct.remoteRomClass = std::get<17>(classInfo);
 
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 
@@ -3250,7 +3251,7 @@ JITaaSHelpers::packRemoteROMClassInfo(J9Class *clazz, TR_J9VM *fe, TR_Memory *tr
    TR_OpaqueClassBlock * componentClass = fe->getComponentClassFromArrayClass((TR_OpaqueClassBlock *)clazz);
    TR_OpaqueClassBlock * arrayClass = fe->getArrayClassFromComponentClass((TR_OpaqueClassBlock *)clazz);
    uintptrj_t totalInstanceSize = clazz->totalInstanceSize;
-   return std::make_tuple(packROMClass(clazz->romClass, trMemory), methodsOfClass, baseClass, numDims, parentClass, TR::Compiler->cls.getITable((TR_OpaqueClassBlock *) clazz), methodTracingInfo, classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass, classLoader, hostClass, componentClass, arrayClass, totalInstanceSize);
+   return std::make_tuple(packROMClass(clazz->romClass, trMemory), methodsOfClass, baseClass, numDims, parentClass, TR::Compiler->cls.getITable((TR_OpaqueClassBlock *) clazz), methodTracingInfo, classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass, classLoader, hostClass, componentClass, arrayClass, totalInstanceSize, clazz->romClass);
    }
 
 J9ROMClass *
@@ -3427,6 +3428,11 @@ JITaaSHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo, Cl
       case CLASSINFO_TOTAL_INSTANCE_SIZE :
          {
          *(uintptrj_t *)data = classInfo.totalInstanceSize;
+         }
+         break;
+      case CLASSINFO_REMOTE_ROM_CLASS :
+         {
+         *(J9ROMClass **)data = classInfo.remoteRomClass;
          }
          break;
       default :

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -44,6 +44,7 @@ class ClientSessionData
       void freeClassInfo(); // this method is in place of a destructor. We can't have destructor
       // because it would be called after inserting ClassInfo into the ROM map, freeing romClass
       J9ROMClass *romClass; // romClass content exists in persistentMemory at the server
+      J9ROMClass *remoteRomClass; // pointer to the corresponding ROM class on the client
       J9Method *methodsOfClass;
       // Fields meaningful for arrays
       TR_OpaqueClassBlock *baseComponentClass; 
@@ -269,10 +270,11 @@ class JITaaSHelpers
       CLASSINFO_ARRAY_CLASS,
       CLASSINFO_TOTAL_INSTANCE_SIZE,
       CLASSINFO_CLASS_OF_STATIC_CACHE,
+      CLASSINFO_REMOTE_ROM_CLASS,
       };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
-   using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<uint8_t>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t>;
+   using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<uint8_t>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t, J9ROMClass *>;
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, TR_J9VM *fe, TR_Memory *trMemory);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1459,6 +1459,15 @@ TR_J9ServerVM::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference
     return (intptrj_t)callSite;
 }
 
+uintptrj_t
+TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz)
+   {
+   J9ROMClass *remoteRomClass = NULL;
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *) clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_REMOTE_ROM_CLASS, (void *) &remoteRomClass);
+   return (uintptrj_t) remoteRomClass;
+   }
+
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -167,6 +167,7 @@ public:
    virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType) override;
    virtual void reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding) override;
    virtual intptrj_t methodTrampolineLookup( TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override;
+   virtual uintptrj_t getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz) override;
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);


### PR DESCRIPTION
[skip ci]
`TR_J9VM::getPersistentClassPointerFromClassPointer` returns a pointer
to a ROM class. However, on the server, we store a copy of client's
ROM class, and calling this method would return a pointer to that copy.
But this method is always used to measure the offset of a ROM class
from the beginning of shared cache.
Thus, we need to get a pointer to the ROM class on the client side.
Do it by adding a pointer to ClassInfo struct, so that for all cached
ROM classes we know its pointer on the client.