### PR TITLE
Remove uses of INTERP_SMALL_MONITOR_SLOT (VM/OMR/DDR)

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ public class ObjectFieldInfo {
 	public static final int fj9object_t_SizeOf =
 			(J9BuildFlags.gc_compressedPointers ? U32.SIZEOF : UDATA.SIZEOF);
 	public static final int j9objectmonitor_t_SizeOf =
-			(J9BuildFlags.interp_smallMonitorSlot ? U32.SIZEOF : UDATA.SIZEOF);
+			(J9BuildFlags.gc_compressedPointers ? U32.SIZEOF : UDATA.SIZEOF);
 
 	int instanceObjectCount;
 	int instanceSingleCount;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/AbstractPointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/AbstractPointer.java
@@ -553,7 +553,7 @@ public abstract class AbstractPointer extends DataType {
 		if (address == 0) {
 			throw new NullPointerDereference();
 		}
-		if (J9BuildFlags.interp_smallMonitorSlot) {
+		if (J9BuildFlags.gc_compressedPointers) {
 			return J9ObjectMonitorPointer.cast(0xFFFFFFFFL & (long)(getAddressSpace().getIntAt(address + offset)));
 		} else {
 			return J9ObjectMonitorPointer.cast(getAddressSpace().getPointerAt(address + offset));

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/ObjectMonitorReferencePointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/ObjectMonitorReferencePointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ import com.ibm.j9ddr.vm29.types.UDATA;
 public class ObjectMonitorReferencePointer extends Pointer
 {
 	public static final ObjectMonitorReferencePointer NULL = new ObjectMonitorReferencePointer(0);
-	public static final long SIZEOF = J9BuildFlags.interp_smallMonitorSlot ? U32.SIZEOF : UDATA.SIZEOF;
+	public static final long SIZEOF = J9BuildFlags.gc_compressedPointers ? U32.SIZEOF : UDATA.SIZEOF;
 	
 	protected ObjectMonitorReferencePointer(long address)
 	{

--- a/runtime/compiler/x/runtime/X86LockReservation.nasm
+++ b/runtime/compiler/x/runtime/X86LockReservation.nasm
@@ -60,7 +60,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFF05h
 ; this stupidness is required because masm2gas can't handle
 ; ifdef on definitions
 
-%ifdef ASM_J9VM_INTERP_SMALL_MONITOR_SLOT
+%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
 eq_J9Monitor_LockWord         equ 04h
 %else
 eq_J9Monitor_LockWord         equ 08h
@@ -87,7 +87,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
     %else
         lea _rcx, [%1 + eq_J9Monitor_LockWord]           ; load the address of object lock word
     %endif
-    %ifdef ASM_J9VM_INTERP_SMALL_MONITOR_SLOT
+    %ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
         mov  eax, [_rcx]
     %else
         mov _rax, [_rcx]
@@ -125,7 +125,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
 %endif
 %endif
 
-%ifdef ASM_J9VM_INTERP_SMALL_MONITOR_SLOT
+%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
     lock cmpxchg [_rcx],  ebp                       ; try taking the lock
 %else
     lock cmpxchg [_rcx], _rbp                       ; try taking the lock

--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -216,11 +216,11 @@ done:
 	static VMINLINE j9objectmonitor_t
 	compareAndSwapLockword(j9objectmonitor_t volatile *lockEA, j9objectmonitor_t oldValue, j9objectmonitor_t newValue, bool readBeforeCAS = false)
 	{
-#if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
 		j9objectmonitor_t contents = VM_AtomicSupport::lockCompareExchangeU32(lockEA, oldValue, newValue, readBeforeCAS);
-#else /* J9VM_INTERP_SMALL_MONITOR_SLOT */
+#else /* J9VM_GC_COMPRESSED_POINTERS */
 		j9objectmonitor_t contents = VM_AtomicSupport::lockCompareExchange(lockEA, oldValue, newValue, readBeforeCAS);
-#endif /* J9VM_INTERP_SMALL_MONITOR_SLOT */
+#endif /* J9VM_GC_COMPRESSED_POINTERS */
 		return contents;
 	}
 

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -38,11 +38,11 @@ typedef UDATA j9objectclass_t;
 /*
  * Define type used to represent the lock in the 'monitor' slot of an object's header
  */
-#ifdef J9VM_INTERP_SMALL_MONITOR_SLOT
+#ifdef J9VM_GC_COMPRESSED_POINTERS
 typedef U_32 j9objectmonitor_t;
-#else /* J9VM_INTERP_SMALL_MONITOR_SLOT */
+#else /* J9VM_GC_COMPRESSED_POINTERS */
 typedef UDATA j9objectmonitor_t;
-#endif /* J9VM_INTERP_SMALL_MONITOR_SLOT */
+#endif /* J9VM_GC_COMPRESSED_POINTERS */
 
 /*
  * Define the type system for object pointers.
@@ -667,7 +667,7 @@ typedef struct J9IndexableObject* mm_j9array_t;
 #define J9OBJECT_MONITOR_OFFSET(vmThread,object) offsetof(J9Object,monitor)
 #endif
 
-#if defined (J9VM_INTERP_SMALL_MONITOR_SLOT) || !defined (J9VM_ENV_DATA64)
+#if defined (J9VM_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
 #define J9OBJECT_MONITOR(vmThread, object) ((void)0, (j9objectmonitor_t)J9OBJECT_U32_LOAD(vmThread, object, J9OBJECT_MONITOR_OFFSET(vmThread,object)))
 #define J9OBJECT_SET_MONITOR(vmThread, object, value) ((void)0, J9OBJECT_U32_STORE(vmThread, object,J9OBJECT_MONITOR_OFFSET(vmThread,object), value))
 #else

--- a/runtime/util/thrinfo.c
+++ b/runtime/util/thrinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@
 #define READU_ADDR(fieldAddr) dbgReadUDATA((UDATA *)(fieldAddr))
 #define READP(field) ((void *)READU(field))
 #define READP_ADDR(fieldAddr) ((void *)READU_ADDR(fieldAddr))
-#if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
 #define READMON(field) dbgReadU32((U_32 *)&(field))
 #define READMON_ADDR(fieldAddr) dbgReadU32((U_32 *)(fieldAddr))
 #else

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -319,7 +319,7 @@ cancelLockReservation(J9VMThread* vmStruct)
 					Assert_VM_true(J9_FLATLOCK_COUNT(oldLock) == 0);
 				}
 
-#if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
 				compareAndSwapU32(lockEA, oldLock, newLock);
 #else
 				compareAndSwapUDATA(lockEA, oldLock, newLock);

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,7 +110,7 @@ cacheObjectMonitorForLookup(J9JavaVM* vm, J9VMThread* vmStruct, J9ObjectMonitor*
 static J9HashTable*
 createMonitorTable(J9JavaVM *vm, char *tableName) {
 
-#if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
 #define MONTABLE_FLAGS J9HASH_TABLE_ALLOCATE_ELEMENTS_USING_MALLOC32
 #else
 #define MONTABLE_FLAGS 0

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -100,7 +100,7 @@ void freeVMThread(J9JavaVM *vm, J9VMThread *vmThread)
 		j9mem_free_memory(vmThread->riParameters);
 	}
 #endif /* defined(J9VM_PORT_RUNTIME_INSTRUMENTATION) */
-#if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
 	j9mem_free_memory32(vmThread->startOfMemoryBlock);
 #else
 	j9mem_free_memory(vmThread->startOfMemoryBlock);

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -117,7 +117,7 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 		/* Create the vmThread */
 		void *startOfMemoryBlock = NULL;
 		UDATA vmThreadAllocationSize = J9VMTHREAD_ALIGNMENT + ROUND_TO(sizeof(UDATA), vm->vmThreadSize);
-#if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
 		startOfMemoryBlock = (void *)j9mem_allocate_memory32(vmThreadAllocationSize, OMRMEM_CATEGORY_THREADS);
 #else
 		startOfMemoryBlock = (void *)j9mem_allocate_memory(vmThreadAllocationSize, OMRMEM_CATEGORY_THREADS);


### PR DESCRIPTION
Replace with GC_COMPRESSED_POINTERS

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>