### PR TITLE
Removing GCC symlinks from the Ubuntu16 ppcle docker container

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/ubuntu16/Dockerfile
@@ -65,13 +65,6 @@ RUN apt-get update \
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV XML::Parser
 
-# Create links for c++,g++,cc,gcc
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
-
 # Install ccache
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends ccache


### PR DESCRIPTION
The symlinks are currently broken in the container
Removing the symlinks will allow a default gcc to be used
This will fix system tests on this container

[skip ci]
Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>