### PR TITLE
Array class can get methods

### DIFF
--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -894,15 +894,16 @@ Java_java_lang_Class_getMethodImpl(JNIEnv *env, jobject recv, jobject name, jobj
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	j9object_t resultObject = NULL;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
-	J9Class *clazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9_JNI_UNWRAP_REFERENCE(recv));
 
 	PORT_ACCESS_FROM_VMC(currentThread);
 	if ((NULL == name) || (NULL == partialSignature)) {
 		vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 	} else {
+		J9Class *clazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9_JNI_UNWRAP_REFERENCE(recv));
 		J9ROMClass *romClass = clazz->romClass;
-		/* primitives/arrays don't have local methods */
-		if (!J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass)) {
+
+		/* primitives doesn't have local methods */
+		if (!J9ROMCLASS_IS_PRIMITIVE_TYPE(romClass)) {
 			J9Method *currentMethod = NULL;
 			j9object_t nameObject = J9_JNI_UNWRAP_REFERENCE(name);
 			j9object_t signatureObject = J9_JNI_UNWRAP_REFERENCE(partialSignature);


### PR DESCRIPTION
`Array` class can get methods

`java.lang.Class.getMethodImpl()` is modified to allow `array` class to find any public method inherited by the array type from `Object` except method `clone()`.

**Java doc** [java.base/java/lang/Class.html#getMethod(java.lang.String,java.lang.Class...)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getMethod(java.lang.String,java.lang.Class...))
```
If this Class object represents an array type, then this method finds any public method inherited by the array type from Object except method clone().
```

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>