### PR TITLE
Remove dead code in JNI linkage on X86-64

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,8 +117,6 @@ int32_t TR::AMD64JNILinkage::computeMemoryArgSize(
    TR::Node *callNode,
    int32_t first,
    int32_t last,
-   int8_t direction,
-   bool isJNI,
    bool passThread)
    {
    int32_t size= 0;
@@ -133,7 +131,7 @@ int32_t TR::AMD64JNILinkage::computeMemoryArgSize(
    // that the evaluation order is left-to-right and that the JNI env
    // pointer will be in a register as the first argument.
    //
-   if (isJNI && passThread)
+   if (passThread)
       {
       TR_ASSERT(!_systemLinkage->getProperties().passArgsRightToLeft(), "JNI argument evaluation expected to be left-to-right");
       TR_ASSERT(_systemLinkage->getProperties().getNumIntegerArgumentRegisters() > 0, "JNI env pointer expected to be passed in a register.");
@@ -145,7 +143,7 @@ int32_t TR::AMD64JNILinkage::computeMemoryArgSize(
 
    bool allocateOnCallerFrame = false;
 
-   for (int32_t i = first; i != last; i += direction)
+   for (int32_t i = first; i != last; i++)
       {
       TR::Node *child = callNode->getChild(i);
       TR::DataType type = child->getDataType();
@@ -202,7 +200,6 @@ int32_t TR::AMD64JNILinkage::computeMemoryArgSize(
 int32_t TR::AMD64JNILinkage::buildArgs(
       TR::Node *callNode,
       TR::RegisterDependencyConditions *deps,
-      bool isJNI,
       bool passThread,
       bool passReceiver)
    {
@@ -216,38 +213,27 @@ int32_t TR::AMD64JNILinkage::buildArgs(
    int32_t                  offset            = 0;
    uint16_t                 numIntArgs        = 0,
                             numFloatArgs      = 0;
-   int32_t                  first, last, direction;
+   int32_t                  first, last;
 
    int32_t                  numCopiedRegs = 0;
    TR::Register             *copiedRegs[TR::X86LinkageProperties::MaxArgumentRegisters];
 
-   if (_systemLinkage->getProperties().passArgsRightToLeft())
-      {
-      TR_ASSERT(!isJNI, "JNI dispatch expected to be left-to-right.");
-      first = lastNodeArgument;
-      last  = firstNodeArgument - 1;
-      direction = -1;
-      }
-   else
-      {
-      if (!passReceiver)
-         first = firstNodeArgument + 1;
-      else first = firstNodeArgument;
-      last  = lastNodeArgument + 1;
-      direction = 1;
-      }
+   TR_ASSERT(!_systemLinkage->getProperties().passArgsRightToLeft(), "JNI dispatch expected to be left-to-right.");
+
+   if (!passReceiver)
+      first = firstNodeArgument + 1;
+   else first = firstNodeArgument;
+   last = lastNodeArgument + 1;
 
    // We need to know how many arguments will be passed on the stack in order to add the right
    // amount of slush first for proper alignment.
    //
-   int32_t memoryArgSize = computeMemoryArgSize(callNode, first, last, direction, isJNI, passThread);
+   int32_t memoryArgSize = computeMemoryArgSize(callNode, first, last, passThread);
 
    // For JNI callout there may be some extra information (such as the VMThread pointer)
    // that has been preserved on the stack that must be accounted for in this calculation.
    //
-   int32_t adjustedMemoryArgSize = memoryArgSize;
-   if (isJNI)
-      adjustedMemoryArgSize += _JNIDispatchInfo.argSize;
+   int32_t adjustedMemoryArgSize = memoryArgSize + _JNIDispatchInfo.argSize;
 
    if (adjustedMemoryArgSize > 0)
       {
@@ -263,7 +249,7 @@ int32_t TR::AMD64JNILinkage::buildArgs(
 
    // Evaluate the JNI env pointer first.
    //
-   if (isJNI && passThread)
+   if (passThread)
       {
       TR::RealRegister::RegNum rregIndex = _systemLinkage->getProperties().getIntegerArgumentRegister(0);
       TR::Register *argReg = cg()->allocateRegister();
@@ -294,7 +280,7 @@ int32_t TR::AMD64JNILinkage::buildArgs(
       }
 
    int32_t i;
-   for (i = first; i != last; i += direction)
+   for (i = first; i != last; i++)
       {
       TR::Node *child = callNode->getChild(i);
       TR::DataType type = child->getDataType();
@@ -328,7 +314,7 @@ int32_t TR::AMD64JNILinkage::buildArgs(
          }
 
       TR::Register *vreg;
-      if (isJNI && type == TR::Address)
+      if (type == TR::Address)
          vreg = processJNIReferenceArg(child);
       else
          vreg = cg()->evaluate(child);
@@ -787,7 +773,7 @@ void TR::AMD64JNILinkage::buildOutgoingJNIArgsAndDependencies(
 
    // Evaluate outgoing arguments on the system stack and build pre-conditions.
    //
-   _JNIDispatchInfo.argSize += buildArgs(callNode, _JNIDispatchInfo.callPostDeps, true, passThread, passReceiver);
+   _JNIDispatchInfo.argSize += buildArgs(callNode, _JNIDispatchInfo.callPostDeps, passThread, passReceiver);
 
    // Build post-conditions.
    //
@@ -1405,20 +1391,6 @@ TR::Register *TR::AMD64JNILinkage::buildDirectJNIDispatch(TR::Node *callNode)
    bool wrapRefs;
    bool passReceiver;
    bool passThread;
-
-   //TR::ResolvedMethodSymbol *resolvedMethodSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
-   //TR_ResolvedMethod       *resolvedMethod = resolvedMethodSymbol->getResolvedMethod();
-   //TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-
-   //bool dropVMAccess = !fej9->jniRetainVMAccess(resolvedMethod);
-   //bool isJNIGCPoint = !fej9->jniNoGCPoint(resolvedMethod);
-   //bool killNonVolatileGPRs = isJNIGCPoint;
-   //bool checkExceptions = !fej9->jniNoExceptionsThrown(resolvedMethod);
-   //bool createJNIFrame = !fej9->jniNoNativeMethodFrame(resolvedMethod);
-   //bool tearDownJNIFrame = !fej9->jniNoSpecialTeardown(resolvedMethod);
-   //bool wrapRefs = !fej9->jniDoNotWrapObjects(resolvedMethod);
-   //bool passReceiver = !fej9->jniDoNotPassReceiver(resolvedMethod);
-   //bool passThread = !fej9->jniDoNotPassThread(resolvedMethod);
 
    if (!isGPUHelper)
       {

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,8 +48,8 @@ class AMD64JNILinkage : public TR::AMD64PrivateLinkage
       TR::AMD64PrivateLinkage(cg),
          _systemLinkage(systemLinkage) {}
 
-   int32_t computeMemoryArgSize(TR::Node *callNode, int32_t first, int32_t last, int8_t direction, bool isJNI, bool passThread = true);
-   int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool isJNI, bool passThread = true, bool passReceiver = true);
+   int32_t computeMemoryArgSize(TR::Node *callNode, int32_t first, int32_t last, bool passThread = true);
+   int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool passThread = true, bool passReceiver = true);
    TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool omitDedicatedFrameRegister);
    void switchToMachineCStack(TR::Node *callNode);
    void switchToJavaStack(TR::Node *callNode);


### PR DESCRIPTION
The parameter `isJNI` is always true, and hence the logics handling the
false case is dead; removing them.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>