### PR TITLE
Use constant factory for new constant in DDR

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -93,6 +93,7 @@ import com.ibm.j9ddr.vm29.types.U16;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.U8;
 import com.ibm.j9ddr.vm29.types.UDATA;
+import com.ibm.j9ddr.vm29.j9.J9ConstantHelper;
 
 public class J9BCUtil {
 	private static final String nl = System.getProperty("line.separator");
@@ -691,10 +692,12 @@ public class J9BCUtil {
 	}
 
 
+	private static final long J9AccClassIsUnmodifiableBit = J9ConstantHelper.getLong(J9JavaAccessFlags.class, "J9AccClassIsUnmodifiable", 0);
+
 	/*
-	 * Dump a printed representation of the specified @accessFlags to stdout.
-	 * Answer zero on success
+	 * Dump a printed representation of the specified @accessFlags to @out.
 	 */
+
 	private static void dumpClassJ9ExtraModifiers(PrintStream out, long accessFlags) {
 		if ((accessFlags & J9CfrClassFile.CFR_ACC_REFERENCE_WEAK) != 0)
 			out.append("(weak) ");
@@ -708,7 +711,7 @@ public class J9BCUtil {
 			out.append("(preverified) ");
 		if ((accessFlags & J9JavaAccessFlags.J9AccClassAnonClass) != 0)
 			out.append("(anonClass) ");
-		if ((accessFlags & J9JavaAccessFlags.J9AccClassIsUnmodifiable) != 0)
+		if ((accessFlags & J9AccClassIsUnmodifiableBit) != 0)
 			out.append("(unmodifiable) ");
 	}
 


### PR DESCRIPTION
Using the constant directly will make the code fail on older core files
where it is not defined.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>