### PR TITLE
Remove TR_EnableJITaaSRemoteAOT Env Flag

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -320,6 +320,7 @@ private:
       );
 #endif
 
+   bool shouldPerformLocalComp(const TR_MethodToBeCompiled *entry);
    }; // CompilationInfoPerThreadBase
 }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -735,9 +735,8 @@ TR_J9VMBase::TR_J9VMBase(
          }
 
    _sharedCache = NULL;
-   static bool isRemoteAOT = feGetEnv("TR_EnableJITaaSRemoteAOT") != NULL;
    if (TR::Options::sharedClassCache() ||
-       (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE && isRemoteAOT))
+       (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE))
       // shared classes and AOT must be enabled, or we should be on the JITaaS server with remote AOT enabled
       {
       if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
@@ -765,12 +764,7 @@ TR_J9VMBase::freeSharedCache()
    {
    if (_sharedCache)        // shared classes and AOT must be enabled
       {
-      if (_compInfo && (_compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE))
-         {
-         static bool isRemoteAOT = feGetEnv("TR_EnableJITaaSRemoteAOT") != NULL;
-         TR_ASSERT(isRemoteAOT, "Found shared cache with remote AOT disabled.");
-         }
-      else
+      if (_compInfo && (_compInfo->getPersistentInfo()->getJITaaSMode() != SERVER_MODE))
          {
          TR_ASSERT(TR::Options::sharedClassCache(), "Found shared cache with option disabled");
          }


### PR DESCRIPTION

[skip ci]
`TR_EnableJITaaSRemoteAOT` env flag is removed from
both client and server. This change requires SVM support
in JITaaS #5158.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>