### PR TITLE
Fix handling of defining accessor and proxy classes in Java 12

### DIFF
--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -61,6 +61,15 @@ Java_java_lang_ClassLoader_defineClassImpl(JNIEnv *env, jobject receiver, jstrin
 	}
 #endif /* J9VM_OPT_DYNAMIC_LOAD_SUPPORT */
 
+	if (NULL == protectionDomain) {
+		/*
+		 * Only trusted code has access to JavaLangAccess.defineClass();
+		 * callers only provide a NULL protectionDomain when exemptions
+		 * are required.
+		 */
+		options |= J9_FINDCLASS_FLAG_UNSAFE;
+	}
+
 	jclass result = defineClassCommon(env, receiver, className, classRep, offset, length, protectionDomain, options, NULL);
 
 	if (J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID) && (NULL == result) && (NULL == currentThread->currentException)) {

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -116,9 +116,10 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr335_interfacePrivateMethod_mode100</testCaseName>
+		<testCaseName>jsr335_interfacePrivateMethod</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
+			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \


### PR DESCRIPTION
This is a replay of #5129 for the 0.13 release branch.

* exempt classes defined with no protection domain
* don't limit jsr335_interfacePrivateMethod test to mode 100

Fixes: #5087
Fixes: #5107