### PR TITLE
Salt on Nursery resize

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -183,10 +183,17 @@ MM_GCExtensions::identityHashDataAddRange(MM_EnvironmentBase *env, MM_MemorySubS
 	J9IdentityHashData* hashData = getJavaVM()->identityHashData;
 	if (J9_IDENTITY_HASH_SALT_POLICY_STANDARD == hashData->hashSaltPolicy) {
 		if (MEMORY_TYPE_NEW == (subspace->getTypeFlags() & MEMORY_TYPE_NEW)) {
-			if ((UDATA)lowAddress < hashData->hashData1) {
+			if (hashData->hashData1 == (UDATA)highAddress) {
+				/* Expanding low bound */
 				hashData->hashData1 = (UDATA)lowAddress;
-			}
-			if ((UDATA)highAddress > hashData->hashData2) {
+			} else if (hashData->hashData2 == (UDATA)lowAddress) {
+				/* Expanding high bound */
+				hashData->hashData2 = (UDATA)highAddress;
+			} else {
+				/* First expand */
+				Assert_MM_true(UDATA_MAX == hashData->hashData1);
+				Assert_MM_true(0 == hashData->hashData2);
+				hashData->hashData1 = (UDATA)lowAddress;
 				hashData->hashData2 = (UDATA)highAddress;
 			}
 		}
@@ -199,11 +206,18 @@ MM_GCExtensions::identityHashDataRemoveRange(MM_EnvironmentBase *env, MM_MemoryS
 	J9IdentityHashData* hashData = getJavaVM()->identityHashData;
 	if (J9_IDENTITY_HASH_SALT_POLICY_STANDARD == hashData->hashSaltPolicy) {
 		if (MEMORY_TYPE_NEW == (subspace->getTypeFlags() & MEMORY_TYPE_NEW)) {
-			if ((UDATA)lowAddress > hashData->hashData1) {
-				hashData->hashData1 = (UDATA)lowAddress;
-			}
-			if ((UDATA)highAddress < hashData->hashData2) {
-				hashData->hashData2 = (UDATA)highAddress;
+			if (hashData->hashData1 == (UDATA)lowAddress) {
+				/* Contracting low bound */
+				Assert_MM_true(hashData->hashData1 <= (UDATA)highAddress);
+				Assert_MM_true((UDATA)highAddress <= hashData->hashData2);
+				hashData->hashData1 = (UDATA)highAddress;
+			} else if (hashData->hashData2 == (UDATA)highAddress) {
+				/* Contracting high bound */
+				Assert_MM_true(hashData->hashData1 <= (UDATA)lowAddress);
+				Assert_MM_true((UDATA)lowAddress <= hashData->hashData2);
+				hashData->hashData2 = (UDATA)lowAddress;
+			} else {
+				Assert_MM_unreachable();
 			}
 		}
 	}


### PR DESCRIPTION
Fix incorrect update of low/high Nursery bounds for Hash Salt
calculation purposes.

On Nursery contract, the new bounds would end up being the range of
contracted area. An example:
old Nursery bounds hashData1/2 ff740000/100000000
low/highAddress (range being contracted) ff740000/ff760000
new Nursery bounds hashData1/2 ff740000/ff760000

Instead, the correct new bounds of Nursery should be: ff760000/100000000

This is relatively benign problem for STW Scavenger (there would be less
variety in Salt value). However, this a malign problem for Concurrent
Scavenger. The salt value (hence, hash value, too) would change for
objects that are allocated during active CS cycle and has been just
hashed, if there was a Nursery contract at the end of that cycle.
Such an object would reside in Nursery both before and after the
second/last STW increment of CS cycle, but salt value would be
different, because the Nursery range for Salt calculation was
incorrectly updated, and that object would be incorrectly treated as out
of Nursery, after the contract.

Some other minor ranges in the logic is to ensure that range being
contracted/expanded is always exactly at the border of exactly one of
the lower or higher bound.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>