### PR TITLE
Update conditions surrounding JVM_GetClassName / JVM_InitClassName

### DIFF
--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -76,8 +76,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_GetClassContext@4" />
 		<export name="_JVM_GetClassLoader@8" />
 		<export name="_JVM_GetClassName@8">
-			<include-if condition="spec.java12 or not spec.java11"/>
-			<exclude-if condition="spec.java13"/>
+			<exclude-if condition="spec.java11"/>
 		</export>
 		<export name="_JVM_GetClassSignature@8" />
 		<export name="_JVM_GetEnclosingMethodInfo@8" />
@@ -333,9 +332,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_GetNestHost"/>
 		<export name="JVM_GetNestMembers"/>
 		<export name="JVM_AreNestMates"/>
-		<export name="JVM_InitClassName">
-			<exclude-if condition="spec.java12 and not spec.java13"/>
-		</export>
+		<export name="JVM_InitClassName"/>
 	</exports>
 
 	<exports group="jdk12">

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -230,7 +230,9 @@ static char * newPath = NULL;
 J9JavaVM *BFUjavaVM = NULL;
 
 static jclass jlClass = NULL;
+#ifdef J9VM_IVE_RAW_BUILD
 static jfieldID classNameFID = NULL;
+#endif /* J9VM_IVE_RAW_BUILD */
 static jmethodID classDepthMID = NULL;
 static jmethodID classLoaderDepthMID = NULL;
 static jmethodID currentClassLoaderMID = NULL;
@@ -5254,11 +5256,11 @@ J9Class* java_lang_Class_vmRef(JNIEnv* env, jobject clazz);
  * in interface version 6.
  */
 jstring JNICALL
-#if (JAVA_SPEC_VERSION < 11) || (JAVA_SPEC_VERSION == 12)
+#if JAVA_SPEC_VERSION < 11
 JVM_GetClassName
-#else /* (JAVA_SPEC_VERSION < 11) || (JAVA_SPEC_VERSION == 12) */
+#else /* JAVA_SPEC_VERSION < 11 */
 JVM_InitClassName
-#endif /* (JAVA_SPEC_VERSION < 11) || (JAVA_SPEC_VERSION == 12) */
+#endif /* JAVA_SPEC_VERSION < 11 */
 (JNIEnv *env, jclass theClass)
 {
 	J9JavaVM* vm = ((J9VMThread*)env)->javaVM;
@@ -5312,13 +5314,13 @@ JVM_InitClassName
 
 			result = (*env)->NewStringUTF(env, name);
 			j9mem_free_memory(name);
-#if (JAVA_SPEC_VERSION >= 11) && (JAVA_SPEC_VERSION != 12)
+#if JAVA_SPEC_VERSION >= 11
 			// JVM_InitClassName is expected to also cache the result in the 'name' field
 			(*env)->SetObjectField(env, theClass, classNameFID, result);
 			if ((*env)->ExceptionCheck(env)) {
 				result = NULL;
 			}
-#endif /* (JAVA_SPEC_VERSION >= 11) && (JAVA_SPEC_VERSION != 12) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 			return result;
 		}
 	}

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -67,9 +67,9 @@ _X(JVM_GetClassAnnotations,JNICALL,true,jbyteArray ,JNIEnv *env, jclass target)
 _X(JVM_GetClassConstantPool,JNICALL,true,jobject ,JNIEnv *env, jclass target)
 _X(JVM_GetClassContext,JNICALL,true,jobject ,JNIEnv *env)
 _X(JVM_GetClassLoader,JNICALL,true,jobject ,JNIEnv *env, jobject obj)
-_IF([(JAVA_SPEC_VERSION < 11) || (JAVA_SPEC_VERSION == 12)],
+_IF([JAVA_SPEC_VERSION < 11],
 	[_X(JVM_GetClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)])
-_IF([(JAVA_SPEC_VERSION == 11) || (JAVA_SPEC_VERSION >= 13)],
+_IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_InitClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)])
 _X(JVM_GetClassSignature,JNICALL,true,jstring,JNIEnv *env, jclass target)
 _X(JVM_GetEnclosingMethodInfo,JNICALL,true,jobjectArray ,JNIEnv *env, jclass theClass)


### PR DESCRIPTION
`JVM_InitClassName` is now also used for Java 12 (not just 11 and 13).