### PR TITLE
AArch64: Add files in compiler/aarch64/{codegen,env}/ to aarch64.mk

### DIFF
--- a/runtime/compiler/build/files/target/aarch64.mk
+++ b/runtime/compiler/build/files/target/aarch64.mk
@@ -42,4 +42,10 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/env/OMRCPU.cpp \
     omr/compiler/aarch64/env/OMRDebugEnv.cpp
 
-JIT_PRODUCT_SOURCE_FILES+=
+JIT_PRODUCT_SOURCE_FILES+= \
+    compiler/aarch64/codegen/J9ARM64Snippet.cpp \
+    compiler/aarch64/codegen/J9CodeGenerator.cpp \
+    compiler/aarch64/codegen/J9TreeEvaluator.cpp \
+    compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp \
+    compiler/aarch64/codegen/StackCheckFailureSnippet.cpp \
+    compiler/aarch64/env/J9CPU.cpp


### PR DESCRIPTION
This commit add .cpp files in compiler/aarch64/{codegen,env}/ to
JIT_PRODUCT_SOURCE_FILES in aarch64.mk.

Signed-off-by: knn-k <konno@jp.ibm.com>