### PR TITLE
CMake: Adjust names of redirector artifacts

### DIFF
--- a/runtime/redirector/CMakeLists.txt
+++ b/runtime/redirector/CMakeLists.txt
@@ -45,6 +45,8 @@ target_include_directories(jvm_redirect
 set_target_properties(jvm_redirect PROPERTIES
 	LIBRARY_OUTPUT_NAME jvm
 	LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+	ARCHIVE_OUTPUT_NAME redirector_jvm
+	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
 install(


### PR DESCRIPTION
On platforms which generate a static import library for shared libraries,
we need to adjust the output name, to conform with what existing build
systems expect

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>