### PR TITLE
(v0.14.0-release) Set JVM_INTERFACE_VERSION to 5 for JDK12.0.1

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5348,7 +5348,11 @@ JVM_GetInterfaceVersion(void)
 
 	Trc_SC_GetInterfaceVersion_Entry();
 	if (J2SE_CURRENT_VERSION >= J2SE_V11) {
-		result = 6;
+		if (J2SE_CURRENT_VERSION == J2SE_V12) {
+			result = 5; /* JDK12 hasn't got same update as JDK11 & HEAD */
+		} else {
+			result = 6; /* JDK11 & HEAD */
+		}
 	}
 	Trc_SC_GetInterfaceVersion_Exit(result);
 


### PR DESCRIPTION
Set `JVM_INTERFACE_VERSION` to `5` for `JDK12.0.1`

`JDK12.0.1` doesn't have the change (`JVM_INTERFACE_VERSION = 6`) like `JDK 11.0.3, 12.0.2 and 13`.
Set `JVM_INTERFACE_VERSION` to `5` for `JDK12.0.1` (`Release 0.14.0 branch`).

This code was tested before, travis build is sufficient for sanity check.  

closes: https://github.com/eclipse/openj9/issues/5553

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>