### PR TITLE
Look at field declaring class when verify fields

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -238,14 +238,7 @@ static bool verifyFieldAccess(void *curStruct, TR::SymbolReference *field, TR::C
       if (isFabricatedVarHandleField(field, comp))
          fieldClass = fej9->getSystemClassFromClassName("java/lang/invoke/VarHandle", strlen("java/lang/invoke/VarHandle"));
       else
-         {
-         //
-         // TODO: getDeclaringClassFromFieldOrStatic would be better, but it's a
-         // little scarier because it's new.  getClassFromFieldOrStatic should be
-         // more conservative in this case, so probably more suitable for
-         // r13.java.
-         fieldClass = field->getOwningMethod(comp)->getClassFromFieldOrStatic(comp, field->getCPIndex());
-         }
+         fieldClass = field->getOwningMethod(comp)->getDeclaringClassFromFieldOrStatic(comp, field->getCPIndex());
 
       if (fieldClass == NULL)
          return false;


### PR DESCRIPTION
All the fields with the same declaring class are aliased together.
For example, class A is the parent class having field A.f and class B
and class C are 2 subclasses of A. A.f, B.f C.f are all aliased
together. Therefore to verify if a known object x is compatible with a
field symRef C.f we should check if object is instance of the declaring
class A but not the symRef C.f 's field class C. The object would still be
valid if it's class B.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>