### PR TITLE
Update options for compilation request

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7676,7 +7676,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   (vm->isAOT_DEPRECATED_DO_NOT_USE() || that->_methodBeingCompiled->isAotLoad()),
                   that->getCompThreadId());
 
-
             // JITaaS TODO determine if we care to support annotations
             if (that->_methodBeingCompiled->isRemoteCompReq())
                options->setOption(TR_EnableAnnotations,false);

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2279,6 +2279,16 @@ J9::Options::fePostProcessJIT(void * base)
          }
       }
 
+   self()->setupJITaaSOptions();
+
+   return true;
+   }
+
+void
+J9::Options::setupJITaaSOptions()
+   {
+   TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
+
    if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE ||
        compInfo->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
       {
@@ -2312,8 +2322,6 @@ J9::Options::fePostProcessJIT(void * base)
                compInfo->getPersistentInfo()->getJITaaSServerAddress().c_str(),
                compInfo->getPersistentInfo()->getJITaaSServerPort());
       }
-
-   return true;
    }
 
 bool
@@ -2333,6 +2341,8 @@ J9::Options::fePostProcessAOT(void * base)
          TR::Options::getDebug()->printFilters();
          }
       }
+
+   self()->setupJITaaSOptions();
 
    return true;
    }

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -350,6 +350,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    bool  showOptionsInEffect();
    bool  showPID();
    void openLogFiles(J9JITConfig *jitConfig);
+
+   void setupJITaaSOptions();
    };
 
 }

--- a/runtime/compiler/rpc/StreamTypes.hpp
+++ b/runtime/compiler/rpc/StreamTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,13 +59,13 @@ namespace JITaaS
    class StreamTypeMismatch: public virtual StreamFailure
       {
    public:
-      StreamTypeMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "type mismatch"); }
+      StreamTypeMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "Type mismatch: %s", message.c_str()); }
       };
 
    class StreamArityMismatch: public virtual StreamFailure
       {
    public:
-      StreamArityMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "arity mismatch"); }
+      StreamArityMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "Arity mismatch: %s", message.c_str()); }
       };
 
    class ServerCompFailure: public virtual std::exception


### PR DESCRIPTION
Update options for compilation request

A new option object is created for each compilation in `wrappedCompile()`. 
The new option object is constructed from `_aotCmdLineOptions` 
instead of `_jitCmdLineOptions` when AOT is used. However options for jitaa
were only set in `fePostProcessJIT()` but not in `fePostProcessAOT()`.
Add a helper method `setupJITaasOptions()` to be called by both JIT and AOT
option post processes. 

[skip ci]

Fixes: #5016

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>