### PR TITLE
Remove ManagementUtils.convertToOpenType()

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2018 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -373,87 +373,6 @@ public final class ManagementUtils {
 		} catch (IllegalArgumentException e) {
 			if (ManagementUtils.VERBOSE_MODE) {
 				e.printStackTrace(System.err);
-			}
-		}
-
-		return result;
-	}
-
-	private static final Map<Class<?>, Function<Object, CompositeData>> compositeConverterMap = new ConcurrentHashMap<>();
-
-	static {
-		// Register converters for all types in this module.
-		addCompositeConverter(LockInfo.class, LockInfoUtil::toCompositeData);
-		addCompositeConverter(MemoryNotificationInfo.class, MemoryNotificationInfoUtil::toCompositeData);
-		addCompositeConverter(MemoryUsage.class, MemoryUsageUtil::toCompositeData);
-		addCompositeConverter(MonitorInfo.class, MonitorInfoUtil::toCompositeData);
-		addCompositeConverter(StackTraceElement.class, StackTraceElementUtil::toCompositeData);
-		addCompositeConverter(ThreadInfo.class, ThreadInfoUtil::toCompositeData);
-	}
-
-	public static <T> void addCompositeConverter(Class<T> clazz, Function<T, CompositeData> object) {
-		// This cast is safe because we use the runtime class of the data
-		// to locate the entry in the map before applying the function.
-		@SuppressWarnings("unchecked")
-		Function<Object, CompositeData> converter = (Function<Object, CompositeData>) object;
-
-		compositeConverterMap.put(clazz, converter);
-	}
-
-	/**
-	 * Convenience method to convert an object, <code>data</code> from its
-	 * Java type <code>realClass</code> to the specified open MBean type
-	 * <code>openClass</code>.
-	 *
-	 * @param <T>
-	 *            the open MBean class
-	 * @param data
-	 *            the object to be converted
-	 * @param openClass
-	 *            the open MBean class
-	 * @param realClass
-	 *            the real Java type of <code>data</code>
-	 * @return a new instance of type <code>openClass</code>
-	 */
-	@SuppressWarnings("unchecked")
-	public static <T> T convertToOpenType(Object data, Class<T> openClass, Class<?> realClass) {
-		// Bail out early on null input.
-		if (data == null) {
-			return null;
-		}
-
-		T result = null;
-
-		if (openClass.isArray() && realClass.isArray()) {
-			Class<?> openElementClass = openClass.getComponentType();
-			Class<?> realElementClass = realClass.getComponentType();
-			Object[] dataArray = (Object[]) data;
-			int length = dataArray.length;
-
-			result = (T) Array.newInstance(openElementClass, length);
-
-			for (int i = 0; i < length; ++i) {
-				Array.set(result, i, convertToOpenType(dataArray[i], openElementClass, realElementClass));
-			}
-		} else if (openClass.equals(CompositeData.class)) {
-			Function<Object, CompositeData> converter = compositeConverterMap.get(realClass);
-
-			if (converter != null) {
-				result = (T) converter.apply(data);
-			}
-		} else if (openClass.equals(TabularData.class)) {
-			if (realClass.equals(Map.class)) {
-				result = (T) toSystemPropertiesTabularData((Map<String, String>) data);
-			}
-		} else if (openClass.equals(String[].class)) {
-			if (realClass.equals(List.class)) {
-				List<?> list = (List<?>) data;
-
-				result = (T) list.toArray(new String[list.size()]);
-			}
-		} else if (openClass.equals(String.class)) {
-			if (realClass.isEnum()) {
-				result = (T) ((Enum<?>) data).name();
 			}
 		}
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/AvailableProcessorsNotificationInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/AvailableProcessorsNotificationInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,6 @@ package com.ibm.lang.management;
 import javax.management.openmbean.CompositeData;
 
 import com.ibm.java.lang.management.internal.ManagementUtils;
-import com.ibm.lang.management.internal.AvailableProcessorsNotificationInfoUtil;
 
 /**
  * Encapsulates the details of a DLPAR notification emitted by a
@@ -40,10 +39,6 @@ import com.ibm.lang.management.internal.AvailableProcessorsNotificationInfoUtil;
 public class AvailableProcessorsNotificationInfo {
 
 	public static final String AVAILABLE_PROCESSORS_CHANGE = "com.ibm.management.available.processors.change"; //$NON-NLS-1$
-
-	static {
-		AvailableProcessorsNotificationInfoUtil.registerConverters();
-	}
 
 	private final int newAvailableProcessors;
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/JvmCpuMonitorInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/JvmCpuMonitorInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,10 +38,6 @@ public final class JvmCpuMonitorInfo {
 
 	private static final int HASHMASK = 0x0FFFFFFF;
 	private static final int NUM_USER_DEFINED_CATEGORY = 5;
-
-	static {
-		JvmCpuMonitorInfoUtil.registerConverters();
-	}
 
 	private long timestamp;
 	private long applicationCpuTime;

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryUsage.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryUsage.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,10 +37,6 @@ import com.ibm.lang.management.internal.MemoryUsageUtil;
 public class MemoryUsage {
 
 	private static final int HASHMASK = 0x0FFFFFFF;
-
-	static {
-		MemoryUsageUtil.registerConverters();		
-	}
 
 	private long total;
 	private long free;

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ProcessingCapacityNotificationInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ProcessingCapacityNotificationInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,6 @@ package com.ibm.lang.management;
 import javax.management.openmbean.CompositeData;
 
 import com.ibm.java.lang.management.internal.ManagementUtils;
-import com.ibm.lang.management.internal.ProcessingCapacityNotificationInfoUtil;
 
 /**
  * Encapsulates the details of a DLPAR notification emitted by a
@@ -40,10 +39,6 @@ import com.ibm.lang.management.internal.ProcessingCapacityNotificationInfoUtil;
 public class ProcessingCapacityNotificationInfo {
 
 	public static final String PROCESSING_CAPACITY_CHANGE = "com.ibm.management.processing.capacity.change"; //$NON-NLS-1$
-
-	static {
-		ProcessingCapacityNotificationInfoUtil.registerConverters();
-	}
 
 	private final int newProcessingCapacity;
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ProcessorUsage.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ProcessorUsage.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2016 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,10 +40,6 @@ import com.ibm.lang.management.internal.ProcessorUsageUtil;
 public class ProcessorUsage {
 
 	private static final int HASHMASK = 0x0FFFFFFF;
-
-	static {
-		ProcessorUsageUtil.registerConverters();
-	}
 
 	private long user;
 	private long system;

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/AvailableProcessorsNotificationInfoUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/AvailableProcessorsNotificationInfoUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,14 +61,6 @@ public final class AvailableProcessorsNotificationInfoUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link AvailableProcessorsNotificationInfo} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(AvailableProcessorsNotificationInfo.class,
-				AvailableProcessorsNotificationInfoUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/JvmCpuMonitorInfoUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/JvmCpuMonitorInfoUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,13 +69,6 @@ public final class JvmCpuMonitorInfoUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link JvmCpuMonitorInfo} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(JvmCpuMonitorInfo.class, JvmCpuMonitorInfoUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/MemoryUsageUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/MemoryUsageUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,13 +64,6 @@ public final class MemoryUsageUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link MemoryUsage} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(MemoryUsage.class, MemoryUsageUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ProcessingCapacityNotificationInfoUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ProcessingCapacityNotificationInfoUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,14 +61,6 @@ public final class ProcessingCapacityNotificationInfoUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link ProcessingCapacityNotificationInfo} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(ProcessingCapacityNotificationInfo.class,
-				ProcessingCapacityNotificationInfoUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ProcessorUsageUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ProcessorUsageUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,13 +68,6 @@ public final class ProcessorUsageUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link ProcessorUsage} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(ProcessorUsage.class, ProcessorUsageUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMemoryUsage.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSMemoryUsage.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2016 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,6 @@ import com.ibm.virtualization.management.internal.GuestOSMemoryUsageUtil;
 public final class GuestOSMemoryUsage {
 
 	private static final int HASHMASK = 0x0FFFFFFF;
-
-	static {
-		GuestOSMemoryUsageUtil.registerConverters();
-	}
 
 	private long memUsed;
 	private long timestamp;

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSProcessorUsage.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/GuestOSProcessorUsage.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2016 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,10 +44,6 @@ import com.ibm.virtualization.management.internal.GuestOSProcessorUsageUtil;
 public final class GuestOSProcessorUsage {
 
 	private static final int HASHMASK = 0x0FFFFFFF;
-
-	static {
-		GuestOSProcessorUsageUtil.registerConverters();
-	}
 
 	private long cpuTime;
 	private long timestamp;

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/internal/GuestOSMemoryUsageUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/internal/GuestOSMemoryUsageUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,13 +61,6 @@ public final class GuestOSMemoryUsageUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link GuestOSMemoryUsage} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(GuestOSMemoryUsage.class, GuestOSMemoryUsageUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/internal/GuestOSProcessorUsageUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/virtualization/management/internal/GuestOSProcessorUsageUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,13 +63,6 @@ public final class GuestOSProcessorUsageUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link GuestOSProcessorUsage} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(GuestOSProcessorUsage.class, GuestOSProcessorUsageUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,6 @@ import javax.management.openmbean.CompositeDataView;
 import javax.management.openmbean.CompositeType;
 
 import com.ibm.java.lang.management.internal.ManagementUtils;
-import com.sun.management.GarbageCollectorMXBean;
 import com.sun.management.internal.GarbageCollectionNotificationInfoUtil;
 
 /**
@@ -89,10 +88,6 @@ public class GarbageCollectionNotificationInfo implements CompositeDataView {
 	 * "com.ibm.lang.management.gc.notification" which matches RI naming for compatibility.
 	 */
 	public static final String GARBAGE_COLLECTION_NOTIFICATION = "com.sun.management.gc.notification"; //$NON-NLS-1$
-
-	static {
-		GarbageCollectionNotificationInfoUtil.registerConverters();
-	}
 
 	/**
 	 * Comment for <code>gcName</code>

--- a/jcl/src/jdk.management/share/classes/com/sun/management/GcInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/GcInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,10 +52,6 @@ import com.sun.management.internal.GcInfoUtil;
  * @since   1.9
  */
 public class GcInfo implements CompositeData, CompositeDataView {
-
-	static {
-		GcInfoUtil.registerConverters();
-	}
 
 	/**
 	 * Comment for <code>index</code>

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotificationInfoUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotificationInfoUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,14 +63,6 @@ public final class GarbageCollectionNotificationInfoUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link GarbageCollectionNotificationInfo} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(GarbageCollectionNotificationInfo.class,
-				GarbageCollectionNotificationInfoUtil::toCompositeData);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/GcInfoUtil.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/GcInfoUtil.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,13 +94,6 @@ public final class GcInfoUtil {
 		}
 
 		return compositeType;
-	}
-
-	/**
-	 * Register converters for the {@link GcInfo} class.
-	 */
-	public static void registerConverters() {
-		ManagementUtils.addCompositeConverter(GcInfo.class, GcInfoUtil::toCompositeData);
 	}
 
 	/**

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementFactory.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package org.openj9.test.java.lang.management;
 
 import org.testng.annotations.AfterClass;
@@ -62,7 +61,9 @@ import com.ibm.lang.management.ProcessingCapacityNotificationInfo;
 
 // These classes are not public API.
 import com.ibm.java.lang.management.internal.MemoryMXBeanImpl;
+import com.ibm.java.lang.management.internal.MemoryNotificationInfoUtil;
 import com.ibm.lang.management.internal.ExtendedOperatingSystemMXBeanImpl;
+import com.ibm.lang.management.internal.ProcessingCapacityNotificationInfoUtil;
 
 @SuppressWarnings({ "nls", "static-method", "unused" })
 @Test(groups = { "level.sanity" })
@@ -77,6 +78,7 @@ public class TestManagementFactory {
 
 	@AfterClass
 	protected void tearDown() throws Exception {
+		// do nothing
 	}
 
 	@Test
@@ -326,7 +328,6 @@ public class TestManagementFactory {
 			proxy.setVerbose(!initialVal);
 			AssertJUnit.assertTrue(proxy.isVerbose() != initialVal);
 			proxy.setVerbose(initialVal);
-
 		} catch (IOException e) {
 			Assert.fail("Unexpected IOException : " + e.getMessage());
 			e.printStackTrace();
@@ -353,7 +354,6 @@ public class TestManagementFactory {
 					logger.debug("UnsupportedOperationException occurred, as expected: " + t.getMessage());
 				}
 			}
-
 		} catch (IOException e) {
 			Assert.fail("Unexpected IOException : " + e.getMessage());
 			e.printStackTrace();
@@ -505,7 +505,7 @@ public class TestManagementFactory {
 			try {
 				MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 				MemoryNotificationInfo info = new MemoryNotificationInfo("Bob", mu, 42);
-				CompositeData cd = TestUtil.toCompositeData(info);
+				CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 				Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 						new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 				notification.setUserData(cd);
@@ -549,7 +549,7 @@ public class TestManagementFactory {
 			try {
 				MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 				MemoryNotificationInfo info = new MemoryNotificationInfo("Tim", mu, 42);
-				CompositeData cd = TestUtil.toCompositeData(info);
+				CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 				Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 						new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 				notification.setUserData(cd);
@@ -595,7 +595,7 @@ public class TestManagementFactory {
 			// Fire off a notification and ensure that the listener receives it.
 			MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 			MemoryNotificationInfo info = new MemoryNotificationInfo("Marcel", mu, 42);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 					new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -657,7 +657,7 @@ public class TestManagementFactory {
 			// Fire off a notification and ensure that the listener receives it.
 			MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 			MemoryNotificationInfo info = new MemoryNotificationInfo("Marcel", mu, 42);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 					new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -781,7 +781,6 @@ public class TestManagementFactory {
 			AssertJUnit.assertEquals(proxy.isVerbose(), ManagementFactory.getMemoryMXBean().isVerbose());
 
 			// TODO : Test out setVerbose when the VM API is implemented.
-
 		} catch (IOException e) {
 			Assert.fail("Unexpected IOException : " + e.getMessage());
 			e.printStackTrace();
@@ -1091,7 +1090,7 @@ public class TestManagementFactory {
 			// Fire off a notification and ensure that the listener receives it.
 			try {
 				ProcessingCapacityNotificationInfo info = new ProcessingCapacityNotificationInfo(24);
-				CompositeData cd = TestUtil.toCompositeData(info);
+				CompositeData cd = ProcessingCapacityNotificationInfoUtil.toCompositeData(info);
 				Notification notification = new Notification(
 						ProcessingCapacityNotificationInfo.PROCESSING_CAPACITY_CHANGE,
 						new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 12);
@@ -1139,7 +1138,7 @@ public class TestManagementFactory {
 			// Fire off a notification and ensure that the listener receives it.
 			try {
 				ProcessingCapacityNotificationInfo info = new ProcessingCapacityNotificationInfo(240);
-				CompositeData cd = TestUtil.toCompositeData(info);
+				CompositeData cd = ProcessingCapacityNotificationInfoUtil.toCompositeData(info);
 				Notification notification = new Notification(
 						ProcessingCapacityNotificationInfo.PROCESSING_CAPACITY_CHANGE,
 						new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 12);

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementUtils.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package org.openj9.test.java.lang.management;
 
 import org.openj9.test.util.VersionCheck;
@@ -32,6 +31,8 @@ import org.testng.AssertJUnit;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.InvalidKeyException;
 
+// This class is not public API.
+import com.ibm.java.lang.management.internal.StackTraceElementUtil;
 
 @Test(groups = { "level.sanity" })
 public class TestManagementUtils {
@@ -45,6 +46,7 @@ public class TestManagementUtils {
 
 	@AfterClass
 	protected void tearDown() throws Exception {
+		// do nothing
 	}
 
 	/*
@@ -234,7 +236,7 @@ public class TestManagementUtils {
 	public final void testToStackTraceElementCompositeData() {
 		// Null file name
 		StackTraceElement st = new StackTraceElement("foo.bar.DeclaringClass", "methodName", null, 42);
-		CompositeData cd = TestUtil.toCompositeData(st);
+		CompositeData cd = StackTraceElementUtil.toCompositeData(st);
 		int numValues = (VersionCheck.major() >= 9) ? 8 : 5;
 
 		// Examine the returned CompositeData
@@ -253,7 +255,7 @@ public class TestManagementUtils {
 
 		// Non-null file name
 		st = new StackTraceElement("foo.bar.DeclaringClass", "methodName", "DeclaringClass.java", -1);
-		cd = TestUtil.toCompositeData(st);
+		cd = StackTraceElementUtil.toCompositeData(st);
 
 		AssertJUnit.assertEquals(numValues, cd.values().size());
 		AssertJUnit.assertEquals("foo.bar.DeclaringClass", cd.get("className"));
@@ -271,7 +273,7 @@ public class TestManagementUtils {
 
 		// Native method
 		st = new StackTraceElement("foo.bar.DeclaringClass", "methodName", "DeclaringClass.java", -2);
-		cd = TestUtil.toCompositeData(st);
+		cd = StackTraceElementUtil.toCompositeData(st);
 
 		// Examine the returned CompositeData
 		AssertJUnit.assertEquals(numValues, cd.values().size());
@@ -322,15 +324,6 @@ public class TestManagementUtils {
 	 */
 	@Test
 	public final void testConvertFromOpenType() {
-		// TODO Auto-generated method stub
-
-	}
-
-	/*
-	 * Test method for 'com.ibm.lang.management.ManagementUtils.convertToOpenType(Object, Class<T>, Class<?>) <T>'
-	 */
-	@Test
-	public final void testConvertToOpenType() {
 		// TODO Auto-generated method stub
 
 	}

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package org.openj9.test.java.lang.management;
 
 import org.testng.annotations.AfterClass;
@@ -64,7 +63,9 @@ import com.ibm.lang.management.MemoryMXBean;
 
 import org.openj9.test.util.process.Task;
 
-// This class is not public API.
+// These classes are not public API.
+import com.ibm.java.lang.management.internal.MemoryNotificationInfoUtil;
+import com.ibm.java.lang.management.internal.MemoryUsageUtil;
 import com.ibm.lang.management.internal.ExtendedMemoryMXBeanImpl;
 
 @Test(groups = { "level.sanity" })
@@ -269,7 +270,7 @@ public class TestMemoryMXBean {
 
 		// Now check that the other, readonly attributes can't be set.
 		MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
-		CompositeData cd = TestUtil.toCompositeData(mu);
+		CompositeData cd = MemoryUsageUtil.toCompositeData(mu);
 		attr = new Attribute("HeapMemoryUsage", cd);
 		try {
 			mbs.setAttribute(objName, attr);
@@ -861,7 +862,7 @@ public class TestMemoryMXBean {
 		try {
 			MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 			MemoryNotificationInfo info = new MemoryNotificationInfo("Tim", mu, 42);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 					new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -908,7 +909,7 @@ public class TestMemoryMXBean {
 		try {
 			MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 			MemoryNotificationInfo info = new MemoryNotificationInfo("Tim", mu, 42);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 					new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -940,7 +941,7 @@ public class TestMemoryMXBean {
 		try {
 			MemoryUsage mu = new MemoryUsage(1, 2, 3, 4);
 			MemoryNotificationInfo info = new MemoryNotificationInfo("Tim", mu, 42);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
 					new ObjectName(ManagementFactory.MEMORY_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -1024,7 +1025,6 @@ public class TestMemoryMXBean {
 /**
  * Helper class
  */
-
 class MyTestListener implements NotificationListener {
 	private int count = 0;
 

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryNotificationInfo.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryNotificationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package org.openj9.test.java.lang.management;
 
 import org.testng.annotations.AfterClass;
@@ -32,6 +31,8 @@ import java.lang.management.MemoryUsage;
 
 import javax.management.openmbean.CompositeData;
 
+// This class is not public API.
+import com.ibm.java.lang.management.internal.MemoryNotificationInfoUtil;
 
 @Test(groups = { "level.sanity" })
 public class TestMemoryNotificationInfo {
@@ -82,7 +83,7 @@ public class TestMemoryNotificationInfo {
 
 	@Test
 	public final void testFrom() {
-		CompositeData cd = TestUtil.toCompositeData(goodMNI);
+		CompositeData cd = MemoryNotificationInfoUtil.toCompositeData(goodMNI);
 		AssertJUnit.assertNotNull(cd);
 		MemoryNotificationInfo mni = MemoryNotificationInfo.from(cd);
 		AssertJUnit.assertNotNull(mni);

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryUsage.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryUsage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package org.openj9.test.java.lang.management;
 
 import org.testng.annotations.AfterClass;
@@ -36,6 +35,9 @@ import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
+
+// This class is not public API.
+import com.ibm.java.lang.management.internal.MemoryUsageUtil;
 
 @Test(groups = { "level.sanity" })
 public class TestMemoryUsage {
@@ -62,6 +64,7 @@ public class TestMemoryUsage {
 
 	@AfterClass
 	protected void tearDown() throws Exception {
+		// do nothing
 	}
 
 	/**
@@ -112,7 +115,7 @@ public class TestMemoryUsage {
 	 */
 	@Test
 	public void testFrom() {
-		CompositeData cd = TestUtil.toCompositeData(goodMU);
+		CompositeData cd = MemoryUsageUtil.toCompositeData(goodMU);
 		AssertJUnit.assertNotNull(cd);
 		MemoryUsage mu = MemoryUsage.from(cd);
 		AssertJUnit.assertNotNull(mu);
@@ -135,6 +138,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu = MemoryUsage.from(cd);
 			Assert.fail("Method should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 	}
 
@@ -148,6 +152,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu1 = new MemoryUsage(-3, USED_VAL, COMMITTED_VAL, MAX_VAL);
 			Assert.fail("Constructor should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 
 		// Check max value less than -1...
@@ -155,6 +160,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu1 = new MemoryUsage(INIT_VAL, USED_VAL, COMMITTED_VAL, -27);
 			Assert.fail("Constructor should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 
 		// Check negative used ...
@@ -162,6 +168,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu1 = new MemoryUsage(INIT_VAL, -100, COMMITTED_VAL, MAX_VAL);
 			Assert.fail("Constructor should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 
 		// Check negative committed ...
@@ -169,6 +176,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu1 = new MemoryUsage(INIT_VAL, USED_VAL, -32, MAX_VAL);
 			Assert.fail("Constructor should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 
 		// Check used larger than committed ...
@@ -176,6 +184,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu1 = new MemoryUsage(INIT_VAL, USED_VAL * 1000, COMMITTED_VAL, MAX_VAL);
 			Assert.fail("Constructor should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 
 		// Check that if max has been defined, committed is not larger ...
@@ -183,6 +192,7 @@ public class TestMemoryUsage {
 			MemoryUsage mu1 = new MemoryUsage(INIT_VAL, USED_VAL, COMMITTED_VAL * 1000, MAX_VAL);
 			Assert.fail("Constructor should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
+			// expected
 		}
 
 		// Check that if max has *not* been defined, committed can be larger ...
@@ -191,7 +201,6 @@ public class TestMemoryUsage {
 		} catch (IllegalArgumentException e) {
 			Assert.fail("Constructor should not have thrown IllegalArgumentException");
 		}
-
 	}
 
 	private static CompositeData createBadCompositeDataObject() {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package org.openj9.test.java.lang.management;
 
 import org.testng.annotations.AfterClass;
@@ -56,12 +55,15 @@ import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 
 import com.ibm.lang.management.AvailableProcessorsNotificationInfo;
+import com.ibm.lang.management.CpuLoadCalculationConstants;
 import com.ibm.lang.management.ProcessingCapacityNotificationInfo;
 import com.ibm.lang.management.TotalPhysicalMemoryNotificationInfo;
 
-// This class is not part of the public API.
+// These classes are not part of the public API.
+import com.ibm.lang.management.internal.AvailableProcessorsNotificationInfoUtil;
 import com.ibm.lang.management.internal.ExtendedOperatingSystemMXBeanImpl;
-import com.ibm.lang.management.CpuLoadCalculationConstants;
+import com.ibm.lang.management.internal.ProcessingCapacityNotificationInfoUtil;
+import com.ibm.lang.management.internal.TotalPhysicalMemoryNotificationInfoUtil;
 
 @Test(groups = { "level.sanity" })
 public class TestOperatingSystemMXBean {
@@ -112,7 +114,7 @@ public class TestOperatingSystemMXBean {
 			attribs.put("MaxFileDescriptorCount", new AttributeData(Long.TYPE.getName(), true, false, false));
 			attribs.put("OpenFileDescriptorCount", new AttributeData(Long.TYPE.getName(), true, false, false));
 		}
-		/*At present, we don't have support for one of the APIs. Test what's
+		/* At present, we don't have support for one of the APIs. Test what's
 		 * there and exclude the other; enable when the API becomes available
 		 * on Z and OSX.
 		 */
@@ -144,6 +146,7 @@ public class TestOperatingSystemMXBean {
 
 	@AfterClass
 	protected void tearDown() throws Exception {
+		// do nothing
 	}
 
 	@Test
@@ -215,16 +218,18 @@ public class TestOperatingSystemMXBean {
 
 		// A nonexistent attribute should throw an AttributeNotFoundException
 		try {
-			long rpm = ((Long)(mbs.getAttribute(objName, "RPM")));
+			long rpm = (Long) mbs.getAttribute(objName, "RPM");
 			Assert.fail("Should have thrown an AttributeNotFoundException.");
 		} catch (Exception e1) {
+			// expected
 		}
 
 		// Type mismatch should result in a casting exception
 		try {
-			String bad = (String)(mbs.getAttribute(objName, "AvailableProcessors"));
+			String bad = (String) mbs.getAttribute(objName, "AvailableProcessors");
 			Assert.fail("Should have thrown a ClassCastException");
-		} catch (Exception e2) {
+		} catch (Exception e1) {
+			// expected
 		}
 	}
 
@@ -236,6 +241,7 @@ public class TestOperatingSystemMXBean {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
 		} catch (Exception e1) {
+			// expected
 		}
 
 		attr = new Attribute("Arch", "ie Bunker");
@@ -243,6 +249,7 @@ public class TestOperatingSystemMXBean {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
 		} catch (Exception e1) {
+			// expected
 		}
 
 		attr = new Attribute("Version", "27 and a half");
@@ -250,6 +257,7 @@ public class TestOperatingSystemMXBean {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
 		} catch (Exception e1) {
+			// expected
 		}
 
 		attr = new Attribute("AvailableProcessors", new Integer(2));
@@ -257,6 +265,7 @@ public class TestOperatingSystemMXBean {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception.");
 		} catch (Exception e1) {
+			// expected
 		}
 
 		// Try and set the Name attribute with an incorrect type.
@@ -264,7 +273,8 @@ public class TestOperatingSystemMXBean {
 		try {
 			mbs.setAttribute(objName, attr);
 			Assert.fail("Should have thrown an exception");
-		} catch (Exception e2) {
+		} catch (Exception e1) {
+			// expected
 		}
 	}
 
@@ -287,7 +297,7 @@ public class TestOperatingSystemMXBean {
 	/**
 	 * IBM attribute
 	 */
-	@Test(groups = { "disable.os.zos", "disable.os.aix"})
+	@Test(groups = { "disable.os.zos", "disable.os.aix" })
 	public void testgetCommittedVirtualMemorySize() {
 		AssertJUnit.assertTrue(osb.getCommittedVirtualMemorySize() > 0);
 	}
@@ -303,10 +313,10 @@ public class TestOperatingSystemMXBean {
 	/**
 	 * IBM attribute
 	 */
-	@Test(priority=-1) // set priority=-1 make it executed before any other tests
+	@Test(priority = -1) // priority is -1 so this test executes before any other
 	public void testGetProcessCPULoad() {
 		// first time it's -1.0
-		AssertJUnit.assertTrue(osb.getProcessCpuLoad() ==  CpuLoadCalculationConstants.ERROR_VALUE);
+		AssertJUnit.assertTrue(osb.getProcessCpuLoad() == CpuLoadCalculationConstants.ERROR_VALUE);
 		// sleep for a while otherwise next call will still return -1.0
 		try {
 			Thread.sleep(2000);
@@ -329,8 +339,8 @@ public class TestOperatingSystemMXBean {
 			 * the APIs as object-methods.  Instead, check the corresponding attributes.
 			 */
 			try {
-				maxFileDecriptors = ((Long)(mbs.getAttribute(objName, "MaxFileDescriptorCount"))).longValue();
-				openFileDecriptors = ((Long)(mbs.getAttribute(objName, "OpenFileDescriptorCount"))).longValue();
+				maxFileDecriptors = ((Long) mbs.getAttribute(objName, "MaxFileDescriptorCount")).longValue();
+				openFileDecriptors = ((Long) mbs.getAttribute(objName, "OpenFileDescriptorCount")).longValue();
 			} catch (AttributeNotFoundException e) {
 				Assert.fail("Unexpected AttributeNotFoundException exception: " + e.getMessage());
 			} catch (MBeanException e) {
@@ -448,7 +458,7 @@ public class TestOperatingSystemMXBean {
 					 * available on z/OS and OSX.
 					 */
 					if (isSupportedOS) {
-						AssertJUnit.assertTrue(((Long)(value)) > 0);
+						AssertJUnit.assertTrue(((Long)value) > 0);
 					}
 				} else {
 					Assert.fail("Unexpected attribute name returned! " + name);
@@ -505,6 +515,7 @@ public class TestOperatingSystemMXBean {
 					new String[] { "java.lang.Long", "java.lang.Long" });
 			Assert.fail("Should have thrown an exception.");
 		} catch (Exception e) {
+			// expected
 		}
 	}
 
@@ -571,7 +582,7 @@ public class TestOperatingSystemMXBean {
 		// Fire off a notification and ensure that the listener receives it.
 		try {
 			AvailableProcessorsNotificationInfo info = new AvailableProcessorsNotificationInfo(2);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = AvailableProcessorsNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(
 					AvailableProcessorsNotificationInfo.AVAILABLE_PROCESSORS_CHANGE,
 					new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 42);
@@ -619,7 +630,7 @@ public class TestOperatingSystemMXBean {
 		// Fire off a notification and ensure that the listener receives it.
 		try {
 			ProcessingCapacityNotificationInfo info = new ProcessingCapacityNotificationInfo(50);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = ProcessingCapacityNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(ProcessingCapacityNotificationInfo.PROCESSING_CAPACITY_CHANGE,
 					new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -666,7 +677,7 @@ public class TestOperatingSystemMXBean {
 		// Fire off a notification and ensure that the listener receives it.
 		try {
 			TotalPhysicalMemoryNotificationInfo info = new TotalPhysicalMemoryNotificationInfo(100 * 1024);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = TotalPhysicalMemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(
 					TotalPhysicalMemoryNotificationInfo.TOTAL_PHYSICAL_MEMORY_CHANGE,
 					new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 42);
@@ -714,7 +725,7 @@ public class TestOperatingSystemMXBean {
 		// Fire off a notification and ensure that the listener receives it.
 		try {
 			AvailableProcessorsNotificationInfo info = new AvailableProcessorsNotificationInfo(2);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = AvailableProcessorsNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(
 					AvailableProcessorsNotificationInfo.AVAILABLE_PROCESSORS_CHANGE,
 					new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 42);
@@ -745,7 +756,7 @@ public class TestOperatingSystemMXBean {
 		// Fire off a notification and ensure that the listener receives it.
 		try {
 			ProcessingCapacityNotificationInfo info = new ProcessingCapacityNotificationInfo(50);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = ProcessingCapacityNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(ProcessingCapacityNotificationInfo.PROCESSING_CAPACITY_CHANGE,
 					new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 42);
 			notification.setUserData(cd);
@@ -775,7 +786,7 @@ public class TestOperatingSystemMXBean {
 		// Fire off a notification and ensure that the listener receives it.
 		try {
 			TotalPhysicalMemoryNotificationInfo info = new TotalPhysicalMemoryNotificationInfo(100 * 1024);
-			CompositeData cd = TestUtil.toCompositeData(info);
+			CompositeData cd = TotalPhysicalMemoryNotificationInfoUtil.toCompositeData(info);
 			Notification notification = new Notification(
 					TotalPhysicalMemoryNotificationInfo.TOTAL_PHYSICAL_MEMORY_CHANGE,
 					new ObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME), 42);

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestUtil.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,11 +21,6 @@
  *******************************************************************************/
 package org.openj9.test.java.lang.management;
 
-import javax.management.openmbean.CompositeData;
-
-// This class is not public API.
-import com.ibm.java.lang.management.internal.ManagementUtils;
-
 /**
  * Centralized access to internal management classes.
  */
@@ -43,16 +38,11 @@ public final class TestUtil {
 	}
 
 	/**
-	* Helper function that tells whether we are running on Unix or not.
-	* @return Returns true if we are running on Unix; false, otherwise.
-	*/
-
+	 * Helper function that tells whether we are running on Unix or not.
+	 * @return Returns true if we are running on Unix; false, otherwise.
+	 */
 	public static boolean isRunningOnUnix() {
 		return isUnix;
-	}
-
-	public static CompositeData toCompositeData(Object data) {
-		return ManagementUtils.convertToOpenType(data, CompositeData.class, data.getClass());
 	}
 
 	private TestUtil() {


### PR DESCRIPTION
* it was only used in test code and there's public API to achieve the same goals
* this allows for removal of all the registrations of composite type converters which had a significant impact on startup performance (see #5373)
* also use a nested class rather than a lambda (via a method handle) to register available beans
* update management tests