### PR TITLE
Fix issue relate with CollectionUsageThreshold of memory pool

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_get_collector_id,
 	j9gc_pools_memory,
 	j9gc_pool_maxmemory,
+	j9gc_pool_memoryusage,
 	j9gc_get_gc_action,
 	j9gc_get_gc_cause,
 	j9gc_get_private_hook_interface,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,6 +80,7 @@ extern J9_CFUNC UDATA j9gc_is_local_collector(J9JavaVM* javaVM, UDATA gcID);
 extern J9_CFUNC UDATA j9gc_get_collector_id(OMR_VMThread *omrVMThread);
 extern J9_CFUNC UDATA j9gc_pools_memory(J9JavaVM* javaVM, UDATA poolIDs, UDATA* totals, UDATA* frees, BOOLEAN gcEnd);
 extern J9_CFUNC UDATA j9gc_pool_maxmemory(J9JavaVM* javaVM, UDATA poolID);
+extern J9_CFUNC UDATA j9gc_pool_memoryusage(J9JavaVM *javaVM, UDATA poolID, UDATA *free, UDATA *total);
 extern J9_CFUNC const char* j9gc_get_gc_action(J9JavaVM* javaVM, UDATA gcID);
 extern J9_CFUNC const char* j9gc_get_gc_cause(OMR_VMThread* omrVMthread);
 extern J9_CFUNC struct J9HookInterface** j9gc_get_private_hook_interface(J9JavaVM *javaVM);

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,6 +75,7 @@ UDATA j9gc_is_local_collector(J9JavaVM *javaVM, UDATA gcID);
 UDATA j9gc_get_collector_id(OMR_VMThread *omrVMThread);
 UDATA j9gc_pools_memory(J9JavaVM *javaVM, UDATA poolIDs, UDATA *totals, UDATA *frees, BOOLEAN gcEnd);
 UDATA j9gc_pool_maxmemory(J9JavaVM *javaVM, UDATA poolID);
+UDATA j9gc_pool_memoryusage(J9JavaVM *javaVM, UDATA poolID, UDATA *free, UDATA *total);
 const char *j9gc_get_gc_action(J9JavaVM *javaVM, UDATA gcID);
 const char *j9gc_get_gc_cause(OMR_VMThread *omrVMthread);
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -777,6 +777,7 @@ typedef struct J9JavaLangManagementData {
 	U_32 supportedMemoryPools;
 	U_32 supportedNonHeapMemoryPools;
 	U_32 supportedCollectors;
+	U_32 lastGCID;
 	struct J9MemoryPoolData *memoryPools;
 	struct J9NonHeapMemoryData *nonHeapMemoryPools;
 	struct J9GarbageCollectorData *garbageCollectors;
@@ -4257,6 +4258,7 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA ( *j9gc_get_collector_id)(OMR_VMThread *omrVMThread);
 	UDATA ( *j9gc_pools_memory)(struct J9JavaVM* javaVM, UDATA poolIDs, UDATA* totals, UDATA* frees, BOOLEAN gcEnd);
 	UDATA ( *j9gc_pool_maxmemory)(struct J9JavaVM* javaVM, UDATA poolID);
+	UDATA ( *j9gc_pool_memoryusage)(struct J9JavaVM *javaVM, UDATA poolID, UDATA *free, UDATA *total);
 	const char* (*j9gc_get_gc_action)(struct J9JavaVM* javaVM, UDATA gcID);
 	const char* (*j9gc_get_gc_cause)(struct OMR_VMThread* omrVMthread);
 	J9HookInterface** (*j9gc_get_private_hook_interface)(struct J9JavaVM *javaVM);


### PR DESCRIPTION
	- we should only check if the notification for
	CollectionUsageThreshold need to be fired at the end of
	the collection, which try to recycle the memory pool.
	- for BackCompatible mode scavenge does not try to reclaim
	memory from the whole heap, so we do not fire the notification of
	CollectionUsageThreshold at the end scavenge.
	- record the last GC ID for retrieving more detail gcInfo of
	last GC from J9GarbageCollectorDataMemoryPoolMXBean
	.getCollectionUsage() getPreCollectionUsage() and
	isCollectionUsageThresholdExceeded() also match the same rule.
       - fix potential IllegalArgumentException issue.

relate:https://github.com/eclipse/openj9/pull/2993 
