### PR TITLE
Eliminate getClassFromNewArrayTypeNonNull messages

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -434,6 +434,10 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._stringCompressionEnabled = fe->isStringCompressionEnabledVM();
          vmInfo._hasSharedClassCache = TR::Options::sharedClassCache();
          vmInfo._elgibleForPersistIprofileInfo = vmInfo._isIProfilerEnabled ? fe->getIProfiler()->elgibleForPersistIprofileInfo(comp) : NULL;
+         for (int32_t i = 0; i <= 7; i++)
+            {
+            vmInfo._arrayTypeClasses[i] = fe->getClassFromNewArrayTypeNonNull(i + 4);
+            }
          client->write(vmInfo);
          }
          break;
@@ -522,12 +526,6 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          {
          int32_t index = std::get<0>(client->getRecvData<int32_t>());
          client->write(fe->getClassFromNewArrayType(index));
-         }
-         break;
-      case J9ServerMessageType::VM_getClassFromNewArrayTypeNonNull:
-         {
-         int32_t index = std::get<0>(client->getRecvData<int32_t>());
-         client->write(fe->getClassFromNewArrayTypeNonNull(index));
          }
          break;
       case J9ServerMessageType::VM_isCloneable:

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -93,6 +93,7 @@ class ClientSessionData
       bool _stringCompressionEnabled;
       bool _hasSharedClassCache;
       bool _elgibleForPersistIprofileInfo;
+      TR_OpaqueClassBlock *_arrayTypeClasses[8];
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1494,13 +1494,9 @@ TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * c
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromNewArrayTypeNonNull(int32_t arrayType)
    {
-   // This query is needed for inline allocation, which requires array class to
-   // be non-NULL, but getClassFromNewArrayType returns NULL in AOT mode
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassFromNewArrayTypeNonNull, arrayType);
-   auto clazz = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
-   TR_ASSERT(clazz, "class must not be NULL");
-   return clazz;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_arrayTypeClasses[arrayType - 4];
    }
 
 bool

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -217,9 +217,8 @@ enum J9ServerMessageType
    VM_getVMInfo = 301;
    VM_isAnonymousClass = 302;
    VM_dereferenceStaticAddress = 303;
-   VM_getClassFromNewArrayTypeNonNull = 304;
-   VM_getClassFromCP = 305;
-   VM_getROMMethodFromRAMMethod = 306;
+   VM_getClassFromCP = 304;
+   VM_getROMMethodFromRAMMethod = 305;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
Every time SVM is created,
`TR_J9VMBase::getClassFromNewArrayTypeNonNull` gets
called 8 times. Since SVM is create for every
compilation (even non-AOT), this results in lots of
remote messages.
Array classes fetched by this method are accessed from
javaVM, so they should not change during runtime.
Thus, we can cache them in VMInfo and only fetch once
per client.