### PR TITLE
Remove obsolete JPP flag

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
@@ -75,17 +75,17 @@ final class Attachment extends Thread implements Response {
 				Class<?> agentClass;
 				Class<?> startRemoteArgumentType;
 				try {
-					/*[IF Sidecar19-SE-OpenJ9]*/
+					/*[IF Sidecar19-SE]*/
 					agentClass = Class.forName("jdk.internal.agent.Agent"); //$NON-NLS-1$
-					/*[ELSE] Sidecar19-SE-OpenJ9 */
+					/*[ELSE] Sidecar19-SE */
 					agentClass = Class.forName("sun.management.Agent"); //$NON-NLS-1$
-					/*[ENDIF] Sidecar19-SE-OpenJ9 */
+					/*[ENDIF] Sidecar19-SE */
 					
-					/*[IF Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9]*/
+					/*[IF Sidecar19-SE | Sidecar18-SE-OpenJ9]*/
 					startRemoteArgumentType = String.class;
-					/*[ELSE] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+					/*[ELSE] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 					startRemoteArgumentType = Properties.class;
-					/*[ENDIF] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+					/*[ENDIF] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 					startLocalManagementAgentMethod = agentClass.getDeclaredMethod(START_LOCAL_MANAGEMENT_AGENT);
 					startRemoteManagementAgentMethod = agentClass.getDeclaredMethod(START_REMOTE_MANAGEMENT_AGENT, startRemoteArgumentType);
 					startLocalManagementAgentMethod.setAccessible(true);
@@ -416,13 +416,13 @@ final class Attachment extends Thread implements Response {
 			IPC.logMessage("startAgent"); //$NON-NLS-1$
 			if (null != MethodRefsHolder.startRemoteManagementAgentMethod) {
 				Object startArgument;
-				/*[IF Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9]*/
+				/*[IF Sidecar19-SE | Sidecar18-SE-OpenJ9]*/
 				startArgument = agentProperties.entrySet().stream()
 						.map(entry -> entry.getKey() + "=" + entry.getValue()) //$NON-NLS-1$
 						.collect(java.util.stream.Collectors.joining(",")); //$NON-NLS-1$
-				/*[ELSE] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+				/*[ELSE] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 				startArgument = agentProperties;
-				/*[ENDIF] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+				/*[ENDIF] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 				MethodRefsHolder.startRemoteManagementAgentMethod.invoke(null, startArgument);
 				return true;
 			}


### PR DESCRIPTION
Sidecar19-SE-OpenJ9 was used to distinguish Build 148 of Java 9 from the current build.
Since B148 is dead we need only select Java 9 or later.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>