### PR TITLE
Link redirector with libdl.so on non-Windows platforms

### DIFF
--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2007, 2018 IBM Corp. and others
+Copyright (c) 2007, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,6 +81,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</objects>
 		<libraries>
 			<library name="omrutil" type="external"/>
+			<library name="dl" type="system">
+				<exclude-if condition="spec.win_.*"/>
+			</library>
 		</libraries>
 	</artifact>
 


### PR DESCRIPTION
Avoids errors linking to (redirector) `libjvm.so` alone.

Fixes: #5047