### PR TITLE
Quiet MultiThreadedArrayCopyTest test case

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/arraycopy/MultiThreadedArrayCopyTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/arraycopy/MultiThreadedArrayCopyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,11 +82,6 @@ public class MultiThreadedArrayCopyTest implements Runnable {
 					System.err.println("dest = " + Arrays.asList(dest));
 				}
 			}
-			
-			if ((loop % (count / 10)) == 0) {
-				System.out.println(name + " - " + Arrays.asList(dest));
-			}
-			
 		}
 	}
 	


### PR DESCRIPTION
This patch deletes test information that is displayed at standard output when the MultiThreadedArrayCopyTest test case succeeded

Fixes: #200

[ci skip]
Signed-off-by: Zhongyi.li1 <zhongyi.li1@ibm.com>