### PR TITLE
Add Flattened ValueType Array load/store Implementation

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -179,6 +179,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_getLockwordAddress,
 	j9gc_objaccess_cloneObject,
 	j9gc_objaccess_copyObjectFields,
+	j9gc_objaccess_indexableFlatObjectAddress,
 	j9gc_objaccess_cloneIndexableObject,
 	j9gc_objaccess_asConstantPoolObject,
 #if defined(J9VM_GC_REALTIME)

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -60,6 +60,10 @@ protected:
 	UDATA _ownableSynchronizerLinkOffset; /** Offset within java/util/concurrent/locks/AbstractOwnableSynchronizer of the ownable synchronizer link field */
 public:
 
+	MMINLINE j9flatobject_t indexableFlatObjectAddress(J9VMThread *vmThread, J9IndexableObject *arrayRef, J9Class *clazz, I_32 index) {
+		return (j9flatobject_t)(indexableEffectiveAddress(vmThread, arrayRef, index, J9ARRAYCLASS_GET_STRIDE(clazz)));
+	}
+
 	/* member function */
 private:
 	/**

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -616,6 +616,16 @@ j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Obj
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
 	return barrier->copyObjectFields(vmThread, valueClass, srcObject, srcOffset, destObject, destOffset);
+}
+
+/**
+ * Called by to get address of a flattened array
+ */
+j9flatobject_t
+j9gc_objaccess_indexableFlatObjectAddress(J9VMThread *vmThread, J9IndexableObject *arrayRef, J9Class *clazz, I_32 index)
+{
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->indexableFlatObjectAddress(vmThread, arrayRef, clazz, index);
 }
 
 /**

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -97,6 +97,7 @@ extern J9_CFUNC void j9gc_objaccess_indexableStoreAddress(J9VMThread *vmThread, 
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_cloneObject(J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject);
 extern J9_CFUNC void j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset);
+extern J9_CFUNC j9flatobject_t j9gc_objaccess_indexableFlatObjectAddress(J9VMThread *vmThread, J9IndexableObject *arrayRef, J9Class *clazz, I_32 index);
 extern J9_CFUNC j9object_t j9gc_objaccess_asConstantPoolObject(J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags);
 extern J9_CFUNC jvmtiIterationControl j9mm_iterate_heaps(J9JavaVM *vm, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl(*func)(J9JavaVM *vm, struct J9MM_IterateHeapDescriptor *heapDesc, void *userData), void *userData);
 extern J9_CFUNC int gcStartupHeapManagement(J9JavaVM * vm);

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -362,6 +362,10 @@ public:
 		copyObjectFields(currentThread, objectClass, original, mixedObjectGetHeaderSize(), copy, mixedObjectGetHeaderSize());
 	}
 
+	VMINLINE j9flatobject_t inlineIndexableFlatObjectAddress(J9VMThread *vmThread, J9IndexableObject *arrayRef, J9Class *clazz, I_32 index)
+	{
+		return (j9flatobject_t)vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_indexableFlatObjectAddress(vmThread, arrayRef, clazz, index);
+	}
 
 	/**
 	 * Copy valueType from sourceObject to destObject
@@ -2667,6 +2671,7 @@ private:
 			internalStaticPreStoreObjectSATB(vmThread, object, destAddress, value);
 		}
 	}
+
 
 	/**
 	 * Perform the preStore barrier for WRT

--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -62,7 +62,7 @@ extern "C" {
 #if JAVA_SPEC_VERSION >= 11
 #define J9VM_OPT_VALHALLA_NESTMATES
 #endif
-
+#define J9VM_OPT_VALHALLA_VALUE_TYPES
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -75,6 +75,9 @@ typedef UDATA fj9object_t;
 typedef UDATA fj9array_t;
 #endif
 
+/* j9flatobject_t is a pointer to a headerless object */
+typedef UDATA j9flatobject_t;
+
 /**
  * Internal references.  
  * Some modules need a structure type for objects that describe the header to effectively perform work.  

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4297,6 +4297,7 @@ typedef struct J9MemoryManagerFunctions {
 	j9objectmonitor_t*  ( *j9gc_objaccess_getLockwordAddress)(struct J9VMThread *vmThread, j9object_t object) ;
 	void  ( *j9gc_objaccess_cloneObject)(struct J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject) ;
 	void ( *j9gc_objaccess_copyObjectFields)(struct J9VMThread *vmThread, J9Class* valueClass, j9object_t srcObject, UDATA srcOffset, j9object_t destObject, UDATA destOffset) ;
+	j9flatobject_t ( *j9gc_objaccess_indexableFlatObjectAddress)(struct J9VMThread *vmThread, J9IndexableObject *arrayRef, J9Class *clazz, I_32 index);
 	void  ( *j9gc_objaccess_cloneIndexableObject)(struct J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject) ;
 	j9object_t  ( *j9gc_objaccess_asConstantPoolObject)(struct J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags) ;
 #if defined(J9VM_GC_REALTIME)

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5803,10 +5803,8 @@ done:
 						arrayrefClass = VM_VMHelpers::currentClass(arrayrefClass);
 					}
 
-					UDATA stride = J9ARRAYCLASS_GET_STRIDE(arrayrefClass);
-					/* There is only support for contiguous arrays and only -Xgcpolicy:nogc has support. Support for discontiguous arrays and the other GC policies will come later. */
-					UDATA headerSize = ((MM_GCExtensionsBase *)vm->gcExtensions)->indexableObjectModel.getHeaderSize();
-					_objectAccessBarrier.copyObjectFields(_currentThread, ((J9ArrayClass*)arrayrefClass)->leafComponentType, arrayref, ((index * stride) + headerSize), newObjectRef, headerSize);
+					UDATA elementAddress = _objectAccessBarrier.inlineIndexableFlatObjectAddress(_currentThread, (J9IndexableObject *)arrayref, arrayrefClass, index);
+					_objectAccessBarrier.copyObjectFields(_currentThread, ((J9ArrayClass*)arrayrefClass)->leafComponentType, (j9object_t)elementAddress, 0, (j9object_t)newObjectRef, J9_OBJECT_HEADER_SIZE);
 					value = newObjectRef;
 				}
 #endif /* ifdef J9VM_OPT_VALHALLA_VALUE_TYPES */
@@ -5844,10 +5842,9 @@ done:
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
 					J9Class *arrayrefClass = J9OBJECT_CLAZZ(_currentThread, arrayref);
 					if (J9_IS_J9CLASS_VALUETYPE(arrayrefClass) && J9_IS_J9CLASS_FLATTENED(arrayrefClass)) {
-						UDATA stride = J9ARRAYCLASS_GET_STRIDE(arrayrefClass);
 						/* There is only support for contiguous arrays and only -Xgcpolicy:nogc has support. Support for discontiguous arrays and the other GC policies will come later. */
-						UDATA headerSize = ((MM_GCExtensionsBase *)vm->gcExtensions)->indexableObjectModel.getHeaderSize();
-						_objectAccessBarrier.copyObjectFields(_currentThread, ((J9ArrayClass*)arrayrefClass)->leafComponentType, value, headerSize, arrayref, ((index * stride) + headerSize));
+						UDATA elementAddress = _objectAccessBarrier.inlineIndexableFlatObjectAddress(_currentThread, arrayref, arrayrefClass, index);
+						_objectAccessBarrier.copyObjectFields(_currentThread, ((J9ArrayClass*)arrayrefClass)->leafComponentType, value, J9_OBJECT_HEADER_SIZE, (j9object_t)elementAddress, 0);
 					} else 
 #endif /* ifdef J9VM_OPT_VALHALLA_VALUE_TYPES */
 					{

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2876,6 +2876,7 @@ fail:
 				ramArrayClass->lockOffset = (UDATA)TMP_OFFSETOF_J9INDEXABLEOBJECT_MONITOR;
 #endif
 				if (J9_IS_J9CLASS_VALUETYPE(elementClass) && J9_IS_J9CLASS_FLATTENED(elementClass)) {
+					ramClass->classFlags |= (elementClass->classFlags & J9ClassIsValueType);
 					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));
 					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2876,7 +2876,7 @@ fail:
 				ramArrayClass->lockOffset = (UDATA)TMP_OFFSETOF_J9INDEXABLEOBJECT_MONITOR;
 #endif
 				if (J9_IS_J9CLASS_VALUETYPE(elementClass) && J9_IS_J9CLASS_FLATTENED(elementClass)) {
-					ramClass->classFlags |= (elementClass->classFlags & J9ClassIsValueType);
+					ramClass->classFlags |= J9ClassIsValueType;
 					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));
 					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {


### PR DESCRIPTION
Steps:
> Load/Store the object dirrectly in the VT array rather than storing its reference.
> Use the copyObjectFields macro to store the element directly in the VT array.

Related #5021

Signed-off-by: Aidan Ha <qbha@edu.uwaterloo.ca>