### PR TITLE
(v0.14.0) Add machine info detection

### DIFF
--- a/test/TestConfig/src/build_envInfo.xml
+++ b/test/TestConfig/src/build_envInfo.xml
@@ -46,26 +46,27 @@
 		<jar jarfile="./EnvDetector.jar" filesonly="true">
 			<fileset dir="${build}"/>
 			<manifest>
-				<attribute name="Main-Class" value="org.openj9.java.EnvDetector"/>
+				<attribute name="Main-Class" value="org.openj9.envInfo.EnvDetector"/>
 			</manifest>
 		</jar>
 	</target>
 
 	<target name="run" depends="dist">
 		<property name="javaexecutable.java" value="${JAVA_BIN}/java" />
-		<java jar="./EnvDetector.jar" fork="true" failonerror="true" jvm="${javaexecutable.java}"/>
+		<java jar="./EnvDetector.jar" fork="true" failonerror="true" jvm="${javaexecutable.java}">
+			<arg value="JavaInfo"/>
+		</java>
 	</target>
 
 	<target name="clean" description="clean up">
+		<delete file="../autoGenEnv.mk" />
 		<delete dir="${build}" />
-		<delete file="EnvDetector.jar" />		
+		<delete file="EnvDetector.jar" />
 	</target>
 
 	<target name="build">
-		<delete file="../autoGenEnv.mk" />
 		<antcall target="clean" inheritall="true" />
 		<antcall target="run" inheritall="true" />
-		<antcall target="clean" inheritall="true" />
 	</target>
 
 </project>

--- a/test/TestConfig/src/org/openj9/envInfo/EnvDetector.java
+++ b/test/TestConfig/src/org/openj9/envInfo/EnvDetector.java
@@ -20,43 +20,77 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-package org.openj9.java;
+package org.openj9.envInfo;
 
-import java.io.*;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-
+import java.io.BufferedWriter;
 
 public class EnvDetector {
-    /** 
-     * This method create autoGenEnv.mk file for auto detecting environment.
-     */
-     public static void main(String[] args) {
-        
-        JavaInfo envDetection = new JavaInfo();
-        String SPECInfo = envDetection.getSPEC(); 
-        int javaVersionInfo = envDetection.getJDKVersion(); 
-        String javaImplInfo = envDetection.getJDKImpl();
-        if (SPECInfo == null || javaVersionInfo == -1 || javaImplInfo == null) {
-            System.exit(1);
-        }
-        String SPECvalue = "DETECTED_SPEC=" + SPECInfo + "\n";
-        String JDKVERSIONvalue = "DETECTED_JDK_VERSION="+ javaVersionInfo + "\n";
-        String JDKIMPLvalue = "DETECTED_JDK_IMPL=" + javaImplInfo + "\n";
+	static boolean isMachineInfo = false;
+	static boolean isJavaInfo = false;
 
-        BufferedWriter output = null;
-        try { 
-            output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("../autoGenEnv.mk")));
-            output.write("########################################################\n");
-            output.write("# This is an auto generated file. Please do NOT modify!\n");
-            output.write("########################################################\n");
-            output.write(SPECvalue);
-            output.write(JDKVERSIONvalue);
-            output.write(JDKIMPLvalue);
-            output.close(); 
-        } catch ( IOException e ) {
-            e.printStackTrace(); 
-        }
-    }
+	public static void main(String[] args) {
+		parseArgs(args);
+	}
+
+	private static void parseArgs(String[] args) {
+		for (int i = 0; i < args.length; i++) {
+			String option = args[i].toLowerCase();
+			if (option.equals("machineinfo")) {
+				getMachineInfo();
+			} else if (option.equals("javainfo")) {
+				getJavaInfo();
+			}
+		}
+	}
+
+	/*
+	 * getJavaInfo() is used for AUTO_DETECT
+	 */
+	private static void getJavaInfo() {
+		JavaInfo envDetection = new JavaInfo();
+		String SPECInfo = envDetection.getSPEC();
+		int javaVersionInfo = envDetection.getJDKVersion();
+		String javaImplInfo = envDetection.getJDKImpl();
+		if (SPECInfo == null || javaVersionInfo == -1 || javaImplInfo == null) {
+			System.exit(1);
+		}
+		String SPECvalue = "DETECTED_SPEC=" + SPECInfo + "\n";
+		String JDKVERSIONvalue = "DETECTED_JDK_VERSION=" + javaVersionInfo + "\n";
+		String JDKIMPLvalue = "DETECTED_JDK_IMPL=" + javaImplInfo + "\n";
+
+		/**
+		 * autoGenEnv.mk file will be created to store auto detected java info.
+		 */
+		BufferedWriter output = null;
+		try {
+			output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("../autoGenEnv.mk")));
+			output.write("########################################################\n");
+			output.write("# This is an auto generated file. Please do NOT modify!\n");
+			output.write("########################################################\n");
+			output.write(SPECvalue);
+			output.write(JDKVERSIONvalue);
+			output.write(JDKIMPLvalue);
+			output.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	private static void getMachineInfo() {
+		MachineInfo machineInfo = new MachineInfo();
+
+		machineInfo.getMachineInfo(MachineInfo.UNAME_CMD);
+		machineInfo.getMachineInfo(MachineInfo.SYS_ARCH_CMD);
+		machineInfo.getMachineInfo(MachineInfo.PROC_ARCH_CMD);
+		machineInfo.getMachineInfo(MachineInfo.SYS_OS_CMD);
+		machineInfo.getMachineInfo(MachineInfo.CPU_CORES_CMD);
+
+		machineInfo.getRuntimeInfo();
+		machineInfo.getSpaceInfo("");
+		System.out.println(machineInfo);
+	}
 }

--- a/test/TestConfig/src/org/openj9/envInfo/JavaInfo.java
+++ b/test/TestConfig/src/org/openj9/envInfo/JavaInfo.java
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-package org.openj9.java;
+package org.openj9.envInfo;
 
 import java.io.*;
 import java.io.IOException;

--- a/test/TestConfig/src/org/openj9/envInfo/MachineInfo.java
+++ b/test/TestConfig/src/org/openj9/envInfo/MachineInfo.java
@@ -1,0 +1,283 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.envInfo;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.file.*;
+import java.lang.management.ManagementFactory;
+public class MachineInfo {
+	private static final int _1 = 1;
+	public static String UNAME_CMD = "uname -a";
+	public static String SYS_ARCH_CMD = "uname -m";
+	public static String PROC_ARCH_CMD = "uname -p";
+
+	public static String INSTALLED_MEM_CMD = "grep MemTotal /proc/meminfo | awk '{print $2}";
+	public static String FREE_MEM_CMD = "grep MemFree /proc/meminfo | awk '{print $2}";
+	public static String CPU_CORES_CMD = "cat /proc/cpuinfo | grep processor | wc -l";
+
+	public static String NUMA_CMD = "numactl --show | grep 'No NUMA support available on this system";
+	public static String SYS_VIRT_CMD = "";
+
+	// Software
+	public static String SYS_OS_CMD = "uname -s";
+	public static String KERNEL_VERSION_CMD = "uname -r";
+	public static String GCC_VERSION_CMD = "gcc -dumpversion";
+
+	public static final String XLC_VERSION_CMD = "xlC -qversion | grep 'Version' ";
+	public static final String GDB_VERSION_CMD = "gdb --version | head -1"; // debugger on Linux
+	public static String LLDB_VERSION_CMD = "lldb --version"; // debugger on Darwin/Mac
+	public static final String GCLIBC_VERSION_CMD = "ldd --version | head -1";
+
+	// Console
+	public static final String NUM_JAVA_PROCESSES_CMD = "ps -ef | grep -i [j]ava | wc -l";
+	public static final String ACTIVE_JAVA_PROCESSES_CMD = "ps -ef | grep -i [j]ava";
+
+	String uname = "";
+	String installedMem = "";
+	String freeMem = "";
+	String cpuCores = "";
+	String cpuModel = "";
+	String cpuSpeed = "";
+	String sysArch = "";
+	String sysOS = "";
+	String procArch = "";
+	String numa = "Unknown";
+	String sysVirt = "Unknown";
+	long totalMemory = -1;
+	long freeMemory = -1;
+	
+	String vmVendor = "";
+	String vmVersion = "";
+	String specVendor = "";
+	String specVersion = "";
+	String javaVersion = "";
+
+	public String toString() {
+		return "\nuname: " + uname
+		+ "\ncpuCores: " + cpuCores 
+		+ "\nsysArch: " + sysArch 
+		+ "\nprocArch: " + procArch 
+		+ "\nsysOS: " + sysOS
+		+ "\n"
+		+ "\nvmVendor: " + vmVendor 
+		+ "\nvmVersion: " + vmVersion 
+		+ "\nspecVendor: " + specVendor 
+		+ "\nspecVersion: " + specVersion 
+		+ "\njavaVersion: " + javaVersion 
+		+ "\n"
+		+"\nTotal memory (bytes): " + totalMemory
+		+"\nFree memory (bytes): " + freeMemory
+		+ "\n";
+	}
+
+	public long getFreeMemory() {
+		return freeMemory;
+	}
+
+	public void setFreeMemory(long freeMemory) {
+		this.freeMemory = freeMemory;
+	}
+
+	public long getTotalMemory() {
+		return totalMemory;
+	}
+
+	public void setTotalMemory(long totalMemory) {
+		this.totalMemory = totalMemory;
+	}
+
+	public String getUname() {
+		return uname;
+	}
+
+	public void setUname(String uname) {
+		this.uname = uname;
+	}
+
+	public String getVmVendor() {
+		return vmVendor;
+	}
+
+	public void setVmVendor(String vmVendor) {
+		this.vmVendor = vmVendor;
+	}
+
+	public String getVmVersion() {
+		return vmVersion;
+	}
+
+	public void setVmVersion(String vmVersion) {
+		this.vmVersion = vmVersion;
+	}
+
+	public String getSpecVendor() {
+		return specVendor;
+	}
+
+	public void setSpecVendor(String specVendor) {
+		this.specVendor = specVendor;
+	}
+
+	public String getSpecVersion() {
+		return specVersion;
+	}
+
+	public void setSpecVersion(String specVersion) {
+		this.specVersion = specVersion;
+	}
+
+	public String getJavaVersion() {
+		return javaVersion;
+	}
+
+	public void setJavaVersion(String javaVersion) {
+		this.javaVersion = javaVersion;
+	}
+
+	public String getInstalledMem() {
+		return installedMem;
+	}
+
+	public void setInstalledMem(String installedMem) {
+		this.installedMem = installedMem;
+	}
+
+	public String getFreeMem() {
+		return freeMem;
+	}
+
+	public void setFreeMem(String freeMem) {
+		this.freeMem = freeMem;
+	}
+
+	public String getCpuCores() {
+		return cpuCores;
+	}
+
+	public void setCpuCores(String cpuCores) {
+		this.cpuCores = cpuCores;
+	}
+
+	public String getCpuModel() {
+		return cpuModel;
+	}
+
+	public void setCpuModel(String cpuModel) {
+		this.cpuModel = cpuModel;
+	}
+
+	public String getCpuSpeed() {
+		return cpuSpeed;
+	}
+
+	public void setCpuSpeed(String cpuSpeed) {
+		this.cpuSpeed = cpuSpeed;
+	}
+
+	public String getSysArch() {
+		return sysArch;
+	}
+
+	public void setSysArch(String sysArch) {
+		this.sysArch = sysArch;
+	}
+
+	public String getSysOS() {
+		return sysOS;
+	}
+
+	public void setSysOS(String sysOS) {
+		this.sysOS = sysOS;
+	}
+
+	public String getProcArch() {
+		return procArch;
+	}
+
+	public void setProcArch(String procArch) {
+		this.procArch = procArch;
+	}
+
+	public String getNuma() {
+		return numa;
+	}
+
+	public void setNuma(String numa) {
+		this.numa = numa;
+	}
+
+	public String getSysVirt() {
+		return sysVirt;
+	}
+
+	public void setSysVirt(String sysVirt) {
+		this.sysVirt = sysVirt;
+	}
+
+	public void getRuntimeInfo() {
+		setVmVendor(ManagementFactory.getRuntimeMXBean().getVmVendor());
+		setVmVersion(ManagementFactory.getRuntimeMXBean().getVmVersion());
+		setSpecVendor(ManagementFactory.getRuntimeMXBean().getSpecVendor());
+		setSpecVersion(ManagementFactory.getRuntimeMXBean().getSpecVersion());
+		setJavaVersion(System.getProperty("java.version"));
+
+		setFreeMemory(Runtime.getRuntime().freeMemory());
+		setTotalMemory(Runtime.getRuntime().totalMemory());
+	}
+
+	public void getMachineInfo(String command) {
+		try {
+			Process proc = Runtime.getRuntime().exec(command);
+			BufferedReader sout = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+			String line = sout.readLine();
+			if (command.equals(MachineInfo.UNAME_CMD)) {
+				setUname(line);
+			} else if (command.equals(MachineInfo.SYS_ARCH_CMD)) {
+				setSysArch(line);
+			} else if (command.equals(MachineInfo.PROC_ARCH_CMD)) {
+				setProcArch(line);
+			} else if (command.equals(MachineInfo.SYS_OS_CMD)) {
+				setSysOS(line);
+			} else if (command.equals(MachineInfo.CPU_CORES_CMD)) {
+				setCpuCores(line);
+				if (getCpuCores() == null) {
+					setCpuCores("" + Runtime.getRuntime().availableProcessors());
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void getSpaceInfo(String path) {
+		Path userPath = Paths.get(path);
+		File file = userPath.toAbsolutePath().toFile();
+
+		System.out.println("File path: " + file.getAbsolutePath());
+		System.out.println("Total space (bytes): " + file.getTotalSpace());
+		System.out.println("Free space (bytes): " + file.getFreeSpace());
+		System.out.println("Usable space (bytes): " + file.getUsableSpace());
+	}
+}


### PR DESCRIPTION
Cherry pick of the #5384 commit for the 0.14 release branch.

Without this, there are failures running the system tests
```
===============================================
Running test MachineInfo_0 ...
===============================================
MachineInfo_0 Start Time: Sun Apr  7 15:43:30 2019 Epoch Time (ms): 1554669810373
variation: NoOptions
JVM_OPTIONS: -Xcompressedrefs 
Error: Could not find or load main class org.openj9.envInfo.EnvDetector
Caused by: java.lang.ClassNotFoundException: org.openj9.envInfo.EnvDetector

MachineInfo_0_FAILED
```