### PR TITLE
Add shared classes issue to milestone 1 release notes

### DIFF
--- a/doc/release-notes/0.14/0.14.md
+++ b/doc/release-notes/0.14/0.14.md
@@ -154,6 +154,13 @@ The v0.14.0 release contains the following known issues and limitations:
 <td valign="top">None</td>
 </tr>
 
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5380">#5380</a></td>
+<td valign="top">Changes to the shared classes cache generation number</td>
+<td valign="top">All platforms</td>
+<td valign="top">The format of classes that are stored in the shared classes cache is changed due to <a href="https://github.com/eclipse/openj9/pull/1831">eclipse/openj9#1831</a>. As a result, the shared cache generation number is changed, which causes the JVM to create a new shared classes cache, rather than re-creating or reusing an existing cache.</td>
+<td valign="top">To save space, all existing shared caches can be removed unless they are in use by an earlier release. For more information about destroying a shared classes cache, see <a href="https://www.eclipse.org/openj9/docs/xshareclasses/" target="_blank">-Xshareclasses</a> option.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
Issue added to 0.14 release notes re change to shared classes
cache and suggestion to remove existing caches.

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>