### PR TITLE
Set _started to false in shutdownForStats() after exitWriteMutex()

### DIFF
--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -5557,12 +5557,12 @@ SH_CompositeCacheImpl::shutdownForStats(J9VMThread* currentThread)
 			notifyPagesRead(CASTART(_theca), CAEND(_theca), DIRECTION_FORWARD, false);
 		}
 
-		_started = false;
-
-		if (exitWriteMutex(currentThread, fnName) != 0) {
+		if (exitWriteMutex(currentThread, fnName, false) != 0) {
+			_started = false;
 			retval = -1;
 			goto done;
 		}
+		_started = false;
 	}
 
 	if (_commonCCInfo->writeMutexEntryCount != 0) {


### PR DESCRIPTION
exitWriteMutex() can eventually call into unprotectHeaderReadWriteArea()
where we are asserting _started to be true. So set _started to false
after exitWriteMutex() inside shutdownForStats()

Fixes #4984

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>