### PR TITLE
Implement jstack

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1296,13 +1296,17 @@ K0800="Invalid Unicode code point - {0}"
 K0801="Last character in replacement string can't be \, character to be escaped is required."
 K0802="Last character in replacement string can't be $, group index is required."
 
-# attach API
+# attach API and openj9.tools.attach.diagnostics 
+
 K0803="File {0} is owned by {1}, should be owned by current user"
 K0804="Illegal file {0} found in target directory"
 K0805="{0} has permissions {1}, should have owner access only"
 K0806="Cannot verify permissions {0}"
 K0807="Cannot delete file {0}"
 K0808="Cannot create new file {0}"
+K0809="Exception connecting to {0}"
+K080A="Incompatible target VM, using protocol version {0}"
+
 
 #java.lang.ref.Reference
 K0900="Create a new Reference, since a Reference cannot be cloned."

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Command.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Command.java
@@ -2,7 +2,7 @@
 package com.ibm.tools.attach.target;
 
 /*******************************************************************************
- * Copyright (c) 2009, 2015 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,5 +54,6 @@ public interface Command {
 	static final String GET_AGENT_PROPERTIES = "ATTACH_GETAGENTPROPERTIES"; //$NON-NLS-1$
 	static final String START_MANAGEMENT_AGENT = "ATTACH_START_MANAGEMENT_AGENT"; //$NON-NLS-1$
 	static final String START_LOCAL_MANAGEMENT_AGENT = "ATTACH_START_LOCAL_MANAGEMENT_AGENT"; //$NON-NLS-1$
+	static final String GET_THREAD_GROUP_INFO = "ATTACH_GET_THREAD_INFO"; //$NON-NLS-1$
 
 }

--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -28,11 +28,14 @@ exports com.ibm.jit.crypto to ibm.crypto.hdwrcca;
 /*[ENDIF]*/
 exports com.ibm.sharedclasses.spi to openj9.sharedclasses, java.management, java.rmi;
 exports com.ibm.oti.vm to java.management, jdk.attach, jdk.management, openj9.jvm, openj9.sharedclasses;
-exports com.ibm.oti.util to java.management, jdk.attach, jdk.management, openj9.sharedclasses;
-exports com.ibm.tools.attach.target to jdk.attach, jdk.management;
+exports com.ibm.oti.util to java.management, jdk.attach, jdk.jcmd, jdk.management, openj9.sharedclasses;
+exports com.ibm.tools.attach.target to jdk.attach, jdk.jcmd, jdk.management;
+exports openj9.tools.attach.diagnostics.spi to jdk.attach, jdk.jcmd;
+exports openj9.tools.attach.diagnostics.base to jdk.jcmd;
 exports jdk.internal.org.objectweb.asm to openj9.dtfj, openj9.dtfjview;
 // Following allows dtfj/dtfjview modules invoke module addReads & addExports programmatically via reflection APIs
 exports jdk.internal.module to openj9.dtfj, openj9.dtfjview;
 uses com.ibm.sharedclasses.spi.SharedClassProvider;
+uses openj9.tools.attach.diagnostics.spi.TargetDiagnosticsProvider;
 uses com.ibm.gpu.spi.GPUAssist.Provider;
 exports com.ibm.gpu.spi to openj9.gpu;

--- a/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticProperties.java
+++ b/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticProperties.java
@@ -1,0 +1,277 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.base;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Comparator;
+import java.util.Properties;
+
+/**
+ * Augments Properties with convenience methods to add ints, booleans, and
+ * longs.
+ *
+ */
+public class DiagnosticProperties {
+	private final Properties baseProperties;
+
+	private static final String JAVA_LANG_STRING = "java.lang.String"; //$NON-NLS-1$
+
+	/**
+	 * Set this to "true" to enable verbose mode
+	 */
+	public static final String DEBUG_PROPERTY = "openj9.tools.attach.diagnostics.debug"; //$NON-NLS-1$
+
+	/**
+	 * For development use only
+	 */
+	public static boolean isDebug = Boolean.getBoolean(DEBUG_PROPERTY);
+
+	/**
+	 * @param props Properties object received from the target.
+	 */
+	public DiagnosticProperties(Properties props) {
+		baseProperties = props;
+	}
+
+	/**
+	 * Create an empty list of properties.
+	 */
+	public DiagnosticProperties() {
+		baseProperties = new Properties();
+	}
+
+	/**
+	 * Add a property with an integer value.
+	 * 
+	 * @param key   property name
+	 * @param value property value
+	 */
+	public void put(String key, int value) {
+		baseProperties.setProperty(key, Integer.toString(value));
+	}
+
+	/**
+	 * Add a property with a String value.
+	 * 
+	 * @param key   property name
+	 * @param value property value
+	 */
+	public void put(String key, String value) {
+		baseProperties.setProperty(key, value);
+	}
+
+	/**
+	 * Add a property with an long value.
+	 * 
+	 * @param key   property name
+	 * @param value property value
+	 */
+	public void put(String key, long value) {
+		baseProperties.setProperty(key, Long.toString(value));
+	}
+
+	/**
+	 * Add a property with a boolean value.
+	 * 
+	 * @param key   property name
+	 * @param value property value
+	 */
+	public void put(String key, boolean value) {
+		baseProperties.setProperty(key, Boolean.toString(value));
+	}
+
+	private void checkExists(String key) throws IOException {
+		if (!containsField(key)) {
+			throw new IOException("key " + key + " not found"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	/**
+	 * Test if the given property is present.
+	 * 
+	 * @param key property name
+	 * @return true if the property name is found
+	 */
+	public boolean containsField(String key) {
+		return baseProperties.containsKey(key);
+	}
+
+	/**
+	 * Retrieve the value of a property and convert it to an int.
+	 * 
+	 * @param key name of the property
+	 * @return value of the property as an int
+	 * @throws NumberFormatException if the value is not a string representing a
+	 *                               number.
+	 * @throws IOException           if the property is missing
+	 */
+	public int getInt(String key) throws NumberFormatException, IOException {
+		checkExists(key);
+		return Integer.parseInt(baseProperties.getProperty(key));
+	}
+
+	/**
+	 * Retrieve the value of a property and convert it to an long.
+	 * 
+	 * @param key name of the property
+	 * @return value of the property as a long
+	 * @throws NumberFormatException if the value is not a string representing a
+	 *                               number.
+	 * @throws IOException           if the property is missing
+	 */
+	public long getLong(String key) throws NumberFormatException, IOException {
+		checkExists(key);
+		return Long.parseLong(baseProperties.getProperty(key));
+	}
+
+	/**
+	 * Retrieve the value of a property and convert it to a boolean.
+	 * 
+	 * @param key name of the property
+	 * @return value of the property as a boolean
+	 * @throws IOException if the property is missing
+	 */
+	public boolean getBoolean(String key) throws IOException {
+		checkExists(key);
+		return Boolean.parseBoolean(baseProperties.getProperty(key));
+	}
+
+	/**
+	 * Return a property value for the given key.
+	 * 
+	 * @param key property name
+	 * @return property value or null if the property is not found
+	 */
+	public String getPropertyOrNull(String key) {
+		return baseProperties.getProperty(key);
+	}
+
+	/**
+	 * Retrieve a value of a simple type, i.e. boxed scalar type, from a specified
+	 * property. Return null if the type is not recognized, the value is absent, or the
+	 * value is the empty string (unless the type is String).
+	 * 
+	 * @param typeName Fully qualified name of the type
+	 * @param key      Name of the property containing the value
+	 * @return object containing the value or null on error.
+	 * @throws NumberFormatException if the property is malformed
+	 */
+	public Object getSimple(String typeName, String key) throws NumberFormatException {
+		Object value = null;
+		String valueString = baseProperties.getProperty(key);
+		if ((null != valueString) && 
+				(JAVA_LANG_STRING.equals(typeName) || !valueString.isEmpty())) {
+			switch (typeName) {
+			case "java.lang.Boolean": //$NON-NLS-1$
+				value = Boolean.valueOf(valueString);
+				break;
+			case "java.lang.Character": //$NON-NLS-1$
+				value = Character.valueOf(valueString.charAt(0));
+				break;
+			case "java.lang.Byte": //$NON-NLS-1$
+				value = Byte.valueOf(valueString);
+				break;
+			case "java.lang.Short": //$NON-NLS-1$
+				value = Short.valueOf(valueString);
+				break;
+			case "java.lang.Integer": //$NON-NLS-1$
+				value = Integer.valueOf(valueString);
+				break;
+			case "java.lang.Long": //$NON-NLS-1$
+				value = Long.valueOf(valueString);
+				break;
+			case "java.lang.Float": //$NON-NLS-1$
+				value = Float.valueOf(valueString);
+				break;
+			case "java.lang.Double": //$NON-NLS-1$
+				value = Double.valueOf(valueString);
+				break;
+			case JAVA_LANG_STRING:
+				value = valueString;
+				break;
+			default:
+				break;
+			}
+		}
+		return value;
+	}
+
+	/**
+	 * Print a DiagnosticProperties object.
+	 * 
+	 * @param msg   Message to print before properties. May be null.
+	 * @param props DiagnosticProperties object to dump
+	 */
+	public static void dumpPropertiesIfDebug(String msg, DiagnosticProperties props) {
+		dumpPropertiesIfDebug(msg, props.baseProperties);
+	}
+
+	/**
+	 * Print a list of properties in sorted order if debugging is enabled.
+	 * 
+	 * @param msg   Message to print before properties. May be null.
+	 * @param props Properties object to dump
+	 */
+	public static void dumpPropertiesIfDebug(String msg, final Properties props) {
+		if (DiagnosticProperties.isDebug) {
+			if (null != msg) {
+				System.err.println(msg);
+			}
+			if (null != props) {
+				final String result = printProperties(props);
+				System.err.print(result);
+			}
+		}
+	}
+
+	/**
+	 * Print a Properties object in sorted key order.
+	 * 
+	 * @param props object to dump
+	 * @return String representation of props
+	 */
+	public static String printProperties(final Properties props) {
+		final StringWriter buff = new StringWriter(1000);
+		try (PrintWriter buffWriter = new PrintWriter(buff)) {
+			props.entrySet().stream().sorted(Comparator.comparing(e -> e.getKey().toString())).forEach(theEntry -> {
+				buffWriter.print(theEntry.getKey());
+				buffWriter.print("="); //$NON-NLS-1$
+				buffWriter.println((String) theEntry.getValue());
+			});
+		}
+		final String result = buff.toString();
+		return result;
+	}
+
+	/**
+	 * Return the underlying properties object by reference.
+	 * 
+	 * @return Properties object
+	 */
+	public Properties toProperties() {
+		return baseProperties;
+	}
+}

--- a/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticsInfo.java
+++ b/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticsInfo.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+package openj9.tools.attach.diagnostics.base;
 
-exports com.ibm.java.lang.management.internal to jdk.jcmd, jdk.management;
-uses com.ibm.sharedclasses.spi.SharedClassProvider;
+/**
+ * Container for information about a JVM's threads
+ *
+ */
+public interface DiagnosticsInfo {
+	String OPENJ9_DIAGNOSTICS_PREFIX = "openj9_diagnostics."; //$NON-NLS-1$
+	String JAVA_INFO = OPENJ9_DIAGNOSTICS_PREFIX + "java_info"; //$NON-NLS-1$
+
+	@Override
+	String toString();
+
+	/**
+	 * Print the information about the remote Java VM.
+	 * 
+	 * @return contents of system property "java.vm.info"
+	 */
+	String getJavaInfo();
+
+}

--- a/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/spi/TargetDiagnosticsProvider.java
+++ b/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/spi/TargetDiagnosticsProvider.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+package openj9.tools.attach.diagnostics.spi;
 
-exports com.ibm.java.lang.management.internal to jdk.jcmd, jdk.management;
-uses com.ibm.sharedclasses.spi.SharedClassProvider;
+import java.io.IOException;
+
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+
+/**
+ * Define an API for an attach API target to obtain diagnostic information on
+ * its JVM.
+ *
+ */
+public interface TargetDiagnosticsProvider {
+
+	/**
+	 * Acquire the stacks of all running threads in the current VM and encode them
+	 * into a set of properties.
+	 * 
+	 * @return properties object
+	 * @throws IOException on communication error
+	 */
+	public DiagnosticProperties getThreadGroupInfo() throws IOException;
+
+}

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -771,8 +771,8 @@ public class ThreadInfo {
 				result.append(String.format(" on %s owned by \"%s\" Id=%d",  //$NON-NLS-1$
 						lockName, lockOwnerName, Long.valueOf(lockOwnerId)));
 			}
+			result.append(ls);
 			if (stackTraces != null && stackTraces.length > 0) {
-				result.append(ls);
 				MonitorInfo[] lockList = getLockedMonitors();
 				MonitorInfo[] lockArray = new MonitorInfo[stackTraces.length];
 				for (MonitorInfo mi: lockList) {
@@ -792,9 +792,6 @@ public class ThreadInfo {
 					}
 					++stackDepth;
 				}
-			} else {
-				result.append(" null"); //$NON-NLS-1$
-				result.append(ls);
 			}
 			TOSTRING_VALUE = result.toString();
 		}

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -2,7 +2,7 @@
 package com.ibm.tools.attach.attacher;
 
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.AttachPermission;
-import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.spi.AttachProvider;
 import com.ibm.tools.attach.target.Advertisement;
@@ -52,7 +51,7 @@ public class OpenJ9AttachProvider extends AttachProvider {
 	}
 
 	@Override
-	public VirtualMachine attachVirtualMachine(String id)
+	public OpenJ9VirtualMachine attachVirtualMachine(String id)
 			throws AttachNotSupportedException, IOException {
 
 		checkAttachSecurity();
@@ -71,7 +70,7 @@ public class OpenJ9AttachProvider extends AttachProvider {
 	}
 
 	@Override
-	public VirtualMachine attachVirtualMachine (
+	public OpenJ9VirtualMachine attachVirtualMachine (
 			VirtualMachineDescriptor descriptor)
 			throws AttachNotSupportedException, IOException {
 

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -2,7 +2,7 @@
 package com.ibm.tools.attach.attacher;
 
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -263,6 +263,18 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 				options, true));
 		String response = AttachmentConnection.streamReceiveString(responseStream);
 		parseResponse(response);
+	}
+
+	/**
+	 * Request thread information, including stack traces, from a target VM.
+	 * 
+	 * @return properties object containing serialized thread information
+	 * @throws IOException in case of a communication error
+	 */
+	public Properties getThreadInfo() throws IOException {
+		IPC.logMessage("enter getThreadInfo"); //$NON-NLS-1$
+		AttachmentConnection.streamSend(commandStream, Command.GET_THREAD_GROUP_INFO);
+		return IPC.receiveProperties(responseStream, true);
 	}
 
 	private void lockAllAttachNotificationSyncFiles(

--- a/jcl/src/jdk.attach/share/classes/module-info.java.extra
+++ b/jcl/src/jdk.attach/share/classes/module-info.java.extra
@@ -24,3 +24,4 @@
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
 provides com.sun.tools.attach.spi.AttachProvider with com.ibm.tools.attach.attacher.OpenJ9AttachProvider;
+exports com.ibm.tools.attach.attacher to jdk.jcmd;

--- a/jcl/src/jdk.jcmd/share/classes/module-info.java
+++ b/jcl/src/jdk.jcmd/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,5 +23,10 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
-exports com.ibm.java.lang.management.internal to jdk.jcmd, jdk.management;
-uses com.ibm.sharedclasses.spi.SharedClassProvider;
+module jdk.jcmd {
+  exports openj9.tools.attach.diagnostics.info;
+  provides openj9.tools.attach.diagnostics.spi.TargetDiagnosticsProvider with openj9.tools.attach.diagnostics.target.TargetDiagnosticsProviderImpl;
+  requires java.base;
+  requires java.management;
+  requires jdk.attach;
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
@@ -1,0 +1,127 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.attacher;
+
+import static com.ibm.oti.util.Msg.getString;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import com.ibm.tools.attach.attacher.OpenJ9AttachProvider;
+import com.ibm.tools.attach.attacher.OpenJ9VirtualMachine;
+import com.ibm.tools.attach.target.IPC;
+import com.sun.tools.attach.AttachNotSupportedException;
+
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+import openj9.tools.attach.diagnostics.base.DiagnosticsInfo;
+import openj9.tools.attach.diagnostics.info.ThreadGroupInfo;
+
+/**
+ * This class allows a Attach API attacher to query a target JVM about
+ * diagnostic information such as JIT compilation, threads, classes, etc.
+ * Instances must be created using the getDiagnostics() factory method.
+ *
+ */
+public class AttacherDiagnosticsProvider {
+
+	private OpenJ9VirtualMachine vm;
+
+	/**
+	 * Acquire the stacks of all running threads in the current VM and encode them
+	 * into a set of properties.
+	 * 
+	 * @param printSynchronizers indicate if ownable synchronizers should be printed
+	 * @return properties object
+	 * @throws IOException on communication error
+	 */
+	public DiagnosticsInfo getThreadGroupInfo(boolean printSynchronizers) throws IOException {
+		IPC.logMessage("enter getRemoteThreadGroupInfo"); //$NON-NLS-1$
+		checkAttached();
+		Properties threadInfo = vm.getThreadInfo();
+		DiagnosticProperties.dumpPropertiesIfDebug("Properties from target:", threadInfo); //$NON-NLS-1$
+		ThreadGroupInfo info = new ThreadGroupInfo(threadInfo, printSynchronizers);
+		IPC.logMessage("exit getRemoteThreadGroupInfo"); //$NON-NLS-1$
+		return info;
+	}
+
+	/**
+	 * Call equivalent com.sun.tools.attach.VirtualMachine method.
+	 * 
+	 * @param vmid ID of target
+	 * @throws IOException on communication error
+	 */
+	public void attach(String vmid) throws IOException {
+		OpenJ9AttachProvider attachProv = new OpenJ9AttachProvider();
+		IPC.logMessage("DiagnosticsProviderImpl attaching to ", vmid); //$NON-NLS-1$
+		try {
+			vm = attachProv.attachVirtualMachine(vmid);
+		} catch (AttachNotSupportedException e) {
+			/*[MSG "K0809", "Exception connecting to {0}"] */
+			throw new IOException(getString("K0809", vmid)); //$NON-NLS-1$
+		}
+		IPC.logMessage("DiagnosticsProviderImpl attached to ", vmid); //$NON-NLS-1$
+	}
+
+	/**
+	 * Call equivalent com.sun.tools.attach.VirtualMachine method.
+	 * 
+	 * @throws IOException on communication error
+	 */
+	public void detach() throws IOException {
+		if (null != vm) {
+			vm.detach();
+			vm = null;
+		}
+	}
+
+	/**
+	 * Call equivalent com.sun.tools.attach.VirtualMachine method.
+	 * 
+	 * @return properties from target VM
+	 * @throws IOException on communication error
+	 */
+	public Properties getSystemProperties() throws IOException {
+		checkAttached();
+		return vm.getSystemProperties();
+	}
+
+	/**
+	 * Call equivalent com.sun.tools.attach.VirtualMachine method.
+	 * 
+	 * @return properties from target VM
+	 * @throws IOException on communication error
+	 */
+	public Properties getAgentProperties() throws IOException {
+		checkAttached();
+		return vm.getAgentProperties();
+	}
+
+	private void checkAttached() throws IOException {
+		if (null == vm) {
+			/*[MSG "K0544", "Target not attached"] */
+			throw new IOException(getString("K0554")); //$NON-NLS-1$
+		}
+	}
+
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/info/JvmInfo.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/info/JvmInfo.java
@@ -1,0 +1,169 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.info;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.management.openmbean.ArrayType;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+
+import com.ibm.java.lang.management.internal.LockInfoUtil;
+import com.ibm.java.lang.management.internal.MonitorInfoUtil;
+import com.ibm.java.lang.management.internal.StackTraceElementUtil;
+
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+
+/**
+ * Methods for converting between properties and CompositeTypes
+ *
+ */
+public class JvmInfo {
+	protected static final String ARRAY_SIZE = "array_size"; //$NON-NLS-1$
+
+	protected static void addFields(DiagnosticProperties props, String keyPrefix, CompositeType compType,
+			CompositeData compData) {
+		for (String k : compType.keySet()) {
+			String keyString = keyPrefix + k;
+			Object value = compData.get(k);
+			OpenType<?> valueType = compType.getType(k);
+
+			boolean valuePresent = (null != value);
+			if (JvmInfo.isSimpleType(valueType)) {
+				if (valuePresent) {
+					props.put(keyString, value.toString());
+				}
+			} else {
+				props.put(keyString, valuePresent);
+				if (valuePresent) {
+					if (valueType.isArray()) {
+						ArrayType<?> valueArrayType = (ArrayType<?>) valueType;
+						CompositeType elementType = getCompositeType(valueArrayType.getElementOpenType());
+						CompositeData[] valueArray = (CompositeData[]) value;
+						int arrayLength = valueArray.length;
+						props.put(keyString + ARRAY_SIZE, arrayLength);
+						for (int i = 0; i < arrayLength; ++i) {
+							String newPrefix = keyString + '.' + Integer.toString(i) + '.';
+							addFields(props, newPrefix, elementType, valueArray[i]);
+						}
+					} else {
+						CompositeType newCompType = getCompositeType(valueType);
+						String newPrefix = keyString + '.';
+						CompositeData newCompData = (CompositeData) value;
+						addFields(props, newPrefix, newCompType, newCompData);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the CompositeType object based on a name
+	 * 
+	 * @param typeIdentifier Name of the type
+	 * @return CompositeType for that type; null if the type is unrecognized.
+	 */
+	protected static CompositeType getCompositeType(OpenType<?> typeIdentifier) {
+		CompositeType result = null;
+
+		String typeName = typeIdentifier.getTypeName();
+		switch (typeName) {
+		case "java.lang.management.LockInfo": //$NON-NLS-1$
+			result = LockInfoUtil.getCompositeType();
+			break;
+		case "java.lang.management.MonitorInfo": //$NON-NLS-1$
+			result = MonitorInfoUtil.getCompositeType();
+			break;
+		case "java.lang.StackTraceElement": //$NON-NLS-1$
+			result = StackTraceElementUtil.getCompositeType();
+			break;
+		default:
+			break;
+		}
+		return result;
+	}
+
+	/**
+	 * Convert a Properties into a CompositeData object
+	 * 
+	 * @param props          Source of the data
+	 * @param propertyPrefix Used to filter the data
+	 * @param compType       type description
+	 * @return Filled-in CompositeData object
+	 * @throws IOException if the properties are invalid
+	 */
+	protected static CompositeData extractFields(DiagnosticProperties props, String propertyPrefix,
+			CompositeType compType) throws IOException {
+		Set<String> keys = compType.keySet();
+		int numKeys = keys.size();
+		String[] itemNames = keys.toArray(new String[numKeys]);
+		Object[] itemValues = new Object[numKeys];
+		try {
+			for (int cursor = 0; cursor < numKeys; ++cursor) {
+				String k = itemNames[cursor];
+				String keyString = propertyPrefix + k;
+				Object value = null;
+				OpenType<?> valueType = compType.getType(k);
+				if (JvmInfo.isSimpleType(valueType)) {
+					value = props.getSimple(valueType.getTypeName(), keyString);
+				} else {
+					boolean valuePresent = props.getBoolean(keyString);
+					if (valuePresent) {
+						if (valueType.isArray()) {
+							int arrayLength = props.getInt(keyString + ARRAY_SIZE);
+							ArrayType<?> valueArrayType = (ArrayType<?>) valueType;
+							CompositeType elementType = getCompositeType(valueArrayType.getElementOpenType());
+							CompositeData[] valueArray = new CompositeData[arrayLength];
+							for (int i = 0; i < arrayLength; ++i) {
+								String newPrefix = keyString + '.' + Integer.toString(i) + '.';
+								CompositeData compData = extractFields(props, newPrefix, elementType);
+								valueArray[i] = compData;
+							}
+							value = valueArray;
+						} else { /* composed type */
+							CompositeType newCompType = getCompositeType(valueType);
+							String newPrefix = keyString + '.';
+							CompositeData compData = extractFields(props, newPrefix, newCompType);
+							value = compData;
+						}
+					}
+				}
+				itemValues[cursor] = value;
+			}
+			CompositeDataSupport result = new CompositeDataSupport(compType, itemNames, itemValues);
+			return result;
+		} catch (NumberFormatException | OpenDataException e) {
+			throw new IOException(e);
+		}
+	}
+
+	static boolean isSimpleType(OpenType<?> valueType) {
+		return SimpleType.class.isAssignableFrom(valueType.getClass());
+	}
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/info/JvmThreadInfo.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/info/JvmThreadInfo.java
@@ -1,0 +1,105 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.info;
+
+import static openj9.tools.attach.diagnostics.info.ThreadGroupInfo.THREAD_GROUP_PREFIX;
+
+import java.io.IOException;
+import java.lang.management.ThreadInfo;
+import java.util.Properties;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeType;
+
+import com.ibm.java.lang.management.internal.ThreadInfoUtil;
+
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+
+/**
+ * Container for information on a foreign JVM's thread
+ *
+ */
+public class JvmThreadInfo extends JvmInfo {
+
+	private final ThreadInfo myInfo;
+
+	/**
+	 * Construct a JvmThreadInfo using a generic Properties file.
+	 * 
+	 * @param props     properties object produced by
+	 *                  ThreadGroupInfo.getThreadProperties()
+	 * @param threadNum ordinal position of the thread in the list or threads
+	 * @throws IOException if data cannot be converted
+	 */
+	public JvmThreadInfo(Properties props, int threadNum) throws IOException {
+		this(new DiagnosticProperties(props), threadNum);
+	}
+
+	/**
+	 * Get the ThreadInfo object for a thread on a target VM.
+	 * 
+	 * @return ThreadInfo object or null if the data was not parsable.
+	 */
+	public ThreadInfo getThreadInfo() {
+		return myInfo;
+	}
+	
+	static void put(ThreadInfo info, DiagnosticProperties props, int threadNum) {
+		CompositeData threadData = ThreadInfoUtil.toCompositeData(info);
+		String keyPrefix = thrdNumPrefix(threadNum);
+		CompositeType compType = ThreadInfoUtil.getCompositeType();
+		addFields(props, keyPrefix, compType, threadData);
+	}
+
+	static String thrdNumPrefix(int threadNum) {
+		return THREAD_GROUP_PREFIX + "thread_num." //$NON-NLS-1$
+				+ threadNum + '.';
+	}
+
+	/**
+	 * Parse a properties file from a foreign JVM. This may contain information for
+	 * multiple threads.
+	 * 
+	 * @param props     properties object produced by
+	 *                  ThreadGroupInfo.getThreadProperties()
+	 * @param threadNum ordinal position of the thread in the list or threads
+	 * @throws IOException if the properties are invalid
+	 */
+	JvmThreadInfo(DiagnosticProperties props, int threadNum) throws IOException {
+		String threadNumPrefix = thrdNumPrefix(threadNum);
+		CompositeType threadType = ThreadInfoUtil.getCompositeType();
+		CompositeData compData = extractFields(props, threadNumPrefix, threadType);
+		ThreadInfo extractedInfo = null;
+		try {
+			extractedInfo = (null != compData) ? ThreadInfo.from(compData) : null;
+		} catch (IllegalArgumentException e) {
+			extractedInfo = null;
+			if (DiagnosticProperties.isDebug) {
+				e.printStackTrace();
+			}
+		}
+		myInfo = extractedInfo;
+	}
+
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/info/ThreadGroupInfo.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/info/ThreadGroupInfo.java
@@ -1,0 +1,223 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.info;
+
+import static com.ibm.oti.util.Msg.getString;
+import java.io.IOException;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Properties;
+
+import com.ibm.tools.attach.target.IPC;
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+import openj9.tools.attach.diagnostics.base.DiagnosticsInfo;
+
+/**
+ * Class for encoding and decoding stack traces for transmission via attach API.
+ */
+public class ThreadGroupInfo implements DiagnosticsInfo {
+
+	private static final String CURRENT_GROUPINFO_VERSION = "0"; //$NON-NLS-1$
+	private static final String TIME_FORMAT_STRING = "\t%s time: %d ns%n"; //$NON-NLS-1$
+	static final String THREAD_GROUP_PREFIX = "threadgroup."; //$NON-NLS-1$
+	static final String CPU_TIME = "cpu_time"; //$NON-NLS-1$
+	static final String USER_TIME = "user_time"; //$NON-NLS-1$
+	private static final String THREAD_GROUP_VERSION = THREAD_GROUP_PREFIX + "version"; //$NON-NLS-1$
+	private static final String NUM_THREADS = THREAD_GROUP_PREFIX + "num_threads"; //$NON-NLS-1$
+
+	private final int numThreads;
+	private final JvmThreadInfo[] myThreads;
+	private final String groupInfoVersion;
+	private final DiagnosticProperties myProps;
+	private final String javaInfo;
+	private boolean addSynchronizers;
+
+	/**
+	 * Create an object from received properties.
+	 * 
+	 * @param props Properties receive from the target
+	 * @param printSynchronizers add ownable synchronizers to output
+	 * @throws IOException if properties file is corrupt
+	 */
+	public ThreadGroupInfo(Properties props, boolean printSynchronizers) throws IOException {
+		addSynchronizers = printSynchronizers;
+		try {
+			myProps = new DiagnosticProperties(props);
+			if (myProps.containsField(IPC.PROPERTY_DIAGNOSTICS_ERROR)
+					&& myProps.getBoolean(IPC.PROPERTY_DIAGNOSTICS_ERROR)) {
+				String targetMsg = myProps.getPropertyOrNull(IPC.PROPERTY_DIAGNOSTICS_ERRORMSG);
+				String msg = myProps.getPropertyOrNull(IPC.PROPERTY_DIAGNOSTICS_ERRORTYPE);
+				if ((null != targetMsg) && !targetMsg.isEmpty()) {
+					msg = msg + ": " + targetMsg; //$NON-NLS-1$
+				}
+				throw new IOException(msg);
+			}
+			if (!myProps.containsField(NUM_THREADS)) {
+				throw new IOException(IPC.INCOMPATIBLE_JAVA_VERSION);
+			}
+			numThreads = myProps.getInt(NUM_THREADS);
+			groupInfoVersion = props.getProperty(THREAD_GROUP_VERSION);
+			if (!checkVersion(groupInfoVersion)) {
+				/*[MSG "K080A", "Incompatible target VM uses protocol version {0}"] */
+				throw new IOException(getString("K080A", groupInfoVersion)); //$NON-NLS-1$
+			}
+			javaInfo = props.getProperty(DiagnosticsInfo.JAVA_INFO);
+
+			if (numThreads <= 0) {
+				throw new UnsupportedOperationException("Cannot determine number of threads"); //$NON-NLS-1$
+			}
+			myThreads = new JvmThreadInfo[numThreads];
+			for (int i = 0; i < numThreads; ++i) {
+				myThreads[i] = new JvmThreadInfo(myProps, i);
+			}
+		} catch (NumberFormatException e) {
+			throw new IOException(e);
+		}
+	}
+
+	/**
+	 * Acquire stack traces for all running threads.
+	 * 
+	 * @return Properties objects thread information
+	 */
+	public static DiagnosticProperties getThreadInfoProperties() {
+		ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+		ThreadInfo infos[] = threadBean.dumpAllThreads(true, true);
+		DiagnosticProperties props = getThreadInfoPropertiesImpl(threadBean, infos);
+		return props;
+	}
+
+	/**
+	 * Acquire stack traces for selected threads.
+	 * 
+	 * @param threadIds list of threads to query
+	 * @return Properties objects thread information
+	 * @note some entries my be null if a specified thread no longer exists
+	 */
+	public static DiagnosticProperties getThreadInfoProperties(long[] threadIds) {
+		ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+		int numThreads = threadIds.length;
+		ThreadInfo infos[] = new ThreadInfo[numThreads];
+		for (int i = 0; i < numThreads; ++i) {
+			infos[i] = threadBean.getThreadInfo(threadIds[i]);
+		}
+		DiagnosticProperties myProps = getThreadInfoPropertiesImpl(threadBean, infos);
+		return myProps;
+	}
+
+	private static DiagnosticProperties getThreadInfoPropertiesImpl(ThreadMXBean threadBean, ThreadInfo[] infos) {
+		DiagnosticProperties props = new DiagnosticProperties();
+		props.put(IPC.PROPERTY_DIAGNOSTICS_ERROR, false);
+		int n = infos.length;
+		props.put(NUM_THREADS, n);
+		props.put(THREAD_GROUP_VERSION, CURRENT_GROUPINFO_VERSION);
+		props.put(DiagnosticsInfo.JAVA_INFO, System.getProperty("java.vm.info")); //$NON-NLS-1$
+		boolean addCpuTime = threadBean.isThreadCpuTimeSupported() && threadBean.isThreadCpuTimeEnabled();
+		for (int i = 0; i < n; ++i) {
+			if (null == infos[i]) {
+				continue;
+			}
+			JvmThreadInfo.put(infos[i], props, i);
+			if (addCpuTime) {
+				String prefix = JvmThreadInfo.thrdNumPrefix(i);
+				long id = infos[i].getThreadId();
+				long cpuTime = threadBean.getThreadCpuTime(id);
+				props.put(prefix + CPU_TIME, cpuTime);
+				long userTime = threadBean.getThreadUserTime(id);
+				props.put(prefix + USER_TIME, userTime);
+			}
+		}
+		DiagnosticProperties.dumpPropertiesIfDebug("Threads:", props.toProperties()); //$NON-NLS-1$
+		return props;
+	}
+
+	int activeCount() {
+		return numThreads;
+	}
+
+	@Override
+	public String toString() {
+		String newline = System.lineSeparator();
+		StringBuffer buff = new StringBuffer(2000);
+		for (int i = 0; i < numThreads; ++i) {
+			ThreadInfo ti = myThreads[i].getThreadInfo();
+			if (null == ti) {
+				/* incompatible data. Dump the raw data. */
+				buff.setLength(0);
+				break;
+			}
+			buff.append(ti.toString());
+			LockInfo[] syncs = ti.getLockedSynchronizers();
+			if (addSynchronizers) {
+				buff.append(String.format("%n\tLocked ownable synchronizers: %d%n", //$NON-NLS-1$
+						Integer.valueOf(syncs.length)));
+				for (LockInfo s : syncs) {
+					buff.append(String.format("\t- %s%n", s.toString())); //$NON-NLS-1$
+				}
+				buff.append(newline);
+			}
+			String prefix = JvmThreadInfo.thrdNumPrefix(i);
+			try {
+				String cpuTimeKey = prefix + CPU_TIME;
+				String userTimeKey = prefix + USER_TIME;
+				if (myProps.containsField(cpuTimeKey)) {
+					long cpuTime = myProps.getLong(cpuTimeKey);
+					buff.append(String.format(TIME_FORMAT_STRING, "CPU", Long.valueOf(cpuTime))); //$NON-NLS-1$
+				}
+				if (myProps.containsField(userTimeKey)) {
+					long userTime = myProps.getLong(userTimeKey);
+					buff.append(String.format(TIME_FORMAT_STRING, "User", Long.valueOf(userTime))); //$NON-NLS-1$
+				}
+			} catch (NumberFormatException | IOException e) {
+				/* EMPTY: ignore missing optional information */
+			}
+			buff.append(newline);
+		}
+		String result = buff.toString();
+		if (result.isEmpty()) {
+			result = "Incompatible data from target VM:" //$NON-NLS-1$
+					+ newline + DiagnosticProperties.printProperties(myProps.toProperties());
+		}
+		return result;
+	}
+
+	public String getGroupInfoVersion() {
+		return groupInfoVersion;
+	}
+
+	@Override
+	public String getJavaInfo() {
+		return javaInfo;
+	}
+
+	private static boolean checkVersion(String version) {
+		/*
+		 * only one protocol version for now. Update the algorithm as versions are added
+		 */
+		return CURRENT_GROUPINFO_VERSION.equals(version);
+	}
+
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/target/TargetDiagnosticsProviderImpl.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/target/TargetDiagnosticsProviderImpl.java
@@ -1,6 +1,6 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+package openj9.tools.attach.diagnostics.target;
 
-exports com.ibm.java.lang.management.internal to jdk.jcmd, jdk.management;
-uses com.ibm.sharedclasses.spi.SharedClassProvider;
+import java.io.IOException;
+
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+import openj9.tools.attach.diagnostics.info.ThreadGroupInfo;
+import openj9.tools.attach.diagnostics.spi.TargetDiagnosticsProvider;
+
+/**
+ * This class allows a Attach API attacher to query a target JVM about
+ * diagnostic information such as JIT compilation, threads, classes, etc.
+ * Instances must be created using the getDiagnostics() factory method.
+ *
+ */
+public class TargetDiagnosticsProviderImpl implements TargetDiagnosticsProvider {
+
+	@Override
+	public DiagnosticProperties getThreadGroupInfo() throws IOException {
+		DiagnosticProperties threadInfoProperties = ThreadGroupInfo.getThreadInfoProperties();
+		DiagnosticProperties.dumpPropertiesIfDebug("Thread group properties", threadInfoProperties); //$NON-NLS-1$
+		return threadInfoProperties;
+	}
+
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jps.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jps.java
@@ -21,7 +21,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-package openj9.tools.attach.diagnostics;
+package openj9.tools.attach.diagnostics.tools;
 
 import java.io.IOException;
 import java.util.List;

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstack.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstack.java
@@ -1,0 +1,157 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.tools;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ibm.tools.attach.target.AttachHandler;
+import com.ibm.tools.attach.target.IPC;
+
+import openj9.tools.attach.diagnostics.attacher.AttacherDiagnosticsProvider;
+import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
+import openj9.tools.attach.diagnostics.base.DiagnosticsInfo;
+
+/**
+ * JStack 
+ * A tool for listing thread information about another Java process
+ *
+ */
+public class Jstack {
+
+	private static List<String> vmids;
+	private static boolean printProperties;
+	private static boolean printSynchronizers;
+	/**
+	 * Print a list of Java processes and information about them.
+	 * @param args Arguments to the application
+	 */
+	public static void main(String[] args) {
+		PrintStream out = System.out;
+
+		if (!parseArguments(args)) {
+			System.exit(1);
+		}
+		AttacherDiagnosticsProvider diagProvider = new AttacherDiagnosticsProvider();
+
+		String myId = AttachHandler.getVmId();
+		out.println(LocalDateTime.now());
+		for (String vmid: vmids) {
+			if (vmid.equals(myId)) {
+				continue;
+			}
+			/* if the ID looks like a process ID, check if it is running */
+			if (vmid.matches("\\d+")) { //$NON-NLS-1$
+				long pid = Long.parseLong(vmid);
+				if (!IPC.processExists(pid)) {
+					continue;
+				}
+			}
+			try {
+				diagProvider.attach(vmid);
+				DiagnosticsInfo groupInfo = diagProvider.getThreadGroupInfo(printSynchronizers);
+				out.printf("Virtual machine: %s JVM information %s%n", vmid, groupInfo.getJavaInfo()); //$NON-NLS-1$
+				out.println(groupInfo.toString());
+				if (printProperties) {
+					out.println("System properties:"); //$NON-NLS-1$
+					out.println(diagProvider.getSystemProperties());
+					out.println("Agent properties:"); //$NON-NLS-1$
+					out.println(diagProvider.getAgentProperties());
+				}
+			} catch (Exception e) {
+				System.err.printf("Error getting data from %s", vmid); //$NON-NLS-1$
+				final String msg = e.getMessage();
+				if (null == msg) {
+					System.err.println();
+				} else {
+					if (msg.matches(IPC.INCOMPATIBLE_JAVA_VERSION)) {
+						System.err.println(": incompatible target JVM"); //$NON-NLS-1$
+					} else {
+						System.err.printf(": %s%n", msg); //$NON-NLS-1$
+					}
+				}
+				if (DiagnosticProperties.isDebug) {
+					e.printStackTrace();
+				}
+			} finally {
+				try {
+					diagProvider.detach();
+				} catch (IOException e) {
+					/* ignore */
+				}
+			}
+		}
+	}
+
+	@SuppressWarnings("nls")
+	private static boolean parseArguments(String[] args) {
+		boolean okay = true;
+		printProperties = DiagnosticProperties.isDebug;
+		printSynchronizers = false;
+		final String HELPTEXT = "jstack: listing thread information about another Java process%n"
+				+ " Usage:%n"
+				+ "    jstack <vmid>*%n"
+				+ "        <vmid>: Attach API VM ID as shown in jps or other Attach API-based tools%n"
+				+ "        <vmid>s are read from stdin if none are supplied as arguments%n"
+				+ "    -p: print the target's system and agent properties%n"
+				+ "    -l: Long format. Print the thread's ownable synchronizers%n"
+				+ "    -J: supply arguments to the Java VM running jps%n"
+				;
+		vmids = new ArrayList<>();
+		for (String a: args) {
+			if (!a.startsWith("-")) {
+				vmids.add(a);
+			} else if (a.equals("-p")) {
+				printProperties = true;
+			} else if (a.equals("-l")) {
+				printSynchronizers = true;
+			} else {
+				System.err.printf(HELPTEXT);
+				okay = false;
+				break;
+			}
+		}
+
+		if (okay && vmids.isEmpty()) {
+			/* grab the VMIDs from stdin. */
+			try (BufferedReader jpsOutReader = new BufferedReader(new InputStreamReader(System.in))) {
+				vmids = jpsOutReader.lines()
+						.map(s -> s.trim())
+						.filter(s -> !s.isEmpty())
+						.collect(Collectors.toList());
+				okay = true;
+			} catch (IOException e) {
+				/* ignore */
+			}
+		}
+		return okay;
+	}
+}
+

--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -218,7 +218,7 @@
 					</else>
 				</if>
 				
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED" />
+				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED  --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.base/openj9.tools.attach.diagnostics.base=ALL-UNNAMED --add-exports jdk.jcmd/openj9.tools.attach.diagnostics.info=ALL-UNNAMED" />
 				<echo>===addExports:		${addExports}</echo>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -445,6 +445,58 @@
 	</test>
 
 	<test>
+		<testCaseName>TestJstack_SE80</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
+	-Dcom.ibm.tools.attach.timeout=15000 \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJstack \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		 </impls>
+	</test>
+
+	<test>
+		<testCaseName>TestJstack</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
+	-Dcom.ibm.tools.attach.timeout=15000 \
+	--add-exports jdk.jcmd/openj9.tools.attach.diagnostics.info=ALL-UNNAMED \
+	--add-exports java.base/openj9.tools.attach.diagnostics.base=ALL-UNNAMED \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJstack \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>9+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		 </impls>
+	</test>
+
+	<test>
 		<testCaseName>TestFileLocking_SE80</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/AttachApiTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/AttachApiTest.java
@@ -21,7 +21,10 @@
  *******************************************************************************/
 package org.openj9.test.attachAPI;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -30,8 +33,10 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
+import org.openj9.test.util.PlatformInfo;
 import org.openj9.test.util.StringPrintStream;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -62,6 +67,12 @@ abstract class AttachApiTest {
 
 	protected static void log(String outLine) {
 		logger.debug(outLine);
+	}
+	
+	public void logProperties(Properties props) {
+		PrintStream stream = StringPrintStream.factory();
+		props.keySet().stream().sorted().forEach(k -> stream.println(k + "=" + props.getProperty((String)k))); //$NON-NLS-1$ 
+		logger.debug(stream.toString());
 	}
 
 	void setVmOptions(String option) {
@@ -163,6 +174,10 @@ abstract class AttachApiTest {
 		Assert.assertTrue((null != targetPid) && !targetPid.equalsIgnoreCase("failed"), "target attach API failed to launch");
 	}
 
+	protected static Optional<String> search(String needle, List<String> haystack) {
+		return haystack.stream().filter(s -> s.contains(needle)).findFirst();
+	}
+
 	protected boolean checkLoadAgentOutput(String errOutput,
 			String testString) {
 		return errOutput.contains(testString);
@@ -199,6 +214,26 @@ abstract class AttachApiTest {
 			/* ignore */
 		}
 		return outputLines;
+	}
+
+	/**
+	 * Find an executable in the jdk directory and fail if it is missing.
+	 * @param commandRoot Base name of the command, without ".exe" 
+	 */
+	protected void getJdkUtilityPath(final String commandRoot) {
+		final String commandWithSuffix = 
+				PlatformInfo.isWindows() ? commandRoot + ".exe" : commandRoot;
+		String javaHomeString = System.getProperty("java.home");
+		File javaHome = new File(javaHomeString);
+		File javaHomeBin = new File(javaHome, "bin");
+		File  commandFile = new File(javaHomeBin, commandWithSuffix);
+		if (!commandFile.exists()) { /* Java 8 has 2 bin directories, and JAVA_HOME is probably pointing at jre */
+			log("Did not find " + commandFile.getAbsolutePath());
+			File javaHomeParentBin = new File(javaHome.getParentFile(), "bin");
+			commandFile = new File(javaHomeParentBin, commandWithSuffix);
+			assertTrue("Did not find " + commandFile.getAbsolutePath(), commandFile.exists());
+		}
+		commandName = commandFile.getAbsolutePath();
 	}
 	
 }

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -126,16 +126,6 @@ public class TestJps extends AttachApiTest {
 		tgtMgr.terminateTarget();
 	}
 
-	/**
-	 * Look for a string in a list of strings using case sensitive substring searching
-	 * @param needle string for which to search
-	 * @param haystack list of strings in which to search
-	 * @return first string in haystack containing needle
-	 */
-	static Optional<String> search(String needle, List<String> haystack) {
-		return haystack.stream().filter(s -> s.contains(needle)).findFirst();
-	}
-
 	@BeforeMethod
 	protected void setUp(Method testMethod) {
 		testName = testMethod.getName();

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstack.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstack.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.attachAPI;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.Thread.State;
+import java.lang.management.ThreadInfo;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.openj9.test.util.StringPrintStream;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import openj9.tools.attach.diagnostics.info.JvmThreadInfo;
+import openj9.tools.attach.diagnostics.info.ThreadGroupInfo;
+
+@Test(groups = { "level.extended" })
+public class TestJstack extends AttachApiTest {
+
+	private static final String JSTACK_COMMAND = "jstack"; //$NON-NLS-1$
+	Object syncObject = new Object();
+
+	@Test
+	public void testSingleThread() throws IOException {
+		try {
+			Thread testThread = new Thread(this::method1);
+			testThread.start();
+			while (testThread.getState() != State.WAITING) {
+				try {
+					Thread.sleep(1); /* sleep the minimum practical time */
+				} catch (InterruptedException e) {
+					/* ignore */
+				}
+			}
+			long[] threadIds = new long[] { testThread.getId() };
+			Properties props = ThreadGroupInfo.getThreadInfoProperties(threadIds).toProperties();
+			logProperties(props);
+			JvmThreadInfo jvmThrInfo = new JvmThreadInfo(props, 0);
+			ThreadInfo thrInfo = jvmThrInfo.getThreadInfo();
+			log(thrInfo.toString());
+			compareThreadInfo(thrInfo, testThread);
+		} finally {
+			synchronized (syncObject) {
+				syncObject.notifyAll();
+			}
+		}
+	}
+
+	@Test
+	/* basic sanity: fetch and print the thread information */
+	public void testAllThreads() throws IOException {
+		Properties props = ThreadGroupInfo.getThreadInfoProperties().toProperties();
+		logProperties(props);
+		ThreadGroupInfo grpInfo = new ThreadGroupInfo(props, false);
+		log(grpInfo.toString());
+	}
+
+	@Test
+	public void testMonitors() throws IOException {
+		synchronized (syncObject) {
+			Thread testThread = new Thread(this::syncMethod, "testMonitorsThread"); //$NON-NLS-1$
+			testThread.start();
+			while (testThread.getState() != State.BLOCKED) {
+				try {
+					Thread.sleep(1); /* sleep the minimum practical time */
+				} catch (InterruptedException e) {
+					/* ignore */
+				}
+			}
+			Properties props = ThreadGroupInfo.getThreadInfoProperties().toProperties();
+			logProperties(props);
+			ThreadGroupInfo grpInfo = new ThreadGroupInfo(props, false);
+			String jstackOutput = grpInfo.toString();
+			log("jstack output:\n" + jstackOutput); //$NON-NLS-1$
+			assertTrue(jstackOutput.toLowerCase().contains("locked java.lang.object"), "missing 'locked' information"); //$NON-NLS-1$//$NON-NLS-2$
+			assertTrue(jstackOutput.toLowerCase().contains("blocked on java.lang.object"), //$NON-NLS-1$
+					"missing 'blocked' information"); //$NON-NLS-1$
+		}
+	}
+
+	@Test
+	public void testRemote() throws IOException {
+		String myId = TargetManager.getVmId();
+		List<String> jpsOutput = runCommand(Collections.singletonList(myId));
+		StringBuilder buff = new StringBuilder("jstack output:\n"); //$NON-NLS-1$
+		jpsOutput.forEach(s -> {
+			buff.append(s);
+			buff.append("\n"); //$NON-NLS-1$
+		});
+		log(buff.toString());
+		Optional<String> searchResult = search(testName, jpsOutput);
+		assertTrue(searchResult.isPresent(), "Method name missing"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testSynchronizers() throws IOException {
+		String myId = TargetManager.getVmId();
+		List<String> args = new ArrayList<>();
+		args.add(myId);
+		args.add("-l"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommand(args);
+		StringBuilder buff = new StringBuilder("jstack output:\n"); //$NON-NLS-1$
+		jpsOutput.forEach(s -> {
+			buff.append(s);
+			buff.append("\n"); //$NON-NLS-1$
+		});
+		log(buff.toString());
+		Optional<String> searchResult = search(testName, jpsOutput);
+		assertTrue(searchResult.isPresent(), "Method name missing"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testProperties() throws IOException {
+		Properties myProps = System.getProperties();
+		final String TEST_VALUE = "test_property_value"; //$NON-NLS-1$
+		final String TEST_PROPERTY = "test.property"; //$NON-NLS-1$
+		myProps.setProperty(TEST_PROPERTY, TEST_VALUE);
+		String myId = TargetManager.getVmId();
+		List<String> args = new ArrayList<>();
+		args.add(myId);
+		args.add("-p"); //$NON-NLS-1$
+		List<String> jpsOutput = runCommand(args);
+		StringBuilder buff = new StringBuilder("jstack output:\n"); //$NON-NLS-1$
+		jpsOutput.forEach(s -> {
+			buff.append(s);
+			buff.append("\n"); //$NON-NLS-1$
+		});
+		log(buff.toString());
+		Optional<String> searchResult = search(TEST_VALUE, jpsOutput);
+		assertTrue(searchResult.isPresent(), TEST_PROPERTY + " missing"); //$NON-NLS-1$
+	}
+
+	@BeforeMethod
+	protected void setUp(Method testMethod) {
+		testName = testMethod.getName();
+		log("------------------------------------\nstarting " + testName); //$NON-NLS-1$
+	}
+
+	@BeforeSuite
+	protected void setupSuite() {
+		assertTrue("This test is valid only on OpenJ9", //$NON-NLS-1$
+				System.getProperty("java.vm.vendor").contains("OpenJ9")); //$NON-NLS-1$//$NON-NLS-2$
+		getJdkUtilityPath(JSTACK_COMMAND);
+	}
+
+	protected void compareThreadInfo(ThreadInfo thrInfo, Thread testThread) {
+		assertEquals(thrInfo.getThreadId(), testThread.getId(), "wrong ID:"); //$NON-NLS-1$
+		assertEquals(thrInfo.getThreadName(), testThread.getName(), "wrong name:"); //$NON-NLS-1$
+		assertEquals(thrInfo.getThreadState(), testThread.getState(), "wrong state:"); //$NON-NLS-1$
+		StackTraceElement[] expectedStackTrace = testThread.getStackTrace();
+		StackTraceElement[] actualStackTrace = testThread.getStackTrace();
+		compareStackTraces(expectedStackTrace, actualStackTrace);
+	}
+
+	protected void compareStackTraces(StackTraceElement[] expectedStackTrace, StackTraceElement[] actualStackTrace) {
+		boolean match = Arrays.equals(expectedStackTrace, actualStackTrace);
+		if (!match) {
+			PrintStream expectedStream = StringPrintStream.factory();
+			Arrays.stream(expectedStackTrace).forEach(e -> expectedStream.println(e.toString()));
+			logger.error("expected:\n" + expectedStream.toString()); //$NON-NLS-1$
+
+			PrintStream actualStream = StringPrintStream.factory();
+			Arrays.stream(actualStackTrace).forEach(e -> actualStream.println(e.toString()));
+			logger.error("actual:\n" + actualStream.toString()); //$NON-NLS-1$
+			logger.error("Wrong stack trace"); //$NON-NLS-1$
+		}
+	}
+
+	void method1() {
+		method2();
+	}
+
+	void method2() {
+		synchronized (syncObject) {
+			try {
+				log("method2: Wait"); //$NON-NLS-1$
+				syncObject.wait();
+				log("method2: Resume");//$NON-NLS-1$
+			} catch (InterruptedException e) {
+				/* ignore */
+			}
+		}
+	}
+
+	void syncMethod() {
+		log("syncMethod: Acquire monitor");//$NON-NLS-1$
+		synchronized (syncObject) {
+			log("syncMethod: Acquired monitor");//$NON-NLS-1$
+		}
+		log("syncMethod: Release monitor");//$NON-NLS-1$
+	}
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -90,6 +90,11 @@
 			<class name="org.openj9.test.attachAPI.TestJps"/>
 		</classes>
 	</test>
+	<test name="TestJstack">
+		<classes>
+			<class name="org.openj9.test.attachAPI.TestJstack"/>
+		</classes>
+	</test>
 	
 	<test name="TestFileLocking">
 		<classes>


### PR DESCRIPTION
Create general tooling to convert mxbeans to properties and vice versa.  Add
directories and modules as required: for Java 8 some modules go into rt.jar and
others to tools.jar.  Add service providers to allows java.base to access
classes from foreign modules.  Update module exports, classpath and jpp
configuration.  Reorganize tools directory to ease filtering source
directories.  Add tests for jstack.

Needs coordinated changes in extensions repositories.

- https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/279
- https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/146
- https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/35
- https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/90

Fixes https://github.com/eclipse/openj9/issues/4858

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>