### PR TITLE
WIP: Cache resolved methods globally

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2882,9 +2882,6 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Mem
    if (rtResolve)
       jitConfig->runtimeFlags |= J9JIT_RUNTIME_RESOLVE; // JITaaS FIXME: don't change global flags
 
-   // disable caching of resolved methods if env variable TR_DisableResolvedMethodsCaching is set
-   TR_ResolvedJ9JITaaSServerMethod::_useCaching = !feGetEnv("TR_DisableResolvedMethodsCaching");
-
    unpackRegex(options->_disabledOptTransformations);
    unpackRegex(options->_disabledInlineSites);
    unpackRegex(options->_disabledOpts);

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -70,6 +70,7 @@ class ClientSessionData
       TR_FieldAttributesCache *_staticAttributesCache;
       TR_FieldAttributesCache *_fieldAttributesCacheAOT;
       TR_FieldAttributesCache *_staticAttributesCacheAOT;
+      TR_ResolvedMethodInfoCache *_resolvedMethodInfoCache;
       };
 
    struct J9MethodInfo

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1515,6 +1515,14 @@ TR_J9ServerVM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    return std::get<0>(stream->read<J9ROMMethod *>());
    }
 
+uint32_t
+TR_J9ServerVM::getCompilationID()
+   {
+   // use sequence number as compilation ID
+   uint32_t id = ((TR::CompilationInfoPerThreadRemote *) _compInfoPT)->getSeqNo();
+   return id;
+   }
+
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -172,6 +172,7 @@ public:
    virtual bool isStringCompressionEnabledVM() override;
    virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp) override;
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
+   uint32_t getCompilationID();
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);


### PR DESCRIPTION
Implement global, per RAM class, cross-compilation caching of
resolved methods on the server.
The main challenge with global caching is that resolved methods
are allocated in heap memory, on both the client and the server,
thus they only exist for the duration of one compilation.
We could change allocation to persistent, but that would increase
memory footprint on the client, which should be avoided at all costs.
I addressed this problem by storing data needed to create a resolved
method persistently on the server, and using "on-demand" mirror creation,
i.e. client mirror is recreated only when it's needed.
This global caching is done in addition to local per-compilation caching
that was already being done. I left it in, because local caching is
cheaper, as it doesn't require global lock on RAM class table, and
it doesn't need to recreate mirror on the client.

This is a brief description of the solution I used:
1. Server creates a resolved method for the first time, by making
a remote call to the client.

2. Server saves attributes used to create resolved method
(i.e. `TR_ResolvedJ9JITaaSServerMethodInfo`) in a persistent map
in `ClassInfo`. `ClassInfo` corresponds to class to which this
resolved method belongs. It also saves resolved method into
a local cache.

3. The next time server needs to create the same resolved method,
it will look into the local cache first.
If local cache doesn't have it, server will look into a global cache.
It will find attributes that will be used
to create resolved method without making a remote call.
If a relocatable version of resolved method is required, appropriate
validation record will be created as well.

4. However, _remoteMirror pointer of a newly created resolved method
might be invalid, because client resolved method only exists for the
duration of one compilation. It is set to NULL to indicate that
remote mirror does not exist.

5.
   a. If a method that requires _remoteMirror to exist is called,
we make a remote call to the client and recreate the mirror.
   b. However, there are a few methods that are called very frequently,
so making a remote call every time we need to recreate a mirror
nullifies most of the message savings of global caching.
For such methods, parameters needed for remote mirror creation are
explicitly added to the main message, so recreating a resolved method
will not incur any extra messages.
