### PR TITLE
Quiet MultiThreadedArrayCopyTest test case

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/arraycopy/MultiThreadedArrayCopyTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/arraycopy/MultiThreadedArrayCopyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
This patch delete test information showed up at standard output when the test MultiThreadedArrayCopyTest succeeded

Fixes: #200 
[skip ci]
Signed-off-by: Zhongyi.li1 <zhongyi.li1@ibm.com>