### PR TITLE
Add tests targets to the pipelines variables file

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -393,18 +393,14 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
 def get_test_target_names() {
     def targetNames = []
-    def targets = TESTS_TARGETS.split(",")
 
-    targets.each { target ->
-        switch (target.trim().toLowerCase()) {
-            case "_sanity":
-                targetNames.addAll(["sanity.functional", "sanity.system"])
-                break
-            case "_extended":
-                targetNames.addAll(["extended.functional", "extended.system"])
-                break
-            default:
-                targetNames.add(target.trim())
+    if (TESTS_TARGETS && TESTS_TARGETS.trim() != 'none') {
+        for (target in TESTS_TARGETS.trim().replaceAll("\\s","").toLowerCase().tokenize(',')) {
+            if (VARIABLES.tests_targets && VARIABLES.tests_targets."${target}") {
+                targetNames.addAll(VARIABLES.tests_targets."${target}".keySet())
+            } else {
+                targetNames.add(target)
+            }
         }
     }
 

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -456,17 +456,29 @@ def set_test_variables() {
 def set_test_targets() {
     TESTS_TARGETS = params.TESTS_TARGETS
     if (!TESTS_TARGETS) {
-        // set default TESTS_TARGETS for pipeline job (run all tests)
-        TESTS_TARGETS = "_sanity,_extended"
+        // set default TESTS_TARGETS for pipeline job (fetch from variables file)
+        TESTS_TARGETS = get_default_test_targets()
     }
 
     EXCLUDED_TESTS = []
     if (VARIABLES."${SPEC}".excluded_tests) {
         def excludedTests = get_value(VARIABLES."${SPEC}".excluded_tests, SDK_VERSION)
         if (excludedTests) {
-            EXCLUDED_TESTS.addAll(excludedTests)
+            EXCLUDED_TESTS.addAll(excludedTests.keySet())
         }
     }
+
+    echo "TESTS_TARGETS: ${TESTS_TARGETS}"
+    echo "EXCLUDED_TESTS: ${EXCLUDED_TESTS}"
+}
+
+def get_default_test_targets() {
+    if (VARIABLES.tests_targets && VARIABLES.tests_targets.default) {
+        // VARIABLES.tests_targets.default is a map where all values are null
+        return VARIABLES.tests_targets.default.keySet().join(',')
+    }
+
+    return ''
 }
 
 def set_slack_channel() {

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -324,6 +324,11 @@ def get_summary_table(identifier) {
         return ''
     }
 
+    if (!TESTS_TARGETS) {
+        // default to value set in variables file
+        TESTS_TARGETS = variableFile.get_default_test_targets()
+    }
+
     def buildReleases = get_sorted_releases()
 
     def headerCols = ['']

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -90,6 +90,16 @@ build_discarder:
 restart_timeout:
   time: '5'
   units: 'HOURS'
+tests_targets:
+  sanity:
+    ? sanity.functional
+  extended:
+    ? extended.functional
+  default: &defaultTests
+    ? extended.functional
+    ? extended.system
+    ? sanity.functional
+    ? sanity.system
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#
@@ -317,25 +327,13 @@ x86-64_linux_cm:
       next: 'source /opt/rh/devtoolset-7/enable'
   excluded_tests:
     8:
-      - 'sanity.functional'
-      - 'sanity.system'
-      - 'extended.functional'
-      - 'extended.system'
+      <<: *defaultTests
     11:
-      - 'sanity.functional'
-      - 'sanity.system'
-      - 'extended.functional'
-      - 'extended.system'
+      <<: *defaultTests
     12:
-      - 'sanity.functional'
-      - 'sanity.system'
-      - 'extended.functional'
-      - 'extended.system'
+      <<: *defaultTests
     next:
-      - 'sanity.functional'
-      - 'sanity.system'
-      - 'extended.functional'
-      - 'extended.system'
+      <<: *defaultTests
 #========================================#
 # Linux x86 64bits Large Heap
 #========================================#


### PR DESCRIPTION
Move hard-coded test targets to the variables file.
Reformat Jenkins files to default tests targets to the value set in the
variables file when no build parameter is provided.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>