### PR TITLE
Replace J2SE_VERSION macro with JAVA_SPEC_VERSION

### DIFF
--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -226,7 +226,7 @@ public:
 	bool isClassUnmodifiable() const {
 		bool unmodifiable = false;
 		if (NULL != _javaVM) {
-			if ((J2SE_VERSION(_javaVM) >= J2SE_V11) && isClassAnon()) {
+			if ((JAVA_SPEC_VERSION >= J2SE_V11) && isClassAnon()) {
 				unmodifiable = true;
 			} else if (NULL == J9VMJAVALANGOBJECT_OR_NULL(_javaVM)) {
 				/* Object is currently only allowed to be redefined in fast HCR */

--- a/runtime/bcutil/bcutil.c
+++ b/runtime/bcutil/bcutil.c
@@ -120,9 +120,9 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 {
 	IDATA returnVal = J9VMDLLMAIN_OK;
 	I_32 rc = J9JIMAGE_NO_ERROR;
-	J9VMDllLoadInfo* loadInfo;
+	J9VMDllLoadInfo* loadInfo = NULL;
 	J9JImageIntf *jimageIntf = NULL;
-	J9TranslationBufferSet* translationBuffers;
+	J9TranslationBufferSet* translationBuffers = NULL;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	VMI_ACCESS_FROM_JAVAVM((JavaVM*)vm);
@@ -134,7 +134,7 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 		/* Note that verbose support should have already been initialized in an earlier stage */
 		case BUFFERS_ALLOC_STAGE :
 			loadInfo = FIND_DLL_TABLE_ENTRY( THIS_DLL_NAME );
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				rc = initJImageIntf(&jimageIntf, vm, PORTLIB);
 				if (J9JIMAGE_NO_ERROR != rc) {
 					loadInfo->fatalErrorStr = "failed to initialize JImage interface";

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1556,13 +1556,13 @@ _errorFound:
 static I_32 
 checkMethods(J9CfrClassFile* classfile, U_8* segment, U_32 vmVersionShifted, U_32 flags)
 {
-	J9CfrMethod* method;
+	J9CfrMethod* method = NULL;
 	U_32 value = 0;
 	U_32 maskedValue = 0;
 	U_32 errorCode = 0;
 	U_32 offset = 0;
-	U_32 i;
-	BOOLEAN nameIndexOK;
+	U_32 i = 0;
+	BOOLEAN nameIndexOK = FALSE;
 	U_32 classfileVersion = flags & BCT_MajorClassFileVersionMask;
 
 	for (i = 0; i < classfile->methodsCount; i++) {
@@ -1609,7 +1609,7 @@ checkMethods(J9CfrClassFile* classfile, U_8* segment, U_32 vmVersionShifted, U_3
 
 			/* Leave this here to find usages of the following check:
 			 * J2SE_19 has been deprecated and replaced with J2SE_V11
-			 * if (J2SE_VERSION(vm) >= J2SE_V11) { 
+			 * if (JAVA_SPEC_VERSION >= J2SE_V11) { 
 			 */
 			} else if (vmVersionShifted >= BCT_Java9MajorVersionShifted) {
 				if (J9_ARE_NO_BITS_SET(method->accessFlags, CFR_ACC_STATIC)) {

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -144,7 +144,7 @@ internalDefineClass(
 		/* Host class can only be set for anonymous classes, which are defined by Unsafe.defineAnonymousClass.
 		 * For other cases, host class is set to NULL.
 		 */
-		if ((NULL != hostClass) && (J2SE_VERSION(vm) >= J2SE_V11)) {
+		if ((NULL != hostClass) && (JAVA_SPEC_VERSION >= J2SE_V11)) {
 			J9ROMClass *hostROMClass = hostClass->romClass;
 			/* This error-check should only be done for anonymous classes. */
 			Trc_BCU_Assert_True(isAnonFlagSet);
@@ -532,13 +532,13 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 
 	/* Determine allowed class file version */
 #ifdef J9VM_OPT_SIDECAR
-	if (J2SE_VERSION(vm) >= J2SE_V13) {
+	if (JAVA_SPEC_VERSION >= J2SE_V13) {
 		translationFlags |= BCT_Java13MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_V12) {
+	} else if (JAVA_SPEC_VERSION >= J2SE_V12) {
 		translationFlags |= BCT_Java12MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_V11) {
+	} else if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		translationFlags |= BCT_Java11MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_18) {
+	} else if (JAVA_SPEC_VERSION >= J2SE_18) {
 		translationFlags |= BCT_Java8MajorVersionShifted;
 	}
 #endif
@@ -747,7 +747,7 @@ callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediat
 			localBuffer);
 
 	/* The module of a class transformed by a JVMTI agent needs access to unnamed modules */
-	if ((J2SE_VERSION(vm) >= J2SE_V11)
+	if ((JAVA_SPEC_VERSION >= J2SE_V11)
 		&& (classFileBytesReplacedByRIA || classFileBytesReplacedByRCA)
 		&& (NULL != loadData->romClass)
 	) {

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -102,7 +102,7 @@ findLocallyDefinedClass(J9VMThread * vmThread, J9Module * j9module, U_8 * classN
 	Trc_BCU_findLocallyDefinedClass_Entry(mbString, classPathEntryCount);
 	
 	/* Search patch path of the module before looking up in bootclasspath */
-	if (J2SE_VERSION(javaVM) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		if (NULL == module) {
 			if (J9_ARE_NO_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
 				module = javaVM->javaBaseModule;

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1829,7 +1829,7 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 		 */
 		/* Leave this here to find usages of the following check:
 		 * J2SE_19 has been deprecated and replaced with J2SE_V11
-		 * if (J2SE_VERSION(vm) >= J2SE_V11) {
+		 * if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		 */
 		if (vmVersionShifted >= BCT_Java9MajorVersionShifted) {
 			if (classfile->majorVersion >= 51) {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6015,9 +6015,7 @@ static TrustedMethod untrustedMethods[] =
 bool
 TR_J9VMBase::argumentCanEscapeMethodCall(TR::MethodSymbol * method, int32_t argIndex)
    {
-   int32_t numberOfTrustedClasses = INT_MAX;
-   if (_jitConfig->javaVM->j2seVersion != 0)
-      numberOfTrustedClasses = 4;
+   int32_t numberOfTrustedClasses = 4;
 
    int32_t i;
    TR::RecognizedMethod methodId = method->getRecognizedMethod();

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -261,7 +261,7 @@ MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
 	}
 
 #if defined(OMR_ENV_DATA64)
-	if (J2SE_VERSION((J9JavaVM *)getOmrVM()->_language_vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		/* extend java default max memory to 25% of usable RAM */
 		memoryMax = OMR_MAX(memoryMax, usablePhysicalMemory / 4);
 	}

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -548,11 +548,11 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 {
 	J9JavaVM *vm = vmThread->javaVM;
 	MM_StringTable *stringTable = MM_GCExtensions::getExtensions(vm->omrVM)->getStringTable();
-	J9Class *stringClass;
+	J9Class *stringClass = NULL;
 	j9object_t result = NULL;
-	j9object_t charArray;
+	j9object_t charArray = NULL;
 	UDATA allocateFlags = J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE;
-	UDATA unicodeLength;
+	UDATA unicodeLength = 0;
 	bool isCompressable = false;
 
 	Trc_MM_createJavaLangString_Entry(vmThread, length, data, stringFlags);
@@ -644,13 +644,13 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 
 		if (IS_STRING_COMPRESSION_ENABLED_VM(vm)) {
 			if (isCompressable) {
-				if (J2SE_VERSION(vm) >= J2SE_V11) {
+				if (JAVA_SPEC_VERSION >= J2SE_V11) {
 					J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 0);
 				} else {
 					J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32)unicodeLength);
 				}
 			} else {
-				if (J2SE_VERSION(vm) >= J2SE_V11) {
+				if (JAVA_SPEC_VERSION >= J2SE_V11) {
 					J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 1);
 				} else {
 					J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32)unicodeLength | (I_32)0x80000000);
@@ -677,7 +677,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 				}
 			}
 		} else {
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 1);
 			} else {
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32)unicodeLength);
@@ -765,7 +765,7 @@ setupCharArray(J9VMThread *vmThread, j9object_t sourceString, j9object_t newStri
 
 		J9VMJAVALANGSTRING_SET_VALUE(vmThread, newString, newChars);
 
-		if (J2SE_VERSION(vm) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			J9VMJAVALANGSTRING_SET_CODER(vmThread, newString, J9VMJAVALANGSTRING_CODER(vmThread, sourceString));
 		} else {
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, newString, J9VMJAVALANGSTRING_COUNT(vmThread, sourceString));
@@ -917,13 +917,13 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 
 	if (IS_STRING_COMPRESSION_ENABLED_VM(vm)) {
 		if (isCompressable) {
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 0);
 			} else {
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength);
 			}
 		} else {
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 1);
 			} else {
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength | (I_32)0x80000000);
@@ -950,7 +950,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 			}
 		}
 	} else {
-		if (J2SE_VERSION(vm) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 1);
 		} else {
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength);

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -476,8 +476,7 @@ MM_MarkingDelegate::processReferenceList(MM_EnvironmentBase *env, MM_HeapRegionD
 				referenceStats->_cleared += 1;
 
 				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
-				J9JavaVM * javaVM = (J9JavaVM*)env->getLanguageVM();
-				if ((J9AccClassReferencePhantom == referenceObjectType) && ((J2SE_VERSION(javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+				if ((J9AccClassReferencePhantom == referenceObjectType) && (JAVA_SPEC_VERSION <= J2SE_18)) {
 					/* Phantom objects keep their referent - scanning will be done after the enqueuing */
 					_markingScheme->inlineMarkObject(env, referent);
 				} else {

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -77,8 +77,7 @@ MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_He
 				referenceStats->_cleared += 1;
 
 				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
-				J9JavaVM * javaVM = (J9JavaVM*)env->getLanguageVM();
-				if ((J9AccClassReferencePhantom == referenceObjectType) && ((J2SE_VERSION(javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+				if ((J9AccClassReferencePhantom == referenceObjectType) && (JAVA_SPEC_VERSION <= J2SE_18)) {
 					/* Scanning will be done after the enqueuing */
 					_scavenger->copyObjectSlot(env, &referentSlotObject);
 				} else {

--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -1226,7 +1226,7 @@ MM_RealtimeMarkingScheme::processReferenceList(MM_EnvironmentRealtime *env, MM_H
 				referenceStats->_cleared += 1;
 
 				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
-				if ((J9AccClassReferencePhantom == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+				if ((J9AccClassReferencePhantom == referenceObjectType) && (JAVA_SPEC_VERSION <= J2SE_18)) {
 					/* Scanning will be done after the enqueuing */
 					markObject(env, referent);
 				} else {

--- a/runtime/gc_structs/ConstantPoolObjectSlotIterator.hpp
+++ b/runtime/gc_structs/ConstantPoolObjectSlotIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ public:
 			_cpDescriptionIndex = 0;
 		}
 		/* Check if the system is condy-enabled */
-		if (J2SE_VERSION(vm) < J2SE_V11) {
+		if (JAVA_SPEC_VERSION < J2SE_V11) {
 			_condyEnabled = false;
 		} else {
 			_condyEnabled = true;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -5124,7 +5124,7 @@ MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegi
 				J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj) = GC_ObjectModel::REF_STATE_CLEARED;
 				
 				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
-				if ((J9AccClassReferencePhantom == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+				if ((J9AccClassReferencePhantom == referenceObjectType) && (JAVA_SPEC_VERSION <= J2SE_18)) {
 					/* Scanning will be done after the enqueuing */
 					copyAndForward(env, region->_allocateData._owningContext, referenceObj, &referentSlotObject);
 					if (GC_ObjectModel::REF_STATE_REMEMBERED == previousState) {

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1631,7 +1631,7 @@ MM_GlobalMarkingScheme::processReferenceList(MM_EnvironmentVLHGC *env, J9Object*
 				J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj) = GC_ObjectModel::REF_STATE_CLEARED;
 
 				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
-				if ((J9AccClassReferencePhantom == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+				if ((J9AccClassReferencePhantom == referenceObjectType) && (JAVA_SPEC_VERSION <= J2SE_18)) {
 					/* Scanning will be done after the enqueuing */
 					markObject(env, referent);
 					_interRegionRememberedSet->rememberReferenceForMark(env, referenceObj, referent);

--- a/runtime/gc_vlhgc/PartialMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.cpp
@@ -1746,7 +1746,7 @@ MM_PartialMarkingScheme::processReferenceList(MM_EnvironmentVLHGC *env, J9Object
 				J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj) = GC_ObjectModel::REF_STATE_CLEARED;
 
 				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
-				if ((J9AccClassReferencePhantom == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+				if ((J9AccClassReferencePhantom == referenceObjectType) && (JAVA_SPEC_VERSION <= J2SE_18)) {
 					/* Scanning will be done after the enqueuing */
 					markObject(env, referent);
 					_interRegionRememberedSet->rememberReferenceForMark(env, referenceObj, referent);

--- a/runtime/gc_vlhgc/RuntimeExecManager.cpp
+++ b/runtime/gc_vlhgc/RuntimeExecManager.cpp
@@ -103,7 +103,7 @@ MM_RuntimeExecManager::jniNativeBindHook(J9HookInterface** hook, UDATA eventNum,
 		J9UTF8 *methodSignature = J9ROMMETHOD_SIGNATURE(romMethod);
 		BOOLEAN literalCheck = FALSE;
 		
-		if ((J2SE_VERSION(vmThread->javaVM) & J2SE_VERSION_MASK) <= J2SE_18) {
+		if (JAVA_SPEC_VERSION <= J2SE_18) {
 			/* Assuming J2SE_18, no other lower level supported */
 			literalCheck = J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(classNameUTF8), J9UTF8_LENGTH(classNameUTF8), CLASS_NAME1);
 		} else {

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1405,7 +1405,7 @@ setNLSCatalog(struct J9PortLibrary* portLib)
 	const char *nlsSearchPaths = NULL;
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	if (J2SE_CURRENT_VERSION >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		/*
 		 * j9libBuffer doesn't end in a slash, but j9nls_set_catalog ignores everything after
 		 * the last slash. Append a slash to our local copy of j9libBuffer
@@ -1510,7 +1510,7 @@ static jint initializeReflectionGlobals(JNIEnv * env, BOOLEAN includeAccessors) 
 	}
 
 	if (includeAccessors) {
-		if (J2SE_VERSION(vm) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			clazzConstructorAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/ConstructorAccessorImpl");
 			clazzMethodAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/MethodAccessorImpl");
 		} else {
@@ -1792,7 +1792,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 	/* Register the J9 memory categories with the port library */
 	j9portLibrary.omrPortLibrary.port_control(&j9portLibrary.omrPortLibrary, J9PORT_CTLDATA_MEM_CATEGORIES_SET, (UDATA)&j9MasterMemCategorySet);
 
-	Assert_SC_true(J2SE_CURRENT_VERSION >= J2SE_18);
+	Assert_SC_true(JAVA_SPEC_VERSION >= J2SE_18);
 	setNLSCatalog(&j9portLibrary);
 
 
@@ -1854,7 +1854,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 			zipFuncs = (J9ZipFunctionTable*) J9_GetInterface(IF_ZIPSUP, &j9portLibrary, j9binBuffer);
 #endif /* CALL_BUNDLED_FUNCTIONS_DIRECTLY */
 		}
-		if (J2SE_CURRENT_VERSION >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			optionsDefaultFileLocation = jvmBufferData(j9libBuffer);
 		} else {
 			optionsDefaultFileLocation = jvmBufferData(j9binBuffer);
@@ -1864,7 +1864,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		if (
 				/* Add the default options file */
 				(0 != addOptionsDefaultFile(&j9portLibrary, &vmArgumentsList, optionsDefaultFileLocation, localVerboseLevel))
-				|| (0 != addXjcl(&j9portLibrary, &vmArgumentsList, J2SE_CURRENT_VERSION))
+				|| (0 != addXjcl(&j9portLibrary, &vmArgumentsList))
 				|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dcom.ibm.oti.vm.bootstrap.library.path=",
 						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
 				|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dsun.boot.library.path=",
@@ -1873,7 +1873,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer),
 						libpathValue, ldLibraryPathValue))
 				|| (0 != addJavaHome(&j9portLibrary, &vmArgumentsList, altJavaHomeSpecified, jvmBufferData(j9libBuffer)))
-				|| (doAddExtDir && (0 != addExtDir(&j9portLibrary, &vmArgumentsList, jvmBufferData(j9libBuffer), args, J2SE_CURRENT_VERSION)))
+				|| (doAddExtDir && (0 != addExtDir(&j9portLibrary, &vmArgumentsList, jvmBufferData(j9libBuffer), args)))
 				|| (0 != addUserDir(&j9portLibrary, &vmArgumentsList, cwd))
 				|| (0 != addJavaPropertiesOptions(&j9portLibrary, &vmArgumentsList, localVerboseLevel))
 				|| (0 != addJarArguments(&j9portLibrary, &vmArgumentsList, specialArgs.executableJarPath, zipFuncs, localVerboseLevel))
@@ -1912,7 +1912,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		}
 	}
 
-	createParams.j2seVersion = J2SE_CURRENT_VERSION;
+	createParams.j2seVersion = JAVA_SPEC_VERSION;
 	if (jvmInSubdir) {
 		createParams.j2seVersion |= J2SE_LAYOUT_VM_IN_SUBDIR;
 	}
@@ -5349,7 +5349,7 @@ JVM_GetInterfaceVersion(void)
 	jint result = 4;	/* JDK8 */
 
 	Trc_SC_GetInterfaceVersion_Entry();
-	if (J2SE_CURRENT_VERSION >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		result = 6;
 	}
 	Trc_SC_GetInterfaceVersion_Exit(result);

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -93,7 +93,7 @@ lookupInterfaceMethod(J9VMThread *currentThread, J9Class *lookupClass, J9UTF8 *n
 		Assert_JCL_true(!J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccStatic));
 
 		/* Starting Java 11 Nestmates, invokeInterface is allowed to target private interface methods */
-		if ((J2SE_VERSION(currentThread->javaVM) < J2SE_V11) && J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPrivate)) {
+		if ((JAVA_SPEC_VERSION < J2SE_V11) && J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPrivate)) {
 			/* [PR 67082] private interface methods require invokespecial, not invokeinterface.*/
 			vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9NLS_JCL_PRIVATE_INTERFACE_REQUIRES_INVOKESPECIAL);
 			method = NULL;

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -117,12 +117,11 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 		if (romMethod != NULL) {
 			J9UTF8 * utf = NULL;
 			j9object_t string = NULL;
-			UDATA j2seVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
 
 			PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, element);
 
 			/* Fill in module name and version */
-			if (j2seVersion >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				J9Module *module = NULL;
 				U_8 *classNameUTF = NULL;
 				UDATA length = 0;

--- a/runtime/jcl/common/jniidcacheinit.c
+++ b/runtime/jcl/common/jniidcacheinit.c
@@ -135,7 +135,7 @@ initializeSunReflectConstantPoolIDCache(JNIEnv* env)
 	if (!isClassIDAlreadyCached) {	
 
 		/* Load sun/reflect/ConstantPool */
-		if (J2SE_VERSION(javaVM) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			sunReflectConstantPool = (*env)->FindClass(env, "jdk/internal/reflect/ConstantPool");
 		} else {
 			sunReflectConstantPool = (*env)->FindClass(env, "sun/reflect/ConstantPool");

--- a/runtime/jcl/common/mgmtruntime.c
+++ b/runtime/jcl/common/mgmtruntime.c
@@ -59,12 +59,11 @@ Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_getUptimeImpl(JNIEn
 jboolean JNICALL
 Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_isBootClassPathSupportedImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
-	if (J2SE_VERSION(javaVM) < J2SE_V11) {
-		return JNI_TRUE;
-	} else {
-		return JNI_FALSE;
+	jboolean ret = JNI_FALSE;
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
+		ret = JNI_TRUE;
 	}
+	return ret;
 }
 
 /**

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -80,7 +80,7 @@ computeJCLRuntimeFlags(J9JavaVM *vm)
 #endif
 
 #ifdef J9VM_OPT_MODULE
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		flags |= JCL_RTFLAG_OPT_MODULE;
 	}
 #endif
@@ -116,7 +116,7 @@ standardInit( J9JavaVM *vm, char *dllName)
 	jclConstantPool->romConstantPool = J9_ROM_CP_FROM_ROM_CLASS(jclROMClass);
 
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
-	if (J2SE_VERSION(vm) < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		/* Process the command-line bootpath additions/modifications */
 		if (computeFinalBootstrapClassPath(vm)) {
 			goto _fail;
@@ -210,7 +210,7 @@ standardInit( J9JavaVM *vm, char *dllName)
 	internalInitializeJavaLangClassLoader((JNIEnv*)vmThread);
 	if (vmThread->currentException) goto _fail;
 
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		result = registerJdkInternalReflectConstantPoolNatives((JNIEnv*)vmThread);
 		if (JNI_OK != result) {
 			fprintf(stderr, "Failed to register natives for jdk.internal.reflect.ConstantPool\n");
@@ -296,7 +296,7 @@ standardPreconfigure(JavaVM *jvm)
 	J9JavaVM* vm = (J9JavaVM*)jvm;
 
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
-	if (J2SE_VERSION(vm) < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		/* Now, based on java.home we can compute the default bootpath */
 		if (initializeBootClassPathSystemProperty(vm)) {
 			goto _fail;
@@ -527,7 +527,7 @@ initializeBootstrapClassPath(J9JavaVM *vm)
 	BOOLEAN initClassPathEntry = FALSE;
 
 	/* Get the BP from the VM sysprop */
-	if (J2SE_VERSION(vm) < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		(*VMI)->GetSystemProperty(VMI, BOOT_PATH_SYS_PROP, &path);
 	} else {
 		(*VMI)->GetSystemProperty(VMI, BOOT_CLASS_PATH_APPEND_PROP, &path);

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -913,11 +913,9 @@ registerJdkInternalMiscUnsafeNativesJava10(JNIEnv *env, jclass clazz) {
 void JNICALL
 Java_jdk_internal_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 {
-	J9VMThread *currentThread = (J9VMThread*)env;
-
 	Java_sun_misc_Unsafe_registerNatives(env, clazz);
 	registerJdkInternalMiscUnsafeNativesCommon(env, clazz);
-	if (J2SE_VERSION(currentThread->javaVM) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		registerJdkInternalMiscUnsafeNativesJava10(env, clazz);
 	}
 }

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -521,7 +521,7 @@ Java_java_lang_System_startSNMPAgent(JNIEnv *env, jclass jlClass)
 		jclass smAClass = NULL;
 		jmethodID startAgent = NULL;
 		
-		if (J2SE_VERSION(vm) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			smAClass = (*env)->FindClass(env, "jdk/internal/agent/Agent");
 		} else {
 			smAClass = (*env)->FindClass(env, "sun/management/Agent");

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -257,7 +257,6 @@ scarInit(J9JavaVM * vm)
 	jint result = 0;
 #if defined(WIN32)
 	char *dbgwrapperStr = NULL;
-	UDATA jclVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
 #endif
 
 	/* We need to overlay java.dll functions */
@@ -276,11 +275,9 @@ scarInit(J9JavaVM * vm)
 #endif
 
 #if defined(WIN32) && !defined(OPENJ9_BUILD)
-	switch (jclVersion) {
-	case J2SE_18:
+	if (JAVA_SPEC_VERSION == J2SE_18) {
 		dbgwrapperStr = "dbgwrapper80";
-		break;
-	default:
+	} else {
 		Assert_JCL_unreachable();
 	}
 
@@ -447,7 +444,7 @@ scarPreconfigure(J9JavaVM * vm)
 		return JNI_ERR;
 	}
 
-	if (J2SE_VERSION(vm) < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		char *vmSpecificDirectoryPath = "jclSC180";
 
 		rc = addVMSpecificDirectories(vm, &i, vmSpecificDirectoryPath);
@@ -586,7 +583,7 @@ addVMSpecificDirectories(J9JavaVM *vm, UDATA *cursor, char * subdirName)
 
 #define VM_JAR "vm.jar"
 
-	if ((NULL != vm->j2seRootDirectory) && (J2SE_LAYOUT(vm) & J2SE_LAYOUT_VM_IN_SUBDIR)) {
+	if ((NULL != vm->j2seRootDirectory) && J2SE_IS_LAYOUT_VM_IN_SUBDIR(vm)) {
 		/* 3 +1s from: dir sep, !, dir sep*/
 		int subDirPathLength = 1 + j2seRootPathLength + 1 + (int)strlen(subdirName) + 1;
 		/* +1 for NUL-terminator */

--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,10 +115,12 @@ jobject getPlatformPropertyList(JNIEnv * env, const char *strings[], int propInd
 {
 	PORT_ACCESS_FROM_ENV(env);
 	I_32 result = 0;
-	char *charResult = NULL, *envSpace = NULL;
-	jobject plist;
+	char *charResult = NULL;
+	char *envSpace = NULL;
+	jobject plist = NULL;
 	char userdir[EsMaxPath];
-	char home[EsMaxPath], *homeAlloc = NULL;
+	char home[EsMaxPath];
+	char *homeAlloc = NULL;
 #if defined(J9PWENT)
 	struct passwd *pwentry = NULL;
 #endif
@@ -126,13 +128,11 @@ jobject getPlatformPropertyList(JNIEnv * env, const char *strings[], int propInd
 	/* Hard coded file/path separators and other values */
 
 #if defined(J9ZOS390)
-	if (J2SE_VERSION_FROM_ENV(env)) {
-		strings[propIndex++] = "platform.notASCII";
-		strings[propIndex++] = "true";
+	strings[propIndex++] = "platform.notASCII";
+	strings[propIndex++] = "true";
 
-		strings[propIndex++] = "os.encoding";
-		strings[propIndex++] = "ISO8859_1";
-	}
+	strings[propIndex++] = "os.encoding";
+	strings[propIndex++] = "ISO8859_1";
 #endif
 
 	strings[propIndex++] = "file.separator";

--- a/runtime/jcl/win32/syshelp.c
+++ b/runtime/jcl/win32/syshelp.c
@@ -176,13 +176,13 @@ jobject getPlatformPropertyList(JNIEnv *env, const char *strings[], int propInde
 
 char* getPlatformFileEncoding(JNIEnv *env, char *codepage, int size, int encodingType) {
 	PORT_ACCESS_FROM_ENV(env);
-	LCID threadLocale;
+	LCID threadLocale = 0;
 	CPINFO cpInfo;
-	int cp;
+	int cp = 0;
 #ifdef UNICODE
-	int i;
+	int i = 0;
 #endif
-	int length;
+	int length = 0;
 
 	/* Called with codepage == NULL to initialize the locale */
 	if (!codepage) return NULL;
@@ -218,7 +218,7 @@ char* getPlatformFileEncoding(JNIEnv *env, char *codepage, int size, int encodin
 	if (GetCPInfo(cp, &cpInfo) && cpInfo.MaxCharSize > 1) {
 		if (cp == 936) {
 			J9JavaVM* vm = ((J9VMThread *)env)->javaVM;
-			if (J2SE_VERSION(vm) < J2SE_V11) {
+			if (JAVA_SPEC_VERSION < J2SE_V11) {
 				if (IsValidCodePage(54936)) {
 					return "GB18030";
 				}

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -177,19 +177,16 @@ jvmtiError JNICALL
 jvmtiGetVersionNumber(jvmtiEnv* env,
 	jint* version_ptr)
 {
-	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	jvmtiError rc;
+	jvmtiError rc = JVMTI_ERROR_NONE;
 	jint rv_version = JVMTI_1_2_3_SPEC_VERSION;
 
 	Trc_JVMTI_jvmtiGetVersionNumber_Entry(env);
 
 	ENSURE_NON_NULL(version_ptr);
 
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		rv_version = JVMTI_VERSION_11;
 	}
-
-	rc = JVMTI_ERROR_NONE;
 
 done:
 	if (NULL != version_ptr) {

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -586,12 +586,11 @@ jvmtiHookVMStarted(J9HookInterface** hook, UDATA eventNum, void* eventData, void
 
 	if (callback != NULL) {
 		J9VMThread *currentThread = data->vmThread;
-		J9JavaVM *vm = currentThread->javaVM;
-		UDATA hadVMAccess;
+		UDATA hadVMAccess = 0;
 		UDATA javaOffloadOldState = 0;
 		BOOLEAN reportEvent = TRUE;
 
-	 	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	 	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 	 		if (j9env->capabilities.can_generate_early_vmstart == 0) {
 	 			reportEvent = FALSE;
 	 		}
@@ -618,7 +617,7 @@ jvmtiHookModuleSystemStarted(J9HookInterface** hook, UDATA eventNum, void* event
 	Trc_JVMTI_jvmtiHookModuleSystemStarted_Entry();
 
 	Assert_JVMTI_true(J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED));
-	Assert_JVMTI_true(J2SE_VERSION(vm) >= J2SE_V11);
+	Assert_JVMTI_true(JAVA_SPEC_VERSION >= J2SE_V11);
 
 	/*
 	 * In Java9 the VMStart event can be triggered from either the J9HOOK_VM_STARTED
@@ -2293,11 +2292,10 @@ jvmtiHookClassFileLoadHook(J9HookInterface** hook, UDATA eventNum, void* eventDa
 	J9VMClassLoadHookEvent * data = eventData;
 	J9JVMTIEnv * j9env = userData;
 	jvmtiEventClassFileLoadHook callback = j9env->callbacks.ClassFileLoadHook;
-	J9JavaVM * vm = j9env->vm;
 
 	Trc_JVMTI_jvmtiHookClassFileLoadHook_Entry();
 
-	if ((J2SE_VERSION(vm) >= J2SE_V11)
+	if ((JAVA_SPEC_VERSION >= J2SE_V11)
 		&& (j9env->capabilities.can_generate_early_class_hook_events == 0)
 	) {
 		ENSURE_EVENT_PHASE_START_OR_LIVE(jvmtiHookClassFileLoadHook, j9env);

--- a/runtime/jvmti/jvmtiStartup.c
+++ b/runtime/jvmti/jvmtiStartup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,9 +290,9 @@ prependSystemAgentPath(J9JavaVM * vm, J9JVMTIAgentLibrary * agentLibrary, char *
 
 	if(vm->j2seRootDirectory) {
 		UDATA superSeparatorIndex = -1;
-		UDATA bufferSize;
+		UDATA bufferSize = 0;
 
-		if(J2SE_LAYOUT(vm) & J2SE_LAYOUT_VM_IN_SUBDIR) {
+		if(J2SE_IS_LAYOUT_VM_IN_SUBDIR(vm)) {
 			/* load the DLL from the parent of the j2seRootDir - find the last dir separator and declare that the end. */
 			superSeparatorIndex = strrchr(vm->j2seRootDirectory, DIR_SEPARATOR) - vm->j2seRootDirectory;
 			bufferSize = superSeparatorIndex + 1 + sizeof(DIR_SEPARATOR_STR) + strlen(dllName);  /* +1 for NUL */

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -27,45 +27,15 @@
 /**
  * Constants for supported J2SE versions.
  */
-#define J2SE_18   0x0800
-#define J2SE_V11  0x0B00            /* This refers Java 11 */
-#define J2SE_V12  0x0C00            /* This refers Java 12 */
-#define J2SE_V13  0x0D00            /* This refers Java 13 */
-/* Shared class cache is using JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) to get the Java version.
- * So bits 9 to 16 of the J2SE constant should match the java version number.
- */
+#define J2SE_18   0x08
+#define J2SE_V11  0x0B            /* This refers Java 11 */
+#define J2SE_V12  0x0C            /* This refers Java 12 */
+#define J2SE_V13  0x0D            /* This refers Java 13 */
 
 /**
- * Masks for extracting major and full versions.
+ * Constant and Macro checking if JVM is in subdir
  */
-#define J2SE_VERSION_MASK 0xFF00
-#define J2SE_RELEASE_MASK 0xFFF0
-#define J2SE_SERVICE_RELEASE_MASK 0xFFFF
-
-#define J2SE_JAVA_SPEC_VERSION_SHIFT 8
-/* J2SE_CURRENT_VERSION is the current Java version supported by VM for a JCL level. */
-#define J2SE_CURRENT_VERSION (JAVA_SPEC_VERSION << J2SE_JAVA_SPEC_VERSION_SHIFT)
-
-/**
- * Masks and constants for describing J2SE shapes.
- */
-#define J2SE_LAYOUT_VM_IN_SUBDIR 0x100000
-#define J2SE_LAYOUT_MASK 		0xF00000
-#define J2SE_LAYOUT(javaVM) 	((javaVM)->j2seVersion & J2SE_LAYOUT_MASK)
-
-/**
- * Macro to extract the J2SE version given a J9JavaVM.
- */
-#define J2SE_VERSION(javaVM) 	((javaVM)->j2seVersion & J2SE_SERVICE_RELEASE_MASK)
-
-/**
- * Macro to extract J2SE version given a JNIEnv.
- */
-#define J2SE_VERSION_FROM_ENV(env) J2SE_VERSION(((J9VMThread*)env)->javaVM)
-
-/**
- * Macro to extract java spec version from J2SE version.
- */
-#define JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) 	((j2seVersion) >> J2SE_JAVA_SPEC_VERSION_SHIFT)
+#define J2SE_LAYOUT_VM_IN_SUBDIR 0x01
+#define J2SE_IS_LAYOUT_VM_IN_SUBDIR(javaVM)        (J2SE_LAYOUT_VM_IN_SUBDIR == ((javaVM)->j2seVersion & J2SE_LAYOUT_VM_IN_SUBDIR))
 
 #endif /* j2sever_h */

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -133,33 +133,33 @@ typedef struct J9ClassLoaderWalkState {
 
 #define IS_STRING_COMPRESSED(vmThread, object) \
 	(IS_STRING_COMPRESSION_ENABLED(vmThread) ? \
-		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_V11 ? \
+		(JAVA_SPEC_VERSION >= J2SE_V11 ? \
 			(((I_32) J9VMJAVALANGSTRING_CODER(vmThread, object)) == 0) : \
 			(((I_32) J9VMJAVALANGSTRING_COUNT(vmThread, object)) >= 0)) : \
 		FALSE)
 
 #define IS_STRING_COMPRESSED_VM(javaVM, object) \
 	(IS_STRING_COMPRESSION_ENABLED_VM(javaVM) ? \
-		(J2SE_VERSION(javaVM) >= J2SE_V11 ? \
+		(JAVA_SPEC_VERSION >= J2SE_V11 ? \
 			(((I_32) J9VMJAVALANGSTRING_CODER_VM(javaVM, object)) == 0) : \
 			(((I_32) J9VMJAVALANGSTRING_COUNT_VM(javaVM, object)) >= 0)) : \
 		FALSE)
 
 #define J9VMJAVALANGSTRING_LENGTH(vmThread, object) \
 	(IS_STRING_COMPRESSION_ENABLED(vmThread) ? \
-		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_V11 ? \
+		(JAVA_SPEC_VERSION >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE(vmThread, J9VMJAVALANGSTRING_VALUE(vmThread, object)) >> ((I_32) J9VMJAVALANGSTRING_CODER(vmThread, object))) : \
 			(J9VMJAVALANGSTRING_COUNT(vmThread, object) & 0x7FFFFFFF)) : \
-		(J2SE_VERSION((vmThread)->javaVM) >= J2SE_V11 ? \
+		(JAVA_SPEC_VERSION >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE(vmThread, J9VMJAVALANGSTRING_VALUE(vmThread, object)) >> 1) : \
 			(J9VMJAVALANGSTRING_COUNT(vmThread, object))))
 
 #define J9VMJAVALANGSTRING_LENGTH_VM(javaVM, object) \
 	(IS_STRING_COMPRESSION_ENABLED_VM(javaVM) ? \
-		(J2SE_VERSION(javaVM) >= J2SE_V11 ? \
+		(JAVA_SPEC_VERSION >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE_VM(javaVM, J9VMJAVALANGSTRING_VALUE_VM(javaVM, object)) >> ((I_32) J9VMJAVALANGSTRING_CODER_VM(javaVM, object))) : \
 			(J9VMJAVALANGSTRING_COUNT_VM(javaVM, object) & 0x7FFFFFFF)) : \
-		(J2SE_VERSION(javaVM) >= J2SE_V11 ? \
+		(JAVA_SPEC_VERSION >= J2SE_V11 ? \
 			(J9INDEXABLEOBJECT_SIZE_VM(javaVM, J9VMJAVALANGSTRING_VALUE_VM(javaVM, object)) >> 1) : \
 			(J9VMJAVALANGSTRING_COUNT_VM(javaVM, object))))
 
@@ -293,7 +293,7 @@ static const struct { \
 
 #define J9_IS_J9MODULE_OPEN(module) (TRUE == module->isOpen)
 
-#define J9_ARE_MODULES_ENABLED(vm) (J2SE_VERSION(vm) >= J2SE_V11)
+#define J9_ARE_MODULES_ENABLED(vm) (JAVA_SPEC_VERSION >= J2SE_V11)
 
 /* Macro for VM internalVMFunctions */
 #if defined(J9_INTERNAL_TO_VM)

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,7 +102,7 @@ uintptr_t
 getValuesFromShcFilePrefix(struct J9PortLibrary* portLibrary, const char* filename, struct J9PortShcVersion* versionData);
 
 uint32_t
-getShcModlevelForJCL(uintptr_t j2seVersion);
+getShcModlevelForJCL();
 
 uint32_t
 getJCLForShcModlevel(uintptr_t modlevel);

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2207,11 +2207,10 @@ j9cached_file_sync(struct J9PortLibrary *portLibrary, IDATA fd);
  * Populate a J9PortShcVersion struct with the version data of the running JVM
  *
  * @param [in] vm  pointer to J9JavaVM structure
- * @param [in] j2seVersion  The j2se version the JVM is running
  * @param [out] result  The struct to populate
  */
 void
-setCurrentCacheVersion(J9JavaVM *vm, UDATA j2seVersion, J9PortShcVersion* result);
+setCurrentCacheVersion(J9JavaVM *vm, J9PortShcVersion* result);
 
 /**
  * Get the running JVM feature

--- a/runtime/oti/vmargs_api.h
+++ b/runtime/oti/vmargs_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,11 +120,10 @@ addOptionsDefaultFile(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsL
  * This allocates memory for the options string and adds the argument to the list.
  * @param portLib port library
  * @param vmArgumentsList current list of arguments
- * @param j2seVersion java version number
  * @return 0 on success, negative value on failure
  */
 IDATA
-addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2seVersion);
+addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList);
 
 /*
  * Add argument to set com.ibm.oti.vm.bootstrap.library.path or sun.boot.library.path
@@ -176,11 +175,10 @@ addJavaHome(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA 
  * @param vmArgumentsList current list of arguments
  * @param jrelibPath path to library directory
  * @param launcherArgs JavaVMInitArgs passed in from the launcher
- * @param j2seVersion java version number
  * @return 0 on success, negative value on failure
  */
 IDATA
-addExtDir(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jrelibPath, JavaVMInitArgs *launcherArgs, UDATA j2seVersion);
+addExtDir(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jrelibPath, JavaVMInitArgs *launcherArgs);
 
 /**
  * Add argument to set user.dir

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -434,7 +434,7 @@ J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 	case VM_INITIALIZATION_COMPLETE:
 		tempThr = UT_THREAD_FROM_VM_THREAD(vm->mainThread);
 #ifdef J9VM_OPT_SIDECAR
-		if (J2SE_VERSION(vm)) {
+		{
 			/* Force loading of the Trace class. See defect 162723, this is required because of some nuance
 			 * in the early initialization of DB/2 (which uses the Trace class).
 			 */
@@ -444,7 +444,7 @@ J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 			(*env)->ExceptionClear(env);
 		}
 #endif
-		/* overwrite the header settings now that we have full vm->j2seVersion info */
+		/* overwrite the header settings now */
 		if (OMR_ERROR_NONE != populateTraceHeaderInfo(vm)) {
 			return J9VMDLLMAIN_FAILED;
 		}
@@ -1029,14 +1029,14 @@ runtimeSetTraceOptions(J9VMThread * thr,const char * traceOptions)
 static omr_error_t
 populateTraceHeaderInfo(J9JavaVM *vm)
 {
-	JavaVMInitArgs  *vmInitArgs;
-	char *options;
-	char *fullversion;
+	JavaVMInitArgs  *vmInitArgs = NULL;
+	char *options = NULL;
+	char *fullversion = NULL;
 	omr_error_t ret = OMR_ERROR_NONE;
 
 	PORT_ACCESS_FROM_JAVAVM( vm );
 
-	/* overwrite the header settings now that we have full vm->j2seVersion info */
+	/* overwrite the header settings now */
 	vmInitArgs = (JavaVMInitArgs  *) vm->vmArgsArray->actualVMArgs;
 	if (vmInitArgs) {
 		int i;

--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -113,7 +113,7 @@ j9shr_iterateSharedCaches(J9JavaVM *vm,	const char *ctrlDirName, UDATA groupPerm
  		void *user_data)
 {
 	J9SharedCacheInfo callbackData;
-	SH_OSCache_Info *cacheInfo;
+	SH_OSCache_Info *cacheInfo = NULL;
 	J9Pool *cacheList = NULL;
 	J9Pool *snapshotList = NULL;
 	pool_state state;
@@ -127,11 +127,11 @@ j9shr_iterateSharedCaches(J9JavaVM *vm,	const char *ctrlDirName, UDATA groupPerm
 		}
 		/* Don't include old generations */
 		cacheList = getCacheList(vm, vm->sharedCacheAPI->ctrlDirName, vmGroupPerm, false, SHR_STATS_REASON_ITERATE); 
-		snapshotList = SH_OSCache::getAllCacheStatistics(vm, vm->sharedCacheAPI->ctrlDirName, vmGroupPerm, 0, J2SE_VERSION(vm), false, false, SHR_STATS_REASON_ITERATE, false);
+		snapshotList = SH_OSCache::getAllCacheStatistics(vm, vm->sharedCacheAPI->ctrlDirName, vmGroupPerm, 0, false, false, SHR_STATS_REASON_ITERATE, false);
 	} else {
 		/* Don't include old generations */
 		cacheList = getCacheList(vm, ctrlDirName, groupPerm, false, SHR_STATS_REASON_ITERATE);
-		snapshotList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, J2SE_VERSION(vm), false, false, SHR_STATS_REASON_ITERATE, false);
+		snapshotList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, false, false, SHR_STATS_REASON_ITERATE, false);
 	}
 
 	if (NULL == cacheList || pool_numElements(cacheList) == 0) {
@@ -409,12 +409,12 @@ deleteExpiredSharedCache(void *element, void *param)
 static J9Pool*
 getCacheList(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, bool includeOldGenerations, UDATA reason)
 {
-	J9Pool* cacheList;
+	J9Pool* cacheList = NULL;
 	
 	Trc_SHR_CLM_getCacheList_Entry();
 
 	/* Verbose flags not required - do not want to see permissions error accessing all caches */
-	cacheList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, J2SE_VERSION(vm), includeOldGenerations, false, reason, true);
+	cacheList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, includeOldGenerations, false, reason, true);
 	
 	Trc_SHR_CLM_getCacheList_Exit();
 	return cacheList;
@@ -425,12 +425,12 @@ getCacheList(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, bool
 static J9Pool*
 findIncompatibleCachesForName(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char* name)
 {
-	J9Pool* cacheList;
+	J9Pool* cacheList = NULL;
 
 	Trc_SHR_CLM_findIncompatibleCachesForName_Entry(name);
 	
 	/* Verbose flags not required - do not want to see permissions error accessing all caches */
-	cacheList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, J2SE_VERSION(vm), true, true, SHR_STATS_REASON_GETNAME, true);
+	cacheList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, true, true, SHR_STATS_REASON_GETNAME, true);
 	
 	Trc_SHR_CLM_findIncompatibleCachesForName_Exit();
 	return cacheList;
@@ -461,7 +461,7 @@ j9shr_list_caches(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm,
 	
 	/* Don't include old generations, don't populate javacore data */
 	cacheList = getCacheList(vm, ctrlDirName, groupPerm, false, SHR_STATS_REASON_LIST);
-	snapshotList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, J2SE_VERSION(vm), false, false, SHR_STATS_REASON_LIST, false);
+	snapshotList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, false, false, SHR_STATS_REASON_LIST, false);
 
 	noCacheExist = (NULL == cacheList) || (0 == pool_numElements(cacheList));
 	noSnapshotExist = (NULL == snapshotList) || (0 == pool_numElements(snapshotList));
@@ -643,7 +643,7 @@ j9shr_destroy_all_snapshot(struct J9JavaVM* vm, const char* ctrlDirName, UDATA g
 	param.groupPerm = groupPerm;
 	param.ctrlDirName = ctrlDirName;
 
-	snapshotList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, J2SE_VERSION(vm), true, false, SHR_STATS_REASON_DESTROY, false);
+	snapshotList = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, groupPerm, 0, true, false, SHR_STATS_REASON_DESTROY, false);
 
 	if ((NULL == snapshotList) || (0 == pool_numElements(snapshotList))) {
 		Trc_SHR_CLM_j9shr_destroy_all_snapshot_noSnapshots();
@@ -693,14 +693,14 @@ IDATA
 j9shr_destroySharedCache(J9JavaVM *vm, const char *ctrlDirName, const char *name, U_32 cacheType, BOOLEAN useCommandLineValues)
 {
 	J9PortShcVersion versionData;
-	const char *cacheName;
+	const char *cacheName = NULL;
 	char modifiedCacheName[CACHE_ROOT_MAXLEN];
 	char *modifiedCacheNamePtr = modifiedCacheName;
-	const char *ctrlDir;
+	const char *ctrlDir = NULL;
 	UDATA verboseFlags = 0;
 	IDATA rc = 0;
 
-	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	if (useCommandLineValues == TRUE){
 		cacheName = vm->sharedCacheAPI->cacheName;
 		versionData.cacheType = (U_32) vm->sharedCacheAPI->cacheType;

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -375,7 +375,7 @@ SH_CompositeCacheImpl::initialize(J9JavaVM* vm, BlockPtr memForConstructor, J9Sh
 	Trc_SHR_CC_initialize_Entry1(memForConstructor, sharedClassConfig, cacheName, cacheTypeRequired, UnitTest::unitTest);
 
 	commonInit(vm);
-	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = cacheTypeRequired;
 
 	if ((UnitTest::NO_TEST != UnitTest::unitTest) && (UnitTest::CORRUPT_CACHE_TEST != UnitTest::unitTest)) {
@@ -1139,10 +1139,10 @@ SH_CompositeCacheImpl::startup(J9VMThread* currentThread, J9SharedClassPreinitCo
 			}
 		}
 	} else {
-		IDATA lockID;
+		IDATA lockID = 0;
 		bool OSCStarted = false;
 
-		setCurrentCacheVersion(vm, J2SE_VERSION(currentThread->javaVM), &versionData);
+		setCurrentCacheVersion(vm, &versionData);
 
 		/* Note that OSCache startup does not leave any kind of lock on the cache, so the cache file could in theory
 		 * be recreated by another process whenever we're not holding a lock on it. This can happen until attach() is called */

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -198,8 +198,8 @@ public:
 
 	static UDATA statCache(J9PortLibrary* portLibrary, const char* cacheDirName, const char* cacheNameWithVGen, bool displayNotFoundMsg);
 
-	static J9Pool* getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, bool includeOldGenerations, bool ignoreCompatible, UDATA reason, bool isCache);
-	static IDATA getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char* cacheNameWithVGen, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, SH_OSCache_Info* result, UDATA reason);
+	static J9Pool* getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA localVerboseFlags, bool includeOldGenerations, bool ignoreCompatible, UDATA reason, bool isCache);
+	static IDATA getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char* cacheNameWithVGen, UDATA groupPerm, UDATA localVerboseFlags, SH_OSCache_Info* result, UDATA reason);
 	
 	static IDATA getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirName, char* buffer, UDATA bufferSize, const char* cacheNameWithVGen);
 

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -157,8 +157,8 @@ bool
 SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
 		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer, UDATA reason)
 {
-	I_32 mmapCapabilities;
-	IDATA retryCntr;
+	I_32 mmapCapabilities = 0;
+	IDATA retryCntr = 0;
 	bool creatingNewCache = false;
 	struct J9FileStat statBuf;
 	IDATA errorCode = J9SH_OSCACHE_FAILURE;
@@ -169,7 +169,7 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 #if defined(OPENJ9_BUILD)
 	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
 #endif /* OPENJ9_BUILD */

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -145,7 +145,7 @@ bool
 SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks, UDATA create,
 		UDATA verboseFlags_, U_64 runtimeFlags_, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitializer* i, UDATA reason)
 {
-	IDATA retryCount;
+	IDATA retryCount = 0;
 	IDATA shsemrc = 0;
 	IDATA semLength = 0;
 	LastErrorInfo lastErrorInfo;
@@ -155,7 +155,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 #if defined(OPENJ9_BUILD)
 	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
 #endif /* OPENJ9_BUILD */
@@ -2662,7 +2662,7 @@ SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA n
 	Trc_SHR_OSC_Sysv_restoreFromSnapshot_Entry();
 
 	_verboseFlags = vm->sharedClassConfig->verboseFlags;
-	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_SNAPSHOT;
 
 	if (-1 == SH_OSCache::getCacheDir(vm, ctrlDirName, cacheDirName, J9SH_MAXPATH, J9PORT_SHR_CACHE_TYPE_SNAPSHOT)) {

--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,7 +154,7 @@ public:
 
 	static UDATA getHeaderSize(void);
 
-	static IDATA findAllKnownCaches(struct J9PortLibrary* portlib, UDATA j2seVersion, struct J9Pool* cacheList);
+	static IDATA findAllKnownCaches(struct J9PortLibrary* portlib, struct J9Pool* cacheList);
 
 	static UDATA findfirst(struct J9PortLibrary *portLibrary, char *cacheDir, char *resultbuf);
 	

--- a/runtime/shared_common/SCImplementedAPI.cpp
+++ b/runtime/shared_common/SCImplementedAPI.cpp
@@ -473,7 +473,7 @@ j9shr_classStoreTransaction_start(void * tobj, J9VMThread* currentThread, J9Clas
 		IDATA helperID = 0;
 		U_16 cpType = CP_TYPE_CLASSPATH;
 
-		if ((J2SE_VERSION(vm) >= J2SE_V11)
+		if ((JAVA_SPEC_VERSION >= J2SE_V11)
 			|| ((NULL != classPathEntries) && (-1 != obj->entryIndex))
 		) {
 			/* For class loaded from modules that entryIndex is -1. classPathEntries can be NULL. */
@@ -489,7 +489,7 @@ j9shr_classStoreTransaction_start(void * tobj, J9VMThread* currentThread, J9Clas
 			if (!classpath && !infoFound) {
 				UDATA pathEntryCount = cpEntryCount;
 
-				if (J2SE_VERSION(vm) >= J2SE_V11) {
+				if (JAVA_SPEC_VERSION >= J2SE_V11) {
 					if (classloader == vm->systemClassLoader) {
 						if (J9_ARE_NO_BITS_SET(localRuntimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHEBOOTCLASSES)) {
 							/* User specified noBootclasspath - do not continue */

--- a/runtime/shared_common/hookhelpers.cpp
+++ b/runtime/shared_common/hookhelpers.cpp
@@ -71,7 +71,7 @@ makeClasspathItems(J9JavaVM* vm, J9ClassPathEntry* classPathEntries, I_16 entryC
 	bool ret = true;
 	bool ignoreStateChange = false;
 
-	if (bootstrap && (J2SE_VERSION(vm) >= J2SE_V11)) {
+	if (bootstrap && (JAVA_SPEC_VERSION >= J2SE_V11)) {
 		J9ClassPathEntry* modulePath = vm->modulesPathEntry;
 		if (CPE_TYPE_JIMAGE == modulePath->type) {
 			prototype = PROTO_JIMAGE;
@@ -226,7 +226,7 @@ createClasspath(J9VMThread* currentThread, J9ClassPathEntry* classPathEntries, U
 
 	I_16 supportedEntries = (I_16)entryCount;
 	
-	if (!infoFound && J2SE_VERSION(currentThread->javaVM) >= J2SE_V11) {
+	if (!infoFound && (JAVA_SPEC_VERSION >= J2SE_V11)) {
 		/* Add module entry */
 		supportedEntries += 1;
 	}
@@ -258,7 +258,7 @@ createClasspath(J9VMThread* currentThread, J9ClassPathEntry* classPathEntries, U
 		if (vm->sharedClassConfig->bootstrapCPI) {
 			j9mem_free_memory(vm->sharedClassConfig->bootstrapCPI);
 		}
-		if (J2SE_VERSION(vm) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			vm->sharedClassConfig->lastBootstrapCPE = vm->modulesPathEntry;
 		} else {
 			vm->sharedClassConfig->lastBootstrapCPE = classPathEntries;

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -94,7 +94,7 @@ latestUserDefinedLoaderIterator(J9VMThread * currentThread, J9StackWalkState * w
 	 * In Java 9+, vm->extensionClassLoader is the PlatformClassLoader.
 	 */
 	BOOLEAN isPlatformClassLoader = FALSE;
-	if ((J2SE_VERSION(vm) >= J2SE_V11) && (classLoader == vm->extensionClassLoader)) {
+	if ((JAVA_SPEC_VERSION >= J2SE_V11) && (classLoader == vm->extensionClassLoader)) {
 		isPlatformClassLoader = TRUE;
 	}
 
@@ -399,7 +399,9 @@ static jint
 initializeReflectionGlobals(JNIEnv * env,BOOLEAN includeAccessors) {
 	J9VMThread *vmThread = (J9VMThread *) env;
 	J9JavaVM * vm = vmThread->javaVM;
-	jclass clazz, clazzConstructorAccessorImpl, clazzMethodAccessorImpl;
+	jclass clazz = NULL;
+	jclass clazzConstructorAccessorImpl = NULL;
+	jclass clazzMethodAccessorImpl = NULL;
 
 	clazz = (*env)->FindClass(env, "java/lang/Class");
 	if (NULL == clazz) {
@@ -422,7 +424,7 @@ initializeReflectionGlobals(JNIEnv * env,BOOLEAN includeAccessors) {
 	}
 #endif /* defined(J9VM_OPT_METHOD_HANDLE) && !defined(J9VM_IVE_RAW_BUILD) */
 	
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		clazzConstructorAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/ConstructorAccessorImpl");
 		clazzMethodAccessorImpl = (*env)->FindClass(env, "jdk/internal/reflect/MethodAccessorImpl");
 	} else {
@@ -721,10 +723,10 @@ JVM_GetSystemPackages_Impl(JNIEnv* env)
 				result = (*env)->NewObjectArray(env, (jsize) packageCount, jlsClass, NULL);
 				if (result) {
 					for (i = 0; i < packageCount; i++) {
-						j9object_t packageString;
+						j9object_t packageString = NULL;
 						jobject packageStringRef = NULL;
 						const U_8* packageName = NULL;
-						UDATA packageNameLength;
+						UDATA packageNameLength = 0;
 
 						funcs->internalEnterVMFromJNI(vmThread);
 						packageName = getPackageName(packageIDList[i], &packageNameLength);
@@ -732,7 +734,7 @@ JVM_GetSystemPackages_Impl(JNIEnv* env)
 						 * java.lang.Package.getSystemPackages() expects a trailing slash in Java 8
 						 * but no trailing slash in Java 9.
 						 */
-						if (J2SE_VERSION(vm) >= J2SE_V11) {
+						if (JAVA_SPEC_VERSION >= J2SE_V11) {
 							packageString = vm->memoryManagerFunctions->j9gc_createJavaLangString(vmThread,
 									(U_8*) packageName, packageNameLength, 0);
 						} else {

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -808,9 +808,9 @@ zeroOutCache(J9JavaVM *vm, I_32 cacheType)
 	char cacheName[J9SH_MAXPATH];
 	char fullPath[J9SH_MAXPATH];
 	J9PortShcVersion versionData;
-	J9MmapHandle *mapFileHandle;
-	I_64 cacheSize;
-	IDATA fd;
+	J9MmapHandle *mapFileHandle = NULL;
+	I_64 cacheSize = 0;
+	IDATA fd = 0;
 	IDATA rc = PASS;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -823,7 +823,7 @@ zeroOutCache(J9JavaVM *vm, I_32 cacheType)
 	if (rc < 0) {
 		ERRPRINTF("Cannot get a directory\n");
 	}
-	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = cacheType;
 	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true);
 	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
@@ -876,7 +876,7 @@ truncateCache(J9JavaVM *vm, I_32 cacheType)
 	char cacheName[J9SH_MAXPATH];
 	char fullPath[J9SH_MAXPATH];
 	J9PortShcVersion versionData;
-	IDATA fd;
+	IDATA fd = 0;
 	IDATA rc = PASS;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -889,7 +889,7 @@ truncateCache(J9JavaVM *vm, I_32 cacheType)
 	if (rc < 0) {
 		ERRPRINTF("Cannot get a directory\n");
 	}
-	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = cacheType;
 	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true);
 	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);

--- a/runtime/tests/shared/OSCacheTestMmap.cpp
+++ b/runtime/tests/shared/OSCacheTestMmap.cpp
@@ -32,7 +32,7 @@ extern "C" {
 #include <string.h>
 
 extern "C" {
-void setCurrentCacheVersion(J9JavaVM *vm, UDATA j2seVersion, J9PortShcVersion *versionData);
+void setCurrentCacheVersion(J9JavaVM *vm, J9PortShcVersion *versionData);
 }
 
 J9VMThread *SH_OSCacheTestMmap::currentThread = NULL;
@@ -50,8 +50,8 @@ SH_OSCacheTestMmap::testBasic(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	Init *init = NULL;
 	SH_OSCache *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
-	UDATA cacheSize;
-	char *q;
+	UDATA cacheSize = 0;
+	char *q = NULL;
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
@@ -59,7 +59,7 @@ SH_OSCacheTestMmap::testBasic(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 	
 	rc = j9shmem_getDir(NULL, flags, cacheDir, J9SH_MAXPATH);
@@ -146,7 +146,7 @@ SH_OSCacheTestMmap::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	rc = j9shmem_getDir(NULL, flags, cacheDir, J9SH_MAXPATH);
@@ -210,7 +210,7 @@ SH_OSCacheTestMmap::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	SH_OSCachemmap *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
 	IDATA rc = PASS;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
@@ -218,7 +218,7 @@ SH_OSCacheTestMmap::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -300,16 +300,16 @@ SH_OSCacheTestMmap::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	J9ProcessHandle pid[MAX_PROCESS];
 	IDATA rc = PASS;
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	struct j9shsem_handle *launchsem;
-	SH_OSCachemmap *oscHandle;
+	struct j9shsem_handle *launchsem = NULL;
+	SH_OSCachemmap *oscHandle = NULL;
 	char cacheDir[J9SH_MAXPATH];
 	Init *init = NULL;
-	J9SharedClassPreinitConfig *piconfig;
-	IDATA semhandle;
+	J9SharedClassPreinitConfig *piconfig = NULL;
+	IDATA semhandle = 0;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
@@ -317,7 +317,7 @@ SH_OSCacheTestMmap::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -446,12 +446,12 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 	J9Pool *cacheStat = NULL;
 	IDATA rc = FAIL;
 	IDATA ret = 0;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	UDATA numCacheBeforeTest = 0;
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if(NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -498,7 +498,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat != NULL) {
 		numCacheBeforeTest += pool_numElements(cacheStat);
@@ -520,7 +520,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, false, false, SHR_STATS_REASON_TEST, true);
 	if(cacheStat == NULL) {
 		j9tty_printf(PORTLIB, "testGetAllCacheStatistics: failed to get cache statistics - there should be at least one cache!\n");
 		goto cleanup;
@@ -558,15 +558,15 @@ IDATA
 SH_OSCacheTestMmap::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j9cmdlineOptions *arg, UDATA child)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	SH_OSCachemmap *osc;
+	SH_OSCachemmap *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
-	J9SharedClassPreinitConfig* piconfig;
-	J9ProcessHandle pid;
-	IDATA rc;
+	J9SharedClassPreinitConfig* piconfig = NULL;
+	J9ProcessHandle pid = NULL;
+	IDATA rc = 0;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
@@ -574,7 +574,7 @@ SH_OSCacheTestMmap::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (osc = (SH_OSCachemmap *)j9mem_allocate_memory(SH_OSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
@@ -653,13 +653,13 @@ SH_OSCacheTestMmap::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	PORT_ACCESS_FROM_PORT(portLibrary);
 	SH_OSCachemmap *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
-	J9ProcessHandle pid;
+	J9ProcessHandle pid = NULL;
 	IDATA rc = PASS;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
@@ -667,7 +667,7 @@ SH_OSCacheTestMmap::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -749,11 +749,11 @@ SH_OSCacheTestMmap::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	J9ProcessHandle pid;
 	IDATA rc = FAIL;
 	IDATA ret = 0;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
@@ -761,7 +761,7 @@ SH_OSCacheTestMmap::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -38,7 +38,7 @@ extern "C" {
 #include "ut_j9shr.h"
 
 extern "C" {
-void setCurrentCacheVersion(J9JavaVM *vm, UDATA j2seVersion, J9PortShcVersion *versionData);
+void setCurrentCacheVersion(J9JavaVM *vm, J9PortShcVersion *versionData);
 }
 
 J9VMThread *SH_OSCacheTestSysv::currentThread = NULL;
@@ -48,10 +48,12 @@ SH_OSCacheTestSysv::testBasic(J9PortLibrary* portLibrary, J9JavaVM *vm)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
 	IDATA rc = PASS;
-	SH_OSCachesysv *osc = NULL, *osc1 = NULL;
+	SH_OSCachesysv *osc = NULL;
+	SH_OSCachesysv *osc1 = NULL;
 	Init *initObj = NULL;
 	J9SharedClassPreinitConfig *piconfig = NULL;
-	char *s, *r;
+	char *s = NULL;
+	char *r = NULL;
 	J9PortShcVersion versionData;
 	char cacheDir[J9SH_MAXPATH];
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
@@ -60,7 +62,7 @@ SH_OSCacheTestSysv::testBasic(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
 	
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	rc = j9shmem_getDir(NULL, flags, cacheDir, J9SH_MAXPATH);
@@ -175,21 +177,21 @@ SH_OSCacheTestSysv::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	J9ProcessHandle pid[MAX_PROCESS];
 	IDATA rc = PASS;
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	struct j9shsem_handle *launchsem;
-	SH_OSCachesysv *oscHandle;
+	struct j9shsem_handle *launchsem = NULL;
+	SH_OSCachesysv *oscHandle = NULL;
 	char cacheDir[J9SH_MAXPATH];
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /*  defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 	
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -318,14 +320,14 @@ SH_OSCacheTestSysv::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	SH_OSCachesysv *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
 	IDATA rc = PASS;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /*  defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -402,14 +404,14 @@ SH_OSCacheTestSysv::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	SH_OSCachesysv *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
 	IDATA rc = PASS;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -483,7 +485,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	J9Pool *cacheStat = NULL;
 	IDATA rc = FAIL;
 	IDATA ret = 0;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	char* ctrlDirName = NULL;
 	char cacheDirName[J9SH_MAXPATH];
 	char* testDir = NULL;
@@ -491,7 +493,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	J9PortShcVersion versionData;
 	U_32 flags = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if(NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -541,7 +543,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat != NULL) {
 		numCacheBeforeTest += pool_numElements(cacheStat);
@@ -565,7 +567,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	}
 
 	/* Search for caches in "/tmp/javasharedresources". */
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_CURRENT_VERSION, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat == NULL) {
 		j9tty_printf(PORTLIB, "testGetAllCacheStatistics: failed to get cache statistics - there should be at least one cache!\n");
@@ -604,21 +606,21 @@ IDATA
 SH_OSCacheTestSysv::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j9cmdlineOptions *arg, UDATA child)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	SH_OSCachesysv *osc;
+	SH_OSCachesysv *osc = NULL;
 	char cacheDir[J9SH_MAXPATH];
-	J9SharedClassPreinitConfig* piconfig;
+	J9SharedClassPreinitConfig* piconfig = NULL;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
-	IDATA rc;
+	IDATA rc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if	defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (osc = (SH_OSCachesysv *)j9mem_allocate_memory(SH_OSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
@@ -702,18 +704,18 @@ SH_OSCacheTestSysv::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	char cacheDir[J9SH_MAXPATH];
 	J9ProcessHandle pid = NULL; 
 	IDATA rc = PASS;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -799,14 +801,14 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	U_64 shmmax64 = 0;
 	U_64 shmmax = 0;
 	IDATA i = 0;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -880,7 +882,7 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 #if defined(OPENJ9_BUILD)
 			defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 #else /* OPENJ9_BUILD */
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 			}
 #endif /* OPENJ9_BUILD */
@@ -951,18 +953,18 @@ SH_OSCacheTestSysv::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	J9ProcessHandle pid = NULL;
 	IDATA rc = FAIL;
 	IDATA ret = 0;
-	J9SharedClassPreinitConfig *piconfig;
+	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	int argc = arg->argc;
 	char **argv = arg->argv;
-	char * childargv[SHRTEST_MAX_CMD_OPTS];
+	char * childargv[SHRTEST_MAX_CMD_OPTS] = {NULL};
 	UDATA childargc = 0;
 	U_32 flags = J9SHMEM_GETDIR_APPEND_BASEDIR;
 
 #if defined(OPENJ9_BUILD)
 	flags |= J9SHMEM_GETDIR_USE_USERHOME;
 #endif /* defined(OPENJ9_BUILD) */
-	setCurrentCacheVersion(vm, J2SE_CURRENT_VERSION, &versionData);
+	setCurrentCacheVersion(vm, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {

--- a/runtime/tests/shared/SharedCacheAPITest.cpp
+++ b/runtime/tests/shared/SharedCacheAPITest.cpp
@@ -39,7 +39,7 @@ static CacheInfo cacheInfoList[NUM_CACHE + NUM_SNAPSHOT];
 I_32 cacheCount;
 I_32 testCacheCount;
 
-void setCurrentCacheVersion(J9JavaVM *vm, UDATA j2seVersion, J9PortShcVersion *versionData);
+void setCurrentCacheVersion(J9JavaVM *vm, J9PortShcVersion *versionData);
 IDATA j9shr_createCacheSnapshot(J9JavaVM* vm, const char* cacheName);
 
 void
@@ -211,8 +211,8 @@ countSharedCacheCallback(J9JavaVM *vm, J9SharedCacheInfo *cacheInfo, void *userD
 IDATA
 validateSharedCacheCallback(J9JavaVM *vm, J9SharedCacheInfo *cacheInfo, void *userData)
 {
-	I_32 i;
-	UDATA cacheSize;
+	I_32 i = 0;
+	UDATA cacheSize = 0;
 	UDATA addrMode = J9SH_ADDRMODE;
 
 	cacheCount++;
@@ -236,7 +236,7 @@ validateSharedCacheCallback(J9JavaVM *vm, J9SharedCacheInfo *cacheInfo, void *us
 			&& (J9SH_OSCACHE_UNKNOWN == (IDATA)cacheInfo->isCorrupt)
 			&& (1 == cacheInfo->isCompatible)
 			&& (addrMode == cacheInfo->addrMode)
-			&& (getShcModlevelForJCL(J2SE_VERSION(vm)) == cacheInfo->modLevel)
+			&& (getShcModlevelForJCL() == cacheInfo->modLevel)
 			&& (J9SH_OSCACHE_UNKNOWN == cacheInfo->lastDetach)
 			&& (J9SH_OSCACHE_UNKNOWN == (IDATA)cacheInfo->os_shmid)
 			&& (J9SH_OSCACHE_UNKNOWN == (IDATA)cacheInfo->os_semid)
@@ -260,7 +260,7 @@ validateSharedCacheCallback(J9JavaVM *vm, J9SharedCacheInfo *cacheInfo, void *us
 				(CACHE_SIZE != cacheInfo->softMaxBytes) ||
 				(cacheInfo->freeBytes != (cacheSize - cacheInfoList[i].debugBytes)) ||
 				(cacheInfo->addrMode != addrMode) ||
-				(cacheInfo->modLevel != getShcModlevelForJCL(J2SE_VERSION(vm)) ||
+				(cacheInfo->modLevel != getShcModlevelForJCL() ||
 				(cacheInfo->lastDetach <= 0))) {
 				continue;
 			}

--- a/runtime/util/shchelp_j9.c
+++ b/runtime/util/shchelp_j9.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,15 +29,14 @@
  * Populate a J9PortShcVersion struct with the version data of the running JVM
  *
  * @param [in] vm  pointer to J9JavaVM structure.*
- * @param [in] j2seVersion  The j2se version the JVM is running
  * @param [out] result  The struct to populate
  */
 void
-setCurrentCacheVersion(J9JavaVM *vm, UDATA j2seVersion, J9PortShcVersion* result)
+setCurrentCacheVersion(J9JavaVM *vm, J9PortShcVersion* result)
 {
 	result->esVersionMajor = EsVersionMajor;
 	result->esVersionMinor = EsVersionMinor;
-	result->modlevel = getShcModlevelForJCL(j2seVersion);
+	result->modlevel = getShcModlevelForJCL();
 	result->addrmode = J9SH_ADDRMODE;
 	result->cacheType = 0;			/* initialize to 0 */
 	result->feature = getJVMFeature(vm);

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -667,13 +667,12 @@ addOptionsDefaultFile(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsL
 }
 
 IDATA
-addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2seVersion)
+addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList)
 {
 	char *dllName = J9_JAVA_SE_DLL_NAME;
 	size_t dllNameLength = sizeof(J9_JAVA_SE_DLL_NAME);
 	size_t argumentLength = -1;
 	char *argString = NULL;
-	UDATA j2seReleaseValue = j2seVersion & J2SE_RELEASE_MASK;
 	J9JavaVMArgInfo *optArg = NULL;
 	
 	PORT_ACCESS_FROM_PORT(portLib);
@@ -1003,7 +1002,7 @@ addJavaHome(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA 
 }
 
 IDATA
-addExtDir(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jrelibPath, JavaVMInitArgs *launcherArgs, UDATA j2seVersion)
+addExtDir(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jrelibPath, JavaVMInitArgs *launcherArgs)
 {
 	char *javaHomeEnd = strrchr(jrelibPath, DIR_SEPARATOR);
 	size_t argumentLength = 1; /* add the \0 */

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -155,23 +155,18 @@ getModLevelFromName(const char* cacheNameWithVGen)
 }
 
 /**
- * Return the modification level for a given j2se version
+ * Return the modification level according to JAVA_SPEC_VERSION
  * 
- * @param [in] j2seVersion  The j2se version
- * 
- * @return the modification level or 0 if one cannot be found
+ * @return the modification level
  */
 uint32_t
-getShcModlevelForJCL(uintptr_t j2seVersion)
+getShcModlevelForJCL()
 {
 	uint32_t modLevel = 0;
-	switch (j2seVersion) {
-	case J2SE_18 :
+	if (JAVA_SPEC_VERSION == J2SE_18) {
 		modLevel = J9SH_MODLEVEL_JAVA8;
-		break;
-	default: 
-		modLevel = JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion);
-		break;
+	} else {
+		modLevel = JAVA_SPEC_VERSION;
 	}
 	return modLevel;
 }

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -181,7 +181,7 @@ dumpMemorySizes(J9JavaVM *jvm)
 #endif /* J9VM_INTERP_GROWABLE_STACKS */
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	if (J2SE_VERSION(jvm) && jvm->sharedClassPreinitConfig) {				/* Only show for J2SE */
+	if (jvm->sharedClassPreinitConfig) {
 		/* Init updatedWithDefaults to the current values in jvm->sharedClassPreinitConfig, 
 		 * b/c if new members are added to J9SharedClassPreinitConfig this will cause the 
 		 * default value (set by VMInitStages() in jvminit.c) to be used.

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1466,7 +1466,7 @@ obj:;
 						 * superclass/superinterfaces, so AbstractMethodError is the correct error to throw.
 						 * For default or protected methods or JDK levels prior to 11, throw IllegalAccessError.
 						 */
-						if ((J2SE_VERSION(_vm) < J2SE_V11) || (J9_ARE_NO_BITS_SET(modifiers, J9AccPrivate))) {
+						if ((JAVA_SPEC_VERSION < J2SE_V11) || (J9_ARE_NO_BITS_SET(modifiers, J9AccPrivate))) {
 							exception = J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSERROR;
 							_sendMethod = method;
 						}

--- a/runtime/vm/classloadersearch.c
+++ b/runtime/vm/classloadersearch.c
@@ -57,7 +57,7 @@ addToBootstrapClassLoaderSearch(J9JavaVM * vm, const char * pathSegment,
 	}
 
 	if (classLoaderType & CLS_TYPE_ADD_TO_SYSTEM_PROPERTY) {
-		if (J2SE_VERSION(vm) < J2SE_V11) {
+		if (JAVA_SPEC_VERSION < J2SE_V11) {
 			rc = addToSystemProperty(vm, BOOT_PATH_SYS_PROP, pathSegment);
 		} else {
 			rc = addToSystemProperty(vm, BOOT_CLASS_PATH_APPEND_PROP, pathSegment);
@@ -182,7 +182,7 @@ addZipToLoader(J9JavaVM * vm, const char * filename, J9ClassLoader * classLoader
 		zip_releaseZipFile(vm->portLibrary, &zipFile);
 	}
 
-	if ((classLoader == vm->systemClassLoader) && (J2SE_VERSION(vm) >= J2SE_V11)) {
+	if ((classLoader == vm->systemClassLoader) && (JAVA_SPEC_VERSION >= J2SE_V11)) {
 		if (0 == addJarToSystemClassLoaderClassPathEntries(vm, filename)) {
 			rc = CLS_ERROR_OUT_OF_MEMORY;
 		}
@@ -196,7 +196,7 @@ addZipToLoader(J9JavaVM * vm, const char * filename, J9ClassLoader * classLoader
 			jclass classLoaderClass = NULL;
 			jmethodID mid = NULL;
 
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				jclass jimModules = getJimModules(currentThread);
 				jstring moduleNameString = NULL;
 				jobject vmModule = NULL;

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -520,7 +520,7 @@ callFindLocallyDefinedClass(J9VMThread* vmThread, J9Module *j9module, U_8* class
 			}
 		} else {
 			/* The class is found in shared class cache. */
-			if (J2SE_VERSION(vmThread->javaVM) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				if (localBuffer->entryIndex >= 0) {
 					localBuffer->loadLocationType = LOAD_LOCATION_CLASSPATH;
 				} else {
@@ -558,7 +558,7 @@ attemptDynamicClassLoad(J9VMThread* vmThread, J9Module *j9module, U_8* className
 	Trc_VM_internalFindClass_attemptDynamicClassLoad_entry(vmThread, classLoader->classLoaderObject, classNameLength, className);
 
 	/* try to load classes from system class loader */
-	if ((J2SE_VERSION(vmThread->javaVM) >= J2SE_V11)
+	if ((JAVA_SPEC_VERSION >= J2SE_V11)
 		|| ((NULL != classLoader->classPathEntries) && (classLoader == vmThread->javaVM->systemClassLoader))
 	) {
 		IDATA findResult = -1;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2016,15 +2016,15 @@ internalCreateRAMClassFromROMClassImpl(J9VMThread *vmThread, J9ClassLoader *clas
 	UDATA vTableSlots = 0;
 	UDATA jitVTableSlots = 0;
 	UDATA *vTable = NULL;
-	UDATA classSize;
-	UDATA result;
-	J9Class *interfaceHead;
+	UDATA classSize = 0;
+	UDATA result = 0;
+	J9Class *interfaceHead = NULL;
 	BOOLEAN foundCloneable = FALSE;
 	UDATA extendedMethodBlockSize = 0;
-	UDATA totalStaticSlots;
+	UDATA totalStaticSlots = 0;
 	UDATA interfaceCount = 0;
 	J9ROMFieldOffsetWalkState romWalkState;
-	J9ROMFieldOffsetWalkResult *romWalkResult;
+	J9ROMFieldOffsetWalkResult *romWalkResult = NULL;
 	BOOLEAN hotswapping = (0 != (options & J9_FINDCLASS_FLAG_NO_DEBUG_EVENTS));
 	BOOLEAN fastHCR = (0 != (options & J9_FINDCLASS_FLAG_FAST_HCR));
 	UDATA *iTable = NULL;
@@ -2071,7 +2071,7 @@ fail:
 
 			/* If the lock class is not yet loaded, skip allocating the instance - will be fixed up once the class is loaded */
 			if (lockClass != NULL) {
-				j9object_t lockObject;
+				j9object_t lockObject = NULL;
 				UDATA allocateFlags = J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE;
 
 				PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, (j9object_t)state->classObject);
@@ -2249,7 +2249,7 @@ fail:
 		Trc_VM_CreateRAMClassFromROMClass_overriddenFinalMethod(vmThread, J9UTF8_LENGTH(badName), J9UTF8_DATA(badName), J9UTF8_LENGTH(badSig), J9UTF8_DATA(badSig));
 		
 		if (!hotswapping) {
-			U_8 *verifyErrorString;
+			U_8 *verifyErrorString = NULL;
 
 			popFromClassLoadingStack(vmThread);
 			omrthread_monitor_exit(javaVM->classTableMutex);
@@ -2293,7 +2293,7 @@ fail:
 	}
 	if (classSize != 0) {
 		if (ramClass == NULL) {
-			J9MemorySegment *segment;
+			J9MemorySegment *segment = NULL;
 			RAMClassAllocationRequest allocationRequests[RAM_CLASS_FRAGMENT_COUNT];
 			UDATA minimumSuperclassArraySizeBytes = (sizeof(UDATA) * javaVM->minimumSuperclassArraySize);
 			UDATA superclassSizeBytes = 0;
@@ -2494,7 +2494,7 @@ fail:
 			/* Initialize the methods. */
 			if (romClass->romMethodCount != 0) {
 				J9Method *currentRAMMethod = ramClass->ramMethods;
-				UDATA i;
+				UDATA i = 0;
 				UDATA methodCount = romClass->romMethodCount;
 				J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
 				for (i = 0; i < methodCount; i++) {
@@ -2722,7 +2722,7 @@ fail:
 						J9VMCONSTANTPOOL_JAVALANGCLASSLOADER,
 						J9VMCONSTANTPOOL_JAVALANGTHREAD,
 				};
-				UDATA i;
+				UDATA i = 0;
 
 				for (i = 0; i < sizeof(uncloneableClasses) / sizeof(UDATA); i++) {
 					J9Class * uncloneableClass = J9VMCONSTANTPOOL_CLASSREF_AT(javaVM, uncloneableClasses[i])->value;
@@ -2819,7 +2819,7 @@ fail:
 					omrthread_monitor_exit(javaVM->classLoaderModuleAndLocationMutex);
 				}
 			}
-			if ((J2SE_VERSION(javaVM) >= J2SE_V11) && (NULL == classBeingRedefined)) {
+			if ((JAVA_SPEC_VERSION >= J2SE_V11) && (NULL == classBeingRedefined)) {
 				ramClass->module = module;
 				if (TrcEnabled_Trc_MODULE_setPackage) {
 					trcModulesSettingPackage(vmThread, ramClass, classLoader, className);
@@ -2828,8 +2828,8 @@ fail:
 		} else {
 			if (J9ROMCLASS_IS_ARRAY(romClass)) {
 				/* fill in the special array class fields */
-				UDATA arity;
-				J9Class *leafComponentType;
+				UDATA arity = 0;
+				J9Class *leafComponentType = NULL;
 				J9ArrayClass *ramArrayClass = (J9ArrayClass *)ramClass;
 				J9ArrayClass *elementArrayClass = (J9ArrayClass *)elementClass;
 				/* Is the elementClass an array or an object? */
@@ -2943,8 +2943,7 @@ retry:
 
 	/* To prevent deadlock, release the classTableMutex before loading the classes required for the new class. */
 	omrthread_monitor_exit(javaVM->classTableMutex);
-
-	if (J2SE_VERSION(javaVM) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		if (NULL == classBeingRedefined) {
 			if (J9ROMCLASS_IS_ARRAY(romClass)) {
 				/* At this point the elementClass has been loaded. No

--- a/runtime/vm/dllsup.c
+++ b/runtime/vm/dllsup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,9 +72,9 @@ UDATA loadJ9DLLWithPath(J9JavaVM * vm, J9VMDllLoadInfo* info, char *dllName) {
 
 	if (NULL != dllDirectory) {
 		UDATA superSeparatorIndex = -1;
-		UDATA bufferSize;
+		UDATA bufferSize = 0;
 
-		if((info->loadFlags & XRUN_LIBRARY) && (J2SE_LAYOUT(vm) & J2SE_LAYOUT_VM_IN_SUBDIR)) {
+		if((info->loadFlags & XRUN_LIBRARY) && J2SE_IS_LAYOUT_VM_IN_SUBDIR(vm)) {
 			/* load the DLL from the parent of the j2seRootDir - find the last dir separator and declare that the end. */
 			superSeparatorIndex = strrchr(dllDirectory, DIR_SEPARATOR) - dllDirectory;
 			bufferSize = superSeparatorIndex + 1 + sizeof(DIR_SEPARATOR_STR) + strlen(dllName);  /* +1 for NUL */

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -100,7 +100,7 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 /* assumes VM access */
 static UDATA
 printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *romClass, J9ROMMethod * romMethod, J9UTF8 * sourceFile, UDATA lineNumber, J9ClassLoader* classLoader) {
-	const char* format;
+	const char* format = NULL;
 	J9JavaVM *vm = vmThread->javaVM;
 	J9InternalVMFunctions * vmFuncs = vm->internalVMFunctions;
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -122,9 +122,8 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *rom
 		char versionBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		BOOLEAN freeModuleName = FALSE;
 		BOOLEAN freeModuleVersion = FALSE;
-		UDATA j2seVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
 
-		if (j2seVersion >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			moduleNameUTF = JAVA_BASE_MODULE;
 			moduleVersionUTF = JAVA_MODULE_VERSION;
 

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -394,11 +394,11 @@ getObjectClass(JNIEnv *env, jobject obj)
 jint JNICALL
 getVersion(JNIEnv *env)
 {
-	if (J2SE_VERSION(((J9VMThread*)env)->javaVM) >= J2SE_V11) {
-		return JNI_VERSION_10;
-	} else {
-		return JNI_VERSION_1_8;
+	jint jniVersion = JNI_VERSION_1_8;
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
+		jniVersion = JNI_VERSION_10;
 	}
+	return jniVersion;
 }
 
 jsize JNICALL

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1357,7 +1357,7 @@ initializeClassPathEntry (J9JavaVM * javaVM, J9ClassPathEntry *cpEntry)
 		return CPE_TYPE_DIRECTORY;
 	}
 
-	if ((EsIsFile == attr) && (J2SE_VERSION(javaVM) >= J2SE_V11)) {
+	if ((EsIsFile == attr) && (JAVA_SPEC_VERSION >= J2SE_V11)) {
 		J9JImageIntf *jimageIntf = javaVM->jimageIntf;
 		if (NULL != jimageIntf) {
 			UDATA jimageHandle = 0;
@@ -1591,14 +1591,15 @@ j9print_internal_version(J9PortLibrary *portLib) {
 /* The equivalent of a J9VMDllMain for the VM init module */
 
 IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
-	J9VMDllLoadInfo *loadInfo;
+	J9VMDllLoadInfo *loadInfo = NULL;
 	IDATA returnVal = J9VMDLLMAIN_OK;
 	IDATA argIndex = -1;
 	IDATA argIndex2 = -1;
 	IDATA optionValueSize = 0;
-	char* optionValue, *optionExtra;
+	char* optionValue = NULL;
+	char* optionExtra = NULL;
 	char* parseErrorOption = NULL;
-	IDATA parseError;
+	IDATA parseError = 0;
 	BOOLEAN lockwordWhat = FALSE;
 	UDATA rc = 0;
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -1849,7 +1850,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 					enableGcOnIdle = TRUE;
 				} else if (-1 == argIndexGcOnIdleDisable) {
 					if (inContainer
-						|| ((J2SE_VERSION(vm) >= J2SE_V11) && J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_TUNE_VIRTUALIZED))
+						|| ((JAVA_SPEC_VERSION >= J2SE_V11) && J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_TUNE_VIRTUALIZED))
 					) {
 						enableGcOnIdle = TRUE;
 					}
@@ -2041,7 +2042,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 
 			if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
 				goto _error;
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				vm->modularityPool = pool_new(OMR_MAX(sizeof(J9Package),sizeof(J9Module)),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_MODULES, POOL_FOR_PORT(vm->portLibrary));
 				if (NULL == vm->modularityPool) {
 					goto _error;
@@ -2171,7 +2172,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			break;
 
 		case BYTECODE_TABLE_SET:
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				rc = initializeModulesPath(vm);
 				if (0 != rc) {
 					loadInfo = FIND_DLL_TABLE_ENTRY( FUNCTION_VM_INIT );
@@ -2190,7 +2191,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				goto _error;
 			}
 
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				BOOLEAN patchPathResult = FALSE;
 
 				vm->javaBaseModule = pool_newElement(vm->modularityPool);
@@ -2496,7 +2497,7 @@ static void consumeVMArgs(J9JavaVM* vm, J9VMInitArgs* j9vm_args) {
 	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XNOJIT, NULL, TRUE);
 	findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XRUN, NULL, TRUE);
 
-	if (J2SE_VERSION(vm) < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XBOOTCLASSPATH_COLON, NULL, TRUE);
 		findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XBOOTCLASSPATH_P_COLON, NULL, TRUE);
 	}
@@ -2907,7 +2908,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 	vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_CLASSLOADER_LOCKING_ENABLED | J9_EXTENDED_RUNTIME_REDUCE_CPU_MONITOR_OVERHEAD; /* enabled by default */
 	vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_ENABLE_CPU_MONITOR; /* Cpu monitoring is enabled by default */
 	vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_ALLOW_CONTENDED_FIELDS; /* Allow contended fields on bootstrap classes */
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		vm->extendedRuntimeFlags |= (UDATA)J9_EXTENDED_RUNTIME_RESTRICT_IFA; /* Enable zAAP switching for Registered Natives and JVMTI callbacks by default in Java 9 and later. */
 	}
 	vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_OSR_SAFE_POINT; /* Enable OSR safe point by default */
@@ -3150,7 +3151,7 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 	}
 
 	/* -Xbootclasspath and -Xbootclasspath/p are not supported from Java 9 onwards */
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		if (FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, VMOPT_XBOOTCLASSPATH_COLON, NULL) != -1) {
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNRECOGNISED_CMD_LINE_OPT, "-Xbootclasspath");
@@ -3584,7 +3585,7 @@ threadInitStages(J9JavaVM* vm, IDATA stage, void* reserved)
 IDATA
 zeroInitStages(J9JavaVM* vm, IDATA stage, void* reserved)
 {
-	J9VMDllLoadInfo* loadInfo;
+	J9VMDllLoadInfo* loadInfo = NULL;
 	IDATA returnVal = J9VMDLLMAIN_OK;
 	IDATA argIndex1 = -1;
 	BOOLEAN describe = FALSE;
@@ -3594,7 +3595,7 @@ zeroInitStages(J9JavaVM* vm, IDATA stage, void* reserved)
 	switch(stage) {
 		case PORT_LIBRARY_GUARANTEED :
 			/* -Xzero option is removed from Java 9 */
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				vm->zeroOptions = 0;
 			} else {
 				vm->zeroOptions = J9VM_ZERO_SHAREBOOTZIPCACHE;
@@ -6451,7 +6452,6 @@ shutDownHookWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo
 static void
 signalDispatch(J9VMThread *vmThread, I_32 signal)
 {
-	J9JavaVM *vm = vmThread->javaVM;
 	J9NameAndSignature nas = {0};
 	I_32 args[] = {signal};
 
@@ -6462,7 +6462,7 @@ signalDispatch(J9VMThread *vmThread, I_32 signal)
 
 	enterVMFromJNI(vmThread);
 
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		runStaticMethod(vmThread, (U_8 *)"jdk/internal/misc/Signal", &nas, 1, (UDATA *)args);
 	} else {
 		runStaticMethod(vmThread, (U_8 *)"sun/misc/Signal", &nas, 1, (UDATA *)args);
@@ -6576,14 +6576,14 @@ static jint
 initializeDDR(J9JavaVM * vm)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	I_64 ddrFileLength;
+	I_64 ddrFileLength = 0;
 	char * filename = J9DDR_DAT_FILE;
 	char * j9ddrDatDir = NULL;
 	jint rc = JNI_OK;
 
 #if defined(J9VM_OPT_SIDECAR)
 	/* Append the VM path to the filename if it's available */
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		j9ddrDatDir = vm->j9libvmDirectory;
 	} else {
 		j9ddrDatDir = vm->j2seRootDirectory;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -148,7 +148,7 @@ BOOLEAN
 requirePackageAccessCheck(J9JavaVM *vm, J9ClassLoader *srcClassLoader, J9Module *srcModule, J9Class *targetClass)
 {
 	BOOLEAN checkFlag = TRUE;
-	if (J2SE_VERSION(vm) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		if (srcModule == targetClass->module) {
 			if (NULL != srcModule) {
 				/* same named module */
@@ -449,10 +449,10 @@ bail:
 J9Method *   
 resolveStaticMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags, J9RAMStaticMethodRef *ramCPEntry)
 {
-	J9ROMMethodRef *romMethodRef;
-	J9Class *resolvedClass;
+	J9ROMMethodRef *romMethodRef = NULL;
+	J9Class *resolvedClass = NULL;
 	J9Method *method = NULL;
-	J9Class *cpClass;
+	J9Class *cpClass = NULL;
 	J9Class *methodClass = NULL;
 	BOOLEAN isResolvedClassAnInterface = FALSE;
 	bool jitCompileTimeResolve = J9_ARE_ANY_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_JIT_COMPILE_TIME | J9_RESOLVE_FLAG_AOT_LOAD_TIME);
@@ -489,7 +489,7 @@ tryAgain:
 		cpClass = J9_CLASS_FROM_CP(ramCP);
 		lookupOptions |= J9_LOOK_CLCONSTRAINTS;
 
-		if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_V11) {
+		if (JAVA_SPEC_VERSION >= J2SE_V11) {
 			/* This check is only required in Java9 and there have been applications that
 			 * fail when this check is enabled on Java8.
 			 */
@@ -1025,11 +1025,11 @@ J9Method *
 resolveInterfaceMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags, J9RAMInterfaceMethodRef *ramCPEntry)
 {
 	J9Method *returnValue = NULL;
-	J9ROMMethodRef *romMethodRef;
-	J9Class *interfaceClass;
-	J9ROMNameAndSignature *nameAndSig;
-	J9Method *method;
-	J9Class *cpClass;
+	J9ROMMethodRef *romMethodRef = NULL;
+	J9Class *interfaceClass = NULL;
+	J9ROMNameAndSignature *nameAndSig = NULL;
+	J9Method *method = NULL;
+	J9Class *cpClass = NULL;
 	J9JavaVM *vm = vmStruct->javaVM;
 	bool jitCompileTimeResolve = J9_ARE_ANY_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_JIT_COMPILE_TIME | J9_RESOLVE_FLAG_AOT_LOAD_TIME);
 	bool canRunJavaCode = !jitCompileTimeResolve && J9_ARE_NO_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_REDEFINE_CLASS);
@@ -1094,7 +1094,7 @@ resolveInterfaceMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA
 					 * vTable or iTable.  Use the index into ramMethods in interfaceClass. This is
 					 * only allowed in JDK11 and beyond.
 					 */
-					if (J2SE_VERSION(vm) < J2SE_V11) {
+					if (JAVA_SPEC_VERSION < J2SE_V11) {
 nonpublic:
 						if (throwException) {
 							setIllegalAccessErrorNonPublicInvokeInterface(vmStruct, method);
@@ -1158,10 +1158,10 @@ resolveInterfaceMethodRef(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA cpI
 J9Method *   
 resolveSpecialMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags, J9RAMSpecialMethodRef *ramCPEntry)
 {
-	J9ROMMethodRef *romMethodRef;
-	J9Class *resolvedClass;
-	J9Class *currentClass;
-	J9ROMNameAndSignature *nameAndSig;
+	J9ROMMethodRef *romMethodRef = NULL;
+	J9Class *resolvedClass = NULL;
+	J9Class *currentClass = NULL;
+	J9ROMNameAndSignature *nameAndSig = NULL;
 	J9Method *method = NULL;
 	bool jitCompileTimeResolve = J9_ARE_ANY_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_JIT_COMPILE_TIME | J9_RESOLVE_FLAG_AOT_LOAD_TIME);
 	bool canRunJavaCode = !jitCompileTimeResolve && J9_ARE_NO_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_REDEFINE_CLASS);
@@ -1210,7 +1210,7 @@ resolveSpecialMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 		lookupOptions |= J9_LOOK_CLCONSTRAINTS;
 	}
 
-	if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		/* This check is only required in Java9 and there have been applications that
 		 * fail when this check is enabled on Java8.
 		 */

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -101,7 +101,7 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 		if ( modifiers & J9AccPublic ) {
 			/* Public */
 			if ((sourceClass != destClass)
-				&& (J2SE_VERSION(vm) >= J2SE_V11) 
+				&& (JAVA_SPEC_VERSION >= J2SE_V11) 
 				&& J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)
 				&& !J9ROMCLASS_IS_PRIMITIVE_TYPE(destClass->romClass)
 			) {

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -536,7 +536,6 @@ initializeSystemProperties(J9JavaVM * vm)
 	jint i = 0;
 	JavaVMInitArgs *initArgs = NULL;
 	char *jclName = J9_DEFAULT_JCL_DLL_NAME;
-	UDATA j2seVersion = J2SE_VERSION(vm);
 	const char* propValue = NULL;
 	UDATA rc = J9SYSPROP_ERROR_NONE;
 
@@ -565,7 +564,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		return J9SYSPROP_ERROR_OUT_OF_MEMORY;
 	}
 
-	if (j2seVersion >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		rc = addModularitySystemProperties(vm);
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
@@ -579,16 +578,13 @@ initializeSystemProperties(J9JavaVM * vm)
 		const char *specificationVersion = NULL;
 
 		/* Properties that always exist */
-		switch (j2seVersion) {
-		case J2SE_18:
+		/* JAVA_SPEC_VERSION has only two possible values here: J2SE_18 or J2SE_V11 */
+		if (JAVA_SPEC_VERSION == J2SE_18) {
 			classVersion = "52.0";
 			specificationVersion = "1.8";
-			break;
-		case J2SE_V11:
-		default:
+		} else {
 			classVersion = "55.0";
 			specificationVersion = "11";
-			break;
 		}
 		rc = addSystemProperty(vm, "java.class.version", classVersion, 0);
 		if (J9SYSPROP_ERROR_NONE != rc) {
@@ -703,7 +699,7 @@ initializeSystemProperties(J9JavaVM * vm)
 
 	/* We don't have enough information yet. Put in placeholders. */
 #if defined(J9VM_OPT_SIDECAR)
-	if (j2seVersion < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		rc = addSystemProperty(vm, BOOT_PATH_SYS_PROP, "", J9SYSPROP_FLAG_WRITEABLE);
 	} else {
 		rc = addSystemProperty(vm, BOOT_CLASS_PATH_APPEND_PROP, "", J9SYSPROP_FLAG_WRITEABLE);
@@ -743,7 +739,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	}
 
 	/* -Xzero option is removed from Java 9 */
-	if (j2seVersion < J2SE_V11) {
+	if (JAVA_SPEC_VERSION < J2SE_V11) {
 		rc = addSystemProperty(vm, "com.ibm.zero.version", "2", 0);
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
@@ -755,7 +751,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		char *agentPath = NULL;
 		UDATA agentPathLength = 0;
 
-		if (J2SE_LAYOUT_VM_IN_SUBDIR == (J2SE_LAYOUT(vm) & J2SE_LAYOUT_VM_IN_SUBDIR)) {
+		if (J2SE_IS_LAYOUT_VM_IN_SUBDIR(vm)) {
 			/* Use the parent of the j2seRootDir - find the last dir separator and declare that the end. */
 			agentPathLength = strrchr(vm->j2seRootDirectory, DIR_SEPARATOR) - vm->j2seRootDirectory;
 		} else {
@@ -847,7 +843,7 @@ initializeSystemProperties(J9JavaVM * vm)
 					goto fail;
 				}
 			}
-			if (j2seVersion >= J2SE_V11) {
+			if (JAVA_SPEC_VERSION >= J2SE_V11) {
 				if ('\0' != propValue[0]) {
 					/* Support for java.endorsed.dirs and java.ext.dirs is disabled in Java 9+. */
 					if (0 == strncmp(JAVA_ENDORSED_DIRS, propNameCopy, sizeof(JAVA_ENDORSED_DIRS))) {
@@ -888,7 +884,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		}
 	}
 	
-	if (j2seVersion >= J2SE_V11) {
+	if (JAVA_SPEC_VERSION >= J2SE_V11) {
 		/* On Java 9 support for java.endorsed.dirs is disabled. If java.home/lib/endorsed dir is found, JVM fails to startup. *
 		 * Similarly, support for java.ext.dirs is disabled. If java.home/lib/ext dir is found, JVM fails to startup.
 		 */

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -35,7 +35,7 @@
 #include "j2sever.h"
 
 /* processReferenceMonitor is only used for Java 9 and later */
-#define J9_IS_PROCESS_REFERENCE_MONITOR_ENABLED(vm) (J2SE_VERSION(vm) >= J2SE_V11)
+#define J9_IS_PROCESS_REFERENCE_MONITOR_ENABLED(vm) (JAVA_SPEC_VERSION >= J2SE_V11)
 
 UDATA initializeVMThreading(J9JavaVM *vm)
 {


### PR DESCRIPTION
Replace `J2SE_VERSION` macro with `JAVA_SPEC_VERSION`

`J2SE_VERSION(javaVM)` now is equivalent to `JAVA_SPEC_VERSION`, replace it to simplify the code;
Added missing variable initialization around code with `JAVA_SPEC_VERSION` changes;

Reviewers: @DanHeidinga @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>