### PR TITLE
Report max storage limits for JIT Data/Code Cache via JMX

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -756,6 +756,7 @@ typedef struct J9NonHeapMemoryData {
 	U_64 postCollectionUsed;
 	U_64 peakSize;
 	U_64 peakUsed;
+	U_64 maxSize;
 }J9NonHeapMemoryData;
 
 typedef struct J9JavaLangManagementData {


### PR DESCRIPTION
- Report max storage limits of JIT Data Cache and JIT Code Cache
	via the max value of MemoryUsage(getUsage, getPeakUsage) of
	java.lang.management.MemoryPoolMXBean (memoryType: non-heap).
- Report max storage limits of JIT Data Cache and JIT Code Cache
	via the max value of MemoryUsage(GcInfo) of
	com.sun.management.GarbageCollectorMXBean(GarbageCollectionNotificationInfo, getLastGcInfo).

Fixes: #4674 

Signed-off-by: Lin Hu <linhu@ca.ibm.com>