### PR TITLE
Reduce PersistIprofileInfo messages sent to the JITaaS client

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -419,7 +419,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          break;
       case J9ServerMessageType::VM_getVMInfo:
          {
-         ClientSessionData::VMInfo vmInfo;
+         ClientSessionData::VMInfo vmInfo = {};
          vmInfo._systemClassLoader = fe->getSystemClassLoader();
          vmInfo._processID = fe->getProcessID();
          vmInfo._canMethodEnterEventBeHooked = fe->canMethodEnterEventBeHooked();
@@ -432,7 +432,8 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._compressedReferenceShift = TR::Compiler->om.compressedReferenceShift();
          vmInfo._cacheStartAddress = fe->sharedCache() ? fe->sharedCache()->getCacheStartAddress() : 0;
          vmInfo._stringCompressionEnabled = fe->isStringCompressionEnabledVM();
-
+         vmInfo._hasSharedClassCache = TR::Options::sharedClassCache();
+         vmInfo._elgibleForPersistIprofileInfo = vmInfo._isIProfilerEnabled ? fe->getIProfiler()->elgibleForPersistIprofileInfo(comp) : NULL;
          client->write(vmInfo);
          }
          break;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -91,6 +91,8 @@ class ClientSessionData
       int32_t _compressedReferenceShift;
       UDATA _cacheStartAddress;
       bool _stringCompressionEnabled;
+      bool _hasSharedClassCache;
+      bool _elgibleForPersistIprofileInfo;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -345,6 +345,13 @@ TR_IProfiler::walkILTreeForEntries(uintptrj_t *pcEntries, uint32_t &numEntries, 
    return bytesFootprint;
    }
 
+bool
+TR_IProfiler::elgibleForPersistIprofileInfo(TR::Compilation *comp) const
+   {
+      return (TR::Options::sharedClassCache() &&
+             !comp->getOption(TR_DisablePersistIProfile) &&
+             isIProfilingEnabled());
+   }
 
 void
 TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol, TR_ResolvedMethod *resolvedMethod, TR::Compilation *comp)
@@ -367,9 +374,7 @@ TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol
    fprintf(stderr, "persistIprofileInfo for %s while compiling %s\n", methodSig, comp->signature());
 #endif
 
-   if (TR::Options::sharedClassCache()        // shared classes must be enabled
-      && !comp->getOption(TR_DisablePersistIProfile) &&
-      isIProfilingEnabled() &&
+   if (elgibleForPersistIprofileInfo(comp) &&
       (!SCfull || !comp->getOption(TR_DisableUpdateJITBytesSize)))
       {
       TR_J9VMBase *fej9 = (TR_J9VMBase *)_vm;

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -519,6 +519,7 @@ public:
    leave the TR_ResolvedMethodSymbol argument for debugging purpose when called from Ilgen
    */
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp); // JITaaS: mark virtual
+   bool elgibleForPersistIprofileInfo(TR::Compilation *comp) const;
 
    void checkMethodHashTable();
 

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -763,6 +763,11 @@ TR_JITaaSIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, 
    // resolvedMethodSymbol is only used for debugging on the client, so we don't have to send it
    auto serverMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method);
    auto stream = TR::CompilationInfo::getStream();
-   stream->write(JITaaS::J9ServerMessageType::IProfiler_persistIprofileInfo, serverMethod->getRemoteMirror());
-   auto recv = stream->read<JITaaS::Void>();
+   ClientSessionData *clientSessionData = comp->fej9()->_compInfoPT->getClientData();
+
+   if (clientSessionData->getOrCacheVMInfo(stream)->_elgibleForPersistIprofileInfo)
+      {
+      stream->write(JITaaS::J9ServerMessageType::IProfiler_persistIprofileInfo, serverMethod->getRemoteMirror());
+      auto recv = stream->read<JITaaS::Void>();
+      }
    }


### PR DESCRIPTION
[skip ci]
PersistIprofileInfo messages are sent to the JITaaS client even
when there is no SCC at the client. Added `_hasSharedClassCache`
and `_elgibleForPersistIprofileInfo` in `ClientSessionData::VMInfo`
to help the server decide whether or not to send PersistIprofileInfo.

Fixes #5297

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>