### PR TITLE
Minor cleanup with forceOutOfLineVMAccess()

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.cpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -248,15 +248,12 @@ MM_EnvironmentDelegate::reacquireCriticalHeapAccess(uintptr_t data)
         VM_VMAccess::clearPublicFlags(vmThread, J9_PUBLIC_FLAGS_NOT_AT_SAFE_POINT);
 }
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
 void
 MM_EnvironmentDelegate::forceOutOfLineVMAccess()
 {
-	Assert_MM_true(MM_GCExtensions::getExtensions(_env->getOmrVM())->concurrentScavenger);
-	J9VMThread *vmThread = (J9VMThread *)_env->getOmrVMThread()->_language_vmthread;
+	J9VMThread *vmThread = (J9VMThread *)_env->getLanguageVMThread();
 	VM_VMAccess::setPublicFlags(vmThread, J9_PUBLIC_FLAGS_DISABLE_INLINE_VM_ACCESS_ACQUIRE);
 }
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #if defined (J9VM_GC_THREAD_LOCAL_HEAP)
 /**

--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -151,9 +151,7 @@ public:
 
 	void reacquireCriticalHeapAccess(uintptr_t data);
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	void forceOutOfLineVMAccess();
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	/**


### PR DESCRIPTION
As part of preparation for more usage in near future:
- remove the assert it's used only for Concurrent Scavenger (the call
sites will check if CS is enabled or not prior to calling)
- remove #ifdefs, to not force call sites to use it too, hence resulting
in easier to read code. The amount of code behind it is small and there
is no real reason to hide it under ifdef even for non CS configuration.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>