### PR TITLE
Include compressed pointers flag in m4 defines

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -356,6 +356,9 @@ ifeq ($(HOST_ARCH),z)
         ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
             M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
         endif
+        ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
+            M4_DEFINES+=J9VM_GC_COMPRESSED_POINTERS
+        endif
     endif
 
     ifeq ($(BUILD_CONFIG),debug)

--- a/runtime/compiler/build/toolcfg/zos-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/zos-xlc/common.mk
@@ -190,6 +190,10 @@ ifeq ($(HOST_BITS),64)
     ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
         M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
     endif
+
+    ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
+        M4_DEFINES+=J9VM_GC_COMPRESSED_POINTERS
+    endif
 endif
 
 ifeq ($(BUILD_CONFIG),debug)

--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -206,6 +206,9 @@ ifeq ($(HOST_ARCH),z)
         ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
             M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
         endif
+        ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
+            M4_DEFINES+=J9VM_GC_COMPRESSED_POINTERS
+        endif
     endif
 
     ifeq ($(BUILD_CONFIG),debug)


### PR DESCRIPTION
Compressed header is being replaced by compressed pointers.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>