### PR TITLE
Invoke Read Barrier during monitor cache lookup check

### DIFF
--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -265,7 +265,12 @@ monitorTableAt(J9VMThread* vmStruct, j9object_t object)
 #else
 	objectMonitor = vmStruct->cachedMonitor;
 #endif
-	if ((objectMonitor != NULL) && (((J9ThreadAbstractMonitor*)objectMonitor->monitor)->userData == (UDATA) object)) {
+	/* If we are in a middle of a concurrent GC that may move objects, existing barriers ensure that object ptr is always up-to-date. We also
+	 * have to make sure that the entry in the thread local caches points to the up-to-date location of the cached object, before we proceed
+	 * with the comparison. Otherwise, we may miss to identify cache hit. Hence, we call a 'weak' read barrier (only updating slot if object already moved,
+	 * but not triggering a copy) on userData slot.
+	 */
+	if ((objectMonitor != NULL) && (J9MONITORTABLE_OBJECT_LOAD_VM(vm, &((J9ThreadAbstractMonitor*)objectMonitor->monitor)->userData) == object)) {
 		HIT();
 		TRACE("Cache hit");
 		Trc_VM_monitorTableAt_CacheHit_Exit(vmStruct, objectMonitor);


### PR DESCRIPTION
During the check if a cached monitor's object matches the input object,
when accessing monitor table object slot, use Read Barrier, so that
object address is properly updated, if need.

No stability issue was observed due to the lack of this barrier. This
update should just marginally improve cache hit ratio (if Concurrent
Scavenger cycle is active and if monitor's object slots wasn't already
updated during the cycle).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>