### PR TITLE
CMake: Pass VERBATIM option to add_custom_command

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -122,6 +122,7 @@ if(J9VM_GEN_NLS)
 		OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/java.properties"
 		DEPENDS j9nls
 		COMMAND "${Java_JAVA_EXECUTABLE}" -cp "$<TARGET_PROPERTY:j9nls,JAR_FILE>" com.ibm.oti.NLSTool.J9NLS -source "${CMAKE_CURRENT_SOURCE_DIR}"
+		VERBATIM
 	)
 	add_custom_target(j9vm_nlsgen
 		DEPENDS
@@ -138,11 +139,13 @@ endif()
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"
 	DEPENDS oti/helpers.m4 redirector/generated.c.m4
 	COMMAND m4 -I "${CMAKE_CURRENT_SOURCE_DIR}/oti" -I "${CMAKE_CURRENT_SOURCE_DIR}/redirector" "${CMAKE_CURRENT_SOURCE_DIR}/redirector/generated.c.m4" > generated.c
+	VERBATIM
 	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/redirector"
 )
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/j9vm/generated.h"
 	DEPENDS oti/helpers.m4 redirector/forwarders.m4 j9vm/generated.h.m4
 	COMMAND m4 -I "${CMAKE_CURRENT_SOURCE_DIR}/oti" -I "${CMAKE_CURRENT_SOURCE_DIR}/redirector" "${CMAKE_CURRENT_SOURCE_DIR}/j9vm/generated.h.m4" > generated.h
+	VERBATIM
 	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/j9vm"
 )
 

--- a/runtime/cmake/J9vmGenAsm.cmake
+++ b/runtime/cmake/J9vmGenAsm.cmake
@@ -69,6 +69,7 @@ function(j9vm_gen_asm)
 			OUTPUT ${base_name}.s
 			DEPENDS ${m4_file} run_constgen
 			COMMAND m4 ${m4_includes} ${m4_defines} ${CMAKE_CURRENT_SOURCE_DIR}/${m4_file} > ${base_name}.s
+			VERBATIM
 		)
 	endforeach()
 endfunction(j9vm_gen_asm)

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -49,6 +49,7 @@ add_custom_command(
 	OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/env/ut_j9jit.h
 	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ut_j9jit.h
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/ut_j9jit.h" "${CMAKE_CURRENT_SOURCE_DIR}/env/ut_j9jit.h"
+	VERBATIM
 )
 add_custom_target(j9jit_tracegen DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/env/ut_j9jit.h)
 

--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -69,6 +69,7 @@ if(J9VM_GEN_CP)
 	add_custom_command(
 		OUTPUT parsed_cache.txt
 		COMMAND "${CMAKE_COMMAND}" -N -L > "${CMAKE_CURRENT_BINARY_DIR}/parsed_cache.txt"
+		VERBATIM
 		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
 	)
 	add_custom_command(
@@ -81,6 +82,7 @@ if(J9VM_GEN_CP)
 				-outputDir "${CONST_POOL_OUT_DIR}"
 				-cmakeCache "${CMAKE_CURRENT_BINARY_DIR}/parsed_cache.txt"
 				-version ${JAVA_SPEC_VERSION}
+		VERBATIM
 		DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/parsed_cache.txt" j9vmcp objectmodel
 	)
 	add_custom_target(run_cptool

--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -37,6 +37,7 @@ add_custom_command(
 	OUTPUT ${j9vm_BINARY_DIR}/oti/jilconsts.inc ${j9vm_BINARY_DIR}/oti/jilvalues.m4
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${j9vm_BINARY_DIR}/oti
 	COMMAND  constgen
+	VERBATIM
 	WORKING_DIRECTORY ${j9vm_BINARY_DIR}
 )
 add_custom_target(run_constgen


### PR DESCRIPTION
This ensures that all commands are properly escaped

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>