### PR TITLE
JDK12 j.l.Class.toGenericString() appends type parameters

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2337,6 +2337,18 @@ private void appendTypeParameters(StringBuilder nameBuilder) {
 			if (comma) nameBuilder.append(',');
 			nameBuilder.append(t);
 			comma = true;
+/*[IF Java12]*/
+			Type[] types = t.getBounds();
+			if (types.length == 1 && types[0].equals(Object.class)) {
+				// skip in case the only bound is java.lang.Object
+			} else {
+				String prefix = " extends "; //$NON-NLS-1$
+				for (Type type : types) {
+					nameBuilder.append(prefix).append(type.getTypeName());
+					prefix = " & "; //$NON-NLS-1$
+				}
+			}
+/*[ENDIF] Java12 */
 		}
 		nameBuilder.append('>');
 	}


### PR DESCRIPTION
JDK12 `j.l.Class.toGenericString()` appends type parameters

For each type parameter, skip the case that it has only one bound and the bound is `java.lang.Object`, otherwise append ` extends ` following by type name and ` & ` if there are more than one bound.

Manually verified that this PR passes the test in https://github.com/eclipse/openj9/issues/4938

fixes #4938 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>