### PR TITLE
AArch64: Allow both native build and cross build

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -228,6 +228,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<preclude flag="env_sharedLibsUseGlobalTable"/>
 		</precludes>
 	</flag>
+	<flag id="env_crossbuild">
+		<description>Use toolchain for cross build.</description>
+		<ifRemoved>Build uses native build environment.</ifRemoved>
+	</flag>
 	<flag id="env_data64">
 		<description>Default register width is 64-bits.</description>
 		<ifRemoved>Default register width is 32-bits.</ifRemoved>

--- a/buildspecs/linux_aarch64_cmprssptrs_cross.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs_cross.spec
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<spec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/j9/builder/spec" xsi:schemaLocation="http://www.ibm.com/j9/builder/spec spec-v1.xsd" id="linux_aarch64_cmprssptrs_cross">
+	<name>Linux AArch64 Compressed Pointers</name>
+	<asmBuilderName>LinuxAArch64</asmBuilderName>
+	<cpuArchitecture>ARMv8</cpuArchitecture>
+	<os>linux</os>
+	<defaultJCL>Sidecar</defaultJCL>
+	<defaultSizes>desktop (256M + big OS stack + growable JIT caches)</defaultSizes>
+	<priority>100</priority>
+	<owners>
+		<owner>konno@jp.ibm.com</owner>
+	</owners>
+	<properties>
+		<property name="SE6_extension" value="tar.gz"/>
+		<property name="SE6_package" value="xr64"/>
+		<property name="aotTarget" value="aarch64-linux"/>
+		<property name="directoryDelimiter" value="/"/>
+		<property name="graph_arch.cpu" value="{$spec.arch.cpuISA$}"/>
+		<property name="graph_commands.chroot" value=""/>
+		<property name="graph_commands.unix.remote_host" value=""/>
+		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
+		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_label.classlib" value="150"/>
+		<property name="graph_label.java60_26" value="pxr64cmprssptrs60_26"/>
+		<property name="graph_label.java7" value="pxr64cmprssptrs70"/>
+		<property name="graph_label.java70_27" value="pxr64cmprssptrs70_27"/>
+		<property name="graph_label.java8" value="pxr64cmprssptrs80"/>
+		<property name="graph_label.java9" value="pxr64cmprssptrs90"/>
+		<property name="graph_label.osid" value="lnx"/>
+		<property name="graph_label.profile" value="_cmprssptrs"/>
+		<property name="graph_make_parallel_arg" value="-j `numberOfCPUs`"/>
+		<property name="graph_req.arch0" value="arch:aarch64"/>
+		<property name="graph_req.arch1" value="arch:64bit"/>
+		<property name="graph_req.aux0" value=""/>
+		<property name="graph_req.build" value="{$common.req.build.java9$}"/>
+		<property name="graph_req.build2" value="{$common.req.build.java8$}"/>
+		<property name="graph_req.machine" value="{$machine_mapping.x86$}"/>
+		<property name="graph_req.os" value="{$machine_mapping.linux$}"/>
+		<property name="graph_req.os.build" value="{$spec.property.graph_req.os$}"/>
+		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
+		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>
+		<property name="graph_se_classlib.java6" value="jcl_se.zip"/>
+		<property name="graph_variants" value="linux_2.4,linux_2.6,linux_hammer"/>
+		<property name="isReallyUnix" value="true"/>
+		<property name="j2seRuntimeDir" value="jre/lib/aarch64"/>
+		<property name="j2seTags" value="pxr64cmprssptrs60,j9vmxr64cmprssptrs24"/>
+		<property name="j9BuildName" value="linux_aarch64"/>
+		<property name="j9dt.compileTarget" value="makefile"/>
+		<property name="j9dt.make" value="gmake"/>
+		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
+		<property name="javatestPlatform" value="linux_aarch64"/>
+		<property name="jclMemoryMax" value="-Xmx32m"/>
+		<property name="jclOSStackSizeMax" value=""/>
+		<property name="jdiTestsSupported" value="true"/>
+		<property name="jgrinderTestingSupported" value="true"/>
+		<property name="jitTestingOptLevel" value="optlevel=warm"/>
+		<property name="localRootPath" value="$(J9_UNIX_ROOT)"/>
+		<property name="longLimitCmd" value=""/>
+		<property name="main_shortname" value="xr64"/>
+		<property name="os.lineDelimiter" value="unix"/>
+		<property name="platform_arch" value="aarch64"/>
+		<property name="sun.jdk7.platform_id" value="linux-aarch64"/>
+		<property name="sun.jdk8.platform_id" value="linux-aarch64"/>
+		<property name="svn_stream" value=""/>
+		<property name="uma_make_cmd_ar" value="$(OPENJ9_CC_PREFIX)-ar"/>
+		<property name="uma_make_cmd_as" value="$(OPENJ9_CC_PREFIX)-as"/>
+		<property name="uma_make_cmd_cc" value="$(OPENJ9_CC_PREFIX)-gcc"/>
+		<property name="uma_make_cmd_cpp" value="$(OPENJ9_CC_PREFIX)-cpp -E -P"/>
+		<property name="uma_make_cmd_cxx" value="$(OPENJ9_CC_PREFIX)-g++"/>
+		<property name="uma_make_cmd_cxx_dll_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_ranlib" value="$(OPENJ9_CC_PREFIX)-ranlib"/>
+		<property name="uma_processor" value="aarch64"/>
+		<property name="uma_type" value="unix,linux"/>
+	</properties>
+	<features>
+		<feature id="cmprssptrs"/>
+		<feature id="combogc"/>
+		<feature id="core"/>
+		<feature id="dbgext"/>
+		<feature id="se"/>
+		<feature id="se60_26"/>
+		<feature id="se7"/>
+		<feature id="se70_27"/>
+	</features>
+	<source>
+		<project id="com.ibm.jvmti.tests"/>
+		<project id="compiler"/>
+	</source>
+	<flags>
+		<flag id="arch_aarch64" value="true"/>
+		<flag id="build_autobuild" value="false"/>
+		<flag id="build_dropToHursley" value="true"/>
+		<flag id="build_j2se" value="true"/>
+		<flag id="build_java8" value="false"/>
+		<flag id="build_java9" value="false"/>
+		<flag id="build_openj9" value="true"/>
+		<flag id="build_vmContinuous" value="true"/>
+		<flag id="env_crossbuild" value="true"/>
+		<flag id="env_hasFPU" value="true"/>
+		<flag id="env_littleEndian" value="true"/>
+		<flag id="gc_batchClearTLH" value="true"/>
+		<flag id="gc_debugAsserts" value="true"/>
+		<flag id="gc_inlinedAllocFields" value="true"/>
+		<flag id="gc_minimumObjectSize" value="true"/>
+		<flag id="gc_tlhPrefetchFTA" value="true"/>
+		<flag id="graph_cmdLineTester" value="true"/>
+		<flag id="graph_compile" value="true"/>
+		<flag id="graph_enableTesting_Java8" value="true"/>
+		<flag id="graph_j2seSanity" value="true"/>
+		<flag id="graph_jgrinder" value="true"/>
+		<flag id="graph_plumhall" value="true"/>
+		<flag id="graph_useJTCTestingPlaylist" value="true"/>
+		<flag id="graph_verification" value="true"/>
+		<flag id="interp_aotCompileSupport" value="true"/>
+		<flag id="interp_aotRuntimeSupport" value="true"/>
+		<flag id="interp_debugSupport" value="true"/>
+		<flag id="interp_enableJitOnDesktop" value="true"/>
+		<flag id="interp_flagsInClassSlot" value="true"/>
+		<flag id="interp_gpHandler" value="true"/>
+		<flag id="interp_growableStacks" value="true"/>
+		<flag id="interp_hotCodeReplacement" value="true"/>
+		<flag id="interp_nativeSupport" value="true"/>
+		<flag id="interp_profilingBytecodes" value="true"/>
+		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="ive_jxeFileRelocator" value="true"/>
+		<flag id="ive_jxeInPlaceRelocator" value="true"/>
+		<flag id="ive_jxeNatives" value="true"/>
+		<flag id="ive_jxeOERelocator" value="true"/>
+		<flag id="ive_jxeStreamingRelocator" value="true"/>
+		<flag id="ive_romImageHelpers" value="true"/>
+		<flag id="jit_classUnloadRwmonitor" value="true"/>
+		<flag id="jit_dynamicLoopTransfer" value="true"/>
+		<flag id="jit_fullSpeedDebug" value="true"/>
+		<flag id="jit_gcOnResolveSupport" value="true"/>
+		<flag id="jit_newInstancePrototype" value="true"/>
+		<flag id="jit_supportsDirectJNI" value="true"/>
+		<flag id="module_algorithm_test" value="true"/>
+		<flag id="module_bcutil" value="true"/>
+		<flag id="module_bcverify" value="true"/>
+		<flag id="module_cassume" value="true"/>
+		<flag id="module_cfdumper" value="true"/>
+		<flag id="module_codegen_aarch64" value="true"/>
+		<flag id="module_codegen_common" value="true"/>
+		<flag id="module_codegen_ilgen" value="true"/>
+		<flag id="module_codegen_opt" value="true"/>
+		<flag id="module_codert_aarch64" value="true"/>
+		<flag id="module_codert_common" value="true"/>
+		<flag id="module_codert_vm" value="true"/>
+		<flag id="module_ddr" value="true"/>
+		<flag id="module_ddr_gdb_plugin" value="true"/>
+		<flag id="module_ddrext" value="true"/>
+		<flag id="module_gdb" value="true"/>
+		<flag id="module_gdb_plugin" value="true"/>
+		<flag id="module_gptest" value="true"/>
+		<flag id="module_j9vm" value="true"/>
+		<flag id="module_j9vmtest" value="true"/>
+		<flag id="module_jextractnatives" value="true"/>
+		<flag id="module_jit_aarch64" value="true"/>
+		<flag id="module_jit_common" value="true"/>
+		<flag id="module_jit_vm" value="true"/>
+		<flag id="module_jitrt_aarch64" value="true"/>
+		<flag id="module_jitrt_common" value="true"/>
+		<flag id="module_jniargtests" value="true"/>
+		<flag id="module_jnichk" value="true"/>
+		<flag id="module_jniinv" value="true"/>
+		<flag id="module_jnitest" value="true"/>
+		<flag id="module_jvmti" value="true"/>
+		<flag id="module_jvmtitst" value="true"/>
+		<flag id="module_lifecycle_tests" value="true"/>
+		<flag id="module_masm2gas" value="true"/>
+		<flag id="module_porttest" value="true"/>
+		<flag id="module_rasdump" value="true"/>
+		<flag id="module_rastrace" value="true"/>
+		<flag id="module_shared" value="true"/>
+		<flag id="module_shared_common" value="true"/>
+		<flag id="module_shared_test" value="true"/>
+		<flag id="module_shared_util" value="true"/>
+		<flag id="module_verbose" value="true"/>
+		<flag id="module_zip" value="true"/>
+		<flag id="module_zlib" value="true"/>
+		<flag id="opt_annotations" value="true"/>
+		<flag id="opt_bigInteger" value="true"/>
+		<flag id="opt_debugInfoServer" value="true"/>
+		<flag id="opt_debugJsr45Support" value="true"/>
+		<flag id="opt_deprecatedMethods" value="true"/>
+		<flag id="opt_dynamicLoadSupport" value="true"/>
+		<flag id="opt_icbuilderSupport" value="true"/>
+		<flag id="opt_infoServer" value="true"/>
+		<flag id="opt_invariantInterning" value="true"/>
+		<flag id="opt_jvmti" value="true"/>
+		<flag id="opt_jxeLoadSupport" value="true"/>
+		<flag id="opt_memoryCheckSupport" value="true"/>
+		<flag id="opt_methodHandle" value="true"/>
+		<flag id="opt_multiVm" value="true"/>
+		<flag id="opt_panama" value="false"/>
+		<flag id="opt_reflect" value="true"/>
+		<flag id="opt_remoteConsoleSupport" value="true"/>
+		<flag id="opt_sharedClasses" value="true"/>
+		<flag id="opt_sidecar" value="true"/>
+		<flag id="opt_srpAvlTreeSupport" value="true"/>
+		<flag id="opt_stringCompression" value="true"/>
+		<flag id="opt_useFfi" value="true"/>
+		<flag id="opt_useFfiOnly" value="true"/>
+		<flag id="opt_valhallaValueTypes" value="false"/>
+		<flag id="opt_zero" value="true"/>
+		<flag id="opt_zipSupport" value="true"/>
+		<flag id="opt_zlibCompression" value="true"/>
+		<flag id="opt_zlibSupport" value="true"/>
+		<flag id="port_omrsigSupport" value="false"/>
+		<flag id="port_signalSupport" value="true"/>
+		<flag id="prof_eventReporting" value="true"/>
+		<flag id="ras_dumpAgents" value="true"/>
+		<flag id="ras_eyecatchers" value="true"/>
+		<flag id="size_optimizeSendTargets" value="true"/>
+		<flag id="test_cunit" value="true"/>
+		<flag id="test_jvmti" value="true"/>
+		<flag id="thr_asyncNameUpdate" value="true"/>
+		<flag id="thr_lockNursery" value="true"/>
+		<flag id="thr_lockReservation" value="true"/>
+		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_gnuDebugSymbols" value="true"/>
+		<flag id="uma_supportsIpv6" value="true"/>
+	</flags>
+</spec>

--- a/buildspecs/linux_aarch64_cross.spec
+++ b/buildspecs/linux_aarch64_cross.spec
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<spec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/j9/builder/spec" xsi:schemaLocation="http://www.ibm.com/j9/builder/spec spec-v1.xsd" id="linux_aarch64_cross">
+	<name>Linux AArch64</name>
+	<asmBuilderName>LinuxAArch64</asmBuilderName>
+	<cpuArchitecture>ARMv8</cpuArchitecture>
+	<os>linux</os>
+	<defaultJCL>Sidecar</defaultJCL>
+	<defaultSizes>desktop (256M + big OS stack + growable JIT caches)</defaultSizes>
+	<priority>100</priority>
+	<owners>
+		<owner>konno@jp.ibm.com</owner>
+	</owners>
+	<properties>
+		<property name="SE6_extension" value="tar.gz"/>
+		<property name="SE6_package" value="xr64"/>
+		<property name="aotTarget" value="aarch64-linux"/>
+		<property name="directoryDelimiter" value="/"/>
+		<property name="graph_arch.cpu" value="{$spec.arch.cpuISA$}"/>
+		<property name="graph_commands.chroot" value=""/>
+		<property name="graph_commands.unix.remote_host" value=""/>
+		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
+		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_label.classlib" value="150"/>
+		<property name="graph_label.java60_26" value="pxr6460_26"/>
+		<property name="graph_label.java7" value="pxr6470"/>
+		<property name="graph_label.java70_27" value="pxr6470_27"/>
+		<property name="graph_label.java8" value="pxr6480"/>
+		<property name="graph_label.java8_raw" value="jdk8-linux-arm"/>
+		<property name="graph_label.java9" value="pxr6490"/>
+		<property name="graph_label.osid" value="lnx"/>
+		<property name="graph_label.profile" value=""/>
+		<property name="graph_make_parallel_arg" value="-j `numberOfCPUs`"/>
+		<property name="graph_req.arch0" value="arch:aarch64"/>
+		<property name="graph_req.arch1" value="arch:64bit"/>
+		<property name="graph_req.aux0" value=""/>
+		<property name="graph_req.build" value="{$common.req.build.java9$}"/>
+		<property name="graph_req.build2" value="{$common.req.build.java8$}"/>
+		<property name="graph_req.machine" value="{$machine_mapping.x86$}"/>
+		<property name="graph_req.os" value="{$machine_mapping.linux$}"/>
+		<property name="graph_req.os.build" value="{$spec.property.graph_req.os$}"/>
+		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
+		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>
+		<property name="graph_se_classlib.java6" value="jcl_se.zip"/>
+		<property name="graph_variants" value="linux_2.4,linux_2.6,linux_hammer"/>
+		<property name="isReallyUnix" value="true"/>
+		<property name="j2seRuntimeDir" value="jre/lib/aarch64"/>
+		<property name="j2seTags" value="pxr6460,j9vmxr6424"/>
+		<property name="j9BuildName" value="linux_aarch64"/>
+		<property name="j9dt.compileTarget" value="makefile"/>
+		<property name="j9dt.make" value="gmake"/>
+		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
+		<property name="javatestPlatform" value="linux_aarch64"/>
+		<property name="jclMemoryMax" value="-Xmx32m"/>
+		<property name="jclOSStackSizeMax" value=""/>
+		<property name="jdiTestsSupported" value="true"/>
+		<property name="jgrinderTestingSupported" value="true"/>
+		<property name="jitTestingOptLevel" value="optlevel=warm"/>
+		<property name="localRootPath" value="$(J9_UNIX_ROOT)"/>
+		<property name="longLimitCmd" value=""/>
+		<property name="main_shortname" value="xr64"/>
+		<property name="os.lineDelimiter" value="unix"/>
+		<property name="platform_arch" value="aarch64"/>
+		<property name="sun.jdk7.platform_id" value="linux-aarch64"/>
+		<property name="sun.jdk8.platform_id" value="linux-aarch64"/>
+		<property name="svn_stream" value=""/>
+		<property name="uma_make_cmd_ar" value="$(OPENJ9_CC_PREFIX)-ar"/>
+		<property name="uma_make_cmd_as" value="$(OPENJ9_CC_PREFIX)-as"/>
+		<property name="uma_make_cmd_cc" value="$(OPENJ9_CC_PREFIX)-gcc"/>
+		<property name="uma_make_cmd_cpp" value="$(OPENJ9_CC_PREFIX)-cpp -E -P"/>
+		<property name="uma_make_cmd_cxx" value="$(OPENJ9_CC_PREFIX)-g++"/>
+		<property name="uma_make_cmd_cxx_dll_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_ranlib" value="$(OPENJ9_CC_PREFIX)-ranlib"/>
+		<property name="uma_processor" value="aarch64"/>
+		<property name="uma_type" value="unix,linux"/>
+	</properties>
+	<features>
+		<feature id="combogc"/>
+		<feature id="core"/>
+		<feature id="dbgext"/>
+		<feature id="se"/>
+		<feature id="se60_26"/>
+		<feature id="se7"/>
+		<feature id="se70_27"/>
+	</features>
+	<source>
+		<project id="com.ibm.jvmti.tests"/>
+		<project id="compiler"/>
+	</source>
+	<flags>
+		<flag id="arch_aarch64" value="true"/>
+		<flag id="build_autobuild" value="false"/>
+		<flag id="build_dropToHursley" value="true"/>
+		<flag id="build_j2se" value="true"/>
+		<flag id="build_java8" value="false"/>
+		<flag id="build_vmContinuous" value="true"/>
+		<flag id="env_crossbuild" value="true"/>
+		<flag id="env_data64" value="true"/>
+		<flag id="env_hasFPU" value="true"/>
+		<flag id="env_littleEndian" value="true"/>
+		<flag id="gc_batchClearTLH" value="true"/>
+		<flag id="gc_debugAsserts" value="true"/>
+		<flag id="gc_inlinedAllocFields" value="true"/>
+		<flag id="gc_minimumObjectSize" value="true"/>
+		<flag id="gc_tlhPrefetchFTA" value="true"/>
+		<flag id="graph_cmdLineTester" value="true"/>
+		<flag id="graph_compile" value="true"/>
+		<flag id="graph_enableTesting_Java8" value="true"/>
+		<flag id="graph_j2seSanity" value="true"/>
+		<flag id="graph_jgrinder" value="true"/>
+		<flag id="graph_plumhall" value="true"/>
+		<flag id="graph_useJTCTestingPlaylist" value="true"/>
+		<flag id="graph_verification" value="true"/>
+		<flag id="interp_aotCompileSupport" value="true"/>
+		<flag id="interp_aotRuntimeSupport" value="true"/>
+		<flag id="interp_debugSupport" value="true"/>
+		<flag id="interp_enableJitOnDesktop" value="true"/>
+		<flag id="interp_flagsInClassSlot" value="true"/>
+		<flag id="interp_gpHandler" value="true"/>
+		<flag id="interp_growableStacks" value="true"/>
+		<flag id="interp_hotCodeReplacement" value="true"/>
+		<flag id="interp_nativeSupport" value="true"/>
+		<flag id="interp_profilingBytecodes" value="true"/>
+		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="ive_jxeFileRelocator" value="true"/>
+		<flag id="ive_jxeInPlaceRelocator" value="true"/>
+		<flag id="ive_jxeNatives" value="true"/>
+		<flag id="ive_jxeOERelocator" value="true"/>
+		<flag id="ive_jxeStreamingRelocator" value="true"/>
+		<flag id="ive_romImageHelpers" value="true"/>
+		<flag id="jit_classUnloadRwmonitor" value="true"/>
+		<flag id="jit_dynamicLoopTransfer" value="true"/>
+		<flag id="jit_fullSpeedDebug" value="true"/>
+		<flag id="jit_gcOnResolveSupport" value="true"/>
+		<flag id="jit_newInstancePrototype" value="true"/>
+		<flag id="jit_supportsDirectJNI" value="true"/>
+		<flag id="module_algorithm_test" value="true"/>
+		<flag id="module_bcutil" value="true"/>
+		<flag id="module_bcverify" value="true"/>
+		<flag id="module_cassume" value="true"/>
+		<flag id="module_cfdumper" value="true"/>
+		<flag id="module_codegen_aarch64" value="true"/>
+		<flag id="module_codegen_common" value="true"/>
+		<flag id="module_codegen_ilgen" value="true"/>
+		<flag id="module_codegen_opt" value="true"/>
+		<flag id="module_codert_aarch64" value="true"/>
+		<flag id="module_codert_common" value="true"/>
+		<flag id="module_codert_vm" value="true"/>
+		<flag id="module_ddr" value="true"/>
+		<flag id="module_ddr_gdb_plugin" value="true"/>
+		<flag id="module_ddrext" value="true"/>
+		<flag id="module_gdb" value="true"/>
+		<flag id="module_gdb_plugin" value="true"/>
+		<flag id="module_gptest" value="true"/>
+		<flag id="module_j9vm" value="true"/>
+		<flag id="module_j9vmtest" value="true"/>
+		<flag id="module_jextractnatives" value="true"/>
+		<flag id="module_jit_aarch64" value="true"/>
+		<flag id="module_jit_common" value="true"/>
+		<flag id="module_jit_vm" value="true"/>
+		<flag id="module_jitrt_aarch64" value="true"/>
+		<flag id="module_jitrt_common" value="true"/>
+		<flag id="module_jniargtests" value="true"/>
+		<flag id="module_jnichk" value="true"/>
+		<flag id="module_jniinv" value="true"/>
+		<flag id="module_jnitest" value="true"/>
+		<flag id="module_jvmti" value="true"/>
+		<flag id="module_jvmtitst" value="true"/>
+		<flag id="module_lifecycle_tests" value="true"/>
+		<flag id="module_masm2gas" value="true"/>
+		<flag id="module_porttest" value="true"/>
+		<flag id="module_rasdump" value="true"/>
+		<flag id="module_rastrace" value="true"/>
+		<flag id="module_shared" value="true"/>
+		<flag id="module_shared_common" value="true"/>
+		<flag id="module_shared_test" value="true"/>
+		<flag id="module_shared_util" value="true"/>
+		<flag id="module_verbose" value="true"/>
+		<flag id="module_zip" value="true"/>
+		<flag id="module_zlib" value="true"/>
+		<flag id="opt_annotations" value="true"/>
+		<flag id="opt_bigInteger" value="true"/>
+		<flag id="opt_debugInfoServer" value="true"/>
+		<flag id="opt_debugJsr45Support" value="true"/>
+		<flag id="opt_deprecatedMethods" value="true"/>
+		<flag id="opt_dynamicLoadSupport" value="true"/>
+		<flag id="opt_icbuilderSupport" value="true"/>
+		<flag id="opt_infoServer" value="true"/>
+		<flag id="opt_invariantInterning" value="true"/>
+		<flag id="opt_jvmti" value="true"/>
+		<flag id="opt_jxeLoadSupport" value="true"/>
+		<flag id="opt_memoryCheckSupport" value="true"/>
+		<flag id="opt_methodHandle" value="true"/>
+		<flag id="opt_multiVm" value="true"/>
+		<flag id="opt_panama" value="false"/>
+		<flag id="opt_reflect" value="true"/>
+		<flag id="opt_remoteConsoleSupport" value="true"/>
+		<flag id="opt_sharedClasses" value="true"/>
+		<flag id="opt_sidecar" value="true"/>
+		<flag id="opt_srpAvlTreeSupport" value="true"/>
+		<flag id="opt_stringCompression" value="true"/>
+		<flag id="opt_useFfi" value="true"/>
+		<flag id="opt_useFfiOnly" value="true"/>
+		<flag id="opt_valhallaValueTypes" value="false"/>
+		<flag id="opt_zero" value="true"/>
+		<flag id="opt_zipSupport" value="true"/>
+		<flag id="opt_zlibCompression" value="true"/>
+		<flag id="opt_zlibSupport" value="true"/>
+		<flag id="port_omrsigSupport" value="false"/>
+		<flag id="port_signalSupport" value="true"/>
+		<flag id="prof_eventReporting" value="true"/>
+		<flag id="ras_dumpAgents" value="true"/>
+		<flag id="ras_eyecatchers" value="true"/>
+		<flag id="size_optimizeSendTargets" value="true"/>
+		<flag id="test_cunit" value="true"/>
+		<flag id="test_jvmti" value="true"/>
+		<flag id="thr_asyncNameUpdate" value="true"/>
+		<flag id="thr_lockNursery" value="true"/>
+		<flag id="thr_lockReservation" value="true"/>
+		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_gnuDebugSymbols" value="true"/>
+		<flag id="uma_supportsIpv6" value="true"/>
+	</flags>
+</spec>

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -277,7 +277,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<makefilestubs>
 			<makefilestub data="UMA_EXE_POSTFIX_FLAGS+=-static">
 				<include-if condition="spec.linux_arm.*"/>
-				<include-if condition="spec.linux_aarch64.*" />
+				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</makefilestub>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="include ddr_cpp_headers.mk"/>
@@ -295,11 +295,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 			<library name="j9thrstatic" type="external">
 				<include-if condition="spec.linux_arm.*"/>
-				<include-if condition="spec.linux_aarch64.*" />
+				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</library>
 			<library name="j9thr">
 				<exclude-if condition="spec.linux_arm.*"/>
-				<exclude-if condition="spec.linux_aarch64.*" />
+				<exclude-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</library>
 			<library name="j9portautoblob"/>
 			<library name="j9ddr_cppewautoblob"/>
@@ -348,14 +348,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<commands>
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; ./j9ddrgen" type="all">
 				<exclude-if condition="spec.linux_arm.*"/>
-				<exclude-if condition="spec.linux_aarch64.*"/>
+				<exclude-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild"/>
 				<exclude-if condition="spec.linux_ztpf.*"/>
 			</command>
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; qemu-arm -r '9' ./j9ddrgen" type="all">
 				<include-if condition="spec.linux_arm.*"/>
 			</command>
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; qemu-aarch64 -r '9' ./j9ddrgen" type="all">
-				<include-if condition="spec.linux_aarch64.*"/>
+				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild"/>
 			</command>
 			<command line="cd $(UMA_PATH_TO_ROOT); if [ -x ../build_j9ddrgen.sh ] &amp;&amp; [ ! -e ../j9ddrgen.completed ] ; then ../build_j9ddrgen.sh ; fi" type="all">
 				<include-if condition="spec.linux_ztpf.*"/>

--- a/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
@@ -30,9 +30,6 @@ CONFIGURE_ARGS += \
 OPENJ9_CC_PREFIX ?= aarch64-linux-gnu
 
 CONFIGURE_ARGS += \
-	--host=$(OPENJ9_CC_PREFIX) \
-	--build=x86_64-pc-linux-gnu \
-	'OMR_CROSS_CONFIGURE=yes' \
 	--enable-OMRTHREAD_LIB_UNIX \
 	--enable-OMR_ARCH_AARCH64 \
 	--enable-OMR_ENV_DATA64 \
@@ -40,11 +37,18 @@ CONFIGURE_ARGS += \
 	--enable-OMR_GC_TLH_PREFETCH_FTA \
 	--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 
-ifeq (linux_aarch64_cmprssptrs, $(SPEC))
+ifneq (,$(findstring _cmprssptrs,$(SPEC)))
 	CONFIGURE_ARGS += \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT
+endif
+
+ifneq (,$(findstring _cross,$(SPEC)))
+	CONFIGURE_ARGS += \
+	--host=$(OPENJ9_CC_PREFIX) \
+	--build=x86_64-pc-linux-gnu \
+	'OMR_CROSS_CONFIGURE=yes'
 endif
 
 ifeq (default,$(origin AS))

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -34,7 +34,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<makefilestubs>
 			<makefilestub data="UMA_EXE_POSTFIX_FLAGS+=-static">
 				<include-if condition="spec.linux_arm.*" />
-				<include-if condition="spec.linux_aarch64.*" />
+				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</makefilestub>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 		</makefilestubs>
@@ -51,11 +51,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 			<library name="j9thrstatic" type="external">
 				<include-if condition="spec.linux_arm.*" />
-				<include-if condition="spec.linux_aarch64.*" />
+				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</library>
 			<library name="j9thr">
 				<exclude-if condition="spec.linux_arm.*" />
-				<exclude-if condition="spec.linux_aarch64.*" />
+				<exclude-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</library>
 			<library name="j9hashtable" type="external"/>
 			<library name="j9avl" type="external"/>
@@ -99,14 +99,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<commands>
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; ./constgen" type="all">
 				<exclude-if condition="spec.linux_arm.*"/>
-				<exclude-if condition="spec.linux_aarch64.*"/>
+				<exclude-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 				<exclude-if condition="spec.linux_ztpf.*"/>
 			</command>
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; qemu-arm -r '9' ./constgen" type="all">
 				<include-if condition="spec.linux_arm.*"/>
 			</command>
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; qemu-aarch64 -r '9' ./constgen" type="all">
-				<include-if condition="spec.linux_aarch64.*"/>
+				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</command>
 			<command line="cd $(UMA_PATH_TO_ROOT); if [ -x ../build_constgen.sh ] &amp;&amp; [ ! -e ../constgen.completed ] ; then ../build_constgen.sh ; fi" type="all">
 				<include-if condition="spec.linux_ztpf.*"/>


### PR DESCRIPTION
This commit adds a new flag for cross build in j9.flags, and new spec
files that use the flag for cross build of AArch64 runtime.

Fixes: #5285

Signed-off-by: knn-k <konno@jp.ibm.com>