### PR TITLE
CMake: Remove Agent_OnAttach from vmruntimestateagent

### DIFF
--- a/runtime/runtimetools/vmruntimestateagent/CMakeLists.txt
+++ b/runtime/runtimetools/vmruntimestateagent/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(vmruntimestateagent
 omr_add_exports(vmruntimestateagent
 	Agent_OnUnload
 	Agent_OnLoad
-	Agent_OnAttach
 )
 
 install(


### PR DESCRIPTION
vmruntimestateagent does not actually export the Agent_OnAttach symbol

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>