### PR TITLE
Fix fields/staticsAreSame for remote AOT

### DIFF
--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -326,6 +326,10 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(
 bool
 TR_ResolvedJ9JITaaSServerMethod::fieldsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame)
    {
+   if (TR::comp()->compileRelocatableCode())
+      // in AOT, this should always return false, because mainline compares class loaders
+      // with fe->sameClassLoaders, which always returns false for AOT compiles
+      return false;
    TR_ResolvedJ9JITaaSServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(m2);
    if (getClassLoader() != serverMethod2->getClassLoader())
       return false;
@@ -364,6 +368,10 @@ TR_ResolvedJ9JITaaSServerMethod::fieldsAreSame(int32_t cpIndex1, TR_ResolvedMeth
 bool
 TR_ResolvedJ9JITaaSServerMethod::staticsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame)
    {
+   if (TR::comp()->compileRelocatableCode())
+      // in AOT, this should always return false, because mainline compares class loaders
+      // with fe->sameClassLoaders, which always returns false for AOT compiles
+      return false;
    TR_ResolvedJ9JITaaSServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(m2);
    if (getClassLoader() != serverMethod2->getClassLoader())
       return false;


### PR DESCRIPTION
In mainline, we use fe->sameClassLoaders(..) to verify
that classes to which fields/statics compared in
`TR_ResolvedJ9Method::fields/staticsAreSame` belong are loaded by
the same class loader. For AOT that method always returns false.
In JITaaS implementation, we replaced a front-end call with
`getClassLoader() != method2->getClassLoader()`, because server
resolved methods always cache their class loader, so this allows
us to avoid a remote message.
However, this doesn't work correctly in AOT mode, so I added a guard
to always return false if doing an AOT compile.
