### PR TITLE
Always link portlibrary against rt on linux

### DIFF
--- a/runtime/port/CMakeLists.txt
+++ b/runtime/port/CMakeLists.txt
@@ -157,7 +157,7 @@ if(OMR_OS_WINDOWS)
 	)
 endif()
 
-if(OMR_NEED_LIBRT)
+if(OMR_OS_LINUX)
 	target_link_libraries(j9prt PRIVATE rt)
 endif()
 


### PR DESCRIPTION
This is needed for the shm_* family of functions

Signed-off-by: Andrew Young <youngar17@gmail.com>