### PR TITLE
Change and refactor targeted inlining heuristic

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -933,7 +933,9 @@
 
    // JSR292
    java_lang_invoke_ArgumentMoverHandle_permuteArgs,
+   java_lang_invoke_ArgumentMoverHandle_extra,
    java_lang_invoke_AsTypeHandle_convertArgs,
+   java_lang_invoke_BruteArgumentMoverHandle_extra,
    java_lang_invoke_CatchHandle_numCatchTargetArgsToPassThrough,
    java_lang_invoke_CollectHandle_numArgsToCollect,
    java_lang_invoke_CollectHandle_numArgsToPassThrough,
@@ -996,6 +998,7 @@
    java_lang_invoke_MethodHandle_invokeExactTargetAddress,
    java_lang_invoke_MethodHandle_invokeWithArgumentsHelper,
    java_lang_invoke_MethodHandles_getStackClass,
+   java_lang_invoke_MethodHandle_type,
    java_lang_invoke_MethodHandle_undoCustomizationLogic,
    java_lang_invoke_PrimitiveHandle_initializeClassIfRequired,
    java_lang_invoke_MutableCallSite_getTarget,

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -675,7 +675,7 @@ public:
    //getSymbolAndFindInlineTarget queries
    virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
    virtual int checkInlineableWithoutInitialCalleeSymbol (TR_CallSite* callsite, TR::Compilation* comp);
-   virtual int checkInlineableTarget (TR_CallTarget* target, TR_CallSite* callsite, TR::Compilation* comp, bool inJSR292InliningPasses);
+   virtual int checkInlineableTarget (TR_CallTarget* target, TR_CallSite* callsite);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    virtual bool inlineRecognizedCryptoMethod(TR_CallTarget* target, TR::Compilation* comp);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3853,6 +3853,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {  TR::java_lang_invoke_MethodHandle_invoke                   ,   13, "invokeGeneric",              (int16_t)-1, "*"}, // Older name from early versions of the jsr292 spec
       {  TR::java_lang_invoke_MethodHandle_invokeExact              ,   11, "invokeExact",                (int16_t)-1, "*"},
       {  TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress ,   24, "invokeExactTargetAddress",   (int16_t)-1, "*"},
+      {x(TR::java_lang_invoke_MethodHandle_type                     ,   "type",                       "()Ljava/lang/invoke/MethodType;")},
       {x(TR::java_lang_invoke_MethodHandle_invokeWithArgumentsHelper,   "invokeWithArgumentsHelper",  "(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_lang_invoke_MethodHandle_asType, "asType", "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;")},
       {x(TR::java_lang_invoke_MethodHandle_asType_instance, "asType", "(Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;")},
@@ -3978,7 +3979,30 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
 
    static X ArgumentMoverHandleMethods[] =
       {
-      {x(TR::java_lang_invoke_ArgumentMoverHandle_permuteArgs,  "permuteArgs",   "(I)I")},
+      {x(TR::java_lang_invoke_ArgumentMoverHandle_permuteArgs,        "permuteArgs",   "(I)I")},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_Z",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_B",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_C",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_S",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_I",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_J",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_F",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_D",       (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,           7, "extra_L",       (int16_t)-1, "*"},
+      {  TR::unknownMethod}
+      };
+
+   static X BruteArgumentMoverHandleMethods[] =
+      {
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_Z",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_B",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_C",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_S",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_I",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_J",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_F",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_D",        (int16_t)-1, "*"},
+      {  TR::java_lang_invoke_ArgumentMoverHandle_extra,         7, "extra_L",        (int16_t)-1, "*"},
       {  TR::unknownMethod}
       };
 
@@ -4505,6 +4529,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       { "org/apache/harmony/luni/platform/OSMemory", OSMemoryMethods },
       { "java/util/concurrent/atomic/AtomicBoolean", JavaUtilConcurrentAtomicBooleanMethods },
       { "java/util/concurrent/atomic/AtomicInteger", JavaUtilConcurrentAtomicIntegerMethods },
+      { "java/lang/invoke/BruteArgumentMoverHandle", BruteArgumentMoverHandleMethods },
       { 0 }
       };
 
@@ -7332,6 +7357,7 @@ getMethodHandleThunkDetails(TR_J9ByteCodeIlGenerator *ilgen, TR::Compilation *co
 bool
 TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
    {
+
    TR::MethodSymbol * symbol = symRef->getSymbol()->castToMethodSymbol();
    int32_t archetypeParmCount = symbol->getMethod()->numberOfExplicitParameters() + (symbol->isStatic() ? 0 : 1);
 

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -36,9 +36,9 @@ class TR_J9InnerPreexistenceInfo;
  * Class TR_MultipleCallTargetInliner
  * ==================================
  *
- * Exception Directed Optimization (EDO) enables more aggressive 
- * inlining that the JIT does in cases when the call graph of the 
- * callee being inlined has some throw statements that would get 
+ * Exception Directed Optimization (EDO) enables more aggressive
+ * inlining that the JIT does in cases when the call graph of the
+ * callee being inlined has some throw statements that would get
  * caught in a catch block of the caller.
  *
  * The end goal is to give the JIT optimizer (value propagation in
@@ -234,6 +234,21 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
       bool validateArguments(TR_CallTarget *calltarget, TR_LinkHead<TR_ParameterMapping> &map);
       virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
       virtual TR_InlinerFailureReason checkIfTargetInlineable(TR_CallTarget* target, TR_CallSite* callsite, TR::Compilation* comp);
+      /** \brief
+       *     This query decides whether the given callee should be considered to inline in targeted inlining.
+       */
+      static bool isJSR292Method(TR_ResolvedMethod *resolvedMethod);
+      /** \brief
+       *     This query decides whether the given callee should be considered to inline in both targeted inlining and normal inlining.
+       *
+       *  \notes
+       *     The methods are in 3 kinds: 1. VarHandle operation methods 2. small getters 3. leaf method handles
+       */
+      static bool isJSR292AlwaysInlineableMethod(TR_ResolvedMethod *resolvedMethod);
+      /** \brief
+       *     This query defines a group of methods that are small getters in the java/lang/invoke package
+       */
+      static bool isJSR292SmallGetterMethod(TR_ResolvedMethod *resolvedMethod);
    };
 
 class TR_J9JSR292InlinerPolicy : public TR_J9InlinerPolicy


### PR DESCRIPTION
This change refactored the logic in checkIfTargetInlineable to make
the code clearer. The heuristic around jsr292 methods are separated into
different inlining policy.

A few recognized small getters are added as inlineable targets in
targeted inlining.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>

https://github.com/eclipse/openj9/issues/4837