### PR TITLE
Create jni.h.m4 to generate different versions of jni.h

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -156,16 +156,24 @@ endif()
 
 # Generate jvmti header
 if(J9VM_IS_NON_STAGING)
-	set(JVMTI_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
-	file(MAKE_DIRECTORY "${JVMTI_HEADER_DIR}")
+	set(J9VM_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
+	file(MAKE_DIRECTORY "${J9VM_INCLUDE_DIR}")
 else()
-	set(JVMTI_HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+	set(J9VM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 endif()
-add_custom_command(OUTPUT "${JVMTI_HEADER_DIR}/jvmti.h"
+add_custom_command(OUTPUT "${J9VM_INCLUDE_DIR}/jvmti.h"
 	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4"
 	COMMAND m4 -D "JAVA_SPEC_VERSION=${JAVA_SPEC_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4" > "jvmti.h"
 	VERBATIM
-	WORKING_DIRECTORY "${JVMTI_HEADER_DIR}"
+	WORKING_DIRECTORY "${J9VM_INCLUDE_DIR}"
+)
+
+#Generate jni header
+add_custom_command(OUTPUT "${J9VM_INCLUDE_DIR}/jni.h" 
+	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/jni.h.m4"
+   	COMMAND m4 -D "JAVA_SPEC_VERSION=${JAVA_SPEC_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/include/jni.h.m4" > "jni.h"
+	VERBATIM
+	WORKING_DIRECTORY "${J9VM_INCLUDE_DIR}"
 )
 
 # Note we do this here rather than in the redirector directory to work arround
@@ -188,7 +196,8 @@ add_custom_target(j9vm_m4gen
 	DEPENDS
 		"${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"
 		"${CMAKE_CURRENT_BINARY_DIR}/j9vm/generated.h"
-		"${JVMTI_HEADER_DIR}/jvmti.h"
+		"${J9VM_INCLUDE_DIR}/jni.h"
+		"${J9VM_INCLUDE_DIR}/jvmti.h"
 )
 
 if(J9VM_IS_NON_STAGING)

--- a/runtime/include/jni.h.m4
+++ b/runtime/include/jni.h.m4
@@ -53,8 +53,8 @@ extern "C" {
 #define JNI_VERSION_1_4 0x00010004
 #define JNI_VERSION_1_6 0x00010006
 #define JNI_VERSION_1_8 0x00010008
-#define JNI_VERSION_9   0x00090000
-#define JNI_VERSION_10  0x000A0000
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, `#define JNI_VERSION_9   0x00090000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 10), 1, `#define JNI_VERSION_10  0x000A0000', `dnl')
 
 #define JVMEXT_VERSION_1_1 0x7E010001
 
@@ -429,7 +429,7 @@ struct JNINativeInterface_ {
 	void * (JNICALL * GetDirectBufferAddress)(JNIEnv *env, jobject buf);
 	jlong (JNICALL * GetDirectBufferCapacity)(JNIEnv *env, jobject buf);
 	jobjectRefType (JNICALL * GetObjectRefType)(JNIEnv* env, jobject obj);
-	jobject (JNICALL * GetModule)(JNIEnv *env, jclass clazz);
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, `	jobject (JNICALL * GetModule)(JNIEnv *env, jclass clazz);', `dnl')
 };
 struct JNIEnv_ {
 	const struct JNINativeInterface_ *functions;
@@ -665,7 +665,7 @@ struct JNIEnv_ {
 	void* GetDirectBufferAddress(jobject buf) { return functions->GetDirectBufferAddress(this, buf); }
 	jlong GetDirectBufferCapacity(jobject buf) { return functions->GetDirectBufferCapacity(this, buf); }
 	jobjectRefType GetObjectRefType(jobject obj) { return functions->GetObjectRefType(this, obj); }
-	jobject GetModule(jclass clazz) { return functions->GetModule(this, clazz); }
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, `	jobject GetModule(jclass clazz) { return functions->GetModule(this, clazz); }', `dnl')
 #endif
 };
 

--- a/runtime/include/module.xml
+++ b/runtime/include/module.xml
@@ -35,9 +35,20 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</commands>
 	</artifact>
 
+	<artifact type="target" name="jni.h" all="false">
+		<dependencies>
+			<dependency name="jni.h.m4"/>
+		</dependencies>
+		<commands>
+			<command type="all" line="m4 -D JAVA_SPEC_VERSION=$(VERSION_MAJOR) jni.h.m4 > jni.h"/>
+			<command type="clean" line="$(RM) jni.h"/>
+		</commands>
+	</artifact>	
+
 	<artifact type="target" name="j9include_generate" all="false">
 		<dependencies>
 			<dependency name="jvmti.h"/>
+			<dependency name="jni.h"/>
 		</dependencies>
 	</artifact>
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1659,8 +1659,12 @@ JVM_IsSupportedJNIVersion(jint version)
 	case JNI_VERSION_1_4:
 	case JNI_VERSION_1_6:
 	case JNI_VERSION_1_8:
+#if JAVA_SPEC_VERSION >= 9
 	case JNI_VERSION_9:
+#endif /* JAVA_SPEC_VERSION >= 9 */
+#if JAVA_SPEC_VERSION >= 10
 	case JNI_VERSION_10:
+#endif /* JAVA_SPEC_VERSION >= 10 */
 		return JNI_TRUE;
 
 	default:

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2100,8 +2100,12 @@ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args) {
 	case JNI_VERSION_1_4:
 	case JNI_VERSION_1_6:
 	case JNI_VERSION_1_8:
+#if JAVA_SPEC_VERSION >= 9
 	case JNI_VERSION_9:
+#endif /* JAVA_SPEC_VERSION >= 9 */
+#if JAVA_SPEC_VERSION >= 10
 	case JNI_VERSION_10:
+#endif /* JAVA_SPEC_VERSION >= 10 */
 		return JNI_OK;
 	}
 	

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -927,8 +927,12 @@ JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 			|| (jniVersion == JNI_VERSION_1_4)
 			|| (jniVersion == JNI_VERSION_1_6)
 			|| (jniVersion == JNI_VERSION_1_8)
+#if JAVA_SPEC_VERSION >= 9
 			|| (jniVersion == JNI_VERSION_9)
+#endif /* JAVA_SPEC_VERSION >= 9 */
+#if JAVA_SPEC_VERSION >= 10
 			|| (jniVersion == JNI_VERSION_10)
+#endif /* JAVA_SPEC_VERSION >= 10 */
 		) {
 			return JNI_OK;
 		} else {

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,9 @@ static void JNICALL releasePrimitiveArrayCritical(JNIEnv *env, jarray array, voi
 static const jchar * JNICALL getStringCritical(JNIEnv *env, jstring str, jboolean *isCopy);
 static void JNICALL releaseStringCritical(JNIEnv *env, jstring str, const jchar * elems);
 
+#if JAVA_SPEC_VERSION >= 9
 static jobject JNICALL getModule(JNIEnv *env, jclass clazz);
+#endif /* JAVA_SPEC_VERSION >= 9 */
 
 #define FIND_CLASS gpCheckFindClass
 #define TO_REFLECTED_METHOD gpCheckToReflectedMethod
@@ -1463,7 +1465,9 @@ struct JNINativeInterface_ EsJNIFunctions = {
 	getDirectBufferAddress,
 	getDirectBufferCapacity,
 	getObjectRefType,
+#if JAVA_SPEC_VERSION >= 9
 	getModule,
+#endif /* JAVA_SPEC_VERSION >= 9 */
 };
 
 void  initializeJNITable(J9JavaVM *vm)
@@ -2223,6 +2227,7 @@ done:
 	return rc;
 }
 
+#if JAVA_SPEC_VERSION >= 9
 static jobject JNICALL
 getModule(JNIEnv *env, jclass clazz)
 {
@@ -2242,6 +2247,7 @@ getModule(JNIEnv *env, jclass clazz)
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 	return module;
 }
+#endif /* JAVA_SPEC_VERSION >= 9 */
 
 
 IDATA

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -394,11 +394,11 @@ getObjectClass(JNIEnv *env, jobject obj)
 jint JNICALL
 getVersion(JNIEnv *env)
 {
-	if (J2SE_VERSION(((J9VMThread*)env)->javaVM) >= J2SE_V11) {
-		return JNI_VERSION_10;
-	} else {
-		return JNI_VERSION_1_8;
-	}
+#if JAVA_SPEC_VERSION >= 10
+	return JNI_VERSION_10;
+#else /* JAVA_SPEC_VERSION >= 10 */
+	return JNI_VERSION_1_8;
+#endif /* JAVA_SPEC_VERSION >= 10 */
 }
 
 jsize JNICALL

--- a/runtime/vm/jvminitcommon.c
+++ b/runtime/vm/jvminitcommon.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,6 +133,11 @@ jniVersionIsValid(UDATA jniVersion)
 		   || (jniVersion == JNI_VERSION_1_4) 
 		   || (jniVersion == JNI_VERSION_1_6) 
 		   || (jniVersion == JNI_VERSION_1_8)
+#if JAVA_SPEC_VERSION >= 9
 		   || (jniVersion == JNI_VERSION_9)
-		   || (jniVersion == JNI_VERSION_10);
+#endif /* JAVA_SPEC_VERSION >= 9 */
+#if JAVA_SPEC_VERSION >= 10
+		   || (jniVersion == JNI_VERSION_10)
+#endif /* JAVA_SPEC_VERSION >= 10 */
+		   ;
 }


### PR DESCRIPTION
generate different jni.h

we use m4 to generate different jni header files to support different JDKs

we need to generate jni header by using m4 so that it is specific to
the Java release version, since vm will support Java 8, 9, 10, 11, 12.

There are some changes:

- use m4 preprocessor and macros to generate different header
- add macros in jnicsup.cpp to support different header files
- add new dependencies in module.xml and cmake file to generate jni.h in include directory

Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>