### PR TITLE
Use spaces instead of tabs in module-info files

### DIFF
--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -20,16 +20,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-  /*[IF PLATFORM-mz31 | PLATFORM-mz64 | PLATFORM-xz64]*/
-  exports com.ibm.jit.crypto to ibm.crypto.hdwrcca;
-  /*[ENDIF]*/
-  exports com.ibm.sharedclasses.spi to openj9.sharedclasses, java.management, java.rmi;
-  exports com.ibm.oti.vm to java.management, jdk.attach, jdk.management, openj9.jvm, openj9.sharedclasses;
-  exports com.ibm.oti.util to java.management, jdk.attach, jdk.management, openj9.sharedclasses;
-  exports com.ibm.tools.attach.target to jdk.attach, jdk.management;
-  exports jdk.internal.org.objectweb.asm to openj9.dtfj, openj9.dtfjview;
-  // Following allows dtfj/dtfjview modules invoke module addReads & addExports programmatically via reflection APIs
-  exports jdk.internal.module to openj9.dtfj, openj9.dtfjview;
-  uses com.ibm.sharedclasses.spi.SharedClassProvider;
-  uses com.ibm.gpu.spi.GPUAssist.Provider;
-  exports com.ibm.gpu.spi to openj9.gpu;
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
+/*[IF PLATFORM-mz31 | PLATFORM-mz64 | PLATFORM-xz64]*/
+exports com.ibm.jit.crypto to ibm.crypto.hdwrcca;
+/*[ENDIF]*/
+exports com.ibm.sharedclasses.spi to openj9.sharedclasses, java.management, java.rmi;
+exports com.ibm.oti.vm to java.management, jdk.attach, jdk.management, openj9.jvm, openj9.sharedclasses;
+exports com.ibm.oti.util to java.management, jdk.attach, jdk.management, openj9.sharedclasses;
+exports com.ibm.tools.attach.target to jdk.attach, jdk.management;
+exports jdk.internal.org.objectweb.asm to openj9.dtfj, openj9.dtfjview;
+// Following allows dtfj/dtfjview modules invoke module addReads & addExports programmatically via reflection APIs
+exports jdk.internal.module to openj9.dtfj, openj9.dtfjview;
+uses com.ibm.sharedclasses.spi.SharedClassProvider;
+uses com.ibm.gpu.spi.GPUAssist.Provider;
+exports com.ibm.gpu.spi to openj9.gpu;

--- a/jcl/src/java.management/share/classes/module-info.java.extra
+++ b/jcl/src/java.management/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,5 +20,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-	exports com.ibm.java.lang.management.internal to jdk.management;
-	uses com.ibm.sharedclasses.spi.SharedClassProvider;
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
+exports com.ibm.java.lang.management.internal to jdk.management;
+uses com.ibm.sharedclasses.spi.SharedClassProvider;

--- a/jcl/src/jdk.attach/share/classes/module-info.java.extra
+++ b/jcl/src/jdk.attach/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,4 +20,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-	provides com.sun.tools.attach.spi.AttachProvider with com.ibm.tools.attach.attacher.OpenJ9AttachProvider;
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
+provides com.sun.tools.attach.spi.AttachProvider with com.ibm.tools.attach.attacher.OpenJ9AttachProvider;

--- a/jcl/src/jdk.management/share/classes/module-info.java.extra
+++ b/jcl/src/jdk.management/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-	exports com.ibm.lang.management;
-	exports openj9.lang.management;
-	exports com.ibm.virtualization.management;
-	provides sun.management.spi.PlatformMBeanProvider with com.ibm.lang.management.internal.PlatformMBeanProvider;
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
+exports com.ibm.lang.management;
+exports openj9.lang.management;
+exports com.ibm.virtualization.management;
+provides sun.management.spi.PlatformMBeanProvider with com.ibm.lang.management.internal.PlatformMBeanProvider;

--- a/jcl/src/openj9.cuda/share/classes/module-info.java
+++ b/jcl/src/openj9.cuda/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.cuda {
-	requires java.base;
-	exports com.ibm.cuda;
+  requires java.base;
+  exports com.ibm.cuda;
 }

--- a/jcl/src/openj9.dataaccess/share/classes/module-info.java
+++ b/jcl/src/openj9.dataaccess/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.dataaccess {
-	exports com.ibm.dataaccess;
+  exports com.ibm.dataaccess;
 }

--- a/jcl/src/openj9.dtfj/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfj/share/classes/module-info.java
@@ -21,6 +21,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 /**
  * Diagnostic Tool Framework for Java&trade; (DTFJ)
  *
@@ -29,19 +31,19 @@
  * tools. DTFJ works with data from a system dump or a Javadump.
  */
 module openj9.dtfj {
-	requires transitive java.desktop;
-	requires transitive java.logging;
-	requires java.xml;
-	requires openj9.traceformat;
-	/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
-	requires com.ibm.jzos;
-	/*[ENDIF]*/
-	exports com.ibm.dtfj.image;
-	exports com.ibm.dtfj.image.j9 to openj9.dtfjview;
-	exports com.ibm.dtfj.java;
-	exports com.ibm.dtfj.runtime;
-	exports com.ibm.dtfj.utils.file to openj9.dtfjview;
-	exports com.ibm.java.diagnostics.utils to openj9.dtfjview;
-	exports com.ibm.java.diagnostics.utils.commands to openj9.dtfjview;
-	exports com.ibm.java.diagnostics.utils.plugins to openj9.dtfjview;
+  requires transitive java.desktop;
+  requires transitive java.logging;
+  requires java.xml;
+  requires openj9.traceformat;
+  /*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
+  requires com.ibm.jzos;
+  /*[ENDIF]*/
+  exports com.ibm.dtfj.image;
+  exports com.ibm.dtfj.image.j9 to openj9.dtfjview;
+  exports com.ibm.dtfj.java;
+  exports com.ibm.dtfj.runtime;
+  exports com.ibm.dtfj.utils.file to openj9.dtfjview;
+  exports com.ibm.java.diagnostics.utils to openj9.dtfjview;
+  exports com.ibm.java.diagnostics.utils.commands to openj9.dtfjview;
+  exports com.ibm.java.diagnostics.utils.plugins to openj9.dtfjview;
 }

--- a/jcl/src/openj9.dtfjview/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfjview/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,13 +20,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-module openj9.dtfjview {
-	requires openj9.dtfj;
-	requires java.logging;
 
-	exports com.ibm.jvm.dtfjview.commands to openj9.dtfj;
-	exports com.ibm.jvm.dtfjview.commands.infocommands to openj9.dtfj;
-	exports com.ibm.jvm.dtfjview.commands.setcommands to openj9.dtfj;
-	exports com.ibm.jvm.dtfjview.commands.showcommands to openj9.dtfj;
-	exports com.ibm.jvm.dtfjview.commands.xcommands to openj9.dtfj;
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
+module openj9.dtfjview {
+  requires openj9.dtfj;
+  requires java.logging;
+
+  exports com.ibm.jvm.dtfjview.commands to openj9.dtfj;
+  exports com.ibm.jvm.dtfjview.commands.infocommands to openj9.dtfj;
+  exports com.ibm.jvm.dtfjview.commands.setcommands to openj9.dtfj;
+  exports com.ibm.jvm.dtfjview.commands.showcommands to openj9.dtfj;
+  exports com.ibm.jvm.dtfjview.commands.xcommands to openj9.dtfj;
 }

--- a/jcl/src/openj9.gpu/share/classes/module-info.java
+++ b/jcl/src/openj9.gpu/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,9 +20,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.gpu {
-	requires java.base;
-	requires openj9.cuda;
-	exports com.ibm.gpu;
-	provides com.ibm.gpu.spi.GPUAssist.Provider with com.ibm.gpu.internal.CudaGPUAssistProvider;
+  requires java.base;
+  requires openj9.cuda;
+  exports com.ibm.gpu;
+  provides com.ibm.gpu.spi.GPUAssist.Provider with com.ibm.gpu.internal.CudaGPUAssistProvider;
 }

--- a/jcl/src/openj9.jvm/share/classes/module-info.java
+++ b/jcl/src/openj9.jvm/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.jvm {
-	exports com.ibm.jvm;
+  exports com.ibm.jvm;
 }

--- a/jcl/src/openj9.sharedclasses/share/classes/module-info.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.sharedclasses {
-	requires java.base;
-	exports com.ibm.oti.shared;
-	provides com.ibm.sharedclasses.spi.SharedClassProvider with com.ibm.oti.shared.provider.SharedClassProviderImpl;
+  requires java.base;
+  exports com.ibm.oti.shared;
+  provides com.ibm.sharedclasses.spi.SharedClassProvider with com.ibm.oti.shared.provider.SharedClassProviderImpl;
 }

--- a/jcl/src/openj9.traceformat/share/classes/module-info.java
+++ b/jcl/src/openj9.traceformat/share/classes/module-info.java
@@ -20,6 +20,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.traceformat {
-	exports com.ibm.jvm.trace.format.api;
+  exports com.ibm.jvm.trace.format.api;
 }

--- a/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
+++ b/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
+
 module openj9.zosconditionhandling {
   exports com.ibm.le.conditionhandling;
 }


### PR DESCRIPTION
* tabs are not supported by the dependency discovery mechanism in openjdk

This is a replay of #5260 for the 0.14 release branch.