### PR TITLE
Remove aarch64-linux-gnu- from native build

### DIFF
--- a/buildspecs/linux_aarch64.spec
+++ b/buildspecs/linux_aarch64.spec
@@ -84,16 +84,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="sun.jdk7.platform_id" value="linux-aarch64"/>
 		<property name="sun.jdk8.platform_id" value="linux-aarch64"/>
 		<property name="svn_stream" value=""/>
-		<property name="uma_make_cmd_ar" value="$(OPENJ9_CC_PREFIX)-ar"/>
-		<property name="uma_make_cmd_as" value="$(OPENJ9_CC_PREFIX)-as"/>
-		<property name="uma_make_cmd_cc" value="$(OPENJ9_CC_PREFIX)-gcc"/>
-		<property name="uma_make_cmd_cpp" value="$(OPENJ9_CC_PREFIX)-cpp -E -P"/>
-		<property name="uma_make_cmd_cxx" value="$(OPENJ9_CC_PREFIX)-g++"/>
+		<property name="uma_make_cmd_ar" value="ar"/>
+		<property name="uma_make_cmd_as" value="as"/>
+		<property name="uma_make_cmd_cc" value="gcc"/>
+		<property name="uma_make_cmd_cpp" value="cpp -E -P"/>
+		<property name="uma_make_cmd_cxx" value="g++"/>
 		<property name="uma_make_cmd_cxx_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
-		<property name="uma_make_cmd_ranlib" value="$(OPENJ9_CC_PREFIX)-ranlib"/>
+		<property name="uma_make_cmd_ranlib" value="ranlib"/>
 		<property name="uma_processor" value="aarch64"/>
 		<property name="uma_type" value="unix,linux"/>
 	</properties>

--- a/buildspecs/linux_aarch64_cmprssptrs.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs.spec
@@ -83,16 +83,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="sun.jdk7.platform_id" value="linux-aarch64"/>
 		<property name="sun.jdk8.platform_id" value="linux-aarch64"/>
 		<property name="svn_stream" value=""/>
-		<property name="uma_make_cmd_ar" value="$(OPENJ9_CC_PREFIX)-ar"/>
-		<property name="uma_make_cmd_as" value="$(OPENJ9_CC_PREFIX)-as"/>
-		<property name="uma_make_cmd_cc" value="$(OPENJ9_CC_PREFIX)-gcc"/>
-		<property name="uma_make_cmd_cpp" value="$(OPENJ9_CC_PREFIX)-cpp -E -P"/>
-		<property name="uma_make_cmd_cxx" value="$(OPENJ9_CC_PREFIX)-g++"/>
+		<property name="uma_make_cmd_ar" value="ar"/>
+		<property name="uma_make_cmd_as" value="as"/>
+		<property name="uma_make_cmd_cc" value="gcc"/>
+		<property name="uma_make_cmd_cpp" value="cpp -E -P"/>
+		<property name="uma_make_cmd_cxx" value="g++"/>
 		<property name="uma_make_cmd_cxx_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
-		<property name="uma_make_cmd_ranlib" value="$(OPENJ9_CC_PREFIX)-ranlib"/>
+		<property name="uma_make_cmd_ranlib" value="ranlib"/>
 		<property name="uma_processor" value="aarch64"/>
 		<property name="uma_type" value="unix,linux"/>
 	</properties>

--- a/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
@@ -49,25 +49,24 @@ ifneq (,$(findstring _cross,$(SPEC)))
 	--host=$(OPENJ9_CC_PREFIX) \
 	--build=x86_64-pc-linux-gnu \
 	'OMR_CROSS_CONFIGURE=yes'
-endif
 
-ifeq (default,$(origin AS))
-	AS = $(OPENJ9_CC_PREFIX)-as
-endif
-ifeq (default,$(origin CC))
-	CC = $(OPENJ9_CC_PREFIX)-gcc
-endif
-ifeq (default,$(origin CXX))
-	CXX = $(OPENJ9_CC_PREFIX)-g++
-endif
-ifeq (default,$(origin AR))
-	AR = $(OPENJ9_CC_PREFIX)-ar
+	ifeq (default,$(origin AS))
+		AS = $(OPENJ9_CC_PREFIX)-as
+	endif
+	ifeq (default,$(origin CC))
+		CC = $(OPENJ9_CC_PREFIX)-gcc
+	endif
+	ifeq (default,$(origin CXX))
+		CXX = $(OPENJ9_CC_PREFIX)-g++
+	endif
+	ifeq (default,$(origin AR))
+		AR = $(OPENJ9_CC_PREFIX)-ar
+	endif
 endif
 
 CONFIGURE_ARGS += 'AS=$(AS)'
 CONFIGURE_ARGS += 'CC=$(CC)'
 CONFIGURE_ARGS += 'CXX=$(CXX)'
-CONFIGURE_ARGS += 'OBJCOPY=$(OPENJ9_CC_PREFIX)-objcopy'
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o
 


### PR DESCRIPTION
The native build on AArch64 Linux uses aarch64-linux-gnu-gcc and other
commands with the aarch64-linux-gnu- prefix, which are used in the cross
build.
This commit removes the use of those unnecessary prefix from the native
build.

Signed-off-by: knn-k <konno@jp.ibm.com>