### PR TITLE
Fix DDR parse error

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -354,6 +354,8 @@ typedef struct {
 } J9_UNMODIFIABLE_CLASS_ANNOTATION_DATA;
 
 #if defined(__cplusplus)
+/* Hide the asserts from DDR */
+#if !defined(TYPESTUBS_H)
 static_assert((sizeof(J9_UNMODIFIABLE_CLASS_ANNOTATION_DATA) == (3 + LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION))), "Annotation structure is not packed correctly");
 /* '/' is the lowest numbered character which appears in the annotation name (assume
  * that no '$' exists in there). The name length must be smaller than '/' in order
@@ -361,6 +363,7 @@ static_assert((sizeof(J9_UNMODIFIABLE_CLASS_ANNOTATION_DATA) == (3 + LITERAL_STR
  * complex matching algorithm.
  */
 static_assert((LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION) < (size_t)'/'), "Annotation contains invalid characters");
+#endif /* !TYPESTUBS_H */
 #endif /* __cplusplus */
 
 #endif /* J9_H */


### PR DESCRIPTION
DDR does not handle static_assert, and does not need to see them, so
ifdef them out for DDR.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>