### PR TITLE
Reduce connections from per comp to per compthread

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -612,9 +612,10 @@ public:
 
    TR_MethodToBeCompiled *addMethodToBeCompiled(TR::IlGeneratorMethodDetails &details, void *pc, CompilationPriority priority,
       bool async, TR_OptimizationPlan *optPlan, bool *queued, TR_YesNoMaybe methodIsInSharedCache);
-   TR_MethodToBeCompiled *addRemoteMethodToBeCompiled(JITaaS::J9ServerStream *stream);
+   TR_MethodToBeCompiled *addOutOfProcessMethodToBeCompiled(JITaaS::J9ServerStream *stream);
    void                   queueEntry(TR_MethodToBeCompiled *entry);
    void                   recycleCompilationEntry(TR_MethodToBeCompiled *cur);
+   void                   requeueOutOfProcessEntry(TR_MethodToBeCompiled *entry);
    TR_MethodToBeCompiled *adjustCompilationEntryAndRequeue(TR::IlGeneratorMethodDetails &details,
                                                            TR_PersistentMethodInfo *methodInfo,
                                                            TR_Hotness newOptLevel, bool useProfiling,

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -68,6 +68,7 @@ struct TR_MethodToBeCompiled;
 class TR_ResolvedMethod;
 class TR_RelocationRuntime;
 class ClientSessionData;
+namespace JITaaS { class J9ClientStream; }
 
 enum CompilationThreadState
    {
@@ -247,6 +248,9 @@ class CompilationInfoPerThreadBase
    void                   setClientData(ClientSessionData *data) { _cachedClientDataPtr = data; }
    ClientSessionData     *getClientData() { return _cachedClientDataPtr; }
 
+   void                   setClientStream(JITaaS::J9ClientStream *stream) { _clientStream = stream; }
+   JITaaS::J9ClientStream *getClientStream() { return _clientStream; }
+
    protected:
 
    TR::CompilationInfo &        _compInfo;
@@ -275,6 +279,7 @@ class CompilationInfoPerThreadBase
 
    // JITaaS
    ClientSessionData * _cachedClientDataPtr;
+   JITaaS::J9ClientStream * _clientStream;
 
 private:
    void logCompilationSuccess(

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2289,6 +2289,9 @@ remoteCompile(
    )
    {
    TR_ASSERT(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS, "Client must work with VM access");
+   // JITaas: if TR_EnableJITaaSPerCompCon is set, then each remote compilation establishes a new connection 
+   // instead of re-using the connection shared within a compilation thread
+   static bool enableJITaaSPerCompConn = feGetEnv("TR_EnableJITaaSPerCompConn") ? true : false;
 
    // Prepare the parameters for the compilation request
    J9Class *clazz = J9_CLASS_FROM_METHOD(method);
@@ -2298,6 +2301,54 @@ remoteCompile(
    std::string detailsStr = std::string((char*) &details, sizeof(TR::IlGeneratorMethodDetails));
    TR::CompilationInfo *compInfo = compInfoPT->getCompilationInfo();
    bool useAotCompilation = compInfoPT->getMethodBeingCompiled()->_useAotCompilation;
+   JITaaS::J9ClientStream *client = NULL;
+   if (enableJITaaSPerCompConn)
+      {
+      try 
+         {
+         client = new (PERSISTENT_NEW) JITaaS::J9ClientStream(compInfo->getPersistentInfo());
+         }
+      catch (const JITaaS::StreamFailure &e)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
+
+         compiler->failCompilation<JITaaS::StreamFailure>(e.what());
+         }
+      catch (const std::bad_alloc &e)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
+      
+         compiler->failCompilation<std::bad_alloc>(e.what());
+         }
+      }
+   else
+      {
+      client = compInfoPT->getClientStream();
+      if (!client)
+         {
+         try
+            {
+            client = new (PERSISTENT_NEW) JITaaS::J9ClientStream(compInfo->getPersistentInfo());
+            compInfoPT->setClientStream(client);
+            }
+         catch (const JITaaS::StreamFailure &e)
+            {
+            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
+
+            compiler->failCompilation<JITaaS::StreamFailure>(e.what());
+            }
+         catch (const std::bad_alloc &e)
+            {
+            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
+      
+            compiler->failCompilation<std::bad_alloc>(e.what());
+            }
+         }
+      }
 
    if (compiler->getOption(TR_UseSymbolValidationManager))
        {
@@ -2325,9 +2376,6 @@ remoteCompile(
    compInfo->incCompReqSeqNo();
    compInfo->getSequencingMonitor()->exit();
 
- 
-   JITaaS::J9ClientStream client(compInfo->getPersistentInfo());
-
    uint32_t statusCode = compilationFailure;
    std::string codeCacheStr;
    std::string dataCacheStr;
@@ -2335,6 +2383,7 @@ remoteCompile(
    std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended;
    std::string logFileStr;
    std::string svmSymbolToIdStr;
+   JITaaS::Status status; 
    try
       {
       // release VM access just before sending the compilation request
@@ -2347,7 +2396,7 @@ remoteCompile(
             "Client sending compReq seqNo=%u to server for method %s @ %s.",
             seqNo, compiler->signature(), compiler->getHotnessName());
          }
-      client.buildCompileRequest(TR::comp()->getPersistentInfo()->getJITaaSId(), romMethodOffset, 
+      client->buildCompileRequest(TR::comp()->getPersistentInfo()->getJITaaSId(), romMethodOffset,
                                  method, clazz, compiler->getMethodHotness(), detailsStr, details.getType(), unloadedClasses,
                                  classInfoTuple, optionsStr, recompMethodInfoStr, seqNo, useAotCompilation);
       // re-acquire VM access and check for possible class unloading
@@ -2363,8 +2412,8 @@ remoteCompile(
          comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted in handleServerMessage");
          }
 
-      while(!handleServerMessage(&client, compiler->fej9vm()));
-      auto recv = client.getRecvData<uint32_t, std::string, std::string, CHTableCommitData, std::vector<TR_OpaqueClassBlock*>, std::string, std::string>();
+      while(!handleServerMessage(client, compiler->fej9vm()));
+      auto recv = client->getRecvData<uint32_t, std::string, std::string, CHTableCommitData, std::vector<TR_OpaqueClassBlock*>, std::string, std::string>();
       statusCode = std::get<0>(recv);
       codeCacheStr = std::get<1>(recv);
       dataCacheStr = std::get<2>(recv);
@@ -2374,15 +2423,20 @@ remoteCompile(
       svmSymbolToIdStr = std::get<6>(recv);
       if (statusCode >= compilationMaxError)
          throw JITaaS::StreamTypeMismatch("Did not receive a valid TR_CompilationErrorCode as the final message on the stream.");
+      status = client->waitForFinish();
       }
    catch (const JITaaS::StreamFailure &e)
       {
       if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
-      
+         
+      client->~J9ClientStream();
+      TR_Memory::jitPersistentFree(client);
+      compInfoPT->setClientStream(NULL);
+
       compiler->failCompilation<JITaaS::StreamFailure>(e.what());
       }
-   JITaaS::Status status = client.waitForFinish();
+
    TR_MethodMetaData *metaData = NULL;
    if (status.ok() && (statusCode == compilationOK || statusCode == compilationNotNeeded))
       {
@@ -2495,6 +2549,12 @@ remoteCompile(
       {
       compInfoPT->getMethodBeingCompiled()->_compErrCode = statusCode;
       compiler->failCompilation<JITaaS::ServerCompFailure>("JITaaS compilation failed.");
+      }
+
+   if (enableJITaaSPerCompConn && client)
+      {
+      client->~J9ClientStream();
+      TR_Memory::jitPersistentFree(client);
       }
    return metaData;
    }
@@ -3655,6 +3715,8 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
 void
 TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider)
    {
+   static bool enableJITaaSPerCompConn = feGetEnv("TR_EnableJITaaSPerCompConn") ? true : false;
+
    bool abortCompilation = false;
    uint64_t clientId = 0;
    TR::CompilationInfo *compInfo = getCompilationInfo();
@@ -3890,6 +3952,15 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             getCompThreadId(), e.what());
       stream->cancel(); // This does nothing for raw sockets
       abortCompilation = true;
+#ifdef JITAAS_USE_RAW_SOCKETS
+      if (!enableJITaaSPerCompConn)
+         {
+         // Delete server stream
+         stream->~J9ServerStream();
+         TR_Memory::jitPersistentFree(stream);
+         entry._stream = NULL;
+         }
+#endif
       }
    catch (const JITaaS::StreamCancel &e)
       {
@@ -3897,6 +3968,15 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream cancelled by client while compThreadID=%d was reading the compilation request: %s",
             getCompThreadId(), e.what());
       abortCompilation = true;
+#ifdef JITAAS_USE_RAW_SOCKETS
+      if (!enableJITaaSPerCompConn)
+         {
+         // Delete server stream
+         stream->~J9ServerStream();
+         TR_Memory::jitPersistentFree(stream);
+         entry._stream = NULL;
+         }
+#endif
       }
    catch (const JITaaS::StreamOOO &e)
       {
@@ -3942,7 +4022,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
 
       // Put the request back into the pool
       setMethodBeingCompiled(NULL); // Must have the compQmonitor
-      compInfo->recycleCompilationEntry(&entry);
+
+      compInfo->requeueOutOfProcessEntry(&entry);
 
       // Reset the pointer to the cached client session data
       if (getClientData())
@@ -3957,12 +4038,16 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
                   TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,"client (%llu) deleted", (unsigned long long)clientId);
                }
             }
-         setClientData(nullptr);
+         setClientData(NULL);
          }
 #ifdef JITAAS_USE_RAW_SOCKETS
-      // Delete server stream
-      stream->~J9ServerStream();
-      TR_Memory::jitPersistentFree(stream);
+      if (enableJITaaSPerCompConn)
+         {
+         // Delete server stream
+         stream->~J9ServerStream();
+         TR_Memory::jitPersistentFree(stream);
+         entry._stream = NULL;
+         }
 #endif
       return;
       }
@@ -4000,7 +4085,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          }
       }
 
-   setClientData(nullptr); // Reset the pointer to the cached client session data
+   setClientData(NULL); // Reset the pointer to the cached client session data
 
    _customClassByNameMap.clear(); // reset before next compilation starts
    entry._newStartPC = startPC;
@@ -4012,8 +4097,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    compInfo->decreaseQueueWeightBy(entry._weight);
    // Put the request back into the pool
    setMethodBeingCompiled(NULL);
-   compInfo->recycleCompilationEntry(&entry);
-
+   compInfo->requeueOutOfProcessEntry(&entry);
    compInfo->printQueue();
 
    // Release the queue slot monitor
@@ -4075,10 +4159,15 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          compInfo->setSuspendThreadDueToLowPhysicalMemory(false);
       }
 
+   
 #ifdef JITAAS_USE_RAW_SOCKETS
-   // Delete server stream
-   stream->~J9ServerStream();
-   TR_Memory::jitPersistentFree(stream);
+   if (enableJITaaSPerCompConn)
+      {
+      // Delete server stream
+      stream->~J9ServerStream();
+      TR_Memory::jitPersistentFree(stream);
+      entry._stream = NULL;
+      }
 #endif
    }
 

--- a/runtime/compiler/rpc/raw/J9Client.cpp
+++ b/runtime/compiler/rpc/raw/J9Client.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,9 @@
 
 namespace JITaaS
 {
+
+int J9ClientStream::_numConnectionsOpened = 0;
+int J9ClientStream::_numConnectionsClosed = 0;
 
 // Create SSL context, load certs and keys. Only needs to be done once.
 // This is called during startup from rossa.cpp
@@ -245,6 +248,7 @@ J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    BIO *ssl = openSSLConnection(_sslCtx, connfd);
    initStream(connfd, ssl);
+   _numConnectionsOpened++;
    }
 
 Status

--- a/runtime/compiler/rpc/raw/J9Client.hpp
+++ b/runtime/compiler/rpc/raw/J9Client.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,10 @@ public:
    static void static_init(TR::PersistentInfo *info);
 
    J9ClientStream(TR::PersistentInfo *info);
-   virtual ~J9ClientStream() {}
+   virtual ~J9ClientStream()
+      {
+      _numConnectionsClosed++;
+      }
 
    template <typename... T>
    void buildCompileRequest(T... args)
@@ -76,6 +79,9 @@ public:
       }
 
    void shutdown();
+
+   static int _numConnectionsOpened;
+   static int _numConnectionsClosed;
 
 private:
    uint32_t _timeout;

--- a/runtime/compiler/rpc/raw/J9Server.cpp
+++ b/runtime/compiler/rpc/raw/J9Server.cpp
@@ -41,8 +41,11 @@
 #include "rpc/SSLProtobufStream.hpp"
 #include <openssl/err.h>
 
+
 namespace JITaaS
 {
+int J9ServerStream::_numConnectionsOpened = 0;
+int J9ServerStream::_numConnectionsClosed = 0;
 
 bool useSSL(TR::PersistentInfo *info)
    {
@@ -54,6 +57,7 @@ J9ServerStream::J9ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    _msTimeout(timeout)
    {
    initStream(connfd, ssl);
+   _numConnectionsOpened++;
    }
 
 // J9Stream destructor is used instead

--- a/runtime/compiler/rpc/raw/J9Server.hpp
+++ b/runtime/compiler/rpc/raw/J9Server.hpp
@@ -39,7 +39,10 @@ class J9ServerStream : J9Stream
    {
 public:
    J9ServerStream(int connfd, BIO *ssl, uint32_t timeout);
-   virtual ~J9ServerStream() {}
+   virtual ~J9ServerStream() 
+      {
+      _numConnectionsClosed++;
+      }
 
    template <typename ...T>
    void write(J9ServerMessageType type, T... args)
@@ -67,6 +70,9 @@ public:
       {
       return _clientId;
       }
+
+   static int _numConnectionsOpened;
+   static int _numConnectionsClosed;
 
 private:
    void finish();

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,13 +31,14 @@
 void J9CompileDispatcher::compile(JITaaS::J9ServerStream *stream)
    {
    TR::CompilationInfo * compInfo = getCompilationInfo(_jitConfig);
+
    TR_MethodToBeCompiled *entry = NULL;
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server received request for stream %p", stream);
       {
       // Grab the compilation monitor to queue this entry and notify a compilation thread
       OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
-      if (compInfo->addRemoteMethodToBeCompiled(stream))
+      if (compInfo->addOutOfProcessMethodToBeCompiled(stream))
          {
          // successfully queued the new entry, so notify a thread
          compInfo->getCompilationMonitor()->notifyAll();


### PR DESCRIPTION
- Currently JITaaS client establishes a new connection to JITaaS server for every compilation. This change reduces the connections to one per compilation thread. This change reduces the number of SSL/TCP handshakes.
- Added two environment variables TR_EnableJITaaSPerCompConn and TR_PrintJITaaSConnStats. When TR_EnableJITaaSPerCompConn is set, we are reverting back to the old way where each client compilation establishes a new connection. When TR_PrintJITaaSConnStats is set, JITaaS connections stats (the number of connections opened and closed on both the server and client) will be printed out.
- Renamed `addRemoteMethodToBeCompiled` to `addOutOfProcessMethodToBeCompiled` as this is a server routine. We use the term `remote` for client routines and `outOfProcess` for server routines.

Issue: #5289
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>