### PR TITLE
Remove stale allocation fence

### DIFF
--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -2052,6 +2052,7 @@ TR::TreeTop *TR_StringPeepholes::detectPattern(TR::Block *block, TR::TreeTop *tt
       initTree->getNode()->setAndIncChild(0,appendedString[0]);
       }
 
+   removeAllocationFenceOfNew(newTree);
    removePendingPushOfResult(newTree);
    TR::TransformUtil::removeTree(comp(), newTree);
 
@@ -2133,6 +2134,19 @@ void TR_StringPeepholes::removePendingPushOfResult(TR::TreeTop *callTreeTop)
             TR::TransformUtil::removeTree(comp(), cursor);
          cursor = cursor->getNextTreeTop();
          }
+      }
+   }
+
+// If new tree is going to be removed, the allocationfence on the new node
+// has to be removed as well
+void TR_StringPeepholes::removeAllocationFenceOfNew(TR::TreeTop *newTreeTop)
+   {
+   TR::TreeTop *cursor = newTreeTop->getNextTreeTop();
+   if (cursor
+       && cursor->getNode()->getOpCodeValue() == TR::allocationFence
+       && cursor->getNode()->getFirstChild() == newTreeTop->getNode()->getFirstChild())
+      {
+      TR::TransformUtil::removeTree(comp(), cursor);
       }
    }
 

--- a/runtime/compiler/optimizer/StringPeepholes.hpp
+++ b/runtime/compiler/optimizer/StringPeepholes.hpp
@@ -104,6 +104,7 @@ class TR_StringPeepholes : public TR::Optimization
    bool skipNodeUnderOSR(TR::Node *node);
    bool invalidNodeUnderOSR(TR::Node *node);
    void removePendingPushOfResult(TR::TreeTop *callTreeTop);
+   void removeAllocationFenceOfNew(TR::TreeTop *newTreeTop);
    void postProcessTreesForOSR(TR::TreeTop *startTree, TR::TreeTop *endTree);
 
    bool _stringClassesRedefined;


### PR DESCRIPTION
StringPeepHoles deletes `new` node of StringBuilder/StringBuffer but
leaves allocation fence in place. The stale allocation fence will cause
failure in later attempt to remove pending push temps. This change fixes
it.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>