### PR TITLE
Add draft release notes for 0.14.0

### DIFF
--- a/doc/release-notes/0.14/0.14.md
+++ b/doc/release-notes/0.14/0.14.md
@@ -22,27 +22,31 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# Eclipse OpenJ9 version 0.13 release notes
+# Eclipse OpenJ9 version 0.14 release notes
 
-These release notes support the [Eclipse OpenJ9 0.13 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.13/plan).
+:construction: These release notes are *work in progress* for the next release of OpenJ9.
+
+These release notes support the [Eclipse OpenJ9 0.14 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.14/plan).
 
 
 ## Binaries and supported environments
 
-OpenJ9 release 0.13 supports OpenJDK 12. Binaries are available at the AdoptOpenJDK project:
+OpenJ9 release 0.14 supports OpenJDK 8, 11, and 12. Binaries are available at the AdoptOpenJDK project:
 
-- [OpenJDK with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)
+- [OpenJDK 8 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK 11 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK 12 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)
 
 All builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
 
-:pencil: On Linux and AIX platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK.
+:pencil: On Linux&reg; and AIX&reg; platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](https://eclipse.org/openj9/docs/openj9_support/index.html).
 
 
 ## Notable changes in this release
 
-The following table covers notable changes in v0.13. Further information about these changes can be found in the [user documentation](https://www.eclipse.org/openj9/docs/version0.13/).
+The following table covers notable changes in v0.14. Further information about these changes can be found in the [user documentation](https://www.eclipse.org/openj9/docs/version0.14/).
 
 <table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1"><thead align="left">
 <tr valign="bottom">
@@ -54,43 +58,43 @@ The following table covers notable changes in v0.13. Further information about t
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4655">#4655</a></td>
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5023">#5023</a></td>
 <td valign="top">Extended platform support for software-based pause-less garbage collection</td>
-<td valign="top">OpenJDK8 and later (Linux on POWER LE and AIX platforms)</td>
-<td valign="top">Reduced garbage collection pause times when using -Xgc:concurrentScavenge with the gencon GC policy for Linux on POWER LE and
-AIX platforms. </td>
+<td valign="top">OpenJDK8 and later (Linux on POWER BE)</td>
+<td valign="top">Reduced garbage collection pause times when using -Xgc:concurrentScavenge with the gencon GC policy for Linux on POWER BE. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/227">#227</a></td>
+<tr><td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/275">#275</a> <a href="https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/135">#135</a></td>
 <td valign="top">OpenSSL 1.0.2 support</td>
-<td valign="top">OpenJDK12 (All platforms)</td>
+<td valign="top">OpenJDK8 and OpenJDK11 (All platforms)</td>
 <td valign="top">Improved cryptographic performance for the Digest, CBC, GCM, and RSA algorithms. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4655">#4655</a></td>
-<td valign="top">New Java process status tool (jps)</td>
-<td valign="top">OpenJDK12 (All platforms)</td>
-<td valign="top">The tool can be used to query running Java processes. </td>
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4435">#4435</a></td>
+<td valign="top">New -XX:[+|-]IgnoreUnrecognizedXXColonOptions command-line option</td>
+<td valign="top">OpenJDK8 and later (All platforms)</td>
+<td valign="top">Ability to discover -XX: options that the VM does not recognize on the command line. </td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2837">#2837</a></td>
-<td valign="top">Ability to print a Java dump to STDOUT/STDERR</td>
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/4988">#4988</a></td>
+<td valign="top">New -XX:[+|-]ReadIPInfoForRAS command-line option</td>
 <td valign="top">OpenJDK8 and later (All platforms)</td>
-<td valign="top">Although printing to a file is the best approach for recording a Java dump, the ability to print to STDOUT/STDERR can be useful in some scenarios.</td>
+<td valign="top">Ability to skip a nameserver request to avoid the situation where hostname and IP address cannot be resolved and an application pauses for up to 60 seconds until the request times out.</td>
 </tr>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/1932">#1932</a></td>
-<td valign="top">Control group (cgroup) information is recorded in a Java dump file</td>
-<td valign="top">OpenJDK8 and later (All platforms)</td>
-<td valign="top">Improved diagnostic capability where cgroups are used to control resources. For example, the Docker engine uses cgroups for Docker containers. </td>
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3483">#3483</a></td>
+<td valign="top">DDR support enabled on macOS&reg; platforms</td>
+<td valign="top">OpenJDK8 and later (macOS platform)</td>
+<td valign="top">In earlier releases, DDR support was not available on the macOS platform, which affected problem diagnosis for the VM, garbage collector, and JIT compiler.</td>
 </tr>
+
 
 </table>
 
 
 ## Known Issues
 
-The v0.13.0 release contains the following known issues and limitations:
+The v0.14.0 release contains the following known issues and limitations:
 
 <table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1">
 <thead align="left">
@@ -103,13 +107,6 @@ The v0.13.0 release contains the following known issues and limitations:
 </tr>
 </thead>
 <tbody>
-
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3483">#3483</a></td>
-<td valign="top">DDR support</td>
-<td valign="top">macOS</td>
-<td valign="top">Inability to diagnose problems with the VM, garbage collector, or JIT.</td>
-<td valign="top">None</td>
-</tr>
 
 <tr><td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/54">#54</a></td>
 <td valign="top">Signal handling</td>
@@ -151,4 +148,4 @@ The v0.13.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.13.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.13.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.14.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.14.0).


### PR DESCRIPTION
Included:

- ConcurrentScavenge support on Linux BE
- 2 new -XX options
- OpenSSL 1.0.2 on 8 and 11
- DDR enabled on macOS

[ci skip]

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>