### PR TITLE
WIP: Adopt OMR's Instruction Simplification Phase

### DIFF
--- a/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -51,6 +51,7 @@
     SetupForInstructionSelectionPhase,
     RemoveUnusedLocalsPhase,
     InstructionSelectionPhase,
+    InstructionSimplificationPhase,
     CreateStackAtlasPhase,
 
     RegisterAssigningPhase,


### PR DESCRIPTION
eclipse/omr#3278 introduced an unified instruction simplication phase,
OpenJ9 should adopt it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>