### PR TITLE
AArch64: Update Dockerfile for cross-compilation

### DIFF
--- a/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -42,18 +42,6 @@ RUN apt-get update \
     gcc-7 \
     git \
     git-core \
-    libasound2-dev \
-    libcups2-dev \
-    libdwarf-dev \
-    libelf-dev \
-    libfontconfig1-dev \
-    libfreetype6-dev \
-    libnuma-dev \
-    libx11-dev \
-    libxext-dev \
-    libxrender-dev \
-    libxt-dev \
-    libxtst-dev \
     make \
     pkg-config \
     qemu \
@@ -99,8 +87,8 @@ RUN cd /root \
 ADD \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2_1.1.3-5_arm64.deb                \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5_arm64.deb            \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8%2bdeb9u2_arm64.deb         \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8%2bdeb9u2_arm64.deb    \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8%2bdeb9u3_arm64.deb         \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8%2bdeb9u3_arm64.deb    \
     http://ftp.us.debian.org/debian/pool/main/d/dwarfutils/libdwarf-dev_20161124-1+deb9u1_arm64.deb  \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.6.3-3.2_arm64.deb            \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6-dev_2.6.3-3.2_arm64.deb        \


### PR DESCRIPTION
This commit updates the Dockerfile for aarch64 cross-compilation.
- Update the file names for missing libcups libraries
- Remove unnecessary libraries for x86

Signed-off-by: knn-k <konno@jp.ibm.com>