### PR TITLE
Remove Reporting Locks From Realtime/VLHGC Verbose Handlers

### DIFF
--- a/runtime/gc_verbose_handler_realtime/VerboseHandlerOutputRealtime.cpp
+++ b/runtime/gc_verbose_handler_realtime/VerboseHandlerOutputRealtime.cpp
@@ -59,19 +59,12 @@ MM_VerboseHandlerOutputRealtime::initialize(MM_EnvironmentBase *env, MM_VerboseM
 
 	_mmHooks = J9_HOOK_INTERFACE(MM_GCExtensions::getExtensions(_extensions)->hookInterface);
 
-	if (initSuccess) {
-		if (!_outputLock.initialize(env, &MM_GCExtensions::getExtensions(env)->lnrlOptions, "MM_VerboseHandlerOutputRealtime:_outputLock")) {
-			initSuccess = false;
-		}
-	}
-
 	return initSuccess;
 }
 
 void
 MM_VerboseHandlerOutputRealtime::tearDown(MM_EnvironmentBase *env)
 {
-	_outputLock.tearDown();
 	MM_VerboseHandlerOutput::tearDown(env);
 }
 
@@ -177,18 +170,6 @@ MM_VerboseHandlerOutputRealtime::getCycleType(UDATA type)
 	}
 
 	return cycleType;
-}
-
-void
-MM_VerboseHandlerOutputRealtime::enterAtomicReportingBlock()
-{
-	_outputLock.acquire();
-}
-
-void
-MM_VerboseHandlerOutputRealtime::exitAtomicReportingBlock()
-{
-	_outputLock.release();
 }
 
 void

--- a/runtime/gc_verbose_handler_realtime/VerboseHandlerOutputRealtime.hpp
+++ b/runtime/gc_verbose_handler_realtime/VerboseHandlerOutputRealtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@
 #include "mmhook.h"
 #include "mmprivatehook.h"
 
-#include "LightweightNonReentrantLock.hpp"
 #include "VerboseHandlerOutput.hpp"
 #include "GCExtensions.hpp"
 
@@ -104,8 +103,6 @@ private:
 	UDATA _syncGCStartClassLoadersUnloaded; /**< The unloaded class loader count at the start of a sync GC */
 	UDATA _syncGCStartClassesUnloaded; /**< The unloaded class count at the start of a sync GC */
 	UDATA _syncGCStartAnonymousClassesUnloaded; /**< The unloaded anonymous class count at the start of a sync GC */
-
-	MM_LightweightNonReentrantLock _outputLock;	/**< Since VLHGC can sometimes have multiple threads trying to access verbose (one reporting events while another reports exclusive), this lock is required to ensure that the writer only sees each report, atomically */
 
 protected:
 	J9HookInterface** _mmHooks;  /**< Pointers to the Hook interface */
@@ -242,7 +239,6 @@ protected:
 		_syncGCStartClassLoadersUnloaded(0),
 		_syncGCStartClassesUnloaded(0),
 		_syncGCStartAnonymousClassesUnloaded(0),
-		_outputLock(),
 		_mmHooks(NULL)
 	{};
 
@@ -251,9 +247,6 @@ protected:
 
 	virtual bool getThreadName(char *buf, UDATA bufLen, OMR_VMThread *vmThread);
 	virtual void writeVmArgs(MM_EnvironmentBase* env);
-
-	virtual void enterAtomicReportingBlock();
-	virtual void exitAtomicReportingBlock();
 
 public:
 	static MM_VerboseHandlerOutput *newInstance(MM_EnvironmentBase *env, MM_VerboseManager *manager);

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -90,19 +90,12 @@ MM_VerboseHandlerOutputVLHGC::initialize(MM_EnvironmentBase *env, MM_VerboseMana
 
 	_mmHooks = J9_HOOK_INTERFACE(MM_GCExtensions::getExtensions(_extensions)->hookInterface);
 
-	if (initSuccess) {
-		if (!_outputLock.initialize(env, &MM_GCExtensions::getExtensions(env)->lnrlOptions, "MM_VerboseHandlerOutputVLHGC:_outputLock")) {
-			initSuccess = false;
-		}
-	}
-
 	return initSuccess;
 }
 
 void
 MM_VerboseHandlerOutputVLHGC::tearDown(MM_EnvironmentBase *env)
 {
-	_outputLock.tearDown();
 	MM_VerboseHandlerOutput::tearDown(env);
 }
 
@@ -744,20 +737,6 @@ MM_VerboseHandlerOutputVLHGC::getCycleType(UDATA type)
 
 	return cycleType;
 }
-
-void
-MM_VerboseHandlerOutputVLHGC::enterAtomicReportingBlock()
-{
-	_outputLock.acquire();
-}
-
-void
-MM_VerboseHandlerOutputVLHGC::exitAtomicReportingBlock()
-{
-	_outputLock.release();
-}
-
-
 
 void
 verboseHandlerTaxationEntryPoint(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,6 @@
 
 #include "VerboseHandlerOutput.hpp"
 
-#include "LightweightNonReentrantLock.hpp"
 #include "GCExtensions.hpp"
 
 class MM_EnvironmentBase;
@@ -40,8 +39,7 @@ class MM_WorkPacketStats;
 class MM_VerboseHandlerOutputVLHGC : public MM_VerboseHandlerOutput
 {
 private:
-	MM_LightweightNonReentrantLock _outputLock;	/**< Since VLHGC can sometimes have multiple threads trying to access verbose (one reporting events while another reports exclusive), this lock is required to ensure that the writer only sees each report, atomically */
-
+	
 protected:
 	J9HookInterface** _mmHooks;  /**< Pointers to the Hook interface */
 
@@ -118,9 +116,6 @@ protected:
 	 */	
 	virtual const char *getCycleType(UDATA type);
 
-	virtual void enterAtomicReportingBlock();
-	virtual void exitAtomicReportingBlock();
-
 	virtual bool initialize(MM_EnvironmentBase *env, MM_VerboseManager *manager);
 	virtual void tearDown(MM_EnvironmentBase *env);
 
@@ -129,7 +124,6 @@ protected:
 
 	MM_VerboseHandlerOutputVLHGC(MM_GCExtensions *extensions)
 		: MM_VerboseHandlerOutput(extensions)
-		, _outputLock()
 		, _mmHooks(NULL)
 	{};
 


### PR DESCRIPTION
Atomic reporting locks and functions (`enterAtomicReportingBlock` and `exitAtomicReportingBlock`) need to be removed from derived realtime/VLHGC verbose handlers. These lock and functions have been implemented in the OMR base class  (`VerboseHandlerOutput.hpp`)

Signed-off-by: Salman Rana <salman.rana@ibm.com>