### PR TITLE
Look for additional opportunities for stack allocation

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -584,7 +584,8 @@ class TR_EscapeAnalysis : public TR::Optimization
    TR_UseDefInfo             *_useDefInfo;
    bool                      _invalidateUseDefInfo;
    TR_BitVector              *_otherDefsForLoopAllocation;
-   TR_BitVector              *_localObjectsValueNumbers;
+   TR_BitVector              *_nonColdLocalObjectsValueNumbers;
+   TR_BitVector              *_allLocalObjectsValueNumbers;
    TR_BitVector              *_notOptimizableLocalObjectsValueNumbers;
    TR_BitVector              *_notOptimizableLocalStringObjectsValueNumbers;
    TR_BitVector              *_blocksWithFlushOnEntry;


### PR DESCRIPTION
This introduces some further refinements to detect opportunities for Escape Analysis (EA) in loops where references are copied between local variables.

This change considers the right-hand side of an assignment to be harmless for the purposes of EA if it was an object that was locally allocated by a previous pass of EA, not only if it is a candidate for local allocation in the current pass of EA.

This change was prototyped by Andrew Craik <ajcraik@ca.ibm.com>.

Also, fixed a bug in trace code that was getting the class name of a `TR::New` operation incorrectly.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>