### PR TITLE
Cache resolved virtual methods created from offset

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1186,6 +1186,20 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
             }
          }
          break;
+      case J9ServerMessageType::ResolvedMethod_getResolvedVirtualMethod:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *, I_32, bool, TR_ResolvedJ9Method *>();
+         auto clazz = std::get<0>(recv);
+         auto offset = std::get<1>(recv);
+         auto ignoreRTResolve = std::get<2>(recv);
+         auto owningMethod = std::get<3>(recv);
+         TR_OpaqueMethodBlock *ramMethod = fe->getResolvedVirtualMethod(clazz, offset, ignoreRTResolve);
+         TR_ResolvedJ9JITaaSServerMethodInfo methodInfo; 
+         if (ramMethod)
+            TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodMirror(methodInfo, ramMethod, 0, owningMethod, fe, trMemory);
+         client->write(ramMethod, methodInfo);
+         }
+         break;
       case J9ServerMessageType::ResolvedMethod_virtualMethodIsOverridden:
          {
          TR_ResolvedJ9Method *method = std::get<0>(client->getRecvData<TR_ResolvedJ9Method *>());

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -246,7 +246,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
    return 0;
 #else
    TR_ResolvedMethod *resolvedMethod = nullptr;
-   if (getCachedResolvedMethod({TR_ResolvedMethodType::Virtual, cpIndex, nullptr}, &resolvedMethod, unresolvedInCP)) 
+   if (getCachedResolvedMethod({TR_ResolvedMethodType::VirtualFromCP, cpIndex, nullptr}, &resolvedMethod, unresolvedInCP)) 
       return resolvedMethod;
 
    // See if the constant pool entry is already resolved or not
@@ -301,7 +301,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
       TR::DebugCounter::incStaticDebugCounter(comp, "resources.resolvedMethods/virtual:#bytes", sizeof(TR_ResolvedJ9Method));
       
       }
-   cacheResolvedMethod({TR_ResolvedMethodType::Virtual, cpIndex, nullptr}, resolvedMethod, unresolvedInCP);
+   cacheResolvedMethod({TR_ResolvedMethodType::VirtualFromCP, cpIndex, nullptr}, resolvedMethod, unresolvedInCP);
 
    return resolvedMethod;
 #endif
@@ -686,20 +686,32 @@ TR_ResolvedMethod *
 TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp, TR_OpaqueClassBlock * classObject, I_32 virtualCallOffset, bool ignoreRtResolve)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-   // the frontend method performs a RPC
-   void * ramMethod = fej9->getResolvedVirtualMethod(classObject, virtualCallOffset, ignoreRtResolve);
-   TR_ResolvedMethod *m;
+   if (fej9->_jitConfig->runtimeFlags & J9JIT_RUNTIME_RESOLVE && !ignoreRtResolve)
+      return NULL;
+
+   TR_ResolvedMethod *resolvedMethod = NULL;
+   // If method is already cached, return right away
+   if (getCachedResolvedMethod({TR_ResolvedMethodType::VirtualFromOffset, virtualCallOffset, classObject}, &resolvedMethod)) 
+      return resolvedMethod;
+
+   // Remote call finds RAM method at offset and creates a resolved method at the client
+   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve, (TR_ResolvedJ9Method *) getRemoteMirror());
+   auto recv = _stream->read<TR_OpaqueMethodBlock *, TR_ResolvedJ9JITaaSServerMethodInfo>();
+   auto ramMethod = std::get<0>(recv);
+   auto &methodInfo = std::get<1>(recv);
+
    // it seems better to override this method for AOT but that's what baseline is doing
    // maybe there is a reason for it
    if (_fe->isAOT_DEPRECATED_DO_NOT_USE())
       {
-      m = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), this) : 0;
+      resolvedMethod = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), methodInfo, this) : 0;
       }
    else
       {
-      m = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), this) : 0;
+      resolvedMethod = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), methodInfo, this) : 0;
       }
-   return m;
+   cacheResolvedMethod({TR_ResolvedMethodType::VirtualFromOffset, virtualCallOffset, classObject}, resolvedMethod);
+   return resolvedMethod;
    }
 
 bool

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -120,7 +120,7 @@ namespace std
 // Since one cache contains different types of resolved methods, need to uniquely identify
 // each type. Apparently, the same cpIndex may refer to both virtual or special method,
 // for different method calls, so using TR_ResolvedMethodType is necessary.
-enum TR_ResolvedMethodType {Virtual, Interface, Static, Special};
+enum TR_ResolvedMethodType {VirtualFromCP, VirtualFromOffset, Interface, Static, Special};
 struct
 TR_ResolvedMethodKey
    {
@@ -257,8 +257,8 @@ private:
    char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    virtual char * fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind = heapAlloc) override;
    void unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo);
-   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedMethod *resolvedMethod, bool *unresolvedInCP);
-   bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP);
+   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedMethod *resolvedMethod, bool *unresolvedInCP = NULL);
+   bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
    };
 
 class TR_ResolvedRelocatableJ9JITaaSServerMethod : public TR_ResolvedJ9JITaaSServerMethod

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -102,12 +102,15 @@ enum J9ServerMessageType
    ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror = 147;
    ResolvedMethod_isUnresolvedString = 148;
    ResolvedMethod_stringConstant = 149;
+   ResolvedMethod_getResolvedVirtualMethod = 150;
 
-   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 150;
-   ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 151;
-   ResolvedRelocatableMethod_fieldAttributes = 152;
-   ResolvedRelocatableMethod_staticAttributes = 153;
-   ResolvedRelocatableMethod_getFieldType = 154;
+   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 160;
+   ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 161;
+   ResolvedRelocatableMethod_fieldAttributes = 162;
+   ResolvedRelocatableMethod_staticAttributes = 163;
+   ResolvedRelocatableMethod_getFieldType = 164;
+
+
    // For TR_J9ServerVM methods
    VM_isClassLibraryClass = 200;
    VM_isClassLibraryMethod = 201;


### PR DESCRIPTION
When JITaaS is run with `initialOptLevel=hot`,
`VM_getResolvedVirtualMethod` and `mirrorResolvedJ9Method`
are the 2 most frequent messages by an order of magnitude.
I did 2 things to reduce the number of these messages:
1. Cache resolved methods in per-compilation cache, just
like other types of resolved methods.
2. When resolved method is not cached,
`TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod`
makes only 1 remote call, instead of 2, as before.