### PR TITLE
Disable SVM during Startup

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7451,6 +7451,14 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   options->setOption(TR_EnableGRACostBenefitModel, false);
                }
 
+            // Disable AOT w/ SVM during startup
+            if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP)
+               {
+               static char *dontDisableSVMDuringStartup = feGetEnv("TR_DontDisableSVMDuringStartup");
+               if (!dontDisableSVMDuringStartup)
+                  options->setOption(TR_UseSymbolValidationManager, false);
+               }
+
             // See if we need to inset GCR trees
             if (!details.supportsInvalidation())
                {


### PR DESCRIPTION
Mild admission of defeat, but since there are issues in startup on multiple platforms in Java 11, this is a temporary solution until a better one is implemented. For the most part it seems the reason SVM regresses startup is because of increased load failures that comes from compiling at invocation count 1000 (or 250) but loading at invocation count 20 (https://github.com/eclipse/openj9/issues/4897).