### PR TITLE
CMake: link jilgen against omrport

### DIFF
--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(constgen
 	PRIVATE
 		j9vm_interface
 
-		j9prt
+		omrport
 		j9thr
 )
 


### PR DESCRIPTION
Omrport is the cmake equivlent of j9prtstatic

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>