### PR TITLE
Update JDK12 InterfaceVersion to 6

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5348,11 +5348,7 @@ JVM_GetInterfaceVersion(void)
 
 	Trc_SC_GetInterfaceVersion_Entry();
 	if (J2SE_CURRENT_VERSION >= J2SE_V11) {
-		if (J2SE_CURRENT_VERSION == J2SE_V12) {
-			result = 5; /* JDK12 hasn't got same update as JDK11 & HEAD */
-		} else {
-			result = 6; /* JDK11 & HEAD */
-		}
+		result = 6;
 	}
 	Trc_SC_GetInterfaceVersion_Exit(result);
 


### PR DESCRIPTION
Update `JDK12 InterfaceVersion` to `6`

`JDK12 JVM_GetInterfaceVersion` should return `6` after latest extension update. (`JDK11` and `HEAD` already return `6`)

Awaiting for @andrew-m-leonard confirmation at https://github.com/eclipse/openj9/issues/5223#issuecomment-476293433

Reviewer: @pshipton 
FYI: @DanHeidinga @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>