### PR TITLE
Jitaas version checking

### DIFF
--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -77,6 +77,7 @@ typedef enum {
    compilationAOTNoSupportForAOTFailure            = 51,
    compilationStreamFailure                        = 52,
    compilationStreamLostMessage                    = 53,
+   compilationVersionCheckFailed                   = 54,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -60,6 +60,15 @@ public:
    void write(T... args)
       {
       _cMsg.set_status(true);
+      if (_versionCheckStatus == NOTDONE)
+         {
+         _cMsg.set_version(MAJOR_NUMBER << 24 | MINOR_NUMBER << 8 | PATCH_NUMBER);
+         }
+      else
+         {
+         // Need to clear version so version data is not sent.
+         _cMsg.clear_version();
+         }
       setArgs<T...>(_cMsg.mutable_data(), args...);
       writeBlocking(_cMsg);
       }
@@ -83,6 +92,22 @@ public:
    static int _numConnectionsOpened;
    static int _numConnectionsClosed;
 
+   bool getVersionStatus()
+      {
+      if ((_versionCheckStatus == PASSED) ||
+           (_versionCheckStatus == NOTDONE))
+         return true;
+      else
+         return false;
+      }
+
+   void setVersionStatus(bool result)
+      {
+      if (result)
+         _versionCheckStatus = PASSED;
+      else
+         _versionCheckStatus = FAILED;
+      }
 private:
    uint32_t _timeout;
 

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -89,6 +89,24 @@ J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, st
       }
    }
 
+bool
+J9ServerStream::checkVersion(uint32_t version)
+   {
+   bool result = false;
+   uint8_t clientMajorNumber = version >> 24;
+   uint16_t clientMinorNumber = (version & 0x00FFFF00)  >> 8;
+
+   if ((clientMajorNumber == MAJOR_NUMBER) &&
+       (clientMinorNumber == MINOR_NUMBER))
+      result = true;
+   if (!result)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+          TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "version check failed %d %d", clientMajorNumber, clientMinorNumber);
+      }
+   return result;
+   }
+
 void initSSL()
    {
    SSL_load_error_strings();

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -26,6 +26,16 @@
 #include "rpc/SSLProtobufStream.hpp"
 #include "env/TRMemory.hpp"
 
+static const uint8_t MAJOR_NUMBER = 0;
+static const uint16_t MINOR_NUMBER = 1;
+static const uint8_t PATCH_NUMBER = 0;
+
+enum VersionStatus
+{
+   FAILED = 0,
+   PASSED = 1,
+   NOTDONE = 2,
+};
 namespace JITaaS
 {
 using namespace google::protobuf::io;
@@ -41,7 +51,8 @@ protected:
       _sslOutputStream(NULL),
       _connfd(-1)
       {
-      // set everything to NULL, in case the child stream fails to call initStream
+      _versionCheckStatus = NOTDONE;
+      // set everything to nullptr, in case the child stream fails to call initStream
       // which initializes these variables
       }
 
@@ -134,6 +145,7 @@ protected:
    SSLOutputStream *_sslOutputStream;
    ZeroCopyInputStream *_inputStream;
    ZeroCopyOutputStream *_outputStream;
+   VersionStatus _versionCheckStatus;
    };
 };
 

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -300,6 +300,7 @@ message J9ClientMessage
    {
    bool status = 1;
    AnyData data = 2;
+   uint32 version = 3;
    }
 
 service J9CompileService


### PR DESCRIPTION
Client and server needs to be compatible.
Any kind of uncompatiblity will lead to the crash.
To ensure this, there will be a version check
between client and server. Every connection will
require one message exchange between client and
server for their version compatibility check.

If the compatibility check fail the connection
on the server will be closed and client will
see compilation failure.