### PR TITLE
Build OpenJ9 Linux x86-64 on CentOS 6 instead of Ubuntu

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -218,12 +218,12 @@ aix_ppc-64_cmprssptrs:
 #========================================#
 linux_x86-64_cmprssptrs:
   boot_jdk:
-    8: '/usr/lib/jvm/java-7-openjdk-amd64'
+    8: '/usr/lib/jvm/jdk-7'
     9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-90'
-    11: '/usr/lib/jvm/adoptojdk-java-11'
-    12: '/usr/lib/jvm/adoptojdk-java-11'
-    next: '/usr/lib/jvm/adoptojdk-java-11'
+    11: '/usr/lib/jvm/jdk-11'
+    12: '/usr/lib/jvm/jdk-11'
+    next: '/usr/lib/jvm/jdk-11'
   release:
     8: 'linux-x86_64-normal-server-release'
     9: 'linux-x86_64-normal-server-release'
@@ -235,12 +235,12 @@ linux_x86-64_cmprssptrs:
   openjdk_reference_repo: '/home/jenkins/openjdk_cache'
   node_labels:
     build:
-      8: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      9: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      10: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      11: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      12: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      next: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
+      8: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      9: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      10: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      11: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      12: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      next: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
   extra_getsource_options:
     8: '--openssl-version=1.1.1a'
     11: '--openssl-version=1.1.1a'
@@ -250,22 +250,22 @@ linux_x86-64_cmprssptrs:
     11: '--with-openssl=fetched'
     12: '--with-openssl=fetched'
   build_env:
-    vars:
-      8: 'CC=gcc-7 CXX=g++-7'
-      11: 'CC=gcc-7 CXX=g++-7'
-      12: 'CC=gcc-7 CXX=g++-7'
-      next: 'CC=gcc-7 CXX=g++-7'
+    cmd:
+      8: 'source /opt/rh/devtoolset-7/enable'
+      11: 'source /opt/rh/devtoolset-7/enable'
+      12: 'source /opt/rh/devtoolset-7/enable'
+      next: 'source /opt/rh/devtoolset-7/enable'
 #========================================#
 # Linux x86 64bits Compressed Pointers /w CMake
 #========================================#
 linux_x86-64_cmprssptrs_cmake:
   boot_jdk:
-    8: '/usr/lib/jvm/java-7-openjdk-amd64'
+    8: '/usr/lib/jvm/jdk-7'
     9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-90'
-    11: '/usr/lib/jvm/adoptojdk-java-11'
-    12: '/usr/lib/jvm/adoptojdk-java-11'
-    next: '/usr/lib/jvm/adoptojdk-java-11'
+    11: '/usr/lib/jvm/jdk-11'
+    12: '/usr/lib/jvm/jdk-11'
+    next: '/usr/lib/jvm/jdk-11'
   release:
     8: 'linux-x86_64-normal-server-release'
     9: 'linux-x86_64-normal-server-release'
@@ -277,12 +277,12 @@ linux_x86-64_cmprssptrs_cmake:
   openjdk_reference_repo: '/home/jenkins/openjdk_cache'
   node_labels:
     build:
-      8: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      9: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      10: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      11: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      12: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      next: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
+      8: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      9: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      10: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      11: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      12: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      next: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
   extra_getsource_options:
     8: '--openssl-version=1.1.1a'
     11: '--openssl-version=1.1.1a'
@@ -302,22 +302,22 @@ linux_x86-64_cmprssptrs_cmake:
     12: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
     next: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
   build_env:
-    vars:
-      8: 'CC=gcc-7 CXX=g++-7'
-      11: 'CC=gcc-7 CXX=g++-7'
-      12: 'CC=gcc-7 CXX=g++-7'
-      next: 'CC=gcc-7 CXX=g++-7'
+    cmd:
+      8: 'source /opt/rh/devtoolset-7/enable'
+      11: 'source /opt/rh/devtoolset-7/enable'
+      12: 'source /opt/rh/devtoolset-7/enable'
+      next: 'source /opt/rh/devtoolset-7/enable'
 #========================================#
 # Linux x86 64bits Large Heap
 #========================================#
 linux_x86-64:
   boot_jdk:
-    8: '/usr/lib/jvm/java-7-openjdk-amd64'
+    8: '/usr/lib/jvm/jdk-7'
     9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-90'
-    11: '/usr/lib/jvm/adoptojdk-java-11'
-    12: '/usr/lib/jvm/adoptojdk-java-11'
-    next: '/usr/lib/jvm/adoptojdk-java-11'
+    11: '/usr/lib/jvm/jdk-11'
+    12: '/usr/lib/jvm/jdk-11'
+    next: '/usr/lib/jvm/jdk-11'
   release:
     8: 'linux-x86_64-normal-server-release'
     9: 'linux-x86_64-normal-server-release'
@@ -329,12 +329,12 @@ linux_x86-64:
   openjdk_reference_repo: '/home/jenkins/openjdk_cache'
   node_labels:
     build:
-      8: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      9: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      10: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      11: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      12: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-      next: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
+      8: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      9: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      10: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      11: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      12: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
+      next: 'ci.role.build && hw.arch.x86 && sw.os.cent.6'
   extra_getsource_options:
     8: '--openssl-version=1.1.1a'
     11: '--openssl-version=1.1.1a'
@@ -347,11 +347,11 @@ linux_x86-64:
     12: '--with-noncompressedrefs --with-openssl=fetched'
     next: '--with-noncompressedrefs'
   build_env:
-    vars:
-      8: 'CC=gcc-7 CXX=g++-7'
-      11: 'CC=gcc-7 CXX=g++-7'
-      12: 'CC=gcc-7 CXX=g++-7'
-      next: 'CC=gcc-7 CXX=g++-7'
+    cmd:
+      8: 'source /opt/rh/devtoolset-7/enable'
+      11: 'source /opt/rh/devtoolset-7/enable'
+      12: 'source /opt/rh/devtoolset-7/enable'
+      next: 'source /opt/rh/devtoolset-7/enable'
 #========================================#
 # Windows x86 64bits Compressed Pointers
 #========================================#


### PR DESCRIPTION
Update variable for Linux x86 64bit platform:
- use CentOS 6 build systems
- use devtoolset-7 as gcc toolchain
- update boot jdk

Issue: https://github.com/eclipse/openj9/issues/4063

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>