### PR TITLE
(v0.13.0-release) Separate java.vendor and java.vm.vendor

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -400,7 +400,6 @@ private static void ensureProperties(boolean isInitialization) {
 	java.lang.VersionProps.init(initializedProperties);
 	/* VersionProps.init(systemProperties) above sets java.specification.version value which is used to set java.vm.specification.version. */
 	initializedProperties.put("java.vm.specification.version", initializedProperties.get("java.specification.version")); //$NON-NLS-1$ //$NON-NLS-2$
-	initializedProperties.put("java.vm.vendor", initializedProperties.get("java.vendor")); //$NON-NLS-1$ //$NON-NLS-2$
 /*[ELSE]
 	/* VersionProps.init requires systemProperties to be set */
 	systemProperties = initializedProperties;

--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -48,9 +48,11 @@
 
 #define VENDOR_SHORT_NAME "OpenJ9"
 
+#define JAVA_VM_VENDOR "Eclipse OpenJ9"
+
 #if JAVA_SPEC_VERSION < 12
-/* Pre-JDK12 version use following defines to set system properties
- * java.vendor, java.vendor.url and java.vm.vendor within vmprop.c:initializeSystemProperties(vm).
+/* Pre-JDK12 versions use following defines to set system properties
+ * java.vendor and java.vendor.url within vmprop.c:initializeSystemProperties(vm).
  * JDK12 (assuming future versions as well) sets these properties via java.lang.VersionProps.init(systemProperties) 
  * and following settings within System.ensureProperties().
  */

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -615,12 +615,13 @@ initializeSystemProperties(J9JavaVM * vm)
 			goto fail;
 		}
 
-		rc = addSystemProperty(vm, "java.vm.vendor", JAVA_VENDOR, 0);
-		if (J9SYSPROP_ERROR_NONE != rc) {
-			goto fail;
-		}
 	}
 #endif /* JAVA_SPEC_VERSION < 12 */
+
+	rc = addSystemProperty(vm, "java.vm.vendor", JAVA_VM_VENDOR, 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
 
 	rc = addSystemProperty(vm, "com.ibm.oti.vm.library.version", J9_DLL_VERSION_STRING, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {

--- a/test/functional/Java8andUp/src/org/openj9/test/support/Support_Exec.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/support/Support_Exec.java
@@ -1,7 +1,7 @@
 package org.openj9.test.support;
 
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corp. and others
+ * Copyright (c) 2010, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -140,7 +140,7 @@ public class Support_Exec {
 			String[] classpath) {
 		int baseArgs = 0;
 		String[] execArgs = null;
-		String vendor = System.getProperty("java.vendor");
+		String vendor = System.getProperty("java.vm.vendor");
 		boolean onUnix = File.separatorChar == '/';
 		String classPathString = "";
 		if (classpath != null)


### PR DESCRIPTION
Separate `java.vendor` and `java.vm.vendor`

Removed the setting of `java.vm.vendor` with `java.vm` value;
Added `JAVA_VM_VENDOR` to be set for `java.vm.vendor` regardless of `java.vendor` values.

Additional notes:
1. For `JDK12+`, it can be built with `--with-vendor-name` and `--with-vendor-url`, and the values specified will be set to `java.vendor` and `java.vendor.url` via `java.lang.VersionProps.init(systemProperties)`;
2. For `JDK8 & 11`, change to following defines are required:
https://github.com/eclipse/openj9/blob/0bd089b36679fe0e3c5bfd63df0fcfc22c16c36d/runtime/include/vendor_version.h#L57-L58
just like [AdoptOpenJDK patch](https://github.com/AdoptOpenJDK/openjdk-build/blob/aefabfd2ac9f0eec39bcd78a4ac1633afce32605/git-hg/jdk8u/patches/0001-Set-vendor-information.patch#L18-L23);
3. Attempted to use configuration options `--with-vendor-name` for JDK 8 & 11 builds (particularly for JDK 11), it requires passing the value to `closed/OpenJ9.gmk` and to `include/j9cfg.h.ftl` via `uma.spec.properties` which requires more changes for legacy builds without incoming makefile options. `JDK12+` provides a generic way to set a customized `java.vendor` and it doesn't seem worth to duplicate the effort for earlier versions;
4. System property `java.vendor.url.bug` was set by `RI` but not `OpenJ9`, not adding it in this PR. 

#5041 for the 0.13 branch
closes: #5002 

Reviewer: @pshipton 
FYI: @DanHeidinga @smlambert  


Signed-off-by: Jason Feng <fengj@ca.ibm.com>