### PR TITLE
Remove duplicate definition of mcc_printf

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -53,19 +53,6 @@
 #include "env/IO.hpp"
 #include "runtime/HookHelpers.hpp"
 
-
-/*
- *  *  Debugging help
- *   */
-#ifdef CODECACHE_DEBUG
-#define mcc_printf if (CodeCacheDebug) printf
-#define mcc_hashprintf /*printf*/
-#else
-#define mcc_printf
-#define mcc_hashprintf
-#endif
-
-
 OMR::CodeCacheMethodHeader *getCodeCacheMethodHeader(char *p, int searchLimit, J9JITExceptionTable * metaData);
 
 #define addFreeBlock2(start, end) addFreeBlock2WithCallSite((start), (end), __FILE__, __LINE__)


### PR DESCRIPTION
mcc_printf is defined in OMR. The definition in OMR was changed, so now
this duplicate definition is causing a compilation error. Since this
definition serves no purpose (is not used, has no effect), remove it.

Signed-off-by: Robert Young <rwy0717@gmail.com>