### PR TITLE
Move classlib.properties to Java 8 extension repo

### DIFF
--- a/runtime/classlib.properties
+++ b/runtime/classlib.properties
@@ -1,7 +1,0 @@
-# Properties file for Java 9 and beyond
-
-# Shape of the class library (e.g. Sun.Basic, Harmony)
-shape=vm.shape
-
-# Version of the class library
-version=1.9

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -457,7 +457,7 @@ scarPreconfigure(J9JavaVM * vm)
 
 		rc = loadClasslibPropertiesFile(vm, &i);
 		if (rc <= 0) {
-			/* loadClasslibPropertiesFile can't find any bootpath from classlib.properties, bail. */
+			/* loadClasslibPropertiesFile can't find any bootpath from classlib.properties, fail. */
 			goto error;
 		}
 


### PR DESCRIPTION
Move `classlib.properties` to `Java 8 extension` repo

`classlib.properties` is only used by `Java 8`;
Moving it to `Java 8 extension` repo;
Also fixed a typo.

Additional note: historically this file was owned by `JCL`, at one point it was moved to `JVM` to accommodate different `JVM shape and JCL level`. Since the `shape` has been removed by https://github.com/eclipse/openj9/pull/4795, this file can be moved back to `JCL`, i.e., `extension` now. 

Depends on: https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/273

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>