### PR TITLE
Final changes for 0.13.0 GA

### DIFF
--- a/doc/release-notes/0.13/0.13.md
+++ b/doc/release-notes/0.13/0.13.md
@@ -31,9 +31,11 @@ These release notes support the [Eclipse OpenJ9 0.13 release plan](https://proje
 
 OpenJ9 release 0.13 supports OpenJDK 12. Binaries are available at the AdoptOpenJDK project:
 
-- [OpenJDK with OpenJ9 version 8](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)
+- [OpenJDK with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)
 
 All builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
+
+:pencil: On Linux and AIX platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](https://eclipse.org/openj9/docs/openj9_support/index.html).
 


### PR DESCRIPTION
Added a note about AdoptOpenJDK binaries not bundling
OpenSSL on Linux and AIX.

Fixed the link title to the Adopt OpenJDK 12 with OpenJ9 binaries.

[ci-skip]

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>