### PR TITLE
Remove unnecessary GCC option on X86

### DIFF
--- a/runtime/gc/CMakeLists.txt
+++ b/runtime/gc/CMakeLists.txt
@@ -26,11 +26,7 @@ add_library(j9gc SHARED
 
 )
 
-if(OMR_TOOLCONFIG STREQUAL "gnu")
-	if(OMR_ARCH_X86)
-		target_compile_options(j9gc PRIVATE -fpeel-loops)
-	endif()
-elseif(OMR_TOOLCONFIG STREQUAL "msvc")
+if(OMR_TOOLCONFIG STREQUAL "msvc")
 	target_compile_options(j9gc PRIVATE /w34189)
 endif()
 

--- a/runtime/gc/module.xml
+++ b/runtime/gc/module.xml
@@ -48,9 +48,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="all"/>
 		</exports>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86[^-]*"/>
 			</flag>

--- a/runtime/gc_api/module.xml
+++ b/runtime/gc_api/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_api" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_base/module.xml
+++ b/runtime/gc_base/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,9 +37,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="all"/>
 		</exports>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86[^-]*"/>
 			</flag>

--- a/runtime/gc_check/module.xml
+++ b/runtime/gc_check/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_check" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_include/module.xml
+++ b/runtime/gc_include/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,9 +27,6 @@
 		<include-if condition="spec.flags.module_gc_include" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_modron_standard/module.xml
+++ b/runtime/gc_modron_standard/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_modron_standard" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_modron_startup/module.xml
+++ b/runtime/gc_modron_startup/module.xml
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_modron_startup" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<!-- mminit and mmparse include a number of static functions which aren't all used in some specifications. Suppress warnings about these. -->
 			<flag name="-Wno-unused-function" asmflag="false" definition="false">
 				<include-if condition="spec.linux_x86.*"/>

--- a/runtime/gc_realtime/module.xml
+++ b/runtime/gc_realtime/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2007, 2018 IBM Corp. and others
+Copyright (c) 2007, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_realtime" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_stats/module.xml
+++ b/runtime/gc_stats/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_stats" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_structs/module.xml
+++ b/runtime/gc_structs/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_structs" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_tests/hooktests/module.xml
+++ b/runtime/gc_tests/hooktests/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2009, 2017 IBM Corp. and others
+  Copyright (c) 2009, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,9 +34,6 @@
 			<group name="all"/>
 		</exports>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_trace/module.xml
+++ b/runtime/gc_trace/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_trace" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_trace_standard/module.xml
+++ b/runtime/gc_trace_standard/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2009, 2018 IBM Corp. and others
+Copyright (c) 2009, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_trace and spec.flags.module_gc_modron_standard" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_trace_vlhgc/module.xml
+++ b/runtime/gc_trace_vlhgc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2009, 2018 IBM Corp. and others
+Copyright (c) 2009, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.module_gc_trace and spec.flags.gc_vlhgc" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_verbose_handler_realtime/module.xml
+++ b/runtime/gc_verbose_handler_realtime/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2010, 2018 IBM Corp. and others
+Copyright (c) 2010, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.gc_realtime" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_verbose_handler_standard_java/module.xml
+++ b/runtime/gc_verbose_handler_standard_java/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2014, 2017 IBM Corp. and others
+  Copyright (c) 2014, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,9 +27,6 @@
 		<include-if condition="spec.flags.gc_modronStandard" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_verbose_handler_vlhgc/module.xml
+++ b/runtime/gc_verbose_handler_vlhgc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2010, 2018 IBM Corp. and others
+Copyright (c) 2010, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,9 +25,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<include-if condition="spec.flags.gc_vlhgc" />
 		<phase>core quick</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gc_verbose_java/module.xml
+++ b/runtime/gc_verbose_java/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2014, 2017 IBM Corp. and others
+  Copyright (c) 2014, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,11 +25,6 @@
 <module>
 	<artifact type="static" name="j9gcvrbjava">
 		<phase>core quick</phase>
-		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
-		</flags>
 		<includes>
 			<include path="j9include"/>
 			<include path="j9oti"/>

--- a/runtime/gc_verbose_old/module.xml
+++ b/runtime/gc_verbose_old/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2014, 2017 IBM Corp. and others
+  Copyright (c) 2014, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,11 +25,6 @@
 <module>
 	<artifact type="static" name="j9gcvrbold">
 		<phase>core quick</phase>
-		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
-		</flags>
 		<includes>
 			<include path="j9include"/>
 			<include path="j9oti"/>

--- a/runtime/gc_verbose_old_events/module.xml
+++ b/runtime/gc_verbose_old_events/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module>
 	<artifact type="static" name="j9gcvrbevents">
 		<phase>core quick</phase>
-		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
-		</flags>
 		<includes>
 			<include path="j9include"/>
 			<include path="j9oti"/>

--- a/runtime/gc_vlhgc/module.xml
+++ b/runtime/gc_vlhgc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2009, 2017 IBM Corp. and others
+  Copyright (c) 2009, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,9 +27,6 @@
 		<include-if condition="spec.flags.gc_vlhgc" />
 		<phase>core</phase>
 		<flags>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
-			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>
 			</flag>

--- a/runtime/gcchk/module.xml
+++ b/runtime/gcchk/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,9 +40,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flags>
 			<flag name="USING_ANSI">
 				<include-if condition="spec.linux_ppc.*"/>
-			</flag>
-			<flag name="-fpeel-loops" asmflag="false" definition="false">
-				<include-if condition="spec.linux_x86.*"/>
 			</flag>
 			<flag name="/w34189" asmflag="false" definition="false">
 				<include-if condition="spec.win_x86.*"/>


### PR DESCRIPTION
-fpeel-loops is now part of default O3 optimizations, and hence it is
unnecessary to separately supply it. In addition, this option is not
supported by clang. By removing -fpeel-loops, there is no effect when
compiling with GCC but enabling support of clang.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>