### PR TITLE
Extend summary table to include all downstream builds

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -420,9 +420,9 @@ def get_test_job_name(targetName, spec, version) {
 * Limits the search only to the downstream builds with given names.
 * Returns a map of builds.
 */
-def get_downstream_builds(upstreamBuild, downstreamJobNames) {
+def get_downstream_builds(upstreamBuild, upstreamJobName, downstreamJobNames) {
     def downstreamBuilds = [:]
-    def pattern = /.*${upstreamBuild.projectName}.*${upstreamBuild.number}.*/
+    def pattern = /.*${upstreamJobName}.*${upstreamBuild.number}.*/
     def startTime = System.currentTimeMillis()
 
     for (name in downstreamJobNames.sort()) {
@@ -430,7 +430,7 @@ def get_downstream_builds(upstreamBuild, downstreamJobNames) {
         if (job) {
             def builds = [:]
             //find downstream jobs
-            for (build in job.getBuilds().byTimestamp(upstreamBuild.startTimeInMillis, System.currentTimeMillis())) {
+            for (build in job.getBuilds().byTimestamp(upstreamBuild.getStartTimeInMillis(), System.currentTimeMillis())) {
                 if ((build && build.getCause(hudson.model.Cause.UpstreamCause) && build.getCause(hudson.model.Cause.UpstreamCause).upstreamRun)
                     && (build.getCause(hudson.model.Cause.UpstreamCause).upstreamRun==~pattern)) {
                         // cache all builds (in case of multiple runs)
@@ -447,7 +447,7 @@ def get_downstream_builds(upstreamBuild, downstreamJobNames) {
     }
 
     elapsedTime = (System.currentTimeMillis() - startTime)/1000
-    echo "Time spent fetching downstream jobs: ${elapsedTime} seconds"
+    echo "Time spent fetching downstream jobs for ${upstreamJobName}: ${elapsedTime} seconds"
 
     return downstreamBuilds
 }
@@ -462,6 +462,27 @@ def get_build_embedded_status_link(build) {
         return "<a href=\"${buildLink}\"><img src=\"${buildLink}badge/icon\"></a>"
     }
     return ''
+}
+
+/*
+* Returns a map storing the downstream job names for given version and spec.
+*/
+def get_downstream_job_names(spec, version) {
+    /* e.g. [build:                 Build-JDK11-linux_390-64_cmprssptrs,
+             extended.functional:   Test-extended.functional-JDK11-linux_390-64_cmprssptrs,
+             extended.system:       Test-extended.system-JDK11-linux_390-64_cmprssptrs,
+             sanity.functional:     Test-sanity.functional-JDK11-linux_390-64_cmprssptrs,
+             sanity.system:         Test-sanity.system-JDK11-linux_390-64_cmprssptrs]
+    */
+
+    downstreamJobNames = [:]
+    downstreamJobNames.put('build', get_build_job_name(spec, version))
+
+    for (target in get_test_target_names().sort()) {
+        downstreamJobNames.put(target, get_test_job_name(target, spec, version))
+    }
+
+    return downstreamJobNames
 }
 
 return this

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -146,41 +146,43 @@ timeout(time: 12, unit: 'HOURS') {
                 def TEST_NODES = get_node_labels(params.TEST_NODE_LABELS, BUILD_SPECS.keySet())
 
                 BUILD_SPECS.each { SPEC, SDK_VERSIONS ->
-                    SDK_VERSIONS.each { SDK_VERSION ->
-                        def job_name = get_pipeline_name(SPEC, SDK_VERSION)
-                        pipelineNames.add(job_name)
+                    if (VARIABLES."${SPEC}") {
+                        SDK_VERSIONS.each { SDK_VERSION ->
+                            def job_name = get_pipeline_name(SPEC, SDK_VERSION)
+                            pipelineNames.add(job_name)
 
-                        // set OpenJDK repos and branch for the downstream build
-                        def REPO = OPENJDK_REPO.get(SDK_VERSION).get(SPEC)
-                        def BRANCH = OPENJDK_BRANCH.get(SDK_VERSION).get(SPEC)
+                            // set OpenJDK repos and branch for the downstream build
+                            def REPO = OPENJDK_REPO.get(SDK_VERSION).get(SPEC)
+                            def BRANCH = OPENJDK_BRANCH.get(SDK_VERSION).get(SPEC)
 
-                        // set nodes for the downstream builds
-                        def BUILD_NODE = ''
-                        if (BUILD_NODES[SPEC]) {
-                            BUILD_NODE = BUILD_NODES[SPEC]
+                            // set nodes for the downstream builds
+                            def BUILD_NODE = ''
+                            if (BUILD_NODES[SPEC]) {
+                                BUILD_NODE = BUILD_NODES[SPEC]
+                            }
+                            def TEST_NODE = ''
+                            if (TEST_NODES[SPEC]) {
+                                TEST_NODE = TEST_NODES[SPEC]
+                            }
+
+                            def EXTRA_GETSOURCE_OPTIONS = get_value_by_spec(EXTRA_GETSOURCE_OPTIONS_MAP, SDK_VERSION, SPEC)
+                            def EXTRA_CONFIGURE_OPTIONS = get_value_by_spec(EXTRA_CONFIGURE_OPTIONS_MAP, SDK_VERSION, SPEC)
+                            def EXTRA_MAKE_OPTIONS = get_value_by_spec(EXTRA_MAKE_OPTIONS_MAP, SDK_VERSION, SPEC)
+                            def OPENJDK_CLONE_DIR = get_value_by_spec(OPENJDK_CLONE_DIR_MAP, SDK_VERSION, SPEC)
+
+                            def ADOPTOPENJDK_REPO = ''
+                            def ADOPTOPENJDK_BRANCH = ''
+                            if (ADOPTOPENJDK_MAP.get(SDK_VERSION)) {
+                                ADOPTOPENJDK_REPO = ADOPTOPENJDK_MAP.get(SDK_VERSION).get('repoUrl')
+                                ADOPTOPENJDK_BRANCH = ADOPTOPENJDK_MAP.get(SDK_VERSION).get('branch')
+                            }
+
+                            if (AUTOMATIC_GENERATION != 'false'){
+                                variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline')
+                            }
+
+                            builds["${job_name}"] = { build(job_name, REPO, BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, AUTOMATIC_GENERATION) }
                         }
-                        def TEST_NODE = ''
-                        if (TEST_NODES[SPEC]) {
-                            TEST_NODE = TEST_NODES[SPEC]
-                        }
-
-                        def EXTRA_GETSOURCE_OPTIONS = get_value_by_spec(EXTRA_GETSOURCE_OPTIONS_MAP, SDK_VERSION, SPEC)
-                        def EXTRA_CONFIGURE_OPTIONS = get_value_by_spec(EXTRA_CONFIGURE_OPTIONS_MAP, SDK_VERSION, SPEC)
-                        def EXTRA_MAKE_OPTIONS = get_value_by_spec(EXTRA_MAKE_OPTIONS_MAP, SDK_VERSION, SPEC)
-                        def OPENJDK_CLONE_DIR = get_value_by_spec(OPENJDK_CLONE_DIR_MAP, SDK_VERSION, SPEC)
-
-                        def ADOPTOPENJDK_REPO = ''
-                        def ADOPTOPENJDK_BRANCH = ''
-                        if (ADOPTOPENJDK_MAP.get(SDK_VERSION)) {
-                            ADOPTOPENJDK_REPO = ADOPTOPENJDK_MAP.get(SDK_VERSION).get('repoUrl')
-                            ADOPTOPENJDK_BRANCH = ADOPTOPENJDK_MAP.get(SDK_VERSION).get('branch')
-                        }
-
-                        if (AUTOMATIC_GENERATION != 'false'){
-                            variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline')
-                        }
-
-                        builds["${job_name}"] = { build(job_name, REPO, BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, AUTOMATIC_GENERATION) }
                     }
                 }
             } finally {
@@ -246,7 +248,7 @@ def build(JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRAN
                     string(name: 'EXTRA_CONFIGURE_OPTIONS', value: EXTRA_CONFIGURE_OPTIONS),
                     string(name: 'EXTRA_MAKE_OPTIONS', value: EXTRA_MAKE_OPTIONS),
                     string(name: 'OPENJDK_CLONE_DIR', value: OPENJDK_CLONE_DIR),
-                    booleanParam(name: 'AUTOMATIC_GENERATION', value: AUTOMATIC_GENERATION)]
+                    string(name: 'AUTOMATIC_GENERATION', value: AUTOMATIC_GENERATION)]
         return JOB
     }
 }
@@ -307,12 +309,13 @@ def get_pipeline_name(spec, version) {
 * Returns an HTML summary table for the downstream builds.
 */
 def get_summary_table() {
-    def builds = buildFile.get_downstream_builds(currentBuild, pipelineNames)
-    if (builds.isEmpty()) {
+    // fetch the downstream builds of the current build
+    def pipelineBuilds = buildFile.get_downstream_builds(currentBuild, currentBuild.projectName, pipelineNames)
+    if (pipelineBuilds.isEmpty()) {
         return ''
     }
 
-    def buildReleases = variableFile.get_build_releases(BUILD_SPECS)
+    def buildReleases = get_sorted_releases()
     def specShortNames = ['aix_ppc-64_cmprssptrs'          : 'aix-ppc64',
                           'linux_390-64_cmprssptrs'        : 'linux-s390x',
                           'linux_ppc-64_cmprssptrs_le'     : 'linux-ppc64le',
@@ -325,7 +328,7 @@ def get_summary_table() {
                           'osx_x86-64'                     : 'osx-x64-XL',
                           'osx_x86-64_cmprssptrs'          : 'osx-x64']
 
-    def headerCols = ['Platform']
+    def headerCols = ['']
     headerCols.addAll(buildReleases)
 
     // summary table
@@ -341,23 +344,80 @@ def get_summary_table() {
 
     // table body
     summaryText += "<tbody>"
+
     for (spec in BUILD_SPECS.keySet().sort()){
         // table row
         summaryText += "<tr>"
-        summaryText += "<td>${specShortNames[spec]}</td>"
+        summaryText += "<td style=\"font-weight: bold;\">${specShortNames[spec]}</td>"
+        def showLabel = true
 
         buildReleases.each { release ->
             // table cell
-            def pipelineName = get_pipeline_name(spec, release)
-            def build = builds.get(pipelineName)
-            def statusLink = buildFile.get_build_embedded_status_link(build)
+            def innerTable = "<table><tbody>"
 
-            summaryText += "<td>${statusLink}</td>"
+            def pipelineName = get_pipeline_name(spec, release)
+            def build = pipelineBuilds.get(pipelineName)
+            def downstreamJobNames = buildFile.get_downstream_job_names(spec, release)
+
+            if (build) {
+                def pipelineLink = buildFile.get_build_embedded_status_link(build)
+                innerTable += "<tr style=\"text-align: right\"><td colspan=\"2\">${pipelineLink}</td><td>${build.getDurationString()}</td></tr>"
+
+                // add pipeline's downstream builds
+                def downstreamBuilds = buildFile.get_downstream_builds(build, pipelineName, downstreamJobNames.values())
+
+                downstreamJobNames.each { label, jobName ->
+                    def downstreamBuild = downstreamBuilds.get(jobName)
+                    def link = ''
+                    def runtime = ''
+
+                    if (downstreamBuild) {
+                        link = buildFile.get_build_embedded_status_link(downstreamBuild)
+                        runtime = downstreamBuild.getDurationString()
+                    }
+
+                    if (showLabel) {
+                        //show downstream jobs short names only once per platform
+                        innerTable += "<tr><td>${label}</td><td>${link}</td><td style=\"text-align: right\">${runtime}</td></tr>"
+                    } else {
+                        innerTable += "<tr><td colspan=\"2\">${link}</td><td style=\"text-align: right\">${runtime}</td></tr>"
+                    }
+                }
+            } else {
+                downstreamJobNames.keySet().each {
+                    innerTable += "<tr><td colspan=\"3\">${it}</td></tr>"
+                }
+            }
+
+            innerTable += "</tbody></table>"
+            summaryText += "<td>${innerTable}</td>"
+
+            // do not show the jobs short names for the other releases
+            showLabel = false
         }
         summaryText += "</tr>"
     }
+
     summaryText += "</tbody>"
     summaryText += "</table>"
 
     return summaryText
+}
+
+/*
+* Returns the sorted build releases.
+*/
+def get_sorted_releases() {
+    // not using comparator due to https://issues.jenkins-ci.org/browse/JENKINS-44924
+
+    def unsortedReleases = variableFile.get_build_releases(BUILD_SPECS)
+    def sortedReleases = []
+
+    for (release in RELEASES) {
+        if (unsortedReleases.contains(release)) {
+            sortedReleases.add(release)
+        }
+    }
+
+    return sortedReleases
 }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -52,24 +52,10 @@ timestamps {
         jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_DIRS_MAP, USER_CREDENTIALS_ID, BUILD_LIST, SETUP_LABEL, ghprbGhRepository, ghprbActualCommit, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, BUILD_NAME)
     } finally {
         //display the build status of the downstream jobs
-        def downstreamBuilds = buildFile.get_downstream_builds(currentBuild, get_downstream_job_names(SPEC, SDK_VERSION))
+        def downstreamBuilds = buildFile.get_downstream_builds(currentBuild, currentBuild.projectName, buildFile.get_downstream_job_names(SPEC, SDK_VERSION).values())
         add_badges(downstreamBuilds)
         add_summary_badge(downstreamBuilds)
     }
-}
-
-/*
-* Returns the list of the downstream jobs.
-*/
-def get_downstream_job_names(spec, version) {
-    downstreamJobNames = []
-    downstreamJobNames.add(buildFile.get_build_job_name(spec, version))
-
-    for (target in buildFile.get_test_target_names()) {
-        downstreamJobNames.add(buildFile.get_test_job_name(target, spec, version))
-    }
-
-    return downstreamJobNames
 }
 
 /*


### PR DESCRIPTION
Add build and test pipelines status and runtime to the downstream jobs
summary.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>