### PR TITLE
Adopt Java 12 jdk.internal.reflect.Reflection & ASM requirement

### DIFF
--- a/test/functional/JavaAgentTest/build.xml
+++ b/test/functional/JavaAgentTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,11 +45,22 @@
 		<echo>===executable:			${compiler.javac}</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
+			<matches string="${JDK_VERSION}" pattern="^(8|9|10|11)$$" />
+			<then>
+				<property name="src_version" location="./src_java8" />
+			</then>
+			<else> 
+				<!-- Java 12+ -->
+				<property name="src_version" location="./src_java12" />
+			</else>
+		</if>
+		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />							
-					<src path="${transformerListener}" />							
+					<src path="${src}" />
+					<src path="${src_version}" />
+					<src path="${transformerListener}" />
 					<classpath>
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar" />
@@ -61,14 +72,15 @@
 				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.util=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.commons=ALL-UNNAMED"/>				
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
-					<src path="${transformerListener}" />							
+					<src path="${src_version}" />
+					<src path="${transformerListener}" />
 					<compilerarg line='${addExports}' />
 					<classpath>
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar"/>
 					</classpath>
-				</javac>										
+				</javac>
 			</else>
 		</if>
 	</target>

--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -46,7 +46,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 
@@ -72,7 +72,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 
@@ -97,7 +97,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 
@@ -124,7 +124,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 
@@ -150,7 +150,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 
@@ -175,7 +175,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 
@@ -200,7 +200,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 

--- a/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/FieldAdder.java
+++ b/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/FieldAdder.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest.util;
+
+import static jdk.internal.org.objectweb.asm.Opcodes.ASM7;
+
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.tree.FieldNode;
+import jdk.internal.org.objectweb.asm.util.CheckClassAdapter;
+
+public class FieldAdder extends CheckClassAdapter
+{
+	private final FieldNode _fn;
+	private final String _className;
+	private final String _methodName;
+
+	public FieldAdder(ClassVisitor cv, FieldNode fn, String className, String methodName)
+	{
+		super(ASM7, cv, true);
+		_fn = fn;
+		_className = className;
+		_methodName = methodName;
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
+	{
+		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+		if (name.equals(_methodName)) {
+			mv = new MethodInstrumentAdapter_InitializeNewStatic(access, name, desc, mv, _className);
+		}
+		return mv;
+	}
+
+	@Override
+	public void visitEnd()
+	{
+		_fn.accept(cv);
+		super.visitEnd();
+	}
+}

--- a/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodAddAdapter.java
+++ b/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodAddAdapter.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest.util;
+
+import static jdk.internal.org.objectweb.asm.Opcodes.GETSTATIC;
+import static jdk.internal.org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static jdk.internal.org.objectweb.asm.Opcodes.ASM7;
+
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.util.CheckClassAdapter;
+
+public class MethodAddAdapter extends CheckClassAdapter {
+
+	public MethodAddAdapter(CheckClassAdapter cv) {
+		super(ASM7, cv, true);
+	}
+
+	/* Used for instrumenting an existing method in java/lang/ClassLoader
+	 * (non-Javadoc)
+	 * @see jdk.internal.org.objectweb.asm.util.CheckClassAdapter#visitMethod(int, java.lang.String, java.lang.String, java.lang.String, java.lang.String[])
+	 */
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions ) {
+	   if ( name.contains( "getResource" )) {
+		   return new MethodInstrumentAdapter_CallNewMethod( access,
+				   					name,
+			   						desc,
+			   						super.visitMethod(access, name, desc, signature, exceptions)
+               			) ;
+	   } else {
+		   return super.visitMethod(access, name, desc, signature, exceptions);
+	   }
+	}
+
+	/* Used for adding a new method in java/lang/ClassLoader class
+	 * (non-Javadoc)
+	 * @see jdk.internal.org.objectweb.asm.util.CheckClassAdapter#visitEnd()
+	 */
+	public void visitEnd() {
+		Label L0 = new Label();
+		Label L1 = new Label();
+
+		MethodVisitor mv = cv.visitMethod( Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "myAddedMethod", "()V", null, null );
+		mv.visitCode();
+		mv.visitLabel(L0);
+		mv.visitFieldInsn( GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;" );
+		mv.visitLdcInsn( "**IN ADDED METHOD**");
+		mv.visitMethodInsn( INVOKEVIRTUAL, "java/io/PrintStream", "println", "(Ljava/lang/String;)V" );
+
+		mv.visitLabel(L1);
+		mv.visitInsn( RETURN );
+
+		mv.visitLocalVariable("this", "Ljava/lang/ClassLoader;", null, L0, L1, 0);
+		/*mv.visitInsn( ICONST_1 );
+		mv.visitFieldInsn( PUTSTATIC, "com/ibm/j9/refreshgccache/test/RefreshGCCacheTestMain", "addedSwitchHit", "Z" );
+		mv.visitInsn( RETURN );
+		*/
+		mv.visitMaxs(2, 1);
+		mv.visitEnd();
+		super.visitEnd();
+	}
+}

--- a/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_AddPrintOut.java
+++ b/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_AddPrintOut.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,28 +20,31 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 package org.openj9.test.javaagenttest.util;
+
 import jdk.internal.org.objectweb.asm.Label;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.internal.org.objectweb.asm.commons.AdviceAdapter;
 import org.openj9.test.javaagenttest.AgentMain;
 
-public class MethodInstrumentAdapter_CallNewMethod extends AdviceAdapter {
-
+public class MethodInstrumentAdapter_AddPrintOut extends AdviceAdapter {
 	String methodName = null;
 
-	public MethodInstrumentAdapter_CallNewMethod( int access, String name, String desc, MethodVisitor mv ) {
-		super( ASM4, mv, access, name, desc );
+	public MethodInstrumentAdapter_AddPrintOut( int access, String name, String desc, MethodVisitor mv ) {
+		super(ASM7, mv, access, name, desc );
 		methodName = name;
 	}
 
-	/* Add a call to the added method at the beginning of this method
+	/*
+	 * Add some logic at the beginning of this method
 	 * (non-Javadoc)
 	 * @see jdk.internal.org.objectweb.asm.commons.AdviceAdapter#onMethodEnter()
 	 */
 	@Override
 	protected void onMethodEnter() {
-		AgentMain.logger.debug("Class: MethodInstrumentAdapter_CallNewMethod is attempting to add call in method : " + methodName);
+		AgentMain.logger.debug("Class: MethodInstrumentAdapter_AddPrintOut is attempting to add call in method : " + methodName);
 		mv.visitLabel(new Label());
-		mv.visitMethodInsn( INVOKESTATIC, "java/lang/ClassLoader", "myAddedMethod", "()V" );
+		mv.visitFieldInsn( GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;" );
+		mv.visitLdcInsn( "**IN INSTRUMENTED METHOD**");
+		mv.visitMethodInsn( INVOKEVIRTUAL, "java/io/PrintStream", "println", "(Ljava/lang/String;)V" );
 	}
 }

--- a/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_CallNewMethod.java
+++ b/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_CallNewMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,28 +25,22 @@ import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.internal.org.objectweb.asm.commons.AdviceAdapter;
 import org.openj9.test.javaagenttest.AgentMain;
 
-public class MethodInstrumentAdapter_InitializeNewStatic extends AdviceAdapter
-{
+public class MethodInstrumentAdapter_CallNewMethod extends AdviceAdapter {
+	String methodName = null;
 
-	private String _methodName = null;
-	private String _className = null;
-
-	public MethodInstrumentAdapter_InitializeNewStatic(int access, String name, String desc, MethodVisitor mv, String className)
-	{
-		super(ASM4, mv, access, name, desc);
-		_methodName = name;
-		_className = className;
+	public MethodInstrumentAdapter_CallNewMethod( int access, String name, String desc, MethodVisitor mv ) {
+		super(ASM7, mv, access, name, desc );
+		methodName = name;
 	}
 
+	/* Add a call to the added method at the beginning of this method
+	 * (non-Javadoc)
+	 * @see jdk.internal.org.objectweb.asm.commons.AdviceAdapter#onMethodEnter()
+	 */
 	@Override
-	protected void onMethodEnter()
-	{
-		AgentMain.logger.debug("Class: MethodInstrumentAdapter_InitializeNewStatic is attempting to initialize new static field : " + _methodName);
+	protected void onMethodEnter() {
+		AgentMain.logger.debug("Class: MethodInstrumentAdapter_CallNewMethod is attempting to add call in method : " + methodName);
 		mv.visitLabel(new Label());
-
-		/* initialize new integer array */
-		mv.visitInsn(ICONST_5);
-		mv.visitIntInsn(NEWARRAY, T_INT);
-		mv.visitFieldInsn(PUTSTATIC, _className, "new_static_int_array", "[I");
+		mv.visitMethodInsn( INVOKESTATIC, "java/lang/ClassLoader", "myAddedMethod", "()V" );
 	}
 }

--- a/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_InitializeNewStatic.java
+++ b/test/functional/JavaAgentTest/src_java12/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_InitializeNewStatic.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest.util;
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.commons.AdviceAdapter;
+import org.openj9.test.javaagenttest.AgentMain;
+
+public class MethodInstrumentAdapter_InitializeNewStatic extends AdviceAdapter
+{
+	private String _methodName = null;
+	private String _className = null;
+
+	public MethodInstrumentAdapter_InitializeNewStatic(int access, String name, String desc, MethodVisitor mv, String className)
+	{
+		super(ASM7, mv, access, name, desc);
+		_methodName = name;
+		_className = className;
+	}
+
+	@Override
+	protected void onMethodEnter()
+	{
+		AgentMain.logger.debug("Class: MethodInstrumentAdapter_InitializeNewStatic is attempting to initialize new static field : " + _methodName);
+		mv.visitLabel(new Label());
+
+		/* initialize new integer array */
+		mv.visitInsn(ICONST_5);
+		mv.visitIntInsn(NEWARRAY, T_INT);
+		mv.visitFieldInsn(PUTSTATIC, _className, "new_static_int_array", "[I");
+	}
+}

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/Cmvc196982.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/Cmvc196982.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest;
+
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.FieldVisitor;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Type;
+import static jdk.internal.org.objectweb.asm.Opcodes.ASM4;
+
+
+public class Cmvc196982 {
+
+	private static final Logger logger = Logger.getLogger(Cmvc196982.class);
+
+	@Retention(value=RUNTIME)
+	public @interface MyAnnotation1 {}
+
+	@Retention(value=RUNTIME)
+	public @interface MyAnnotation2 {}
+
+	public static class C {
+		@MyAnnotation1
+		public C() {}
+		@MyAnnotation1
+		public void m() {}
+		@MyAnnotation1
+		public int f;
+	}
+
+	private Field annotationCacheField;
+	private Field methodAnnotationsField;
+	private Field fieldAnnotationsField;
+	private Field constructorAnnotationsField;
+	private Field reflectCacheField;
+	private Field reflectFieldRoot;
+	private Field reflectMethodRoot;
+	private Field reflectConstructorRoot;
+
+	@BeforeMethod(groups = { "level.sanity" })
+	protected void setUp() throws Exception {
+		logger.info("Cmvc196982 is setting up... ");
+
+		methodAnnotationsField = Method.class.getDeclaredField("annotations");
+		fieldAnnotationsField = Field.class.getDeclaredField("annotations");
+		constructorAnnotationsField = Constructor.class.getDeclaredField("annotations");
+		annotationCacheField = Class.class.getDeclaredField("annotationCache");
+		methodAnnotationsField.setAccessible(true);
+		fieldAnnotationsField.setAccessible(true);
+		constructorAnnotationsField.setAccessible(true);
+		annotationCacheField.setAccessible(true);
+
+		reflectCacheField = Class.class.getDeclaredField("reflectCache");
+		reflectCacheField.setAccessible(true);
+
+		reflectFieldRoot = Field.class.getDeclaredField("root");
+		reflectMethodRoot = Method.class.getDeclaredField("root");
+		reflectConstructorRoot = Constructor.class.getDeclaredField("root");
+		reflectFieldRoot.setAccessible(true);
+		reflectMethodRoot.setAccessible(true);
+		reflectConstructorRoot.setAccessible(true);
+	}
+
+	/**
+	 * Check that the reflect caches for a ClassLoader are flushed when a class it has loaded is redefined.
+	 * This is a white-box test, using reflection to inspect private fields of ClassLoader and Method, Field
+	 * & Constructor. A target class, containing a field, a method and a default constructor, each annotated
+	 * with MyAnnotation1, is redefined to add MyAnnotation2 to each element.
+	 * The reflect caches should be non-null before the call to redefine and should be null afterwards. The
+	 * annotation attribute bytes from reflect objects obtained before the call to redefine should remain the
+	 * same afterwards. Refetched reflect objects should contain updated annotation attribute bytes (indicating
+	 * that they have been populated by the VM rather than returned from the reflect cache).
+	 *
+	 * @throws ReflectiveOperationException
+	 * @throws SecurityException
+	 * @throws IOException
+	 */
+	@Test(groups = { "level.sanity", "level.extended" })
+	public void testAddingAnnotationsFlushesReflectCache() throws ReflectiveOperationException, SecurityException, IOException {
+
+		logger.info("Cmvc196982 is testing testAddingAnnotationsFlushesReflectCache()... ");
+
+		Class<?> clazz = C.class;
+		Method m = clazz.getMethod("m");
+		Field f = clazz.getField("f");
+		Constructor<?> c = clazz.getConstructor();
+		clazz.getAnnotations();
+
+		/* Reflect caches should be non-null before redefine, due to the reflect calls above */
+		AssertJUnit.assertNotNull("reflect cache is null before redefine", reflectCacheField.get(clazz) );
+		AssertJUnit.assertNotNull("annotation cache is null before redefine", annotationCacheField.get(clazz) );
+
+		/* Equivalent objects returned from reflect cache should share "root" field */
+		checkRoots();
+
+		/* Fetch annotations byte arrays before redefining */
+		byte[] methodBeforeRedefine = (byte[]) methodAnnotationsField.get(m);
+		byte[] fieldBeforeRedefine = (byte[]) fieldAnnotationsField.get(f);
+		byte[] constructorBeforeRedefine = (byte[]) constructorAnnotationsField.get(c);
+
+		/* Parse original annotations byte arrays */
+		Annotation[] methodOriginalAnnotations = m.getAnnotations();
+		Annotation[] fieldOriginalAnnotations = f.getAnnotations();
+		Annotation[] constructorOriginalAnnotations = c.getAnnotations();
+
+		AgentMain.redefineClass(clazz, addAnnotation(clazz, MyAnnotation2.class));
+
+		/* Reflect caches should be nulled by the redefine above */
+		AssertJUnit.assertNull("reflect cache is not null after redefine", reflectCacheField.get(clazz) );
+		AssertJUnit.assertNull("annotation cache is not null after redefine", annotationCacheField.get(clazz) );
+
+		/* Cache should be repopulated, and equivalent objects returned from reflect cache should share "root" field */
+		checkRoots();
+
+		/* Fetch annotations byte arrays after redefining */
+		byte[] methodAfterRedefine = (byte[]) methodAnnotationsField.get(m);
+		byte[] fieldAfterRedefine = (byte[]) fieldAnnotationsField.get(f);
+		byte[] constructorAfterRedefine = (byte[]) constructorAnnotationsField.get(c);
+
+		/* Refetch reflect objects */
+		m = clazz.getMethod("m");
+		f = clazz.getField("f");
+		c = clazz.getConstructor();
+
+		/* Fetch annotations byte arrays from refetched reflect objects */
+		byte[] methodAfterRefetch = (byte[]) methodAnnotationsField.get(m);
+		byte[] fieldAfterRefetch = (byte[]) fieldAnnotationsField.get(f);
+		byte[] constructorAfterRefetch = (byte[]) constructorAnnotationsField.get(c);
+
+		checkAnnotations(methodBeforeRedefine, methodAfterRedefine, methodAfterRefetch, methodOriginalAnnotations, m.getAnnotations());
+		checkAnnotations(fieldBeforeRedefine, fieldAfterRedefine, fieldAfterRefetch, fieldOriginalAnnotations, f.getAnnotations());
+		checkAnnotations(constructorBeforeRedefine, constructorAfterRedefine, constructorAfterRefetch, constructorOriginalAnnotations, c.getAnnotations());
+	}
+
+	/* Reflect objects returned from the cache should share their "root" field */
+	private void checkRoots() throws ReflectiveOperationException, SecurityException {
+		Class<?> clazz = C.class;
+
+		Field f1 = clazz.getField("f");
+		Field f2 = clazz.getField("f");
+		AssertJUnit.assertNotNull("Field instances not cached ", reflectFieldRoot.get(f1));
+		AssertJUnit.assertEquals(reflectFieldRoot.get(f2), reflectFieldRoot.get(f1));
+
+
+		Method m1 = clazz.getMethod("m");
+		Method m2 = clazz.getMethod("m");
+		AssertJUnit.assertNotNull("Field instances not cached ", reflectMethodRoot.get(m1));
+		AssertJUnit.assertEquals(reflectMethodRoot.get(m2), reflectMethodRoot.get(m1));
+
+		Constructor<?> c1 = clazz.getConstructor();
+		Constructor<?> c2 = clazz.getConstructor();
+		AssertJUnit.assertNotNull("Field instances not cached ", reflectConstructorRoot.get(c1));
+		AssertJUnit.assertEquals(reflectConstructorRoot.get(c2), reflectConstructorRoot.get(c1));
+	}
+
+	private void checkAnnotations(byte[] beforeRedefine, byte[] afterRedefine, byte[] afterRefetch, Annotation[] originalAnnotations, Annotation[] refetchedAnnotations) {
+		AssertJUnit.assertArrayEquals("annotations byte array changed during redefine", beforeRedefine, afterRedefine);
+		AssertJUnit.assertFalse("annotations byte array didn't change after refetching Method", Arrays.equals(afterRedefine, afterRefetch));
+		AssertJUnit.assertFalse("annotations weren't updated after refetching Method", Arrays.equals(originalAnnotations, refetchedAnnotations));
+		AssertJUnit.assertEquals("too many annotations on original method", originalAnnotations.length, 1 );
+	}
+
+	/*
+	 * Transform classToTransform by adding the given annotation to all already-annotated methods, fields and constructors in the class.
+	 * Return the modified class file bytes.
+	 */
+	private byte[] addAnnotation(Class<?> classToTransform, final Class<?> annotation) throws IOException {
+		ClassWriter writer = new ClassWriter(0);
+		new ClassReader(Type.getInternalName(classToTransform)).accept(new ClassVisitor(ASM4, writer) {
+			@Override
+			public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+				return new MethodVisitor(ASM4, cv.visitMethod(access, name, desc, signature, exceptions)) {
+					@Override
+					public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+						mv.visitAnnotation(Type.getDescriptor(annotation), true).visitEnd();
+						return mv.visitAnnotation(desc, visible);
+					}
+				};
+			}
+			@Override
+			public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+				return new FieldVisitor(ASM4, cv.visitField(access, name, desc, signature, value)) {
+					@Override
+					public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+						fv.visitAnnotation(Type.getDescriptor(annotation), true).visitEnd();
+						return fv.visitAnnotation(desc, visible);
+					}
+				};
+			}
+		}, 0);
+		return writer.toByteArray();
+	}
+}

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/CustomClassVisitor.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/CustomClassVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,6 @@ import org.openj9.test.javaagenttest.AgentMain;
 import static jdk.internal.org.objectweb.asm.Opcodes.ASM4;
 
 public class CustomClassVisitor extends ClassVisitor {
-
 	String className = null;
 
 	public CustomClassVisitor(ClassVisitor cv, String className) {

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/FieldAdder.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/FieldAdder.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest.util;
+
+import static jdk.internal.org.objectweb.asm.Opcodes.ASM5;
+
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.tree.FieldNode;
+import jdk.internal.org.objectweb.asm.util.CheckClassAdapter;
+
+public class FieldAdder extends CheckClassAdapter
+{
+	private final FieldNode _fn;
+	private final String _className;
+	private final String _methodName;
+
+	public FieldAdder(ClassVisitor cv, FieldNode fn, String className, String methodName)
+	{
+		super(ASM5, cv, true);
+		_fn = fn;
+		_className = className;
+		_methodName = methodName;
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
+	{
+		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+		if (name.equals(_methodName)) {
+			mv = new MethodInstrumentAdapter_InitializeNewStatic(access, name, desc, mv, _className);
+		}
+		return mv;
+	}
+
+	@Override
+	public void visitEnd()
+	{
+		_fn.accept(cv);
+		super.visitEnd();
+	}
+}

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodAddAdapter.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodAddAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,6 @@ import jdk.internal.org.objectweb.asm.Label;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.internal.org.objectweb.asm.Opcodes;
 import jdk.internal.org.objectweb.asm.util.CheckClassAdapter;
-
 
 public class MethodAddAdapter extends CheckClassAdapter {
 

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_AddPrintOut.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_AddPrintOut.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest.util;
+
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.commons.AdviceAdapter;
+import org.openj9.test.javaagenttest.AgentMain;
+
+public class MethodInstrumentAdapter_AddPrintOut extends AdviceAdapter {
+	String methodName = null;
+
+	public MethodInstrumentAdapter_AddPrintOut( int access, String name, String desc, MethodVisitor mv ) {
+		super(ASM4, mv, access, name, desc );
+		methodName = name;
+	}
+
+	/*
+	 * Add some logic at the beginning of this method
+	 * (non-Javadoc)
+	 * @see jdk.internal.org.objectweb.asm.commons.AdviceAdapter#onMethodEnter()
+	 */
+	@Override
+	protected void onMethodEnter() {
+		AgentMain.logger.debug("Class: MethodInstrumentAdapter_AddPrintOut is attempting to add call in method : " + methodName);
+		mv.visitLabel(new Label());
+		mv.visitFieldInsn( GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;" );
+		mv.visitLdcInsn( "**IN INSTRUMENTED METHOD**");
+		mv.visitMethodInsn( INVOKEVIRTUAL, "java/io/PrintStream", "println", "(Ljava/lang/String;)V" );
+	}
+}

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_CallNewMethod.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_CallNewMethod.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.javaagenttest.util;
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.commons.AdviceAdapter;
+import org.openj9.test.javaagenttest.AgentMain;
+
+public class MethodInstrumentAdapter_CallNewMethod extends AdviceAdapter {
+	String methodName = null;
+
+	public MethodInstrumentAdapter_CallNewMethod( int access, String name, String desc, MethodVisitor mv ) {
+		super(ASM4, mv, access, name, desc );
+		methodName = name;
+	}
+
+	/* Add a call to the added method at the beginning of this method
+	 * (non-Javadoc)
+	 * @see jdk.internal.org.objectweb.asm.commons.AdviceAdapter#onMethodEnter()
+	 */
+	@Override
+	protected void onMethodEnter() {
+		AgentMain.logger.debug("Class: MethodInstrumentAdapter_CallNewMethod is attempting to add call in method : " + methodName);
+		mv.visitLabel(new Label());
+		mv.visitMethodInsn( INVOKESTATIC, "java/lang/ClassLoader", "myAddedMethod", "()V" );
+	}
+}

--- a/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_InitializeNewStatic.java
+++ b/test/functional/JavaAgentTest/src_java8/org/openj9/test/javaagenttest/util/MethodInstrumentAdapter_InitializeNewStatic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,43 +20,32 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 package org.openj9.test.javaagenttest.util;
-
-import static jdk.internal.org.objectweb.asm.Opcodes.ASM5;
-
-import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.Label;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.tree.FieldNode;
-import jdk.internal.org.objectweb.asm.util.CheckClassAdapter;
+import jdk.internal.org.objectweb.asm.commons.AdviceAdapter;
+import org.openj9.test.javaagenttest.AgentMain;
 
-
-public class FieldAdder extends CheckClassAdapter
+public class MethodInstrumentAdapter_InitializeNewStatic extends AdviceAdapter
 {
-	private final FieldNode _fn;
-	private final String _className;
-	private final String _methodName;
+	private String _methodName = null;
+	private String _className = null;
 
-	public FieldAdder(ClassVisitor cv, FieldNode fn, String className, String methodName)
+	public MethodInstrumentAdapter_InitializeNewStatic(int access, String name, String desc, MethodVisitor mv, String className)
 	{
-		super(ASM5, cv, true);
-		_fn = fn;
+		super(ASM4, mv, access, name, desc);
+		_methodName = name;
 		_className = className;
-		_methodName = methodName;
 	}
 
 	@Override
-	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
+	protected void onMethodEnter()
 	{
-		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-		if (name.equals(_methodName)) {
-			mv = new MethodInstrumentAdapter_InitializeNewStatic(access, name, desc, mv, _className);
-		}
-		return mv;
-	}
+		AgentMain.logger.debug("Class: MethodInstrumentAdapter_InitializeNewStatic is attempting to initialize new static field : " + _methodName);
+		mv.visitLabel(new Label());
 
-	@Override
-	public void visitEnd()
-	{
-		_fn.accept(cv);
-		super.visitEnd();
+		/* initialize new integer array */
+		mv.visitInsn(ICONST_5);
+		mv.visitIntInsn(NEWARRAY, T_INT);
+		mv.visitFieldInsn(PUTSTATIC, _className, "new_static_int_array", "[I");
 	}
 }


### PR DESCRIPTION
Adopt `Java 12 jdk.internal.reflect.Reflection` & `ASM` requirement

Added source directories `src_java12` for `Java 12` and `src_java8` for earlier versions;
`Cmvc196982` is modified for `Java 12` to get field values via package access method reflection instead of direct field reflection which is prohibited since `Java 12`;
Updated `jdk.internal.org.objectweb.asm.Opcodes.ASM4/ASM5` to `ASM7` for `Java 12`;
Enabled previously disabled tests for `Java 12`.

Verified manually that this PR passes the tests in https://github.com/eclipse/openj9/issues/4658 and https://github.com/eclipse/openj9/issues/4663

closes: #4658 
closes: #4663

Reviewers: @pshipton @llxia 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>