### PR TITLE
AArch64: Add libssl files to Dockerfile

### DIFF
--- a/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -98,6 +98,8 @@ ADD \
     http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng16-16_1.6.28-1_arm64.deb          \
     http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng-dev_1.6.28-1_arm64.deb           \
     http://ftp.us.debian.org/debian/pool/main/libs/libsm/libsm-dev_1.2.2-1+b3_arm64.deb              \
+    http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1b-1_arm64.deb                 \
+    http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl-dev_1.1.1b-1_arm64.deb                \
     http://ftp.us.debian.org/debian/pool/main/libx/libx11/libx11-6_1.6.4-3%2bdeb9u1_arm64.deb        \
     http://ftp.us.debian.org/debian/pool/main/libx/libx11/libx11-dev_1.6.4-3%2bdeb9u1_arm64.deb      \
     http://ftp.us.debian.org/debian/pool/main/libx/libxext/libxext6_1.3.3-1+b2_arm64.deb             \

--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -716,7 +716,7 @@ bash configure --openjdk-target=${OPENJ9_CC_PREFIX} \
 
   where:
 
-  - `path_to_library` uses a custom OpenSSL v1.1.x library that's already built.
+  - `path_to_library` uses an OpenSSL v1.1.x library that's already built.  You can use `${OPENJ9_CC_DIR}/${OPENJ9_CC_PREFIX}/libc/usr` as `path_to_library` when you are configuring in the Docker container.
   - Use of `fetched`/`system` options for `--with-openssl=` is not tested.
 
 ### 5. Build


### PR DESCRIPTION
This commit adds libssl files to the Dockerfile for AArch64 cross-compilation.
It also updates the Build Instructions with the information on how to build
the runtime with OpenSSL support.

Signed-off-by: knn-k <konno@jp.ibm.com>