### PR TITLE
Remove deprecated Equality compare and branch IL Opcodes

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -6588,7 +6588,6 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                switch(n->getOpcode())
                   {
                   case TR::ifbcmpeq:
-                  case TR::ifsucmpeq:
                   case TR::ificmpeq:
                      takenBV.empty();
                      ntakenBV = *bv[tID];
@@ -6599,7 +6598,6 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                         }
                      break;
                   case TR::ifbcmpne:
-                  case TR::ifsucmpne:
                   case TR::ificmpne:
                      takenBV = *bv[tID];
                      ntakenBV.empty();

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -9188,7 +9188,6 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       {
       case TR::ificmpne:
       case TR::ifbcmpne:
-      case TR::ifsucmpne:
       case TR::ifscmpne:
       case TR::iflcmpne:
       case TR::ifacmpne:


### PR DESCRIPTION
Remove Equality compare and branch opcodes -
ifsucmpeq,
ifsucmpne

https://github.com/eclipse/omr/issues/2657

Signed-off-by: Somesh Sharma <someshsharma0312@gmail.com>