### PR TITLE
CMake: update include path

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -190,6 +190,7 @@ target_include_directories(j9vm_interface
 		${CMAKE_CURRENT_SOURCE_DIR}/oti
 		${CMAKE_CURRENT_SOURCE_DIR}/include
 		${J9VM_OMR_DIR}/include_core
+		${CMAKE_CURRENT_BINARY_DIR}/include
 		${CMAKE_CURRENT_BINARY_DIR}/omr
 		${CMAKE_CURRENT_BINARY_DIR}
 		${CMAKE_BINARY_DIR}


### PR DESCRIPTION
non-staging build requires updated include path due to where
openj9-version-info.h is generated

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>