### PR TITLE
Fix handling of 'volatile' qualifier

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -716,7 +716,7 @@ public class StructureReader {
 			declaredType = stripUnderscore(declaredType);
 		}
 
-		private static final Pattern QualifierPattern = Pattern.compile("\\s*\\b(const|volatile)\\s+");
+		private static final Pattern QualifierPattern = Pattern.compile("\\s*\\b(const|volatile)\\b\\s*");
 
 		private static String stripTypeQualifiers(String type) {
 			return filterOutPattern(type, QualifierPattern).trim();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureTypeManager.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureTypeManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corp. and others
+ * Copyright (c) 2010, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -156,7 +156,7 @@ public class StructureTypeManager
 		}
 	}
 
-	private static final Pattern CVQualifierPattern = Pattern.compile("\\s*\\b(const|volatile)\\s+");
+	private static final Pattern CVQualifierPattern = Pattern.compile("\\s*\\b(const|volatile)\\b\\s*");
 
 	public int getType(String rawType)
 	{


### PR DESCRIPTION
* there isn't necessarily a space after 'const' or 'volatile'
  e.g. the owner field of a monitor has type 'J9Thread*volatile'