### PR TITLE
Locking Code Revision

### DIFF
--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -34,8 +34,8 @@
 IDATA 
 objectMonitorExit(J9VMThread* vmStruct, j9object_t object) 
 {
-	j9objectmonitor_t *lockEA;
-	j9objectmonitor_t lock;
+	j9objectmonitor_t *lockEA = NULL;
+	j9objectmonitor_t lock = 0;
 
 	Assert_VM_true(vmStruct != NULL);
 	Assert_VM_true(0 == ((UDATA)vmStruct & OBJECT_HEADER_LOCK_BITS_MASK));
@@ -109,9 +109,9 @@ objectMonitorExit(J9VMThread* vmStruct, j9object_t object)
 		return 0;
 	} else if (J9_LOCK_IS_INFLATED(lock)) {
 		/* Dealing with an inflated monitor */
-		J9ObjectMonitor *objectMonitor;
-		J9ThreadAbstractMonitor *monitor;
-		IDATA rc;
+		J9ObjectMonitor *objectMonitor = NULL;
+		J9ThreadAbstractMonitor *monitor = NULL;
+		IDATA rc = 0;
 		IDATA deflate = 1;
 		
 		objectMonitor = J9_INFLLOCK_OBJECT_MONITOR(lock);		
@@ -206,8 +206,8 @@ objectMonitorExit(J9VMThread* vmStruct, j9object_t object)
 J9ObjectMonitor * 
 objectMonitorInflate(J9VMThread* vmStruct, j9object_t object, UDATA lock) 
 {
-	J9ObjectMonitor * objectMonitor = monitorTableAt(vmStruct, object);
-	omrthread_monitor_t monitor;
+	J9ObjectMonitor *objectMonitor = monitorTableAt(vmStruct, object);
+	omrthread_monitor_t monitor = NULL;
 
 	if (objectMonitor == NULL) {
 		return NULL;
@@ -257,8 +257,8 @@ objectMonitorEnter(J9VMThread* vmStruct, j9object_t object)
 void
 cancelLockReservation(J9VMThread* vmStruct)
 {
-	j9object_t object;
-	j9objectmonitor_t lock;
+	j9object_t object = NULL;
+	j9objectmonitor_t lock = 0;
 
 	Trc_VM_cancelLockReservation_Entry(vmStruct, vmStruct->blockingEnterObject);
 	Assert_VM_mustHaveVMAccess(vmStruct);
@@ -278,8 +278,9 @@ cancelLockReservation(J9VMThread* vmStruct)
 	}
 
 	if ( (lock & (OBJECT_HEADER_LOCK_INFLATED | OBJECT_HEADER_LOCK_RESERVED)) == OBJECT_HEADER_LOCK_RESERVED) {
-		j9objectmonitor_t oldLock, newLock;
-		j9objectmonitor_t* lockEA;
+		j9objectmonitor_t oldLock = 0;
+		j9objectmonitor_t newLock = 0;
+		j9objectmonitor_t *lockEA = NULL;
 		J9VMThread* reservationOwner = J9_FLATLOCK_OWNER(lock);
 
 		Trc_VM_cancelLockReservation_reservationOwner(vmStruct, reservationOwner);
@@ -367,10 +368,7 @@ cancelLockReservation(J9VMThread* vmStruct)
 IDATA 
 objectMonitorDestroy(J9JavaVM *vm, J9VMThread* vmThread, omrthread_monitor_t monitor)
 {
-	IDATA rc; 
-
-	rc = omrthread_monitor_destroy_nolock(vmThread->osThread, monitor);
-	return rc;
+	return (IDATA)omrthread_monitor_destroy_nolock(vmThread->osThread, monitor);
 }
 
 /**

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -558,7 +558,17 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #endif /* defined(OMR_THR_YIELD_ALG) */
 	
 #if defined(LINUX)
-	/* if Completely Fair Scheduler is detected, and sched_compat_yield=0, default to -Xthr:minimizeUserCPU */
+	/* Check the sched_compat_yield setting for the versions of the Completely Fair Scheduler (CFS) which
+	 * have broken the thread_yield behavior. If running in CFS and sched_compat_yield=0, the CPU yielding
+	 * behavior is moderated to act as though CFS is not enabled by increasing the yield count to 270 in
+	 * the three-tier spinlock loops.
+	 *
+	 * sched_compat_yield=1 uses the aggressive CPU yielding behavior of some versions of the O(1)
+	 * scheduler and uses the default yield counts (= 45).
+	 *
+	 * Newer Linux versions no longer support the sched_compat_yield flag since the thread_yield behavior
+	 * is restored to something stable.
+	 */
 	if ('0' == j9util_sched_compat_yield_value(vm)) {
 #if defined(OMR_THR_YIELD_ALG)
 		**(UDATA**)omrthread_global("yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_INCREASING_USLEEP;


### PR DESCRIPTION
**Fix code formatting in monhelpers.c**

1) Remove unneeded code.
2) Initialize the variables during declaration to avoid any potential
issues.

**Fix the comment regarding sched_compat_yield and yield count settings**

If the Completely Fair Scheduler is detected and sched_compat_yield=0,
we do not default to the -Xthr:minimizeUserCPU settings. Instead, we
increase the yield counts to 270 in the three-tier spinlock loops. Refer
to the updated comment for more details.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>