### PR TITLE
AArch64: Enable build of JIT shared library

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -173,6 +173,10 @@ ifeq ($(HOST_ARCH),arm)
     CX_FLAGS+=-fPIC -mfloat-abi=hard -mfpu=vfp -march=armv6 -marm
 endif
 
+ifeq ($(HOST_ARCH),aarch64)
+    CX_FLAGS+=-fPIC
+endif
+
 ifeq ($(C_COMPILER),clang)
     CX_FLAGS+=-Wno-parentheses -Werror=header-guard
 endif

--- a/runtime/compiler/module.xml
+++ b/runtime/compiler/module.xml
@@ -23,8 +23,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module>
 	<artifact type="target" name="j9jitlauncher">
 		<include-if condition="spec.flags.interp_nativeSupport"/>
-		<!-- TODO: Build of aarch64 JIT is disabled for the time being -->
-		<exclude-if condition="spec.linux_aarch64.*" />
 		<phase>jit j2se</phase>
 
 		<dependencies>


### PR DESCRIPTION
This commit enables the build of JIT shared library for aarch64.
The library can be linked, while it cannot be loaded by the VM at
this point because of undefined symbols.

Closes: #4854

Signed-off-by: knn-k <konno@jp.ibm.com>