### PR TITLE
Correctly check if string compression is enabled

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -431,6 +431,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._overflowSafeAllocSize = static_cast<uint64_t>(fe->getOverflowSafeAllocSize());
          vmInfo._compressedReferenceShift = TR::Compiler->om.compressedReferenceShift();
          vmInfo._cacheStartAddress = fe->sharedCache() ? fe->sharedCache()->getCacheStartAddress() : 0;
+         vmInfo._stringCompressionEnabled = fe->isStringCompressionEnabledVM();
 
          client->write(vmInfo);
          }

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -90,6 +90,7 @@ class ClientSessionData
       uint64_t _overflowSafeAllocSize;
       int32_t _compressedReferenceShift;
       UDATA _cacheStartAddress;
+      bool _stringCompressionEnabled;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8196,6 +8196,12 @@ TR_J9VMBase::setInlineThresholds (TR::Compilation *comp, int32_t &callerWeightLi
    return;
    }
 
+bool
+TR_J9VMBase::isStringCompressionEnabledVM()
+   {
+   return IS_STRING_COMPRESSION_ENABLED_VM(getJ9JITConfig()->javaVM);
+   }
+
 TR_OpaqueClassBlock *
 TR_J9VM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1027,6 +1027,7 @@ public:
 
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass);
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) { return false; }
+   virtual bool isStringCompressionEnabledVM();
 
 protected:
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1481,6 +1481,14 @@ TR_J9ServerVM::getClassFromNewArrayTypeNonNull(int32_t arrayType)
    }
 
 bool
+TR_J9ServerVM::isStringCompressionEnabledVM()
+   {
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_stringCompressionEnabled;
+   }
+
+bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
    TR_ASSERT(vettedForAOT, "The TR_J9SharedCacheServerVM version of this method is expected to be called only from isClassLibraryMethod.\n"

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -169,6 +169,7 @@ public:
    virtual void reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding) override;
    virtual intptrj_t methodTrampolineLookup( TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override;
    virtual uintptrj_t getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz) override;
+   virtual bool isStringCompressionEnabledVM() override;
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1011,8 +1011,8 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
          TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesEnableStringCompressionFolding;
          TR_ASSERT(node->getDataType() == TR::Int32, "Java_lang_String_enableCompression must be Int32");
-         bool fieldValue = *(int32_t*)sym->castToStaticSymbol()->getStaticAddress() != 0;
-         bool compressionEnabled = IS_STRING_COMPRESSION_ENABLED_VM(static_cast<TR_J9VMBase *>(comp->fe())->getJ9JITConfig()->javaVM);
+         bool fieldValue = ((TR_J9VM *) comp->fej9())->dereferenceStaticFinalAddress(sym->castToStaticSymbol()->getStaticAddress(), TR::Int32).dataInt32Bit != 0;
+         bool compressionEnabled = comp->fej9()->isStringCompressionEnabledVM();
          TR_ASSERT((fieldValue && compressionEnabled) || (!fieldValue && !compressionEnabled),
             "java/lang/String.enableCompression and javaVM->strCompEnabled must be in sync");
          if (fieldValue)


### PR DESCRIPTION
- Add a front-end query to check if client has
string compression enabled in VM.
- Replace dereference of client-side address with
a front-end query.