### PR TITLE
Get special-case invokeinterface receiver early

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3967,6 +3967,7 @@ TR_J9ByteCodeIlGenerator::genInvokeInterface(int32_t cpIndex)
       _methodSymbol->setMayHaveInlineableCall(true);
       TR::TreeTop *prevLastTree = _block->getExit()->getPrevTreeTop();
       TR::Node *callNode = NULL;
+      TR::Node *receiver = topn(improperMethod->numberOfExplicitParameters());
       if (improperMethod->isPrivate() || improperMethod->convertToMethod()->isFinalInObject())
          {
          TR::SymbolReference *symRef = symRefTab()->findOrCreateMethodSymbol(
@@ -4008,7 +4009,7 @@ TR_J9ByteCodeIlGenerator::genInvokeInterface(int32_t cpIndex)
       TR::TransformUtil::separateNullCheck(comp(), callTree, comp()->getOption(TR_TraceILGen));
 
       uint32_t interfaceCPIndex = owningMethod->classCPIndexOfMethod(cpIndex);
-      push(callNode->getArgument(0));
+      push(receiver);
       genInstanceof(interfaceCPIndex);
       TR::Node *instanceof = pop();
 


### PR DESCRIPTION
In 7295e2c8 the JIT compiler was modified so that it could generate IL for "improper" `invokeinterface` bytecode instructions, i.e. those targeting private methods or methods of `Object`. For these invocations, the dispatch does not naturally perform the type check required for `invokeinterface`, so an explicit type check is generated ahead of the call. This type check needs the receiver of the call, which until now has been read from the resulting call node. The problem is that it's possible that the node is no longer a call by the time the type check is generated, e.g. in the case of a call to `Object.getClass()`, the call becomes `aloadi <javaLangClassFromClass>` during `genInvokeDirect()`.

The receiver is now read from the stack before calling `genInvokeDirect()` or `genInvokeWithVFTChild()` so that the type check will be unaffected by any such transformations.