### PR TITLE
Class redefinition CallSite propagation

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1164,8 +1164,8 @@ redefineClassesCommon(jvmtiEnv* env,
 			if (!extensionsEnabled) {
 				/* Fast HCR path - where the J9Class is redefined in place. */
 
-				/* Add method equivalences for the methods that were re-defined (reverse of before!). */
-				rc = fixMethodEquivalences(currentThread, classPairs, jitEventDataPtr, TRUE, &methodEquivalences, extensionsUsed);
+				/* Add method equivalences for the methods that were re-defined (reverse of before!). Propagate any equivalent resolved callsites. */
+				rc = fixMethodEquivalencesAndCallSites(currentThread, classPairs, jitEventDataPtr, TRUE, &methodEquivalences, extensionsUsed);
 				if (rc != JVMTI_ERROR_NONE) {
 					goto failed;
 				}
@@ -1230,8 +1230,8 @@ redefineClassesCommon(jvmtiEnv* env,
 				/* Unresolve all classes */
 				unresolveAllClasses(currentThread, classPairs, methodPairs, extensionsUsed);
  
-				/* Update method equivalences */
-				rc = fixMethodEquivalences(currentThread, classPairs, jitEventDataPtr, FALSE, &methodEquivalences, extensionsUsed);
+				/* Update method equivalences. Propagate any equivalent resolved callsites. */
+				rc = fixMethodEquivalencesAndCallSites(currentThread, classPairs, jitEventDataPtr, FALSE, &methodEquivalences, extensionsUsed);
 				if (rc != JVMTI_ERROR_NONE) {
 					goto failed;
 				}

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2106,7 +2106,7 @@ enum jvmtiError
 verifyNewClasses (J9VMThread * currentThread, jint class_count, J9JVMTIClassPair * classPairs);
 
 jvmtiError
-fixMethodEquivalences(J9VMThread * currentThread, 
+fixMethodEquivalencesAndCallSites(J9VMThread * currentThread, 
 	J9HashTable * classPairs,
 	J9JVMTIHCRJitEventData * eventData,
 	BOOLEAN fastHCR, J9HashTable ** methodEquivalences,

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -1196,6 +1196,8 @@ static void allSlotsInCallSiteDataDo (J9ROMClass* romClass, J9ROMClassWalkCallba
 	 *			U_16 argument[argumentCount];
 	 *		} bootStrapMethodData[romClass->bsmCount];
 	 * }
+	 * 
+	 * Note: SRP is 32 bits
 	 */
 	BOOLEAN rangeValid;
 	UDATA index, bsmArgumentCount;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -2031,6 +2031,7 @@ retry:
 
 		/* Walk bsmData - skip all bootstrap methods before bsmIndex */
 		for (U_32 i = 0; i < bsmIndex; i++) {
+			/* increment by size of bsm data plus header */
 			bsmData += (bsmData[1] + 2);
 		}
 
@@ -2087,8 +2088,9 @@ resolveInvokeDynamic(J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA callSite
 		return methodHandle;
 	}
 
-	/* Walk bsmData */
+	/* Walk bsmData - skip all bootstrap methods before bsmIndex */
 	for (i = 0; i < bsmIndex; i++) {
+		/* increment by size of bsm data plus header */
 		bsmData += bsmData[1] + 2;
 	}
 


### PR DESCRIPTION
Fixes: #4542
Tests: https://github.com/eclipse/openj9/pull/5029

Method equivalence is used to determine whether CallSites should be propagated.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>