### PR TITLE
Handle NullPointerExceptions in ThreadInfo.from()

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -610,7 +610,7 @@ public class ThreadInfo {
 				daemonVal = ((Boolean) cd.get("daemon")).booleanValue(); //$NON-NLS-1$
 				priorityVal = ((Integer) cd.get("priority")).intValue(); //$NON-NLS-1$
 				/*[ENDIF]*/
-			} catch (InvalidKeyException e) {
+			} catch (NullPointerException | InvalidKeyException e) {
 				// throw an IllegalArgumentException as the CompositeData
 				// object does not contain an expected key
 				/*[MSG "K05E6", "CompositeData object does not contain expected key."]*/


### PR DESCRIPTION
If the CompositeData is missing a key the parsing code will throw an NPE.
catch it and translate it to an IllegalArgumentException.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>