### PR TITLE
z/TPF updates resulting from build env changes

### DIFF
--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -1,3 +1,4 @@
+################################################################################
 # Copyright (c) 2019, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
@@ -17,10 +18,9 @@
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
 
-JIT_PRODUCT_BACKEND_SOURCES+= \
-    omr/compiler/aarch64/runtime/CodeSync.cpp
-
-JIT_PRODUCT_SOURCE_FILES+= \
-    compiler/aarch64/runtime/Recomp.cpp \
-    compiler/aarch64/runtime/Recompilation.spp
+j9jit_files(
+	aarch64/runtime/Recomp.cpp
+	aarch64/runtime/Recompilation.spp
+)

--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -21,6 +21,7 @@
 ################################################################################
 
 j9jit_files(
+	aarch64/runtime/PicBuilder.spp
 	aarch64/runtime/Recomp.cpp
 	aarch64/runtime/Recompilation.spp
 )

--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+#include "jilconsts.inc"
+
+	.globl	_interpreterUnresolvedStaticGlue
+	.globl	_interpreterUnresolvedSpecialGlue
+	.globl	_interpreterUnresolvedDirectVirtualGlue
+	.globl	_interpreterUnresolvedClassGlue
+	.globl	_interpreterUnresolvedClassGlue2
+	.globl	_interpreterUnresolvedStringGlue
+	.globl	_interpreterUnresolvedStaticDataGlue
+	.globl	_interpreterUnresolvedStaticDataStoreGlue
+	.globl	_interpreterUnresolvedInstanceDataGlue
+	.globl	_interpreterUnresolvedInstanceDataStoreGlue
+	.globl	_virtualUnresolvedHelper
+	.globl	_interfaceCallHelper
+	.globl	_interpreterVoidStaticGlue
+	.globl	_interpreterSyncVoidStaticGlue
+	.globl	_interpreterIntStaticGlue
+	.globl	_interpreterSyncIntStaticGlue
+	.globl	_interpreterLongStaticGlue
+	.globl	_interpreterSyncLongStaticGlue
+	.globl	_interpreterFloatStaticGlue
+	.globl	_interpreterSyncFloatStaticGlue
+	.globl	_interpreterDoubleStaticGlue
+	.globl	_interpreterSyncDoubleStaticGlue
+	.globl	_nativeStaticHelper
+
+#define SETVAL(A,B) .set A, B
+#include "runtime/Helpers.inc"
+#undef SETVAL
+
+	.text
+	.align 2
+
+_interpreterUnresolvedStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedSpecialGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedDirectVirtualGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedClassGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedClassGlue2:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedStringGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedStaticDataGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedStaticDataStoreGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedInstanceDataGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterUnresolvedInstanceDataStoreGlue:
+	hlt	#0	// Not implemented yet
+
+_virtualUnresolvedHelper:
+	hlt	#0	// Not implemented yet
+
+_interfaceCallHelper:
+	hlt	#0	// Not implemented yet
+
+_interpreterVoidStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncVoidStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterIntStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncIntStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterLongStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncLongStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterFloatStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncFloatStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterDoubleStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_interpreterSyncDoubleStaticGlue:
+	hlt	#0	// Not implemented yet
+
+_nativeStaticHelper:
+	hlt	#0	// Not implemented yet

--- a/runtime/compiler/aarch64/runtime/Recomp.cpp
+++ b/runtime/compiler/aarch64/runtime/Recomp.cpp
@@ -20,9 +20,45 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/TreeEvaluator.hpp"
+#include "control/Recompilation.hpp"
 
-void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction, TR::CodeGenerator *cg)
+// Called at runtime to get the body info from the start PC
+//
+TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *startPC)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+bool J9::Recompilation::isAlreadyPreparedForRecompile(void *startPC)
+   {
+   TR_UNIMPLEMENTED();
+   return FALSE;
+   }
+
+void J9::Recompilation::fixUpMethodCode(void *startPC)
    {
    TR_UNIMPLEMENTED();
    }
+
+void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStartPC, TR_FrontEnd *fe)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *fe)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+#if defined(TR_HOST_ARM64)
+void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo)
+   {
+   TR_UNIMPLEMENTED();
+   }
+#endif

--- a/runtime/compiler/aarch64/runtime/Recompilation.spp
+++ b/runtime/compiler/aarch64/runtime/Recompilation.spp
@@ -20,9 +20,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/TreeEvaluator.hpp"
+	.file "Recompilation.s"
 
-void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction, TR::CodeGenerator *cg)
-   {
-   TR_UNIMPLEMENTED();
-   }
+	.globl	_initialInvokeExactThunkGlue
+	.globl	_revertToInterpreterGlue
+
+_initialInvokeExactThunkGlue:
+	hlt	#0	// Not implemented yet
+
+_revertToInterpreterGlue:
+	hlt	#0	// Not implemented yet

--- a/runtime/compiler/build/files/host/aarch64.mk
+++ b/runtime/compiler/build/files/host/aarch64.mk
@@ -22,5 +22,6 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/runtime/CodeSync.cpp
 
 JIT_PRODUCT_SOURCE_FILES+= \
+    compiler/aarch64/runtime/PicBuilder.spp \
     compiler/aarch64/runtime/Recomp.cpp \
     compiler/aarch64/runtime/Recompilation.spp

--- a/runtime/compiler/build/files/target/aarch64.mk
+++ b/runtime/compiler/build/files/target/aarch64.mk
@@ -21,6 +21,7 @@
 JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp \
     omr/compiler/aarch64/codegen/ARM64Debug.cpp \
+    omr/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp \
     omr/compiler/aarch64/codegen/ARM64Instruction.cpp \
     omr/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp \
     omr/compiler/aarch64/codegen/ARM64SystemLinkage.cpp \

--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -75,7 +75,7 @@ ZASM_SCRIPT?=$(JIT_SCRIPT_DIR)/s390m4check.pl
 
 # Set up z/TPF directories and flags
 # Note: -isystem $(TPF_ROOT) is used for a2e calls to opensource functions
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/redhat/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit
 
 TPF_INCLUDES := $(foreach d,$(TPF_ROOT),-I$d/base/a2e/headers)
 TPF_INCLUDES += $(foreach d,$(TPF_ROOT),-I$d/base/include)
@@ -267,6 +267,7 @@ SOLINK_EXTRA_ARGS+=-Wl,-soname=libj9jit29.so
 SOLINK_EXTRA_ARGS+=-Wl,--as-needed
 SOLINK_EXTRA_ARGS+=-Wl,--eh-frame-hdr
 SOLINK_EXTRA_ARGS+=$(foreach d,$(TPF_ROOT),-L$d/base/lib)
+SOLINK_EXTRA_ARGS+=$(foreach d,$(TPF_ROOT),-L$d/base/stdlib)
 SOLINK_EXTRA_ARGS+=$(foreach d,$(TPF_ROOT),-L$d/opensource/stdlib)
 
 SOLINK_FLAGS+=$(SOLINK_FLAGS_EXTRA)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1221,7 +1221,7 @@ TR::CompilationInfo::disableAOTCompilations()
 #endif
 
 
-#if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM))
+#if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
 
 // Note: this method must be called only when we know that AOT mode for shared classes is enabled !!
 bool TR::CompilationInfo::isRomClassForMethodInSharedCache(J9Method *method, J9JavaVM *javaVM)
@@ -5844,7 +5844,7 @@ TR::CompilationInfoPerThreadBase::outputVerboseMMapEntries(
 #pragma option_override(TR::CompilationInfo::compile(J9VMThread *, TR_MethodToBeCompiled *, bool), "OPT(SPILL,256)")
 #endif
 
-#if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM))
+#if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
 TR_MethodMetaData *
 TR::CompilationInfoPerThreadBase::installAotCachedMethod(
    J9VMThread *vmThread,
@@ -6002,7 +6002,7 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
       }
    return metaData;
    }
-#endif // defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM))
+#endif // defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
 
 //--------------- queueAOTUpgrade ----------
 // The entry currently being processed will be cloned with the clone being an upgrade

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1136,6 +1136,9 @@ JIT_HELPER(_countingRecompileMethod);
 JIT_HELPER(_induceRecompilation);
 JIT_HELPER(_revertToInterpreterGlue);
 
+#elif defined(TR_HOST_ARM64)
+JIT_HELPER(_revertToInterpreterGlue);
+
 #elif defined(TR_HOST_S390)
 
 JIT_HELPER(_countingRecompileMethod);
@@ -1238,6 +1241,9 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_ARMcountingPatchCallSite,             (void *)_countingPatchCallSite,   TR_Helper);
    SET(TR_ARMinduceRecompilation,               (void *)_induceRecompilation,     TR_Helper);
    SET(TR_ARMrevertToInterpreterGlue,           (void *)_revertToInterpreterGlue, TR_Helper);
+
+#elif defined(TR_HOST_ARM64)
+   SET(TR_ARM64revertToInterpreterGlue,           (void *)_revertToInterpreterGlue, TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390samplingRecompileMethod,          (void *)_samplingRecompileMethod,   TR_Helper);

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -576,6 +576,37 @@ JIT_HELPER(icallVMprJavaSendStaticSync1);
 JIT_HELPER(icallVMprJavaSendStaticSyncJ);
 JIT_HELPER(icallVMprJavaSendStaticSyncF);
 JIT_HELPER(icallVMprJavaSendStaticSyncD);
+
+#elif defined(TR_HOST_ARM64)
+JIT_HELPER(_interpreterUnresolvedStaticGlue);
+JIT_HELPER(_interpreterUnresolvedSpecialGlue);
+JIT_HELPER(_interpreterUnresolvedDirectVirtualGlue);
+JIT_HELPER(_interpreterUnresolvedClassGlue);
+JIT_HELPER(_interpreterUnresolvedClassGlue2);
+JIT_HELPER(_interpreterUnresolvedStringGlue);
+JIT_HELPER(_interpreterUnresolvedStaticDataGlue);
+JIT_HELPER(_interpreterUnresolvedStaticDataStoreGlue);
+JIT_HELPER(_interpreterUnresolvedInstanceDataGlue);
+JIT_HELPER(_interpreterUnresolvedInstanceDataStoreGlue);
+JIT_HELPER(_virtualUnresolvedHelper);
+JIT_HELPER(_interfaceCallHelper);
+JIT_HELPER(icallVMprJavaSendVirtual0);
+JIT_HELPER(icallVMprJavaSendVirtual1);
+JIT_HELPER(icallVMprJavaSendVirtualJ);
+JIT_HELPER(icallVMprJavaSendVirtualF);
+JIT_HELPER(icallVMprJavaSendVirtualD);
+JIT_HELPER(_interpreterVoidStaticGlue);
+JIT_HELPER(_interpreterSyncVoidStaticGlue);
+JIT_HELPER(_interpreterIntStaticGlue);
+JIT_HELPER(_interpreterSyncIntStaticGlue);
+JIT_HELPER(_interpreterLongStaticGlue);
+JIT_HELPER(_interpreterSyncLongStaticGlue);
+JIT_HELPER(_interpreterFloatStaticGlue);
+JIT_HELPER(_interpreterSyncFloatStaticGlue);
+JIT_HELPER(_interpreterDoubleStaticGlue);
+JIT_HELPER(_interpreterSyncDoubleStaticGlue);
+JIT_HELPER(_nativeStaticHelper);
+
 #elif defined(TR_HOST_S390)
 JIT_HELPER(outlinedNewObject);
 JIT_HELPER(outlinedNewArray);
@@ -1519,6 +1550,36 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARMjitMathHelperDoubleCompareGE,      (void *) jitMathHelperDoubleCompareGE,  TR_Helper);
    SET(TR_ARMjitMathHelperDoubleCompareGEU,     (void *) jitMathHelperDoubleCompareGEU, TR_Helper);
    SET(TR_ARMjitCollapseJNIReferenceFrame,      (void *) jitCollapseJNIReferenceFrame,  TR_Helper);
+
+#elif defined(TR_HOST_ARM64)
+   SET(TR_ARM64interpreterUnresolvedStaticGlue,            (void *) _interpreterUnresolvedStaticGlue,               TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedSpecialGlue,           (void *) _interpreterUnresolvedSpecialGlue,              TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedDirectVirtualGlue,     (void *) _interpreterUnresolvedDirectVirtualGlue,        TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedClassGlue,             (void *) _interpreterUnresolvedClassGlue,                TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedClassGlue2,            (void *) _interpreterUnresolvedClassGlue2,               TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedStringGlue,            (void *) _interpreterUnresolvedStringGlue,               TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedStaticDataGlue,        (void *) _interpreterUnresolvedStaticDataGlue,           TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedStaticDataStoreGlue,   (void *) _interpreterUnresolvedStaticDataStoreGlue,      TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedInstanceDataGlue,      (void *) _interpreterUnresolvedInstanceDataGlue,         TR_Helper);
+   SET(TR_ARM64interpreterUnresolvedInstanceDataStoreGlue, (void *) _interpreterUnresolvedInstanceDataStoreGlue,    TR_Helper);
+   SET(TR_ARM64virtualUnresolvedHelper,                    (void *) _virtualUnresolvedHelper,                       TR_Helper);
+   SET(TR_ARM64interfaceCallHelper,                        (void *) _interfaceCallHelper,                           TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtual0,         (void *) icallVMprJavaSendVirtual0,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtual1,         (void *) icallVMprJavaSendVirtual1,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtualJ,         (void *) icallVMprJavaSendVirtualJ,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtualF,         (void *) icallVMprJavaSendVirtualF,        TR_Helper);
+   SET(TR_ARM64icallVMprJavaSendVirtualD,         (void *) icallVMprJavaSendVirtualD,        TR_Helper);
+   SET(TR_ARM64interpreterVoidStaticGlue,         (void *) _interpreterVoidStaticGlue,       TR_Helper);
+   SET(TR_ARM64interpreterSyncVoidStaticGlue,     (void *) _interpreterSyncVoidStaticGlue,   TR_Helper);
+   SET(TR_ARM64interpreterIntStaticGlue,          (void *) _interpreterIntStaticGlue,        TR_Helper);
+   SET(TR_ARM64interpreterSyncIntStaticGlue,      (void *) _interpreterSyncIntStaticGlue,    TR_Helper);
+   SET(TR_ARM64interpreterLongStaticGlue,         (void *) _interpreterLongStaticGlue,       TR_Helper);
+   SET(TR_ARM64interpreterSyncLongStaticGlue,     (void *) _interpreterSyncLongStaticGlue,   TR_Helper);
+   SET(TR_ARM64interpreterFloatStaticGlue,        (void *) _interpreterFloatStaticGlue,      TR_Helper);
+   SET(TR_ARM64interpreterSyncFloatStaticGlue,    (void *) _interpreterSyncFloatStaticGlue,  TR_Helper);
+   SET(TR_ARM64interpreterDoubleStaticGlue,       (void *) _interpreterDoubleStaticGlue,     TR_Helper);
+   SET(TR_ARM64interpreterSyncDoubleStaticGlue,   (void *) _interpreterSyncDoubleStaticGlue, TR_Helper);
+   SET(TR_ARM64nativeStaticHelper,                (void *) _nativeStaticHelper,              TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390double2Long,                                (void *) 0,                                              TR_Helper);

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -33,6 +33,9 @@
 
 #include "EnvironmentBase.hpp"
 #include "Forge.hpp"
+#if defined(J9VM_GC_IDLE_HEAP_MANAGER)
+ #include  "IdleGCManager.hpp"
+#endif /* defined(J9VM_GC_IDLE_HEAP_MANAGER) */
 #include "MemorySubSpace.hpp"
 #include "ObjectModel.hpp"
 #include "ReferenceChainWalkerMarkMap.hpp"
@@ -173,6 +176,13 @@ MM_GCExtensions::tearDown(MM_EnvironmentBase *env)
 		(*tmpHookInterface)->J9HookShutdownInterface(tmpHookInterface);
 		*tmpHookInterface = NULL; /* avoid issues with double teardowns */
 	}
+
+#if defined(J9VM_GC_IDLE_HEAP_MANAGER)
+	if (NULL != idleGCManager) {
+		idleGCManager->kill(env);
+		idleGCManager = NULL;
+	}
+#endif /* defined(J9VM_GC_IDLE_HEAP_MANAGER) */
 
 	MM_GCExtensionsBase::tearDown(env);
 }

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -183,10 +183,17 @@ MM_GCExtensions::identityHashDataAddRange(MM_EnvironmentBase *env, MM_MemorySubS
 	J9IdentityHashData* hashData = getJavaVM()->identityHashData;
 	if (J9_IDENTITY_HASH_SALT_POLICY_STANDARD == hashData->hashSaltPolicy) {
 		if (MEMORY_TYPE_NEW == (subspace->getTypeFlags() & MEMORY_TYPE_NEW)) {
-			if ((UDATA)lowAddress < hashData->hashData1) {
+			if (hashData->hashData1 == (UDATA)highAddress) {
+				/* Expanding low bound */
 				hashData->hashData1 = (UDATA)lowAddress;
-			}
-			if ((UDATA)highAddress > hashData->hashData2) {
+			} else if (hashData->hashData2 == (UDATA)lowAddress) {
+				/* Expanding high bound */
+				hashData->hashData2 = (UDATA)highAddress;
+			} else {
+				/* First expand */
+				Assert_MM_true(UDATA_MAX == hashData->hashData1);
+				Assert_MM_true(0 == hashData->hashData2);
+				hashData->hashData1 = (UDATA)lowAddress;
 				hashData->hashData2 = (UDATA)highAddress;
 			}
 		}
@@ -199,11 +206,18 @@ MM_GCExtensions::identityHashDataRemoveRange(MM_EnvironmentBase *env, MM_MemoryS
 	J9IdentityHashData* hashData = getJavaVM()->identityHashData;
 	if (J9_IDENTITY_HASH_SALT_POLICY_STANDARD == hashData->hashSaltPolicy) {
 		if (MEMORY_TYPE_NEW == (subspace->getTypeFlags() & MEMORY_TYPE_NEW)) {
-			if ((UDATA)lowAddress > hashData->hashData1) {
-				hashData->hashData1 = (UDATA)lowAddress;
-			}
-			if ((UDATA)highAddress < hashData->hashData2) {
-				hashData->hashData2 = (UDATA)highAddress;
+			if (hashData->hashData1 == (UDATA)lowAddress) {
+				/* Contracting low bound */
+				Assert_MM_true(hashData->hashData1 <= (UDATA)highAddress);
+				Assert_MM_true((UDATA)highAddress <= hashData->hashData2);
+				hashData->hashData1 = (UDATA)highAddress;
+			} else if (hashData->hashData2 == (UDATA)highAddress) {
+				/* Contracting high bound */
+				Assert_MM_true(hashData->hashData1 <= (UDATA)lowAddress);
+				Assert_MM_true((UDATA)lowAddress <= hashData->hashData2);
+				hashData->hashData2 = (UDATA)lowAddress;
+			} else {
+				Assert_MM_unreachable();
 			}
 		}
 	}

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3994,11 +3994,11 @@ JVM_Open(const char* filename, jint flags, jint mode)
 #endif
 
 #if defined(J9UNIX) || defined(J9ZOS390)
-#if defined(OSX)
+#if defined(OSX) || defined(J9ZTPF)
 #define EXTRA_OPEN_FLAGS 0
 #else
 #define EXTRA_OPEN_FLAGS O_LARGEFILE
-#endif /* defined(OSX) */
+#endif /* defined(OSX) || defined(J9ZTPF) */
 
 #ifndef O_DSYNC
 #define O_DSYNC O_SYNC

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -1,4 +1,4 @@
-# Copyright (c) 1998, 2018 IBM Corp. and others
+# Copyright (c) 1998, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -199,6 +199,7 @@ CXXFLAGS+=$(UMA_C_INCLUDES)
 CPPFLAGS+=$(UMA_C_INCLUDES)
 
 UMA_LINK_PATH += $(foreach d,$(TPF_ROOT),-L$d/base/lib)
+UMA_LINK_PATH += $(foreach d,$(TPF_ROOT),-L$d/base/stdlib)
 UMA_LINK_PATH += $(foreach d,$(TPF_ROOT),-L$d/opensource/stdlib)
 
 </#if>

--- a/runtime/makelib/targets.mk.ztpf.inc.ftl
+++ b/runtime/makelib/targets.mk.ztpf.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2018 IBM Corp. and others
+Copyright (c) 1998, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,8 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 	-o $@ $(UMA_EXE_POSTFIX_FLAGS)
 </#assign>
 
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/redhat/all /ztpf/commit
+# Use updated svt build environment
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit
 
 ifndef j9vm_env_data64
   J9M31 = -m31

--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -76,6 +76,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 				char* methodSpecs = NULL;
 #if !defined(WIN32) && !defined(WIN64)
 				char defaultCacheDir[J9SH_MAXPATH];
+				IDATA ret = 0;
 #endif
 				IDATA argIndex1 = -1;
 				IDATA argIndex2 = -1;
@@ -189,13 +190,12 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 
 #if !defined(WIN32) && !defined(WIN64)
 				/* Get platform default cache directory */
-				if (-1 == j9shr_getCacheDir(vm, NULL, defaultCacheDir, J9SH_MAXPATH, vm->sharedCacheAPI->cacheType)) {
-					SHRCLSSUP_ERR_TRACE(verboseFlags, J9NLS_SHRC_SHRCLSSUP_FAILURE_GET_DEFAULT_DIR_FAILED);
-					Trc_SHR_Assert_ShouldNeverHappen();
-					return J9VMDLLMAIN_FAILED;
-				}
+				ret = j9shr_getCacheDir(vm, NULL, defaultCacheDir, J9SH_MAXPATH, vm->sharedCacheAPI->cacheType);
 
-				if ((NULL != ctrlDirName) && (0 != (strcmp(defaultCacheDir, ctrlDirName)))) {
+				if ((NULL != ctrlDirName)
+					&& (0 == ret)
+					&& (0 != (strcmp(defaultCacheDir, ctrlDirName)))
+				) {
 					vm->sharedCacheAPI->cacheDirPerm = convertPermToDecimal(vm, cacheDirPermStr);
 					if ((UDATA)-1 == vm->sharedCacheAPI->cacheDirPerm) {
 						return J9VMDLLMAIN_FAILED;

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -5557,12 +5557,12 @@ SH_CompositeCacheImpl::shutdownForStats(J9VMThread* currentThread)
 			notifyPagesRead(CASTART(_theca), CAEND(_theca), DIRECTION_FORWARD, false);
 		}
 
-		_started = false;
-
-		if (exitWriteMutex(currentThread, fnName) != 0) {
+		if (exitWriteMutex(currentThread, fnName, false) != 0) {
+			_started = false;
 			retval = -1;
 			goto done;
 		}
+		_started = false;
 	}
 
 	if (_commonCCInfo->writeMutexEntryCount != 0) {

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -152,6 +152,9 @@ ifeq ($(JDK_VERSION),8)
 JDK_HOME := $(JAVA_BIN_TMP)$(D)..$(D)..
 endif
 
+OLD_JAVA_HOME := $(JAVA_HOME)
+export JAVA_HOME := $(JDK_HOME)
+
 #######################################
 # Set OS, ARCH and BITS based on SPEC
 #######################################
@@ -291,6 +294,10 @@ setup_%: testEnvSetup
 	@$(ECHO) set JDK_IMPL to $(JDK_IMPL)
 	@$(ECHO) set JVM_VERSION to $(JVM_VERSION)
 	@$(ECHO) set JCL_VERSION to $(JCL_VERSION)
+	@if [ $(OLD_JAVA_HOME) ]; then \
+		$(ECHO) JAVA_HOME was originally set to $(OLD_JAVA_HOME); \
+	fi
+	@$(ECHO) set JAVA_HOME to $(JAVA_HOME)
 	@$(ECHO) set JAVA_BIN to $(JAVA_BIN)
 	@$(ECHO) set SPEC to $(SPEC)
 	@$(MKTREE) $(Q)$(TESTOUTPUT)$(Q)


### PR DESCRIPTION
The z/linux build environment used to build the z/TPF jvm was updated.
The following changes were needed to openj9 for a clean build:

- base/stdlib was added to link path in makelib/targets.mk.ftl,
- TPF_ROOT directory now uses /zbld in makelib/targets.mk.ztpf.inc.ftl,
- simlar updates were made to compiler/build/toolcfg/ztpf-gcc/common.mk,
- jvm.c was updated to set EXTRA_OPEN_FLAGS to 0 for ZTPF platform.

Signed-off-by: Peter Lemieszewski <lemie@us.ibm.com>