### PR TITLE
Handle mismatched env setup between server and client

### DIFF
--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -60,7 +60,7 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
    _priority = p;
    _numThreadsWaiting = 0;
    _compErrCode = compilationOK;
-   _compilationAttemptsLeft = MAX_COMPILE_ATTEMPTS;
+   _compilationAttemptsLeft = (TR::Options::canJITCompile()) ? MAX_COMPILE_ATTEMPTS : 1;
    _unloadedMethod = false;
    _doAotLoad = false;
    _useAotCompilation = false;


### PR DESCRIPTION
[skip ci]

The client will not request a remote compilation
when `canDoRelocatableCompile` is false and `-Xnojit` is set.
If it was allowed, the server would do a JIT compilation
which contradicts `-Xnojit` set on the client side.
Meanwhile, when the server receives a compilation request
from the client with `_useAotCompilation` set but
the remote AOT is disabled on the server,
the server will discard the compilation request.

Fixes #5163

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>