### PR TITLE
Return NULL instead of throwing when the class name is invalid

### DIFF
--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -56,14 +56,18 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 	J9TranslationLocalBuffer localBuffer = {J9_CP_INDEX_NONE, LOAD_LOCATION_UNKNOWN, NULL};
 
 	if (vm->dynamicLoadBuffers == NULL) {
-		throwNewInternalError(env, "Dynamic loader is unavailable");
-		return NULL;
+		if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+			throwNewInternalError(env, "Dynamic loader is unavailable");
+		}
+		goto done;
 	}
 	dynFuncs = vm->dynamicLoadBuffers;
 
 	if (classRep == NULL) {
-		throwNewNullPointerException(env, NULL);
-		return NULL;
+		if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+			throwNewNullPointerException(env, NULL);
+		}
+		goto done;
 	}
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
@@ -72,18 +76,22 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 		vmFuncs->internalExitVMToJNI(currentThread);
 		/* Make a "flat" copy of classRep */
 		if (length < 0) {
-			throwNewIndexOutOfBoundsException(env, NULL);
-			return NULL;
+			if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+				throwNewIndexOutOfBoundsException(env, NULL);
+			}
+			goto done;
 		}
 		classBytes = j9mem_allocate_memory(length, J9MEM_CATEGORY_CLASSES);
 		if (classBytes == NULL) {
-			vmFuncs->throwNativeOOMError(env, 0, 0);
-			return NULL;
+			if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+				vmFuncs->throwNativeOOMError(env, 0, 0);
+			}
+			goto done;
 		}
 		(*env)->GetByteArrayRegion(env, classRep, offset, length, (jbyte *)classBytes);
 		if ((*env)->ExceptionCheck(env)) {
 			j9mem_free_memory(classBytes);
-			return NULL;
+			goto done;
 		}
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 	}
@@ -123,16 +131,9 @@ retry:
 	if (vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length) != NULL) {
 		/* Bad, we have already defined this class - fail */
 		omrthread_monitor_exit(vm->classTableMutex);
-
-		if (J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
-			/*
-			 * The caller signalled that the name is invalid.
-			 * Don't set a pending exception - the caller will do that.
-			 */
-			goto invalid_name;
+		if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, (UDATA *)*(j9object_t*)className);
 		}
-
-		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, (UDATA *)*(j9object_t*)className);
 		goto done;
 	}
 
@@ -211,18 +212,26 @@ retry:
 	}
 
 done:
-	if ((clazz == NULL) && (currentThread->currentException == NULL)) {
-		/* should not get here -- throw the default exception just in case */
-		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGCLASSFORMATERROR, NULL);
-	}
-			
-	result = vmFuncs->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
+	if (NULL == clazz) {
+		if (J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+			/*
+			 * The caller signalled that the name is invalid. Leave the result NULL and
+			 * clear any pending exception; the caller will throw NoClassDefFoundError.
+			 */
+			currentThread->currentException = NULL;
+ 			currentThread->privateFlags &= ~(UDATA)J9_PRIVATE_FLAGS_REPORT_EXCEPTION_THROW;
+		} else if (NULL == currentThread->currentException) {
+			/* should not get here -- throw the default exception just in case */
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGCLASSFORMATERROR, NULL);
+		}
+	} else {
+		result = vmFuncs->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 
-	if ((NULL != result) && J9CLASS_IS_EXEMPT_FROM_VALIDATION(clazz)) {
-		vmFuncs->fixUnsafeMethods(currentThread, result);
+		if ((NULL != result) && J9CLASS_IS_EXEMPT_FROM_VALIDATION(clazz)) {
+			vmFuncs->fixUnsafeMethods(currentThread, result);
+		}
 	}
 
-invalid_name:
 	vmFuncs->internalExitVMToJNI(currentThread);
 
 	if ((U_8*)utf8NameStackBuffer != utf8Name) {


### PR DESCRIPTION
Prior to #4919, ClassLoader.defineClassImpl() would check if the given
class name and immediately throw NoClassDefFoundError if it was invalid.
Beginning with Java 12, JavaLangAccess.defineClass() is used to define
accessor classes (with invalid names). The name validation must still
be done, but throwing the exception must be delayed until it can be
determined to be the appropriate response. The invalid name is signalled
with a bit in the options parameter to defineClassCommon() which must
not set a pending exception in that case.

This is a replay of #5284 for the 0.14 release branch.