### PR TITLE
Cmdline option to disable CopyForwardMarkCompactHybrid GC

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -637,6 +637,11 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "tarokDisableCopyForwardMarkCompactHybrid")) {
+			extensions->tarokEnableCopyForwardHybrid = false;
+			continue;
+		}
+
 #endif /* defined (J9VM_GC_VLHGC) */
 
 		if(try_scan(&scan_start, "packetListLockSplit=")) {


### PR DESCRIPTION
	- add XXgc:tarokDisableCopyForwardMarkCompactHybrid option for
	disabling Hybrid mode.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>