### PR TITLE
Enable SymbolValidationManager Part 2

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1798,6 +1798,16 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(clazz));
          }
          break;
+      case J9ServerMessageType::ClassEnv_getROMClassRefName:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *, uint32_t>();
+         auto clazz = std::get<0>(recv);
+         auto cpIndex = std::get<1>(recv);
+         int classRefLen;
+         uint8_t *classRefName = TR::Compiler->cls.getROMClassRefName(comp, clazz, cpIndex, classRefLen);
+         client->write(std::string((char *) classRefName, classRefLen));
+         }
+         break;
       case J9ServerMessageType::SharedCache_getClassChainOffsetInSharedCache:
          {
          auto j9class = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -124,6 +124,7 @@ public:
     * @return The entry point of the method at the given offset
     */
    intptrj_t getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset);
+   uint8_t *getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t cpIndex, int &classRefLen);
    };
 
 }

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -243,6 +243,7 @@ enum J9ServerMessageType
    ClassEnv_iTableRomClass = 508;
    ClassEnv_getITable = 509;
    ClassEnv_classHasIllegalStaticFinalFieldModification = 510;
+   ClassEnv_getROMClassRefName = 511;
 
    // For TR_J9SharedCache
    SharedCache_getClassChainOffsetInSharedCache = 600;


### PR DESCRIPTION
Created a new J9ClassEnv method to fetch ROM class ref name
from the client.

Fixes: #5264 