### PR TITLE
Exclude certain test suites per spec from running in the Jenkins pipeline

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -364,6 +364,11 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
         echo "Using VENDOR_TEST_REPOS = ${VENDOR_TEST_REPOS}, VENDOR_TEST_BRANCHES = ${VENDOR_TEST_BRANCHES}, VENDOR_TEST_SHAS = ${VENDOR_TEST_SHAS}, VENDOR_TEST_DIRS = ${VENDOR_TEST_DIRS}, BUILD_LIST = ${BUILD_LIST}" 
 
         for (name in TARGET_NAMES) {
+            // Checking to see if the test should be excluded
+            if (EXCLUDED_TESTS.contains(name)){
+                echo "The '${name}' test suite will be excluded"
+                continue
+            }
             def TEST_FLAG = (name.contains('+jitaas')) ? 'JITAAS' : ''
             def TEST_JOB_NAME = get_test_job_name(get_target_name(name), SPEC, SDK_VERSION, BUILD_IDENTIFIER)
 

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -459,6 +459,14 @@ def set_test_targets() {
         // set default TESTS_TARGETS for pipeline job (run all tests)
         TESTS_TARGETS = "_sanity,_extended"
     }
+
+    EXCLUDED_TESTS = []
+    if (VARIABLES."${SPEC}".excluded_tests) {
+        def excludedTests = get_value(VARIABLES."${SPEC}".excluded_tests, SDK_VERSION)
+        if (excludedTests) {
+            EXCLUDED_TESTS.addAll(excludedTests)
+        }
+    }
 }
 
 def set_slack_channel() {

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -309,6 +309,27 @@ x86-64_linux_cm:
       11: 'source /opt/rh/devtoolset-7/enable'
       12: 'source /opt/rh/devtoolset-7/enable'
       next: 'source /opt/rh/devtoolset-7/enable'
+  excluded_tests:
+    8:
+      - 'sanity.functional'
+      - 'sanity.system'
+      - 'extended.functional'
+      - 'extended.system'
+    11:
+      - 'sanity.functional'
+      - 'sanity.system'
+      - 'extended.functional'
+      - 'extended.system'
+    12:
+      - 'sanity.functional'
+      - 'sanity.system'
+      - 'extended.functional'
+      - 'extended.system'
+    next:
+      - 'sanity.functional'
+      - 'sanity.system'
+      - 'extended.functional'
+      - 'extended.system'
 #========================================#
 # Linux x86 64bits Large Heap
 #========================================#


### PR DESCRIPTION
Certain specs do not have any tests associated with them.
This would not allow these tests to run if they are selected
This will not allow any testing on x86-64_linux_cm

[skip ci]
Resolves #5459
Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>