### PR TITLE
CMake: link j9util against j9stackmap

### DIFF
--- a/runtime/util/CMakeLists.txt
+++ b/runtime/util/CMakeLists.txt
@@ -131,6 +131,7 @@ target_link_libraries(j9util
 		j9vm_gc_includes
 
 		j9simplepool
+		j9stackmap
 )
 
 add_library(j9util_b156 STATIC


### PR DESCRIPTION
j9bcutil_dumpBytecodes requires a number of functions in j9stackmap

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>