### PR TITLE
Add links to 'info thread' command for '!j9vmthread' and '!stack'

### DIFF
--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/infocommands/InfoThreadCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/infocommands/InfoThreadCommand.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,18 +26,19 @@ import java.io.PrintStream;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.ibm.dtfj.image.CorruptData;
 import com.ibm.dtfj.image.CorruptDataException;
 import com.ibm.dtfj.image.DTFJException;
 import com.ibm.dtfj.image.DataUnavailable;
-import com.ibm.dtfj.image.ImageAddressSpace;
 import com.ibm.dtfj.image.ImageProcess;
 import com.ibm.dtfj.image.ImageRegister;
 import com.ibm.dtfj.image.ImageSection;
@@ -64,137 +65,121 @@ import com.ibm.jvm.dtfjview.commands.helpers.StateToString;
 import com.ibm.jvm.dtfjview.commands.helpers.ThreadData;
 import com.ibm.jvm.dtfjview.commands.helpers.Utils;
 
-@DTFJPlugin(version="1.*", runtime=false)
+@DTFJPlugin(version = "1.*", runtime = false)
+@SuppressWarnings({ "boxing", "javadoc", "nls" })
 public class InfoThreadCommand extends BaseJdmpviewCommand {
-	
+
 	private int _pointerSize;
 	private boolean _is_zOS = false;
-	private Map<JavaThread, MonitorState> monitors = new HashMap<JavaThread, MonitorState>();
+	private Map<JavaThread, MonitorState> monitors = new HashMap<>();
 	private long lastRTAddress = 0;
 	private final static String JAVA_LANG_THREAD_CLASS = "java/lang/Thread";
-	
+
 	{
-		addCommand("info thread", "[<native thread ID>|<zOS TCB>|all|*]", "Displays information about Java and native threads");	
+		addCommand("info thread", "[<native thread ID>|<zOS TCB>|all|*]", "Displays information about Java and native threads");
 	}
-	
-	public void run(String command, String[] args, IContext context, PrintStream out) throws CommandException {
-		if(initCommand(command, args, context, out)) {
-			return;		//processing already handled by super class
+
+	@Override
+	public void run(String command, String[] args, IContext context, PrintStream outStream) throws CommandException {
+		if (initCommand(command, args, context, outStream)) {
+			return; // processing already handled by superclass
 		}
 		try {
 			long currentRTAddress = ctx.getRuntime().getJavaVM().getAddress();
-			if(currentRTAddress != lastRTAddress) {
+			if (currentRTAddress != lastRTAddress) {
 				lastRTAddress = currentRTAddress;
-				monitors = new HashMap<JavaThread, MonitorState>();		//reset the monitors
+				monitors = new HashMap<>(); // reset the monitors
 			}
 		} catch (Exception e) {
 			logger.fine("Error getting address of the JVM, cannot use cached monitor values. No JVM in process?");
 			logger.log(Level.FINEST, "Error getting address of the JVM", e);
-			monitors = new HashMap<JavaThread, MonitorState>();		//reset the monitors
+			monitors = new HashMap<>(); // reset the monitors
 		}
 		if (monitors.isEmpty() && ctx.getRuntime() != null) {
 			getMonitors(ctx.getRuntime());
 		}
 		doCommand(args);
 	}
-	
+
 	public void doCommand(String[] args) {
-		
 		try {
-			_is_zOS = ctx.getImage().getSystemType().toLowerCase().indexOf("z/os") >= 0;
+			_is_zOS = ctx.getImage().getSystemType().toLowerCase().contains("z/os");
 		} catch (DataUnavailable e) {
 			out.print(Exceptions.getDataUnavailableString());
 		} catch (CorruptDataException e) {
 			out.print(Exceptions.getCorruptDataExceptionString());
 		}
-		
+
 		String param = null;
-		
-		switch(args.length) {
-			case 0 :
-				try {
-					ImageThread it = ctx.getProcess().getCurrentThread();
-					if (null != it) {
-						param = it.getID();
-					} else {
-						out.print("\nNo current (failing) thread, try specifying a native thread ID, \"all\" or \"*\"\n");
-						
-						ImageProcess ip = ctx.getProcess();
-						if (ip!=null){
-							printThreadSummary(ip);
-						}
-						return;
+
+		switch (args.length) {
+		case 0:
+			try {
+				ImageThread it = ctx.getProcess().getCurrentThread();
+				if (null != it) {
+					param = it.getID();
+				} else {
+					out.println();
+					out.println("No current (failing) thread, try specifying a native thread ID, \"all\" or \"*\"");
+
+					ImageProcess ip = ctx.getProcess();
+					if (ip != null) {
+						printThreadSummary(ip);
 					}
-				} catch (CorruptDataException e) {
-					out.println("exception encountered while getting information about current thread");
 					return;
 				}
-				break;
-			case 1 :
-				if(args[0].equalsIgnoreCase("ALL")) {
-					param = "*";
-				} else {
-					param = args[0];
-				}
-				break;
-			default :
-				out.println("\"info thread\" takes at most one parameter, which, if specified, must be a native thread ID or \"all\" or \"*\"");
+			} catch (CorruptDataException e) {
+				out.println("exception encountered while getting information about current thread");
 				return;
+			}
+			break;
+		case 1:
+			param = args[0];
+			if ("ALL".equalsIgnoreCase(param) || "*".equals(param)) {
+				param = null;
+			}
+			break;
+		default:
+			out.println("\"info thread\" takes at most one parameter, which, if specified, must be a native thread ID or \"all\" or \"*\"");
+			return;
 		}
-		
-		if (param.equals("*")) {
-			printAddressSpaceInfo(null, getJavaThreads(null));
-		} else {
-			printAddressSpaceInfo(param, getJavaThreads(param));
-		}
+
+		printAddressSpaceInfo(param, getJavaThreads(param));
 	}
-	
-	private void printAddressSpaceInfo(String id, Map threads)
-	{
-		Iterator itAddressSpace;
-		ImageAddressSpace ias;
-		int asnum = 0;
-		
+
+	private void printAddressSpaceInfo(String id, Map<String, List<ThreadData>> threads) {
 		if (id == null) { // omit header line if we are only printing one thread
-			out.print("native threads for address space\n");
+			out.println("native threads for address space");
 		}
+
 		printProcessInfo(id, threads);
 
-		
 		if (!threads.isEmpty()) {
-			out.print("\nJava threads not associated with known native threads:\n\n");
-			
+			out.println("Java threads not associated with known native threads:");
+			out.println();
+
 			// retrieve any orphaned Java threads from the hashmap
-			ArrayList ta = (ArrayList)threads.remove(null);
-			if ( ta != null ) {
-				for ( int i=0; i<ta.size(); i++) {
-					ThreadData td = (ThreadData)ta.get(i);
-					printJavaThreadInfo(td.getThread(), false);
+			List<ThreadData> orphans = threads.remove(null);
+
+			if (orphans != null) {
+				for (ThreadData orphan : orphans) {
+					printJavaThreadInfo(orphan.getThread(), false);
 				}
 			}
-			// If that still hasn't emptied the list we've managed to find id's for threads
-			if( !threads.isEmpty() ) {
-				Iterator remainingThreads = threads.values().iterator();
-				while( remainingThreads.hasNext() ) {
-					ThreadData td = (ThreadData)remainingThreads.next();
-					if( td == null ) {
-						continue;
-					}
+
+			// If that hasn't emptied the list we've managed to find ids for threads.
+			for (List<ThreadData> list : threads.values()) {
+				for (ThreadData td : list) {
 					printJavaThreadInfo(td.getThread(), false);
 				}
 			}
 		}
 	}
-	
-	private void printProcessInfo(String id, Map threads)
-	{
-		Iterator itProcess;
-		ImageProcess ip;
-		boolean found = false;
-		
-		ip = ctx.getProcess();
+
+	private void printProcessInfo(String id, Map<String, List<ThreadData>> threads) {
+		ImageProcess ip = ctx.getProcess();
 		_pointerSize = ip.getPointerSize();
-		
+
 		out.print(" process id: ");
 		try {
 			out.print(ip.getID());
@@ -203,30 +188,30 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 		} catch (CorruptDataException e) {
 			out.print(Exceptions.getCorruptDataExceptionString());
 		}
-		out.print("\n\n");
-		found = printThreadInfo(id, threads);
-		
+		out.println();
+		out.println();
+
+		boolean found = printThreadInfo(id, threads);
+
 		if (!found) {
-			out.print(" no native threads found with specified id\n");
+			out.println(" no native threads found with specified id");
+			out.println();
 		}
 	}
-	
-	private boolean printThreadInfo(String id, Map threads)
-	{
-		Iterator itThread;
-		ImageThread it;
+
+	private boolean printThreadInfo(String id, Map<String, List<ThreadData>> threads) {
 		boolean found = false;
-		
-		itThread = ctx.getProcess().getThreads();
-		while (itThread.hasNext())
-		{
+		Iterator<?> itThread = ctx.getProcess().getThreads();
+
+		while (itThread.hasNext()) {
 			Object next = itThread.next();
 			if (next instanceof CorruptData) {
-				out.print("\n  <corrupt data>");
+				out.println();
+				out.print("  <corrupt data>");
 				continue;
 			}
-			it = (ImageThread)next;
-			
+			ImageThread it = (ImageThread) next;
+
 			// Obtain the native thread ID for this thread, and for zOS also obtain the TCB
 			String currentTID = null;
 			String currentTCB = null;
@@ -238,69 +223,65 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			} catch (CorruptDataException e) {
 				// Continue with what we have obtained so far
 			}
-			
+
 			// If the user request was for all threads (id parameter is null) or if we have found a match for
-			// the requested native thread ID or zOS TCB, then go ahead and print out this thread.  
+			// the requested native thread ID or zOS TCB, then go ahead and print out this thread.
 			if (null == id || id.equalsIgnoreCase(currentTID) || id.equalsIgnoreCase(currentTCB)) {
 				out.print("  thread id: ");
-				out.print(currentTID);
-				out.print("\n");
+				out.println(currentTID);
 				printRegisters(it);
-				
-				out.print("   native stack sections:");
-				out.print("\n");
-				
-				Iterator itStackSection = it.getStackSections();
+
+				out.println("   native stack sections:");
+
+				Iterator<?> itStackSection = it.getStackSections();
 				while (itStackSection.hasNext()) {
 					Object nextStackSection = itStackSection.next();
 					if (nextStackSection instanceof CorruptData) {
-						out.print("    " + Exceptions.getCorruptDataExceptionString() + "\n");
+						out.println("    " + Exceptions.getCorruptDataExceptionString());
 						continue;
 					}
-					ImageSection is = (ImageSection)nextStackSection;
+					ImageSection is = (ImageSection) nextStackSection;
 					printStackSection(is);
 				}
 				printStackFrameInfo(it);
-				
-				out.print("   properties:");
-				out.print("\n");
+
+				out.println("   properties:");
 				printProperties(it);
-				
+
 				out.print("   associated Java thread: ");
-				ThreadData td = (ThreadData)threads.remove(currentTID);
-				if (null != td) {
-					out.print("\n");
-					printJavaThreadInfo(td.getThread(), true);
+				List<ThreadData> list = threads.remove(currentTID);
+				if ((null == list) || list.isEmpty()) {
+					out.println("<no associated Java thread>");
 				} else {
-					out.print("<no associated Java thread>\n");
+					out.println();
+					printJavaThreadInfo(list.get(0).getThread(), true);
 				}
-				out.print("\n");
+				out.println();
 				found = true;
 			}
 		}
-		
+
 		return found;
 	}
-	
-	public void printRegisters(ImageThread it)
-	{
+
+	public void printRegisters(ImageThread it) {
 		out.print("   registers:");
 		int count = 0;
-		Iterator itImageRegister = it.getRegisters();
+		Iterator<?> itImageRegister = it.getRegisters();
 		while (itImageRegister.hasNext()) {
 			if (count % 4 == 0) {
-				out.print("\n ");
+				out.println();
+				out.print(" ");
 			}
 			out.print("   ");
-			ImageRegister ir = (ImageRegister)itImageRegister.next();
+			ImageRegister ir = (ImageRegister) itImageRegister.next();
 			printRegisterInfo(ir);
-			count++;
+			count += 1;
 		}
-		out.print("\n");
+		out.println();
 	}
-	
-	public void printRegisterInfo(ImageRegister ir)
-	{
+
+	public void printRegisterInfo(ImageRegister ir) {
 		out.print(Utils.padWithSpaces(ir.getName(), 6) + " = ");
 		try {
 			Number value = ir.getValue();
@@ -329,9 +310,8 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			out.print(Exceptions.getCorruptDataExceptionString());
 		}
 	}
-	
-	public void printStackSection(ImageSection is)
-	{
+
+	public void printStackSection(ImageSection is) {
 		long startAddr = is.getBaseAddress().getAddress();
 		long size = is.getSize();
 		long endAddr = startAddr + size;
@@ -342,31 +322,28 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 		out.print(Utils.toHex(endAddr));
 		out.print(" (length ");
 		out.print(Utils.toHex(size));
-		out.print(")\n");
+		out.println(")");
 	}
-	
-	private void printStackFrameInfo(ImageThread it)
-	{
-		Iterator itStackFrame;
-		ImageStackFrame isf;
-		
+
+	private void printStackFrameInfo(ImageThread it) {
+		Iterator<?> itStackFrame;
+
 		try {
 			itStackFrame = it.getStackFrames();
 		} catch (DataUnavailable d) {
-			out.print("   native stack frames: " + Exceptions.getDataUnavailableString() + "\n");
+			out.println("   native stack frames: " + Exceptions.getDataUnavailableString());
 			return;
 		}
-		
-		out.print("   native stack frames:");
-		out.print("\n");
+
+		out.println("   native stack frames:");
 
 		while (itStackFrame.hasNext()) {
 			Object o = itStackFrame.next();
 			if (o instanceof CorruptData) {
-				out.print("    <corrupt stack frame: "+((CorruptData)o).toString()+">\n");
+				out.println("    <corrupt stack frame: " + ((CorruptData) o).toString() + ">");
 				continue;
 			}
-			isf = (ImageStackFrame)o;
+			ImageStackFrame isf = (ImageStackFrame) o;
 			out.print("    bp: ");
 			try {
 				out.print(toAdjustedHex(isf.getBasePointer().getAddress()));
@@ -390,29 +367,34 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			} catch (CorruptDataException e) {
 				out.print(Exceptions.getCorruptDataExceptionString());
 			}
-			out.print("\n");
+			out.println();
 		}
 	}
-	
-	private Map getJavaThreads(String id)
-	{
-		Map threads = new HashMap();
+
+	private Map<String, List<ThreadData>> getJavaThreads(String id) {
+		Map<String, List<ThreadData>> threads = new HashMap<>();
 		ManagedRuntime mr = ctx.getRuntime();
+
 		if (mr instanceof JavaRuntime) {
-			JavaRuntime jr = (JavaRuntime)mr;
-			Iterator itThread = jr.getThreads();
-			
+			JavaRuntime jr = (JavaRuntime) mr;
+			Iterator<?> itThread = jr.getThreads();
+
 			while (itThread.hasNext()) {
 				Object next = itThread.next();
-				if (next instanceof CorruptData) continue; // skip any corrupt threads
-				
-				JavaThread jt = (JavaThread)next;
-				
+
+				if (next instanceof CorruptData) {
+					continue; // skip any corrupt threads
+				}
+
+				JavaThread jt = (JavaThread) next;
+
 				// Obtain the native thread ID for this thread, and for zOS also obtain the TCB
 				String currentTID = null;
 				String currentTCB = null;
+
 				try {
-					ImageThread it = jt.getImageThread();  
+					ImageThread it = jt.getImageThread();
+
 					currentTID = it.getID();
 					if (_is_zOS) {
 						currentTCB = it.getProperties().getProperty("TCB");
@@ -420,91 +402,83 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 				} catch (DTFJException e) {
 					// Continue with what we have obtained so far
 				}
-				
-				if (null == id) {
-					// thread id set to null means we want all the threads, and we
-					// save all orphaned java threads in a list within the hashmap
-					if ( null == currentTID) {
-						if (threads.containsKey(null)) {
-							ArrayList ta = (ArrayList)threads.get(null);
-							ta.add(new ThreadData(jt, jr));
-						} else {
-							ArrayList ta = new ArrayList(1);
-							ta.add(new ThreadData(jt, jr));
-							threads.put(null, ta);
-						}
-					} else {
-						threads.put(currentTID, new ThreadData(jt, jr));
+
+				// thread id set to null means we want all the threads, and we
+				// save all orphaned java threads in a list within the hashmap
+				// We just want the specific Java thread that matches the native thread ID or zOS TCB
+				if (null == id || id.equalsIgnoreCase(currentTID) || id.equalsIgnoreCase(currentTCB)) {
+					List<ThreadData> ta = threads.get(currentTID);
+					if (ta == null) {
+						ta = new ArrayList<>(1);
+						threads.put(currentTID, ta);
 					}
-				} else if (id.equalsIgnoreCase(currentTID) || id.equalsIgnoreCase(currentTCB)) {
-					// We just want the specific Java thread that matches the native thread ID or zOS TCB
-					threads.put(currentTID, new ThreadData(jt, jr));
-				} 
+					ta.add(new ThreadData(jt, jr));
+				}
 			}
 		}
-		
+
 		return threads;
 	}
-	
-	@SuppressWarnings("rawtypes")
-	private void getMonitors(JavaRuntime jr)
-	{
+
+	private void getMonitors(JavaRuntime jr) {
 		int corruptThreadCount = 0;
 		int corruptMonitorCount = 0;
-		Iterator itMonitor = jr.getMonitors();
+		Iterator<?> itMonitor = jr.getMonitors();
 		while (itMonitor.hasNext()) {
 			Object obj = itMonitor.next();
-			if(obj instanceof CorruptData) {
-				corruptMonitorCount++;
+			if (obj instanceof CorruptData) {
+				corruptMonitorCount += 1;
 				continue;
 			}
-			JavaMonitor jm = (JavaMonitor)obj;
-			Iterator itEnterWaiter = jm.getEnterWaiters();
+			JavaMonitor jm = (JavaMonitor) obj;
+			Iterator<?> itEnterWaiter = jm.getEnterWaiters();
 			while (itEnterWaiter.hasNext()) {
 				obj = itEnterWaiter.next();
-				if(obj instanceof CorruptData) {
-					corruptThreadCount++;
+				if (obj instanceof CorruptData) {
+					corruptThreadCount += 1;
 					continue;
 				}
-				JavaThread jt = (JavaThread)obj;
+				JavaThread jt = (JavaThread) obj;
 				monitors.put(jt, new MonitorState(jm, MonitorState.WAITING_TO_ENTER));
 			}
-			if(corruptThreadCount > 0) {
-				String msg = String.format("Warning : %d corrupt thread(s) were found waiting to enter monitor %s", corruptThreadCount, getMonitorName(jm));
+			if (corruptThreadCount > 0) {
+				String msg = String.format("Warning : %d corrupt thread(s) were found waiting to enter monitor %s",
+						corruptThreadCount, getMonitorName(jm));
 				logger.fine(msg);
 			}
 			corruptThreadCount = 0;
-			Iterator itNotifyWaiter = jm.getNotifyWaiters();
+			Iterator<?> itNotifyWaiter = jm.getNotifyWaiters();
 			while (itNotifyWaiter.hasNext()) {
 				obj = itNotifyWaiter.next();
-				if(obj instanceof CorruptData) {
-					corruptThreadCount++;
+				if (obj instanceof CorruptData) {
+					corruptThreadCount += 1;
 					continue;
 				}
 				JavaThread jt = (JavaThread) obj;
 				monitors.put(jt, new MonitorState(jm, MonitorState.WAITING_TO_BE_NOTIFIED_ON));
 			}
-			if(corruptThreadCount > 0) {
-				String msg = String.format("Warning : %d corrupt thread(s) were found waiting to be notified on monitor %s", corruptThreadCount, getMonitorName(jm));
+			if (corruptThreadCount > 0) {
+				String msg = String.format(
+						"Warning : %d corrupt thread(s) were found waiting to be notified on monitor %s",
+						corruptThreadCount, getMonitorName(jm));
 				logger.fine(msg);
 			}
 		}
-		if(corruptMonitorCount > 0) {
+		if (corruptMonitorCount > 0) {
 			String msg = String.format("Warning : %d corrupt monitor(s) were found", corruptMonitorCount);
 			logger.fine(msg);
 		}
 	}
-	
-	private String getMonitorName(JavaMonitor monitor) {
+
+	private static String getMonitorName(JavaMonitor monitor) {
 		try {
 			return monitor.getName();
 		} catch (CorruptDataException e) {
 			return "<corrupt monitor name>";
 		}
 	}
-	
-	private void printJavaThreadInfo(JavaThread jt, boolean idPrinted)
-	{
+
+	private void printJavaThreadInfo(JavaThread jt, boolean idPrinted) {
 		out.print("    name:          ");
 		try {
 			out.print(jt.getName());
@@ -512,11 +486,11 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			out.print(Exceptions.getCorruptDataExceptionString());
 			logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), e);
 		}
-		out.print("\n");
-		
-		if( !idPrinted ) {
+		out.println();
+
+		if (!idPrinted) {
 			try {
-				if( jt.getImageThread() != null ) {
+				if (jt.getImageThread() != null) {
 					out.print("    id:            ");
 					out.print(jt.getImageThread().getID());
 				}
@@ -527,46 +501,56 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 				out.print(Exceptions.getDataUnavailableString());
 				logger.log(Level.FINEST, Exceptions.getDataUnavailableString(), e);
 			} finally {
-				out.print("\n");
+				out.println();
 			}
 		}
-		
+
 		out.print("    Thread object: ");
 		try {
 			JavaObject threadObj = jt.getObject();
 			if (null == threadObj) {
 				out.print("<no associated Thread object>");
 			} else {
-				String threadClassName = null;
 				try {
 					JavaClass threadClass = threadObj.getJavaClass();
-					threadClassName = threadClass.getName();
-					if( threadClassName != null ) {
-						out.print(threadClassName + " @ " );
+					String threadClassName = threadClass.getName();
+					if (threadClassName != null) {
+						out.print(threadClassName + " @ ");
 					}
 					out.print(Utils.toHex(threadObj.getID().getAddress()));
-					// Navigate to the parent java/lang.Thread class to get the 'tid' and 'isDaemon' fields
-					while (!JAVA_LANG_THREAD_CLASS.equals(threadClass.getName()) && threadClass != null) {
+					// navigate to the parent java/lang/Thread class to get the 'tid' and 'isDaemon' fields
+					while (threadClass != null && !JAVA_LANG_THREAD_CLASS.equals(threadClass.getName())) {
 						threadClass = threadClass.getSuperclass();
 					}
 					if (threadClass != null) {
-						Iterator itField = threadClass.getDeclaredFields();
+						Iterator<?> itField = threadClass.getDeclaredFields();
 						boolean foundThreadId = false;
 						while (itField.hasNext()) {
-							JavaField jf = (JavaField)itField.next();
-							/* "uniqueId" field in java.lang.Thread is renamed to "tid". The old field name is
-							 * checked to preserve functionality of DDR command with old core files that reference
-							 * the "uniqueId" field.
-							 */
-							if (!foundThreadId && (jf.getName().equals("uniqueId") || jf.getName().equals("tid"))) {
-								foundThreadId = true;
-								out.print("\n    ID:            " + Utils.getVal(threadObj, jf));
-							} else if (jf.getName().equals("isDaemon")) {
-								out.print("\n    Daemon:        " + Utils.getVal(threadObj, jf));
+							JavaField jf = (JavaField) itField.next();
+							switch (jf.getName()) {
+							case "uniqueId":
+								/* The field "uniqueId" in java.lang.Thread was renamed "tid".
+								 * We still recognize the old name to preserve functionality
+								 * for old core files using that name.
+								 */
+								// FALL THROUGH
+							case "tid":
+								if (!foundThreadId) {
+									out.println();
+									out.print("    ID:            " + Utils.getVal(threadObj, jf));
+									foundThreadId = true;
+								}
+								break;
+							case "isDaemon":
+								out.println();
+								out.print("    Daemon:        " + Utils.getVal(threadObj, jf));
+								break;
+							default:
+								break;
 							}
 						}
 					}
-				} catch (CorruptDataException cde ) {
+				} catch (CorruptDataException cde) {
 					out.print(" <in-flight or corrupt data encountered>");
 					logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), cde);
 				}
@@ -575,7 +559,7 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			out.print(Exceptions.getCorruptDataExceptionString());
 			logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), cde);
 		}
-		out.print("\n");
+		out.println();
 
 		out.print("    Priority:      ");
 		try {
@@ -585,8 +569,8 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			out.print(Exceptions.getCorruptDataExceptionString());
 			logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), e);
 		}
-		out.print("\n");
-		
+		out.println();
+
 		out.print("    Thread.State:  ");
 		try {
 			out.print(StateToString.getThreadStateString(jt.getState()));
@@ -594,8 +578,8 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			out.print(Exceptions.getCorruptDataExceptionString());
 			logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), cde);
 		}
-		out.print("\n");
-		
+		out.println();
+
 		out.print("    JVMTI state:   ");
 		try {
 			out.print(StateToString.getJVMTIStateString(jt.getState()));
@@ -603,21 +587,21 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			out.print(Exceptions.getCorruptDataExceptionString());
 			logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), cde);
 		}
-		out.print("\n");
-				
+		out.println();
+
 		printThreadBlocker(jt);
-		
+
 		out.print("    Java stack frames: ");
 		printJavaStackFrameInfo(jt);
-		out.print("\n");
+		out.println();
 	}
 
 	private void printThreadBlocker(JavaThread jt) {
 		try {
-			if( (jt.getState() & JavaThread.STATE_PARKED) != 0 ) {
-				out.print("      parked on: ");			
+			if ((jt.getState() & JavaThread.STATE_PARKED) != 0) {
+				out.print("      parked on: ");
 				// java.util.concurrent locks
-				if( jt.getBlockingObject() == null ) {
+				if (jt.getBlockingObject() == null) {
 					out.print("<unknown>");
 				} else {
 					JavaObject jo = jt.getBlockingObject();
@@ -627,9 +611,9 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 					String ownerThreadID = "<null>";
 					out.print(" owner name: ");
 					JavaThread lockOwnerThread = Utils.getParkBlockerOwner(jo, ctx.getRuntime());
-					if( lockOwnerThread != null ) {
+					if (lockOwnerThread != null) {
 						ownerThreadName = lockOwnerThread.getName();
-						if( lockOwnerThread.getImageThread() != null ) {
+						if (lockOwnerThread.getImageThread() != null) {
 							ownerThreadID = lockOwnerThread.getImageThread().getID();
 						}
 					} else {
@@ -637,24 +621,23 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 						// We can still get the owning thread name from the java.lang.Thread object itself.
 						// We won't get a thread id.
 						JavaObject lockOwnerObj = Utils.getParkBlockerOwnerObject(jo, ctx.getRuntime());
-						if( lockOwnerObj != null ) {
+						if (lockOwnerObj != null) {
 							ownerThreadName = Utils.getThreadNameFromObject(lockOwnerObj, ctx.getRuntime(), out);
 						}
 					}
 					out.print("\"" + ownerThreadName + "\"");
 					out.print(" owner id: " + ownerThreadID);
 				}
-				out.print("\n");
-			} else if( (jt.getState() & JavaThread.STATE_IN_OBJECT_WAIT) != 0 ) {
+				out.println();
+			} else if ((jt.getState() & JavaThread.STATE_IN_OBJECT_WAIT) != 0) {
 				out.print("      waiting to be notified on: ");
-			} else if( (jt.getState() & JavaThread.STATE_BLOCKED_ON_MONITOR_ENTER) != 0 )  {
+			} else if ((jt.getState() & JavaThread.STATE_BLOCKED_ON_MONITOR_ENTER) != 0) {
 				out.print("      waiting to enter: ");
 			}
-			if( (jt.getState() & JavaThread.STATE_IN_OBJECT_WAIT) != 0 ||
-				(jt.getState() & JavaThread.STATE_BLOCKED_ON_MONITOR_ENTER) != 0  ) {
+			if ((jt.getState() & (JavaThread.STATE_IN_OBJECT_WAIT | JavaThread.STATE_BLOCKED_ON_MONITOR_ENTER)) != 0) {
 				// java monitors
-				MonitorState ms = (MonitorState)monitors.get(jt);
-				if(ms == null) {
+				MonitorState ms = monitors.get(jt);
+				if (ms == null) {
 					out.println("<monitor information not available>");
 				} else {
 					JavaObject jo = ms.getMonitor().getObject();
@@ -673,15 +656,15 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 						out.print(jo.getJavaClass().getName() + "@0x" + lockID);
 					}
 					out.print(" owner name: ");
-					if( ms.getMonitor().getOwner() != null ) {
+					if (ms.getMonitor().getOwner() != null) {
 						out.print("\"" + ms.getMonitor().getOwner().getName() + "\"");
-						if( ms.getMonitor().getOwner().getImageThread() != null ) {
+						if (ms.getMonitor().getOwner().getImageThread() != null) {
 							out.print(" owner id: " + ms.getMonitor().getOwner().getImageThread().getID());
 						}
 					} else {
 						out.print("<unowned>");
 					}
-					out.print("\n");
+					out.println();
 				}
 			}
 		} catch (CorruptDataException cde) {
@@ -695,47 +678,44 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			logger.log(Level.FINEST, Exceptions.getMemoryAccessExceptionString(), e);
 		}
 	}
-	
-	private void printJavaStackFrameInfo(JavaThread jt)
-	{
-		Iterator itStackFrame;
-		JavaStackFrame jsf;
-		JavaLocation jl;
 
-		itStackFrame = jt.getStackFrames();
+	private void printJavaStackFrameInfo(JavaThread jt) {
+		Iterator<?> itStackFrame = jt.getStackFrames();
 		if (!itStackFrame.hasNext()) {
-			out.print("<no frames to print>\n");
+			out.println("<no frames to print>");
 			return;
 		} else {
-			out.print("\n");
+			out.println();
 		}
 		while (itStackFrame.hasNext()) {
 			// this iterator can contain JavaStackFrame or CorruptData objects
 			Object next = itStackFrame.next();
+			JavaStackFrame jsf;
 			if (next instanceof CorruptData) {
-				out.print("     " + Exceptions.getCorruptDataExceptionString() + "\n");
+				out.println("     " + Exceptions.getCorruptDataExceptionString());
 				return;
 			} else {
-				jsf = (JavaStackFrame)next;
+				jsf = (JavaStackFrame) next;
 			}
+			JavaLocation jl;
 			try {
 				jl = jsf.getLocation();
 			} catch (CorruptDataException e) {
-				out.print("     " + Exceptions.getCorruptDataExceptionString()+ "\n");
+				out.println("     " + Exceptions.getCorruptDataExceptionString());
 				logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), e);
 				return;
 			}
-			
+
 			out.print("     bp: ");
 			try {
 				out.print(toAdjustedHex(jsf.getBasePointer().getAddress()));
 			} catch (CorruptDataException e) {
 				// jsf.getBasePointer() can't throw DataUnavailable, so we don't know if this is really
-				// a corruption. Log the exception but revert to issuing a DataUnavailable message. 
+				// a corruption. Log the exception but revert to issuing a DataUnavailable message.
 				out.print(Exceptions.getDataUnavailableString());
 				logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), e);
 			}
-			
+
 			out.print("  method: ");
 			try {
 				String signature = null;
@@ -751,7 +731,7 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 					out.print(jl.getMethod().getDeclaringClass().getName() + "." +
 							jl.getMethod().getName());
 				} else {
-					out.print(Utils.getReturnValueName(signature) + " " + 
+					out.print(Utils.getReturnValueName(signature) + " " +
 							jl.getMethod().getDeclaringClass().getName() + "." +
 							jl.getMethod().getName() +
 							Utils.getMethodSignatureName(signature));
@@ -771,7 +751,7 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			} catch (CorruptDataException e) {
 				logger.log(Level.FINEST, Exceptions.getCorruptDataExceptionString(), e);
 			}
-			if( !isNative) {
+			if (!isNative) {
 				out.print("  source: ");
 				try {
 					out.print(jl.getFilename());
@@ -795,19 +775,20 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 			} else {
 				out.print("  (Native Method)");
 			}
-			
-			out.print("\n      objects:");
-			Iterator itObjectRefs = jsf.getHeapRoots();
+
+			out.println();
+			out.print("      objects:");
+			Iterator<?> itObjectRefs = jsf.getHeapRoots();
 			if (!itObjectRefs.hasNext()) {
 				out.print(" <no objects in this frame>");
 			}
 			while (itObjectRefs.hasNext()) {
 				Object nextRef = itObjectRefs.next();
 				if (nextRef instanceof CorruptData) {
-					out.print(Exceptions.getCorruptDataExceptionString() + "\n");
+					out.println(Exceptions.getCorruptDataExceptionString());
 					break; // give up on this frame
 				} else {
-					JavaReference jr = (JavaReference)nextRef;
+					JavaReference jr = (JavaReference) nextRef;
 					try {
 						if (jr.isObjectReference()) {
 							JavaObject target = (JavaObject)(jr.getTarget());
@@ -825,90 +806,108 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 					}
 				}
 			}
-			out.print("\n");
+			out.println();
 		}
 	}
 
-	private String toAdjustedHex(long l)
-	{
+	private String toAdjustedHex(long l) {
 		if (_pointerSize > 32) {
 			return "0x" + Utils.toFixedWidthHex(l);
 		} else if (31 == _pointerSize) {
-			return "0x" + Utils.toFixedWidthHex((int)(l & (((long)1) << _pointerSize) - 1));
+			return "0x" + Utils.toFixedWidthHex((int) (l & ((1L << 31) - 1)));
 		} else {
-			return "0x" + Utils.toFixedWidthHex((int)l);
+			return "0x" + Utils.toFixedWidthHex((int) l);
 		}
 	}
-	
-	private void printThreadSummary(ImageProcess ip)
-	{
+
+	private void printThreadSummary(ImageProcess ip) {
 		// Prints a summary list of native thread IDs
 		int count = 0;
-		Iterator itThread = ip.getThreads();
-			
+		Iterator<?> itThread = ip.getThreads();
+
 		while (itThread.hasNext()) {
 			Object next = itThread.next();
-			if (next instanceof CorruptData) continue;
-			ImageThread it = (ImageThread)next;
-			
-			if (count % 8 == 0) {
-				if (0 == count) out.print("\n\nNative thread IDs for current process:");
-				out.print("\n ");
+			if (next instanceof CorruptData) {
+				continue;
 			}
-			
+			ImageThread it = (ImageThread) next;
+
+			if (count % 8 == 0) {
+				out.println();
+				if (0 == count) {
+					out.println();
+					out.println("Native thread IDs for current process:");
+				}
+				out.print(" ");
+			}
+
 			try {
 				out.print(Utils.padWithSpaces(it.getID(), 8));
 			} catch (CorruptDataException e) {
 				out.print(Exceptions.getCorruptDataExceptionString());
 			}
-			count++;
+			count += 1;
 		}
-		out.print("\n");
+		out.println();
 	}
-	private void printProperties(ImageThread it)
-	{
-		Properties jtp = it.getProperties();
-		String[] keys = jtp.keySet().toArray(new String[0]);
-		ArrayList<String> table = new ArrayList<String>(keys.length);
-		int maxLen = 0;
-		Arrays.sort(keys);
+
+	private void printProperties(ImageThread it) {
 		// We may have a lot of properties so print them out in two columns.
-		for( String key: keys ) {
-			String formatted = String.format("%s=%s", key, jtp.get(key));
-			table.add(formatted);
-			maxLen = Math.max(maxLen, formatted.length());
+		List<String> table = it.getProperties().entrySet().stream()
+				.sorted(Comparator.comparing(e -> String.valueOf(e.getKey())))
+				.map(e -> String.format("%s=%s", e.getKey(), e.getValue()))
+				.collect(Collectors.toCollection(ArrayList::new));
+
+		int count = table.size();
+
+		// Ensure the table has an even number of entries.
+		if ((count % 2) != 0) {
+			table.add("");
+			count += 1;
 		}
-		Iterator<String> tableIterator = table.iterator();
-		String tableFormatString = "\t%-"+maxLen+"s\t%-"+maxLen+"s\n";
-		while( tableIterator.hasNext() ) {
-			out.printf(tableFormatString, tableIterator.next(), tableIterator.hasNext()?tableIterator.next():"");
-			
+
+		// Compute the maximum width of entries in the first column.
+		int maxLen = 0;
+
+		for (int i = 0; i < count; i += 2) {
+			maxLen = Math.max(table.get(i).length(), maxLen);
+		}
+
+		String tableFormatString = "    %-" + maxLen + "s   %s%n";
+
+		for (int i = 0; i < count; i += 2) {
+			out.printf(tableFormatString, table.get(i), table.get(i + 1));
 		}
 	}
 
 	@Override
-	public void printDetailedHelp(PrintStream out) {
-		out.println("Displays information about Java and native threads\n\n" +
-				"Parameters: none, native thread ID, zOS TCB address, \"all\", or \"*\"\n\n" +
-				"If no parameter is supplied, information is printed for the current or failing thread, if any\n" +
-				"If a native thread ID or zOS TCB address is supplied, information is printed for that specific thread\n" +
-				"If \"all\", or \"*\" is specified, information is printed for all threads\n\n" +
-				"The following information is printed for each thread:\n" +
-				" - native thread ID\n" +
-				" - registers\n" +
-				" - native stack sections\n" +
-				" - native stack frames: procedure name and base pointer\n" +
-				" - thread properties\n" +
-				" - associated Java thread (if applicable):\n" +
-				"  - name of Java thread\n" +
-				"  - address of associated java.lang.Thread object\n" +
-				"  - current state according to JVMTI specification\n" +
-				"  - current state relative to java.lang.Thread.State\n" +
-				"  - the Java thread priority\n" +
-				"  - the monitor the thread is waiting to enter or waiting on notify\n" +
-				"  - Java stack frames: base pointer, method, source filename and objects on frame\n\n" +
-				"Note: the \"info proc\" command provides a summary list of native thread IDs\n"
+	public void printDetailedHelp(PrintStream outStream) {
+		outStream.printf(""
+				+ "Displays information about Java and native threads%n"
+				+ "%n"
+				+ "Parameters: none, native thread ID, zOS TCB address, \"all\", or \"*\"%n"
+				+ "%n"
+				+ "If no parameter is supplied, information is printed for the current or failing thread, if any%n"
+				+ "If a native thread ID or zOS TCB address is supplied, information is printed for that specific thread%n"
+				+ "If \"all\", or \"*\" is specified, information is printed for all threads%n"
+				+ "%n"
+				+ "The following information is printed for each thread:%n"
+				+ " - native thread ID%n"
+				+ " - registers%n"
+				+ " - native stack sections%n"
+				+ " - native stack frames: procedure name and base pointer%n"
+				+ " - thread properties%n"
+				+ " - associated Java thread (if applicable):%n"
+				+ "  - name of Java thread%n"
+				+ "  - address of associated java.lang.Thread object%n"
+				+ "  - current state according to JVMTI specification%n"
+				+ "  - current state relative to java.lang.Thread.State%n"
+				+ "  - the Java thread priority%n"
+				+ "  - the monitor the thread is waiting to enter or waiting on notify%n"
+				+ "  - Java stack frames: base pointer, method, source filename and objects on frame%n"
+				+ "%n"
+				+ "Note: the \"info proc\" command provides a summary list of native thread IDs%n"
 				);
-		
 	}
+
 }

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/infocommands/InfoThreadCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/infocommands/InfoThreadCommand.java
@@ -545,6 +545,16 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 								out.println();
 								out.print("    Daemon:        " + Utils.getVal(threadObj, jf));
 								break;
+							case "threadRef":
+								try {
+									String hex = Utils.toHex(jf.getLong(threadObj));
+
+									out.println();
+									out.print("    Native info:   !j9vmthread " + hex + "  !stack " + hex);
+								} catch (MemoryAccessException e) {
+									// omit unavailable information
+								}
+								break;
 							default:
 								break;
 							}


### PR DESCRIPTION
First commit: a general cleanup
* avoid raw types
* remove assumption that line separator is '\n'
* use streams to print thread properties

Second commit adds links requested by #5295.