### PR TITLE
CMake: Properly add nlsgen dependencies to omrutil

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -255,6 +255,10 @@ add_subdirectory(gc_glue_java)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_subdirectory("${J9VM_OMR_DIR}" omr)
 
+# Due to CMake technical limitations we can't properly propagate dependencies
+# to omrutil via the glue.
+add_dependencies(omrutil_obj j9vm_nlsgen)
+
 ###
 ### Share library version suffixing
 ###


### PR DESCRIPTION
Since object libraries can't link to interface libraries, the dependencies
from the util glue arent properly propagated to omrutil_obj

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>