### PR TITLE
Call different Build and Test jobs based on BUILD_IDENTIFIER

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -367,7 +367,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                 name -= '+jitaas'
                 TEST_FLAG = 'JITAAS'
             }
-            def TEST_JOB_NAME = get_test_job_name(name, SPEC, SDK_VERSION)
+            def TEST_JOB_NAME = get_test_job_name(name, SPEC, SDK_VERSION, BUILD_IDENTIFIER)
 
             testjobs["${TEST_JOB_NAME}"] = {
                 if (ARTIFACTORY_CREDS) {
@@ -405,14 +405,29 @@ def get_test_target_names() {
     return targetNames
 }
 
-def get_build_job_name(spec, version) {
-    return "Build-JDK${version}-${spec}"
+def get_build_job_name(spec, version, identifier) {
+    id = convert_build_identifier(identifier)
+    return "Build_JDK${version}_${spec}_${id}"
 }
 
-def get_test_job_name(targetName, spec, version) {
-    return "Test-${targetName}-JDK${version}-${spec}"
+def get_test_job_name(targetName, spec, version, identifier) {
+    id = convert_build_identifier(identifier)
+    return "Test_openjdk${version}_j9_${targetName}_${spec}_${id}"
 }
 
+def convert_build_identifier(val) {
+    switch (val) {
+        case "Nightly":
+        case "Release":
+            return val
+            break
+        case ~/^.*-Acceptance$/:
+            return val.substring(0,val.indexOf('-'))
+            break
+        default:
+            return "Personal"
+    }
+}
 /*
 * Finds the downstream builds of a build.
 * Limits the search only to the downstream builds with given names.
@@ -465,7 +480,7 @@ def get_build_embedded_status_link(build) {
 /*
 * Returns a map storing the downstream job names for given version and spec.
 */
-def get_downstream_job_names(spec, version) {
+def get_downstream_job_names(spec, version, identifier) {
     /* e.g. [build:                 Build-JDK11-linux_390-64_cmprssptrs,
              extended.functional:   Test-extended.functional-JDK11-linux_390-64_cmprssptrs,
              extended.system:       Test-extended.system-JDK11-linux_390-64_cmprssptrs,
@@ -474,10 +489,10 @@ def get_downstream_job_names(spec, version) {
     */
 
     downstreamJobNames = [:]
-    downstreamJobNames.put('build', get_build_job_name(spec, version))
+    downstreamJobNames.put('build', get_build_job_name(spec, version, identifier))
 
     for (target in get_test_target_names().sort()) {
-        downstreamJobNames.put(target, get_test_job_name(target, spec, version))
+        downstreamJobNames.put(target, get_test_job_name(target, spec, version, identifier))
     }
 
     return downstreamJobNames

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -51,7 +51,7 @@ def configure() {
     stage('Configure Test') {
         timestamps {
             dir ('openj9/test/TestConfig') {
-                withEnv(["SPEC=${SPEC}", "JAVA_BIN=${JAVA_BIN}", "NATIVE_TEST_LIBS=${NATIVE_TEST_LIBS}"]) {
+                withEnv(["JAVA_BIN=${JAVA_BIN}", "NATIVE_TEST_LIBS=${NATIVE_TEST_LIBS}"]) {
                     sh 'make -f run_configure.mk'
                 }
             }
@@ -71,7 +71,7 @@ def compile() {
     stage('Compile Test') {
         timestamps {
             dir ('openj9/test/TestConfig') {
-                withEnv(["SPEC=${SPEC}", "JAVA_BIN=${JAVA_BIN}", "NATIVE_TEST_LIBS=${NATIVE_TEST_LIBS}"]) {
+                withEnv(["JAVA_BIN=${JAVA_BIN}", "NATIVE_TEST_LIBS=${NATIVE_TEST_LIBS}"]) {
                     sh 'make compile'
                 }
             }
@@ -83,7 +83,7 @@ def test() {
     stage('Test') {
         timestamps {
             dir ('openj9/test/TestConfig') {
-                withEnv(["SPEC=${SPEC}", "JAVA_BIN=${JAVA_BIN}", "NATIVE_TEST_LIBS=${NATIVE_TEST_LIBS}"]) {
+                withEnv(["JAVA_BIN=${JAVA_BIN}", "NATIVE_TEST_LIBS=${NATIVE_TEST_LIBS}"]) {
                     sh "make ${TEST_TARGET}"
                 }
             }

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -337,8 +337,8 @@ def get_user_credentials_id(KEY) {
 * to run a Jenkins job.
 * Fetches the labels from the variables file when the node is not set as build
 * parameter.
-* The node's labels could be a single label - e.g. label1 - or a boolean 
-* expression - e.g. label1 && label2 || label3. 
+* The node's labels could be a single label - e.g. label1 - or a boolean
+* expression - e.g. label1 && label2 || label3.
 */
 def set_node(job_type) {
     // fetch labels for given platform/spec
@@ -507,7 +507,7 @@ def set_build_identifier() {
                 BUILD_IDENTIFIER = "${BUILD_USER_EMAIL}"
             }
         } else {
-            echo "WARNING: Can't determine appropriate BUILD_DENTIFIER automatically. Please add it as a build parameter if you would like it set."
+            echo "WARNING: Can't determine appropriate BUILD_IDENTIFIER automatically. Please add it as a build parameter if you would like it set."
         }
     }
     if (BUILD_IDENTIFIER) {
@@ -609,6 +609,27 @@ def validate_arguments(ARGS) {
             // exported as environment variables and it will overwrite the
             // make SPEC variable set in the configure phase in build.build() method
             SPEC = params.get(arg)
+
+            // TEMPORARILY MAP old spec names to new spec names for PR builds.
+            // This can be removed in #2836.
+            def REVERSE_SPEC_MAP = [
+                    'aix_ppc-64_cmprssptrs' : 'ppc64_aix',
+                    'linux_ppc-64_cmprssptrs_le' : 'ppc64le_linux',
+                    'linux_390-64_cmprssptrs' : 's390x_linux',
+                    'zos_390-64_cmprssptrs' : 's390x_zos',
+                    'linux_x86-64_cmprssptrs' : 'x86-64_linux',
+                    'linux_x86-64' : 'x86-64_linux_xl',
+                    'linux_x86-64_cmprssptrs_cmake' : 'x86-64_linux_cm',
+                    'win_x86' : 'x86-32_windows',
+                    'win_x86-64_cmprssptrs' : 'x86-64_windows',
+                    'osx_x86-64': 'x86-64_mac_xl',
+                    'osx_x86-64_cmprssptrs' : 'x86-64_mac']
+
+            if (REVERSE_SPEC_MAP.keySet().contains(SPEC)) {
+                echo "Converting SPEC:'${SPEC}'..."
+                SPEC = REVERSE_SPEC_MAP[SPEC]
+                echo "to SPEC:'${SPEC}'"
+            }
         }
     }
 }
@@ -715,7 +736,7 @@ def set_vendor_variables() {
         // fetch from variables file
 
         if (VARIABLES.vendor_source && VARIABLES.vendor_source.test) {
-            // parse the vendor source multi-map 
+            // parse the vendor source multi-map
             // and populate the VENDOR_TEST_* maps
 
              VARIABLES.vendor_source.test.each { entry ->
@@ -773,7 +794,7 @@ def get_repo_name_from_url(URL) {
 */
 def get_build_releases(releases_by_specs) {
     def build_releases = []
-    
+
     // find releases to build based on given specs
     releases_by_specs.values().each { versions ->
         build_releases.addAll(versions)
@@ -997,7 +1018,7 @@ def set_adoptopenjdk_tests_repository(build_releases=null) {
 }
 
 // Creates a job using the job DSL plugin on Jenkins
-def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType){
+def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType, id){
 
     // NOTE: The following 4 DEFAULT variables can be configured in the Jenkins Global Config.
     // This allows us to know what the default values are without being told explicitly.
@@ -1017,8 +1038,7 @@ def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType){
 
     // Configruing the build discarder in the downstream project
 
-    DISCARDER_NUM_BUILDS = get_value(VARIABLES.build_discarder.logs, downstreamJobType)
-    DISCARDER_NUM_ARTIFACTS = get_value(VARIABLES.build_discarder.artifacts, downstreamJobType)
+    DISCARDER_NUM_BUILDS = get_value(VARIABLES.build_discarder.logs, id)
 
     def params = [:]
     params.put('JOB_NAME', JOB_NAME)
@@ -1030,7 +1050,6 @@ def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType){
     params.put('VENDOR_CREDENTIALS_ID_DEFAULT', VENDOR_CREDENTIALS_ID_DEFAULT)
     params.put('jobType', downstreamJobType)
     params.put('DISCARDER_NUM_BUILDS', DISCARDER_NUM_BUILDS)
-    params.put('DISCARDER_NUM_ARTIFACTS', DISCARDER_NUM_ARTIFACTS)
 
     def templatePath = 'buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy'
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -29,7 +29,7 @@
  *
  * Parameters:
  *   PLATFORMS: String - Comma separated platforms to build.
- *              Expected values: all or any of the following: 
+ *              Expected values: all or any of the following:
  *              aix_ppc-64_cmprssptrs,
  *              linux_x86-64,
  *              linux_x86-64_cmprssptrs,
@@ -78,17 +78,17 @@
 RELEASES = ['8', '9', '10', '11', '12', 'next']
 CURRENT_RELEASES = ['8', '11', '12', 'next']
 
-SPECS = ['aix_ppc-64_cmprssptrs'      : CURRENT_RELEASES,
-         'linux_390-64_cmprssptrs'    : CURRENT_RELEASES,
-         'linux_ppc-64_cmprssptrs_le' : CURRENT_RELEASES,
-         'linux_x86-64'               : CURRENT_RELEASES,
-         'linux_x86-64_cmprssptrs'    : CURRENT_RELEASES,
-         'linux_x86-64_cmprssptrs_cmake' : ['8', '11'],
-         'win_x86'                    : ['8'],
-         'win_x86-64_cmprssptrs'      : CURRENT_RELEASES,
-         'zos_390-64_cmprssptrs'      : ['11'],
-         'osx_x86-64'                 : CURRENT_RELEASES,
-         'osx_x86-64_cmprssptrs'      : CURRENT_RELEASES]
+SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
+         'ppc64le_linux'  : CURRENT_RELEASES,
+         's390x_linux'    : CURRENT_RELEASES,
+         's390x_zos'      : ['11'],
+         'x86-64_linux_xl': CURRENT_RELEASES,
+         'x86-64_linux'   : CURRENT_RELEASES,
+         'x86-64_linux_cm': ['8', '11'],
+         'x86-64_mac_xl'  : CURRENT_RELEASES,
+         'x86-64_mac'     : CURRENT_RELEASES,
+         'x86-32_windows' : ['8'],
+         'x86-64_windows' : CURRENT_RELEASES]
 
 // Initialize all PARAMETERS (params) to Groovy Variables even if they are not passed
 echo "Initialize all PARAMETERS..."
@@ -186,7 +186,7 @@ try {
                                 }
 
                                 if (AUTOMATIC_GENERATION != 'false'){
-                                    variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline')
+                                    variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline', buildFile.convert_build_identifier(BUILD_IDENTIFIER))
                                 }
 
                                 builds["${job_name}"] = { build(job_name, REPO, BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, AUTOMATIC_GENERATION, CUSTOM_DESCRIPTION) }
@@ -216,7 +216,7 @@ try {
     }
 } finally {
     // add summary badge
-    table = get_summary_table()
+    table = get_summary_table(BUILD_IDENTIFIER)
     if (table) {
         manager.createSummary("plugin.png").appendText(table)
     }
@@ -311,13 +311,13 @@ def get_value_by_spec(map, release, spec) {
 }
 
 def get_pipeline_name(spec, version) {
-    return "Pipeline-Build-Test-JDK${version}-${spec}"
+    return "Pipeline_Build_Test_JDK${version}_${spec}"
 }
 
 /*
 * Returns an HTML summary table for the downstream builds.
 */
-def get_summary_table() {
+def get_summary_table(identifier) {
     // fetch the downstream builds of the current build
     def pipelineBuilds = buildFile.get_downstream_builds(currentBuild, currentBuild.projectName, pipelineNames)
     if (pipelineBuilds.isEmpty()) {
@@ -325,17 +325,6 @@ def get_summary_table() {
     }
 
     def buildReleases = get_sorted_releases()
-    def specShortNames = ['aix_ppc-64_cmprssptrs'          : 'aix-ppc64',
-                          'linux_390-64_cmprssptrs'        : 'linux-s390x',
-                          'linux_ppc-64_cmprssptrs_le'     : 'linux-ppc64le',
-                          'linux_x86-64'                   : 'linux-x64-XL',
-                          'linux_x86-64_cmprssptrs'        : 'linux-x64',
-                          'linux_x86-64_cmprssptrs_cmake'  : 'linux-x64-CM',
-                          'win_x86'                        : 'win-x32',
-                          'win_x86-64_cmprssptrs'          : 'win-x64',
-                          'zos_390-64_cmprssptrs'          : 'zos-390',
-                          'osx_x86-64'                     : 'osx-x64-XL',
-                          'osx_x86-64_cmprssptrs'          : 'osx-x64']
 
     def headerCols = ['']
     headerCols.addAll(buildReleases)
@@ -357,7 +346,7 @@ def get_summary_table() {
     for (spec in BUILD_SPECS.keySet().sort()){
         // table row
         summaryText += "<tr>"
-        summaryText += "<td style=\"font-weight: bold;\">${specShortNames[spec]}</td>"
+        summaryText += "<td style=\"font-weight: bold;\">${spec}</td>"
         def showLabel = true
 
         buildReleases.each { release ->
@@ -368,7 +357,7 @@ def get_summary_table() {
             if (BUILD_SPECS.get(spec).contains(release)) {
                 def pipelineName = get_pipeline_name(spec, release)
                 def build = pipelineBuilds.get(pipelineName)
-                def downstreamJobNames = buildFile.get_downstream_job_names(spec, release)
+                def downstreamJobNames = buildFile.get_downstream_job_names(spec, release, identifier)
 
                 if (build) {
                     def pipelineLink = buildFile.get_build_embedded_status_link(build)

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -38,9 +38,9 @@ timestamps {
 
             buildFile = load 'buildenv/jenkins/common/pipeline-functions'
             SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_SHAS_MAP)
-            BUILD_NAME = buildFile.get_build_job_name(SPEC, SDK_VERSION)
+            BUILD_NAME = buildFile.get_build_job_name(SPEC, SDK_VERSION, BUILD_IDENTIFIER)
             if (params.AUTOMATIC_GENERATION != 'false'){
-                variableFile.create_job(BUILD_NAME, SDK_VERSION, SPEC, 'build')
+                variableFile.create_job(BUILD_NAME, SDK_VERSION, SPEC, 'build', buildFile.convert_build_identifier(BUILD_IDENTIFIER))
             }
         } finally {
             // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
@@ -52,7 +52,7 @@ timestamps {
         jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_DIRS_MAP, USER_CREDENTIALS_ID, BUILD_LIST, SETUP_LABEL, ghprbGhRepository, ghprbActualCommit, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, BUILD_NAME, CUSTOM_DESCRIPTION)
     } finally {
         //display the build status of the downstream jobs
-        def downstreamBuilds = buildFile.get_downstream_builds(currentBuild, currentBuild.projectName, buildFile.get_downstream_job_names(SPEC, SDK_VERSION).values())
+        def downstreamBuilds = buildFile.get_downstream_builds(currentBuild, currentBuild.projectName, buildFile.get_downstream_job_names(SPEC, SDK_VERSION, BUILD_IDENTIFIER).values())
         add_badges(downstreamBuilds)
         add_summary_badge(downstreamBuilds)
     }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -27,16 +27,15 @@ if (!binding.hasVariable('VENDOR_REPO_DEFAULT')) VENDOR_REPO_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_BRANCH_DEFAULT')) VENDOR_BRANCH_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID_DEFAULT = ''
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
-if (!binding.hasVariable('DISCARDER_NUM_ARTIFACTS')) DISCARDER_NUM_ARTIFACTS = '1'
+if (!binding.hasVariable('GIT_URI')) GIT_URI = 'https://github.com/eclipse/openj9.git'
+if (!binding.hasVariable('GIT_BRANCH')) GIT_BRANCH = 'refs/heads/master'
 
-def GIT_URI = 'https://github.com/eclipse/openj9.git'
-def GIT_BRANCH = 'refs/heads/master'
-
-def pipelineScript = ''
-if (jobType == 'build'){
+if (jobType == 'build') {
     pipelineScript = 'buildenv/jenkins/jobs/builds/Build-Test-Any-Platform'
-} else if (jobType == 'pipeline'){
+} else if (jobType == 'pipeline') {
     pipelineScript = 'buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform'
+} else {
+    error "Unknown build type:'${jobType}'"
 }
 
 pipelineJob("$JOB_NAME") {
@@ -60,7 +59,6 @@ pipelineJob("$JOB_NAME") {
     }
     logRotator {
         numToKeep(DISCARDER_NUM_BUILDS.toInteger())
-        artifactNumToKeep(DISCARDER_NUM_ARTIFACTS.toInteger())
     }
     parameters {
         choiceParam('SDK_VERSION', ["${SDK_VERSION}"])
@@ -90,7 +88,7 @@ pipelineJob("$JOB_NAME") {
         stringParam('OPENJDK_CLONE_DIR')
         stringParam('PERSONAL_BUILD')
         stringParam('CUSTOM_DESCRIPTION')
-        
+
         if (jobType == 'pipeline'){
             stringParam('TESTS_TARGETS')
             stringParam('BUILD_NODE')

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -78,20 +78,21 @@ test_dependencies_job_name: 'test.getDependency'
 slack_channel: '#jenkins'
 build_discarder:
   logs:
-    build: 20
-    pipeline: 20
+    Nightly: 10
+    Release: 10
+    OMR: 20
+    OpenJDK: 20
+    Personal: 50
+    # tmp PRs
     pullRequest: 50
-  artifacts:
-    build: 10
-    pipeline: 0
-    pullRequest: 0
+    Pipeline: 100
 restart_timeout:
   time: '5'
   units: 'HOURS'
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#
-linux_ppc-64_cmprssptrs_le:
+ppc64le_linux:
   boot_jdk:
     8: '/usr/lib/jvm/adoptojdk-java-80'
     9: '/usr/lib/jvm/adoptojdk-java-80'
@@ -135,7 +136,7 @@ linux_ppc-64_cmprssptrs_le:
 # Note: boot_jdk 8 must use an Adopt JDK8 build rather than an
 # IBM 7 for the bootJDK or compiling corba will fail to find Object.
 #========================================#
-linux_390-64_cmprssptrs:
+s390x_linux:
   boot_jdk:
     8: '/usr/lib/jvm/adoptojdk-java-s390x-80'
     9: '/usr/lib/jvm/adoptojdk-java-s390x-80'
@@ -177,7 +178,7 @@ linux_390-64_cmprssptrs:
 #========================================#
 # AIX PPC 64bits Compressed Pointers
 #========================================#
-aix_ppc-64_cmprssptrs:
+ppc64_aix:
   boot_jdk:
     8: '/usr/java7'
     9: '/usr/java8_64'
@@ -216,7 +217,7 @@ aix_ppc-64_cmprssptrs:
 #========================================#
 # Linux x86 64bits Compressed Pointers
 #========================================#
-linux_x86-64_cmprssptrs:
+x86-64_linux:
   boot_jdk:
     8: '/usr/lib/jvm/jdk-7'
     9: '/usr/lib/jvm/adoptojdk-java-80'
@@ -258,7 +259,7 @@ linux_x86-64_cmprssptrs:
 #========================================#
 # Linux x86 64bits Compressed Pointers /w CMake
 #========================================#
-linux_x86-64_cmprssptrs_cmake:
+x86-64_linux_cm:
   boot_jdk:
     8: '/usr/lib/jvm/jdk-7'
     9: '/usr/lib/jvm/adoptojdk-java-80'
@@ -310,7 +311,7 @@ linux_x86-64_cmprssptrs_cmake:
 #========================================#
 # Linux x86 64bits Large Heap
 #========================================#
-linux_x86-64:
+x86-64_linux_xl:
   boot_jdk:
     8: '/usr/lib/jvm/jdk-7'
     9: '/usr/lib/jvm/adoptojdk-java-80'
@@ -355,7 +356,7 @@ linux_x86-64:
 #========================================#
 # Windows x86 64bits Compressed Pointers
 #========================================#
-win_x86-64_cmprssptrs:
+x86-64_windows:
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
     9: '/cygdrive/c/openjdk/jdk8'
@@ -396,7 +397,7 @@ win_x86-64_cmprssptrs:
 #========================================#
 # Windows x86 32bits
 #========================================#
-win_x86:
+x86-32_windows:
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
   release:
@@ -414,7 +415,7 @@ win_x86:
 #========================================#
 # OSX x86 64bits Compressed Pointers
 #========================================#
-osx_x86-64_cmprssptrs:
+x86-64_mac:
   boot_jdk:
     8: '/Users/jenkins/bootjdks/adoptojdk-java-8'
     11: '/Users/jenkins/bootjdks/adoptojdk-java-11'
@@ -447,7 +448,7 @@ osx_x86-64_cmprssptrs:
 #========================================#
 # OSX x86 64bits Large Heap
 #========================================#
-osx_x86-64:
+x86-64_mac_xl:
   boot_jdk:
     8: '/Users/jenkins/bootjdks/adoptojdk-java-8'
     11: '/Users/jenkins/bootjdks/adoptojdk-java-11'


### PR DESCRIPTION
- Keep Pipeine-Build-Test* jobs common
- Separates Build* and Test* jobs
- Set BuildDiscarder differently per BUILD_IDENTIFIER
   - Keep different number of build logs depending on
     which BUILD_IDENTIFIER the job is
   - Remove BuildDiscader for Artifacts since we are
     using Artifactory
- Change Spec names to match AdoptOpenJDK convention
- Change Build and Pipeline job names to more closely match AdoptOpenJDK
- Change Test job names to match AdoptOpenJDK
- Allow custom Git repo/branch for autogen jobs
- Remove DISCARDER_NUM_ARTIFACTS from autogen since we are
  using Artifactory now
- Add temporary reverse spec map to allow old specs from old
  style PR builds to map to the new spec names
- Remove SPEC from testing ENV so spec names don't conflict

[skip ci]
Related #2728 (comment)
Related #5210

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>