### PR TITLE
Automatically add labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-suite-failure.md
+++ b/.github/ISSUE_TEMPLATE/test-suite-failure.md
@@ -1,7 +1,7 @@
 ---
 name: OpenJ9 test suite failure
 about: A failing functionality, system, or JTReg test
-
+labels: "test failure"
 ---
 
 Failure link

--- a/.github/ISSUE_TEMPLATE/user-problem.md
+++ b/.github/ISSUE_TEMPLATE/user-problem.md
@@ -1,7 +1,7 @@
 ---
 name: Report a user problem
 about: Must gather information to report a problem
-
+labels: "userRaised"
 ---
 
 Java -version output


### PR DESCRIPTION
As per [1] GitHub supports automatically adding labels to issue
templates. Take advantage of this feature to minimize manual work.

[ci skip]

[1] https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>