### PR TITLE
Change RAT to lazy clean-up for performance

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5320,6 +5320,9 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
 
       if (newState == IDLE_STATE)
          {
+         static char *disableIdleRATCleanup = feGetEnv("TR_disableIdleRATCleanup");
+         if (disableIdleRATCleanup == NULL)
+            persistentInfo->getRuntimeAssumptionTable()->reclaimMarkedAssumptionsFromRAT(-1);
          }
 
       // Logic related to IdleCPU exploitation

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1476,6 +1476,7 @@ static void jitHookGlobalGCStart(J9HookInterface * * hookInterface, UDATA eventN
 
    if (jitConfig && jitConfig->runtimeFlags & J9JIT_GC_NOTIFY)
       printf("\n{GGC");
+   jitReclaimMarkedAssumptions(false);
    }
 
 static void jitHookLocalGCStart(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
@@ -1498,6 +1499,7 @@ static void jitHookLocalGCStart(J9HookInterface * * hookInterface, UDATA eventNu
       printf("\n<jit: enabling stack tracing at gc %d>", jitConfig->gcCount);
       TR::Options::getCmdLineOptions()->setVerboseOption(TR_VerboseGc);
       }
+   jitReclaimMarkedAssumptions(false);
    }
 
 static void jitHookGlobalGCEnd(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
@@ -6786,7 +6788,7 @@ static void jitHookReleaseCodeGlobalGCEnd(J9HookInterface **hook, UDATA eventNum
    MM_GlobalGCEndEvent *event = (MM_GlobalGCEndEvent *)eventData;
    J9VMThread  *vmThread  = (J9VMThread*)event->currentThread->_language_vmthread;
    jitReleaseCodeStackWalk(vmThread->omrVMThread);
-   jitReclaimMarkedAssumptions();
+   jitReclaimMarkedAssumptions(true);
    }
 
 static void jitHookReleaseCodeGCCycleEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData)
@@ -6798,14 +6800,14 @@ static void jitHookReleaseCodeGCCycleEnd(J9HookInterface **hook, UDATA eventNum,
       condYield = event->condYieldFromGCFunction;
 
    jitReleaseCodeStackWalk(omrVMThread,condYield);
-   jitReclaimMarkedAssumptions();
+   jitReclaimMarkedAssumptions(true);
    }
 
 static void jitHookReleaseCodeLocalGCEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData)
    {
    MM_LocalGCEndEvent *event = (MM_LocalGCEndEvent *)eventData;
    jitReleaseCodeStackWalk(event->currentThread);
-   jitReclaimMarkedAssumptions();
+   jitReclaimMarkedAssumptions(true);
    }
 
 

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -89,7 +89,7 @@ class TR_PersistentCHTable
 #endif
 
    protected:
-   void removeAssumptionFromList(OMR::RuntimeAssumption **list, OMR::RuntimeAssumption *assumption, OMR::RuntimeAssumption *prev);
+   void removeAssumptionFromRAT(OMR::RuntimeAssumption *assumption);
 
    private:
    uint8_t _buffer[sizeof(TR_LinkHead<TR_PersistentClassInfo>) * (CLASSHASHTABLE_SIZE + 1)];

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -113,7 +113,7 @@ class TR_RuntimeAssumptionTable
    int32_t getAssumptionCount(int32_t tableId) const { return assumptionCount[tableId]; }
    int32_t getReclaimedAssumptionCount(int32_t tableId) const { return reclaimedAssumptionCount[tableId]; }
    void incReclaimedAssumptionCount(int32_t tableId) { reclaimedAssumptionCount[tableId]++; }
-   void detachFromRAT(OMR::RuntimeAssumption *assumption);
+   void markForDetachFromRAT(OMR::RuntimeAssumption *assumption);
 
    void markAssumptionsAndDetach(void *reclaimedMetaData, bool reclaimPrePrologueAssumptions = false);
 
@@ -132,7 +132,6 @@ class TR_RuntimeAssumptionTable
    friend class OMR::RuntimeAssumption;
    void addAssumption(OMR::RuntimeAssumption *a, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption **sentinel);
    int32_t reclaimAssumptions(void *md, OMR::RuntimeAssumption **hashTable, OMR::RuntimeAssumption **possiblyRelevantHashTable);
-   void markForDetachFromRAT(OMR::RuntimeAssumption *assumption);
 
    // My table of hash tables; init() allocate memory and populate it
    TR_RatHT _tables[LastAssumptionKind];

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -116,7 +116,15 @@ class TR_RuntimeAssumptionTable
    void detachFromRAT(OMR::RuntimeAssumption *assumption);
 
    void markAssumptionsAndDetach(void *reclaimedMetaData, bool reclaimPrePrologueAssumptions = false);
-   void reclaimMarkedAssumptionsFromRAT();
+
+   /**
+    * Walk the table removing entries that have been marked as detached.
+    *
+    * If a clean-up count is specified at most that number of entries will be
+    * removed from the table - this is used to rate limit clean-up activity
+    * and amortize the cost over time.
+    */
+   void reclaimMarkedAssumptionsFromRAT(int32_t cleanupCount = -1);
 
    int32_t countRatAssumptions();
 

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -3021,7 +3021,7 @@ TR_DebugExt::dxPrintRuntimeAssumption(OMR::RuntimeAssumption *ra)
    OMR::RuntimeAssumption *localRuntimeAssumption = (OMR::RuntimeAssumption*) dxMallocAndRead(sizeof(OMR::RuntimeAssumption), ra);
    _dbgPrintf("((OMR::RuntimeAssumption*)0x%p)->_key=0x%x, ", ra, localRuntimeAssumption->_key);
    _dbgPrintf(" ->_next= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNext());
-   _dbgPrintf(" ->_nextAssumptionForSameJittedBody= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextAssumptionForSameJittedBody());
+   _dbgPrintf(" ->_nextAssumptionForSameJittedBody= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextAssumptionForSameJittedBodyEvenIfDead());
    dxFree(localRuntimeAssumption);
    }
 void
@@ -3034,18 +3034,20 @@ TR_DebugExt::dxPrintRuntimeAssumptionList(OMR::RuntimeAssumption *ra)
       }
    OMR::RuntimeAssumption *localRuntimeAssumption = (OMR::RuntimeAssumption*) dxMallocAndRead(sizeof(OMR::RuntimeAssumption), ra);
    _dbgPrintf("((OMR::RuntimeAssumption*)0x%p)->_key=0x%x, ", ra, localRuntimeAssumption->_key);
-   _dbgPrintf(" ->_next= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNext());
-   _dbgPrintf(" ->_nextAssumptionForSameJittedBody= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextAssumptionForSameJittedBody());
-   OMR::RuntimeAssumption *nextRuntimeAssumption = localRuntimeAssumption->getNextAssumptionForSameJittedBody();
+   _dbgPrintf("((OMR::RuntimeAssumption*)0x%p)->isMarkedForDetach()=%d, ", ra, localRuntimeAssumption->isMarkedForDetach());
+   _dbgPrintf(" ->_next= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextEvenIfDead());
+   _dbgPrintf(" ->_nextAssumptionForSameJittedBody= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextAssumptionForSameJittedBodyEvenIfDead());
+   OMR::RuntimeAssumption *nextRuntimeAssumption = localRuntimeAssumption->getNextAssumptionForSameJittedBodyEvenIfDead();
    dxFree(localRuntimeAssumption);
 
    while (nextRuntimeAssumption != ra)
       {
       OMR::RuntimeAssumption *localRuntimeAssumption = (OMR::RuntimeAssumption*) dxMallocAndRead(sizeof(OMR::RuntimeAssumption), nextRuntimeAssumption);
       _dbgPrintf("((OMR::RuntimeAssumption*)0x%p)->_key=0x%x, ", nextRuntimeAssumption, localRuntimeAssumption->_key);
-      _dbgPrintf(" ->_next= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNext());
-      _dbgPrintf(" ->_nextAssumptionForSameJittedBody= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextAssumptionForSameJittedBody());
-      nextRuntimeAssumption = localRuntimeAssumption->getNextAssumptionForSameJittedBody();
+      _dbgPrintf("((OMR::RuntimeAssumption*)0x%p)->isMarkedForDetach()=%d, ", nextRuntimeAssumption, localRuntimeAssumption->isMarkedForDetach());
+      _dbgPrintf(" ->_next= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextEvenIfDead());
+      _dbgPrintf(" ->_nextAssumptionForSameJittedBody= !trprint runtimeassumption 0x%p\n", localRuntimeAssumption->getNextAssumptionForSameJittedBodyEvenIfDead());
+      nextRuntimeAssumption = localRuntimeAssumption->getNextAssumptionForSameJittedBodyEvenIfDead();
       dxFree(localRuntimeAssumption);
       }
    _dbgPrintf("Finish printing runtimeassumptionlist\n");

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -231,18 +231,28 @@ bool OMR::RuntimeAssumption::isAssumingMethod(void *md, bool reclaimPrePrologueA
 void OMR::RuntimeAssumption::dequeueFromListOfAssumptionsForJittedBody()
    {
    // We should not try to detach TR::SentinelRuntimeAssumption
-   TR_ASSERT(getAssumptionKind() != RuntimeAssumptionSentinel, "Sentinel assumptions cannot be detached");
-   OMR::RuntimeAssumption *crt = this->getNextAssumptionForSameJittedBody();
+   TR_ASSERT_FATAL(getAssumptionKind() != RuntimeAssumptionSentinel, "Sentinel assumptions cannot be detached");
+   OMR::RuntimeAssumption *crt = this->getNextAssumptionForSameJittedBodyEvenIfDead();
    OMR::RuntimeAssumption *prev = this;
    TR_ASSERT(crt, "Assumption must be queued when trying to detach");
    while (crt != this)
       {
-      // any such assumption (except the sentinel) must have an assumption location belonging to this body
-      prev = crt;
-      crt = crt->getNextAssumptionForSameJittedBody();
+      if (crt->isMarkedForDetach())
+         {
+         OMR::RuntimeAssumption *next = crt->getNextAssumptionForSameJittedBodyEvenIfDead();
+         prev->setNextAssumptionForSameJittedBody(next);
+         crt->setNextAssumptionForSameJittedBody(NULL);
+         crt = next;
+         }
+      else
+         {
+         // any such assumption (except the sentinel) must have an assumption location belonging to this body
+         prev = crt;
+         crt = crt->getNextAssumptionForSameJittedBodyEvenIfDead();
+         }
       }
    // Now I completed a full circle
-   prev->setNextAssumptionForSameJittedBody(crt->getNextAssumptionForSameJittedBody());
+   prev->setNextAssumptionForSameJittedBody(crt->getNextAssumptionForSameJittedBodyEvenIfDead());
    crt->setNextAssumptionForSameJittedBody(NULL); // assumption no longer in the circular list
    /* need a frontend */
    if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseRuntimeAssumptions))
@@ -266,7 +276,7 @@ bool OMR::RuntimeAssumption::enqueueInListOfAssumptionsForJittedBody(OMR::Runtim
       if (*sentinel == NULL) // ran ouf of memory during runtime
          return false;
       }
-   this->setNextAssumptionForSameJittedBody((*sentinel)->getNextAssumptionForSameJittedBody());
+   this->setNextAssumptionForSameJittedBody((*sentinel)->getNextAssumptionForSameJittedBodyEvenIfDead());
    (*sentinel)->setNextAssumptionForSameJittedBody(this);
    return true;
    }
@@ -335,24 +345,7 @@ void TR_RuntimeAssumptionTable::addAssumption(OMR::RuntimeAssumption *a, TR_Runt
 void
 TR_RuntimeAssumptionTable::detachFromRAT(OMR::RuntimeAssumption *assumption)
    {
-   OMR::RuntimeAssumption **headPtr = getBucketPtr(assumption->getAssumptionKind(), assumption->hashCode());
-   OMR::RuntimeAssumption *cursor = *headPtr;
-   OMR::RuntimeAssumption *prev   = NULL;
-   while (cursor)
-      {
-      OMR::RuntimeAssumption *next = cursor->getNext();
-      if (cursor == assumption)
-         {
-         if (prev)
-            prev->setNext(assumption->getNext());
-         else
-            *headPtr = assumption->getNext();
-         break;
-         }
-      prev = cursor;
-      cursor = next;
-      }
-   TR_ASSERT(cursor, "Must find my assumption in rat\n");
+   markForDetachFromRAT(assumption);
    }
 
 /** 
@@ -370,6 +363,7 @@ void TR_RuntimeAssumptionTable::markForDetachFromRAT(OMR::RuntimeAssumption *ass
    _detachPending[assumption->getAssumptionKind()] = true;
    hashTable->_markedforDetachCount[(assumption->hashCode() % hashTable->_spineArraySize)]++;
    assumption->markForDetach();
+   _marked++;
    }
 
 /**
@@ -379,53 +373,58 @@ void TR_RuntimeAssumptionTable::markForDetachFromRAT(OMR::RuntimeAssumption *ass
  * will be traversed, and only the hashtable linked-lists that have a non-zero 
  * marked for detach count will be traversed.
  */
-void TR_RuntimeAssumptionTable::reclaimMarkedAssumptionsFromRAT()
+void TR_RuntimeAssumptionTable::reclaimMarkedAssumptionsFromRAT(int32_t cleanupCount)
    {
-   TR_RatHT *hashTable;
-   OMR::RuntimeAssumption *cursor, *next, *prev;
-   int kind, reclaimed=0;
-
    assumptionTableMutex->enter();
-   for (kind=0; kind < LastAssumptionKind; kind++) // for each table
+   for (int kind=0; cleanupCount != 0 && kind < LastAssumptionKind; kind++) // for each table
       {
       if (_detachPending[kind] == true)  // Is there anything to remove from this table?
          {
-         hashTable = _tables + kind;
-         for (size_t i = 0; i < hashTable->_spineArraySize; ++i) // for each bucket in the table
+         TR_RatHT *hashTable = _tables + kind;
+         bool fullyCleaned = true;
+         for (size_t i = 0; cleanupCount != 0 && i < hashTable->_spineArraySize; ++i) // for each bucket in the table
             {
+            OMR::RuntimeAssumption *cursor, *next, *prev;
             // Look for linked list nodes to remove until all marked nodes have been deleted
-            for (cursor = hashTable->_htSpineArray[i], prev = NULL; cursor && hashTable->_markedforDetachCount[i] > 0; cursor = next)
+            for (cursor = hashTable->_htSpineArray[i], prev = NULL; cursor && cleanupCount != 0 && hashTable->_markedforDetachCount[i] > 0; cursor = next)
                {
-               next = cursor->getNext();
+               next = cursor->getNextEvenIfDead();
                if (cursor->isMarkedForDetach())
                   {
                   if (prev)
+                     {
                      prev->setNext(next);
+                     }
                   else
                      {
-                     TR_ASSERT( hashTable->_htSpineArray[i] == cursor, "RAT spine head is not cursor!" );
+                     TR_ASSERT_FATAL( hashTable->_htSpineArray[i] == cursor, "RAT spine head is not cursor!" );
                      hashTable->_htSpineArray[i] = next;
                      }
-                  hashTable->_markedforDetachCount[i]--;
+
+                  if (cursor->getNextAssumptionForSameJittedBodyEvenIfDead())
+                     cursor->dequeueFromListOfAssumptionsForJittedBody();
+
                   // Now release the assumption
+                  hashTable->_markedforDetachCount[i]--;
+                  _marked--;
                   incReclaimedAssumptionCount(kind);
                   cursor->reclaim();
                   cursor->paint(); // RAS
                   TR_PersistentMemory::jitPersistentFree(cursor);
-                  reclaimed++; // RAS
+                  cleanupCount--;
                   }
                else
                   {
                   prev = cursor;
                   }
                }
-            TR_ASSERT( hashTable->_markedforDetachCount[i]==0, "RAT detach count should be 0!" );
+            if (hashTable->_markedforDetachCount[i] != 0)
+               fullyCleaned = false;
             }
-         _detachPending[kind] = false;
+         if (fullyCleaned)
+            _detachPending[kind] = false;
          }
       }
-   TR_ASSERT( _marked == reclaimed, "Did not reclaim all the marked assumptions!" );
-   _marked=0;
    assumptionTableMutex->exit();
    }
 
@@ -446,17 +445,17 @@ void TR_RuntimeAssumptionTable::markAssumptionsAndDetach(void * md, bool reclaim
    if (sentry)
       {
       TR_ASSERT(sentry->getAssumptionKind() == RuntimeAssumptionSentinel, "First assumption must be the sentinel\n");
-      OMR::RuntimeAssumption *notReclaimedList = sentry;
+      bool entriesRemain = false;
       for ( cursor=sentry->getNextAssumptionForSameJittedBody(); cursor != sentry; cursor=next)
          {
          next = cursor->getNextAssumptionForSameJittedBody();
          if (cursor->isAssumingMethod(metaData, reclaimPrePrologueAssumptions))
             {
-            markForDetachFromRAT(cursor); // Mark for deletion
-            _marked++;
+            markForDetachFromRAT(cursor);
             }
          else // This could be an assumption to the persistentBodyInfo which is not reclaimed
             {
+            entriesRemain = true;
             #if defined(PROD_WITH_ASSUMES) || defined(DEBUG)
             TR_RuntimeAssumptionKind kind = cursor->getAssumptionKind();
             TR_ASSERT(kind == RuntimeAssumptionOnClassRedefinitionPIC ||
@@ -465,20 +464,12 @@ void TR_RuntimeAssumptionTable::markAssumptionsAndDetach(void * md, bool reclaim
                "non redefinition assumption (RA=%p kind=%d key=%p) left after metadata reclamation\n",
                cursor, kind, cursor->getKey());
             #endif
-            cursor->setNextAssumptionForSameJittedBody(notReclaimedList);
-            notReclaimedList = cursor;
             }
          }
-
-      if (notReclaimedList != sentry) // some entries were not reclaimed
+      
+      if (!entriesRemain)
          {
-         // Must attach the notReclaimedList to the sentinel
-         sentry->setNextAssumptionForSameJittedBody(notReclaimedList);
-         }
-      else // nothing is kept in this list; free the sentry too
-         {
-         sentry->paint(); // RAS
-         TR_PersistentMemory::jitPersistentFree(sentry);
+         sentry->markForDetach();
          metaData->runtimeAssumptionList = NULL;
          }
       }
@@ -495,7 +486,7 @@ void TR_RuntimeAssumptionTable::reclaimAssumptions(OMR::RuntimeAssumption **sent
    OMR::RuntimeAssumption *sentry = *sentinel;
    if (*sentinel != NULL) // list is not empty
       {
-      int32_t numAssumptionsNotReclaimed = 0; // RAS
+      int32_t numAssumptionsNotReclaimed = 0;
       TR_ASSERT(sentry->getAssumptionKind() == RuntimeAssumptionSentinel, "First assumption must be the sentinel\n");
       OMR::RuntimeAssumption *notReclaimedList = sentry;
       OMR::RuntimeAssumption *cursor = sentry->getNextAssumptionForSameJittedBody();
@@ -505,49 +496,36 @@ void TR_RuntimeAssumptionTable::reclaimAssumptions(OMR::RuntimeAssumption **sent
          if (!metaData || cursor->isAssumingMethod(metaData, reclaimPrePrologueAssumptions))
             {
             // Must detach the entry from the RAT
-            detachFromRAT(cursor);
-            incReclaimedAssumptionCount(cursor->getAssumptionKind());
-            cursor->reclaim();
-            cursor->paint(); // RAS
-            TR_PersistentMemory::jitPersistentFree(cursor);
+            markForDetachFromRAT(cursor);
             }
          else // This could be an assumption to the persistentBodyInfo which is not reclaimed
             {
-            cursor->setNextAssumptionForSameJittedBody(notReclaimedList);
-            notReclaimedList = cursor;
-            numAssumptionsNotReclaimed++; // RAS
+            numAssumptionsNotReclaimed++;
             }
          cursor = next;
          }
-      if (notReclaimedList != sentry) // some entries were not reclaimed
+      if (numAssumptionsNotReclaimed > 0)
          {
-         // Must attach the notReclaimedList to the sentinel
-         sentry->setNextAssumptionForSameJittedBody(notReclaimedList);
-
 #ifdef PROD_WITH_ASSUMES
-         if (numAssumptionsNotReclaimed > 1)
+         cursor = sentry->getNextAssumptionForSameJittedBody();
+         while (cursor != sentry)
             {
-            cursor = sentry->getNextAssumptionForSameJittedBody();
-            while (cursor != sentry)
+            TR_RuntimeAssumptionKind kind = cursor->getAssumptionKind();
+            if (kind != RuntimeAssumptionOnClassRedefinitionPIC &&
+                kind != RuntimeAssumptionOnClassRedefinitionUPIC &&
+                kind != RuntimeAssumptionOnClassRedefinitionNOP)
                {
-               TR_RuntimeAssumptionKind kind = cursor->getAssumptionKind();
-               if (kind != RuntimeAssumptionOnClassRedefinitionPIC &&
-                   kind != RuntimeAssumptionOnClassRedefinitionUPIC &&
-                   kind != RuntimeAssumptionOnClassRedefinitionNOP)
-                  {
-                  fprintf(stderr, "%d assumptions were left after metadata %p assumption reclaiming\n", numAssumptionsNotReclaimed, metaData);
-                  fprintf(stderr, "RA=%p kind=%d key=%p assumingPC=%p\n", cursor, cursor->getAssumptionKind(), cursor->getKey(), cursor->getFirstAssumingPC());
-                  TR_ASSERT(false, "non redefinition assumptions left after metadata reclamation\n");
-                  }
-               cursor = cursor->getNextAssumptionForSameJittedBody();
+               fprintf(stderr, "%d assumptions were left after metadata %p assumption reclaiming\n", numAssumptionsNotReclaimed, metaData);
+               fprintf(stderr, "RA=%p kind=%d key=%p assumingPC=%p\n", cursor, cursor->getAssumptionKind(), cursor->getKey(), cursor->getFirstAssumingPC());
+               TR_ASSERT(false, "non redefinition assumptions left after metadata reclamation\n");
                }
+            cursor = cursor->getNextAssumptionForSameJittedBody();
             }
 #endif
          }
-      else // nothing is kept in this list; free the sentry too
+      else
          {
-         sentry->paint(); // RAS
-         TR_PersistentMemory::jitPersistentFree(sentry);
+         sentry->markForDetach();
          *sentinel = NULL;
          }
       }
@@ -624,17 +602,7 @@ TR_RuntimeAssumptionTable::notifyIllegalStaticFinalFieldModificationEvent(TR_Fro
             TR_VerboseLog::vlogRelease();
             }
          cursor->compensate(vm, 0, 0);
-         cursor->dequeueFromListOfAssumptionsForJittedBody();
-         incReclaimedAssumptionCount(cursor->getAssumptionKind());
-         cursor->reclaim();
-         cursor->paint();
-
-         TR_PersistentMemory::jitPersistentFree(cursor);
-         if (prev)
-            prev->setNext(next);
-         else
-            *headPtr = next;
-         cursor = next;
+         markForDetachFromRAT(cursor);
          continue;
          }
       prev = cursor;
@@ -656,12 +624,10 @@ TR_RuntimeAssumptionTable::notifyClassUnloadEvent(TR_FrontEnd *vm, bool isSMP,
    {
    OMR::CriticalSection notifyClassUnloadEvent(assumptionTableMutex);
    OMR::RuntimeAssumption **headPtr = getBucketPtr(RuntimeAssumptionOnClassUnload, hashCode((uintptrj_t)assumingClass));
-   TR_UnloadedClassPicSite *cursor = (TR_UnloadedClassPicSite*)(*headPtr);
-   TR_UnloadedClassPicSite *prev   = 0;
-   while (cursor)
+   for (TR_UnloadedClassPicSite *cursor = (TR_UnloadedClassPicSite*)(*headPtr)
+        ; cursor
+        ; cursor = (TR_UnloadedClassPicSite*)cursor->getNext())
       {
-      TR_UnloadedClassPicSite *next = (TR_UnloadedClassPicSite*)cursor->getNext();
-
       if (cursor->matches((uintptrj_t)assumingClass) &&
           ((unloadedClass == assumingClass) ||
            (cursor->getPicEntry() == (uintptrj_t)unloadedClass) ))
@@ -669,23 +635,9 @@ TR_RuntimeAssumptionTable::notifyClassUnloadEvent(TR_FrontEnd *vm, bool isSMP,
          cursor->compensate(vm, 0, 0);
          if (assumingClass == unloadedClass)
             {
-            // before deleting the assumption, let's take it out from the list hung off persistentJittedBodyInfo
-            // TODO: replace these statements with CHTable::removeAssumptionFromList(OMR::RuntimeAssumption *&list, OMR::RuntimeAssumption *assumption, OMR::RuntimeAssumption *prev);
-            cursor->dequeueFromListOfAssumptionsForJittedBody();
-            incReclaimedAssumptionCount(cursor->getAssumptionKind());
-            cursor->paint(); // RAS
-
-            TR_PersistentMemory::jitPersistentFree(cursor);
-            if (prev)
-               prev->setNext(next);
-            else
-               *headPtr = next;
-            cursor = next;
-            continue;
+            markForDetachFromRAT(cursor);
             }
          }
-      prev = cursor;
-      cursor = next;
       }
    }
 
@@ -847,7 +799,6 @@ TR_RuntimeAssumptionTable::notifyClassRedefinitionEvent(TR_FrontEnd *vm, bool is
       }
    oldHeadPtr = getBucketPtr(RuntimeAssumptionOnClassRedefinitionNOP, hashCode((uintptrj_t)oldKey));
    OMR::RuntimeAssumption* nop_cursor = *oldHeadPtr;
-   OMR::RuntimeAssumption* nop_prev = NULL;
 
    raArray = findAssumptionHashTable(RuntimeAssumptionOnClassRedefinitionNOP)->_htSpineArray;
    if (reportDetails)
@@ -873,21 +824,10 @@ TR_RuntimeAssumptionTable::notifyClassRedefinitionEvent(TR_FrontEnd *vm, bool is
             TR_VerboseLog::vlogRelease();
             }
          nop_cursor->compensate(vm, 0, 0);
-         nop_cursor->dequeueFromListOfAssumptionsForJittedBody();
-         incReclaimedAssumptionCount(nop_cursor->getAssumptionKind());
-         nop_cursor->reclaim();
-         nop_cursor->paint(); // RAS
-
-         // HCR remove the assumption
-         TR_PersistentMemory::jitPersistentFree(nop_cursor);
-         if (nop_prev)
-            nop_prev->setNext(nop_next);
-         else
-            *oldHeadPtr = nop_next;
+         markForDetachFromRAT(nop_cursor);
          nop_cursor = nop_next;
          continue;
          }
-      nop_prev = nop_cursor;
       nop_cursor = nop_next;
       }
 
@@ -1074,7 +1014,6 @@ TR_RuntimeAssumptionTable::notifyMutableCallSiteChangeEvent(TR_FrontEnd *fe, uin
 
    OMR::RuntimeAssumption **headPtr = getBucketPtr(RuntimeAssumptionOnMutableCallSiteChange, hashCode(cookie));
    TR_PatchNOPedGuardSiteOnMutableCallSiteChange *cursor = (TR_PatchNOPedGuardSiteOnMutableCallSiteChange*)(*headPtr);
-   TR_PatchNOPedGuardSiteOnMutableCallSiteChange *prev   = 0;
    while (cursor)
       {
       TR_PatchNOPedGuardSiteOnMutableCallSiteChange *next = (TR_PatchNOPedGuardSiteOnMutableCallSiteChange*)cursor->getNext();
@@ -1089,22 +1028,7 @@ TR_RuntimeAssumptionTable::notifyMutableCallSiteChangeEvent(TR_FrontEnd *fe, uin
             TR_VerboseLog::vlogRelease();
             }
          cursor->compensate(fe, 0, 0);
-
-         // before deleting the assumption, let's take it out from the list hung off persistentJittedBodyInfo
-         // TODO: replace these statements with CHTable::removeAssumptionFromList(OMR::RuntimeAssumption *&list, OMR::RuntimeAssumption *assumption, OMR::RuntimeAssumption *prev);
-         cursor->dequeueFromListOfAssumptionsForJittedBody();
-         incReclaimedAssumptionCount(cursor->getAssumptionKind());
-         cursor->paint(); // RAS
-
-         TR_PersistentMemory::jitPersistentFree(cursor);
-         if (prev)
-            prev->setNext(next);
-         else
-            *headPtr = next;
-         }
-      else
-         {
-         prev = cursor;
+         markForDetachFromRAT(cursor);
          }
       cursor = next;
       }

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -340,12 +340,6 @@ void TR_RuntimeAssumptionTable::addAssumption(OMR::RuntimeAssumption *a, TR_Runt
       }
    }
 
-void
-TR_RuntimeAssumptionTable::detachFromRAT(OMR::RuntimeAssumption *assumption)
-   {
-   markForDetachFromRAT(assumption);
-   }
-
 /** 
  * Mark an assumption for future detach and reclaiming from the RAT
  * @param assumption The assumption to be marked for removal

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -416,11 +416,11 @@ void jitRemoveAllMetaDataForClassLoader(J9VMThread * vmThread, J9ClassLoader * c
 void jitReclaimMarkedAssumptions(bool isEager)
    {
    static char *forceAggressiveRATCleaning = feGetEnv("TR_forceAggressiveRATCleaning");
-   if (isEager && forceAggressiveRATCleaning)
+   if (isEager || forceAggressiveRATCleaning)
       {
       reclaimMarkedAssumptionsFromRAT(-1);
       }
-   else if (!isEager && !forceAggressiveRATCleaning)
+   else
       {
       reclaimMarkedAssumptionsFromRAT(100);
       }

--- a/runtime/compiler/runtime/HookHelpers.hpp
+++ b/runtime/compiler/runtime/HookHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/HookHelpers.hpp
+++ b/runtime/compiler/runtime/HookHelpers.hpp
@@ -35,7 +35,7 @@ struct J9VMThread;
 
 void jitReleaseCodeCollectMetaData(J9JITConfig *jitConfig, J9VMThread *vmThread, J9JITExceptionTable *metaData, OMR::FaintCacheBlock* = 0);
 void jitRemoveAllMetaDataForClassLoader(J9VMThread * vmThread, J9ClassLoader * classLoader);
-void jitReclaimMarkedAssumptions();
+void jitReclaimMarkedAssumptions(bool isEager);
 void vlogReclamation(const char *prefix, J9JITExceptionTable *metaData, size_t bytesToSaveAtStart);
 void freeFastWalkCache(J9VMThread *vmThread, J9JITExceptionTable *metaData);
 

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -490,15 +490,6 @@ TR_PersistentCHTable::removeAssumptionFromList(
       OMR::RuntimeAssumption *assumption,
       OMR::RuntimeAssumption *prev)
    {
-   OMR::RuntimeAssumption *next = assumption->getNext();
-   assumption->dequeueFromListOfAssumptionsForJittedBody();
    TR_RuntimeAssumptionTable *rat = _trPersistentMemory->getPersistentInfo()->getRuntimeAssumptionTable();
-   rat->incReclaimedAssumptionCount(assumption->getAssumptionKind());
-   assumption->paint(); // RAS
-
-   jitPersistentFree(assumption);
-   if (prev)
-      prev->setNext(next);
-   else
-      *list = next;
+   rat->detachFromRAT(assumption);
    }

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -261,23 +261,13 @@ TR_PersistentCHTable::classGotExtended(
       OMR::CriticalSection classGotExtended(assumptionTableMutex);
       OMR::RuntimeAssumption ** headPtr = table->getBucketPtr(RuntimeAssumptionOnClassExtend,
                                          TR_RuntimeAssumptionTable::hashCode((uintptrj_t) superClassId));
-      OMR::RuntimeAssumption *cursor = *headPtr;
-      OMR::RuntimeAssumption *prev   = 0;
-      while (cursor)
+      for (OMR::RuntimeAssumption *cursor = *headPtr; cursor; cursor = cursor->getNext())
          {
-         OMR::RuntimeAssumption *next = cursor->getNext();
-
          if (cursor->matches((uintptrj_t) superClassId))
             {
             cursor->compensate(fe, 0, 0);
-            removeAssumptionFromList(headPtr, cursor, prev);
+            removeAssumptionFromRAT(cursor);
             }
-         else
-            {
-            prev = cursor;
-            }
-
-         cursor = next;
          }
       }
 
@@ -368,23 +358,13 @@ TR_PersistentCHTable::classGotInitialized(
       TR_RuntimeAssumptionTable *table = persistentMemory->getPersistentInfo()->getRuntimeAssumptionTable();
       OMR::RuntimeAssumption ** headPtr = table->getBucketPtr(RuntimeAssumptionOnClassPreInitialize, TR_PatchNOPedGuardSiteOnClassPreInitialize::hashCode(sig, sigLen));
 
-      OMR::RuntimeAssumption *cursor = *headPtr;
-      OMR::RuntimeAssumption *prev   = 0;
-      while (cursor)
+      for (OMR::RuntimeAssumption *cursor = *headPtr; cursor; cursor = cursor->getNext())
          {
-         OMR::RuntimeAssumption *next = cursor->getNext();
-
          if (cursor->matches(sig, sigLen))
             {
             cursor->compensate(fej9, 0, 0);
-            removeAssumptionFromList(headPtr, cursor, prev);
+            removeAssumptionFromRAT(cursor);
             }
-         else
-            {
-            prev = cursor;
-            }
-
-         cursor = next;
          }
       }
 
@@ -404,23 +384,13 @@ TR_PersistentCHTable::methodGotOverridden(
    TR_RuntimeAssumptionTable *table = persistentMemory->getPersistentInfo()->getRuntimeAssumptionTable();
    OMR::RuntimeAssumption ** headPtr = table->getBucketPtr(RuntimeAssumptionOnMethodOverride,
                                         TR_RuntimeAssumptionTable::hashCode((uintptrj_t)overriddenMethod));
-   OMR::RuntimeAssumption *cursor = *headPtr;
-   OMR::RuntimeAssumption *prev   = 0;
-   while (cursor)
+   for (OMR::RuntimeAssumption *cursor = *headPtr; cursor; cursor = cursor->getNext())
       {
-      OMR::RuntimeAssumption *next = cursor->getNext();
-
       if (cursor->matches((uintptrj_t) overriddenMethod))
          {
          cursor->compensate(fe, 0, 0);
-         removeAssumptionFromList(headPtr, cursor, prev);
+         removeAssumptionFromRAT(cursor);
          }
-      else
-         {
-         prev = cursor;
-         }
-
-      cursor = next;
       }
    }
 
@@ -442,23 +412,13 @@ TR_PersistentCHTable::classGotRedefined(
    TR_RuntimeAssumptionTable *table = _trPersistentMemory->getPersistentInfo()->getRuntimeAssumptionTable();
    OMR::RuntimeAssumption **headPtr = table->getBucketPtr(RuntimeAssumptionOnClassExtend,
                                       TR_RuntimeAssumptionTable::hashCode((uintptrj_t) oldClassId));
-   OMR::RuntimeAssumption *cursor = *headPtr;
-   OMR::RuntimeAssumption *prev   = 0;
-   while (cursor)
+   for (OMR::RuntimeAssumption *cursor = *headPtr; cursor; cursor = cursor->getNext())
       {
-      OMR::RuntimeAssumption *next = cursor->getNext();
-
       if (cursor->matches((uintptrj_t) oldClassId))
          {
          cursor->compensate(fe, 0, 0);
-         removeAssumptionFromList(headPtr, cursor, prev);
+         removeAssumptionFromRAT(cursor);
          }
-      else
-         {
-         prev = cursor;
-         }
-
-      cursor = next;
       }
 
    //
@@ -485,10 +445,7 @@ TR_PersistentCHTable::classGotRedefined(
 
 
 void
-TR_PersistentCHTable::removeAssumptionFromList(
-      OMR::RuntimeAssumption **list,
-      OMR::RuntimeAssumption *assumption,
-      OMR::RuntimeAssumption *prev)
+TR_PersistentCHTable::removeAssumptionFromRAT(OMR::RuntimeAssumption *assumption)
    {
    TR_RuntimeAssumptionTable *rat = _trPersistentMemory->getPersistentInfo()->getRuntimeAssumptionTable();
    rat->detachFromRAT(assumption);

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -448,5 +448,5 @@ void
 TR_PersistentCHTable::removeAssumptionFromRAT(OMR::RuntimeAssumption *assumption)
    {
    TR_RuntimeAssumptionTable *rat = _trPersistentMemory->getPersistentInfo()->getRuntimeAssumptionTable();
-   rat->detachFromRAT(assumption);
+   rat->markForDetachFromRAT(assumption);
    }


### PR DESCRIPTION
This change centralizes assumption Runtime Assumption Table clean-up logic by
converting all sites which remove assumptions to simply mark assumptions for
later removal. RAT manipulation functions in RuntimeAssumption are now protected
and accessed by friendship to prevent incorrect manipulation of the next pointers.
Finally, the clean-up routine has gained the ability to do a partial clean-up
which will be used to rate-limit clean-up to amortize the cost.

Rather than cleaning all assumptions at the end of a GC we will now
clean a limited number of assumptions at GC start (both scavenge and
global) to amortize the clean-up cost over time and minimize pauses.
When the JIT control state enters IDLE take the opportunity to eagerly
clean the RAT of any remaining dead assumptions since the CPU is not
required for the application at that moment. Clean-up should be short
especially since during GC cycles we will have already begun cleaning
the RAT.

depends eclipse/omr/pull/3657