### PR TITLE
jdk8: Stop bundling openssl on Linux  platforms, and enable on AIX

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -112,7 +112,7 @@ linux_ppc-64_cmprssptrs_le:
     11: '--openssl-version=1.1.1a'
     12: '--openssl-version=1.1.1a'
   extra_configure_options:
-    8: '--with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-openssl=fetched'
     11: '--with-openssl=fetched'
     12: '--with-openssl=fetched'
   build_env:
@@ -162,7 +162,7 @@ linux_390-64_cmprssptrs:
     11: '--openssl-version=1.1.1a'
     12: '--openssl-version=1.1.1a'
   extra_configure_options:
-    8: '--with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-openssl=fetched'
     11: '--with-openssl=fetched'
     12: '--with-openssl=fetched'
 #========================================#
@@ -194,10 +194,11 @@ aix_ppc-64_cmprssptrs:
       12: 'ci.role.build && hw.arch.ppc64 && sw.os.aix'
       next: 'ci.role.build && hw.arch.ppc64 && sw.os.aix'
   extra_getsource_options:
+    8: '--openssl-version=1.1.1a'
     11: '--openssl-version=1.1.1a'
     12: '--openssl-version=1.1.1a'
   extra_configure_options:
-    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8'
+    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8 --with-openssl=fetched'
     9: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     10: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     11: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8 --with-openssl=fetched'
@@ -236,7 +237,7 @@ linux_x86-64_cmprssptrs:
     11: '--openssl-version=1.1.1a'
     12: '--openssl-version=1.1.1a'
   extra_configure_options:
-    8: '--with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-openssl=fetched'
     11: '--with-openssl=fetched'
     12: '--with-openssl=fetched'
   build_env:
@@ -278,7 +279,7 @@ linux_x86-64_cmprssptrs_cmake:
     11: '--openssl-version=1.1.1a'
     12: '--openssl-version=1.1.1a'
   extra_configure_options:
-    8: '--with-cmake --disable-ddr --with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-cmake --disable-ddr --with-openssl=fetched'
     9: '--with-cmake --disable-ddr'
     10: '--with-cmake --disable-ddr'
     11: '--with-cmake --disable-ddr --with-openssl=fetched'
@@ -330,7 +331,7 @@ linux_x86-64:
     11: '--openssl-version=1.1.1a'
     12: '--openssl-version=1.1.1a'
   extra_configure_options:
-    8: '--with-noncompressedrefs --with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-noncompressedrefs --with-openssl=fetched'
     9: '--with-noncompressedrefs'
     10: '--with-noncompressedrefs'
     11: '--with-noncompressedrefs --with-openssl=fetched'

--- a/test/functional/cmdLineTests/openssl/playlist.xml
+++ b/test/functional/cmdLineTests/openssl/playlist.xml
@@ -25,32 +25,6 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>cmdLineTester_CryptoTest_8</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
-		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)openssl.xml$(Q) \
-		-verbose -explainExcludes -nonZeroExitWhenError; \
-		$(TEST_STATUS)</command>
-		<!-- Temporarily exclude on aix until OpenSSL is enabled on aix -->
-		<platformRequirements>^os.aix</platformRequirements>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-		<subsets>
-			<subset>8</subset>
-		</subsets>
-	</test>
-
-	<test>
 		<testCaseName>cmdLineTester_CryptoTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
@@ -69,9 +43,6 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<subsets>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 
 </playlist>


### PR DESCRIPTION
Same changes as #4191 for jdk8

Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/275

Note these build options are only for OpenJ9 test purposes and do not affect what gets built at Adopt.