### PR TITLE
Reduce messages from server

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -425,7 +425,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    j9thread_t             _osThread;
    J9VMThread            *_compilationThread;
    int32_t                _compThreadPriority; // to reduce number of checks
-   TR::Monitor *_compThreadMonitor;
+   TR::Monitor           *_compThreadMonitor;
    char                  *_activeThreadName; // name of thread when active
    char                  *_suspendedThreadName; // name of thread when suspended
    uint64_t               _lastTimeThreadWasSuspended; // RAS; only accessed by the thread itself

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3358,8 +3358,8 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
    for (uint32_t i = 0; i < numMethods; i++)
       {
-      clientSessionData->getJ9MethodMap().insert({ &methods[i], 
-            {romMethod, NULL, static_cast<bool>(methodTracingInfo[i])} });
+      clientSessionData->getJ9MethodMap().insert({&methods[i], 
+            {romMethod, NULL, static_cast<bool>(methodTracingInfo[i]), (TR_OpaqueClassBlock *)clazz} });
       romMethod = nextROMMethod(romMethod);
       }
    }

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -79,6 +79,7 @@ class ClientSessionData
       // The hashtable is created on demand (NULL means it is missing)
       IPTable_t *_IPData;
       bool _isMethodTracingEnabled;
+      TR_OpaqueClassBlock * _owningClass;
       };
 
    // This struct contains information about VM that does not change during its lifetime.

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -262,6 +262,9 @@ public:
    virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true) override;
    virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex) override;
 
+protected :
+   bool validateClass(TR_OpaqueMethodBlock * method, TR_OpaqueClassBlock* j9class, bool isVettedForAOT);
+ 
    };
 
 #endif // VMJ9SERVER_H


### PR DESCRIPTION
1. getClassFromSignature: Make remote call to client
   and validate it. If it is validated then store class
   or store the NULL.
2. getClassFromMethodBlock: Save the class in the J9MethodMap.
   Check the cache before making remote call.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>