### PR TITLE
Remove workaround in Access.defineClass()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -279,12 +279,7 @@ final class Access implements JavaLangAccess {
 
 	public Class<?> defineClass(ClassLoader classLoader, String className, byte[] classRep, ProtectionDomain protectionDomain, String str) {
 		ClassLoader targetClassLoader = (null == classLoader) ? ClassLoader.bootstrapClassLoader : classLoader;
-/*[IF Java12]
-		// temporary workaround to enable building Java 12 (https://github.com/eclipse/openj9/issues/3641)
-		return jdk.internal.misc.Unsafe.getUnsafe().defineClass(className, classRep, 0, classRep.length, targetClassLoader, protectionDomain);
-/*[ELSE]*/
-		return targetClassLoader.defineClass(className, classRep, 0, classRep.length, protectionDomain);
-/*[ENDIF]*/
+		return targetClassLoader.defineClassInternal(className, classRep, 0, classRep.length, protectionDomain, true /* allowNullProtectionDomain */);
 	}
 
 /*[IF Sidecar19-SE-OpenJ9]*/	

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -538,6 +538,18 @@ protected final Class<?> defineClass (
 		ProtectionDomain protectionDomain) 
 		throws java.lang.ClassFormatError 
 {
+	return defineClassInternal(className, classRep, offset, length, protectionDomain, false /* allowNullProtectionDomain */);
+}
+
+final Class<?> defineClassInternal(
+		final String className, 
+		final byte[] classRep, 
+		final int offset, 
+		final int length, 
+		ProtectionDomain protectionDomain,
+		boolean allowNullProtectionDomain)
+		throws java.lang.ClassFormatError 
+{
 	Certificate[] certs = null; 
 	if (protectionDomain != null) {
 		final CodeSource cs = protectionDomain.getCodeSource();
@@ -555,7 +567,7 @@ protected final Class<?> defineClass (
 		throw new ArrayIndexOutOfBoundsException();
 	}
 
-	if (protectionDomain == null)	{
+	if ((protectionDomain == null) && !allowNullProtectionDomain) {
 		protectionDomain = getDefaultProtectionDomain();
 	}
 	

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -46,28 +46,20 @@ Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader
 	JNIEnv *env, jobject receiver, jstring className, jbyteArray classRep, jint offset, jint length, jobject classLoader, jobject protectionDomain)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
-	J9JavaVM *vm = currentThread->javaVM;
-	jclass result;
 
 	if (NULL == classLoader) {
-		j9object_t classLoaderObject;
+		J9JavaVM *vm = currentThread->javaVM;
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 
-		classLoaderObject = J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, vm->systemClassLoader);
+		j9object_t classLoaderObject = J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, vm->systemClassLoader);
+
 		classLoader = vmFuncs->j9jni_createLocalRef(env, classLoaderObject);
 		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
-	result = defineClassCommon(env, classLoader, className, classRep, offset, length, protectionDomain, J9_FINDCLASS_FLAG_UNSAFE, NULL);
-
-	if (result != NULL) {
-		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-		vm->internalVMFunctions->fixUnsafeMethods(currentThread, result);
-		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
-	}
-
-	return result;
+	return defineClassCommon(env, classLoader, className, classRep, offset, length, protectionDomain, J9_FINDCLASS_FLAG_UNSAFE, NULL);
 }
 
 jclass JNICALL
@@ -116,10 +108,6 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 		throwNewInternalError(env, NULL);
 		return NULL;
 	}
-
-	vmFuncs->internalEnterVMFromJNI(currentThread);
-	vmFuncs->fixUnsafeMethods(currentThread, anonClass);
-	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return anonClass;
 }
@@ -1049,4 +1037,4 @@ illegal:
 	vmFuncs->internalReleaseVMAccess(currentThread);
 }
 
-}
+} /* extern "C" */

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1448,18 +1448,19 @@ exit:
 	}
 
 	/**
-	 * Checks whether a ROM class enforces the final field setting rules.
+	 * Checks whether a class enforces the final field setting rules.
 	 * Classes which are class file version 53 or above enforce the rule
-	 * unless the class was defined via Unsafe.
+	 * unless the class was defined in a way that exempts it from validation.
 	 *
-	 * @param romClass[in] the J9ROMClass to test
+	 * @param ramClass[in] the J9Class to test
 	 *
 	 * @returns true if the class enforces the rules, false if not
 	 */
 	static VMINLINE bool
-	romClassChecksFinalStores(J9ROMClass *romClass)
+	ramClassChecksFinalStores(J9Class *ramClass)
 	{
-		return (romClass->majorVersion >= 53) && !J9ROMCLASS_IS_UNSAFE(romClass);
+		return (!J9CLASS_IS_EXEMPT_FROM_VALIDATION(ramClass))
+			&& (ramClass->romClass->majorVersion >= 53);
 	}
 
 };

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -124,6 +124,9 @@ typedef struct J9ClassLoaderWalkState {
 #define J9CLASS_IS_ARRAY(ramClass) ((J9CLASS_FLAGS(ramClass) & J9_JAVA_CLASS_RAM_ARRAY) != 0)
 #define J9CLASS_IS_MIXED(ramClass) (((J9CLASS_FLAGS(ramClass) >> J9_JAVA_CLASS_RAM_SHAPE_SHIFT) & OBJECT_HEADER_SHAPE_MASK) == OBJECT_HEADER_SHAPE_MIXED)
 
+#define J9CLASS_IS_EXEMPT_FROM_VALIDATION(clazz) \
+	(J9ROMCLASS_IS_UNSAFE((clazz)->romClass) || J9_ARE_ANY_BITS_SET((clazz)->classFlags, J9ClassIsExemptFromValidation))
+
 #define IS_STRING_COMPRESSION_ENABLED(vmThread) (FALSE != ((vmThread)->javaVM)->strCompEnabled)
 
 #define IS_STRING_COMPRESSION_ENABLED_VM(javaVM) (FALSE != (javaVM)->strCompEnabled)

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -443,6 +443,11 @@ extern "C" {
 #define J9_FINDCLASS_FLAG_NO_ISOLATION 0x2000
 #define J9_FINDCLASS_FLAG_ANON 0x4000
 #define J9_FINDCLASS_FLAG_FIND_MODULE_ON_FAIL 0x8000
+/*
+ * The class name supplied by the caller is invalid. If the class is not exempt
+ * (see J9ClassIsExemptFromValidation), a NoClassDefFoundError will be thrown.
+ */
+#define J9_FINDCLASS_FLAG_NAME_IS_INVALID 0x10000
 
 #define J9_FINDKNOWNCLASS_FLAG_INITIALIZE 0x1
 #define J9_FINDKNOWNCLASS_FLAG_EXISTING_ONLY 0x2

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -167,6 +167,7 @@
 #define J9ClassHasWatchedFields 0x100
 #define J9ClassReservableLockWordInit 0x200
 #define J9ClassIsValueType 0x400
+#define J9ClassIsExemptFromValidation 0x2000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2156,7 +2156,7 @@ fixReturnsInUnsafeMethods(J9VMThread * currentThread, J9HashTable * classPairs)
     while (classPair != NULL) {
         J9Class * replacementRAMClass = classPair->replacementClass.ramClass;
 
-        if ((replacementRAMClass != NULL) && J9ROMCLASS_IS_UNSAFE(replacementRAMClass->romClass)) {
+        if ((replacementRAMClass != NULL) && J9CLASS_IS_EXEMPT_FROM_VALIDATION(replacementRAMClass)) {
              vmFuncs->fixUnsafeMethods(currentThread, (jclass) &replacementRAMClass->classObject);
         }
         classPair = hashTableNextDo(&hashTableState);
@@ -3278,7 +3278,7 @@ reloadROMClasses(J9VMThread * currentThread, jint class_count, const jvmtiClassD
 		 * For example, redefined class: sun.reflect.GeneratedMethodAccessor* (unsafe)
 		 * that has a superclass sun.reflect.MethodAccessorImpl */
 
-		if (J9ROMCLASS_IS_UNSAFE(originalRAMClass->romClass)) {
+		if (J9CLASS_IS_EXEMPT_FROM_VALIDATION(originalRAMClass)) {
 			options = options | J9_FINDCLASS_FLAG_UNSAFE;
 		}
 		loadData.classLoader = originalRAMClass->classLoader;
@@ -3385,7 +3385,7 @@ verifyNewClasses(J9VMThread * currentThread, jint class_count, J9JVMTIClassPair 
 	 */
 	for (i = 0; i < class_count; ++i) {
 		/* Do not run bytecode verification on unsafe classes */
-		if (!J9ROMCLASS_IS_UNSAFE(classPairs[i].replacementClass.romClass)) {
+		if (!J9CLASS_IS_EXEMPT_FROM_VALIDATION(classPairs[i].originalRAMClass)) {
 			IDATA result = 0;
 
 			verifyData->classLoader = classPairs[i].originalRAMClass->classLoader;

--- a/runtime/util/resolvehelp.c
+++ b/runtime/util/resolvehelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,7 +98,7 @@ isDirectSuperInterface(J9VMThread *vmStruct, J9Class *resolvedClass, J9Class *cu
 	 */
 	BOOLEAN result = FALSE;
 	J9ROMClass *currentROMClass = currentClass->romClass;
-	if (J9ROMCLASS_IS_UNSAFE(currentROMClass)) {
+	if (J9CLASS_IS_EXEMPT_FROM_VALIDATION(currentClass)) {
 		/* If this is an unsafe class, we skip the check so that a lambda "inherit" super interfaces from its host class. */
 		result = TRUE;
 	} else if (J9_ARE_ANY_BITS_SET(resolvedClass->romClass->modifiers, J9AccInterface) && (currentClass != resolvedClass)) {

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6320,7 +6320,7 @@ resolve:
 					goto resolve;
 				}
 				/* Final field - ensure the running method is allowed to store */
-				if (J9_UNEXPECTED(VM_VMHelpers::romClassChecksFinalStores(ramConstantPool->ramClass->romClass)
+				if (J9_UNEXPECTED(VM_VMHelpers::ramClassChecksFinalStores(ramConstantPool->ramClass)
 					          && !VM_VMHelpers::romMethodIsInitializer(J9_ROM_METHOD_FROM_RAM_METHOD(_literals), true)
 				)) {
 					/* Store not allowed - run the resolve code to throw the exception */
@@ -6494,7 +6494,7 @@ resolve:
 					goto resolve;
 				}
 				/* Final field - ensure the running method is allowed to store */
-				if (J9_UNEXPECTED(VM_VMHelpers::romClassChecksFinalStores(ramConstantPool->ramClass->romClass)
+				if (J9_UNEXPECTED(VM_VMHelpers::ramClassChecksFinalStores(ramConstantPool->ramClass)
 					          && !VM_VMHelpers::romMethodIsInitializer(J9_ROM_METHOD_FROM_RAM_METHOD(_literals), true)
 				)) {
 					/* Store not allowed - run the resolve code to throw the exception */

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -134,7 +134,7 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 		 * - Verify every class whose bytecodes have been modified
 		 * - Do not verify bootstrap classes if the appropriate runtime flag is set
 		 */
-		if (!J9ROMCLASS_IS_UNSAFE(romClass) && (0 == (romClass->optionalFlags & J9_ROMCLASS_OPTINFO_VERIFY_EXCLUDE))) {
+		if (!J9CLASS_IS_EXEMPT_FROM_VALIDATION(clazz) && J9_ARE_NO_BITS_SET(romClass->optionalFlags, J9_ROMCLASS_OPTINFO_VERIFY_EXCLUDE)) {
 			J9BytecodeVerificationData * bcvd = vm->bytecodeVerificationData;
 			if ((J9ROMCLASS_HAS_MODIFIED_BYTECODES(romClass) ||
 				(0 == (bcvd->verificationFlags & J9_VERIFY_SKIP_BOOTSTRAP_CLASSES)) ||

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -160,7 +160,7 @@ processMethod(J9VMThread * currentThread, UDATA lookupOptions, J9Method * method
 
 	/* Check that the found method is visible from the sender */
 
-	if (J9_ARE_NO_BITS_SET(lookupOptions, J9_LOOK_NO_VISIBILITY_CHECK) && (NULL != senderClass) && (!J9ROMCLASS_IS_UNSAFE(senderClass->romClass))) {
+	if (J9_ARE_NO_BITS_SET(lookupOptions, J9_LOOK_NO_VISIBILITY_CHECK) && (NULL != senderClass) && !J9CLASS_IS_EXEMPT_FROM_VALIDATION(senderClass)) {
 		U_32 newModifiers = modifiers;
 		BOOLEAN doVisibilityCheck = TRUE;
 

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -80,7 +80,7 @@ finalFieldSetAllowed(J9VMThread *currentThread, bool isStatic, J9Method *method,
 		 */
 		fieldClass = J9_CURRENT_CLASS(fieldClass);
 		callerClass = J9_CURRENT_CLASS(callerClass);
-		if (VM_VMHelpers::romClassChecksFinalStores(callerClass->romClass)) {
+		if (VM_VMHelpers::ramClassChecksFinalStores(callerClass)) {
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 			if ((fieldClass != callerClass) || !VM_VMHelpers::romMethodIsInitializer(romMethod, isStatic)) {
 				if (canRunJavaCode) {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -257,7 +257,7 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
 	return ((tmpUtfLength == 0) && (tmpStringLength == 0));
 }
 
-#if !defined (J9VM_OUT_OF_PROCESS)
+#if !defined(J9VM_OUT_OF_PROCESS)
 UDATA
 copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, UDATA stringOffset, UDATA stringLength, U_8 *utf8Data, UDATA utf8DataLength)
 {
@@ -428,7 +428,7 @@ verifyQualifiedName(J9VMThread *vmThread, j9object_t string)
 		if ('[' == J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, 0)) {
 			rc = CLASSNAME_VALID_ARRARY;
 		}
-		for (i = 1; i < unicodeLength; i++) {
+		for (i = 0; i < unicodeLength; i++) {
 			U_8 c = J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i);
 			if (c == '/') {
 				rc = CLASSNAME_INVALID;
@@ -449,7 +449,7 @@ verifyQualifiedName(J9VMThread *vmThread, j9object_t string)
 	}
 	return rc;
 }
-#endif
+#endif /* !defined(J9VM_OUT_OF_PROCESS) */
 
 /**
  * Check that each UTF8 character is well-formed.
@@ -567,4 +567,4 @@ methodToString(J9VMThread * vmThread, J9Method* method)
 			J9UTF8_DATA(sig), J9UTF8_LENGTH(sig));
 }
 
-}
+} /* extern "C" */

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -97,7 +97,7 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 				J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(sourceClass->romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(sourceClass->romClass)),
 				J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(destClass->romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(destClass->romClass)));
 #endif
-	if (J9ROMCLASS_IS_UNSAFE(sourceClass->romClass) == 0) {
+	if (!J9CLASS_IS_EXEMPT_FROM_VALIDATION(sourceClass)) {
 		if ( modifiers & J9AccPublic ) {
 			/* Public */
 			if ((sourceClass != destClass)


### PR DESCRIPTION
This is a replay of #4919 for the v0.13.0-release branch.

* Add RAM class flag J9ClassIsExemptFromValidation which is set for
  MagicAccessorImpl and its subclasses which makes them exempt for
  some access and validation rules (like classes defined via unsafe
  API).

* Add and use macro: J9CLASS_IS_EXEMPT_FROM_VALIDATION.

* New flag, J9_FINDCLASS_FLAG_NAME_IS_INVALID, is used to signal
  an invalid class name if the actual loaded class is not exempt.
  If the class being defined is not exempt, defineClassCommon()
  will now return NULL without a pending exception.
  ClassLoader_defineClassImpl() throws an exception only
  in that case.

* Allow JavaLangAccess to define a class with a null ProtectionDomain.

* Map proxy classes to the proper module.

* defineClassCommon() now calls fixUnsafeMethods() as necessary

* fix loop start index in verifyQualifiedName()