### PR TITLE
Enable software concurrent scavenge on z

### DIFF
--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -854,7 +854,7 @@ END_PROC(jitFillOSRBufferReturn)
 
 dnl Expects r3 to already contain the vmThread.
 dnl Expects r4 to already contain the address being loaded from.
-START_PROC(jitReadBarrier)
+START_PROC(jitSoftwareReadBarrier)
 ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
 	staddr r0,JIT_GPR_SAVE_SLOT(0)
 	SAVE_LR
@@ -875,10 +875,10 @@ ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
 	laddr r0,JIT_GPR_SAVE_SLOT(0)
 	blr
 },{
-dnl jitReadBarrier is not supported if OMR_GC_CONCURRENT_SCAVENGER is not set
+dnl jitSoftwareReadBarrier is not supported if OMR_GC_CONCURRENT_SCAVENGER is not set
 	trap
 })
-END_PROC(jitReadBarrier)
+END_PROC(jitSoftwareReadBarrier)
 
 dnl Expects r3 to already contain vmThread.
 dnl Expects r4 to already contain srcObj.

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -992,7 +992,7 @@ END_PROC(jitDecompileOnReturnJ)
 
 })	dnl ASM_J9VM_ENV_DATA64
 
-START_PROC(jitReadBarrier)
+START_PROC(jitSoftwareReadBarrier)
 ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
 	pop uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	SWITCH_TO_C_STACK
@@ -1011,7 +1011,7 @@ ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
 	dnl not supported
 	int 3
 })	dnl OMR_GC_CONCURRENT_SCAVENGER
-END_PROC(jitReadBarrier)
+END_PROC(jitSoftwareReadBarrier)
 
 	FASTCALL_EXTERN(impl_jitReferenceArrayCopy,2)
 START_PROC(jitReferenceArrayCopy)

--- a/runtime/codert_vm/znathelp.m4
+++ b/runtime/codert_vm/znathelp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2017, 2018 IBM Corp. and others
+dnl Copyright (c) 2017, 2019 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -429,6 +429,20 @@ dnl Switch from the C stack to the java stack and jump via tempSlot
 BEGIN_FUNC(jitRunOnJavaStack)
     SWITCH_TO_JAVA_STACK
     BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
+END_CURRENT
+
+dnl CARG2 is expected to contain reference field address
+BEGIN_HELPER(jitSoftwareReadBarrier)
+    SAVE_ALL_REGS(jitSoftwareReadBarrier)
+
+    LR_GPR CARG1,J9VMTHREAD
+    L_GPR CRA,J9TR_VMThread_javaVM(J9VMTHREAD)
+    L_GPR CRA,J9TR_JavaVM_memoryManagerFunctions(CRA)
+    L_GPR CRA,J9TR_J9MemoryManagerFunctions_J9ReadBarrier(CRA)
+    CALL_INDIRECT(CRA)
+
+    RESTORE_ALL_REGS_AND_SWITCH_TO_JAVA_STACK(jitSoftwareReadBarrier)
+    br r14
 END_CURRENT
 
 dnl When the offload helpers are called,

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -83,6 +83,8 @@ public:
 
    void doInstructionSelection();
 
+   void createReferenceReadBarrier(TR::TreeTop* treeTop, TR::Node* parent);
+
    // OSR, not code generator
    void populateOSRBuffer();
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1920,11 +1920,11 @@ UDATA TR_J9VMBase::thisThreadGetConcurrentScavengeActiveByteAddressOffset()
 UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-#if defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
    return offsetof(J9VMThread, readBarrierRangeCheckBaseCompressed);
 #else
    return offsetof(J9VMThread, readBarrierRangeCheckBase);
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390) */
+#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    TR_ASSERT(0,"Field readBarrierRangeCheckBase does not exists in J9VMThread.");
    return 0;
@@ -1937,11 +1937,11 @@ UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
 UDATA TR_J9VMBase::thisThreadGetEvacuateTopAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-#if defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
    return offsetof(J9VMThread, readBarrierRangeCheckTopCompressed);
 #else
    return offsetof(J9VMThread, readBarrierRangeCheckTop);
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390) */
+#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    TR_ASSERT(0,"Field readBarrierRangeCheckTop does not exists in J9VMThread.");
    return 0;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1235,7 +1235,7 @@ TR::Register *J9::Power::TreeEvaluator::irdbarEvaluator(TR::Node *node, TR::Code
 
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 7, cg->trMemory());
    deps->addPostCondition(objReg, TR::RealRegister::NoReg);
-   deps->addPostCondition(locationReg, TR::RealRegister::gr4); //TR_readBarrier helper needs this in gr4.
+   deps->addPostCondition(locationReg, TR::RealRegister::gr4); //TR_softwareReadBarrier helper needs this in gr4.
    deps->addPostCondition(evacuateReg, TR::RealRegister::NoReg);
    deps->addPostCondition(r3Reg, TR::RealRegister::gr3);
    deps->addPostCondition(r11Reg, TR::RealRegister::gr11);
@@ -1292,10 +1292,10 @@ TR::Register *J9::Power::TreeEvaluator::irdbarEvaluator(TR::Node *node, TR::Code
    generateTrg1Src2Instruction(cg, TR::InstOpCode::cmpl4, node, condReg, objReg, evacuateReg);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::bgt, node, endLabel, condReg);
 
-   // TR_readBarrier helper expects the vmThread in r3.
+   // TR_softwareReadBarrier helper expects the vmThread in r3.
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_readBarrier, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
    generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptrj_t)helperSym->getMethodAddress(), deps, helperSym);
 
    // For compr refs caseL if monitored loads is supported and we are loading an address, use monitored loads instruction
@@ -1372,7 +1372,7 @@ TR::Register *J9::Power::TreeEvaluator::ardbarEvaluator(TR::Node *node, TR::Code
 
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 7, cg->trMemory());
    deps->addPostCondition(tempReg, TR::RealRegister::NoReg);
-   deps->addPostCondition(locationReg, TR::RealRegister::gr4); //TR_readBarrier helper needs this in gr4.
+   deps->addPostCondition(locationReg, TR::RealRegister::gr4); //TR_softwareReadBarrier helper needs this in gr4.
    deps->addPostCondition(evacuateReg, TR::RealRegister::NoReg);
    deps->addPostCondition(r3Reg, TR::RealRegister::gr3);
    deps->addPostCondition(r11Reg, TR::RealRegister::gr11);
@@ -1430,10 +1430,10 @@ TR::Register *J9::Power::TreeEvaluator::ardbarEvaluator(TR::Node *node, TR::Code
    generateTrg1Src2Instruction(cg, TR::InstOpCode::Op_cmpl, node, condReg, tempReg, evacuateReg);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::bgt, node, endLabel, condReg);
 
-   // TR_readBarrier helper expects the vmThread in r3.
+   // TR_softwareReadBarrier helper expects the vmThread in r3.
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
-   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_readBarrier, false, false, false);
+   TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
    generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptrj_t)helperSym->getMethodAddress(), deps, helperSym);
 
    // if monitored loads is supported and we are loading an address, use monitored loads instruction
@@ -8921,7 +8921,7 @@ static TR::Register *VMinlineCompareAndSwapObject(TR::Node *node, TR::CodeGenera
       deps->getPostConditions()->getRegisterDependency(0)->setExcludeGPR0();
       deps->addPostCondition(offsetReg, TR::RealRegister::NoReg);
       deps->addPostCondition(tmpReg, TR::RealRegister::NoReg);
-      deps->addPostCondition(locationReg, TR::RealRegister::gr4); //TR_readBarrier helper needs this in gr4.
+      deps->addPostCondition(locationReg, TR::RealRegister::gr4); //TR_softwareReadBarrier helper needs this in gr4.
       deps->addPostCondition(evacuateReg, TR::RealRegister::NoReg);
       deps->addPostCondition(r3Reg, TR::RealRegister::gr3);
       deps->addPostCondition(r11Reg, TR::RealRegister::gr11);
@@ -8958,10 +8958,10 @@ static TR::Register *VMinlineCompareAndSwapObject(TR::Node *node, TR::CodeGenera
 
       generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, locationReg, objReg, offsetReg);
 
-      // TR_readBarrier helper expects the vmThread in r3.
+      // TR_softwareReadBarrier helper expects the vmThread in r3.
       generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, r3Reg, metaReg);
 
-      TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_readBarrier, false, false, false);
+      TR::SymbolReference *helperSym = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_softwareReadBarrier, false, false, false);
       generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptrj_t)helperSym->getMethodAddress(), deps, helperSym);
 
       generateDepLabelInstruction(cg, TR::InstOpCode::label, node, endReadBarrierLabel, deps);

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1058,8 +1058,8 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_typeCheckArrayStore,        (void *)jitTypeCheckArrayStoreWithNullCheck,   TR_Helper);
 #endif
 
-#if defined(TR_HOST_X86) || defined(TR_HOST_POWER)
-   SET(TR_readBarrier,                                      (void *)jitReadBarrier,                                    TR_Helper);
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390)
+   SET(TR_softwareReadBarrier,                              (void *)jitSoftwareReadBarrier,                         TR_Helper);
 #endif
    SET(TR_writeBarrierStore,                                (void *)jitWriteBarrierStore,                              TR_Helper);
    SET(TR_writeBarrierStoreGenerational,                    (void *)jitWriteBarrierStoreGenerational,                  TR_Helper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -55,7 +55,6 @@ extern "C" {
 #define JIT_HELPER(x) extern "C" void x()
 #endif
 
-
 /* #include "VM.hpp" */
 
 JIT_HELPER(jitAcquireVMAccess);  // asm calling-convention helper
@@ -90,7 +89,6 @@ JIT_HELPER(jitNewObject);  // asm calling-convention helper
 JIT_HELPER(jitObjectHashCode);  // asm calling-convention helper
 JIT_HELPER(jitPostJNICallOffloadCheck);  // asm calling-convention helper
 JIT_HELPER(jitPreJNICallOffloadCheck);  // asm calling-convention helper
-JIT_HELPER(jitReadBarrier);  // asm calling-convention helper
 JIT_HELPER(jitReferenceArrayCopy);  // asm calling-convention helper
 JIT_HELPER(jitReleaseVMAccess);  // asm calling-convention helper
 JIT_HELPER(jitReportMethodEnter);  // asm calling-convention helper
@@ -165,6 +163,7 @@ JIT_HELPER(jitReportInstanceFieldRead); // asm calling-convention helper
 JIT_HELPER(jitReportInstanceFieldWrite); // asm calling-convention helper
 JIT_HELPER(jitReportStaticFieldRead); // asm calling-convention helper
 JIT_HELPER(jitReportStaticFieldWrite); // asm calling-convention helper
+JIT_HELPER(jitSoftwareReadBarrier);  // asm calling-convention helper
 
 #ifdef __cplusplus
 }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1014,7 +1014,7 @@ TR::Register* J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node* n
          break;
       case gc_modron_readbar_always:
          generateMemRegInstruction(SMemReg(), node, generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
-         generateHelperCallInstruction(node, TR_readBarrier, NULL, cg);
+         generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
          generateRegMemInstruction(LRegMem(use64BitClasses), node, object, generateX86MemoryReference(address, 0, cg), cg);
          break;
       case gc_modron_readbar_range_check:
@@ -1039,7 +1039,7 @@ TR::Register* J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node* n
          generateRegMemInstruction(CMPRegMem(use64BitClasses), node, object, generateX86MemoryReference(cg->getVMThreadRegister(), cg->comp()->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg), cg);
          generateLabelInstruction(JA4, node, endLabel, cg);
          generateMemRegInstruction(SMemReg(), node, generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
-         generateHelperCallInstruction(node, TR_readBarrier, NULL, cg);
+         generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
          generateRegMemInstruction(LRegMem(use64BitClasses), node, object, generateX86MemoryReference(address, 0, cg), cg);
          generateLabelInstruction(JMP4, node, endLabel, cg);
          }
@@ -9589,7 +9589,7 @@ static TR::Register* inlineCompareAndSwapObjectNative(TR::Node* node, TR::CodeGe
       case gc_modron_readbar_always:
          generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(object, offset, 0, cg), cg);
          generateMemRegInstruction(SMemReg(), node, generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
-         generateHelperCallInstruction(node, TR_readBarrier, NULL, cg);
+         generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
          break;
       case gc_modron_readbar_range_check:
          {
@@ -9616,7 +9616,7 @@ static TR::Register* inlineCompareAndSwapObjectNative(TR::Node* node, TR::CodeGe
          generateLabelInstruction(JA4, node, endLabel, cg);
          generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(object, offset, 0, cg), cg);
          generateMemRegInstruction(SMemReg(), node, generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
-         generateHelperCallInstruction(node, TR_readBarrier, NULL, cg);
+         generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
          generateLabelInstruction(JMP4, node, endLabel, cg);
          }
 

--- a/runtime/vm/guardedstorage.c
+++ b/runtime/vm/guardedstorage.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,6 @@
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 
-J9_EXTERN_BUILDER_SYMBOL(handleSoftwareReadBarrier);
 J9_EXTERN_BUILDER_SYMBOL(handleHardwareReadBarrier);
 
 void
@@ -72,11 +71,7 @@ j9gs_initializeThread(J9VMThread *vmThread)
 			gsControlBlock->designationRegister = 0;
 			gsControlBlock->sectionMask = 0;
 			gsControlBlock->paramListAddr = (uint64_t) &vmThread->gsParameters;
-			if (1 == supportsGuardedStorageFacility) {
-				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleHardwareReadBarrier);
-			} else {
-				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleSoftwareReadBarrier);
-			}
+			vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleHardwareReadBarrier);
 
 			/* Initialize the parameters */
 			j9gs_params_init(&vmThread->gsParameters, gsControlBlock);

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -380,14 +380,6 @@ checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomCla
  * The trap handler that gets invoked when a H/W Read Barrier is triggered
  */
 J9_EXTERN_BUILDER_SYMBOL(handleHardwareReadBarrier);
-
-/**
- * Software Read Barrier Handler
- *
- * The handler that gets invoked by JIT before loads when running concurrent scavenger on hardware
- * that doesn't support guarded storage facility for object that are being evacuated
- */
-J9_EXTERN_BUILDER_SYMBOL(handleSoftwareReadBarrier);
 
 /**
  * Handle a Guarded Storage Event

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2017, 2018 IBM Corp. and others
+dnl Copyright (c) 2017, 2019 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,23 +242,7 @@ PLACE_LABEL(L_GS_FORCE_CRASH)
 END_CURRENT
 })
 
-define({HANDLE_SOFTWARE_READ_BARRIER},{
-BEGIN_HELPER($1)
-    SAVE_ALL_REGS($1)
-    ST_GPR J9SP,J9TR_VMThread_sp(J9VMTHREAD)
-    LR_GPR CARG1,J9VMTHREAD
-    L_GPR CRA,J9TR_VMThread_javaVM(J9VMTHREAD)
-    L_GPR CRA,J9TR_JavaVM_invokeJ9ReadBarrier(CRA)
-    CALL_INDIRECT(CRA)
-    L_GPR J9SP,J9TR_VMThread_sp(J9VMTHREAD)
-    ST_GPR J9SP,JIT_GPR_SAVE_SLOT(J9SP)
-    RESTORE_ALL_REGS_AND_SWITCH_TO_JAVA_STACK($1)
-    BR r14
-END_CURRENT
-})
-
 HANDLE_HARDWARE_READ_BARRIER(handleHardwareReadBarrier)
-HANDLE_SOFTWARE_READ_BARRIER(handleSoftwareReadBarrier)
 })
 
     FILE_END


### PR DESCRIPTION
Implement concurrent scavenge (CS) on z using ardbari opCode to generate
either softare-based or hardware-based CS for reference field loads,
reference array copy, and object compare-and-swap.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>