### PR TITLE
Add Flattened ValueType Array Implementation

### DIFF
--- a/runtime/gc_glue_java/ArrayletObjectModel.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 #include "ArrayletObjectModel.hpp"
 #include "GCExtensionsBase.hpp"
+#include "ModronAssertions.h"
 #include "ObjectModel.hpp"
 
 #if defined(J9VM_GC_ARRAYLETS)
@@ -36,6 +37,12 @@ void
 GC_ArrayletObjectModel::tearDown(MM_GCExtensionsBase *extensions)
 {
 	GC_ArrayletObjectModelBase::tearDown(extensions);
+}
+
+void
+GC_ArrayletObjectModel::AssertBadElementSize()
+{
+	Assert_MM_unreachable();
 }
 
 GC_ArrayletObjectModel::ArrayLayout

--- a/runtime/gc_include/ObjectAllocationAPI.hpp
+++ b/runtime/gc_include/ObjectAllocationAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -168,14 +168,13 @@ public:
 		if (0 != size) {
 			/* Contiguous Array */
 
-			UDATA scale = ((J9ROMArrayClass*)(arrayClass->romClass))->arrayShape;
 
 #if !defined(J9VM_ENV_DATA64)
-			if (!sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE >> scale)))
+			if (!sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE / J9ARRAYCLASS_GET_STRIDE(arrayClass))))
 #endif /* J9VM_ENV_DATA64 */
 			{
 				/* Calculate the size of the object */
-				UDATA dataSize = ((UDATA)size) << scale;
+				UDATA dataSize = ((UDATA)size) * J9ARRAYCLASS_GET_STRIDE(arrayClass);
 				UDATA allocateSize = (dataSize + sizeof(J9IndexableObjectContiguous) + _objectAlignmentInBytes - 1) & ~(UDATA)(_objectAlignmentInBytes - 1);
 				if (allocateSize < J9_GC_MINIMUM_OBJECT_SIZE) {
 					allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -325,9 +325,13 @@ static const struct { \
 
 /* Macros for ValueTypes */
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
-#define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsValueType)
+#define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsValueType)
+#define J9_IS_J9CLASS_FLATTENED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened)
+#define J9_VALUETYPE_FLATTENED_SIZE(clazz)((clazz)->totalInstanceSize - (clazz)->backfillOffset)
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
+#define J9_IS_J9CLASS_FLATTENED(clazz) FALSE
+#define J9_VALUETYPE_FLATTENED_SIZE(clazz)((UDATA) 0) /* It is not possible for this macro to be used since we always check J9_IS_J9CLASS_FLATTENED before ever using it. */
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #if defined(OPENJ9_BUILD)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1711,13 +1711,11 @@ typedef struct J9ModuleExtraInfo {
 	UDATA patchPathCount;
 } J9ModuleExtraInfo;
 
-#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
 typedef struct J9FlattenedClassCache {
 	struct J9Class* clazz;
 	struct J9ROMNameAndSignature* nameAndSignature;
 	UDATA offset;
 } J9FlattenedClassCache;
-#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 struct J9TranslationBufferSet;
 typedef struct J9VerboseStruct {
@@ -2946,9 +2944,7 @@ typedef struct J9Class {
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	struct J9Class* nestHost;
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	struct J9FlattenedClassCache* flattenedClassCache;
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 } J9Class;
 
 /* Interface classes can never be instantiated - overload the totalInstanceSize slot to hold the iTable method count */

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2848,6 +2848,17 @@ fail:
 #if defined(J9VM_THR_LOCK_NURSERY) && defined(J9VM_THR_LOCK_NURSERY_FAT_ARRAYS)
 				ramArrayClass->lockOffset = (UDATA)TMP_OFFSETOF_J9INDEXABLEOBJECT_MONITOR;
 #endif
+				if (J9_IS_J9CLASS_VALUETYPE(elementClass) && J9_IS_J9CLASS_FLATTENED(elementClass)) {
+					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
+						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));
+					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {
+						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(fj9object_t)));
+					} else { /* VT only contains singles (int, short, etc) at this point */
+						J9ARRAYCLASS_SET_STRIDE(ramClass, J9_VALUETYPE_FLATTENED_SIZE(elementClass));
+					}
+				} else {
+					J9ARRAYCLASS_SET_STRIDE(ramClass, (1 << (((J9ROMArrayClass*)romClass)->arrayShape & 0x0000FFFF)));
+				}
 			} else if (J9ROMCLASS_IS_PRIMITIVE_TYPE(ramClass->romClass)) {
 				ramClass->module = module;
 			} else {


### PR DESCRIPTION
Steps:
Add Macros J9_IS_J9CLASS_FLATTENED and J9_VALUETYPE_FLATTENED_SIZE to help determine if the J9Class instance is flatenned
Add Stride calculation for Array classes in creatorramclass.cpp. Utilize the J9ARRAYCLASS_SET_STRIDE that was previously implemented
Modify the space allocation calculation for inlineAllocateIndexableObject and getDataSizeInBytes using the J9ARRAYCLASS_GET_STRIDE Macro

Related #5021

Signed-off-by: Aidan Ha <qbha@edu.uwaterloo.ca>