### PR TITLE
Fix incorrect iTable build

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -297,43 +297,44 @@ addITableMethods(J9VMThread* vmStruct, J9Class *ramClass, J9Class *interfaceClas
 		J9Method *interfaceRamMethod = interfaceClass->ramMethods;
 		while (count-- > 0) {
 			J9ROMMethod *interfaceRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(interfaceRamMethod);
-			J9UTF8 *interfaceMethodName = J9ROMMETHOD_NAME(interfaceRomMethod);
-			J9UTF8 *interfaceMethodSig = J9ROMMETHOD_SIGNATURE(interfaceRomMethod);
-			UDATA vTableOffset = 0;
-			UDATA searchIndex = 0;
+			if (J9ROMMETHOD_IN_ITABLE(interfaceRomMethod)) {
+				J9UTF8 *interfaceMethodName = J9ROMMETHOD_NAME(interfaceRomMethod);
+				J9UTF8 *interfaceMethodSig = J9ROMMETHOD_SIGNATURE(interfaceRomMethod);
+				UDATA vTableOffset = 0;
+				UDATA searchIndex = 0;
 			
-			/* Search the vTable for a public method of the correct name. */
-			while (searchIndex < vTableSize) {
-				J9Method *vTableRamMethod = vTable[searchIndex];
-				J9ROMMethod *vTableRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(vTableRamMethod);
+				/* Search the vTable for a public method of the correct name. */
+				while (searchIndex < vTableSize) {
+					J9Method *vTableRamMethod = vTable[searchIndex];
+					J9ROMMethod *vTableRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(vTableRamMethod);
 
-				if (J9ROMMETHOD_IN_ITABLE(vTableRomMethod)) {
-					J9UTF8 *vTableMethodName = J9ROMMETHOD_NAME(vTableRomMethod);
-					J9UTF8 *vTableMethodSig = J9ROMMETHOD_SIGNATURE(vTableRomMethod);
+					if (J9ROMMETHOD_IN_ITABLE(vTableRomMethod)) {
+						J9UTF8 *vTableMethodName = J9ROMMETHOD_NAME(vTableRomMethod);
+						J9UTF8 *vTableMethodSig = J9ROMMETHOD_SIGNATURE(vTableRomMethod);
 
-					if ((J9UTF8_LENGTH(interfaceMethodName) == J9UTF8_LENGTH(vTableMethodName))
-					&& (J9UTF8_LENGTH(interfaceMethodSig) == J9UTF8_LENGTH(vTableMethodSig))
-					&& (memcmp(J9UTF8_DATA(interfaceMethodName), J9UTF8_DATA(vTableMethodName), J9UTF8_LENGTH(vTableMethodName)) == 0)
-					&& (memcmp(J9UTF8_DATA(interfaceMethodSig), J9UTF8_DATA(vTableMethodSig), J9UTF8_LENGTH(vTableMethodSig)) == 0)
-					) {
-						/* fill in interface index --> vTableOffset mapping */
-						vTableOffset = J9VTABLE_OFFSET_FROM_INDEX(searchIndex);
-						**currentSlot = vTableOffset;
-						(*currentSlot)++;
-						break;
+						if ((J9UTF8_LENGTH(interfaceMethodName) == J9UTF8_LENGTH(vTableMethodName))
+						&& (J9UTF8_LENGTH(interfaceMethodSig) == J9UTF8_LENGTH(vTableMethodSig))
+						&& (memcmp(J9UTF8_DATA(interfaceMethodName), J9UTF8_DATA(vTableMethodName), J9UTF8_LENGTH(vTableMethodName)) == 0)
+						&& (memcmp(J9UTF8_DATA(interfaceMethodSig), J9UTF8_DATA(vTableMethodSig), J9UTF8_LENGTH(vTableMethodSig)) == 0)
+						) {
+							/* fill in interface index --> vTableOffset mapping */
+							vTableOffset = J9VTABLE_OFFSET_FROM_INDEX(searchIndex);
+							**currentSlot = vTableOffset;
+							(*currentSlot)++;
+							break;
+						}
 					}
+					searchIndex++;
 				}
-				searchIndex++;
-			}
 
 #if defined(J9VM_TRACE_ITABLE)
-			{
-				PORT_ACCESS_FROM_VMC(vmStruct);
-				j9tty_printf(PORTLIB, "\n  map %.*s%.*s to vTableOffset=%d (%d)", J9UTF8_LENGTH(interfaceMethodName),
-						J9UTF8_DATA(interfaceMethodName), J9UTF8_LENGTH(interfaceMethodSig), J9UTF8_DATA(interfaceMethodSig), vTableOffset, searchIndex);
-			}
+				{
+					PORT_ACCESS_FROM_VMC(vmStruct);
+					j9tty_printf(PORTLIB, "\n  map %.*s%.*s to vTableOffset=%d (%d)", J9UTF8_LENGTH(interfaceMethodName),
+							J9UTF8_DATA(interfaceMethodName), J9UTF8_LENGTH(interfaceMethodSig), J9UTF8_DATA(interfaceMethodSig), vTableOffset, searchIndex);
+				}
 #endif
-
+			}
 			interfaceRamMethod++;
 		}
 	}
@@ -462,7 +463,7 @@ addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *i
 		for (j=0; j < count; j++) {
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(interfaceMethod);
 			/* Ignore the <clinit> from the interface class. */
-			if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPrivate | J9AccStatic)) {
+			if (J9ROMMETHOD_IN_ITABLE(romMethod)) {
 				J9UTF8 *interfaceMethodNameUTF = J9ROMMETHOD_NAME(romMethod);
 				J9UTF8 *interfaceMethodSigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 				UDATA tempIndex = vTableMethodCount;


### PR DESCRIPTION
The iTable building code was considering all methods in the interface
class, not just the ones that are appropriate for the iTable. This
results in an incorrect iTable shape (and very possibly writing off the
end of the allocated iTable chunk).

Process only methods from the interface which make up the interface
contract (public methods that appear in the vTable).

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>