### PR TITLE
Always set crcValid to 0 when doing stale marking

### DIFF
--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3257,6 +3257,14 @@ SH_CompositeCacheImpl::markStale(J9VMThread* currentThread, BlockPtr blockEnd, b
 	}
 	Trc_SHR_Assert_Equals(currentThread, _commonCCInfo->hasWriteMutexThread);
 	Trc_SHR_CC_markStale_Event(currentThread, ih);
+
+	if (0 != _theca->crcValid) {
+		/* _theca->crcValid is set to 0 when locking the cache. isCacheLocked cannot be true here */
+		Trc_SHR_Assert_False(isCacheLocked);
+		unprotectHeaderReadWriteArea(currentThread, false);
+		_theca->crcValid = 0;
+		protectHeaderReadWriteArea(currentThread, false);
+	}
 
 	/* If the cache is locked, don't bother to unprotect the page as the whole metadata area will be unprotected */
 	if (_doMetaProtect && !isCacheLocked) {


### PR DESCRIPTION
We didn't set crcValid to 0 if the cache is not locked. However, the 
CRC value could become invalid after items are marked stale regardless
of whether cache is locked or not. Make sure crcValid is 0 in
SH_CompositeCacheImpl::markStale().

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>