### PR TITLE
CMake: Add export info to targets

### DIFF
--- a/runtime/hookable/CMakeLists.txt
+++ b/runtime/hookable/CMakeLists.txt
@@ -33,6 +33,10 @@ target_link_libraries(j9hookable
 		j9thr
 )
 
+# OMR keeps track of the exported symbols, and attaches them to j9hook_obj
+get_target_property(hookable_exports j9hook_obj EXPORTED_SYMBOLS)
+omr_add_exports(j9hookable ${hookable_exports})
+
 install(
 	TARGETS j9hookable
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}

--- a/runtime/rastrace/CMakeLists.txt
+++ b/runtime/rastrace/CMakeLists.txt
@@ -67,6 +67,12 @@ target_link_libraries(j9trc
 		j9hookable
 )
 
+omr_add_exports(j9trc
+	JVM_OnUnload
+	JVM_OnLoad
+	J9VMDllMain
+)
+
 install(
 	TARGETS j9trc
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}

--- a/runtime/redirector/CMakeLists.txt
+++ b/runtime/redirector/CMakeLists.txt
@@ -49,6 +49,10 @@ set_target_properties(jvm_redirect PROPERTIES
 	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
+# The redirector should have the same exports as the jvm
+get_target_property(jvm_exports jvm EXPORTED_SYMBOLS)
+omr_add_exports(jvm_redirect ${jvm_exports})
+
 install(
 	TARGETS jvm_redirect
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}/redirector

--- a/runtime/thread/CMakeLists.txt
+++ b/runtime/thread/CMakeLists.txt
@@ -40,6 +40,10 @@ if(OMR_HOST_OS STREQUAL "linux")
 	target_link_libraries(j9thr PUBLIC pthread)
 endif()
 
+# OMR keeps track of the exported symbols, and attaches them to j9thr_obj
+get_target_property(thread_exports j9thr_obj EXPORTED_SYMBOLS)
+omr_add_exports(j9thr ${thread_exports})
+
 install(
 	TARGETS j9thr
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}


### PR DESCRIPTION
Add info about exported symbols to various targets

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>