### PR TITLE
WIP: Swap Inlining and methodhandle inlining

### DIFF
--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -81,8 +81,8 @@ static const OptimizationStrategy J9EarlyGlobalOpts[] =
    {
    { OMR::stringBuilderTransformer             },
    { OMR::stringPeepholes                      }, // need stringpeepholes to catch bigdecimal patterns
-   { OMR::methodHandleInvokeInliningGroup,  OMR::IfMethodHandleInvokes },
    { OMR::inlining                             },
+   { OMR::methodHandleInvokeInliningGroup,  OMR::IfMethodHandleInvokes },
    { OMR::osrGuardInsertion,                OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                       }, // most inlining is done by now
    { OMR::jProfilingBlock                      },
@@ -297,8 +297,8 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::coldBlockOutlining                                                    },
    { OMR::stringBuilderTransformer                                              },
    { OMR::stringPeepholes                                                       }, // need stringpeepholes to catch bigdecimal patterns
-   { OMR::methodHandleInvokeInliningGroup,                OMR::IfMethodHandleInvokes },
    { OMR::inlining                                                              },
+   { OMR::methodHandleInvokeInliningGroup,                OMR::IfMethodHandleInvokes },
    { OMR::osrGuardInsertion,                         OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                       }, // most inlining is done by now
    { OMR::jProfilingBlock                                                       },
@@ -639,8 +639,8 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::coldBlockOutlining                                                    },
    { OMR::stringBuilderTransformer                                              },
    { OMR::stringPeepholes                                                       }, // need stringpeepholes to catch bigdecimal patterns
-   { OMR::methodHandleInvokeInliningGroup,           OMR::IfMethodHandleInvokes      },
    { OMR::inlining                                                              },
+   { OMR::methodHandleInvokeInliningGroup,           OMR::IfMethodHandleInvokes      },
    { OMR::osrGuardInsertion,                         OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                                               }, // most inlining is done by now
    { OMR::jProfilingBlock                                                       },


### PR DESCRIPTION
The old strategy does methodhandle inlining before normal inlining and
only JSR292 callsites in the outer most method are inlined. A lot of
methodhandle inlining opportunities are missed because of this. This
change swaps inlining and methodhandle inlining to do normal inlining
first to expose the JSR292 in the inlined callees as well.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>