### PR TITLE
Change the order of libraries to be linked

### DIFF
--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -84,7 +84,7 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
   UMA_END_DASH_L = -Xlinker --end-group
 </#if>
 
-UMA_EXE_POSTFIX_FLAGS += -lm -lpthread -lc -lrt -ldl -lutil -Wl,-z,origin,-rpath,\$$ORIGIN,--disable-new-dtags,-rpath-link,$(UMA_PATH_TO_ROOT)
+UMA_EXE_POSTFIX_FLAGS += -lm -lrt -lpthread -lc -ldl -lutil -Wl,-z,origin,-rpath,\$$ORIGIN,--disable-new-dtags,-rpath-link,$(UMA_PATH_TO_ROOT)
 
 <#if uma.spec.processor.amd64>
   UMA_MASM2GAS_FLAGS += --64


### PR DESCRIPTION
This commit changes the order of libraries to be linked in
UMA_EXE_POSTFIX_FLAGS for Linux.

Signed-off-by: knn-k <konno@jp.ibm.com>