### PR TITLE
Optimized JNI's null parameter check on X86-64

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,18 +90,8 @@ TR::Register *TR::AMD64JNILinkage::processJNIReferenceArg(TR::Node *child)
 
       if (needsNullParameterCheck)
          {
-      TR::MemoryReference *tempMR = generateX86MemoryReference(refReg, 0, cg());
-         generateMemImmInstruction(CMPMemImms(), child, tempMR, 0, cg());
-
-         TR::MemoryReference *tempMR2 = generateX86MemoryReference(refReg, 0, cg());
-
-         TR::LabelSymbol *notNullLabel = generateLabelSymbol(cg());
-         generateLabelInstruction(JNE4, child, notNullLabel, cg());
-         generateRegMemInstruction(LRegMem(), child, refReg, tempMR2, cg());
-         generateLabelInstruction(LABEL, child, notNullLabel, cg());
-
-         tempMR->decNodeReferenceCounts(cg());
-         tempMR2->decNodeReferenceCounts(cg());
+         generateMemImmInstruction(CMPMemImms(), child, generateX86MemoryReference(refReg, 0, cg()), 0, cg());
+         generateRegMemInstruction(CMOVERegMem(), child, refReg, generateX86MemoryReference(cg()->findOrCreateConstantDataSnippet<intptr_t>(child, 0), cg()), cg());
          }
       }
    else


### PR DESCRIPTION
Convert CMP-JNE-MOV sequence to branch-free CMP-CMOV sequence.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>