### PR TITLE
CMake: link gptest against platform agnostic thread library

### DIFF
--- a/runtime/tests/gp/CMakeLists.txt
+++ b/runtime/tests/gp/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(gptest SHARED
 target_link_libraries(gptest
 	PRIVATE
 		j9vm_interface
-		pthread
+		${OMR_PLATFORM_THREAD_LIBRARY}
 )
 target_include_directories(gptest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
Instead of linking against the platform specific 'pthread' link against
"OMR_PLATFORM_THREAD_LIBRARY" which is set to the appropriate library
for the target platform.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>