### PR TITLE
Change AUTO_DETECT instruction on valuetype tests

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  * 5) export JDK_VERSION=Valhalla
  * 6) export SPEC=linux_x86-64_cmprssptrs
  * 7) export BUILD_LIST=functional/Valhalla
- * 8) export AUTO_DETECT=off
+ * 8) export AUTO_DETECT=false
  * 9) export JDK_IMPL=openj9
  * 10) make -f run_configure.mk && make compile && make _sanity
  */


### PR DESCRIPTION
Update instructions on valuetype tests.

AUTO_DETECT should be changed from "off" to "false" due to 
changes of the implementation of AUTO_DETECT.

[ci skip]

Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>