### PR TITLE
use UDATA to replace int to avoid windows compiling issue

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardDelegate.hpp
+++ b/runtime/gc_vlhgc/CopyForwardDelegate.hpp
@@ -120,7 +120,7 @@ public:
 	/**
 	 * Set the number of regions, which are need to be reserved for Mark/Compact only in CollectionSet due to short of survivor regions for CopyForward
 	 */
-	void setReservedNonEvacuatedRegions(int regionCount)
+	void setReservedNonEvacuatedRegions(UDATA regionCount)
 	{
 		if (NULL != _breadthFirstCopyForwardScheme) {
 			_breadthFirstCopyForwardScheme->setReservedNonEvacuatedRegions(regionCount);

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -1087,7 +1087,7 @@ public:
 		return (0 != _regionCountCannotBeEvacuated);
 	}
 
-	void setReservedNonEvacuatedRegions(int regionCount)
+	void setReservedNonEvacuatedRegions(UDATA regionCount)
 	{
 		_regionCountReservedNonEvacuated = regionCount;
 	}


### PR DESCRIPTION
	- use UDATA to replace int to avoid windows compiling issue

Signed-off-by: Lin Hu <linhu@ca.ibm.com>