### PR TITLE
Remove references to obsolete JPP flag Sidecar19-SE-OpenJ9

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -425,7 +425,7 @@ boolean casAnnotationType(AnnotationType oldType, AnnotationType newType) {
 		localTypeOffset = getUnsafe().objectFieldOffset(field);
 		AnnotationVars.annotationTypeOffset = localTypeOffset;
 	}
-/*[IF Sidecar19-SE-OpenJ9]*/				
+/*[IF Sidecar19-SE]*/
 	return getUnsafe().compareAndSetObject(localAnnotationVars, localTypeOffset, oldType, newType);
 /*[ELSE]
 	return getUnsafe().compareAndSwapObject(localAnnotationVars, localTypeOffset, oldType, newType);
@@ -4010,7 +4010,7 @@ private ReflectCache acquireReflectCache() {
 		ReflectCache newCache = new ReflectCache(this);
 		do {
 			// Some thread will insert this new cache making it available to all.
-/*[IF Sidecar19-SE-OpenJ9]*/				
+/*[IF Sidecar19-SE]*/
 			if (theUnsafe.compareAndSetObject(this, cacheOffset, null, newCache)) {
 /*[ELSE]
 			if (theUnsafe.compareAndSwapObject(this, cacheOffset, null, newCache)) {

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,9 +28,9 @@ import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-/*[IF Sidecar19-SE-OpenJ9]*/
+/*[IF Sidecar19-SE]*/
 import sun.security.util.FilePermCompat;
-/*[ENDIF] Sidecar19-SE-OpenJ9*/
+/*[ENDIF] Sidecar19-SE*/
 
 /**
  * An AccessControlContext encapsulates the information which is needed
@@ -524,11 +524,11 @@ static int checkPermWithCachedPDsImplied(Permission perm, Object[] toCheck, Acce
 					}
 				}
 			}
-			/*[IF Sidecar19-SE-OpenJ9]*/
+			/*[IF Sidecar19-SE]*/
 			if (!((ProtectionDomain) domain).impliesWithAltFilePerm(perm)) {
 			/*[ELSE]*/
 			if (!((ProtectionDomain) domain).implies(perm)) {
-			/*[ENDIF] Sidecar19-SE-OpenJ9*/
+			/*[ENDIF] Sidecar19-SE*/
 				return i; // NOT implied
 			}
 		}
@@ -585,9 +585,9 @@ static boolean checkPermWithCachedPermImplied(Permission perm, Permission[] perm
 					}
 				}
 			}
-			/*[IF Sidecar19-SE-OpenJ9]*/
+			/*[IF Sidecar19-SE]*/
 			permsLimited[j] = FilePermCompat.newPermPlusAltPath(permsLimited[j]);
-			/*[ENDIF] Sidecar19-SE-OpenJ9*/
+			/*[ENDIF] Sidecar19-SE*/
 			if (!notImplied && permsLimited[j].implies(perm)) {
 				success = true; // just implied
 				if (null != cacheChecked) {

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -243,11 +243,11 @@ private static boolean checkPermissionHelper(Permission perm, AccessControlConte
 			if (pDomains != null) {
 				for (int i = 0; i < length ; ++i) {
 					// invoke PD within acc.context first
-					/*[IF Sidecar19-SE-OpenJ9]*/
+					/*[IF Sidecar19-SE]*/
 					if ((pDomains[length - i - 1] != null) && !pDomains[length - i - 1].impliesWithAltFilePerm(perm)) {
 					/*[ELSE]*/
 					if ((pDomains[length - i - 1] != null) && !pDomains[length - i - 1].implies(perm)) {
-					/*[ENDIF] Sidecar19-SE-OpenJ9*/
+					/*[ENDIF] Sidecar19-SE*/
 						throwACE((debug & AccessControlContext.DEBUG_ACCESS_DENIED) != 0, perm, pDomains[length - i - 1], false);
 					}
 				}

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2019 IBM Corp. and others
  *


### PR DESCRIPTION
Change them to plain "Sidecar19-SE".

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>