### PR TITLE
Fix performance with delayed relocations

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2420,7 +2420,7 @@ remoteCompile(
                }
             }
 
-         if (metaData)
+         if (!useAotCompilation || TR::CompilationInfo::canRelocateMethod(compiler))
             {
             TR::compInfoPT->relocateThunks();
             }
@@ -2536,7 +2536,6 @@ remoteCompilationEnd(
       {
       TR_ASSERT(entry->_useAotCompilation, "entry must be an AOT compilation");
       TR_ASSERT(entry->isRemoteCompReq(), "entry must be a remote compilation");
-      
       J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
       TR::CompilationInfo::storeAOTInSharedCache(
          vmThread,
@@ -2630,7 +2629,16 @@ remoteCompilationEnd(
          // AOT compilations can fail on purpose because we want to load
          // the AOT body later on. This case is signalled by having a successful compilation 
          // but canRelocateMethod == false
+         // We still need metadata, because metaData->startPC != 0 indicates that compilation
+         // didn't actually fail.
+         J9JITDataCacheHeader *dataCacheHeader = (J9JITDataCacheHeader *) &dataCacheStr[0];
+         J9JITExceptionTable *metaData = compInfoPT->reloRuntime()->copyMethodMetaData(dataCacheHeader);
+         // Temporarily store meta data pointer.
+         // This is not exactly how it's used in baseline, but in remote AOT we do not use
+         // AOT method data start for anything else, so should be fine.
+         comp->setAotMethodDataStart(metaData);
          TR::CompilationInfo::replenishInvocationCount(method, comp);
+         return metaData;
          }
 #endif /* J9VM_INTERP_AOT_RUNTIME_SUPPORT */
       }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -762,6 +762,21 @@ TR_RelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9JavaVM *pjavaVM, J9
    return NULL;
    }
 
+J9JITExceptionTable *
+TR_RelocationRuntime::copyMethodMetaData(J9JITDataCacheHeader *dataCacheHeader)
+   {
+   TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *) (dataCacheHeader + 1);
+   J9JITDataCacheHeader *exceptionTableCacheEntry = (J9JITDataCacheHeader *)((uint8_t *) dataCacheHeader + aotMethodHeaderEntry->offsetToExceptionTable);
+   uint8_t *newExceptionTableStart = allocateSpaceInDataCache(exceptionTableCacheEntry->size, exceptionTableCacheEntry->type);
+   J9JITExceptionTable *metaData = NULL;
+   if (newExceptionTableStart)
+      {
+      TR_DataCacheManager::copyDataCacheAllocation(reinterpret_cast<J9JITDataCacheHeader *>(newExceptionTableStart), exceptionTableCacheEntry);
+      metaData = reinterpret_cast<J9JITExceptionTable *>(newExceptionTableStart + sizeof(J9JITDataCacheHeader)); // Get new exceptionTable location
+      }
+   return metaData;
+   }
+
 bool TR_RelocationRuntime::_globalValuesInitialized=false;
 
 uintptr_t TR_RelocationRuntime::_globalValueList[TR_NumGlobalValueItems] =

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -247,6 +247,7 @@ class TR_RelocationRuntime {
       uint32_t getNumInlinedAllocRelos() { return 0; }
       uint32_t getNumFailedAllocInlinedRelos() { return 0; }
 #endif
+      virtual J9JITExceptionTable *copyMethodMetaData(J9JITDataCacheHeader *dataCacheHeader);
 
    private:
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize)                           { return NULL; }


### PR DESCRIPTION
Previously, when client wanted to delay relocations
after remote AOT compilation, its meta data would be NULL.
This is incorrect, because control is able to tell if
relocations need to be delayed by checking that relocations
failed but meta data stil exists.
If meta data is NULL, the compilation is treated as a failure,
thus AOTed code never gets loaded from SCC during the same run.
The solution is to temporarily create meta data on the client
for this case.