### PR TITLE
Add J9ARRAYCLASS_SET_STRIDE and J9ARRAYCLASS_GET_STRIDE macros

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2954,6 +2954,9 @@ typedef struct J9Class {
 #define J9INTERFACECLASS_ITABLEMETHODCOUNT(clazz) ((clazz)->totalInstanceSize)
 #define J9INTERFACECLASS_SET_ITABLEMETHODCOUNT(clazz, value) (clazz)->totalInstanceSize = (value)
 
+#define J9ARRAYCLASS_SET_STRIDE(clazz, strideLength) ((clazz)->flattenedClassCache) = (J9FlattenedClassCache*)(UDATA)(strideLength)
+#define J9ARRAYCLASS_GET_STRIDE(clazz) ((UDATA)((clazz)->flattenedClassCache))
+
 typedef struct J9ArrayClass {
 	UDATA eyecatcher;
 	struct J9ROMClass* romClass;
@@ -3003,6 +3006,10 @@ typedef struct J9ArrayClass {
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	struct J9Class* nestHost;
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/* Added temporarily for consistency */
+	UDATA flattenedElementSize;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 } J9ArrayClass;
 
 typedef struct J9HookedNative {


### PR DESCRIPTION
Add J9ARRAYCLASS_SET_STRIDE and J9ARRAYCLASS_GET_STRIDE macros

Add UDATA flattenedElementSize in J9ArrayClass (temporarily) for consistency

Also, separately confirm that the classFlags of the elementTypes are copied over to the arrayRamClass (#5021 (comment))

Related #5021 step 1