### PR TITLE
Disable JITaaSCHTableCommit for Remote AOT

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9585,7 +9585,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
          J9::NewInstanceThunkDetails &mhDetails = static_cast<J9::NewInstanceThunkDetails &>(details);
          J9Class *clazz = mhDetails.classNeedingThunk();
 
-         outOfProcessCompilationEnd(details, jitConfig, fe, entry, comp);
+         outOfProcessCompilationEnd(entry, comp);
          }
       else
          {
@@ -9623,7 +9623,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
       if (startPC)
          {
          if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
-            outOfProcessCompilationEnd(details, jitConfig, fe, entry, comp);
+            outOfProcessCompilationEnd(entry, comp);
          else
             {
             J9::MethodInProgressDetails & dltDetails = static_cast<J9::MethodInProgressDetails &>(details);
@@ -9662,7 +9662,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
          {
          if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
             {
-            outOfProcessCompilationEnd(details, jitConfig, fe, entry, comp);
+            outOfProcessCompilationEnd(entry, comp);
             }
          else
             {
@@ -9703,7 +9703,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
       TR_ASSERT(vmThread, "We must always have a vmThread in compilationEnd()\n");
       if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
          {
-         outOfProcessCompilationEnd(details, jitConfig, fe, entry, comp);
+         outOfProcessCompilationEnd(entry, comp);
          }
       else if (!(jitConfig->runtimeFlags & J9JIT_TOSS_CODE))
          {
@@ -9746,7 +9746,6 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
 
 #if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT)
 
-               TR_Debug *debug = TR::Options::getDebug();
                bool canRelocateMethod = TR::CompilationInfo::canRelocateMethod(comp);
 
                if (canRelocateMethod)

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2345,7 +2345,7 @@ remoteCompile(
          // relocate the received compiled code
          metaData = remoteCompilationEnd(vmThread, compiler, compilee, method, compInfoPT, codeCacheStr, dataCacheStr);
 
-         if (!TR::comp()->getOption(TR_DisableCHOpts))
+         if (!compiler->getOption(TR_DisableCHOpts) && !useAotCompilation)
             {
             TR::ClassTableCriticalSection commit(compiler->fe());
 
@@ -2581,9 +2581,6 @@ remoteCompilationEnd(
 
 void
 outOfProcessCompilationEnd(
-   TR::IlGeneratorMethodDetails &details,
-   J9JITConfig *jitConfig,
-   TR_FrontEnd *fe,
    TR_MethodToBeCompiled *entry,
    TR::Compilation *comp)
    {
@@ -2615,7 +2612,7 @@ outOfProcessCompilationEnd(
    std::string dataCacheStr((char*) dataCacheHeader, dataSize);
 
    CHTableCommitData chTableData;
-   if (!comp->getOption(TR_DisableCHOpts))
+   if (!comp->getOption(TR_DisableCHOpts) && !entry->_useAotCompilation)
       {
       TR_CHTable *chTable = comp->getCHTable();
       chTableData = chTable->computeDataForCHTableCommit(comp);

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -215,8 +215,7 @@ TR_MethodMetaData *remoteCompile(J9VMThread *, TR::Compilation *, TR_ResolvedMet
       J9Method *, TR::IlGeneratorMethodDetails &, TR::CompilationInfoPerThreadBase *);
 TR_MethodMetaData *remoteCompilationEnd(J9VMThread * vmThread, TR::Compilation *comp, TR_ResolvedMethod * compilee, J9Method * method,
                           TR::CompilationInfoPerThreadBase *compInfoPT, const std::string& codeCacheStr, const std::string& dataCacheStr);
-void outOfProcessCompilationEnd(TR::IlGeneratorMethodDetails &details, J9JITConfig *jitConfig,
-      TR_FrontEnd *fe, TR_MethodToBeCompiled *entry, TR::Compilation *comp);
+void outOfProcessCompilationEnd(TR_MethodToBeCompiled *entry, TR::Compilation *comp);
 void printJITaaSMsgStats(J9JITConfig *);
 void printJITaaSCHTableStats(J9JITConfig *, TR::CompilationInfo *);
 void printJITaaSCacheStats(J9JITConfig *, TR::CompilationInfo *);

--- a/runtime/compiler/env/JITaaSCHTable.cpp
+++ b/runtime/compiler/env/JITaaSCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,6 +221,8 @@ bool JITaaSCHTableCommit(
       TR_MethodMetaData *metaData,
       CHTableCommitData &data)
    {
+   TR_ASSERT(!comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE(), "CHTable is not expected to be used in AOT mode");
+
    std::vector<TR_OpaqueClassBlock*> &classes = std::get<0>(data);
    std::vector<TR_OpaqueClassBlock*> &classesThatShouldNotBeNewlyExtended = std::get<1>(data);
    std::vector<TR_ResolvedMethod*> &preXMethods = std::get<2>(data);
@@ -231,9 +233,7 @@ bool JITaaSCHTableCommit(
    std::vector<TR_OpaqueClassBlock*> &classesForOSRRedefinition = std::get<7>(data);
    uint8_t *serverStartPC = std::get<8>(data);
    uint8_t *startPC = (uint8_t*) metaData->startPC;
-
-   if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
-      return true;
+   
    if (vguards.empty() && sideEffectPatchSites.empty() && preXMethods.empty() && classes.empty() && classesThatShouldNotBeNewlyExtended.empty())
       return true;
 


### PR DESCRIPTION
- CHTable commit is not used by AOT, thus disabling it for JITaaS Remote AOT to prevent the null pointer dereference crash
- Remove one line of unused code

Issue: #5108

Signed-off-by: Harry Yu <harryyu1994@gmail.com>