### PR TITLE
AArch64: Add initial version of Linkage files

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/ARM64JNILinkage.hpp"
+
+TR::ARM64JNILinkage::ARM64JNILinkage(TR::CodeGenerator *cg)
+   :TR::ARM64PrivateLinkage(cg)
+   {
+   TR_UNIMPLEMENTED();
+   }

--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ARM64_JNILINKAGE_INCL
+#define ARM64_JNILINKAGE_INCL
+
+#include "codegen/ARM64PrivateLinkage.hpp"
+
+namespace TR {
+
+class ARM64JNILinkage : public TR::ARM64PrivateLinkage
+   {
+   public:
+
+   ARM64JNILinkage(TR::CodeGenerator *cg);
+   };
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/ARM64PrivateLinkage.hpp"
+
+TR::ARM64LinkageProperties TR::ARM64PrivateLinkage::properties =
+   {
+   };
+
+TR::ARM64LinkageProperties& TR::ARM64PrivateLinkage::getProperties()
+   {
+   return properties;
+   }
+
+uint32_t TR::ARM64PrivateLinkage::getRightToLeft()
+   {
+   return getProperties().getRightToLeft();
+   }
+
+void TR::ARM64PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void TR::ARM64PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void TR::ARM64PrivateLinkage::initARM64RealRegisterLinkage()
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void TR::ARM64PrivateLinkage::createEpilogue(TR::Instruction *cursor)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+int32_t TR::ARM64PrivateLinkage::buildArgs(TR::Node *callNode,
+   TR::RegisterDependencyConditions *dependencies)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }
+
+TR::Register *TR::ARM64PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+TR::Register *TR::ARM64PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ARM64_PRIVATELINKAGE_INCL
+#define ARM64_PRIVATELINKAGE_INCL
+
+#include "codegen/Linkage.hpp"
+
+#include "infra/Assert.hpp"
+
+namespace TR { class CodeGenerator; }
+namespace TR { class Instruction; }
+namespace TR { class Register; }
+
+namespace TR {
+
+class ARM64PrivateLinkage : public TR::Linkage
+   {
+   static TR::ARM64LinkageProperties properties;
+
+   public:
+
+   /**
+    * @brief Constructor
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64PrivateLinkage(TR::CodeGenerator *cg) : TR::Linkage(cg) {}
+
+   /**
+    * @brief Answers linkage properties
+    * @return linkage properties
+    */
+   virtual TR::ARM64LinkageProperties& getProperties();
+
+   /**
+    * @brief Gets the RightToLeft flag
+    * @return RightToLeft flag
+    */
+   virtual uint32_t getRightToLeft();
+
+   /**
+    * @brief Maps symbols to locations on stack
+    * @param[in] method : method for which symbols are mapped on stack
+    */
+   virtual void mapStack(TR::ResolvedMethodSymbol *method);
+   /**
+    * @brief Maps an automatic symbol to an index on stack
+    * @param[in] p : automatic symbol
+    * @param[in/out] stackIndex : index on stack
+    */
+   virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex);
+
+   /**
+    * @brief Initializes ARM64 RealRegister linkage
+    */
+   virtual void initARM64RealRegisterLinkage();
+
+   /**
+    * @brief Creates method prologue
+    * @param[in] cursor : instruction cursor
+    */
+   virtual void createPrologue(TR::Instruction *cursor);
+   /**
+    * @brief Creates method prologue
+    * @param[in] cursor : instruction cursor
+    */
+   virtual void createEpilogue(TR::Instruction *cursor);
+
+   /**
+    * @brief Builds method arguments
+    * @param[in] node : caller node
+    * @param[in] dependencies : register dependency conditions
+    */
+   virtual int32_t buildArgs(
+      TR::Node *callNode,
+      TR::RegisterDependencyConditions *dependencies);
+
+   /**
+    * @brief Builds direct dispatch to method
+    * @param[in] node : caller node
+    */
+   virtual TR::Register *buildDirectDispatch(TR::Node *callNode);
+
+   /**
+    * @brief Builds indirect dispatch to method
+    * @param[in] node : caller node
+    */
+   virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
+   };
+
+class ARM64HelperLinkage : public TR::ARM64PrivateLinkage
+   {
+   public:
+
+   /**
+    * @brief Constructor
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64HelperLinkage(TR::CodeGenerator *cg) : TR::ARM64PrivateLinkage(cg) {}
+   };
+
+}
+
+#endif

--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/ARM64Recompilation.hpp"
+
+TR_ARM64Recompilation::TR_ARM64Recompilation(TR::Compilation * comp)
+   : TR::Recompilation(comp)
+   {
+   _countingSupported = true;
+
+   setupMethodInfo();
+   }
+
+TR::Recompilation *TR_ARM64Recompilation::allocate(TR::Compilation *comp)
+   {
+   if (comp->isRecompilationEnabled())
+      {
+      return new (comp->trHeapMemory()) TR_ARM64Recompilation(comp);
+      }
+
+   return NULL;
+   }
+
+TR_PersistentMethodInfo *TR_ARM64Recompilation::getExistingMethodInfo(TR_ResolvedMethod *method)
+   {
+   int8_t *startPC = (int8_t *)method->startAddressForInterpreterOfJittedMethod();
+   TR_PersistentMethodInfo *info = getJittedBodyInfoFromPC(startPC)->getMethodInfo();
+   return(info);
+   }
+
+TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+TR::Instruction *TR_ARM64Recompilation::generatePrologue(TR::Instruction *cursor)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }

--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.hpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ARM64RECOMPILATION_INCL
+#define ARM64RECOMPILATION_INCL
+
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
+
+class TR_ResolvedMethod;
+
+class TR_ARM64Recompilation : public TR::Recompilation
+   {
+   public:
+
+   TR_ARM64Recompilation(TR::Compilation *);
+
+   static TR::Recompilation * allocate(TR::Compilation *);
+
+   virtual TR_PersistentMethodInfo *getExistingMethodInfo(TR_ResolvedMethod *method);
+   virtual TR::Instruction *generatePrePrologue();
+   virtual TR::Instruction *generatePrologue(TR::Instruction *);
+
+   TR::CodeGenerator *cg() { return _compilation->cg(); }
+   };
+
+#endif

--- a/runtime/compiler/aarch64/codegen/CMakeLists.txt
+++ b/runtime/compiler/aarch64/codegen/CMakeLists.txt
@@ -21,7 +21,11 @@
 ################################################################################
 
 j9jit_files(
+	aarch64/codegen/ARM64JNILinkage.cpp
+	aarch64/codegen/ARM64PrivateLinkage.cpp
+	aarch64/codegen/ARM64Recompilation.cpp
 	aarch64/codegen/J9ARM64Snippet.cpp
+	aarch64/codegen/J9AheadOfTimeCompile.cpp
 	aarch64/codegen/J9CodeGenerator.cpp
 	aarch64/codegen/J9TreeEvaluator.cpp
 	aarch64/codegen/J9UnresolvedDataSnippet.cpp

--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/AheadOfTimeCompile.hpp"
+#include "codegen/CodeGenerator.hpp"
+
+J9::ARM64::AheadOfTimeCompile::AheadOfTimeCompile(TR::CodeGenerator *cg) :
+         J9::AheadOfTimeCompile(_relocationTargetTypeToHeaderSizeMap, cg->comp()),
+         _cg(cg)
+   {
+   }
+
+void J9::ARM64::AheadOfTimeCompile::processRelocations()
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+uint8_t *J9::ARM64::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+uint32_t J9::ARM64::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds] =
+   {
+   // TODO: Fill this table
+   0,                                        // TR_ConstantPool                        = 0
+   0,                                        // TR_HelperAddress                       = 1
+   0,                                        // TR_RelativeMethodAddress               = 2
+   0,                                        // TR_AbsoluteMethodAddress               = 3
+   0,                                        // TR_DataAddress                         = 4
+   0,                                        // TR_ClassObject                         = 5
+   0,                                        // TR_MethodObject                        = 6
+   0,                                        // TR_InterfaceObject                     = 7
+   0,                                        // TR_AbsoluteHelperAddress               = 8
+   0,                                        // TR_FixedSequenceAddress                = 9
+   0,                                        // TR_FixedSequenceAddress2               = 10
+   0,                                        // TR_JNIVirtualTargetAddress             = 11
+   0,                                        // TR_JNIStaticTargetAddress              = 12
+   0,                                        // TR_ArrayCopyHelper                     = 13
+   0,                                        // TR_ArrayCopyToc                        = 14
+   0,                                        // TR_BodyInfoAddress                     = 15
+   0,                                        // TR_Thunks                              = 16
+   0,                                        // TR_StaticRamMethodConst                = 17
+   0,                                        // TR_Trampolines                         = 18
+   0,                                        // TR_PicTrampolines                      = 19
+   0,                                        // TR_CheckMethodEnter                    = 20
+   0,                                        // TR_RamMethod                           = 21
+   0,                                        // TR_RamMethodSequence                   = 22
+   0,                                        // TR_RamMethodSequenceReg                = 23
+   0,                                        // TR_VerifyClassObjectForAlloc           = 24
+   0,                                        // TR_ConstantPoolOrderedPair             = 25
+   0,                                        // TR_AbsoluteMethodAddressOrderedPair    = 26
+   0,                                        // TR_VerifyRefArrayForAlloc              = 27
+   0,                                        // TR_J2IThunks                           = 28
+   0,                                        // TR_GlobalValue                         = 29
+   0,                                        // TR_BodyInfoAddressLoad                 = 30
+   0,                                        // TR_ValidateInstanceField               = 31
+   0,                                        // TR_InlinedStaticMethodWithNopGuard     = 32
+   0,                                        // TR_InlinedSpecialMethodWithNopGuard    = 33
+   0,                                        // TR_InlinedVirtualMethodWithNopGuard    = 34
+   0,                                        // TR_InlinedInterfaceMethodWithNopGuard  = 35
+   0,                                        // TR_SpecialRamMethodConst               = 36
+   0,                                        // TR_InlinedHCRMethod                    = 37
+   0,                                        // TR_ValidateStaticField                 = 38
+   0,                                        // TR_ValidateClass                       = 39
+   0,                                        // TR_ClassAddress                        = 40
+   0,                                        // TR_HCR                                 = 41
+   0,                                        // TR_ProfiledMethodGuardRelocation       = 42
+   0,                                        // TR_ProfiledClassGuardRelocation        = 43
+   0,                                        // TR_HierarchyGuardRelocation            = 44
+   0,                                        // TR_AbstractGuardRelocation             = 45
+   0,                                        // TR_ProfiledInlinedMethodRelocation     = 46
+   0,                                        // TR_MethodPointer                       = 47
+   0,                                        // TR_ClassPointer                        = 48
+   0,                                        // TR_CheckMethodExit                     = 49
+   0,                                        // TR_ValidateArbitraryClass              = 50
+   0,                                        // TR_EmitClass                           = 51
+   0,                                        // TR_JNISpecialTargetAddress             = 52
+   0,                                        // TR_VirtualRamMethodConst               = 53
+   0,                                        // TR_InlinedInterfaceMethod              = 54
+   0,                                        // TR_InlinedVirtualMethod                = 55
+   0,                                        // TR_NativeMethodAbsolute                = 56
+   0,                                        // TR_NativeMethodRelative                = 57
+   0,                                        // TR_ArbitraryClassAddress               = 58
+   0,                                        // TR_DebugCounter                        = 59
+   0,                                        // TR_ClassUnloadAssumption               = 60
+   0,                                        // TR_J2IVirtualThunkPointer              = 61
+   0,                                        // TR_InlinedAbstractMethodWithNopGuard   = 62
+   0,                                        // TR_ValidateRootClass                   = 63
+   0,                                        // TR_ValidateClassByName                 = 64
+   0,                                        // TR_ValidateProfiledClass               = 65
+   0,                                        // TR_ValidateClassFromCP                 = 66
+   0,                                        // TR_ValidateDefiningClassFromCP         = 67
+   0,                                        // TR_ValidateStaticClassFromCP           = 68
+   0,                                        // TR_ValidateClassFromMethod             = 69
+   0,                                        // TR_ValidateComponentClassFromArrayClass= 70
+   0,                                        // TR_ValidateArrayClassFromComponentClass= 71
+   0,                                        // TR_ValidateSuperClassFromClass         = 72
+   0,                                        // TR_ValidateClassInstanceOfClass        = 73
+   0,                                        // TR_ValidateSystemClassByName           = 74
+   0,                                        // TR_ValidateClassFromITableIndexCP      = 75
+   0,                                        // TR_ValidateDeclaringClassFromFieldOrStatic = 76
+   0,                                        // TR_ValidateClassClass                  = 77
+   0,                                        // TR_ValidateConcreteSubClassFromClass   = 78
+   0,                                        // TR_ValidateClassChain                  = 79
+   0,                                        // TR_ValidateRomClass                    = 80
+   0,                                        // TR_ValidatePrimitiveClass              = 81
+   0,                                        // TR_ValidateMethodFromInlinedSite       = 82
+   0,                                        // TR_ValidateMethodByName                = 83
+   0,                                        // TR_ValidateMethodFromClass             = 84
+   0,                                        // TR_ValidateStaticMethodFromCP          = 85
+   0,                                        // TR_ValidateSpecialMethodFromCP         = 86
+   0,                                        // TR_ValidateVirtualMethodFromCP         = 87
+   0,                                        // TR_ValidateVirtualMethodFromOffset     = 88
+   0,                                        // TR_ValidateInterfaceMethodFromCP       = 89
+   0,                                        // TR_ValidateMethodFromClassAndSig       = 90
+   0,                                        // TR_ValidateStackWalkerMaySkipFramesRecord = 91
+   0,                                        // TR_ValidateArrayClassFromJavaVM        = 92
+   0,                                        // TR_ValidateClassInfoIsInitialized      = 93
+   0,                                        // TR_ValidateMethodFromSingleImplementer = 94
+   0,                                        // TR_ValidateMethodFromSingleInterfaceImplementer = 95
+   0,                                        // TR_ValidateMethodFromSingleAbstractImplementer = 96
+   0,                                        // TR_ValidateImproperInterfaceMethodFromCP = 97
+   0,                                        // TR_SymbolFromManager                   = 98
+   0,                                        // TR_MethodCallAddress                   = 99
+   0,                                        // TR_DiscontiguousSymbolFromManager      = 100
+   0                                         // TR_ResolvedTrampolines                 = 101
+   };

--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.hpp
@@ -32,7 +32,7 @@ namespace J9 { typedef J9::ARM64::AheadOfTimeCompile AheadOfTimeCompileConnector
 #include "compiler/codegen/J9AheadOfTimeCompile.hpp"
 
 #include "codegen/ARM64AOTRelocation.hpp"
-#include "il/SymbolReference.hpp" // @@
+#include "il/SymbolReference.hpp"
 
 namespace TR { class CodeGenerator; }
 

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -20,24 +20,52 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "codegen/AheadOfTimeCompile.hpp"
+#include "codegen/ARM64JNILinkage.hpp"
+#include "codegen/ARM64PrivateLinkage.hpp"
+#include "codegen/ARM64Recompilation.hpp"
+#include "codegen/ARM64SystemLinkage.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/CodeGenerator_inlines.hpp"
 
 J9::ARM64::CodeGenerator::CodeGenerator() :
       J9::CodeGenerator()
    {
-   TR_UNIMPLEMENTED();
+   TR::CodeGenerator *cg = self();
+
+   cg->setAheadOfTimeCompile(new (cg->trHeapMemory()) TR::AheadOfTimeCompile(cg));
    }
 
 TR::Linkage *
 J9::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   TR::Linkage *linkage;
+   switch (lc)
+      {
+      case TR_Private:
+         linkage = new (self()->trHeapMemory()) TR::ARM64PrivateLinkage(self());
+         break;
+      case TR_System:
+         linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());
+         break;
+      case TR_CHelper:
+      case TR_Helper:
+         linkage = new (self()->trHeapMemory()) TR::ARM64HelperLinkage(self());
+         break;
+      case TR_J9JNILinkage:
+         linkage = new (self()->trHeapMemory()) TR::ARM64JNILinkage(self());
+         break;
+      default :
+         linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());
+         TR_ASSERT_FATAL(false, "Unexpected linkage convention");
+      }
+
+   self()->setLinkage(lc, linkage);
+   return linkage;
    }
 
 TR::Recompilation *
 J9::ARM64::CodeGenerator::allocateRecompilationInfo()
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   return TR_ARM64Recompilation::allocate(self()->comp());
    }

--- a/runtime/compiler/build/files/target/aarch64.mk
+++ b/runtime/compiler/build/files/target/aarch64.mk
@@ -44,7 +44,11 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/env/OMRDebugEnv.cpp
 
 JIT_PRODUCT_SOURCE_FILES+= \
+    compiler/aarch64/codegen/ARM64JNILinkage.cpp \
+    compiler/aarch64/codegen/ARM64PrivateLinkage.cpp \
+    compiler/aarch64/codegen/ARM64Recompilation.cpp \
     compiler/aarch64/codegen/J9ARM64Snippet.cpp \
+    compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp \
     compiler/aarch64/codegen/J9CodeGenerator.cpp \
     compiler/aarch64/codegen/J9TreeEvaluator.cpp \
     compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp \


### PR DESCRIPTION
This commit adds initial version of ARM64*Linkage files in
runtime/compiler/aarch64/codegen/.
It also adds initial version of Recompilation and AheadOfTimeCompile
files, and modifies related files.

Signed-off-by: knn-k <konno@jp.ibm.com>