### PR TITLE
Allow concurrent hot compilations in JITaaS mode

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2310,6 +2310,11 @@ J9::Options::setupJITaaSOptions()
          // no IProfiler info is collected at the server itself
          self()->setOption(TR_DisableIProfilerThread);
          }
+
+      // In the JITaaS world, expensive compilations are performed remotely so there is no risk of blowing the footprint limit on the JVM
+      // Setting _expensiveCompWeight to a large value so that JSR292/hot/scorching compilation are allowed to be executed concurrently
+      TR::Options::_expensiveCompWeight = TR::CompilationInfo::MAX_WEIGHT;
+
       }
 
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))


### PR DESCRIPTION
The heuristics in the JIT don't allow multiple expensive compilation to be performed in parallel to avoid increasing the peak footprint too much. The default value is set such that hot, scorching and JSR292 compilations are considered expensive. However, in JITaaS world such compilation are performed remotely and therefore there is no risk of blowing the footprint limit on the JVM. By setting a large value for "expensiveCompWeight", we are effectively allowing several memory expensive compilations to be performed concurrently.

Issue: #4476
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>