### PR TITLE
Add zNext support

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1879,6 +1879,9 @@ J9::Options::fePreProcess(void * base)
       {
       self()->setOption(TR_InlineVeryLargeCompiledMethods);
       }
+
+   // Disable zNext support until it has been gone through several rounds of functional stress testing
+   self()->setOption(TR_DisableZ15);
 #endif
 
    // On big machines we can afford to spend more time compiling

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -635,6 +635,14 @@ int32_t TR_J9VM::getCompInfo(char *processorName, int32_t stringLength)
             returnValue = snprintf(processorName, stringLength, "z14s (%d)", machineId);
          break;
 
+         case TR_Z15:
+            returnValue = snprintf(processorName, stringLength, "z15 (%d)", machineId);
+         break;
+
+         case TR_Z15s:
+            returnValue = snprintf(processorName, stringLength, "z15 (%d)", machineId);
+         break;
+
          case TR_ZNEXT:
             returnValue = snprintf(processorName, stringLength, "zNext (%d)", machineId);
          break;
@@ -726,6 +734,10 @@ TR_J9VM::initializeProcessorType()
       // For AOT shared classes cache processor compatibility purposes, the following
       // processor settings should not be modified.
       if (TR::Compiler->target.cpu.getS390SupportsZNext())
+         {
+         TR::Compiler->target.cpu.setProcessor(TR_s370gp14);
+         }
+      else if (TR::Compiler->target.cpu.getS390SupportsZ15())
          {
          TR::Compiler->target.cpu.setProcessor(TR_s370gp13);
          }

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -7166,7 +7166,7 @@ J9::Z::TreeEvaluator::pdModifyPrecisionEvaluator(TR::Node * node, TR::CodeGenera
       if (TR::Compiler->target.cpu.getS390SupportsVectorPDEnhancement())
          {
          // Overflow exceptions can be ignored for z15 vector packed decimal VRI-i,f,g and VRR-i instructions. Given
-         // this, VPSOP now becomes suitable for data truncations without incurring excptions which eventually lead to
+         // this, VPSOP now becomes suitable for data truncations without incurring exceptions which eventually lead to
          // performance degradations. This is usually used to truncate high nibble of an even precision PD.
          targetReg = vectorPerformSignOperationHelper(node, cg, true, targetPrec, true, SignOperationType::maintain, false, false, 0, false, true);
          }

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -225,6 +225,36 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
 
    static TR::Register *pdModifyPrecisionEvaluator(TR::Node * node, TR::CodeGenerator * cg);
    static TR::Register *pdshlVectorEvaluatorHelper(TR::Node *node, TR::CodeGenerator *cg);
+
+   /** \brief
+    *     Helper to generate a VPSOP instruction.
+    *
+    *  \param node 
+    *     The node to which the instruction is associated.
+    *  \param cg 
+    *     The codegen object.
+    *  \param setPrecision
+    *     Determines whether the VPSOP instruction will set precision.
+    *  \param precision
+    *     The new precision value.
+    *  \param signedStatus
+    *     Determines whether positive results will carry the preferred positive sign 0xC if true or 0xF if false.
+    *  \param signOpType
+    *     See enum SignOperationType.
+    *  \param signValidityCheck
+    *     Checks if originalSignCode is a valid sign.
+    *  \param digitValidityCheck
+    *     Validate the input digits
+    *  \param sign
+    *     The new sign. Used if signOpType is SignOperationType::setSign. Possible values inclue:
+    *       - positive: 0xA, 0xC 
+    *       - negative: 0xB, 0xD
+    *       - unsigned: 0xF
+    *  \param setConditionCode
+    *     Determines if this instruction sets ConditionCode or not.
+    *  \param ignoreDecimalOverflow
+    *     Turns on the Instruction Overflow Mask (IOM) so no decimal overflow is triggered
+    */
    static TR::Register *vectorPerformSignOperationHelper(TR::Node *node,
                                                          TR::CodeGenerator *cg,
                                                          bool setPrecision,
@@ -232,8 +262,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
                                                          bool signedStatus,
                                                          SignOperationType soType,
                                                          bool signValidityCheck = false,
+                                                         bool digitValidityCheck = true,
                                                          int32_t sign = 0,
-                                                         bool setConditionCode = true);
+                                                         bool setConditionCode = true,
+                                                         bool ignoreDecimalOverflow = false);
 
    static TR::Register *pdchkEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -239,14 +239,14 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
     *     The new precision value.
     *  \param signedStatus
     *     Determines whether positive results will carry the preferred positive sign 0xC if true or 0xF if false.
-    *  \param signOpType
+    *  \param soType
     *     See enum SignOperationType.
     *  \param signValidityCheck
     *     Checks if originalSignCode is a valid sign.
     *  \param digitValidityCheck
     *     Validate the input digits
     *  \param sign
-    *     The new sign. Used if signOpType is SignOperationType::setSign. Possible values inclue:
+    *     The new sign. Used if signOpType is SignOperationType::setSign. Possible values include:
     *       - positive: 0xA, 0xC 
     *       - negative: 0xB, 0xD
     *       - unsigned: 0xF

--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -104,7 +104,16 @@ CPU::TO_PORTLIB_get390_supportsZNext()
    {
 #if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
    J9ProcessorDesc *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   //check for ZNext. To be moved to portlib.
+   return (processorDesc->processor >= PROCESSOR_S390_GP14);
+#endif
+   return false;
+   }
+
+bool
+CPU::TO_PORTLIB_get390_supportsZ15()
+   {
+#if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
+   J9ProcessorDesc *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
    return (processorDesc->processor >= PROCESSOR_S390_GP13);
 #endif
    return false;
@@ -115,7 +124,6 @@ CPU::TO_PORTLIB_get390_supportsZ14()
    {
 #if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
    J9ProcessorDesc *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   //check for Z14. To be moved to portlib.
    return (processorDesc->processor >= PROCESSOR_S390_GP12);
 #endif
    return false;
@@ -126,7 +134,6 @@ CPU::TO_PORTLIB_get390_supportsZ13()
    {
 #if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
    J9ProcessorDesc *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   //check for Z13. To be moved to portlib.
    return (processorDesc->processor >= PROCESSOR_S390_GP11);
 #endif
    return false;
@@ -138,7 +145,6 @@ CPU::TO_PORTLIB_get390_supportsZ6()
    {
 #if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
    J9ProcessorDesc  *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   //check for Z6, ZGryphon, ZHelix or Z13. To be moved to portlib.
    return (processorDesc->processor >= PROCESSOR_S390_GP8);
 #endif
    return false;
@@ -152,7 +158,6 @@ CPU::TO_PORTLIB_get390_supportsZGryphon()
    // instruction is installed
 #if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
    J9ProcessorDesc  *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   //check for ZGryphon, ZHelix or Z13. To be moved to portlib.
    return (processorDesc->processor >= PROCESSOR_S390_GP9);
 #endif
    return false;
@@ -164,7 +169,6 @@ CPU::TO_PORTLIB_get390_supportsZHelix()
    {
 #if defined(TR_HOST_S390) && (defined(J9ZOS390) || defined(LINUX))
    J9ProcessorDesc  *processorDesc = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   //check for ZHelix or Z13. To be moved to portlib.
    return (processorDesc->processor >= PROCESSOR_S390_GP10);
 #endif
    return false;
@@ -219,6 +223,26 @@ CPU::getS390SupportsGuardedStorageFacility()
            _flags.testAny(S390SupportsSideEffectAccessFacility));
    }
 
+bool
+CPU::getS390SupportsMIE3()
+   {
+   return (_flags.testAny(S390SupportsMIE3) &&
+           !(TR::Options::getCmdLineOptions()->getOption(TR_DisableZ15)));
+   }
+
+bool
+CPU::getS390SupportsVectorFacilityEnhancement2()
+   {
+   return (_flags.testAny(S390SupportsVectorFacilityEnhancement2) &&
+           !(TR::Options::getCmdLineOptions()->getOption(TR_DisableZ15)));
+   }
+bool
+CPU::getS390SupportsVectorPDEnhancement()
+   {
+   return (_flags.testAny(S390SupportsVectorPDEnhancementFacility) &&
+           !(TR::Options::getCmdLineOptions()->getOption(TR_DisableZ15)));
+   }
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void
@@ -233,6 +257,8 @@ CPU::initializeS390ProcessorFeatures()
    // On z10 or higher architectures, we should check for facility bits.
    if (TR::Compiler->target.cpu.TO_PORTLIB_get390_supportsZNext())
       TR::Compiler->target.cpu.setS390SupportsZNext();
+   else if (TR::Compiler->target.cpu.TO_PORTLIB_get390_supportsZ15())
+      TR::Compiler->target.cpu.setS390SupportsZ15();
    else if (TR::Compiler->target.cpu.TO_PORTLIB_get390_supportsZ14())
       TR::Compiler->target.cpu.setS390SupportsZ14();
    else if (TR::Compiler->target.cpu.TO_PORTLIB_get390_supportsZ13())
@@ -294,6 +320,24 @@ CPU::initializeS390ProcessorFeatures()
       if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE))
          {
          TR::Compiler->target.cpu.setS390SupportsGuardedStorageFacility();
+         }
+      }
+
+   if (TR::Compiler->target.cpu.getS390SupportsZ15())
+      {
+      if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_3))
+         {
+         TR::Compiler->target.cpu.setS390SupportsMIE3();
+         }
+
+      if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_2))
+         {
+         TR::Compiler->target.cpu.setS390SupportsVectorFacilityEnhancement2();
+         }
+
+      if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY))
+         {
+         TR::Compiler->target.cpu.setS390SupportsVectorPDEnhancement();
          }
       }
    }

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -70,7 +70,8 @@ enum S390SupportsArchitectures
    S390SupportsZEC12       = 6,
    S390SupportsZ13         = 7,
    S390SupportsZ14         = 8,
-   S390SupportsZNext       = 9,
+   S390SupportsZ15         = 9,
+   S390SupportsZNext       = 10,
    S390SupportsLatestArch  = S390SupportsZNext
    };
 
@@ -91,6 +92,9 @@ enum // flags
    S390SupportsVectorPackedDecimalFacility  = 0x00080000,
    S390SupportsGuardedStorageFacility       = 0x00100000,
    S390SupportsSideEffectAccessFacility     = 0x00200000,
+   S390SupportsMIE3                         = 0x00400000,
+   S390SupportsVectorFacilityEnhancement2   = 0x00800000,
+   S390SupportsVectorPDEnhancementFacility  = 0x01000000,
    DummyLastFlag
    };
 
@@ -143,6 +147,9 @@ public:
    bool getS390SupportsZ14() {return getS390SupportsArch(S390SupportsZ14);}
    void setS390SupportsZ14() { setS390SupportsArch(S390SupportsZ14);}
 
+   bool getS390SupportsZ15() {return getS390SupportsArch(S390SupportsZ15);}
+   void setS390SupportsZ15() { setS390SupportsArch(S390SupportsZ15);}
+
    bool getS390SupportsZNext() {return getS390SupportsArch(S390SupportsZNext);}
    void setS390SupportsZNext() { setS390SupportsArch(S390SupportsZNext);}
 
@@ -167,6 +174,17 @@ public:
    bool getS390SupportsVectorPackedDecimalFacility();
    void setS390SupportsVectorPackedDecimalFacility() { _flags.set(S390SupportsVectorPackedDecimalFacility); }
 
+   bool getS390SupportsMIE3();
+   void setS390SupportsMIE3() { _flags.set(S390SupportsMIE3); }
+
+   bool getS390SupportsVectorFacilityEnhancement2();
+   void setS390SupportsVectorFacilityEnhancement2() { _flags.set(S390SupportsVectorFacilityEnhancement2); }
+
+   bool getS390SupportsVectorPDEnhancement();
+   void setS390SupportsVectorPDEnhancement() { _flags.set(S390SupportsVectorPDEnhancementFacility); }
+
+   bool hasPopulationCountInstruction() { return getS390SupportsMIE3(); }
+
    /** \brief
     *     Determines whether the guarded storage facility is available on the current processor.
     *
@@ -180,6 +198,7 @@ public:
 
    static int32_t TO_PORTLIB_get390MachineId();
    static bool TO_PORTLIB_get390_supportsZNext();
+   static bool TO_PORTLIB_get390_supportsZ15();
    static bool TO_PORTLIB_get390_supportsZ14();
    static bool TO_PORTLIB_get390_supportsZ13();
    static bool TO_PORTLIB_get390_supportsZ6();

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -347,6 +347,7 @@ typedef enum J9ProcessorArchitecture {
 	PROCESSOR_S390_GP11,
 	PROCESSOR_S390_GP12,
 	PROCESSOR_S390_GP13,
+	PROCESSOR_S390_GP14,
 
 	PROCESSOR_PPC_UNKNOWN,
 	PROCESSOR_PPC_7XX,
@@ -529,6 +530,18 @@ typedef struct J9ProcessorDesc {
 
 /* STFLE bit 57 - Message-security-assist-extension-5 facility */
 #define J9PORT_S390_FEATURE_MSA_EXTENSION_5 57
+
+/* z15 facilities */
+
+/* STFLE bit 61 - Miscellaneous-instruction-extensions facility 3 */ 
+#define J9PORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_3 61
+
+/* STFLE bit 148 - Vector enhancements facility 2 */
+#define J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_2 148
+
+/* STFLE bit 152 - Vector packed decimal enhancement facility */
+#define J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY 152
+
 
 /*  Linux on Z features
  *  Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on Z.

--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -1143,6 +1143,40 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 
 		desc->processor = PROCESSOR_S390_GP12;
 	}
+	
+    /* z15 facility and processor detection */
+
+	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_3)) {
+		setFeature(desc, J9PORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_3);
+
+		desc->processor = PROCESSOR_S390_GP13;
+	}
+
+	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_2)) {
+#if defined(J9ZOS390)
+		if (getS390zOS_supportsVectorExtensionFacility())
+#elif defined(LINUX) && !defined(J9ZTPF) /* defined(J9ZOS390) */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS))
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_2);
+
+			desc->processor = PROCESSOR_S390_GP13;
+		}
+	}
+
+	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY)) {
+#if defined(J9ZOS390)
+		if (getS390zOS_supportsVectorExtensionFacility())
+#elif defined(LINUX) && !defined(J9ZTPF) /* defined(J9ZOS390) */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS))
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY);
+
+			desc->processor = PROCESSOR_S390_GP13;
+		}
+	}
 
 	/* Set Side Effect Facility without setting GP12. This is because
 	 * this GP12-only STFLE bit can also be enabled on zEC12 (GP10)


### PR DESCRIPTION
Add support for the zNext processor including:

- Processor detection and facility checks
- Vector packed decimal enhancements
- Miscellaneous instruction exploitation
- Improvements to arraycopy instruction selection

Co-authored-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>
Co-authored-by: Filip Jeremic <fjeremic@ca.ibm.com>
Co-authored-by: Nigel Yu <yunigel@ca.ibm.com>
Co-authored-by: Rahil Shah <rahil@ca.ibm.com>

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>