### PR TITLE
Enhance the handling of indexOf in ValuePropagation

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4305,6 +4305,8 @@ static bool foldFinalFieldsIn(char *className, int32_t classNameLength, TR::Comp
       return true;
    else if (classNameLength >= 38 && !strncmp(className, "java/util/concurrent/ThreadLocalRandom", 38))
       return true;
+   else if (classNameLength == 16 && !strncmp(className, "java/lang/String", 16))
+      return true;
    else
       return false;
    }

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -52,8 +52,9 @@ class ValuePropagation : public OMR::ValuePropagation
    virtual bool transformDirectLoad(TR::Node *node);
    bool tryFoldStaticFinalFieldAt(TR::TreeTop* tree, TR::Node* fieldNode);
    virtual void doDelayedTransformations();
-   void transformCallToIconstWithHCRGuard(TR::TreeTop *callTree, int32_t result);
-   void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true);
+   void transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR::Node *result);
+   void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true, bool requiresGuard = false);
+   void transformCallToNodeDelayedTransformations(TR::TreeTop *callTree, TR::Node *result, bool requiresGuard = false);
    uintptrj_t* getObjectLocationFromConstraint(TR::VPConstraint *constraint);
    bool isKnownStringObject(TR::VPConstraint *constraint);
    TR_YesNoMaybe isStringObject(TR::VPConstraint *constraint);
@@ -64,15 +65,17 @@ class ValuePropagation : public OMR::ValuePropagation
 
    TR_YesNoMaybe safeToAddFearPointAt(TR::TreeTop* tt);
 
-   struct TreeIntResultPair {
+   struct TreeNodeResultPair {
       TR_ALLOC(TR_Memory::ValuePropagation)
       TR::TreeTop *_tree;
-      int32_t _result;
-      TreeIntResultPair(TR::TreeTop *tree, int32_t result) : _tree(tree), _result(result) {}
+      TR::Node *_result;
+      bool _requiresHCRGuard;
+      TreeNodeResultPair(TR::TreeTop *tree, TR::Node *result, bool requiresHCRGuard) 
+         : _tree(tree), _result(result), _requiresHCRGuard(requiresHCRGuard) {}
    };
 
    TR::VP_BCDSign **_bcdSignConstraints;
-   List<TreeIntResultPair> _callsToBeFoldedToIconst;
+   List<TreeNodeResultPair> _callsToBeFoldedToNode;
    };
 
 


### PR DESCRIPTION
This change adds special case handling for the intrinsicIndexOfStringUTF16
JITHelper. The changes recognize when the target string is a constant length
of 0 or 1 and generates an appropriate inline sequence (iconst -1 or the
tree (icmpeq of the two chars) - 1). This avoids calling the helper for
a number of trivial examples present in java/net/URI$Parser.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>