### PR TITLE
CMake: Update jilgen for windows

### DIFF
--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(constgen
 add_custom_command(
 	OUTPUT ${j9vm_BINARY_DIR}/oti/jilconsts.inc ${j9vm_BINARY_DIR}/oti/jilvalues.m4
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${j9vm_BINARY_DIR}/oti
-	COMMAND  constgen
+	COMMAND $<TARGET_FILE:constgen>
 	VERBATIM
 	WORKING_DIRECTORY ${j9vm_BINARY_DIR}
 )


### PR DESCRIPTION
Specify executable via $<TARGET_FILE:...>. Since this expansion is
not automatically performed when CMake is in crosscompile mode (which we
do on windows to get cmake generate cygwin makefiles which use MSVC)

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>