### PR TITLE
Module hash function uses J9Module* pointer as key

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -112,6 +112,7 @@ hashTableAtPut(J9HashTable * table, void * value, BOOLEAN collisionIsFailure)
 	} else if (collisionIsFailure) {
 		retval = HASHTABLE_ATPUT_COLLISION_FAILURE;
 	} else {
+		Trc_MODULE_hashTableAtPut(table, value, node);
 		retval = HASHTABLE_ATPUT_SUCCESS;
 	}
 
@@ -320,9 +321,9 @@ trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, con
 
 	if (NULL != moduleNameUTF) {
 		if (0 == strcmp(moduleNameUTF, JAVA_BASE_MODULE)) {
-			Trc_MODULE_creation_package(currentThread, package, "java.base");
+			Trc_MODULE_createPackage(currentThread, package, "java.base", fromModule);
 		} else {
-			Trc_MODULE_creation_package(currentThread, package, moduleNameUTF);
+			Trc_MODULE_createPackage(currentThread, package, moduleNameUTF, fromModule);
 		}
 		if (moduleNameBuf != moduleNameUTF) {
 			j9mem_free_memory(moduleNameUTF);
@@ -342,13 +343,14 @@ addPackageDefinition(J9VMThread * currentThread, J9Module * fromModule, const ch
 	J9Package * j9package = createPackage(currentThread, fromModule, package);
 
 	if (NULL != j9package) {
+		Trc_MODULE_invokeHashTableAtPut(currentThread, "addPackageDefinition", classLoader, classLoader->packageHashTable, &j9package, j9package, "true");
 		retval = (0 == hashTableAtPut(classLoader->packageHashTable, (void*)&j9package, TRUE));
 	}
 
 	if (!retval) {
 		freePackage(currentThread, j9package);
 	} else {
-		if (TrcEnabled_Trc_MODULE_creation_package) {
+		if (TrcEnabled_Trc_MODULE_createPackage) {
 			trcModulesCreationPackage(currentThread, fromModule, package);
 		}
 	}
@@ -423,6 +425,7 @@ addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, const cha
 		retval = addMulPackageDefinitions(currentThread, fromModule, packages, numPackages);
 		if (ERRCODE_SUCCESS == retval) {
 			BOOLEAN const success = (0 == hashTableAtPut(classLoader->moduleHashTable, (void*)&fromModule, TRUE));
+			Trc_MODULE_invokeHashTableAtPut(currentThread, "addModuleDefinition", classLoader, classLoader->moduleHashTable, &fromModule, fromModule, "true");
 			if (NULL != version) {
 				fromModule->version = J9_JNI_UNWRAP_REFERENCE(version);
 			}
@@ -481,7 +484,7 @@ trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModul
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
-		Trc_MODULE_add_module_exports_to_all(currentThread, package, fromModuleNameUTF);
+		Trc_MODULE_addModuleExportsToAll(currentThread, package, fromModuleNameUTF, fromModule);
 		if (fromModuleNameBuf != fromModuleNameUTF) {
 			j9mem_free_memory(fromModuleNameUTF);
 		}
@@ -495,7 +498,7 @@ exportPackageToAll(J9VMThread * currentThread, J9Module * fromModule, const char
 	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, package, &retval);
 	if (NULL != j9package) {
 		j9package->exportToAll = TRUE;
-		if (TrcEnabled_Trc_MODULE_add_module_exports_to_all) {
+		if (TrcEnabled_Trc_MODULE_addModuleExportsToAll) {
 			trcModulesAddModuleExportsToAll(currentThread, fromModule, package);
 		}
 	}
@@ -512,7 +515,7 @@ trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fr
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
-		Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, package, fromModuleNameUTF);
+		Trc_MODULE_addModuleExportsToAllUnnamed(currentThread, package, fromModuleNameUTF, fromModule);
 		if (fromModuleNameBuf != fromModuleNameUTF) {
 			j9mem_free_memory(fromModuleNameUTF);
 		}
@@ -526,7 +529,7 @@ exportPackageToAllUnamed(J9VMThread * currentThread, J9Module * fromModule, cons
 	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, package, &retval);
 	if (NULL != j9package) {
 		j9package->exportToAllUnnamed = TRUE;
-		if (TrcEnabled_Trc_MODULE_add_module_exports_to_all_unnamed) {
+		if (TrcEnabled_Trc_MODULE_addModuleExportsToAllUnnamed) {
 			trcModulesAddModuleExportsToAllUnnamed(currentThread, fromModule, package);
 		}
 	}
@@ -586,7 +589,7 @@ trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, cons
 	char *toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, toModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if ((NULL != fromModuleNameUTF) && (NULL != toModuleNameUTF)) {
-		Trc_MODULE_add_module_exports(currentThread, package, fromModuleNameUTF, toModuleNameUTF);
+		Trc_MODULE_addModuleExports(currentThread, package, fromModuleNameUTF, fromModule, toModuleNameUTF, toModule);
 	}
 	if (fromModuleNameBuf != fromModuleNameUTF) {
 		j9mem_free_memory(fromModuleNameUTF);
@@ -603,6 +606,7 @@ exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, const c
 	J9Package * const j9package = getPackageDefinition(currentThread, fromModule, package, &retval);
 	if (NULL != j9package) {
 		if (isModuleDefined(currentThread, toModule)) {
+			Trc_MODULE_invokeHashTableAtPut(currentThread, "exportPackageToModule(exportsHashTable)", j9package, j9package->exportsHashTable, &toModule, toModule, "false");
 			if (0 == hashTableAtPut(j9package->exportsHashTable, (void*)&toModule, FALSE)) {
 				retval = ERRCODE_SUCCESS;
 				/*
@@ -617,6 +621,7 @@ exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, const c
 					toModule->removeExportsHashTable = vm->internalVMFunctions->hashPackageTableNew(vm, INITIAL_INTERNAL_PACKAGE_HASHTABLE_SIZE);
 				}
 				if (NULL != toModule->removeExportsHashTable) {
+					Trc_MODULE_invokeHashTableAtPut(currentThread, "exportPackageToModule(removeExportsHashTable)", toModule, toModule->removeExportsHashTable, &j9package, j9package, "false");
 					if (0 != hashTableAtPut(toModule->removeExportsHashTable, (void*)&j9package, FALSE)) {
 						retval = ERRCODE_HASHTABLE_OPERATION_FAILED;
 					}
@@ -630,7 +635,7 @@ exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, const c
 			retval = ERRCODE_MODULE_WASNT_FOUND;
 		}
 	}
-	if (ERRCODE_SUCCESS == retval && TrcEnabled_Trc_MODULE_add_module_exports) {
+	if (ERRCODE_SUCCESS == retval && TrcEnabled_Trc_MODULE_addModuleExports) {
 		trcModulesAddModuleExports(currentThread, fromModule, package, toModule);
 	}
 
@@ -650,6 +655,7 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
 			retval = ERRCODE_SUCCESS;
 		} else if (isModuleDefined(currentThread, toModule)) {
 			BOOLEAN success = FALSE;
+			Trc_MODULE_invokeHashTableAtPut(currentThread, "allowReadAccessToModule(readAccessHashTable)", toModule, toModule->readAccessHashTable, &fromModule, fromModule, "false");
 			if (0 == hashTableAtPut(toModule->readAccessHashTable, (void*)&fromModule, FALSE)) {
 				success = TRUE;
 				/*
@@ -663,6 +669,7 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
 					fromModule->removeAccessHashTable = vm->internalVMFunctions->hashModuleTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
 				}
 				if (NULL != fromModule->removeAccessHashTable) {
+					Trc_MODULE_invokeHashTableAtPut(currentThread, "allowReadAccessToModule(removeAccessHashTable)", fromModule, fromModule->removeAccessHashTable, &toModule, toModule, "false");
 					if (0 != hashTableAtPut(fromModule->removeAccessHashTable, (void*)&toModule, FALSE)) {
 						success = FALSE;
 					}
@@ -768,7 +775,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 					if (success) {
 						/* For "java.base" module setting of jrt URL and patch paths is already done during startup. Avoid doing it here. */
 						if (J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
-							Trc_MODULE_definition(currentThread, nameUTF);
+							Trc_MODULE_defineModule(currentThread, nameUTF, j9mod);
 							if (classLoader == vm->systemClassLoader) {
 								success = vmFuncs->setBootLoaderModulePatchPaths(vm, j9mod, (const char *)nameUTF);
 								if (FALSE == success) {
@@ -803,7 +810,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 							vmFuncs->allClassesEndDo(&classWalkState);
 							vm->runtimeFlags |= J9_RUNTIME_JAVA_BASE_MODULE_CREATED;
 							TRIGGER_J9HOOK_JAVA_BASE_LOADED(vm->hookInterface, currentThread);
-							Trc_MODULE_definition(currentThread, "java.base");
+							Trc_MODULE_defineModule(currentThread, "java.base", j9mod);
 						}
 					} else {
 						throwExceptionHelper(currentThread, rc);
@@ -943,7 +950,7 @@ trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *
 #undef	LOOSE_MODULE
 	}
 	if ((NULL != fromModuleNameUTF) && (NULL != toModuleNameUTF)) {
-		Trc_MODULE_add_reads_module(currentThread, fromModuleNameUTF, toModuleNameUTF);
+		Trc_MODULE_addReadsModule(currentThread, fromModuleNameUTF, j9FromMod, toModuleNameUTF, toModule);
 	}
 	if (fromModuleNameBuf != fromModuleNameUTF) {
 		j9mem_free_memory(fromModuleNameUTF);
@@ -987,7 +994,7 @@ JVM_AddReadsModule(JNIEnv * env, jobject fromModule, jobject toModule)
 				if (ERRCODE_SUCCESS != rc) {
 					throwExceptionHelper(currentThread, rc);
 				} else {
-					if (TrcEnabled_Trc_MODULE_add_reads_module) {
+					if (TrcEnabled_Trc_MODULE_addReadsModule) {
 						trcModulesAddReadsModule(currentThread, toModule, j9FromMod, j9ToMod);
 					}
 				}
@@ -1061,7 +1068,7 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, const cha
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 		currentThread, j9mod->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
-		Trc_MODULE_add_module_package(currentThread, package, moduleNameUTF);
+		Trc_MODULE_addModulePackage(currentThread, package, moduleNameUTF, j9mod);
 		if (moduleNameBuf != moduleNameUTF) {
 			j9mem_free_memory(moduleNameUTF);
 		}
@@ -1095,7 +1102,7 @@ JVM_AddModulePackage(JNIEnv * env, jobject module, const char *package)
 		if (ERRCODE_SUCCESS != rc) {
 			throwExceptionHelper(currentThread, rc);
 		} else {
-			if (TrcEnabled_Trc_MODULE_add_module_package) {
+			if (TrcEnabled_Trc_MODULE_addModulePackage) {
 				trcModulesAddModulePackage(currentThread, j9mod, package);
 			}
 		}
@@ -1305,7 +1312,7 @@ JVM_SetBootLoaderUnnamedModule(JNIEnv *env, jobject module) {
 				if (NULL == J9VMJAVALANGCLASSLOADER_UNNAMEDMODULE(currentThread, systemClassLoader->classLoaderObject)) {
 					J9Module *j9mod = createModule(currentThread, modObj, systemClassLoader, NULL /* NULL name field */);
 					J9VMJAVALANGCLASSLOADER_SET_UNNAMEDMODULE(currentThread, systemClassLoader->classLoaderObject, modObj);
-					Trc_MODULE_set_bootloader_unnamed_module(currentThread);
+					Trc_MODULE_setBootloaderUnnamedModule(currentThread, j9mod);
 				} else {
 					vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, "module is already set in the bootclassloader");
 				}

--- a/runtime/util/module.tdf
+++ b/runtime/util/module.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2018 IBM Corp. and others
+// Copyright (c) 2017, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,24 +21,37 @@
 Executable=module
 DATFileName=J9TraceFormat.dat
 
-TraceEntry=Trc_MODULE_freeJ9Module_entry Overhead=1 Level=5 Test Template="free module %s"
+TraceEntry=Trc_MODULE_freeJ9Module_entry Obsolete Overhead=1 Level=5 Test Template="free module %s"
 TraceExit=Trc_MODULE_freeJ9Module_exit NoEnv Overhead=1 Level=5 Test Template=" free j9module(%p)"
 
-TraceEvent=Trc_MODULE_creation_package Overhead=1 Level=4 Test Template="add package %s for module %s"
+TraceEvent=Trc_MODULE_creation_package Obsolete Overhead=1 Level=4 Test Template="add package %s for module %s"
 
-TraceEvent=Trc_MODULE_definition Overhead=1 Level=5 Template="JVM_DefineModule() define module %s"
+TraceEvent=Trc_MODULE_definition Obsolete Overhead=1 Level=5 Template="JVM_DefineModule() define module %s"
 
-TraceEvent=Trc_MODULE_set_bootloader_unnamed_module Overhead=1 Level=5 Template="JVM_SetBootLoaderUnnamedModule() set unnamed module for boot loader"
+TraceEvent=Trc_MODULE_set_bootloader_unnamed_module Obsolete Overhead=1 Level=5 Template="JVM_SetBootLoaderUnnamedModule() set unnamed module for boot loader"
 
-TraceEvent=Trc_MODULE_add_module_exports Overhead=1 Level=5 Test Template="export package %s in module %s to module %s"
-TraceEvent=Trc_MODULE_add_module_exports_to_all Overhead=1 Level=5 Test Template="export package %s in module %s to all modules"
-TraceEvent=Trc_MODULE_add_module_exports_to_all_unnamed Overhead=1 Level=5 Test Template="export package %s in module %s to all unnamed modules"
+TraceEvent=Trc_MODULE_add_module_exports Obsolete Overhead=1 Level=5 Test Template="export package %s in module %s to module %s"
+TraceEvent=Trc_MODULE_add_module_exports_to_all Obsolete Overhead=1 Level=5 Test Template="export package %s in module %s to all modules"
+TraceEvent=Trc_MODULE_add_module_exports_to_all_unnamed Obsolete Overhead=1 Level=5 Test Template="export package %s in module %s to all unnamed modules"
 
-TraceEvent=Trc_MODULE_add_reads_module Overhead=1 Level=5 Test Template="JVM_AddReadsModule() add read from module %s to module %s"
+TraceEvent=Trc_MODULE_add_reads_module Obsolete Overhead=1 Level=5 Test Template="JVM_AddReadsModule() add read from module %s to module %s"
 
-TraceEvent=Trc_MODULE_add_module_package Overhead=1 Level=5 Test Template="JVM_AddModulePackage() add package %s to module %s"
+TraceEvent=Trc_MODULE_add_module_package Obsolete Overhead=1 Level=5 Test Template="JVM_AddModulePackage() add package %s to module %s"
 
-TraceEvent=Trc_MODULE_setting_package Overhead=1 Level=5 Test Template="internally set package/class: %.*s, loader: %s, module: %s"
+TraceEvent=Trc_MODULE_setting_package Obsolete Overhead=1 Level=5 Test Template="internally set package/class: %.*s, loader: %s, module: %s"
 
 TraceException=Trc_VM_checkVisibility_failed_with_errortype Overhead=1 Level=1 Template="checkVisibility from %p (%.*s) to %p (%.*s) failed, error type: %s"
 TraceException=Trc_VM_checkVisibility_failed_with_errortype_romclass Overhead=1 Level=1 Template="checkVisibility from romClass=%p (%.*s) j9mod=%p to romClass=%p (%.*s) j9mod=%p failed, packagedef'n errcode=%zu, error type: %s"
+
+TraceEntry=Trc_MODULE_freeJ9ModuleV2_entry Overhead=1 Level=5 Test Template="free module %s (0x%p)"
+TraceEvent=Trc_MODULE_createPackage Overhead=1 Level=4 Test Template="add package %s for module %s (0x%p)"
+TraceEvent=Trc_MODULE_defineModule Overhead=1 Level=5 Template="JVM_DefineModule() defines module %s (0x%p)"
+TraceEvent=Trc_MODULE_setBootloaderUnnamedModule Overhead=1 Level=5 Template="JVM_SetBootLoaderUnnamedModule() sets unnamed module (0x%p) for boot loader"
+TraceEvent=Trc_MODULE_addModuleExports Overhead=1 Level=5 Test Template="export package %s in module %s (0x%p) to module %s (0x%p)"
+TraceEvent=Trc_MODULE_addModuleExportsToAll Overhead=1 Level=5 Test Template="export package %s in module %s (0x%p) to all modules"
+TraceEvent=Trc_MODULE_addModuleExportsToAllUnnamed Overhead=1 Level=5 Test Template="export package %s in module %s (0x%p) to all unnamed modules"
+TraceEvent=Trc_MODULE_addReadsModule Overhead=1 Level=5 Test Template="JVM_AddReadsModule() adds read from module %s (0x%p) to module %s (0x%p)"
+TraceEvent=Trc_MODULE_addModulePackage Overhead=1 Level=5 Test Template="JVM_AddModulePackage() adds package %s to module %s (0x%p)"
+TraceEvent=Trc_MODULE_setPackage Overhead=1 Level=5 Test Template="internally set package/class: %.*s, loader: %s (0x%p), module: %s (0x%p)"
+TraceEvent=Trc_MODULE_invokeHashTableAtPut Overhead=1 Level=5 Test Template="%s invokes hashTableAtPut() : 0x%p->table (0x%p), value (0x%p, 0x%p) collisionIsFailure (%s)"
+TraceEvent=Trc_MODULE_hashTableAtPut NoEnv Overhead=1 Level=5 Test Template="hashTableAtPut() : table (0x%p), value (0x%p) node (0x%p) collisionIsFailure(false)"

--- a/runtime/vm/ModularityHashTables.c
+++ b/runtime/vm/ModularityHashTables.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include "j9protos.h"
 #include "ut_j9vm.h"
 
-static j9object_t moduleHashGetName(const void* entry);
 static UDATA packageHashFn(void *key, void *userData);
 static UDATA packageHashEqualFn(void *leftKey, void *rightKey, void *userData);
 static UDATA moduleHashFn(void *key, void *userData);
@@ -32,23 +31,12 @@ static UDATA moduleHashEqualFn(void *leftKey, void *rightKey, void *userData);
 static UDATA moduleExtraInfoHashFn(void *key, void *userData);
 static UDATA moduleExtraInfoHashEqualFn(void *tableNode, void *queryNode, void *userData);
 
-static j9object_t
-moduleHashGetName(const void* entry)
-{
-	const J9Module** const modulePtr = (const J9Module**)entry;
-	const J9Module* const  module = *modulePtr;
-	j9object_t moduleName = module->moduleName;
-
-	return moduleName;
-}
-
 static UDATA 
 moduleHashFn(void *key, void *userData) 
 {
-	J9JavaVM* javaVM = (J9JavaVM*) userData;
-	j9object_t name = moduleHashGetName(key);
-
-	return javaVM->memoryManagerFunctions->j9gc_stringHashFn(&name, userData);
+	const J9Module** const modulePtr = (const J9Module**)key;
+	
+	return (UDATA)(*modulePtr);
 }
 
 
@@ -72,17 +60,11 @@ moduleExtraInfoHashFn(void *key, void *userData)
 static UDATA  
 moduleHashEqualFn(void *tableNode, void *queryNode, void *userData)
 {
-	J9JavaVM* javaVM = (J9JavaVM*) userData;
-
 	const J9Module* const tableNodeModule = *((J9Module**)tableNode);
-	j9object_t tableNodeModuleName = tableNodeModule->moduleName;
-
 	const J9Module* const queryNodeModule = *((J9Module**)queryNode);
-	j9object_t queryNodeModuleName = queryNodeModule->moduleName;
 
-	return javaVM->memoryManagerFunctions->j9gc_stringHashEqualFn(&tableNodeModuleName, &queryNodeModuleName, userData) && (tableNodeModule->classLoader == queryNodeModule->classLoader);
+	return tableNodeModule == queryNodeModule;
 }
-
 
 static UDATA  
 packageHashEqualFn(void *tableNode, void *queryNode, void *userData)

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1985,7 +1985,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 		classLoaderNameUTF = classLoaderNameBuf;
 	}
 	if ((NULL != classLoaderNameUTF) && (NULL != moduleNameUTF)) {
-		Trc_MODULE_setting_package(vmThread, J9UTF8_LENGTH(className), J9UTF8_DATA(className), classLoaderNameUTF, moduleNameUTF);
+		Trc_MODULE_setPackage(vmThread, J9UTF8_LENGTH(className), J9UTF8_DATA(className), classLoaderNameUTF, classLoader, moduleNameUTF, ramClass->module);
 		if (moduleNameBuf != moduleNameUTF) {
 			PORT_ACCESS_FROM_VMC(vmThread);
 			j9mem_free_memory(moduleNameUTF);
@@ -2821,7 +2821,7 @@ fail:
 			}
 			if ((J2SE_VERSION(javaVM) >= J2SE_V11) && (NULL == classBeingRedefined)) {
 				ramClass->module = module;
-				if (TrcEnabled_Trc_MODULE_setting_package) {
+				if (TrcEnabled_Trc_MODULE_setPackage) {
 					trcModulesSettingPackage(vmThread, ramClass, classLoader, className);
 				}
 			}

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,7 +290,7 @@ trcModulesFreeJ9ModuleEntry(J9JavaVM *javaVM, J9Module *j9module)
 	char *moduleNameUTF = copyStringToUTF8WithMemAlloc(
 		currentThread, j9module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
-		Trc_MODULE_freeJ9Module_entry(currentThread, moduleNameUTF);
+		Trc_MODULE_freeJ9ModuleV2_entry(currentThread, moduleNameUTF, j9module);
 		if (moduleNameBuf != moduleNameUTF) {
 			j9mem_free_memory(moduleNameUTF);
 		}
@@ -302,7 +302,7 @@ freeJ9Module(J9JavaVM *javaVM, J9Module *j9module) {
 	/* Removed the module from all other modules readAccessHashTable and removeAccessHashtables */
 	J9HashTableState walkState;
 
-	if (TrcEnabled_Trc_MODULE_freeJ9Module_entry) {
+	if (TrcEnabled_Trc_MODULE_freeJ9ModuleV2_entry) {
 		trcModulesFreeJ9ModuleEntry(javaVM, j9module);
 	}
 


### PR DESCRIPTION
Module hash function uses `J9Module*` pointer as key

Module name string object (`J9Module->moduleName`) is interned and shared among different modules with same name. Using module name as key within `moduleHashFn` can't differentiate different modules;
Modified `moduleHashFn` to use the `J9Module*` pointer as key instead of the module name;
Updated `moduleHashEqualFn` accordingly;
Updated trace points to record `J9Module*` pointer values.
Also obsoleted redundant trace points.
Note: `moduleExtraInfoHashFn` uses `J9Module*` pointer as key as well.

Verified that this PR fixed the crash in #4921 (tested at Linux AMD platform).

Closes: #4921 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>