### PR TITLE
Reducing the message getClassFromCP

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1463,9 +1463,24 @@ TR_J9ServerVM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType a
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromCP(J9ConstantPool *cp)
    {
+   auto & constantPoolMap = _compInfoPT->getClientData()->getConstantPoolToClassMap();
+      {
+      // check if the value is cached
+      OMR::CriticalSection getConstantPoolMonitor(_compInfoPT->getClientData()->getConstantPoolMonitor());
+      auto it = constantPoolMap.find(cp);
+      if (it != constantPoolMap.end())
+         return it->second;
+      }
+
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::J9ServerMessageType::VM_getClassFromCP, cp);
-   return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
+   TR_OpaqueClassBlock * clazz = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
+   if (clazz)
+      {
+      OMR::CriticalSection getConstantPoolMonitor(_compInfoPT->getClientData()->getConstantPoolMonitor());
+      constantPoolMap.insert({cp, clazz});
+      }
+   return clazz;
    }
 
 void


### PR DESCRIPTION
Created a constant pool to class cache and check this cache
before making the remote call.

On unloading the class iterate the whole cache to check
the classes from the unload class list and remove the entries

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>