### PR TITLE
CMake: Put jsig import library in /lib folder

### DIFF
--- a/runtime/jsigWrapper/CMakeLists.txt
+++ b/runtime/jsigWrapper/CMakeLists.txt
@@ -64,6 +64,12 @@ if(OMR_OS_LINUX)
 	)
 endif()
 
+if(J9VM_IS_NON_STAGING)
+	set_target_properties(jsig PROPERTIES
+		ARCHIVE_OUTPUT_DIRECTORY ${j9vm_BINARY_DIR}/lib
+	)
+endif()
+
 install(
 	TARGETS jsig
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}


### PR DESCRIPTION
This is required to match behaviour of existing build system

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>