### PR TITLE
Don't generate jvmti.h unless jvmti.h.m4 has changed

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -152,13 +152,14 @@ endif()
 
 # Generate jvmti header
 if(J9VM_IS_NON_STAGING)
-	set(JVMTI_HEADER_DIR  "${CMAKE_CURRENT_BINARY_DIR}/include")
+	set(JVMTI_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 	file(MAKE_DIRECTORY "${JVMTI_HEADER_DIR}")
 else()
-	set(JVMTI_HEADER_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+	set(JVMTI_HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 endif()
-add_custom_command(OUTPUT "${JVMTI_HEADER_DIR}/jvmti.h" 
-   	COMMAND m4 -D "JAVA_SPEC_VERSION=${JAVA_SPEC_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4" > "jvmti.h"
+add_custom_command(OUTPUT "${JVMTI_HEADER_DIR}/jvmti.h"
+	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4"
+	COMMAND m4 -D "JAVA_SPEC_VERSION=${JAVA_SPEC_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4" > "jvmti.h"
 	VERBATIM
 	WORKING_DIRECTORY "${JVMTI_HEADER_DIR}"
 )

--- a/runtime/include/module.xml
+++ b/runtime/include/module.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0"?>
-
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
- 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
- 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
- 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] http://openjdk.java.net/legal/assembly-exception.html
+Copyright (c) 2016, 2019 IBM Corp. and others
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module>
+
 	<artifact type="reference" name="j9include">
 	</artifact>
 
-	<artifact type="target" name="generate_jvmti" all="false">
+	<artifact type="target" name="jvmti.h" all="false">
+		<dependencies>
+			<dependency name="jvmti.h.m4"/>
+		</dependencies>
 		<commands>
 			<command type="all" line="m4 -D JAVA_SPEC_VERSION=$(VERSION_MAJOR) jvmti.h.m4 > jvmti.h"/>
 			<command type="clean" line="$(RM) jvmti.h"/>
@@ -35,8 +37,8 @@
 
 	<artifact type="target" name="j9include_generate" all="false">
 		<dependencies>
-			<dependency name="generate_jvmti"/>
+			<dependency name="jvmti.h"/>
 		</dependencies>
 	</artifact>
-	
+
 </module>


### PR DESCRIPTION
Previously, `jvmti.h` was being regenerated unconditionally, eliminating most of the potential for an incremental build.

Also, in cmake builds, `jvmti.h` was not being updated if `jvmti.h.m4` had changed, leading to potentially incorrect incremental builds.