### PR TITLE
Cache field and static attributes per RAM class

### DIFF
--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -32,6 +32,7 @@
 #include "runtime/J9Profiler.hpp"
 #include "exceptions/RuntimeFailure.hpp"
 #include "env/j9methodServer.hpp"
+#include "control/JITaaSCompilationThread.hpp"
 
 bool J9::Recompilation::_countingSupported = false;
 

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3009,6 +3009,27 @@ ClientSessionData::ClassInfo::freeClassInfo()
       jitPersistentFree(_constantClassPoolCache);
       }
 
+   if (_fieldAttributesCache)
+      {
+      _fieldAttributesCache->~TR_FieldAttributesCache();
+      jitPersistentFree(_fieldAttributesCache);
+      }
+   if (_staticAttributesCache)
+      {
+      _staticAttributesCache->~TR_FieldAttributesCache();
+      jitPersistentFree(_staticAttributesCache);
+      }
+
+   if (_fieldAttributesCacheAOT)
+      {
+      _fieldAttributesCacheAOT->~TR_FieldAttributesCache();
+      jitPersistentFree(_fieldAttributesCacheAOT);
+      }
+   if (_staticAttributesCacheAOT)
+      {
+      _staticAttributesCacheAOT->~TR_FieldAttributesCache();
+      jitPersistentFree(_staticAttributesCacheAOT);
+      }
    }
 
 ClientSessionData::VMInfo *
@@ -3266,6 +3287,10 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct._classOfStaticCache = nullptr;
    classInfoStruct._constantClassPoolCache = nullptr;
    classInfoStruct.remoteRomClass = std::get<17>(classInfo);
+   classInfoStruct._fieldAttributesCache = NULL;
+   classInfoStruct._staticAttributesCache = NULL;
+   classInfoStruct._fieldAttributesCacheAOT = NULL;
+   classInfoStruct._staticAttributesCacheAOT = NULL;
 
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -27,6 +27,7 @@
 #include "control/CompilationThread.hpp"
 #include "rpc/J9Client.hpp"
 #include "env/PersistentCollections.hpp"
+#include "env/j9methodServer.hpp"
 
 class TR_PersistentClassInfo;
 class TR_IPBytecodeHashTableEntry;
@@ -65,6 +66,10 @@ class ClientSessionData
       uintptrj_t totalInstanceSize;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_classOfStaticCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_constantClassPoolCache;
+      TR_FieldAttributesCache *_fieldAttributesCache;
+      TR_FieldAttributesCache *_staticAttributesCache;
+      TR_FieldAttributesCache *_fieldAttributesCacheAOT;
+      TR_FieldAttributesCache *_staticAttributesCacheAOT;
       };
 
    struct J9MethodInfo


### PR DESCRIPTION
- We used to cache field and static attributes per resolved method,
but these methods return attributes of a RAM class field at a
given CP index. This means that we can cache them per RAM class,
in `ClassInfo`.
This significantly reduces the number of remote messages.
- `TR_ResolvedRelocatableJ9JITaaSServerMethod::field(static)Attributes`
used the same caches as non-AOT versions of the method. This didn't
cause problems before, because caches existed only for 1 compilation.
However, now that caches exist for multiple compilations,
this is wrong because an AOT compilation might be followed by a non-AOT
compilation that requests attributes for the same field, and we'll get
a wrong value.
Created separate caches for AOT attributes.