### PR TITLE
(0.14) Fix and re-enable vectorized String.indexOf on 64-bit Power

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -73,11 +73,10 @@ J9::Power::CodeGenerator::CodeGenerator() :
    cg->setSupportsPartialInlineOfMethodHooks();
    cg->setSupportsInliningOfTypeCoersionMethods();
 
-#if 0   
    if (TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX() &&
-      !comp->getOption(TR_DisableFastStringIndexOf) && !TR::Compiler->om.canGenerateArraylets())
+      TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableFastStringIndexOf) &&
+      !TR::Compiler->om.canGenerateArraylets())
       cg->setSupportsInlineStringIndexOf();
-#endif
    
    if (!comp->getOption(TR_DisableReadMonitors))
       cg->setSupportsReadOnlyLocks();

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11782,15 +11782,15 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
    generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cr0, startIndex, endIndex);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, notFoundLabel, cr0);
 
+   // IMPORTANT: The upper 32 bits of a 64-bit register containing an int are undefined. Since the
+   // indices are being passed in as ints, we must ensure that their upper 32 bits are not garbage.
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, result, startIndex);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, endAddress, endIndex);
+
    if (!isLatin1)
       {
-      generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, result, startIndex, startIndex);
-      generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, endAddress, endIndex, endIndex);
-      }
-   else
-      {
-      generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, result, startIndex);
-      generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, endAddress, endIndex);
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, result, result, result);
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, endAddress, endAddress, endAddress);
       }
 
    if (node->getChild(3)->getReferenceCount() == 1)


### PR DESCRIPTION
As discussed in #5211, the fix for vectorized `String.indexOf` on 64-bit Power was merged after the 0.14 code split to allow further testing to weed out any possible issues before it was added to 0.14.

I've been watching both internal and external tests since the original change was merged and haven't seen any failures that could be attributed to this code being enabled again. Based on that, it should be safe to enable this code for the 0.14 release.