### PR TITLE
Read Barrier for atomics on statics

### DIFF
--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -991,6 +991,7 @@ public:
 		} else {
 			j9object_t classObject = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 
+			preStaticReadObject(vmThread, clazz, destAddress);
 			preStaticStoreObject(vmThread, classObject, destAddress, swapObject);
 
 			protectIfVolatileBefore(isVolatile, false);
@@ -1032,6 +1033,7 @@ public:
 		} else {
 			j9object_t classObject = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 
+			preStaticReadObject(vmThread, clazz, destAddress);
 			preStaticStoreObject(vmThread, classObject, destAddress, swapObject);
 
 			protectIfVolatileBefore(isVolatile, false);
@@ -2134,7 +2136,6 @@ protected:
 		internalPreReadObject(vmThread, object, srcAddress);
 	}
 	
-
 	/**
 	 * Read a non-object address (pointer to internal VM data) from an object.
 	 * This function is only concerned with moving the actual data. Do not re-implement

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -813,7 +813,7 @@ MM_StandardAccessBarrier::preObjectRead(J9VMThread *vmThread, J9Class *srcClass,
 {
 	omrobjectptr_t object = *(volatile omrobjectptr_t *)srcAddress;
 
-	if (_extensions->scavenger->isObjectInEvacuateMemory(object)) {
+	if ((NULL !=_extensions->scavenger) && _extensions->scavenger->isObjectInEvacuateMemory(object)) {
 		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
 		Assert_MM_true(_extensions->scavenger->isConcurrentInProgress());
 		Assert_MM_true(_extensions->scavenger->isMutatorThreadInSyncWithCycle(env));


### PR DESCRIPTION
Invoke read barrier prior to execution atomic operations (like
compare&swap) on static class fields. We've already had proper barriers
for both:
- non atomic read of statics
- atomic access of non-statics
but we missed to add it for this combination.

This is a pre-req for statics scanning being removed from roots scanning
for GCs that rely on read barrier (like Concurrent Scavenger).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>