### PR TITLE
Enable CH table for remote AOT 

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2072,8 +2072,12 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          {
          client->getRecvData<JITaaS::Void>();
          auto table = (TR_JITaaSClientPersistentCHTable*)comp->getPersistentInfo()->getPersistentCHTable();
-         TR_OpaqueClassBlock *rootClass = fe->getSystemClassFromClassName("java/lang/Object", 16);
-         TR_PersistentClassInfo* result = table->findClassInfoAfterLocking(rootClass, comp, false);
+         TR_OpaqueClassBlock *rootClass = fe->TR_J9VM::getSystemClassFromClassName("java/lang/Object", 16);
+         TR_PersistentClassInfo* result = table->findClassInfoAfterLocking(
+                                                   rootClass,
+                                                   comp,
+                                                   true,
+                                                   comp->getOption(TR_UseSymbolValidationManager));
          std::string encoded = FlatPersistentClassInfo::serializeHierarchy(result);
          client->write(encoded);
          }


### PR DESCRIPTION
- When fetching the entire persistent CH table
from the client, fetch it even if in AOT mode.
Before that, we wouldn't use persistent CH table
in AOT mode, and I see no reason why we shouldn't
be able to.
- Create SVM validation records when calling
`findClassInfoAfterLocking`.