### PR TITLE
Reference Linkage_inlines files as appropriate

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "codegen/ARM64JNILinkage.hpp"
+#include "codegen/Linkage_inlines.hpp"
 
 TR::ARM64JNILinkage::ARM64JNILinkage(TR::CodeGenerator *cg)
    :TR::ARM64PrivateLinkage(cg)

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "codegen/ARM64PrivateLinkage.hpp"
+#include "codegen/Linkage_inlines.hpp"
 
 TR::ARM64LinkageProperties TR::ARM64PrivateLinkage::properties =
    {

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/GCStackMap.hpp"
 #include "codegen/GenerateInstructions.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/GCStackMap.hpp"
 #include "codegen/GenerateInstructions.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/Register.hpp"
 #include "codegen/RegisterPair.hpp"

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -24,6 +24,7 @@
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/Machine.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/LiveRegister.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"
@@ -267,7 +268,7 @@ TR::Register *TR::PPCJNILinkage::buildDirectDispatch(TR::Node *callNode)
          OMR::RegisterDependencyMap map(deps->getPreConditions()->getRegisterDependency(0), deps->getAddCursorForPre());
          for (int32_t cnt=0; cnt < deps->getAddCursorForPre(); cnt++)
             map.addDependency(deps->getPreConditions()->getRegisterDependency(cnt), cnt);
-         
+
          TR::Register *addrArg, *posArg, *lenArg, *wasteArg;
          if (crc32m2)
             {
@@ -277,7 +278,7 @@ TR::Register *TR::PPCJNILinkage::buildDirectDispatch(TR::Node *callNode)
 
             generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::addi2, callNode, addrArg, addrArg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
             }
-         
+
          if (crc32m3)
             {
             addrArg = map.getSourceWithTarget(TR::Compiler->target.is64Bit()?(TR::RealRegister::gr4):(TR::RealRegister::gr5));

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -23,6 +23,7 @@
 #include "p/codegen/PPCPrivateLinkage.hpp"
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/LiveRegister.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/RealRegister.hpp"
@@ -1087,7 +1088,7 @@ void TR::PPCPrivateLinkage::createPrologue(TR::Instruction *cursor)
       else
          {
          cursor = generateMemSrc1Instruction(cg(), (intSavedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, new (trHeapMemory()) TR::MemoryReference(stackPtr, argSize, 4*(TR::RealRegister::LastGPR-intSavedFirst+1), cg()), machine->getRealRegister(intSavedFirst), cursor);
-         
+
          argSize += (TR::RealRegister::LastGPR - intSavedFirst + 1) * 4;
          }
       }
@@ -1373,7 +1374,7 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
       else
          {
          cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getRealRegister(savedFirst), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), cursor);
-         
+
          saveSize += (TR::RealRegister::LastGPR - savedFirst + 1) * 4;
          }
       }
@@ -1917,33 +1918,33 @@ int32_t TR::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                 
 
    /*
    PPC ABI --
-   AIX 32-bit BE & AIX 64-bit BE & Linux 64-bit BE: 
-   These follow aix-style linkage. 
-   There is a TOC-base register (gr2) that needs to be loaded from function descriptor of that function that is called. 
+   AIX 32-bit BE & AIX 64-bit BE & Linux 64-bit BE:
+   These follow aix-style linkage.
+   There is a TOC-base register (gr2) that needs to be loaded from function descriptor of that function that is called.
    If the callee function is in libj9jitxx.so module, (as in the case of CHelper functions are) then the module's TOC-base can be found in the J9VMThread jitTOC field.
    The TOC can be loaded from the jitTOC field of J9VMThread (pointed to by metaDataRegister).
-  
-   Linux 64-bit LE: There exists a TOC (gr2), but there is no such function descriptor. 
-   The TOC-base set-up is defined by ABI to go through a function's global-entry (relocation). 
+
+   Linux 64-bit LE: There exists a TOC (gr2), but there is no such function descriptor.
+   The TOC-base set-up is defined by ABI to go through a function's global-entry (relocation).
    The global-entry address will be set up in gr12.
 
-   Registers r12, and r2 are always added to the dependency in the situations that they're used. 
-   R12 is added at all times, and is an unreserved register across all platforms. 
-   R2 is added to the dependency only if we're not dealing with a linux 32 bit platform, where it's system reserved. 
-   Ultimately, we don't need an assert or NULL check when searching for these registers within the dependency. 
+   Registers r12, and r2 are always added to the dependency in the situations that they're used.
+   R12 is added at all times, and is an unreserved register across all platforms.
+   R2 is added to the dependency only if we're not dealing with a linux 32 bit platform, where it's system reserved.
+   Ultimately, we don't need an assert or NULL check when searching for these registers within the dependency.
    */
    if(linkage == TR_CHelper)
    {
       if(TR::Compiler->target.isLinux() && TR::Compiler->target.is64Bit() && TR::Compiler->target.cpu.isLittleEndian())
       {
          int32_t helperOffset = (callNode->getSymbolReference()->getReferenceNumber() - 1)*sizeof(intptrj_t);
-         generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr12), 
+         generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr12),
             new(trHeapMemory()) TR::MemoryReference(cg()->getTOCBaseRegister(), helperOffset, TR::Compiler->om.sizeofReferenceAddress(), cg()));
 
       }
       else if (TR::Compiler->target.isAIX() || (TR::Compiler->target.isLinux() && TR::Compiler->target.is64Bit()))
       {
-         generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr2), 
+         generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr2),
             new(trHeapMemory()) TR::MemoryReference(cg()->getMethodMetaDataRegister(), offsetof(J9VMThread, jitTOC), TR::Compiler->om.sizeofReferenceAddress(), cg()));
       }
    }
@@ -1980,7 +1981,7 @@ int32_t TR::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                 
       }
    else if (cg()->comp()->getOption(TR_TraceCG))
       traceMsg(comp(), "Omitting CCR save/restore for helper calls\n");
-   
+
    if (memArgs > 0)
       {
       for (argIndex = 0; argIndex < memArgs; argIndex++)
@@ -2666,7 +2667,7 @@ void TR::PPCPrivateLinkage::buildDirectCall(TR::Node *callNode,
    TR::MethodSymbol *callSymbol    = callSymRef->getSymbol()->castToMethodSymbol();
    TR::ResolvedMethodSymbol *sym   = callSymbol->getResolvedMethodSymbol();
    TR_ResolvedMethod *vmm       = (sym==NULL)?NULL:sym->getResolvedMethod();
-   bool myself = 
+   bool myself =
       (vmm!=NULL && vmm->isSameMethod(comp()->getCurrentMethod()) && !comp()->isDLT()) ?
       true : false;
 

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #include "codegen/AMD64J9SystemLinkage.hpp"
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "env/jittypes.h"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RealRegister.hpp"

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include "codegen/AMD64JNILinkage.hpp"
 
 #include <stdint.h>
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"
 #include "codegen/CodeGenerator.hpp"

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 #include "codegen/X86HelperLinkage.hpp"
 
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/Register.hpp"
 #include "codegen/RegisterDependency.hpp"

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -22,6 +22,7 @@
 
 #include "x/codegen/X86PrivateLinkage.hpp"
 
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/LiveRegister.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"
@@ -660,7 +661,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
    //
    const bool frameIsSmall  = peakSize < STACKCHECKBUFFER;
    const bool frameIsMedium = !frameIsSmall;
-   
+
    if (trace)
       {
       traceMsg(comp(), "\nFrame size: %c%c locals=%d frame=%d peak=%d\n",

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #if defined(TR_TARGET_32BIT)
 
 #include "codegen/IA32J9SystemLinkage.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/RegisterDependency.hpp"
 #include "codegen/X86Instruction.hpp"
 #include "x/codegen/IA32LinkageUtils.hpp"

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -25,6 +25,7 @@
 #include "codegen/IA32JNILinkage.hpp"
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 #include "codegen/IA32PrivateLinkage.hpp"
 
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/LiveRegister.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -24,6 +24,7 @@
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GCStackAtlas.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "codegen/Snippet.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/VirtualGuard.hpp"

--- a/runtime/compiler/z/codegen/J9S390SystemLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/GCStackMap.hpp"
+#include "codegen/Linkage_inlines.hpp"
 #include "compile/Compilation.hpp"
 #include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"


### PR DESCRIPTION
A few files were missed in the original commit.  Include Linkage_inlines.hpp
in them as appropriate.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>