### PR TITLE
Implement TR_J9JITaaSServerSharedCache::addHint

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1744,6 +1744,16 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(fe->sharedCache()->rememberClass(clazz, create));
          }
          break;
+      case J9ServerMessageType::SharedCache_addHint:
+         {
+         auto recv = client->getRecvData<J9Method *, TR_SharedCacheHint>();
+         auto method = std::get<0>(recv);
+         auto hint = std::get<1>(recv);
+         if (fe->sharedCache())
+            fe->sharedCache()->addHint(method, hint);
+         client->write(JITaaS::Void());
+         }
+         break;
       case J9ServerMessageType::runFEMacro_derefUintptrjPtr:
          {
          TR::VMAccessCriticalSection deref(fe);
@@ -3598,7 +3608,6 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    JITaaS::J9ServerStream *stream = entry._stream;
    setMethodBeingCompiled(&entry); // must have compilation monitor
    entry._compInfoPT = this; // create the reverse link
-   _vm = TR_J9VMBase::get(_jitConfig, compThread, TR_J9VMBase::J9_SERVER_VM);
    // update the last time the compilation thread had to do something.
    compInfo->setLastReqStartTime(compInfo->getPersistentInfo()->getElapsedTime());
   
@@ -3608,6 +3617,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
 
    char * clientOptions = NULL;
    TR_OptimizationPlan *optPlan = NULL;
+   _vm = NULL;
    try
       {
       auto req = stream->read<uint64_t, uint32_t, J9Method *, J9Class*, TR_Hotness, std::string,
@@ -3632,6 +3642,16 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          {
          _vm = TR_J9VMBase::get(_jitConfig, compThread, TR_J9VMBase::J9_SHARED_CACHE_SERVER_VM);
          }
+      else
+         {
+         _vm = TR_J9VMBase::get(_jitConfig, compThread, TR_J9VMBase::J9_SERVER_VM);
+         }
+
+      if (_vm->sharedCache())
+         // Set/update stream pointer in shared cache.
+         // Note that if remote-AOT is enabled, even regular J9_SERVER_VM will have a shared cache
+         // This behaviour is consistent with non-JITaaS
+         ((TR_J9JITaaSServerSharedCache *) _vm->sharedCache())->setStream(stream);
 
       if (!ramMethod)
          {

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -172,9 +172,8 @@ public:
    // virtual bool isHint(J9ROMMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT(false, "called"); return false;}
    virtual uint16_t getAllEnabledHints(J9Method *method) override { TR_ASSERT(false, "called"); return 0;}
    // virtual uint16_t getAllEnabledHints(J9ROMMethod *method) override { TR_ASSERT(false, "called"); return 0;}
-   virtual void addHint(J9Method *, TR_SharedCacheHint) override { TR_ASSERT(false, "called"); }
+   virtual void addHint(J9Method *, TR_SharedCacheHint) override;
    // virtual void addHint(J9ROMMethod *, TR_SharedCacheHint) override { TR_ASSERT(false, "called"); }
-   virtual void addHint(TR_ResolvedMethod *, TR_SharedCacheHint) override { TR_ASSERT(false, "called"); }
    virtual bool isMostlyFull() override { TR_ASSERT(false, "called"); return false;}
 
    virtual void *pointerFromOffsetInSharedCache(void *offset) override;
@@ -201,9 +200,10 @@ public:
 
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
 
+   void setStream(JITaaS::J9ServerStream *stream) { _stream = stream; }
+
 private:
    JITaaS::J9ServerStream *_stream;
-
    };
 
 #endif

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -242,6 +242,7 @@ enum J9ServerMessageType
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetInSharedCache = 600;
    SharedCache_rememberClass = 601;
+   SharedCache_addHint = 602;
 
    // For runFEMacro
    runFEMacro_invokeCollectHandleNumArgsToCollect = 700;


### PR DESCRIPTION
- We previously assumed that `addHint` is never called
on the server, but that assumption is incorrect.
Implemented the method.
- Fix caching of `J9ServerStream` pointer inside shared cache.
It's not correct to always use the stream pointer initialized in
`J9JITaaSServerSharedCache` constructor, because that constructor
is only called when front-end is created, which happens once
on the server.
But we create a new stream for each compilation, so the cached pointer
is incorrect. Update it at the beginning of each remote compilation.