### PR TITLE
Disable "-D_FORTIFY_SOURCE=1" in runtime/rastrace for AArch64

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -715,8 +715,7 @@ For building on AArch64 Linux:
 ```
 bash configure --with-freemarker-jar=/<path_to>/freemarker.jar \
                --with-boot-jdk=/<path_to_boot_JDK> \
-               --disable-warnings-as-errors \
-               --disable-warnings-as-errors-openj9
+               --disable-warnings-as-errors
 ```
 
 For building in the Docker container:
@@ -728,8 +727,7 @@ bash configure --openjdk-target=${OPENJ9_CC_PREFIX} \
                --with-freemarker-jar=/root/freemarker.jar \
                --with-boot-jdk=/root/bootjdk11 \
                --with-build-jdk=/root/bootjdk11 \
-               --disable-warnings-as-errors \
-               --disable-warnings-as-errors-openj9
+               --disable-warnings-as-errors
 ```
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.

--- a/runtime/rastrace/module.xml
+++ b/runtime/rastrace/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-   Copyright (c) 2006, 2017 IBM Corp. and others
+   Copyright (c) 2006, 2019 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,6 +49,9 @@
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="CFLAGS+=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1"/>
+			<makefilestub data="trclog.o: CFLAGS+=-U_FORTIFY_SOURCE">
+				<include-if condition="spec.linux_aarch64.*"/>
+			</makefilestub>
 		</makefilestubs>
 		<libraries>
 			<library name="j9util"/>


### PR DESCRIPTION
This commit stops adding "-D_FORTIFY_SOURCE=1" to CFLAGS in
runtime/rastrace when the target platform is AArch64, in order to avoid
compile error with trclog.c.
With this change, "--disable-warnings-as-errors-openj9" can be removed
from the options for configure.

Fixes: #4486

Signed-off-by: knn-k <konno@jp.ibm.com>