### PR TITLE
Fail remote AOT compilation when relocation fails

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2589,6 +2589,14 @@ remoteCompilationEnd(
             }
          else
             {
+            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+               {
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+                                              "JITaaS Relocation failure: %d",
+                                              compInfoPT->reloRuntime()->returnCode());
+               }
+            // relocation failed, fail compilation
+            // attempt to recompile in non-AOT mode
             entry->_doNotUseAotCodeFromSharedCache = true;
             entry->_compErrCode = returnCode;
 
@@ -2596,6 +2604,7 @@ remoteCompilationEnd(
                {
                entry->_tryCompilingAgain = true;
                }
+            comp->failCompilation<J9::AOTRelocationFailed>("Failed to relocate");
             }
          }
 #endif /* J9VM_INTERP_AOT_RUNTIME_SUPPORT */


### PR DESCRIPTION
In `remoteCompilationEnd` we should be failing a compilation
if `prepareRelocateAOTCodeAndData` returned NULL, as it means
that relocation has failed. We already do that for non-AOT
compilations but forgot to add it for AOT.