### PR TITLE
Add Protobuf and OpenSSL to xlinux test containers

### DIFF
--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -118,7 +118,7 @@ RUN yum -y update \
   && yum clean all \
   && ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/bin/cc \
   && ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/bin/gcc \
-  && ln -s /opt/rh/devtoolset-7/root/usr/bin/g++ /usr/bin/g++ 
+  && ln -s /opt/rh/devtoolset-7/root/usr/bin/g++ /usr/bin/g++
 
 # Dependency required by test framework
 RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
@@ -263,19 +263,23 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \
   && git fetch --all
 
-# Install OpenSSL v1.1.0
+# Install OpenSSL v1.1.1b
+# Required for JITaaS  & Crypto functional testing
 RUN cd /tmp \
-  && wget https://www.openssl.org/source/old/1.1.0/openssl-1.1.0g.tar.gz \
-  && tar -xzf openssl-1.1.0g.tar.gz \
-  && rm -f openssl-1.1.0g.tar.gz \
-  && cd /tmp/openssl-1.1.0g \
-  && ./config -Wl,-rpath,/usr/local/lib64 \
+  && wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1b.tar.gz \
+  && tar -xzf OpenSSL_1_1_1b.tar.gz \
+  && rm -f OpenSSL_1_1_1b.tar.gz \
+  && cd /tmp/openssl-OpenSSL_1_1_1b \
+  && ./config --prefix=/usr/local/openssl-1.1.1b --openssldir=/usr/local/openssl-1.1.1b \
   && make \
   && make install \
   && cd .. \
-  && rm -rf openssl-1.1.0g
+  && rm -rf openssl-OpenSSL_1_1_1b \
+  && echo "/usr/local/openssl-1.1.1b/lib" > /etc/ld.so.conf.d/openssl-1.1.1b.conf \
+  && echo "PATH=/usr/local/openssl-1.1.1b/bin:$PATH" > /etc/environment
 
 # Install Protobuf v3.5.1
+# Required for JITaaS
 RUN cd /tmp \
   && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
   && tar -xzf protobuf-cpp-3.5.1.tar.gz \
@@ -286,9 +290,10 @@ RUN cd /tmp \
   && make install \
   && cd .. \
   && rm -rf protobuf-3.5.1
-
-# Run ldconfig to create necessary links and cache to shared libraries
-RUN ldconfig
+# Run ldconfig to create necessary links and cache to protobuf libraries
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usr-local.conf \
+  && ldconfig
 
 # Expose SSH port and run SSHD
 EXPOSE 22

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
@@ -103,5 +103,38 @@ RUN mkdir /var/run/sshd \
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
+# Install OpenSSL v1.1.1b
+# Required for JITaaS & Crypto functional testing
+RUN cd /tmp \
+  && wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1b.tar.gz \
+  && tar -xzf OpenSSL_1_1_1b.tar.gz \
+  && rm -f OpenSSL_1_1_1b.tar.gz \
+  && cd /tmp/openssl-OpenSSL_1_1_1b \
+  && ./config --prefix=/usr/local/openssl-1.1.1b --openssldir=/usr/local/openssl-1.1.1b \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf openssl-OpenSSL_1_1_1b \
+  && echo "/usr/local/openssl-1.1.1b/lib" > /etc/ld.so.conf.d/openssl-1.1.1b.conf \
+  && echo "PATH=/usr/local/openssl-1.1.1b/bin:$PATH" > /etc/environment
+
+# Install Protobuf v3.5.1
+# Required for JITaaS
+RUN cd /tmp \
+  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
+  && tar -xzf protobuf-cpp-3.5.1.tar.gz \
+  && rm -f protobuf-cpp-3.5.1.tar.gz \
+  && cd /tmp/protobuf-3.5.1 \
+  && ./configure \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf protobuf-3.5.1
+
+# Run ldconfig to create necessary links and cache to shared libraries
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usr-local.conf \
+  && ldconfig
+
 # Expose SSH port and run SSH
 EXPOSE 22

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
@@ -79,5 +79,38 @@ RUN mkdir /var/run/sshd \
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
+# Install OpenSSL v1.1.1b
+# Required for JITaaS & Crypto functional testing
+RUN cd /tmp \
+  && wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1b.tar.gz \
+  && tar -xzf OpenSSL_1_1_1b.tar.gz \
+  && rm -f OpenSSL_1_1_1b.tar.gz \
+  && cd /tmp/openssl-OpenSSL_1_1_1b \
+  && ./config --prefix=/usr/local/openssl-1.1.1b --openssldir=/usr/local/openssl-1.1.1b \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf openssl-OpenSSL_1_1_1b \
+  && echo "/usr/local/openssl-1.1.1b/lib" > /etc/ld.so.conf.d/openssl-1.1.1b.conf \
+  && echo "PATH=/usr/local/openssl-1.1.1b/bin:$PATH" > /etc/environment
+
+# Install Protobuf v3.5.1
+# Required for JITaaS
+RUN cd /tmp \
+  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
+  && tar -xzf protobuf-cpp-3.5.1.tar.gz \
+  && rm -f protobuf-cpp-3.5.1.tar.gz \
+  && cd /tmp/protobuf-3.5.1 \
+  && ./configure \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf protobuf-3.5.1
+
+# Run ldconfig to create necessary links and cache to shared libraries
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usr-local.conf \
+  && ldconfig
+
 # Expose SSH port and run SSH
 EXPOSE 22


### PR DESCRIPTION
- Also correctly link runtime libraries by adding
  an ldconfig file in /etc/ld.so.conf.d/ which
  adds the two locations /usr/local/lib and
  /usr/local/lib64

[skip ci]
Related #3912

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>