### PR TITLE
Use consolidated trampoline space reservation API

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -661,21 +661,13 @@ J9::CodeCache::reserveUnresolvedTrampoline(void *cp, int32_t cpIndex)
       OMR::CodeCacheHashEntry *entry = _unresolvedMethodHT->findUnresolvedMethod(cp, cpIndex);
       if (!entry)
          {
-         // don't have any reservation for this particular name/classLoader, make one
-         OMR::CodeCacheTrampolineCode *trampoline = self()->reserveSpaceForTrampoline();
-         if (trampoline)
+         // There isn't a reservation for this particular name/classLoader, make one
+         //
+         retValue = self()->reserveSpaceForTrampoline_bridge();
+         if (retValue == OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
             {
             if (!self()->addUnresolvedMethod(cp, cpIndex))
                retValue = OMR::CodeCacheErrorCode::ERRORCODE_FATALERROR; // couldn't allocate memory from VM
-            }
-         else // no space in this code cache; must allocate a new one
-            {
-            _almostFull = TR_yes;
-            retValue = OMR::CodeCacheErrorCode::ERRORCODE_INSUFFICIENTSPACE;
-            if (config.verboseCodeCache())
-               {
-               TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "CodeCache %p marked as full in reserveUnresolvedTrampoline", this);
-               }
             }
          }
       }

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1962,7 +1962,7 @@ TR_RelocationRecordPicTrampolines::numTrampolines(TR_RelocationTarget *reloTarge
 int32_t
 TR_RelocationRecordPicTrampolines::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
-   if (reloRuntime->codeCache()->reserveNTrampolines(numTrampolines(reloTarget)) != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
+   if (reloRuntime->codeCache()->reserveSpaceForTrampoline_bridge(numTrampolines(reloTarget)) != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
       {
       RELO_LOG(reloRuntime->reloLogger(), 1,"\t\tapplyRelocation: aborting AOT relocation because pic trampoline was not reserved. Will be retried.\n");
       return compilationAotPicTrampolineReloFailure;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -424,7 +424,7 @@ J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
 
    if (!fej9->isAOT_DEPRECATED_DO_NOT_USE())
       {
-      status = curCache->reserveNTrampolines(numTrampolines);
+      status = curCache->reserveSpaceForTrampoline_bridge(numTrampolines);
       if (status != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
          {
          // Current code cache is no good. Must unreserve
@@ -435,8 +435,13 @@ J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
             newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID());
             if (newCache)
                {
-               status = newCache->reserveNTrampolines(numTrampolines);
-               TR_ASSERT(status == OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS, "Failed to reserve trampolines in fresh code cache.");
+               status = newCache->reserveSpaceForTrampoline_bridge(numTrampolines);
+
+               if (status != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
+                  {
+                  TR_ASSERT(0, "Failed to reserve trampolines in fresh code cache.");
+                  newCache->unreserve();
+                  }
                }
             }
          }


### PR DESCRIPTION
Use the `CodeCache::reserveSpaceForTrampoline_bridge` API from OMR in
place of `reserveSpaceForTrampoline` and `reserveNTrampolines`.

The use of the "bridge" API will be short-lived to permit further refactoring.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>