### PR TITLE
Store J9JIT_RUNTIME_RESOLVE per-client on JITaaS

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7679,7 +7679,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          if (that->_methodBeingCompiled->_clientOptions != NULL)
             {
             TR_ASSERT(that->_methodBeingCompiled->isOutOfProcessCompReq(), "Options are already provided only for JITaaS server");
-            options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, p->trMemory());
+            options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, that, p->trMemory());
             options->setLogFileForClientOptions();
             }
          else

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -46,6 +46,7 @@
 #include "control/CompilationThread.hpp"
 #include "runtime/IProfiler.hpp"
 #include "env/j9methodServer.hpp"
+#include "control/JITaaSCompilationThread.hpp"
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
 #include "j9jitnls.h"
@@ -2859,7 +2860,7 @@ J9::Options::packOptions(TR::Options *origOptions)
    }
 
 TR::Options *
-J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Memory *trMemory)
+J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_Memory *trMemory)
    {
    TR::Options *options = (TR::Options *)trMemory->allocateHeapMemory(clientOptionsSize);
    memcpy(options, clientOptions, clientOptionsSize);
@@ -2877,10 +2878,10 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Mem
    
    // receive rtResolve
    // NOTE: this relies on rtResolve being the last option in clientOptions
+   // the J9JIT_RUNTIME_RESOLVE flag from JITaaS client
+   // On JITaaS server, we store this value for each client in ClientSessionData
    bool rtResolve = (bool) *((uint8_t *) options + clientOptionsSize - sizeof(bool));
-   J9JITConfig *jitConfig = (J9JITConfig *) _feBase;
-   if (rtResolve)
-      jitConfig->runtimeFlags |= J9JIT_RUNTIME_RESOLVE; // JITaaS FIXME: don't change global flags
+   compInfoPT->getClientData()->setRtResolve(rtResolve);
 
    // disable caching of resolved methods if env variable TR_DisableResolvedMethodsCaching is set
    TR_ResolvedJ9JITaaSServerMethod::_useCaching = !feGetEnv("TR_DisableResolvedMethodsCaching");

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -37,6 +37,7 @@ namespace J9 { typedef J9::Options OptionsConnector; }
 #include <stdint.h>
 #include "control/OptionsUtil.hpp"
 #include "env/jittypes.h"
+namespace TR { class CompilationInfoPerThreadBase; }
 
 namespace J9
 {
@@ -336,7 +337,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static const size_t FILENAME_MAX_SIZE = 1025;
    static std::string packOptions(TR::Options *origOptions);
-   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Memory *trMemory);
+   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_Memory *trMemory);
    static uint8_t *appendContent(char * &charPtr, uint8_t * curPos, size_t length);
    static std::string packLogFile(TR::FILE *fp);
    void setLogFileForClientOptions(int doubleCompile = 0);

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2862,7 +2862,8 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _classChainDataMap(decltype(_classChainDataMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _unloadedClassAddresses(NULL),
    _requestUnloadedClasses(true),
-   _staticFinalDataMap(decltype(_staticFinalDataMap)::allocator_type(TR::Compiler->persistentAllocator()))
+   _staticFinalDataMap(decltype(_staticFinalDataMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _rtResolve(false)
    {
    updateTimeOfLastAccess();
    _javaLangClassPtr = NULL;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -155,6 +155,9 @@ class ClientSessionData
    TR::Monitor *getStaticMapMonitor() { return _staticMapMonitor; }
    PersistentUnorderedMap<void *, TR_StaticFinalData> &getStaticFinalDataMap() { return _staticFinalDataMap; }
 
+   bool getRtResolve() { return _rtResolve; }
+   void setRtResolve(bool rtResolve) { _rtResolve = rtResolve; }
+
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -191,6 +194,7 @@ class ClientSessionData
    bool           _requestUnloadedClasses; // If true we need to request the current state of unloaded classes from the client
    TR::Monitor *_staticMapMonitor;
    PersistentUnorderedMap<void *, TR_StaticFinalData> _staticFinalDataMap; // stores values at static final addresses in JVM
+   bool _rtResolve; // treat all data references as unresolved
    }; // ClientSessionData
 
 // Hashtable that maps clientUID to a pointer that points to ClientSessionData

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -256,7 +256,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
    if (unresolvedInCP)
        *unresolvedInCP = true;
 
-   if (!((_fe->_jitConfig->runtimeFlags & J9JIT_RUNTIME_RESOLVE) &&
+   if (!((_fe->_compInfoPT->getClientData()->getRtResolve()) &&
          !comp->ilGenRequest().details().isMethodHandleThunk() && // cmvc 195373
          performTransformation(comp, "Setting as unresolved virtual call cpIndex=%d\n",cpIndex) ) || ignoreRtResolve)
       {
@@ -781,7 +781,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(TR::Compilat
 #if TURN_OFF_INLINING
    return 0;
 #else
-   if ((_fe->_jitConfig->runtimeFlags & J9JIT_RUNTIME_RESOLVE) == 0)
+   if (!(_fe->_compInfoPT->getClientData()->getRtResolve()))
       {
       // query for resolved method and create its mirror at the same time
       _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror, _remoteMirror, cpIndex);
@@ -826,7 +826,7 @@ TR_ResolvedMethod *
 TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp, TR_OpaqueClassBlock * classObject, I_32 virtualCallOffset, bool ignoreRtResolve)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-   if (fej9->_jitConfig->runtimeFlags & J9JIT_RUNTIME_RESOLVE && !ignoreRtResolve)
+   if (_fe->_compInfoPT->getClientData()->getRtResolve() && !ignoreRtResolve)
       return NULL;
 
    TR_ResolvedMethod *resolvedMethod = NULL;


### PR DESCRIPTION
Currently JITaaS server receives J9JIT_RUNTIME_RESOLVE info from client and stores it in its global jitConfig runtimeFlag. This becomes a problem when there are multiple clients. This change makes the server store each client's J9JIT_RUNTIME_RESOLVE in client's associated clientSessionData.

Issue: #3372
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>