### PR TITLE
AArch64: Add VirtualGuardRuntime.cpp to aarch64.mk

### DIFF
--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -21,6 +21,8 @@
 ################################################################################
 
 j9jit_files(
+	${omr_SOURCE_DIR}/compiler/aarch64/runtime/CodeSync.cpp
+	${omr_SOURCE_DIR}/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
 	aarch64/runtime/PicBuilder.spp
 	aarch64/runtime/Recomp.cpp
 	aarch64/runtime/Recompilation.spp

--- a/runtime/compiler/build/files/host/aarch64.mk
+++ b/runtime/compiler/build/files/host/aarch64.mk
@@ -19,7 +19,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
 JIT_PRODUCT_BACKEND_SOURCES+= \
-    omr/compiler/aarch64/runtime/CodeSync.cpp
+    omr/compiler/aarch64/runtime/CodeSync.cpp \
+    omr/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
 
 JIT_PRODUCT_SOURCE_FILES+= \
     compiler/aarch64/runtime/PicBuilder.spp \


### PR DESCRIPTION
This commit adds VirtualGuardRuntime.cpp from OMR to aarch64.mk in
runtime/compiler/build/files/host.
This depends on https://github.com/eclipse/omr/pull/3666.

Signed-off-by: knn-k <konno@jp.ibm.com>