### PR TITLE
Fix incorrect macros in m4 files

### DIFF
--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1181,7 +1181,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     LR_GPR  r0,r14
     BASR    r14,rEP                      # Call jitResolvedStaticField
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     LHI     r1,2                                 # shift for addr
 ],[dnl
     LHI     r1,3                                 # shift for addr
@@ -1192,7 +1192,7 @@ ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
     JZ      LMTStaticAddressLoadNoneIsolated
 
     MTComputeStaticAddress(AddressLoad,Obj)
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     LLGF    r3,0(,r2)                        # load comprssed val
     SLLG    r3,r3,0(r1)                       # decompress
     STG     r3,(2*PTR_SIZE)(,r5)             # store val into r2
@@ -1350,7 +1350,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     LG      r1,28(,r14)               # load CP word
     LG      r7,(PTR_SIZE)(,r5)        # load JIT r1, obj to store
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     SLLG    r2,r2,2                   # col offset, data size
     SLLG    r6,r6,2                   # row offset, compressed
     LLGF    r3,8(r6,r3)               # tenantData[row]
@@ -1883,7 +1883,7 @@ LABEL(LcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)  # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load lookup class offset
     LLGFR   r1,r1
@@ -1900,7 +1900,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
     LR_GPR  r14,r0
 ZZ                                  # return interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)  # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -1918,7 +1918,7 @@ LABEL(LcommonJitDispatch)         # interpVtable offset in r2
     LNR_GPR r2,r2                 # negative the interpVtable offset
     AHI_GPR r2,J9TR_InterpVTableOffset
     LR_GPR  r0,r2                 # J9 requires the offset in R0
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -1988,7 +1988,7 @@ LABEL(ifCH1LcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load lookup class offset
     LLGFR   r1,r1
@@ -2005,7 +2005,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
 
 ZZ                                # return interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -2018,7 +2018,7 @@ ZZ # Load the addr of the lookup class
     TM   eq_methodCompiledFlagOffset(r3),J9TR_MethodNotCompiledBit
     JNZ     ifCH1LcommonJitDispatch
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r2,r2
@@ -2068,7 +2068,7 @@ ZZ For zos rEP(r15) is not clobbered, hense not saved
 
     L       CARG2,J9TR_J9Class_classLoader(r2)
 
-ZZ  for J9VM_GC_COMPRESSED_POINTERS
+ZZ  for ASM_J9VM_GC_COMPRESSED_POINTERS
 ZZ  may need to convert r2 to J9Class
 
     L       CARG1,eq_intfAddr_inInterfaceSnippet(,r14)
@@ -2162,7 +2162,7 @@ LABEL(ifCH1LcommonJitDispatch)      # interpVtable offset in rEP
     AHI_GPR rEP,J9TR_InterpVTableOffset
     LR_GPR  r0,rEP                  # J9 requires the offset in R0
     L_GPR   r1,(2*PTR_SIZE)(J9SP)   # Restore "this"
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of lookup class
     LLGFR   r3,r3
@@ -2231,7 +2231,7 @@ LABEL(ifCHMLcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load offset of lookup class
     LLGFR   r1,r1
@@ -2248,7 +2248,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
 
 ZZ                          # returned interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -2263,7 +2263,7 @@ ZZ # Load the address of the lookup class
     JNZ     ifCHMLcommonJitDispatch
 
 ZZ  #Load reciving object classPtr in R2
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r2,r2
@@ -2327,7 +2327,7 @@ LABEL(ifCHMLoopTillUpdate)
 
 ZZ  current slot is now updated,
 ZZ  Lets see if it has same classPtr as we are trying to store
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r0,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r0,r0
@@ -2349,7 +2349,7 @@ ZZ slot we contended for last time
 LABEL(ifCHMUpdateCacheSlot)
 ZZ store class pointer and method EP in the current empty slot
     ST_GPR  r3,PTR_SIZE(,r1)
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     ST  r2,0(,r1)
 ],[dnl
     ST_GPR  r2,0(,r1)
@@ -2363,7 +2363,7 @@ ZZ  Load pic address as second address
     L_GPR   r0,J9TR_J9Class_classLoader(CARG1)
 
 ZZ  Load class pointer as first argument
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       CARG1,0(CARG2)   # May need to convert offset to J9Class
     LLGFR   CARG1,CARG1
 ],[dnl
@@ -2447,7 +2447,7 @@ LABEL(ifCHMLcommonJitDispatch)    # interpVtable offset in rEP
     AHI_GPR rEP,J9TR_InterpVTableOffset
     LR_GPR  r0,rEP                # J9 requires the offset in R0
     L_GPR   r1,(2*PTR_SIZE)(J9SP) # Restore "this"
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3

--- a/runtime/compiler/z/runtime/Recompilation.m4
+++ b/runtime/compiler/z/runtime/Recompilation.m4
@@ -958,7 +958,7 @@ ZZ            rEP - new method Entry Point
 
 ZZ Get the lastCacheSlot pointer into r3.
     L_GPR     r3,eq_lastCachedSlotField_inInterfaceSnippet(r2)
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
 ZZ Load the class offset (32 bits)
     L         r0,J9TR_J9Object_class(,r1)
     LLGFR     r0,r0
@@ -978,7 +978,7 @@ ZZ slots or slots are uninitialized.
     JL        LJumpToNewRoutine
 
 ZZ Compare our class pointer with the class pointer in current slot
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     CL        r0,0(,r3)
 ],[dnl
     CL_GPR    r0,0(,r3)

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -540,7 +540,7 @@ define(MTComputeStaticAddress,[dnl
     NILH    r2,0                      # get col index
     SLLG    r2,r2,0(r1)               # col offset, data size
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_J9VM_GC_COMPRESSED_POINTERS],[dnl
     LGR     r14,r0                    # restore r14
     LG      r1,28(,r14)               # load CP word
     SRLG    r1,r1,8                   # shift amount


### PR DESCRIPTION
Change from compressed header to compressed pointers caused an issue due
to the m4 files not using the ASM_ version of the build flag macros.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>