### PR TITLE
Keep iTable indices stable in fast HCR

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2948,9 +2948,15 @@ typedef struct J9Class {
 	struct J9FlattenedClassCache* flattenedClassCache;
 } J9Class;
 
-/* Interface classes can never be instantiated - overload the totalInstanceSize slot to hold the iTable method count */
+/* Interface classes can never be instantiated, so the following fields in J9Class will not be used:
+ *
+ *	totalInstanceSize -> map to iTable method count
+ *	finalizeLinkOffset -> map to interface method ordering table
+ */
 #define J9INTERFACECLASS_ITABLEMETHODCOUNT(clazz) ((clazz)->totalInstanceSize)
 #define J9INTERFACECLASS_SET_ITABLEMETHODCOUNT(clazz, value) (clazz)->totalInstanceSize = (value)
+#define J9INTERFACECLASS_METHODORDERING(clazz) ((U_32*)((clazz)->finalizeLinkOffset))
+#define J9INTERFACECLASS_SET_METHODORDERING(clazz, value) (clazz)->finalizeLinkOffset = (UDATA)(value)
 
 #define J9ARRAYCLASS_SET_STRIDE(clazz, strideLength) ((clazz)->flattenedClassCache) = (J9FlattenedClassCache*)(UDATA)(strideLength)
 #define J9ARRAYCLASS_GET_STRIDE(clazz) ((UDATA)((clazz)->flattenedClassCache))

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2063,9 +2063,6 @@ void
 fixITables(J9VMThread * currentThread, J9HashTable* classHashTable);
 
 void
-fixITablesForFastHCR(J9VMThread *currentThread, J9HashTable *classHashTable);
-
-void
 fixArrayClasses(J9VMThread * currentThread, J9HashTable* classHashTable);
 
 void

--- a/runtime/util/mthutil.c
+++ b/runtime/util/mthutil.c
@@ -233,16 +233,28 @@ getITableIndexWithinDeclaringClass(J9Method *method)
 {
 	UDATA index = 0;
 	J9Class * const methodClass = J9_CLASS_FROM_METHOD(method);
-	J9Method *ramMethod = methodClass->ramMethods;
-	UDATA const methodCount = methodClass->romClass->romMethodCount;
-	while (method != ramMethod) {
-		if (J9ROMMETHOD_IN_ITABLE(J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod))) {
-			index += 1;
+	J9Method *ramMethods = methodClass->ramMethods;
+	U_32 *ordering = J9INTERFACECLASS_METHODORDERING(methodClass);
+	if (NULL == ordering) {
+		while (method != ramMethods) {
+			if (J9ROMMETHOD_IN_ITABLE(J9_ROM_METHOD_FROM_RAM_METHOD(ramMethods))) {
+				index += 1;
+			}
+			ramMethods += 1;
 		}
-		ramMethod += 1;
+	} else {
+		for(;;) {
+			J9Method *ramMethod = ramMethods + *ordering;
+			if (method == ramMethod) {
+				break;
+			}
+			if (J9ROMMETHOD_IN_ITABLE(J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod))) {
+				index += 1;
+			}
+			ordering += 1;
+		}
 	}
 	return index;
-	
 }
 
 UDATA

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -295,7 +295,12 @@ addITableMethods(J9VMThread* vmStruct, J9Class *ramClass, J9Class *interfaceClas
 		UDATA vTableSize = vTableHeader->size;
 		J9Method **vTable = J9VTABLE_FROM_HEADER(vTableHeader);
 		J9Method *interfaceRamMethod = interfaceClass->ramMethods;
+		U_32 *ordering = J9INTERFACECLASS_METHODORDERING(interfaceClass);
+		UDATA index = 0;
 		while (count-- > 0) {
+			if (NULL != ordering) {
+				interfaceRamMethod = interfaceClass->ramMethods + ordering[index++];
+			}
 			J9ROMMethod *interfaceRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(interfaceRamMethod);
 			if (J9ROMMETHOD_IN_ITABLE(interfaceRomMethod)) {
 				J9UTF8 *interfaceMethodName = J9ROMMETHOD_NAME(interfaceRomMethod);

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc011.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc011.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,21 +121,31 @@ public class rc011 {
 		return "Test redefines to an interface. This will not work on a SUN VM."; 
 	}
 
-	
-	public boolean testReorderingInterfaceMethods() {
-		rc011_testReorderingInterfaceMethods_O1 obj = new rc011_testReorderingInterfaceMethods_O2();
-		rc011_testReorderingInterfaceMethods_O5 obj2 = new rc011_testReorderingInterfaceMethods_O6();
-
+	private boolean verify(rc011_testReorderingInterfaceMethods_O1 obj, rc011_testReorderingInterfaceMethods_O5 obj2, int stage) {
 		if (!"foo".equals(obj.getFoo()) || !"bar".equals(obj.getBar())) {
-			System.out.println("Failed 1: " + obj.getFoo() + " " + obj.getBar());
+			System.out.println("Failed " + stage + ": " + obj.getFoo() + " " + obj.getBar());
 			return false;
 		}
 		if (!"foo".equals(obj2.getFoo()) || !"bar".equals(obj2.getBar())) {
-			System.out.println("Failed 1 (obj2): " + obj2.getFoo() + " " + obj2.getBar());
+			System.out.println("Failed " + stage + " (obj2): " + obj2.getFoo() + " " + obj2.getBar());
 			return false;
 		}
 		if (!"foo2".equals(obj2.getFoo2()) || !"bar2".equals(obj2.getBar2())) {
-			System.out.println("Failed 1 (obj2): " + obj2.getFoo2() + " " + obj2.getBar2());
+			System.out.println("Failed " + stage + " (obj2): " + obj2.getFoo2() + " " + obj2.getBar2());
+			return false;
+		}
+		return true;
+	}
+
+	public boolean testReorderingInterfaceMethods() throws ClassNotFoundException {
+		// Ensure two implementors of the tested interfaces to prevent the
+		// JIT from optimizing away the invokeinterface.
+		Class.forName("com.ibm.jvmti.tests.redefineClasses.rc011_testReorderingInterfaceMethods_O2b");
+		Class.forName("com.ibm.jvmti.tests.redefineClasses.rc011_testReorderingInterfaceMethods_O6b");
+		rc011_testReorderingInterfaceMethods_O1 obj = new rc011_testReorderingInterfaceMethods_O2();
+		rc011_testReorderingInterfaceMethods_O5 obj2 = new rc011_testReorderingInterfaceMethods_O6();
+
+		if (!verify(obj, obj2, 1)) {
 			return false;
 		}
 
@@ -145,16 +155,7 @@ public class rc011 {
 			return false;
 		}
 
-		if (!"foo".equals(obj.getFoo()) || !"bar".equals(obj.getBar())) {
-			System.out.println("Failed 2: " + obj.getFoo() + " " + obj.getBar());
-			return false;
-		}
-		if (!"foo".equals(obj2.getFoo()) || !"bar".equals(obj2.getBar())) {
-			System.out.println("Failed 2 (obj2): " + obj2.getFoo() + " " + obj2.getBar());
-			return false;
-		}
-		if (!"foo2".equals(obj2.getFoo2()) || !"bar2".equals(obj2.getBar2())) {
-			System.out.println("Failed 2 (obj2): " + obj2.getFoo2() + " " + obj2.getBar2());
+		if (!verify(obj, obj2, 2)) {
 			return false;
 		}
 

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc011_testReorderingInterfaceMethods_O2b.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc011_testReorderingInterfaceMethods_O2b.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.redefineClasses;
+
+public class rc011_testReorderingInterfaceMethods_O2b implements rc011_testReorderingInterfaceMethods_O1 {
+	public String getFoo() {
+		return "foo";
+	}
+
+	public String getBar() {
+		return "bar";
+	}
+}

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc011_testReorderingInterfaceMethods_O6b.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc011_testReorderingInterfaceMethods_O6b.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.redefineClasses;
+
+public class rc011_testReorderingInterfaceMethods_O6b implements rc011_testReorderingInterfaceMethods_O5 {
+	public String getFoo() {
+		return "foo";
+	}
+
+	public String getBar() {
+		return "bar";
+	}
+
+	public String getFoo2() {
+		return "foo2";
+	}
+
+	public String getBar2() {
+		return "bar2";
+	}
+
+}


### PR DESCRIPTION
When interface methods were reordered during fast HCR, the VM was not
maintaining the stability of the indices into the iTable. Some uses of
the indices were fixed by the HCR, but several places were missed.

Rather than attempt the missed fixups, keep the iTable indices stable so
nothing needs to be fixed. This is done by maintaining a mapping table
in replaced interface classes which describes the original method order
(in fast HCR methods can not be added or removed, only reordered).

Update the interface method reordering test (rc011) to better test the JIT
behaviour. The test now fails on unpatched VMs.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>