### PR TITLE
Always use non-AOT front-end in packRemoteROMClassInfo

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -276,7 +276,7 @@ class JITaaSHelpers
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
    using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<uint8_t>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t, J9ROMClass *>;
-   static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, TR_J9VM *fe, TR_Memory *trMemory);
+   static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
    static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);


### PR DESCRIPTION
Previously, if `packRemoteROMClassInfo` was called
during AOT compilation, all of the values for class info
would be obtained by calling front-end methods of a
Shared Cache VM.
This is a problem, because shared cache versions of the
methods attempt to validate classes and may return NULL.
This is wrong for 2 reasons:
1. We perform validation on the server.
2. Values packed in `packRemoteROMClassInfo` are cached
on the server, for the entire lifetime of a client.
If a shared cache version of a method sets class info
parameter to NULL, then it will remain NULL on the server,
even for non-AOT compilations. This is wrong, because
non-AOT requires most parameters to be non-NULL.

Fixes: #5077