### PR TITLE
Dynamic checkcast evaluation on x86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -3664,6 +3664,148 @@ TR::Register *J9::X86::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGener
    return resultReg;
    }
 
+inline void generateInlinedCheckCastForDynamicCastClass(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   auto use64BitClasses = TR::Compiler->target.is64Bit() &&
+               (!TR::Compiler->om.generateCompressedObjectHeaders() ||
+               (cg->comp()->compileRelocatableCode() && cg->comp()->getOption(TR_UseSymbolValidationManager)));
+   TR::Register *ObjReg = cg->evaluate(node->getFirstChild());
+   TR::Register *castClassReg = cg->evaluate(node->getSecondChild());
+   TR::Register *temp1Reg = cg->allocateRegister();
+   TR::Register *temp2Reg = cg->allocateRegister();
+   TR::Register *objClassReg = cg->allocateRegister();
+  
+   bool isCheckCastAndNullCheck = (node->getOpCodeValue() == TR::checkcastAndNULLCHK);
+
+   TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *fallThruLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *outlinedCallLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *throwLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *isClassLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *iTableLoopLabel = generateLabelSymbol(cg);
+   startLabel->setStartInternalControlFlow();
+   fallThruLabel->setEndInternalControlFlow();
+   
+   generateLabelInstruction(LABEL, node, startLabel, cg);
+   
+   TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::call, NULL, outlinedCallLabel, fallThruLabel, cg);
+   cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
+
+   // objClassReg holds object class also serves as null check
+   if (isCheckCastAndNullCheck)
+      generateLoadJ9Class(node, objClassReg, ObjReg, cg);
+
+   // temp2Reg holds romClass of cast class, for testing array, interface class type
+   generateRegMemInstruction(LRegMem(), node, temp2Reg, generateX86MemoryReference(castClassReg, offsetof(J9Class, romClass), cg), cg);
+   
+   // If cast class is array, call out of line helper
+   generateMemImmInstruction(TEST4MemImm4, node,
+       generateX86MemoryReference(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
+   generateLabelInstruction(JNE4, node, outlinedCallLabel, cg);
+
+   // objClassReg holds object class  
+   if (!isCheckCastAndNullCheck)
+      {
+      generateRegRegInstruction(TESTRegReg(), node, ObjReg, ObjReg, cg);
+      generateLabelInstruction(JE4, node, fallThruLabel, cg);
+      generateLoadJ9Class(node, objClassReg, ObjReg, cg);
+      }
+
+   // Object not array, inline checks
+   // Check cast class is interface
+   generateMemImmInstruction(TEST4MemImm4, node,
+       generateX86MemoryReference(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface, cg);
+   generateLabelInstruction(JE4, node, isClassLabel, cg);
+   
+   // Obtain I-Table
+   // temp1Reg holds head of J9Class->iTable of obj class
+   generateRegMemInstruction(LRegMem(), node, temp1Reg, generateX86MemoryReference(objClassReg, offsetof(J9Class, iTable), cg), cg);
+   // Loop through I-Table
+   // temp1Reg holds iTable list element through the loop
+   generateLabelInstruction(LABEL, node, iTableLoopLabel, cg);
+   generateRegRegInstruction(TESTRegReg(), node, temp1Reg, temp1Reg, cg);
+   generateLabelInstruction(JE4, node, throwLabel, cg);
+   auto interfaceMR = generateX86MemoryReference(temp1Reg, offsetof(J9ITable, interfaceClass), cg);
+   generateMemRegInstruction(CMPMemReg(), node, interfaceMR, castClassReg, cg);
+   generateRegMemInstruction(LRegMem(), node, temp1Reg, generateX86MemoryReference(temp1Reg, offsetof(J9ITable, next), cg), cg);
+   generateLabelInstruction(JNE4, node, iTableLoopLabel, cg);
+   
+   // Found from I-Table
+   generateLabelInstruction(JMP4, node, fallThruLabel, cg);
+   
+   // cast class is non-interface class
+   generateLabelInstruction(LABEL, node, isClassLabel, cg);
+   // equality test
+   generateRegRegInstruction(CMPRegReg(use64BitClasses), node, objClassReg, castClassReg, cg);
+   generateLabelInstruction(JE4, node, fallThruLabel, cg);
+   
+   // class not equal
+   // temp2 holds cast class depth
+   // class depth mask must be low 16 bits to safely load without the mask.
+   static_assert(J9AccClassDepthMask == 0xffff, "J9_JAVA_CLASS_DEPTH_MASK must be 0xffff");
+   generateRegMemInstruction(TR::Compiler->target.is64Bit()? MOVZXReg8Mem2 : MOVZXReg4Mem2, node,
+            temp2Reg, generateX86MemoryReference(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+   
+   // cast class depth >= obj class depth, throw 
+   generateRegMemInstruction(CMP2RegMem, node, temp2Reg, generateX86MemoryReference(objClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+   generateLabelInstruction(JAE4, node, throwLabel, cg);
+   
+   // check obj class's super class array entry
+   // temp1Reg holds superClasses array of obj class
+   // An alternative sequences requiring one less register may be:
+   // SHL temp2Reg, 3 for 64-bit or 2 for 32-bit
+   // ADD temp2Reg, [temp3Reg, superclasses offset]
+   // CMP classClassReg, [temp2Reg]
+   // On 64 bit, the extra reg isn't likely to cause significant register pressure. 
+   // On 32 bit, it could put more register pressure due to limited number of regs. 
+   // Since 64-bit is more prevalent, we opt to optimize for 64bit in this case
+   generateRegMemInstruction(LRegMem(), node, temp1Reg, generateX86MemoryReference(objClassReg, offsetof(J9Class, superclasses), cg), cg);
+   generateRegMemInstruction(CMPRegMem(use64BitClasses), node, castClassReg,
+       generateX86MemoryReference(temp1Reg, temp2Reg, TR::Compiler->target.is64Bit()?3:2, cg), cg);
+   generateLabelInstruction(JNE4, node, throwLabel, cg);
+   
+   // throw classCastException
+   {
+      TR_OutlinedInstructionsGenerator og(throwLabel, node, cg);
+      generateRegInstruction(PUSHReg, node, objClassReg, cg);
+      generateRegInstruction(PUSHReg, node, castClassReg, cg);
+      auto call = generateHelperCallInstruction(node, TR_throwClassCastException, NULL, cg);
+      call->setNeedsGCMap(0xFF00FFFF);
+      call->setAdjustsFramePointerBy(-2*(int32_t)sizeof(J9Class*));
+   }
+   
+   TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, 8, cg);
+   
+   deps->addPostCondition(ObjReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(castClassReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(temp1Reg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(temp2Reg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(objClassReg, TR::RealRegister::NoReg, cg);
+   
+   TR::Node *callNode = outlinedHelperCall->getCallNode();
+   TR::Register *reg;
+   
+   if (callNode->getFirstChild() == node->getFirstChild())
+      if (reg = callNode->getFirstChild()->getRegister())
+         deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+   
+   if (callNode->getSecondChild() == node->getSecondChild())
+      if (reg = callNode->getSecondChild()->getRegister())
+         deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+   
+   deps->stopAddingConditions();
+   
+   generateLabelInstruction(LABEL, node, fallThruLabel, deps, cg);
+   
+   cg->stopUsingRegister(temp1Reg);
+   cg->stopUsingRegister(temp2Reg);
+   cg->stopUsingRegister(objClassReg);
+   
+   // Decrement use counts on the children
+   //
+   cg->decReferenceCount(node->getFirstChild());
+   cg->decReferenceCount(node->getSecondChild());   
+   }
 
 inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node* node, TR_OpaqueClassBlock* clazz, TR::CodeGenerator* cg, bool isCheckCast)
    {
@@ -3974,7 +4116,11 @@ TR::Register *J9::X86::TreeEvaluator::checkcastinstanceofEvaluator(TR::Node *nod
          break;
       }
    auto clazz = TR::TreeEvaluator::getCastClassAddress(node->getChild(1));
-   if (clazz &&
+   if (isCheckCast && !clazz && !cg->comp()->getOption(TR_DisableInlineCheckCast) && (!cg->comp()->compileRelocatableCode() || cg->comp()->getOption(TR_UseSymbolValidationManager)))
+      {
+      generateInlinedCheckCastForDynamicCastClass(node, cg);
+      }
+   else if (clazz &&
        !TR::Compiler->cls.isClassArray(cg->comp(), clazz) && // not yet optimized
        (!cg->comp()->compileRelocatableCode() || cg->comp()->getOption(TR_UseSymbolValidationManager)) &&
        !cg->comp()->getOption(TR_DisableInlineCheckCast)  &&


### PR DESCRIPTION
Currently on X checkcast evaluator only supports inline evaluation for
constant cast classes. If the cast class is not known at compile time a VM
helper call is generated. With upcoming optimizer changes where certain
instanceOf nodes are transformed into checkcast with dynamic cast class,
there is a need to support the inline evaluation for these new cases. This
PR provides such support. It inlines the checkcast instructions needed for
interface and class case; for array case, a VM helper call is generated,
but this is the same as in constant cast class case since array cases are
believed to be uncommon. As the cast class is dynamic, runtime tests need
to be generated to tell if the cast class is array, interface, or class.
For interface, a tight loop through the itable is generated; for class,
the necessary equality test and superclass test are generated.
Consideration was made to add some form of cache slot similar to the
constant case; but given that the cast class is dynamic, 1) instead of
just 1 slot, we would need 2 slots to match both the cast class and the
cached value in order to produce a hit, and 2) given the dynamic nature
where the cast class will potentially vary every time the checkcast is
executed, the hit rate for the cached pair are likely low. So this as an
initial support only inlines the necessary tests without the cached slots,
which can be added as a followup change in the future.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>