### PR TITLE
Add missed include in ProcessorInfo.cpp

### DIFF
--- a/runtime/gc_realtime/ProcessorInfo.cpp
+++ b/runtime/gc_realtime/ProcessorInfo.cpp
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include "EnvironmentBase.hpp"
+#include "ModronAssertions.h"
 #include "ProcessorInfo.hpp"
 
 /**


### PR DESCRIPTION
Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>