### PR TITLE
Changed the Custom Description to paramter in variable file

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -516,7 +516,7 @@ def set_build_identifier() {
 }
 
 def set_custom_description() {
-    if (CUSTOM_DESCRIPTION){
+    if (params.CUSTOM_DESCRIPTION){
         def TMP_DESC = (currentBuild.description) ? "<br>" + currentBuild.description : ""
         currentBuild.description = CUSTOM_DESCRIPTION + TMP_DESC
     }


### PR DESCRIPTION
Existing pull request builds do not have the CUSTOM_DESCRIPTION parameter defined
so CUSTOM_DESCRIPTION is not defined and will throw an error

[skip ci]
Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>