### PR TITLE
Deprecate PRINT_ME and TRACE_EVAL macros on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -2543,7 +2543,6 @@ J9::Z::TreeEvaluator::BCDCHKEvaluatorImpl(TR::Node * node,
 TR::Register *
 J9::Z::TreeEvaluator::BCDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("BCDCHK", node, cg);
    TR::Node* pdopNode = node->getFirstChild();
    TR::Register* resultReg = pdopNode->getRegister();
    bool isResultPD = pdopNode->getDataType() == TR::PackedDecimal;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3811,7 +3811,6 @@ J9::Z::CodeGenerator::inlineDirectCall(
       TR::Register *&resultReg)
    {
    TR::CodeGenerator *cg = self();
-   PRINT_ME("directCall", node, cg);
 
    TR::MethodSymbol * methodSymbol = node->getSymbol()->getMethodSymbol();
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1912,7 +1912,6 @@ VMwrtbarEvaluator(
 TR::Register *
 J9::Z::TreeEvaluator::awrtbarEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("wrtbar", node, cg);
    TR::Node * owningObjectChild = node->getSecondChild();
    TR::Node * sourceChild = node->getFirstChild();
    TR::Compilation * comp = cg->comp();
@@ -1984,7 +1983,6 @@ J9::Z::TreeEvaluator::awrtbarEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::awrtbariEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("awrtbari", node, cg);
    TR::Node * owningObjectChild = node->getChild(2);
    TR::Node * sourceChild = node->getSecondChild();
    TR::Compilation *comp = cg->comp();
@@ -2127,8 +2125,6 @@ J9::Z::TreeEvaluator::awrtbariEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::monentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("monent", node, cg);
-
    return TR::TreeEvaluator::VMmonentEvaluator(node, cg);
    }
 
@@ -2138,7 +2134,6 @@ J9::Z::TreeEvaluator::monentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::monexitEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("monexit", node, cg);
    return TR::TreeEvaluator::VMmonexitEvaluator(node, cg);
    }
 
@@ -2148,7 +2143,6 @@ J9::Z::TreeEvaluator::monexitEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::monexitfenceEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("monexitfence", node, cg);
    return NULL;
    }
 
@@ -2158,7 +2152,6 @@ J9::Z::TreeEvaluator::monexitfenceEvaluator(TR::Node * node, TR::CodeGenerator *
 TR::Register *
 J9::Z::TreeEvaluator::asynccheckEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("asynccheck", node, cg);
    // used by asynccheck
    // The child contains an inline test.
    //
@@ -2372,7 +2365,6 @@ TR::Register *
 J9::Z::TreeEvaluator::instanceofEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Compilation *comp = cg->comp();
-   PRINT_ME("instanceof", node, cg);
    if (comp->getOption(TR_OptimizeForSpace) || comp->getOption(TR_DisableInlineInstanceOf))
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
@@ -2411,7 +2403,6 @@ TR::Register *
 J9::Z::TreeEvaluator::checkcastEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Compilation *comp = cg->comp();
-   PRINT_ME("checkcast", node, cg);
    if (comp->getOption(TR_OptimizeForSpace) || comp->getOption(TR_DisableInlineCheckCast))
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
@@ -2536,7 +2527,6 @@ J9::Z::TreeEvaluator::generateHelperCallForVMNewEvaluators(TR::Node *node, TR::C
 TR::Register *
 J9::Z::TreeEvaluator::newObjectEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("newObject", node, cg);
    if (cg->comp()->suppressAllocationInlining())
       return generateHelperCallForVMNewEvaluators(node, cg);
    else
@@ -2549,7 +2539,6 @@ J9::Z::TreeEvaluator::newObjectEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 J9::Z::TreeEvaluator::newArrayEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("newArray", node, cg);
    if (cg->comp()->suppressAllocationInlining())
       return generateHelperCallForVMNewEvaluators(node, cg);
    else
@@ -2562,7 +2551,6 @@ J9::Z::TreeEvaluator::newArrayEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::anewArrayEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("anewArray", node, cg);
    if (cg->comp()->suppressAllocationInlining())
       return generateHelperCallForVMNewEvaluators(node, cg);
    else
@@ -2575,7 +2563,6 @@ J9::Z::TreeEvaluator::anewArrayEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 J9::Z::TreeEvaluator::multianewArrayEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("multianewArray", node, cg);
    TR::ILOpCodes opCode = node->getOpCodeValue();
    TR::Node::recreate(node, TR::acall);
    TR::Register * targetRegister = directCallEvaluator(node, cg);
@@ -2649,7 +2636,6 @@ J9::Z::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::CodeGenerator *cg
    TR::Register *
 J9::Z::TreeEvaluator::resolveCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("resolveCHK", node, cg);
    // No code is generated for the resolve check. The child will reference an
    // unresolved symbol and all check handling is done via the corresponding
    // snippet.
@@ -2685,7 +2671,6 @@ J9::Z::TreeEvaluator::resolveCHKEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 J9::Z::TreeEvaluator::DIVCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("DIVCHK", node, cg);
    TR::Compilation *comp = cg->comp();
    TR::Node * secondChild = node->getFirstChild()->getSecondChild();
    TR::DataType dtype = secondChild->getType();
@@ -2820,7 +2805,6 @@ J9::Z::TreeEvaluator::DIVCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("BNDCHK", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
    TR::LabelSymbol * boundCheckFailureLabel = generateLabelSymbol(cg);
@@ -3141,7 +3125,6 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 J9::Z::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ArrayCopyBNDCHK", node, cg);
    // Check that first child >= second child
    //
    // If the first child is a constant and the second isn't, swap the children.
@@ -4334,16 +4317,12 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
 TR::Register *
 J9::Z::TreeEvaluator::ArrayCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ArrayCHK", node, cg);
    return TR::TreeEvaluator::VMarrayCheckEvaluator(node, cg);
    }
-
-
 
 TR::Register *
 J9::Z::TreeEvaluator::conditionalHelperEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("conditionalHelper", node, cg);
    // used by methodEnterhook, and methodExitHook
    // Decrement the reference count on the constant placeholder parameter to
    // the MethodEnterHook call.  An evaluation isn't necessary because the
@@ -11766,8 +11745,6 @@ TR::Register *
 J9::Z::TreeEvaluator::tstartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
 #ifndef PUBLIC_BUILD
-   PRINT_ME("tstart", node, cg);
-
    //   [0x00000000803797c8] (  0)  tstart
    //   [0x0000000080379738] (  1)    branch --> block 28 BBStart at [0x0000000080378bc8]
    //   [0x00000000803f15f8] (  1)      GlRegDeps
@@ -11930,7 +11907,6 @@ TR::Register *
 J9::Z::TreeEvaluator::tfinishEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
 #ifndef PUBLIC_BUILD
-   PRINT_ME("tfinish", node, cg);
    TR::MemoryReference * tempMR1 = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0),0,cg);
    TR::Instruction * cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, tempMR1);
 #endif

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,49 +34,7 @@ namespace J9 { typedef J9::Z::TreeEvaluator TreeEvaluatorConnector; }
 #error J9::Z::TreeEvaluator expected to be a primary connector, but a J9 connector is already defined
 #endif
 
-
 #include "compiler/codegen/J9TreeEvaluator.hpp"  // include parent
-
-
-
-//#define TRACE_EVAL
-#if defined(TRACE_EVAL)
-//
-// this is a handy thing to turn on if you want to figure out what the common
-// code generator is mapping nodes to and what is really being driven through
-// evaluation.
-// It is not on by default (too noisy and expensive) but can be enabled
-// by just defining TRACE_EVAL for this file
-//
-// If we wanted to enable this by default, it would make sense to create a
-// new 'phase' for debugging that could be queried and to have the macro
-// be a test of the tracing before making a function call out, e.g.
-// instead of PRINT_ME(...) we would have:
-// if (compilation->getOutFile() != NULL && compilation->getTraceEval())
-//   {
-//     print("iadd", compilation->getOutFile());
-//   }
-// and then traceEval would be a forced no-inline method
-//
-// Add another version of PRINT_ME, undef EVAL_BLOCK to go back to the old one
-#define EVAL_BLOCK
-#if defined (EVAL_BLOCK)
-#define PRINT_ME(string,node,cg) TR::Delimiter evalDelimiter(cg->comp(), cg->comp()->getOption(TR_TraceCG), "EVAL", string)
-#else
-void
-PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg)
-   {
-   TR::Compilation * compilation = cg->comp();
-   TR::FILE *outFile = compilation->getOutFile();
-   if (outFile != NULL)
-      {
-      diagnostic("EVAL: %s\n", string);
-      }
-   }
-#endif
-#else
-#define PRINT_ME(string,node,cg)
-#endif
 
 #define INSN_HEAP cg->trHeapMemory()
 


### PR DESCRIPTION
These macros have multiple definitions and are causing issues in debug
mode on z/OS. However the macros themselves are not very useful and are
actually expensive during tracing while providing no real value.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>