### PR TITLE
 DDR: add support for OSX core files

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/CoreReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/CoreReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,7 @@ import com.ibm.j9ddr.corereaders.ICoreFileReader.DumpTestResult;
 import com.ibm.j9ddr.corereaders.aix.AIXDumpReaderFactory;
 import com.ibm.j9ddr.corereaders.debugger.JniReader;
 import com.ibm.j9ddr.corereaders.elf.ELFDumpReaderFactory;
+import com.ibm.j9ddr.corereaders.macho.MachoDumpReaderFactory;
 import com.ibm.j9ddr.corereaders.minidump.MiniDumpReader;
 
 /**
@@ -61,6 +62,7 @@ public class CoreReader
 		localReaders.add(JniReader.class);
 		localReaders.add(MiniDumpReader.class);
 		localReaders.add(ELFDumpReaderFactory.class);
+		localReaders.add(MachoDumpReaderFactory.class);
 
 		// Use reflection to find TDumpReader: it is not available on all platforms.
 		try {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/BuildVersionCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/BuildVersionCommand.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class BuildVersionCommand extends LoadCommand
+{
+
+	// version numbers are encoded as nibbles in an int in xxxx.yy.zz format
+	public static class Version
+	{
+		int major;
+		int minor;
+		int patch;
+
+		public Version(int encoding)
+		{
+			for (int i = 8; i > 4; i--) {
+				major = major * 10 + ((encoding >>> (i * 4)) & 0xf);
+			}
+			for (int i = 4; i > 2; i--) {
+				minor = minor * 10 + ((encoding >>> (i * 4)) & 0xf);
+			}
+			for (int i = 2; i > 0; i--) {
+				patch = patch * 10 + ((encoding >>> (i * 4)) & 0xf);
+			}
+		}
+	}
+
+	public static class BuildToolVersion
+	{
+		public static final int TOOL_CLANG = 1;
+		public static final int TOOL_SWIFT = 2;
+		public static final int TOOL_LD	= 3;
+		int toolType;
+		int version;
+	}
+
+	int platform;
+	int minOs;
+	int sdk;
+	int numTools;
+	Version minOsVersion;
+	Version sdkVersion;
+	List<BuildToolVersion> tools;
+	
+	public BuildVersionCommand() {}
+
+	public BuildVersionCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		minOs = stream.readInt();
+		sdk = stream.readInt();
+		minOsVersion = new Version(minOs);
+		sdkVersion = new Version(sdk);
+		numTools = stream.readInt();
+		tools = new ArrayList<>(numTools);
+		for (int i = 0; i < numTools; i++) {
+			BuildToolVersion tool = new BuildToolVersion();
+			tool.toolType = stream.readInt();
+			tool.version = stream.readInt();
+			tools.add(tool);
+		}
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DSymtabCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DSymtabCommand.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class DSymtabCommand extends LoadCommand
+{
+	long indexLocalSymbols;
+	int numLocalSymbols;
+	long indexExternalSymbols;
+	int numExternalSymbols;
+	long indexUndefinedSymbols;
+	int numUndefinedSymbols;
+	long tableOfContentsOffset;
+	int tableOfContentsEntries;
+	long moduleTableOffset;
+	int moduleTableEntries;
+	long externalSymbolTableOffset;
+	int externalSymbolTableEntries;
+	long indirectSymbolTableOffset;
+	int indirectSymbolTableEntries;
+	long externalRelocationOffset;
+	int externalRelocationEntries;
+	long internalRelocationOffset;
+	int internalRelocationEntries;
+
+	public DSymtabCommand() {}
+
+	public DSymtabCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		indexLocalSymbols = stream.readUnsignedInt();
+		numLocalSymbols = stream.readInt();
+		indexExternalSymbols = stream.readUnsignedInt();
+		numExternalSymbols = stream.readInt();
+		indexUndefinedSymbols = stream.readUnsignedInt();
+		numUndefinedSymbols = stream.readInt();
+		tableOfContentsOffset = stream.readUnsignedInt();
+		tableOfContentsEntries = stream.readInt();
+		moduleTableOffset = stream.readUnsignedInt();
+		moduleTableEntries = stream.readInt();
+		externalSymbolTableOffset = stream.readUnsignedInt();
+		externalSymbolTableEntries = stream.readInt();
+		indirectSymbolTableOffset = stream.readUnsignedInt();
+		indirectSymbolTableEntries = stream.readInt();
+		externalRelocationOffset = stream.readUnsignedInt();
+		externalRelocationEntries = stream.readInt();
+		internalRelocationOffset = stream.readUnsignedInt();
+		internalRelocationEntries = stream.readInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DyldInfoCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DyldInfoCommand.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class DyldInfoCommand extends LoadCommand
+{
+	int rebaseOffset;
+	int rebaseSize;
+	int bindOffset;
+	int bindSize;
+	int weakBindOffset;
+	int weakBindSize;
+	int lazyBindOffset;
+	int lazyBindSize;
+	int exportOffset;
+	int exportSize;
+
+	public DyldInfoCommand() {}
+
+	public DyldInfoCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		rebaseOffset = stream.readInt();
+		rebaseSize = stream.readInt();
+		bindOffset = stream.readInt();
+		bindSize = stream.readInt();
+		weakBindOffset = stream.readInt();
+		weakBindSize = stream.readInt();
+		lazyBindOffset = stream.readInt();
+		lazyBindSize = stream.readInt();
+		exportOffset = stream.readInt();
+		exportSize = stream.readInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylibCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylibCommand.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class DylibCommand extends LoadCommand
+{
+
+	public static class Dylib
+	{
+		LoadCommandString name;
+		int timestamp;
+		int currentVersion;
+		int compatibilityVersion;
+	}
+
+	Dylib dylib;
+
+	public DylibCommand() {}
+
+	public DylibCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		dylib = new Dylib();
+		dylib.name = new LoadCommandString();
+		dylib.name.readLcString(stream);
+		dylib.timestamp = stream.readInt();
+		dylib.currentVersion = stream.readInt();
+		dylib.compatibilityVersion = stream.readInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylinkerCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/DylinkerCommand.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class DylinkerCommand extends LoadCommand
+{
+	LoadCommandString subName;
+
+	public DylinkerCommand() {}
+
+	public DylinkerCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		subName = new LoadCommandString();
+		subName.readLcString(stream);
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EncryptionCommand64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EncryptionCommand64.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class EncryptionCommand64 extends LoadCommand
+{
+	long encryptedOffset;
+	long encryptedSize;
+	int encryptionId;
+
+	public EncryptionCommand64() {}
+
+	public EncryptionCommand64 readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		encryptedOffset = stream.readUnsignedInt();
+		encryptedSize = stream.readUnsignedInt();
+		encryptionId = stream.readInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EntryPointCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/EntryPointCommand.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class EntryPointCommand extends LoadCommand
+{
+	long entryOffset;
+	long stackSize;
+
+	public EntryPointCommand() {}
+
+	public EntryPointCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		entryOffset = stream.readLong();
+		stackSize = stream.readLong();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkeditDataCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkeditDataCommand.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class LinkeditDataCommand extends LoadCommand
+{
+	long dataOffset;
+	long dataSize;
+
+	public LinkeditDataCommand() {}
+
+	public LinkeditDataCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		dataOffset = stream.readUnsignedInt();
+		dataSize = stream.readUnsignedInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkerOptionCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LinkerOptionCommand.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class LinkerOptionCommand extends LoadCommand
+{
+	int count;
+	List<String> options;
+
+	public LinkerOptionCommand() {}
+
+	public LinkerOptionCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		count = stream.readInt();
+		int optionsSize = (int) (cmdSize - stream.getStreamPosition());
+		byte optionsBytes[] = new byte[optionsSize];
+		stream.readFully(optionsBytes);
+		int start = 0;
+		for (int i = 0; i < count; i++) {
+			int end = start;
+			while (optionsBytes[end] != 0) {
+				end++;
+			}
+			options.add(new String(optionsBytes, start, end - start, "UTF8"));
+			start = end + 1;
+		}
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LoadCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/LoadCommand.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class LoadCommand
+{
+
+	public static final int LC_REQ_DYLD = 0x80000000;
+
+	// load command constants
+	public static final int LC_SEGMENT = 0x1;
+	public static final int LC_SYMTAB = 0x2;
+	public static final int LC_SYMSEG = 0x3;
+	public static final int LC_THREAD = 0x4;
+	public static final int LC_UNIXTHREAD = 0x5;
+	public static final int LC_LOADFVMLIB = 0x6;
+	public static final int LC_IDFVMLIB = 0x7;
+	public static final int LC_IDENT = 0x8;
+	public static final int LC_FVMFILE = 0x9;
+	public static final int LC_PREPAGE = 0xa;
+	public static final int LC_DYSYMTAB = 0xb;
+	public static final int LC_LOAD_DYLIB = 0xc;
+	public static final int LC_ID_DYLIB = 0xd;
+	public static final int LC_LOAD_DYLINKER = 0xe;
+	public static final int LC_ID_DYLINKER = 0xf;
+	public static final int LC_PREBOUND_DYLIB = 0x10;
+	public static final int LC_ROUTINES = 0x11;
+	public static final int LC_SUB_FRAMEWORK = 0x12;
+	public static final int LC_SUB_UMBRELLA = 0x13;
+	public static final int LC_SUB_CLIENT = 0x14;
+	public static final int LC_SUB_LIBRARY = 0x15;
+	public static final int LC_TWOLEVEL_HINTS = 0x16;
+	public static final int LC_PREBIND_CKSUM = 0x17;
+	public static final int LC_LOAD_WEAK_DYLIB = (0x18 | LC_REQ_DYLD);
+	public static final int LC_SEGMENT_64 = 0x19;
+	public static final int LC_ROUTINES_64 = 0x1a;
+	public static final int LC_UUID = 0x1b;
+	public static final int LC_RPATH = (0x1c | LC_REQ_DYLD);
+	public static final int LC_CODE_SIGNATURE = 0x1d;
+	public static final int LC_SEGMENT_SPLIT_INFO = 0x1e;
+	public static final int LC_REEXPORT_DYLIB = (0x1f | LC_REQ_DYLD);
+	public static final int LC_LAZY_LOAD_DYLIB = 0x20;
+	public static final int LC_ENCRYPTION_INFO = 0x21;
+	public static final int LC_DYLD_INFO = 0x22;
+	public static final int LC_DYLD_INFO_ONLY = (0x22|LC_REQ_DYLD);
+	public static final int LC_LOAD_UPWARD_DYLIB = (0x23 | LC_REQ_DYLD);
+	public static final int LC_VERSION_MIN_MACOSX = 0x24;
+	public static final int LC_VERSION_MIN_IPHONEOS = 0x25;
+	public static final int LC_FUNCTION_STARTS = 0x26;
+	public static final int LC_DYLD_ENVIRONMENT = 0x27;
+	public static final int LC_MAIN = (0x28|LC_REQ_DYLD);
+	public static final int LC_DATA_IN_CODE = 0x29;
+	public static final int LC_SOURCE_VERSION = 0x2A;
+	public static final int LC_DYLIB_CODE_SIGN_DRS = 0x2B;
+	public static final int LC_ENCRYPTION_INFO_64 = 0x2C;
+	public static final int LC_LINKER_OPTION = 0x2D;
+	public static final int LC_LINKER_OPTIMIZATION_HINT = 0x2E;
+	public static final int LC_VERSION_MIN_TVOS = 0x2F;
+	public static final int LC_VERSION_MIN_WATCHOS = 0x30;
+	public static final int LC_NOTE = 0x31;
+	public static final int LC_BUILD_VERSION = 0x32;
+
+	public class LoadCommandString
+	{
+		long offset;
+		String value;
+
+		public LoadCommandString() {}
+
+		public void readLcString(ImageInputStream stream) throws IOException {
+			offset = stream.readInt();
+			long currentOffset = stream.getStreamPosition();
+			stream.seek(absoluteOffset + offset);
+			int stringSize = (int) (cmdSize - offset);
+			byte stringBytes[] = new byte[stringSize];
+			stream.readFully(stringBytes);
+			value = getStringFromAsciiChars(stringBytes);
+			stream.seek(currentOffset);
+		}
+	}
+
+	public static String getStringFromAsciiChars(byte[] chars) throws UnsupportedEncodingException
+	{
+		return getStringFromAsciiChars(chars, 0);
+	}
+
+	public static String getStringFromAsciiChars(byte[] chars, int start)
+	{
+		if ((start < 0) || (start >= chars.length)) {
+			return null;
+		}
+		int count = 0;
+		for (;count < chars.length; count++) {
+			if (0 == chars[start + count]) {
+				break;
+			}
+		}
+		return new String(chars, start, count, StandardCharsets.US_ASCII);
+	}
+
+
+	public int cmdType;
+	public long cmdSize;
+	public long absoluteOffset; // offset from start of core file stream
+	public long segmentOffset; // offset from the start of the current memory segment
+
+	protected LoadCommand() {}
+
+	public LoadCommand(int type, long size, long offset)
+	{
+		cmdType = type;
+		cmdSize = size;
+		this.absoluteOffset = offset;
+	}
+
+	public LoadCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		absoluteOffset = stream.getStreamPosition();
+		segmentOffset = streamSegmentOffset;
+		cmdType = stream.readInt();
+		cmdSize = stream.readUnsignedInt();
+		return this;
+	}
+
+	public static LoadCommand readFullCommand(ImageInputStream stream, long streamOffset, long segmentOffset) throws IOException
+	{
+		LoadCommand command;
+		stream.seek(streamOffset);
+		int cmdType = stream.readInt();
+		switch(cmdType) {
+			case LC_SEGMENT_64:
+				command = new SegmentCommand64();
+				break;
+			case LC_LOAD_DYLIB:
+			case LC_LOAD_WEAK_DYLIB:
+			case LC_ID_DYLIB:
+			case LC_REEXPORT_DYLIB:
+				command = new DylibCommand();
+				break;
+			case LC_SUB_FRAMEWORK:
+			case LC_SUB_CLIENT:
+			case LC_SUB_LIBRARY:
+			case LC_SUB_UMBRELLA:
+				command = new SubCommand();
+				break;
+			case LC_PREBOUND_DYLIB:
+				command = new PreboundDylibCommand();
+				break;
+			case LC_LOAD_DYLINKER:
+			case LC_ID_DYLINKER:
+			case LC_DYLD_ENVIRONMENT:
+				command = new DylinkerCommand();
+				break;
+			case LC_THREAD:
+			case LC_UNIXTHREAD:
+				command = new ThreadCommand();
+				break;
+			case LC_ROUTINES_64:
+				command = new RoutinesCommand64();
+				break;
+			case LC_SYMTAB:
+				command = new SymtabCommand();
+				break;
+			case LC_DYSYMTAB:
+				command = new DSymtabCommand();
+				break;
+			case LC_TWOLEVEL_HINTS:
+				command = new TwoLevelHintsCommand();
+				break;
+			case LC_PREBIND_CKSUM:
+				command = new PrebindChecksumCommand();
+				break;
+			case LC_UUID:
+				command = new UuidCommand();
+				break;
+			case LC_RPATH:
+				command = new RpathCommand();
+				break;
+			case LC_CODE_SIGNATURE:
+			case LC_SEGMENT_SPLIT_INFO:
+			case LC_FUNCTION_STARTS:
+			case LC_DATA_IN_CODE:
+			case LC_DYLIB_CODE_SIGN_DRS:
+			case LC_LINKER_OPTIMIZATION_HINT:
+				command = new LinkeditDataCommand();
+				break;
+			case LC_ENCRYPTION_INFO_64:
+				command = new EncryptionCommand64();
+				break;
+			case LC_VERSION_MIN_MACOSX:
+				command = new VersionMinCommand();
+				break;
+			case LC_BUILD_VERSION:
+				command = new BuildVersionCommand();
+				break;
+			case LC_DYLD_INFO:
+			case LC_DYLD_INFO_ONLY:
+				command = new DyldInfoCommand();
+				break;
+			case LC_LINKER_OPTION:
+				command = new LinkerOptionCommand();
+				break;
+			case LC_MAIN:
+				command = new EntryPointCommand();
+				break;
+			case LC_SOURCE_VERSION:
+				command = new SourceVersionCommand();
+				break;
+			case LC_NOTE:
+				command = new NoteCommand();
+				break;
+			default:
+				command = new LoadCommand();
+		}
+		stream.seek(streamOffset);
+		command.readCommand(stream, segmentOffset);
+		return command;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/MachoDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/MachoDumpReader.java
@@ -1,0 +1,510 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.imageio.stream.FileImageInputStream;
+import javax.imageio.stream.ImageInputStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.DataUnavailableException;
+import com.ibm.j9ddr.corereaders.AbstractCoreReader;
+import com.ibm.j9ddr.corereaders.ICore;
+import com.ibm.j9ddr.corereaders.ILibraryDependentCore;
+import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
+import com.ibm.j9ddr.corereaders.Platform;
+import com.ibm.j9ddr.corereaders.macho.ThreadCommand.ThreadState;
+import com.ibm.j9ddr.corereaders.memory.DumpMemorySource;
+import com.ibm.j9ddr.corereaders.memory.IAddressSpace;
+import com.ibm.j9ddr.corereaders.memory.IMemoryRange;
+import com.ibm.j9ddr.corereaders.memory.IMemorySource;
+import com.ibm.j9ddr.corereaders.memory.IModule;
+import com.ibm.j9ddr.corereaders.memory.ISymbol;
+import com.ibm.j9ddr.corereaders.memory.Module;
+import com.ibm.j9ddr.corereaders.memory.UnbackedMemorySource;
+import com.ibm.j9ddr.corereaders.osthread.IOSStackFrame;
+import com.ibm.j9ddr.corereaders.osthread.IOSThread;
+import com.ibm.j9ddr.corereaders.osthread.IRegister;
+import com.ibm.j9ddr.corereaders.osthread.Register;
+
+/**
+ * There is an implicit assumption in this core reader that the Mach-O cores
+ * are generated on a 64-bit Mac OSX machine, since OpenJ9 only supports OSX
+ * out of the platforms using the Mach-O format.
+ */
+public class MachoDumpReader extends AbstractCoreReader implements ILibraryDependentCore
+{
+
+	//Mach-O identifiers
+	private static final int MACHO_64 = 0xFEEDFACF;
+	private static final int MACHO_64_REV = 0xCFFAEDFE;
+
+	//Mach file types
+	public static final int MH_OBJECT = 0x1;
+	public static final int MH_EXECUTE = 0x2;
+	public static final int MH_FVMLIB = 0x3;
+	public static final int MH_CORE = 0x4;
+	public static final int MH_PRELOAD = 0x5;
+	public static final int MH_DYLIB = 0x6;
+	public static final int MH_DYLINKER = 0x7;
+	public static final int MH_BUNDLE = 0x8;
+	public static final int MH_DYLIB_STUB = 0x9;
+	public static final int MH_DSYM = 0xa;
+	public static final int MH_KEXT_BUNDLE = 0xb;
+
+	// Flags for the mach-o file, see /usr/include/mach-o/loader.h for descriptions
+	private static final int MH_NOUNDEFS = 0x1;
+	private static final int MH_INCRLINK = 0x2;
+	private static final int MH_DYLDLINK = 0x4;
+	private static final int MH_BINDATLOAD = 0x8;
+	private static final int MH_PREBOUND = 0x10;
+	private static final int MH_SPLIT_SEGS = 0x20;
+	private static final int MH_LAZY_INIT = 0x40;
+	private static final int MH_TWOLEVEL = 0x80;
+	private static final int MH_FORCE_FLAT = 0x100;
+	private static final int MH_NOMULTIDEFS = 0x200;
+	private static final int MH_NOFIXPREBINDING = 0x400;
+	private static final int MH_PREBINDABLE = 0x800;
+	private static final int MH_ALLMODSBOUND = 0x1000;
+	private static final int MH_SUBSECTIONS_VIA_SYMBOLS = 0x2000;
+	private static final int MH_CANONICAL = 0x4000;
+	private static final int MH_WEAK_DEFINES = 0x8000;
+	private static final int MH_BINDS_TO_WEAK = 0x10000;
+	private static final int MH_ALLOW_STACK_EXECUTION = 0x20000;
+	private static final int MH_ROOT_SAFE = 0x40000;
+	private static final int MH_SETUID_SAFE = 0x80000;
+	private static final int MH_NO_REEXPORTED_DYLIBS = 0x100000;
+	private static final int MH_PIE = 0x200000;
+	private static final int MH_DEAD_STRIPPABLE_DYLIB = 0x400000;
+	private static final int MH_HAS_TLV_DESCRIPTORS = 0x800000;
+	private static final int MH_NO_HEAP_EXECUTION = 0x1000000;
+	private static final int MH_APP_EXTENSION_SAFE = 0x02000000;
+
+	private static final int CPU_TYPE_X86 = 0x7;
+	private static final int CPU_TYPE_X86_64 = 0x01000007;
+
+	private static final int header64Size = 32;
+	private static final int loadCommandSize = 8;
+
+	private MachFile64 dumpFile;
+	private MachFile64 executableMachFile;
+	private MachFile64 dylinkerMachFile;
+	private List<MachFile64> dylibMachFiles;
+
+	private OSXProcessAddressSpace _process;
+	private IModule _executable;
+	private List<IModule> _modules;
+	private int _signalNumber = -1;
+	
+	public class MachHeader64
+	{
+		public int magic;
+		public int cpuType;
+		public int cpuSubtype;
+		public int fileType;
+		public int numCommands;
+		public long sizeCommands;
+		public int flags;
+
+		public MachHeader64() {}
+
+		public MachHeader64(int magic, int cpuType, int cpuSubtype, int fileType, int numCommands, long sizeCommands, int flags)
+		{
+			this.magic = magic;
+			this.cpuType = cpuType;
+			this.cpuSubtype = cpuSubtype;
+			this.fileType = fileType;
+			this.numCommands = numCommands;
+			this.sizeCommands = sizeCommands;
+			this.flags = flags;
+		}
+
+	}
+
+	public class MachFile64
+	{
+		public MachHeader64 header;
+		public List<LoadCommand> loadCommands;
+		public List<SegmentCommand64> segments;
+		public List<LoadCommand> otherLoads;
+		public ThreadCommand threads;
+		long streamOffset;
+
+		public MachFile64() {}
+
+		public Collection<? extends IMemorySource> getMemoryRangesWithOffset(long vmAddrOffset) throws IOException
+		{
+			List<IMemorySource> ranges = new LinkedList<>();
+			for (SegmentCommand64 segment : segments) {
+				if (segment.fileSize != 0) {
+					// if we somehow can't get the stream length, the length() method returns -1 and we just create the memory source
+					// otherwise, we check that memory segment indicated by the header doesn't run off the end of the file
+					if ((MachoDumpReader.this._fileReader.length() < 0) || (streamOffset + segment.fileOffset + segment.fileSize <= MachoDumpReader.this._fileReader.length())) {
+						ranges.add(new DumpMemorySource(segment.vmaddr + vmAddrOffset, segment.fileSize, streamOffset + segment.fileOffset, MachoDumpReader.this));
+					} else {
+						ranges.add(new UnbackedMemorySource(segment.vmaddr + vmAddrOffset, segment.fileSize, "segment is beyond file end"));
+					}
+				}
+			}
+			return ranges;
+		}
+	}
+
+	public class OSXThread implements IOSThread
+	{
+
+		private final Map<String, Number> registers;
+		private final Properties properties;
+		private final long threadId;
+		private final List<IMemoryRange> memoryRanges = new LinkedList<>();
+		private final List<IOSStackFrame> stackFrames = new LinkedList<>();
+
+		public OSXThread(long tid, ThreadCommand.ThreadState thread)
+		{
+			threadId = tid;
+			registers = thread.registers;
+			properties = new Properties();
+		}
+
+		public long getThreadId() throws CorruptDataException
+		{
+			return threadId;
+		}
+
+		//TODO: unwind stack from the stack pointer
+		public List<? extends IOSStackFrame> getStackFrames()
+		{
+			return null;
+		}
+
+		public Collection<? extends IRegister> getRegisters()
+		{
+			List<IRegister> regList = new ArrayList<IRegister>(registers.size());
+			for (String regName : registers.keySet()) {
+				Number value = registers.get(regName);
+
+				regList.add(new Register(regName,value));
+			}
+			return regList;
+		}
+
+		public Collection<? extends IMemoryRange> getMemoryRanges()
+		{
+			return memoryRanges;
+		}
+
+		public long getInstructionPointer()
+		{
+			return registers.get("rip").longValue();
+		}
+
+		public long getBasePointer()
+		{
+			return registers.get("rbp").longValue();
+		}
+
+		public long getStackPointer()
+		{
+			return registers.get("rsp").longValue();
+		}
+
+		public Properties getProperties()
+		{
+			return properties;
+		}
+	}
+
+	public MachoDumpReader(ImageInputStream in) throws IOException, InvalidDumpFormatException
+	{
+		this.coreFile = null;
+		this._modules = new ArrayList<>();
+		this.dylibMachFiles = new ArrayList<>();
+		setReader(in);
+		readCore();
+	}
+
+	public static boolean isMACHO(byte[] data)
+	{
+		int magic = readInt(data, 0);
+		return isMACHO(magic);
+	}
+
+	private static boolean isMACHO(int magic)
+	{
+		return (magic == MACHO_64) || (magic == MACHO_64_REV);
+	}
+
+	public static ICore getReaderForFile(File f) throws IOException, InvalidDumpFormatException
+	{
+		ImageInputStream in = new FileImageInputStream(f);
+		return getReaderForFile(in);
+	}
+
+	public static ICore getReaderForFile(ImageInputStream in) throws IOException, InvalidDumpFormatException
+	{
+		int magic = in.readInt();
+		if (!isMACHO(magic)) {
+			throw new InvalidDumpFormatException("The supplied file is not an Mach-O core dump.");
+		}
+		return new MachoDumpReader(in);
+	}
+
+	public String getCommandLine() throws DataUnavailableException
+	{
+		throw new DataUnavailableException("No command line available on OSX");
+	}
+
+	public Platform getPlatform()
+	{
+		return Platform.OSX;
+	}
+
+	public String getDumpFormat()
+	{
+		return "macho";
+	}
+
+	public Collection<? extends IAddressSpace> getAddressSpaces()
+	{
+		return Collections.singletonList((IAddressSpace)_process);
+	}
+
+	public Properties getProperties()
+	{
+		Properties props = new Properties();
+		
+		props.setProperty(ICore.SYSTEM_TYPE_PROPERTY, "OSX");
+		props.setProperty(ICore.PROCESSOR_TYPE_PROPERTY, getCpuType());
+		props.setProperty(ICore.PROCESSOR_SUBTYPE_PROPERTY, "");
+		
+		return props;
+	}
+
+	public void executablePathHint(String path)
+	{
+		if (_executable != null) {
+			try {
+				_executable = new Module(_process, path, (List<? extends ISymbol>)_executable.getSymbols(), _executable.getMemoryRanges(), _executable.getLoadAddress(), _executable.getProperties());
+			} catch (DataUnavailableException e) {
+				//do nothing, since we're simply recreating the executable module
+			}
+		}
+	}
+
+	public IModule getExecutable()
+	{
+		return _executable;
+	}
+
+	public List<? extends IModule> getModules()
+	{
+		return _modules;
+	}
+
+	public long getProcessId()
+	{
+		return 0;
+	}
+
+	public List<? extends IOSThread> getThreads()
+	{
+		List<ThreadState> x86ThreadStates = new ArrayList<>(dumpFile.threads.states.size());
+		for(ThreadState state : dumpFile.threads.states) {
+			if (state.flavor == ThreadCommand.x86_THREAD_STATE) {
+				x86ThreadStates.add(state);
+			} else if (_signalNumber == -1 && state.flavor == ThreadCommand.x86_EXCEPTION_STATE) {
+				_signalNumber = state.registers.get("err").intValue();
+			}
+		}
+		List<IOSThread> threads = new ArrayList<IOSThread>(x86ThreadStates.size());
+		for (ThreadState thread : x86ThreadStates) {
+			threads.add(new OSXThread(0, thread));
+		}
+		return threads;
+	}
+
+	public int getSignalNumber()
+	{
+		if (_signalNumber == -1) {
+			getThreads();
+		}
+		return _signalNumber;
+	}
+
+	/**
+	 * A Mach-O core on OSX typically consists of a number of memory segments,
+	 * preceded by the load commands for the core itself. Each memory segment
+	 * either contains another Mach-O file or just data.
+	 * Thus, we iterate through each segment in order to find the Mach files
+	 * representing the executable and the shared libraries.
+	 */
+	private void readCore() throws IOException, InvalidDumpFormatException
+	{
+		dumpFile = readMachFile(0);
+		if (dumpFile.header.fileType != MH_CORE) {
+			throw new InvalidDumpFormatException("The supplied file is not an Mach-O core dump.");
+		}
+		_process = new OSXProcessAddressSpace(8, _fileReader.getByteOrder(), this);
+
+		Collection<? extends IMemorySource> coreMemoryRanges = dumpFile.getMemoryRangesWithOffset(0);
+		_process.addMemorySources(coreMemoryRanges);
+
+		for (SegmentCommand64 segment : dumpFile.segments) {
+			seek(segment.fileOffset);
+			try {
+				int magic = readInt();
+				if (isMACHO(magic)) {
+					MachFile64 innerFile = readMachFile(segment.fileOffset);
+					switch (innerFile.header.fileType) {
+						case MH_EXECUTE:
+							executableMachFile = innerFile;
+							_executable = processExecutableFile(innerFile, segment);
+							break;
+						case MH_DYLIB:
+							dylibMachFiles.add(innerFile);
+							_modules.add(processModuleFile(innerFile, segment));
+							break;
+						case MH_DYLINKER:
+							dylinkerMachFile = innerFile;
+							break;
+						default:
+							break;
+					}
+				}
+			} catch (EOFException e) {
+				// nothing to process if we have a truncated file
+			}
+		}
+		for (LoadCommand lc : dumpFile.otherLoads) {
+			if (lc instanceof ThreadCommand) {
+				dumpFile.threads = (ThreadCommand) lc;
+			}
+		}
+	}
+
+	public MachFile64 readMachFile(long fileOffset) throws IOException, InvalidDumpFormatException
+	{
+		MachFile64 machfile = new MachFile64();
+		machfile.streamOffset = fileOffset;
+		machfile.header = readHeader(fileOffset);
+		if (machfile.header.numCommands > 0) {
+			machfile.loadCommands = new ArrayList<>(machfile.header.numCommands);
+			machfile.segments = new ArrayList<>();
+			machfile.otherLoads = new ArrayList<>();
+		}
+		long currentOffset = fileOffset + header64Size;
+		for (int i = 0; i < machfile.header.numCommands; i++) {
+			LoadCommand command = LoadCommand.readFullCommand(_fileReader, currentOffset, fileOffset);
+			if (command instanceof SegmentCommand64) {
+				SegmentCommand64 segment = (SegmentCommand64) command;
+				machfile.segments.add(segment);
+			} else {
+				machfile.otherLoads.add(command);
+			}
+			machfile.loadCommands.add(command);
+			currentOffset += command.cmdSize;
+		}
+		return machfile;
+	}
+
+	/**
+	 * The two methods processing modules currently do not read in the symbols.
+	 * The symbol data from the core is not necessary for DDR, as later stages
+	 * can collect the symbols from the VM itself.
+	 */
+	private IModule processExecutableFile(MachFile64 executableFile, SegmentCommand64 container) throws IOException, InvalidDumpFormatException
+	{
+		List<ISymbol> symbols = new ArrayList<>();
+		Collection<? extends IMemoryRange> memoryRanges = executableFile.getMemoryRangesWithOffset(container.vmaddr);
+		Module m = new Module(_process, "executable", symbols, memoryRanges, executableFile.streamOffset, new Properties());
+		return m;
+	}
+
+	private IModule processModuleFile(MachFile64 moduleFile, SegmentCommand64 container) throws IOException, InvalidDumpFormatException
+	{
+		DylibCommand dylib = (DylibCommand) moduleFile.otherLoads.stream().filter(c -> (c.cmdType == LoadCommand.LC_ID_DYLIB)).findFirst().get();
+		String moduleName = dylib.dylib.name.value;
+		List<ISymbol> symbols = new ArrayList<>();
+		Collection<? extends IMemoryRange> memoryRanges = moduleFile.getMemoryRangesWithOffset(container.vmaddr);
+		Module m = new Module(_process, moduleName, symbols, memoryRanges, moduleFile.streamOffset, new Properties());
+		return m;
+	}
+
+	public MachHeader64 readHeader(long offset) throws IOException, InvalidDumpFormatException
+	{
+		seek(offset);
+		MachHeader64 header = new MachHeader64();
+		header.magic = readInt();
+		if (header.magic == MACHO_64_REV) {
+			_fileReader.setByteOrder((_fileReader.getByteOrder() == ByteOrder.BIG_ENDIAN) ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+		}
+		header.cpuType = readInt();
+		header.cpuSubtype = readInt();
+		header.fileType = readInt();
+		header.numCommands = readInt();
+		header.sizeCommands = Integer.toUnsignedLong(readInt());
+		header.flags = readInt();
+		readInt(); //reserved section
+		return header;
+	}
+
+	private String getCpuType()
+	{
+		if (dumpFile.header.cpuType == CPU_TYPE_X86_64) {
+			return "X86_64";
+		}
+		else {
+			return "";
+		}
+	}
+
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/MachoDumpReaderFactory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/MachoDumpReaderFactory.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+import com.ibm.j9ddr.corereaders.CoreReader;
+import com.ibm.j9ddr.corereaders.ICore;
+import com.ibm.j9ddr.corereaders.ICoreFileReader;
+import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
+
+public class MachoDumpReaderFactory implements ICoreFileReader
+{
+
+	public ICore processDump(String path) throws InvalidDumpFormatException, IOException
+	{
+		return MachoDumpReader.getReaderForFile(new File(path));
+	}
+
+	public ICore processDump(ImageInputStream in) throws InvalidDumpFormatException, IOException
+	{
+		return MachoDumpReader.getReaderForFile(in);
+	}
+
+	public DumpTestResult testDump(String path) throws IOException
+	{
+		File dumpFile = new File(path);
+		if (! dumpFile.exists()) {
+			return DumpTestResult.FILE_NOT_FOUND;
+		}
+		return MachoDumpReader.isMACHO(CoreReader.getFileHeader(path)) ? DumpTestResult.RECOGNISED_FORMAT : DumpTestResult.UNRECOGNISED_FORMAT;
+	}
+
+	public DumpTestResult testDump(ImageInputStream in) throws IOException
+	{
+		return MachoDumpReader.isMACHO(CoreReader.getFileHeader(in)) ? DumpTestResult.RECOGNISED_FORMAT : DumpTestResult.UNRECOGNISED_FORMAT;
+	}
+
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/NoteCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/NoteCommand.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class NoteCommand extends LoadCommand
+{
+	byte dataOwner[];
+	long offset;
+	long size;
+	
+	public NoteCommand() {}
+
+	public NoteCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		dataOwner = new byte[16];
+		stream.readFully(dataOwner);
+		offset = stream.readLong();
+		size = stream.readLong();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/OSXProcessAddressSpace.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/OSXProcessAddressSpace.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Properties;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.DataUnavailableException;
+import com.ibm.j9ddr.corereaders.ICore;
+import com.ibm.j9ddr.corereaders.Platform;
+import com.ibm.j9ddr.corereaders.memory.IMemorySource;
+import com.ibm.j9ddr.corereaders.memory.IModule;
+import com.ibm.j9ddr.corereaders.memory.MemoryFault;
+import com.ibm.j9ddr.corereaders.memory.ProcessAddressSpace;
+import com.ibm.j9ddr.corereaders.osthread.IOSThread;
+
+public class OSXProcessAddressSpace extends ProcessAddressSpace
+{
+
+	private final MachoDumpReader reader;
+	
+	public OSXProcessAddressSpace(int pointerSizeBytes, ByteOrder byteOrder,
+			MachoDumpReader reader)
+	{
+		super(pointerSizeBytes, byteOrder, reader);
+		this.reader = reader;
+	}
+
+	public ICore getCore() {
+		return reader;
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.j9ddr.corereaders.memory.IProcess#getCommandLine()
+	 */
+	public String getCommandLine() throws DataUnavailableException
+	{
+		return reader.getCommandLine();
+	}
+	
+	@Override
+	public boolean equals(Object o)
+	{
+		if((o == null) || !(o instanceof OSXProcessAddressSpace)) {
+			return false;
+		}
+		OSXProcessAddressSpace space = (OSXProcessAddressSpace) o;
+		return reader.equals(space.reader);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return reader.hashCode();
+	}
+
+	public Properties getEnvironmentVariables() throws CorruptDataException, DataUnavailableException
+	{
+		throw new DataUnavailableException("Can't get environment from core dump");
+	}
+	
+	public IModule getExecutable() throws CorruptDataException
+	{
+		return reader.getExecutable();
+	}
+
+	public List<? extends IModule> getModules() throws CorruptDataException
+	{
+		return reader.getModules();
+	}
+
+	public Platform getPlatform()
+	{
+		return Platform.OSX;
+	}
+
+	public long getProcessId() throws CorruptDataException
+	{
+		return reader.getProcessId();
+	}
+
+	public List<? extends IOSThread> getThreads() throws CorruptDataException
+	{
+		return reader.getThreads();
+	}
+
+	
+	public int getSignalNumber() throws DataUnavailableException
+	{
+		return reader.getSignalNumber();
+	}
+
+	public String readStringAt(long nameAddress) throws MemoryFault
+	{
+		long ptr = nameAddress;
+		
+		while (getByteAt(ptr) != 0) {
+			ptr++;
+		}
+		
+		int stringLength = (int)(ptr - nameAddress);
+		
+		byte[] stringBuffer = new byte[stringLength];
+		
+		getBytesAt(nameAddress, stringBuffer);
+		
+		return new String(stringBuffer, StandardCharsets.US_ASCII);
+	}
+
+	IMemorySource getRangeForAddress(long address)
+	{
+		return memorySources.getRangeForAddress(address);
+	}
+
+	public boolean isFailingProcess() throws DataUnavailableException
+	{
+		throw new DataUnavailableException("Not available on this platform");
+	}
+	
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PrebindChecksumCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PrebindChecksumCommand.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class PrebindChecksumCommand extends LoadCommand
+{
+	int checksum;
+
+	public PrebindChecksumCommand() {}
+
+	public PrebindChecksumCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		checksum = stream.readInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PreboundDylibCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/PreboundDylibCommand.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class PreboundDylibCommand extends LoadCommand
+{
+	LoadCommandString libName;
+	int numModules;
+	LoadCommandString linkedModules;
+
+	public PreboundDylibCommand() {}
+
+	public PreboundDylibCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		libName = new LoadCommandString();
+		libName.readLcString(stream);
+		numModules = stream.readInt();
+		linkedModules = new LoadCommandString();
+		linkedModules.readLcString(stream);
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RoutinesCommand64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RoutinesCommand64.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import javax.imageio.stream.ImageInputStream;
+
+public class RoutinesCommand64 extends LoadCommand
+{
+
+	long initAddress;
+	long initModule;
+
+	public RoutinesCommand64() {}
+
+	public RoutinesCommand64 readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		initAddress = stream.readLong();
+		initModule = stream.readLong();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RpathCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/RpathCommand.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class RpathCommand extends LoadCommand
+{
+	LoadCommandString subName;
+
+	public RpathCommand() {}
+
+	public RpathCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		subName = new LoadCommandString();
+		subName.readLcString(stream);
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SegmentCommand64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SegmentCommand64.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class SegmentCommand64 extends LoadCommand
+{
+
+	public static final int VM_PROT_READ = 0x1;
+	public static final int VM_PROT_WRITE = 0x2;
+	public static final int VM_PROT_EXECUTE = 0x4;
+
+	public static class Section64
+	{
+		public static final int SECTION_TYPE = 0x000000ff;
+		public static final int SECTION_ATTRIBUTES = 0xffffff00;
+		// section types
+		public static final int S_REGULAR = 0x0;
+		public static final int S_ZEROFILL = 0x1;
+		public static final int S_CSTRING_LITERALS = 0x2;
+		public static final int S_4BYTE_LITERALS = 0x3;
+		public static final int S_8BYTE_LITERALS = 0x4;
+		public static final int S_LITERAL_POINTERS = 0x5;
+		public static final int S_NON_LAZY_SYMBOL_POINTERS = 0x6;
+		public static final int S_LAZY_SYMBOL_POINTERS = 0x7;
+		public static final int S_SYMBOL_STUBS = 0x8;
+		public static final int S_MOD_INIT_FUNC_POINTERS = 0x9;
+		public static final int S_MOD_TERM_FUNC_POINTERS = 0xa;
+		public static final int S_COALESCED = 0xb;
+		public static final int S_GB_ZEROFILL = 0xc;
+		public static final int S_INTERPOSING = 0xd;
+		public static final int S_16BYTE_LITERALS = 0xe;
+		public static final int S_DTRACE_DOF = 0xf;
+		public static final int S_LAZY_DYLIB_SYMBOL_POINTERS = 0x10;
+		public static final int S_THREAD_LOCAL_REGULAR = 0x11;
+		public static final int S_THREAD_LOCAL_ZEROFILL = 0x12;
+		public static final int S_THREAD_LOCAL_VARIABLES = 0x13;
+		public static final int S_THREAD_LOCAL_VARIABLE_POINTERS = 0x14;
+		public static final int S_THREAD_LOCAL_INIT_FUNCTION_POINTERS = 0x15;
+
+		// other section attribute flags
+		public static final int SECTION_ATTRIBUTES_USR = 0xff000000;
+		public static final int S_ATTR_PURE_INSTRUCTIONS = 0x80000000;
+		public static final int S_ATTR_NO_TOC = 0x40000000;
+		public static final int S_ATTR_STRIP_STATIC_SYMS = 0x20000000;
+		public static final int S_ATTR_NO_DEAD_STRIP =0x10000000;
+		public static final int S_ATTR_LIVE_SUPPORT =0x08000000;
+		public static final int S_ATTR_SELF_MODIFYING_CODE = 0x04000000;
+		public static final int	S_ATTR_DEBUG = 0x02000000;
+		public static final int SECTION_ATTRIBUTES_SYS = 0x00ffff00;
+		public static final int S_ATTR_SOME_INSTRUCTIONS = 0x00000400;
+		public static final int S_ATTR_EXT_RELOC = 0x00000200;
+		public static final int S_ATTR_LOC_RELOC = 0x00000100;
+
+		public byte[] sectionName;
+		public byte[] segmentName;
+		public long address;
+		public long size;
+		public int fileOffset;
+		public int alignment;
+		public int relocOffset;
+		public int numReloc;
+		public int flags;
+		public int reserved1;
+		public int reserved2;
+		public int reserved3;
+		
+		public Section64()
+		{
+			sectionName = new byte[16];
+			segmentName = new byte[16];
+		}
+
+		public String getSectionName() throws UnsupportedEncodingException
+		{
+			return getStringFromAsciiChars(sectionName);
+		}
+
+		public String getSegmentName() throws UnsupportedEncodingException
+		{
+			return getStringFromAsciiChars(segmentName);
+		}
+	}
+
+	byte[] segmentName; //16 bytes max
+	long vmaddr;
+	long vmsize;
+	long fileOffset;
+	long fileSize;
+	int maxProt;
+	int initialProt;
+	int numSections;
+	int flags;
+	List<Section64> sections;
+
+	public SegmentCommand64()
+	{
+		segmentName = new byte[16];
+	}
+
+	public SegmentCommand64 readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		stream.readFully(segmentName);
+		vmaddr = stream.readLong();
+		vmsize = stream.readLong();
+		fileOffset = stream.readLong();
+		fileSize = stream.readLong();
+		maxProt = stream.readInt();
+		initialProt = stream.readInt();
+		numSections = stream.readInt();
+		flags = stream.readInt();
+		sections = new ArrayList<Section64>(numSections);
+
+		for (int i = 0; i < numSections; i++) {
+			Section64 section = new Section64();
+			stream.readFully(section.sectionName);
+			stream.readFully(section.segmentName);
+			section.address = stream.readLong();
+			section.size = stream.readLong();
+			section.fileOffset = stream.readInt();
+			section.alignment = stream.readInt();
+			section.relocOffset = stream.readInt();
+			section.numReloc = stream.readInt();
+			section.flags = stream.readInt();
+			section.reserved1 = stream.readInt();
+			section.reserved2 = stream.readInt();
+			section.reserved3 = stream.readInt();
+			sections.add(section);
+		}
+		return this;
+}
+
+	public String getName() throws UnsupportedEncodingException
+	{
+		return getStringFromAsciiChars(segmentName);
+	}
+
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SourceVersionCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SourceVersionCommand.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class SourceVersionCommand extends LoadCommand
+{
+	long version;
+
+	public SourceVersionCommand() {}
+
+	public SourceVersionCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		version = stream.readLong();
+		return this;
+	}
+
+	public String getVersionString()
+	{
+		int v1 = ((int)(version >>> 40)) & 0xFFFFFF;
+		int v2 = ((int)(version >>> 30)) & 0x3FF;
+		int v3 = ((int)(version >>> 20)) & 0x3FF;
+		int v4 = ((int)(version >>> 10)) & 0x3FF;
+		int v5 = ((int)version) & 0x3FF;
+		return v1 + "." + v2 + "." + v3 + "." + v4 + "." + v5;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SubCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SubCommand.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class SubCommand extends LoadCommand
+{
+	LoadCommandString subName;
+
+	public SubCommand() {}
+
+	public SubCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		subName = new LoadCommandString();
+		subName.readLcString(stream);
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SymtabCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/SymtabCommand.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class SymtabCommand extends LoadCommand
+{
+	int symtabOffset;
+	int numSymbols;
+	int stringsOffset;
+	int stringsSize;
+	List<SymtabEntry64> entries;
+	byte stringsBytes[];
+	List<String> strings;
+
+	public SymtabCommand() {}
+
+	public SymtabCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		symtabOffset = stream.readInt();
+		numSymbols = stream.readInt();
+		stringsOffset = stream.readInt();
+		stringsSize = stream.readInt();
+		stringsBytes = null;
+		return this;
+	}
+
+	public void readSymbolTable(ImageInputStream stream) throws IOException
+	{
+		stream.seek(symtabOffset + segmentOffset);
+		entries = new ArrayList<>(numSymbols);
+		for (int i = 0; i < numSymbols; i++) {
+			SymtabEntry64 entry = new SymtabEntry64();
+			entry.strIndex = stream.readInt();
+			entry.nType = stream.readByte();
+			entry.nSect = stream.readByte();
+			entry.nDesc = stream.readShort();
+			entry.nValue = stream.readLong();
+			entries.add(entry);
+		}
+
+		stream.seek(stringsOffset + segmentOffset);
+		strings = new ArrayList<>();
+		stringsBytes = new byte[stringsSize];
+		stream.readFully(stringsBytes);
+		for (int i = 0; i < stringsBytes.length;) {
+			int j = i;
+			while (j < stringsBytes.length && stringsBytes[j] != 0) {
+				j++;
+			}
+			String stringEntry = new String(stringsBytes, i, j - i, StandardCharsets.US_ASCII);
+			strings.add(stringEntry);
+			i = j + 1;
+		}
+	}
+
+	public static class SymtabEntry64
+	{
+		int strIndex;
+		byte nType;
+		byte nSect;
+		short nDesc;
+		long nValue;
+
+		//type from getType()
+		public static final int	N_UNDF = 0x0;		/* undefined, n_sect == NO_SECT */
+		public static final int	N_ABS = 0x2;		/* absolute, n_sect == NO_SECT */
+		public static final int	N_SECT = 0xe;		/* defined in section number n_sect */
+		public static final int	N_PBUD = 0xc;		/* prebound undefined (defined in a dylib) */
+		public static final int N_INDR = 0xa;		/* indirect */
+
+		//reference type to support lazy binding of undefined symbols
+		//from getReferenceType()
+		public static final int REFERENCE_FLAG_UNDEFINED_NON_LAZY = 0;
+		public static final int REFERENCE_FLAG_UNDEFINED_LAZY = 1;
+		public static final int REFERENCE_FLAG_DEFINED = 2;
+		public static final int REFERENCE_FLAG_PRIVATE_DEFINED = 3;
+		public static final int REFERENCE_FLAG_PRIVATE_UNDEFINED_NON_LAZY = 4;
+		public static final int REFERENCE_FLAG_PRIVATE_UNDEFINED_LAZY = 5;
+
+		public boolean isStab()
+		{
+			return 0 != (nType & (byte)0xe0);
+		}
+
+		public byte getStab()
+		{
+			return (byte)(nType & (byte)0xe0);
+		}
+
+		public boolean isPrivateExternal()
+		{
+			return 0 != (nType & (byte)0x10);
+		}
+
+		public byte getType()
+		{
+			return (byte)(nType & (byte)0x0e);
+		}
+
+		public boolean isExternal()
+		{
+			return 0 != (nType & (byte)0x01);
+		}
+
+		public int getCommonAlignment()
+		{
+			return (nDesc >>> 8) & 0x0f;
+		}
+
+		public int getReferenceType()
+		{
+			return nDesc & 0x7;
+		}
+
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/ThreadCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/ThreadCommand.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class ThreadCommand extends LoadCommand
+{
+
+	// thread flavors
+	public static final int x86_THREAD_STATE32 = 1;
+	public static final int x86_FLOAT_STATE32 = 2;
+	public static final int x86_EXCEPTION_STATE32 = 3;
+	public static final int x86_THREAD_STATE64 = 4;
+	public static final int x86_FLOAT_STATE64 = 5;
+	public static final int x86_EXCEPTION_STATE64 = 6;
+	public static final int x86_THREAD_STATE = 7;
+	public static final int x86_FLOAT_STATE = 8;
+	public static final int x86_EXCEPTION_STATE = 9;
+	public static final int x86_DEBUG_STATE32 = 10;
+	public static final int x86_DEBUG_STATE64 = 11;
+	public static final int x86_DEBUG_STATE = 12;
+	public static final int THREAD_STATE_NONE = 13;
+	public static final int x86_AVX_STATE32 = 16;
+	public static final int x86_AVX_STATE64 = (x86_AVX_STATE32 + 1);
+	public static final int x86_AVX_STATE = (x86_AVX_STATE32 + 2);
+	public static final int x86_AVX512_STATE32 = 19;
+	public static final int x86_AVX512_STATE64 = (x86_AVX512_STATE32 + 1);
+	public static final int x86_AVX512_STATE =(x86_AVX512_STATE32 + 2);
+
+	public static class ThreadState
+	{
+		int flavor;
+		int sizeInUInts;
+		byte stateBytes[];
+		ByteOrder endianness;
+		Map<String, Number> registers;
+
+		public ThreadState(int flavor, int size, byte state[], ByteOrder endian)
+		{
+			this.flavor = flavor;
+			this.sizeInUInts = size;
+			this.stateBytes = state;
+			this.endianness = endian;
+			registers = new TreeMap<>();
+			switch (flavor) {
+				case x86_THREAD_STATE:
+					fillX86ThreadRegisters();
+					break;
+				case x86_EXCEPTION_STATE:
+					fillX86ExceptionData();
+					break;
+				default:
+					break;
+			}
+		}
+
+		public long readLong(int start)
+		{
+			long ret = (0xFF00000000000000L & (((long) stateBytes[start + 7]) << 56))
+					| (0x00FF000000000000L & (((long) stateBytes[start + 6]) << 48))
+					| (0x0000FF0000000000L & (((long) stateBytes[start + 5]) << 40))
+					| (0x000000FF00000000L & (((long) stateBytes[start + 4]) << 32))
+					| (0x00000000FF000000L & (((long) stateBytes[start + 3]) << 24))
+					| (0x0000000000FF0000L & (((long) stateBytes[start + 2]) << 16))
+					| (0x000000000000FF00L & (((long) stateBytes[start + 1]) << 8))
+					| (0x00000000000000FFL & (stateBytes[start + 0]));
+			return (endianness == ByteOrder.LITTLE_ENDIAN) ? ret : Long.reverseBytes(ret);
+		}
+
+		public int readInt(int start)
+		{
+			int ret = (0xFF000000 & ((stateBytes[start + 3]) << 24))
+					| (0x00FF0000 & ((stateBytes[start + 2]) << 16))
+					| (0x0000FF00 & ((stateBytes[start + 1]) << 8))
+					| (0x000000FF & (stateBytes[start + 0]));
+			return (endianness == ByteOrder.LITTLE_ENDIAN) ? ret : Integer.reverseBytes(ret);
+		}
+
+		public short readShort(int start)
+		{
+			short ret = (short) ((0xFF00 & ((stateBytes[start + 1]) << 8))
+					| (0x00FF & ((short) stateBytes[start + 0])));
+			return (endianness == ByteOrder.LITTLE_ENDIAN) ? ret : Short.reverseBytes(ret);
+		}
+
+		public void fillX86ThreadRegisters()
+		{
+			registers.put("rax", readLong(0));
+			registers.put("rbx", readLong(8));
+			registers.put("rcx", readLong(16));
+			registers.put("rdx", readLong(24));
+			registers.put("rdi", readLong(32));
+			registers.put("rsi", readLong(40));
+			registers.put("rbp", readLong(48));
+			registers.put("rsp", readLong(56));
+			registers.put("r8", readLong(64));
+			registers.put("r9", readLong(72));
+			registers.put("r10", readLong(80));
+			registers.put("r11", readLong(88));
+			registers.put("r12", readLong(96));
+			registers.put("r13", readLong(104));
+			registers.put("r14", readLong(112));
+			registers.put("r15", readLong(120));
+			registers.put("rip", readLong(128));
+			registers.put("rflags", readLong(136));
+			registers.put("cs", readLong(144));
+			registers.put("fs", readLong(152));
+			registers.put("gs", readLong(160));
+		}
+
+		public void fillX86ExceptionData()
+		{
+			registers.put("trapno", readShort(0));
+			registers.put("cpu", readShort(2));
+			registers.put("err", readInt(4));
+			registers.put("faultvaddr", readLong(8));
+		}
+	}
+
+	public List<ThreadState> states;
+
+	public ThreadCommand()
+	{
+		states = new ArrayList<>();
+	}
+
+	public ThreadCommand(int type, long size, long offset)
+	{
+		super(type, size, offset);
+		states = new ArrayList<>();
+	}
+
+	public ThreadCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		long structOffset = 8;
+		while (structOffset < cmdSize) {
+			int flavor = stream.readInt();
+			int size = stream.readInt();
+			byte data[] = new byte[size * 4];
+			stream.readFully(data);
+			states.add(new ThreadCommand.ThreadState(flavor, size, data, stream.getByteOrder()));
+			structOffset += size * 4 + 8;
+		}
+		return this;
+	}
+
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/TwoLevelHintsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/TwoLevelHintsCommand.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class TwoLevelHintsCommand extends LoadCommand
+{
+	long hintTableOffset;
+	int numHints;
+
+	public TwoLevelHintsCommand() {}
+
+	public TwoLevelHintsCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		hintTableOffset = stream.readUnsignedInt();
+		numHints = stream.readInt();
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/UuidCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/UuidCommand.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class UuidCommand extends LoadCommand
+{
+	byte[] uuidBytes; // 16 bytes
+
+	public UuidCommand() {}
+
+	public UuidCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		uuidBytes = new byte[16];
+		stream.readFully(uuidBytes);
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/VersionMinCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/macho/VersionMinCommand.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*******************************************************************************
+ * Portions Copyright (c) 1999-2003 Apple Computer, Inc. All Rights
+ * Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.macho;
+
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+public class VersionMinCommand extends LoadCommand
+{
+	int version;
+	int sdk;
+	BuildVersionCommand.Version osVersion;
+	BuildVersionCommand.Version sdkVersion;
+	
+	public VersionMinCommand() {}
+
+	public VersionMinCommand readCommand(ImageInputStream stream, long streamSegmentOffset) throws IOException
+	{
+		super.readCommand(stream, streamSegmentOffset);
+		version = stream.readInt();
+		sdk = stream.readInt();
+		osVersion = new BuildVersionCommand.Version(version);
+		sdkVersion = new BuildVersionCommand.Version(sdk);
+		return this;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/VMRegMapHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/VMRegMapHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,7 @@ public class VMRegMapHelper
 		ICore core = process.getAddressSpace().getCore();
 		Platform platform = core.getPlatform();
 		boolean is64BitPlatform = (process.bytesPerPointer() == 8) ? true : false;
-		
+
 		switch(platform) {
 		case AIX:
 			if (is64BitPlatform) {
@@ -62,7 +62,7 @@ public class VMRegMapHelper
 				printRegistersForAIX32BitPPC(level, out);
 			}
 			break;
-			
+
 		case LINUX:
 			String processorType = core.getProperties().getProperty(ICore.PROCESSOR_TYPE_PROPERTY);
 			if (is64BitPlatform) {
@@ -83,8 +83,11 @@ public class VMRegMapHelper
 				}
 			}
 			break;
-		
-		
+
+		case OSX:
+			printRegistersForLinux64BitAMD64(level, out);
+			break;
+
 		case WINDOWS:
 			if (is64BitPlatform) {
 				printRegistersForWindows64Bit(level, out);
@@ -92,7 +95,7 @@ public class VMRegMapHelper
 				printRegistersForWindows32Bit(level, out);
 			}
 			break;
-		
+
 		case ZOS:
 			if (is64BitPlatform) {
 				printRegistersForZOS64BitS390(level, out);
@@ -100,13 +103,13 @@ public class VMRegMapHelper
 				printRegistersForZOS32BitS390(level, out);
 			}
 			break;
-		
+
 		default:
 			throw new UnknownArchitectureException(process, "Could not determine platform of core file.");
 		}
-		
+
 	}
-	
+
 	/**
 	 * Prints registers for AIX 64 BIT 
 	 * @param level Level of registers to be printed.

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/FileSniffer.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/FileSniffer.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,10 @@ public class FileSniffer {
     //XCOFF identifiers
 	private static final int CORE_DUMP_XX_VERSION = 0xFEEDDB2;
 	private static final int CORE_DUMP_X_VERSION = 0xFEEDDB1;
+
+	//MACHO identifiers
+	private static final int MACHO_64 = 0xFEEDFACF;
+	private static final int MACHO_64_REV = 0xCFFAEDFE;
     
     private static int[] coreid = new int[]{ELF, MINIDUMP, DR1, DR2};
     
@@ -72,11 +76,12 @@ public class FileSniffer {
     
     //the format for a core file
     public enum CoreFormatType {
-    	ELF,
-    	MINIDUMP,
-    	MVS,
-    	XCOFF,
-    	USERDUMP,
+		ELF,
+		MINIDUMP,
+		MVS,
+		XCOFF,
+		USERDUMP,
+		MACHO,
     	UNKNOWN
     }
     
@@ -109,6 +114,11 @@ public class FileSniffer {
 			//potential AIX core file version strings are at offset 4, so use the second header
 			if((header2 == CORE_DUMP_X_VERSION) || (header2 == CORE_DUMP_XX_VERSION)) {
 				return CoreFormatType.XCOFF;
+			}
+			if((header == MACHO_64) || (header == MACHO_64_REV)) {
+				if (isMachCoreFile(iis, header)) {
+					return CoreFormatType.MACHO;
+				}
 			}
 			return CoreFormatType.UNKNOWN;
 		} finally {
@@ -144,6 +154,11 @@ public class FileSniffer {
 			//potential AIX core file version strings are at offset 4, so use the second header
 			if((header2 == CORE_DUMP_X_VERSION) || (header2 == CORE_DUMP_XX_VERSION)) {
 				return true;
+			}
+			if((header == MACHO_64) || (header == MACHO_64_REV)) {
+				if (isMachCoreFile(iis, header)) {
+					return true;
+				}
 			}
 			return false;
 		} finally {
@@ -186,6 +201,21 @@ public class FileSniffer {
 		}	 
 		iis.setByteOrder(originalOrder);
 		return isCore;
+	}
+
+	/* Check if file is a core file. The file header (found in
+	 * /usr/include/mach-o/loader.h) has 'filetype' as the 4th member,
+	 * and '#define MH_CORE 0x4' as the constant for core file type.
+	*/
+	private static boolean isMachCoreFile(ImageInputStream iis, int header) throws IOException {
+		ByteOrder originalOrder = iis.getByteOrder();
+		if (header == MACHO_64_REV) {
+			iis.setByteOrder(iis.getByteOrder() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+		}
+		iis.seek(12);
+		int filetype = iis.readInt();
+		iis.setByteOrder(originalOrder);
+		return filetype == 4;
 	}
 	
 	public static boolean isJavaCoreFile(InputStream in, long filesize) throws IOException {

--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2018, 2018 IBM Corp. and others
+Copyright (c) 2018, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,18 +97,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</target>
 
 	<!-- Temporarily disable compilation on zos until ddr is supported; github.com/eclipse/openj9/issues/1511 -->
-	<!-- Temporarily disable compilation osx until ddr is supported; github.com/eclipse/openj9/issues/3366 -->
 	<target name="build" >
 		<echo>os.name: ${os.name}</echo>
 		<if>
-			<and>
-				<not>
-					<equals arg1="${os.name}" arg2="z/OS" />
-				</not>
-				<not>
-					<matches string="${os.name}" pattern="(Mac OS X)" />
-				</not>
-			</and>
+			<not>
+				<equals arg1="${os.name}" arg2="z/OS" />
+			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -46,8 +46,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on osx; github.com/eclipse/openj9/issues/3366 -->
-		<platformRequirements>^os.zos,^os.win,^os.osx</platformRequirements>
+		<platformRequirements>^os.zos,^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -103,8 +102,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestCallsites$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on osx; github.com/eclipse/openj9/issues/3366 -->
-		<platformRequirements>^os.zos,^os.win,^os.osx</platformRequirements>
+		<platformRequirements>^os.zos,^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -91,8 +91,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on z/OS and osx; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos,^os.osx</platformRequirements>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -63,8 +63,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- j9ddr.jar is not supported on z/OS and osx; OpenJ9 issue 1511 -->
-		<platformRequirements>^os.zos,^os.osx</platformRequirements>
+		<!-- j9ddr.jar is not supported on z/OS; OpenJ9 issue 1511 -->
+		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/dumpromtests/playlist.xml
+++ b/test/functional/cmdLineTests/dumpromtests/playlist.xml
@@ -40,7 +40,7 @@
 	 -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<!-- disable on AIX https://github.com/eclipse/openj9/issues/3562 -->
-		<platformRequirements>^os.aix,^os.osx</platformRequirements>
+		<platformRequirements>^os.aix</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -38,8 +38,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- Tests excluded on zos and osx because they do not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
-		<platformRequirements>^os.zos,^os.osx</platformRequirements>
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -39,8 +39,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on z/OS and osx; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos,^os.osx</platformRequirements>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Added a core reader for reading OSX Mach-O core files.
Also re-enables DDR tests for OSX.

Resolves #3444, resolves #3366, resolves #3483

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>