### PR TITLE
DDR Extension Test must use '-XstartOnFirstThread' on MacOSX

### DIFF
--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -1,27 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2019 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <project name="DDR Extension Test" default="clean">
 	<taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
@@ -78,7 +76,7 @@
 			<echo>Using JVM : ${JAVA_COMMAND}</echo>
 			<echo>classname = "j9vm.test.corehelper.StackMapCoreGenerator"</echo>
 			<echo>Java VM Args:</echo>
-			<echo>	jvmarg = -Xshareclasses:name=ddrextjunitSCC,destroy</echo>
+			<echo>  jvmarg = -Xshareclasses:name=ddrextjunitSCC,destroy</echo>
 			<echo></echo>
 			<java fork="true" jvm="${JAVA_COMMAND}" classname="j9vm.test.corehelper.StackMapCoreGenerator"
 				timeout="1200000" failonerror="false">
@@ -87,13 +85,18 @@
 			</java>
 	</target>
 
+	<!-- MacOSX needs -XstartOnFirstThread -->
+	<condition property="StartOnFirstThread" value="-XstartOnFirstThread" else="">
+		<os family="mac" />
+	</condition>
+
 	<target name="TCK.run.tests.ddrext" depends="TCK.destroy.cache">
 		<echo>Running the DDR Extension Test</echo>
 		<java fork="true" jvm="${JAVA_COMMAND}" classname="j9vm.test.ddrext.AutoRun"
 			timeout="1200000" failonerror="true">
-			<jvmarg value="${ADDITIONALEXPORTS}" />
+			<jvmarg line="${ADDITIONALEXPORTS} ${StartOnFirstThread}" />
 			<arg value="${system.dump}" />
-			<arg value="${test.list}"/>	
+			<arg value="${test.list}"/>
 			<arg value="${TEST_RESROOT}/ddrplugin.jar" />
 			<classpath refid="tck.class.path" />
 		</java>


### PR DESCRIPTION
Otherwise the test fails with:
>  FAILED TO establish the default connection to the WindowServer

See https://ci.eclipse.org/openj9/job/Test-extended.functional-JDK8-osx_x86-64_cmprssptrs/104.

https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/278 addresses the problems when `jdmpview` is used, but some tests use `DTFJ` directly: they must use `-XstartOnFirstThread` too.