### PR TITLE
Remove the incorrect assert

### DIFF
--- a/doc/compiler/jitaas/Testing.md
+++ b/doc/compiler/jitaas/Testing.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2018 IBM Corp. and others
+Copyright (c) 2018, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,23 +40,39 @@ These are the steps to run the tests on your machine.
    export JAVA_VERSION=SE80
    export JAVA_BIN=/your/sdk/jre/bin
    export SPEC=linux_x86-64_cmprssptrs
+   ```
+   Either `TEST_FLAGS` or `EXTRA_OPTIONS` can be used to run tests with JITaaS. The following will launch both the server and the client during the test.
+   ```
+   export TEST_FLAG="JITAAS"
+   ```
+   The following sets up only the client side which requires manually starting the server before running the test.
+   ```
    export EXTRA_OPTIONS=" -XX:JITaaSClient " # spaces at the start and end are important!
+   ```
+   NOTE: It's important to put spaces before and after `-XX:JITaaSClient`, otherwise
+   some tests will not run properly.
+
+   Compile the test
+   ```
    make -f run_configure.mk
    make compile
    ```
-
    NOTE: to compile and run tests, ant-contrib.jar is needed, and on some systems just installing ant will not install ant-contrib.
    On Ubuntu, the easiest way to get it is to run:
    ```
    sudo apt-get install ant-contrib
    ```
 
-4. Run the tests! First start a server, then do
+
+4. Run the tests!
+
+   Manually start the server if `JITAAS` TEST_FLAG is not used.
+   ```
+   $JAVA_BIN/java -XX:JITaaSServer
+   ```
    ```
    make _sanity
    ```
-   NOTE: It's important to put spaces before and after `-XX:JITaaSClient`, otherwise
-   some tests will not run properly.
    
 5. To rerun the failed tests, run
    ```


### PR DESCRIPTION
Remove the incorrect assert

[skip ci]
When recompilation is not allowed on the client side
(`_allowRecompilation=0`), the persistentCHTable on
the client side is not populated. Therefore CHTableClassMap
is also empty on the server side when `findClassInfo()` is called.

Fixes #5098

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>