### PR TITLE
Eliminate IProfiler_persistIprofileInfo messages

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9623,7 +9623,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
    if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
       {
       // end of compilation, clear per-compilation caches
-      ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearIProfilerMap(comp->trMemory());
+      ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearIProfilerMap();
       ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearResolvedMethodInfoMap(comp->trMemory());
       }
 

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -36,6 +36,7 @@ struct TR_RemoteROMStringKey;
 using IPTable_t = PersistentUnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
 using IPTableHeapEntry = UnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
 using IPTableHeap_t = UnorderedMap<J9Method *, IPTableHeapEntry *>;
+using ResolvedMirrorMethodsPersistIP_t = Vector<TR_ResolvedJ9Method *>;
 
 class ClientSessionData
    {
@@ -249,19 +250,26 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
       void waitForMyTurn(ClientSessionData *clientSession, TR_MethodToBeCompiled &entry); // return false if timeout
       bool getWaitToBeNotified() const { return _waitToBeNotified; }
       void setWaitToBeNotified(bool b) { _waitToBeNotified = b; }
-      void clearIProfilerMap(TR_Memory *trMemory);
+
+      void clearIProfilerMap();
       bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
       TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
       void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo);
       bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedJ9JITaaSServerMethod *owningMethod, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
       TR_ResolvedMethodKey getResolvedMethodKey(TR_ResolvedMethodType type, TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_OpaqueClassBlock *classObject=NULL);
       void clearResolvedMethodInfoMap(TR_Memory *trMemory);
+
+      void clearResolvedMirrorMethodsPersistIPInfo();
+      void cacheResolvedMirrorMethodsPersistIPInfo(TR_ResolvedJ9Method *resolvedMethod);
+      ResolvedMirrorMethodsPersistIP_t *getCachedResolvedMirrorMethodsPersistIPInfo() { return _resolvedMirrorMethodsPersistIPInfo; }
+
    private:
       TR_PersistentMethodInfo *_recompilationMethodInfo;
       uint32_t _seqNo;
       bool _waitToBeNotified; // accessed with clientSession->_sequencingMonitor in hand
       IPTableHeap_t *_methodIPDataPerComp;
       TR_ResolvedMethodInfoCache *_resolvedMethodInfoMap;
+      ResolvedMirrorMethodsPersistIP_t *_resolvedMirrorMethodsPersistIPInfo; //list of mirrors of resolved methods for persisting IProfiler info
    };
 }
 

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -32,12 +32,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h> /// gethostname, read, write
+#include <openssl/err.h>
 #include "J9Server.hpp"
 #include "control/Options.hpp"
 #include "env/VerboseLog.hpp"
 #include "env/TRMemory.hpp"
+#include "env/j9method.h"
 #include "rpc/SSLProtobufStream.hpp"
-#include <openssl/err.h>
 
 
 namespace JITaaS
@@ -70,11 +71,15 @@ J9ServerStream::cancel()
    }
 
 void
-J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended, std::string logFileStr, std::string symbolToIdStr)
+J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData,
+                                 std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended,
+                                 std::string logFileStr, std::string symbolToIdStr,
+                                 std::vector<TR_ResolvedJ9Method*> resolvedMethodsForPersistIprofileInfo)
    {
    try
       {
-      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData, classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr);
+      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData,
+            classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr, resolvedMethodsForPersistIprofileInfo);
       finish();
       }
    catch (std::exception &e)

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -31,6 +31,7 @@
 
 class SSLOutputStream;
 class SSLInputStream;
+class TR_ResolvedJ9Method;
 
 namespace JITaaS
 {
@@ -60,7 +61,10 @@ public:
       }
 
    void cancel();
-   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {}, std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {}, std::string logFileStr = "", std::string symbolToIdStr = "");
+   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {},
+                          std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {},
+                          std::string logFileStr = "", std::string symbolToIdStr = "",
+                          std::vector<TR_ResolvedJ9Method*> = {});
    void setClientId(uint64_t clientId)
       {
       _clientId = clientId;

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -285,7 +285,6 @@ enum J9ServerMessageType
    IProfiler_searchForMethodSample = 901;
    IProfiler_getMaxCallCount = 902;
    IProfiler_setCallCount = 903;
-   IProfiler_persistIprofileInfo = 904;
 
    Recompilation_getExistingMethodInfo = 1000;
    Recompilation_getJittedBodyInfoFromPC = 1001;

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -178,8 +178,8 @@ TR_JITaaSIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
    if (addIt)
       return NULL; // Server should not create any samples
 
-   ClientSessionData *clientSessionData = comp->fej9()->_compInfoPT->getClientData();
-   auto compInfoPT = (TR::CompilationInfoPerThreadRemote *) comp->fej9()->_compInfoPT;
+   auto compInfoPT = (TR::CompilationInfoPerThreadRemote *)(comp->fej9()->_compInfoPT);
+   ClientSessionData *clientSessionData = compInfoPT->getClientData();
    TR_IPBytecodeHashTableEntry *entry = NULL;
 
    // Check the cache first, if allowed
@@ -761,13 +761,13 @@ void
 TR_JITaaSIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp)
    {
    // resolvedMethodSymbol is only used for debugging on the client, so we don't have to send it
-   auto serverMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method);
    auto stream = TR::CompilationInfo::getStream();
-   ClientSessionData *clientSessionData = comp->fej9()->_compInfoPT->getClientData();
+   auto compInfoPT = (TR::CompilationInfoPerThreadRemote *)(comp->fej9()->_compInfoPT);
+   ClientSessionData *clientSessionData = compInfoPT->getClientData();
 
    if (clientSessionData->getOrCacheVMInfo(stream)->_elgibleForPersistIprofileInfo)
       {
-      stream->write(JITaaS::J9ServerMessageType::IProfiler_persistIprofileInfo, serverMethod->getRemoteMirror());
-      auto recv = stream->read<JITaaS::Void>();
+      auto serverMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method);
+      compInfoPT->cacheResolvedMirrorMethodsPersistIPInfo(serverMethod->getRemoteMirror());
       }
    }


### PR DESCRIPTION
[skip ci]
Each inlined method could trigger an `IProfiler_persistIprofileInfo`
update. For each compilation, it would result in more than one
`IProfiler_persistIprofileInfo` messages being sent from the server.
The optimization is to save `IProfiler_persistIprofileInfo` request
during the compilation and send a list of the methods at the end
of the compilation along with `finishCompilation()` message to the client.

Fix #5486

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>