### PR TITLE
Increase _coldUpgradeSampleThreshold to 20

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2456,15 +2456,14 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       self()->setOption(TR_DisableIntrinsics);
       }
 
-   /* Temporary (until SVM is the default)
-    *
-    * If the SVM is not enabled, use the old _coldUpgradeSampleThreshold
+   /* If the SVM is enabled, use a higher _coldUpgradeSampleThreshold
     * for AGGRESSIVE_AOT
     */
-   if (!self()->getOption(TR_EnableSymbolValidationManager)
-       && TR::Options::_aggressivenessLevel == TR::Options::AGGRESSIVE_AOT)
+   if (TR::Options::_aggressivenessLevel == TR::Options::AGGRESSIVE_AOT &&
+       self()->getOption(TR_EnableSymbolValidationManager) &&
+       TR::Options::sharedClassCache())
       {
-      TR::Options::_coldUpgradeSampleThreshold = 10;
+      TR::Options::_coldUpgradeSampleThreshold = 20;
       }
 
    return true;


### PR DESCRIPTION
`_coldUpgradeSampleThreshold` is currently only used in the OpenJ9 project. Because the SVM has resulted in better AOT code quality, under `AGGRESSIVE_AOT`, this PR makes the upgrade sample threshold more conservative by increasing it to 20.