### PR TITLE
Enable SVM for remote AOT

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -451,3 +451,4 @@ J9::ClassEnv::getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int
    {
    return comp->fej9()->getVFTEntry(clazz, offset);
    }
+

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -772,6 +772,16 @@ TR_J9SharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR
    return classChainOffsetInSharedCache;
    }
 
+const void *
+TR_J9SharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+   {
+   return _sharedCacheConfig->storeSharedData(
+         vmThread,
+         key,
+         strlen(key),
+         descriptor);
+   }
+
 TR_J9JITaaSServerSharedCache::TR_J9JITaaSServerSharedCache(TR_J9VMBase *fe)
    : TR_J9SharedCache(fe)
    {
@@ -828,4 +838,14 @@ TR_J9JITaaSServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theH
    TR_ASSERT(_stream, "stream must be initialized by now");
    _stream->write(JITaaS::J9ServerMessageType::SharedCache_addHint, method, theHint);
    _stream->read<JITaaS::Void>();
+   }
+
+const void *
+TR_J9JITaaSServerSharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   std::string dataStr((char *) descriptor->address, descriptor->length);
+
+   _stream->write(JITaaS::J9ServerMessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);
+   return std::get<0>(_stream->read<const void *>());
    }

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -88,6 +88,8 @@ public:
 
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz);
 
+   virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
+
    enum TR_J9SharedCacheDisabledReason
       {
       UNINITIALIZED,
@@ -201,6 +203,7 @@ public:
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
 
    void setStream(JITaaS::J9ServerStream *stream) { _stream = stream; }
+   virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
 
 private:
    JITaaS::J9ServerStream *_stream;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8345,6 +8345,18 @@ TR_J9VM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType address
    return data;
    }
 
+TR_OpaqueClassBlock *
+TR_J9VM::getClassFromCP(J9ConstantPool *cp)
+   {
+   return reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
+   }
+
+J9ROMMethod *
+TR_J9VM::getROMMethodFromRAMMethod(J9Method *ramMethod)
+   {
+   return J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
+   }
+
 //////////////////////////////////////////////////////////
 // TR_J9SharedCacheVM
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1102,6 +1102,8 @@ public:
 
    virtual bool isDecimalFormatPattern( TR::Compilation *comp, TR_ResolvedMethod *method);
    virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType);
+   virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp);
+   virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod);
 
    TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -170,6 +170,8 @@ public:
    virtual intptrj_t methodTrampolineLookup( TR::Compilation *, TR::SymbolReference *symRef, void *callSite) override;
    virtual uintptrj_t getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz) override;
    virtual bool isStringCompressionEnabledVM() override;
+   virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp) override;
+   virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);
@@ -256,6 +258,9 @@ public:
    virtual void * persistThunk(char *signatureChars, uint32_t signatureLength, uint8_t *thunkStart, uint32_t totalSize) { TR_ASSERT(0, "persistThunk should not be called on the server"); return NULL; }
    virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength) override { TR_ASSERT(0, "findPersistentThunk should not be called on the server"); return NULL; }
    virtual J9Class * getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;
+   virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;
+   virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true) override;
+   virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex) override;
 
    };
 

--- a/runtime/compiler/rpc/grpc/J9Server.cpp
+++ b/runtime/compiler/rpc/grpc/J9Server.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,11 +83,11 @@ JITaaS::J9ServerStream::cancel()
    }
 
 void
-JITaaS::J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended, std::string logFileStr)
+JITaaS::J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended, std::string logFileStr, std::string symbolToIdStr)
    {
    try
       {
-      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData, classesThatShouldNotBeNewlyExtended, logFileStr);
+      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData, classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr);
       finish();
       }
 

--- a/runtime/compiler/rpc/grpc/J9Server.hpp
+++ b/runtime/compiler/rpc/grpc/J9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ public:
 
    void finish();
    void cancel();   // Same as finish, but with Status::CANCELLED
-   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {}, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {}, std::string logFileStr = "");
+   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {}, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {}, std::string logFileStr = "", std::string symbolToIdStr = "");
    void acceptNewRPC();
    void setClientId(uint64_t clientId)
       {

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -215,6 +215,8 @@ enum J9ServerMessageType
    VM_isAnonymousClass = 302;
    VM_dereferenceStaticAddress = 303;
    VM_getClassFromNewArrayTypeNonNull = 304;
+   VM_getClassFromCP = 305;
+   VM_getROMMethodFromRAMMethod = 306;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;
@@ -246,6 +248,7 @@ enum J9ServerMessageType
    SharedCache_getClassChainOffsetInSharedCache = 600;
    SharedCache_rememberClass = 601;
    SharedCache_addHint = 602;
+   SharedCache_storeSharedData = 603;
 
    // For runFEMacro
    runFEMacro_invokeCollectHandleNumArgsToCollect = 700;

--- a/runtime/compiler/rpc/raw/J9Server.cpp
+++ b/runtime/compiler/rpc/raw/J9Server.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,11 +68,11 @@ J9ServerStream::cancel()
    }
 
 void
-J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended, std::string logFileStr)
+J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended, std::string logFileStr, std::string symbolToIdStr)
    {
    try
       {
-      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData, classesThatShouldNotBeNewlyExtended, logFileStr);
+      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData, classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr);
       finish();
       }
    catch (std::exception &e)

--- a/runtime/compiler/rpc/raw/J9Server.hpp
+++ b/runtime/compiler/rpc/raw/J9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ public:
       }
 
    void cancel();
-   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {}, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {}, std::string logFileStr = "");
+   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {}, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {}, std::string logFileStr = "", std::string symbolToIdStr = "");
    void setClientId(uint64_t clientId)
       {
       _clientId = clientId;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -371,16 +371,24 @@ struct MethodValidationRecord : public SymbolValidationRecord
    {
    MethodValidationRecord(TR_ExternalRelocationTargetKind kind, TR_OpaqueMethodBlock *method)
       : SymbolValidationRecord(kind),
-        _method(method)
+        _method(method),
+        _definingClass(NULL)
       {}
 
    TR_OpaqueClassBlock *definingClass()
       {
-      return reinterpret_cast<TR_OpaqueClassBlock *>(
-         J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(_method)));
+      TR_ASSERT(_definingClass, "defining class must be already cached");
+      return _definingClass;
+      }
+
+   TR_OpaqueClassBlock *definingClass(TR_J9VM *fe)
+      {
+      _definingClass = fe->getClassOfMethod(_method);
+      return _definingClass;
       }
 
    TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_definingClass;
    };
 
 struct MethodFromClassRecord : public MethodValidationRecord
@@ -748,6 +756,9 @@ public:
    bool inHeuristicRegion() { return (_heuristicRegion > 0); }
 
    static bool assertionsAreFatal();
+
+   std::string serializeSymbolToIDMap(); // JITaaS
+   void deserializeSymbolToIDMap(const std::string &symbolToIdStr);
 
 private:
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -986,7 +986,7 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
 
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
-         J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
+         J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
          void *romMethodOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));


### PR DESCRIPTION
Make changes to Symbol Validation Manager that allow
to use it for remote AOT compilations.
- Replace J9_CLASS_FROM_CP macros with front-end calls.
- Initialize server vm for SVM
- SVM has a map of symbols to their respective ids - `_symbolToIdMap`.
This map is populated during compilation on the server, but is also
used during validation on the client. Thus, at the end of the
compilation we need to send it from server to the client.
- Some methods of `TR_ResolvedJ9Method` and `TR_J9VM` (non-AOT versions)
create SVM records when these methods are called during AOT compilation.
So we need to do the same for base server implementation of these
methods.
- Create new queries for `TR_J9SharedCache` and `TR_J9VM` which are
needed for remote calls

Fixes #4784