### PR TITLE
CMake: remove hardcoded references to 'dl'

### DIFF
--- a/runtime/j9vm/CMakeLists.txt
+++ b/runtime/j9vm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,9 +56,10 @@ target_link_libraries(jvm_common
 		j9hashtable
 		j9pool
 		j9vmi
+
+		${CMAKE_DL_LIBS}
 		# TODO these are platform specific
 		pthread
-		dl
 )
 
 target_include_directories(jvm_common

--- a/runtime/jsigWrapper/CMakeLists.txt
+++ b/runtime/jsigWrapper/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ target_link_libraries(jsig
 
 		omrsig
 		omrutil
-		dl
+		${CMAKE_DL_LIBS}
 )
 
 target_include_directories(jsig PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/runtime/port/CMakeLists.txt
+++ b/runtime/port/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,8 +107,7 @@ target_link_libraries(j9prt
 		j9pool
 		j9hashtable
 		j9thr
-		#TODO fix this, its not platform agnostic
-		dl
+		${CMAKE_DL_LIBS}
 )
 
 if(OMR_NEED_LIBRT)

--- a/runtime/redirector/CMakeLists.txt
+++ b/runtime/redirector/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(jvm_redirect SHARED
 target_link_libraries(jvm_redirect
 	PRIVATE
 		j9vm_interface
-		dl
+		${CMAKE_DL_LIBS}
 )
 target_include_directories(jvm_redirect
 	PRIVATE

--- a/runtime/tests/jsig/CMakeLists.txt
+++ b/runtime/tests/jsig/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,5 @@ target_link_libraries(jsigjnitest
         j9vm_interface
 
         jsig
-        #TODO platform specific
-        dl
+        ${CMAKE_DL_LIBS}
 )

--- a/runtime/tests/redirector/genericlauncher/CMakeLists.txt
+++ b/runtime/tests/redirector/genericlauncher/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,5 @@ target_link_libraries(glaunch
     PRIVATE
         j9vm_interface
 
-        #TODO platform specific
-        dl
+        ${CMAKE_DL_LIBS}
 )

--- a/runtime/tests/redirector/jep178/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,8 +38,7 @@ target_link_libraries(testjep178_static
     PRIVATE
         j9vm_interface
 
-        #TODO platform specific
-        dl
+        ${CMAKE_DL_LIBS}
 )
 
 add_executable(testjep178_dynamic
@@ -49,6 +48,5 @@ target_link_libraries(testjep178_dynamic
     PRIVATE
         j9vm_interface
 
-        #TODO platform specific
-        dl
+        ${CMAKE_DL_LIBS}
 )


### PR DESCRIPTION
Instead link against the platform agnostic `CMAKE_DL_LIBS`

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>