### PR TITLE
Add support for -XX:OnOutOfMemoryError=string

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -268,6 +268,7 @@ enum INIT_STAGE {
 #define VMOPT_XDUMP  "-Xdump"
 #define VMOPT_XDUMP_NONE  "-Xdump:none"
 #define VMOPT_XDUMP_DIRECTORY_EQUALS  "-Xdump:directory="
+#define VMOPT_XDUMP_TOOL_OUTOFMEMORYERROR_EXEC_EQUALS "-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,exec="
 #define VMOPT_XARGENCODING "-Xargencoding"
 #define VMOPT_XARGENCODINGCOLON "-Xargencoding:"
 #define VMOPT_XARGENCODINGUTF8 "-Xargencoding:utf8"
@@ -487,6 +488,7 @@ enum INIT_STAGE {
 #define MAPOPT_XXHEAPDUMPPATH_EQUALS "-XX:HeapDumpPath="
 #define MAPOPT_XXMAXHEAPSIZE_EQUALS "-XX:MaxHeapSize="
 #define MAPOPT_XXINITIALHEAPSIZE_EQUALS "-XX:InitialHeapSize="
+#define MAPOPT_XXONOUTOFMEMORYERROR_EQUALS "-XX:OnOutOfMemoryError="
 
 #define VMOPT_XXACTIVEPROCESSORCOUNT_EQUALS "-XX:ActiveProcessorCount="
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4020,6 +4020,10 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XXINITIALHEAPSIZE_EQUALS, VMOPT_XMS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
+	/* Map -XX:OnOutOfMemoryError= to -Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,exec= */ 
+	if (registerCmdLineMapping(vm, MAPOPT_XXONOUTOFMEMORYERROR_EQUALS, VMOPT_XDUMP_TOOL_OUTOFMEMORYERROR_EXEC_EQUALS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
 
 	return 0;
 }

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,16 +30,43 @@
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/cmdLineTest_J9tests" />
-	<property name="src" location="." />
+	<property name="PROJECT_ROOT" location="." />
+	<property name="src" location="${PROJECT_ROOT}/src" />
+	<property name="build" location="${PROJECT_ROOT}/bin" />
 
-	<target name="dist" description="generate the distribution">
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/cmdLineTest_J9tests.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="${src}" />
+		</jar>
 		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml"/>
-			<fileset dir="${src}" includes="*.mk"/>
+			<fileset dir="${PROJECT_ROOT}" includes="*.xml" />
+			<fileset dir="${PROJECT_ROOT}" includes="*.mk" />
 		</copy>
 	</target>
 	
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
 	<target name="build" >
-		<antcall target="dist" inheritall="true" />
+		<antcall target="clean" inheritall="true" />
 	</target>
 </project>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
@@ -24,11 +24,17 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<suite id="J9 Command-Line Option Tests" timeout="180">
+<suite id="J9 Command-Line Option Tests" timeout="600">
     <variable name="READIPINFOFORRAS" value="-XX:+ReadIPInfoForRAS"/>
     <variable name="NOREADIPINFOFORRAS" value="-XX:-ReadIPInfoForRAS"/>
     <variable name="READIPINFOFORRAS_MESSAGE" value="enabled network query to determine host name and IP address for RAS."/>
     <variable name="NOREADIPINFOFORRAS_MESSAGE" value="disabled network query to determine host name and IP address for RAS."/>
+
+    <variable name="JVM_HEAP_LIMIT" value="-Xmx512m"/>
+    <variable name="ONOUTOFMEMORYERROR_EQUALS" value="-XX:OnOutOfMemoryError="/>
+    <variable name="ONOUTOFMEMORYERROR_JAR" value="-cp $Q$$JARPATH$$Q$ OnOutOfMemoryErrorTest"/>
+    <variable name="JAVALANGOUTOFMEMORYERROR" value="java.lang.OutOfMemoryError:"/>
+    <variable name="JVMREQUESTINGTOOLDUMP" value="JVM Requesting Tool dump using 'java -version'"/>
 
     <test id="Verify Generate a javacore to STDOUT">
         <command>$EXE$ -Xdump:java:events=vmstart,file=/STDOUT/</command>
@@ -58,6 +64,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
         <command>$EXE$ $READIPINFOFORRAS$ $NOREADIPINFOFORRAS$ -verbose:init -version</command>
         <output type="success" caseSensitive="yes" regex="no">$NOREADIPINFOFORRAS_MESSAGE$</output>
         <output type="failure" caseSensitive="yes" regex="no">$READIPINFOFORRAS_MESSAGE$</output>
+    </test>
+
+    <test id="test -XX:OnOutOfMemoryError=">
+        <command>$EXE$ $JVM_HEAP_LIMIT$ $ONOUTOFMEMORYERROR_EQUALS$"java -version" $ONOUTOFMEMORYERROR_JAR$</command>
+        <output type="success" caseSensitive="yes" regex="no">$JAVALANGOUTOFMEMORYERROR$</output>
+        <output type="required" caseSensitive="yes" regex="no">$JVMREQUESTINGTOOLDUMP$</output>
+        <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
     </test>
 </suite>
 

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -66,6 +66,7 @@
 	<test>
 		<testCaseName>cmdLineTest_J9test_extended</testCaseName>
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
 	-Xint -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests.xml$(Q) \

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/OnOutOfMemoryErrorTest.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/OnOutOfMemoryErrorTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file OnOutOfMemoryErrorTest.java
+ * @brief Generates a java.lang.OutOfMemoryError to test the command line option
+ *        -XX:OnOutOfMemoryError=
+ */
+
+class OnOutOfMemoryErrorTest {
+    public static void main(String[] args) {
+        Object test = new double[Integer.MAX_VALUE];
+    }
+}


### PR DESCRIPTION
Map -XX:OnOutOfMemoryError=string to the existing OpenJ9 equivalent -Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,exec=string

Fixes: #4945.

Documentation Issue: https://github.com/eclipse/openj9-docs/issues/242

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>