### PR TITLE
Improve formatting of threadInfo

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -1,10 +1,10 @@
 /*[INCLUDE-IF Sidecar16]*/
 package java.lang;
 
-import java.security.ProtectionDomain;
+import com.ibm.oti.util.Util;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2018 IBM Corp. and others
+ * Copyright (c) 2002, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -248,94 +248,8 @@ public boolean isNativeMethod() {
 /*[ENDIF]*/
 public String toString() {
 	StringBuilder buf = new StringBuilder(80);
-
-	appendTo(buf);
+	Util.printStackTraceElement(this, source, buf, false);
 	return buf.toString();
 }
 
-/**
- * Helper method for toString and for Throwable.print output with PrintStream and PrintWriter
- */
-void appendTo(Appendable buf) {
-	/*[IF Sidecar19-SE]*/
-	if (null != moduleName) {
-		appendTo(buf, moduleName);
-		appendTo(buf, "/"); //$NON-NLS-1$
-	}
-	/*[ENDIF] Sidecar19-SE*/
-	/*[PR CMVC 90361] print "\tat " in Throwable.printStackTrace() for compatibility */
-	appendTo(buf, getClassName());
-	/*[PR CMVC 121726] Exception traces print '46' instead of '.' */
-	appendTo(buf, "."); //$NON-NLS-1$
-	appendTo(buf, getMethodName());
-  
-	appendTo(buf, "("); //$NON-NLS-1$
-	if (isNativeMethod()) {
-		appendTo(buf, "Native Method"); //$NON-NLS-1$
-	} else {
-		String fileName = getFileName();
-
-		if (fileName == null) {
-			appendTo(buf, "Unknown Source"); //$NON-NLS-1$
-		} else {
-			int lineNumber = getLineNumber();
-			
-			appendTo(buf, fileName);
-			if (lineNumber >= 0) {
-				appendTo(buf, ":"); //$NON-NLS-1$
-				appendTo(buf, lineNumber);
-			}
-		}
-	}
-	appendTo(buf, ")"); //$NON-NLS-1$
-	
-	/* Support for -verbose:stacktrace */
-	if (source != null) {
-		appendTo(buf, " from "); //$NON-NLS-1$
-		if (source instanceof String) {
-			appendTo(buf, (String)source);			
-		} else if (source instanceof ProtectionDomain) {
-			ProtectionDomain pd = (ProtectionDomain)source;
-			appendTo(buf, pd.getClassLoader().toString());			
-			appendTo(buf, "(");			 //$NON-NLS-1$
-			appendTo(buf, pd.getCodeSource().getLocation().toString());			
-			appendTo(buf, ")");			 //$NON-NLS-1$
-		}
-	}
-}
-
-/* 
- * CMVC 97756 provide a way of printing this stack trace element without
- *            allocating memory, in particular without String concatenation.
- *            Used when printing a stack trace for an OutOfMemoryError.
- */
-
-/**
- * Helper method for output with PrintStream and PrintWriter
- */
-static void appendTo(Appendable buf, CharSequence s) {
-	try {
-		buf.append(s);
-	} catch (java.io.IOException e) {
-	}
-}
-@SuppressWarnings("all")
-private static final String digits[]={"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$ 
-/**
- * Helper method for output with PrintStream and PrintWriter
- */
-static void appendTo(Appendable buf, int number) {
-	int i;
-	int j = 1;
-	for (i = number; i >= 10; i /= 10) {
-		j *= 10;
-	}
-	appendTo(buf, digits[i]);
-	while (j >= 10) {
-		number -= j * i;
-		j /= 10;
-		i = number / j;
-		appendTo(buf, digits[i]);
-	}
-}
 }

--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,9 @@ import java.util.Collections;
 import java.util.List;
 
 import com.ibm.oti.util.Msg;
+import com.ibm.oti.util.Util;
+import static com.ibm.oti.util.Util.appendTo;
+import static com.ibm.oti.util.Util.appendLnTo;
  
 /**
  * This class is the superclass of all classes which
@@ -457,39 +460,6 @@ private void readObject(ObjectInputStream s)
  */
 
 /**
- * Helper method for output with PrintStream and PrintWriter
- */
-static void appendTo(Appendable buf, CharSequence s) {
-	StackTraceElement.appendTo(buf, s);
-}
-
-/**
- * Helper method for output with PrintStream and PrintWriter
- */
-static void appendTo(Appendable buf, CharSequence s, int indents) {
-	for (int i=0; i<indents; i++) {
-		StackTraceElement.appendTo(buf, "\t"); //$NON-NLS-1$
-	}
-	StackTraceElement.appendTo(buf, s);
-}
-
-/**
- * Helper method for output with PrintStream and PrintWriter
- */
-static void appendTo(Appendable buf, int i) {
-	StackTraceElement.appendTo(buf, i);
-}
-
-/**
- * Helper method for output with PrintStream and PrintWriter
- */
-static void appendLnTo(Appendable buf) {		
-	if (buf instanceof PrintStream) ((PrintStream)buf).println();
-	else if (buf instanceof PrintWriter) ((PrintWriter)buf).println();
-	else appendTo(buf, "\n"); //$NON-NLS-1$
-}
-
-/**
  * Print stack trace
  *  
  * @param	err	
@@ -562,7 +532,7 @@ private StackTraceElement[] printStackTrace(
         }
 		if (outOfMemory) {
 			appendTo(err, "\tat ", indents); //$NON-NLS-1$
-			stack[i].appendTo(err);
+			Util.printStackTraceElement(stack[i], null, err, false);
         }
 		appendLnTo(err);		
     }


### PR DESCRIPTION
Improve formatting of ThreadInfo and StackTraceElement

Move StackTraceElement toString implementation to a utility method to allow
more latitude in formatting.  Make stack trace format match reference
implementation.  Add module version to StackTraceElement's toString().  Add 
locking information.

Fixes https://github.com/eclipse/openj9/issues/4965
Fixes https://github.com/eclipse/openj9/issues/5012

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>