### PR TITLE
Create a new front-end query for getting array classes

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -615,20 +615,7 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
 
       int32_t arrayClassIndex = node->getSecondChild()->getInt();
 
-      // TEMP HACK: getClassFromNewArrayType returns null under AOT because primitive array classes
-      // are not in the SCC. However, here we require that the array class is actually resolved.
-      // VP requires that getClassFromNewArrayType returns null under AOT for some reason so we cannot
-      // just always resolve it.
-      if (TR::CompilationInfo::getStream())
-         {
-         clazz = (J9Class *)self()->fej9()->getClassFromNewArrayType(arrayClassIndex);
-         }
-      else
-         {
-         struct J9Class ** arrayClasses = &self()->fej9()->getJ9JITConfig()->javaVM->booleanArrayClass;
-         clazz = arrayClasses[arrayClassIndex - 4];
-         }
-
+      clazz = (J9Class *) self()->fej9()->getClassFromNewArrayTypeNonNull(arrayClassIndex);
       if (node->getFirstChild()->getOpCodeValue() != TR::iconst)
          {
          classInfo = self()->fej9vm()->getPrimitiveArrayAllocationClass(clazz);

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -522,6 +522,12 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(fe->getClassFromNewArrayType(index));
          }
          break;
+      case J9ServerMessageType::VM_getClassFromNewArrayTypeNonNull:
+         {
+         int32_t index = std::get<0>(client->getRecvData<int32_t>());
+         client->write(fe->getClassFromNewArrayTypeNonNull(index));
+         }
+         break;
       case J9ServerMessageType::VM_isCloneable:
          {
          auto clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -997,6 +997,9 @@ public:
 
    virtual bool classInitIsFinished(TR_OpaqueClassBlock *clazz) { return (((J9Class*)clazz)->initializeStatus & J9ClassInitStatusMask) == J9ClassInitSucceeded; }
 
+   virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
+   virtual TR_OpaqueClassBlock * getClassFromNewArrayTypeNonNull(int32_t arrayType);
+
    // --------------------------------------------------------------------------
    // Object model
    // --------------------------------------------------------------------------
@@ -1060,7 +1063,6 @@ public:
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);
    virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual int32_t               getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz);
-   virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -99,6 +99,7 @@ public:
    virtual bool classInitIsFinished(TR_OpaqueClassBlock *) override;
    virtual int32_t getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock *getClassFromNewArrayType(int32_t arrayType) override;
+   virtual TR_OpaqueClassBlock * getClassFromNewArrayTypeNonNull(int32_t arrayType) override;
    virtual bool isCloneable(TR_OpaqueClassBlock *clazzPointer) override;
    virtual bool canAllocateInlineClass(TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -212,6 +212,7 @@ enum J9ServerMessageType
    VM_getVMInfo = 301;
    VM_isAnonymousClass = 302;
    VM_dereferenceStaticAddress = 303;
+   VM_getClassFromNewArrayTypeNonNull = 304;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -64,10 +64,9 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
    defineGuaranteedID(_rootClass, TR::SymbolType::typeClass);
    defineGuaranteedID(compilee->getPersistentIdentifier(), TR::SymbolType::typeMethod);
 
-   struct J9Class ** arrayClasses = &_fej9->getJ9JITConfig()->javaVM->booleanArrayClass;
    for (int32_t i = 4; i <= 11; i++)
       {
-      TR_OpaqueClassBlock *arrayClass = reinterpret_cast<TR_OpaqueClassBlock *>(arrayClasses[i - 4]);
+      TR_OpaqueClassBlock *arrayClass = _fej9->getClassFromNewArrayTypeNonNull(i);
       TR_OpaqueClassBlock *component = _fej9->getComponentClassFromArrayClass(arrayClass);
       defineGuaranteedID(arrayClass, TR::SymbolType::typeClass);
       defineGuaranteedID(component, TR::SymbolType::typeClass);


### PR DESCRIPTION
Create `TR_J9VMBase::getClassFromNewArrayTypeNonNull` query,
which does the same thing as `TR_J9VMBase::getClassFromNewArrayType`,
except the former always returns an array class, while the latter
returns NULL in AOT mode.
This query is needed for cases when we need to get a pointer to boolean
array class during AOT compile.