### PR TITLE
Persist thunks to SCC for delayed AOT load in JITaaS Remote AOT mode

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -405,6 +405,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    void                   addThunkToBeRelocated(void *thunk, std::string signature);
    void                   addInvokeExactThunkToBeRelocated(TR_J2IThunk *thunk);
    void                   relocateThunks();
+   void                   persistThunksToSCC(const J9JITDataCacheHeader *cacheEntry, uint8_t * existingCode);
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getCustomClassByNameMap() { return _customClassByNameMap; }
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() { return _classesThatShouldNotBeNewlyExtended; }
    uint32_t               getLastLocalGCCounter() { return _lastLocalGCCounter; }

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2377,7 +2377,16 @@ remoteCompile(
                }
             }
 
-         TR::compInfoPT->relocateThunks();
+         if (metaData)
+            {
+            TR::compInfoPT->relocateThunks();
+            }
+         else
+            {
+            // metaData == NULL indicates AOT relocation is delayed
+            // we need to persist the thunks to SCC
+            TR::compInfoPT->persistThunksToSCC((J9JITDataCacheHeader *)&dataCacheStr[0], (uint8_t *)&codeCacheStr[0]);
+            }
 
          TR_ASSERT(!metaData->startColdPC, "coldPC should be null");
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -188,7 +188,7 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
    uint8_t *oldDataStart, *oldCodeStart, *newCodeStart;
    tempDataStart = (uint8_t *)cacheEntry;
 
-   //Check method header is valid
+   // Check method header is valid
    _aotMethodHeaderEntry = (TR_AOTMethodHeader *)(cacheEntry + 1); // skip the header J9JITDataCacheHeader
    if (!aotMethodHeaderVersionsMatch())
       return NULL;


### PR DESCRIPTION
Current code assumes that AOT relocation always happens right after AOT compilation and always relocates thunks, this change adds the appropriate handle for delayed AOT load in JITaaS Remote AOT mode.

[skip ci]
closes: #5147

Signed-off-by: Harry Yu <harryyu1994@gmail.com>