### PR TITLE
CMake: fix dependency issue for `run_cptool` 

### DIFF
--- a/runtime/gc_glue_java/CMakeLists.txt
+++ b/runtime/gc_glue_java/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(j9vm_core_glue
 )
 target_link_libraries(j9vm_core_glue
 	INTERFACE
+		j9vm_interface
 		j9vm_gc_includes
 )
 

--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -83,6 +83,8 @@ if(J9VM_IS_NON_STAGING)
 	set_source_files_properties(${cp_file_name} PROPERTIES GENERATED TRUE)
 	target_sources(jclse PRIVATE ${cp_file_name})
 else()
+	# Create dummy target for run_cptool
+	add_custom_target(run_cptool)
 	target_sources(jclse PRIVATE j9vmconstantpool.c)
 endif()
 


### PR DESCRIPTION
On staging builds, add a dummy target 'run_cptool' to prevent errors
about undefined targets. For non-staging builds, link the core glue
against j9vm_interface so the dependency on `run_cptool` is
propagated

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>