### PR TITLE
Replace j9sock_gethostname with omrsysinfo_get_hostname

### DIFF
--- a/runtime/jcl/common/mgmtruntime.c
+++ b/runtime/jcl/common/mgmtruntime.c
@@ -31,9 +31,10 @@ Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_getNameImpl(JNIEnv 
 	char hostname[256];
 	char result[256];
 	PORT_ACCESS_FROM_ENV( env );
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
 	pid = j9sysinfo_get_pid();
-	j9sock_gethostname( hostname, 256 );
+	omrsysinfo_get_hostname( hostname, 256 );
 	j9str_printf( PORTLIB, result, 256, "%zu@%s", pid, hostname );
 
 	return (*env)->NewStringUTF( env, result );

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -574,12 +574,13 @@ populateRASNetData(J9JavaVM *javaVM, J9RAS *rasStruct)
 	j9addrinfo_t hints;
 	U_64 startTime, endTime;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
 	/* measure the time taken to call the socket APIs, so we can issue a warning */
 	startTime = j9time_current_time_millis();
 
 	/* get the host name and IP addresses */
-	if (0 != j9sock_gethostname((char*)rasStruct->hostname,  sizeof(rasStruct->hostname) )) {
+	if (0 != omrsysinfo_get_hostname((char*)rasStruct->hostname,  sizeof(rasStruct->hostname) )) {
 		/* error so null the buffer so we don't try to work with it on the other side */
 		memset(rasStruct->hostname, 0, sizeof(rasStruct->hostname));
 	}


### PR DESCRIPTION
Leave the current j9sock functions for compatibility with legacy users.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>