### PR TITLE
Fixed freeing of memory for cudaInfo for JIT GPU

### DIFF
--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -2700,7 +2700,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionExits(List<TR::Block>* exitBlocks
       {
       TR::TreeTop *insertionPoint = exitBlock->getEntry();
       
-      TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 5);
+      TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 4);
       helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU, false, false, false);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
       regionExitGPUNode->setSymbolReference(helper);
@@ -2714,11 +2714,8 @@ void TR_SPMDKernelParallelizer::insertGPURegionExits(List<TR::Block>* exitBlocks
       // ptxSourceID
       regionExitGPUNode->setAndIncChild(2, TR::Node::create(insertionPoint->getNode(), TR::iconst, 0, gpuPtxCount));
 
-      // flush block number
-      regionExitGPUNode->setAndIncChild(3, TR::Node::create(insertionPoint->getNode(), TR::iconst, 0, 0));
-
       // **liveSymRef
-      regionExitGPUNode->setAndIncChild(4, TR::Node::createWithSymRef(insertionPoint->getNode(), TR::loadaddr, 0, liveSymRef));
+      regionExitGPUNode->setAndIncChild(3, TR::Node::createWithSymRef(insertionPoint->getNode(), TR::loadaddr, 0, liveSymRef));
 
       TR::Node *treetopNode = TR::Node::create(TR::treetop, 1, regionExitGPUNode);
       TR::TreeTop *initTreeTop = TR::TreeTop::create(comp(), treetopNode, 0, 0);
@@ -2773,7 +2770,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionExitInRegionExits(List<TR::Block>
 
       TR::TreeTop *insertionPoint = regionExitGPUBlock->getEntry();
 
-      TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 5);
+      TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 4);
       helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU, false, false, false);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
       regionExitGPUNode->setSymbolReference(helper);
@@ -2787,11 +2784,8 @@ void TR_SPMDKernelParallelizer::insertGPURegionExitInRegionExits(List<TR::Block>
       // ptxSourceID
       regionExitGPUNode->setAndIncChild(2, TR::Node::create(insertionPoint->getNode(), TR::iconst, 0, gpuPtxId));
 
-      // flush block number
-      regionExitGPUNode->setAndIncChild(3, TR::Node::create(insertionPoint->getNode(), TR::iconst, 0, 0));
-
       // **liveSymRef
-      regionExitGPUNode->setAndIncChild(4, TR::Node::createWithSymRef(insertionPoint->getNode(), TR::loadaddr, 0, liveSymRef));
+      regionExitGPUNode->setAndIncChild(3, TR::Node::createWithSymRef(insertionPoint->getNode(), TR::loadaddr, 0, liveSymRef));
 
       TR::Node *treetopNode = TR::Node::create(TR::treetop, 1, regionExitGPUNode);
       TR::TreeTop *initTreeTop = TR::TreeTop::create(comp(), treetopNode, 0, 0);


### PR DESCRIPTION
In the single GPU kernel case, regionExitGPU calls freeGPUScope
which frees the memory for the cudaInfo object. The code then
calls getStateGPU with the exact same cudaInfo object that was
just freed. This is now changed so that the cudaInfo object is freed
inside getStateGPU instead.

regionExitGPU would also flush data to the CPU in some cases even after an
error case has been triggered. This was changed to no longer happen.

This change also cleans up the code by removing an unused parameter to
regionExitGPU and changing int return types from NULL_DEVICE_PTR to 0.

Closes: #5013
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>