### PR TITLE
Fix TestJps and update String test utilities

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/AttachApiTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/AttachApiTest.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 
 import org.openj9.test.util.PlatformInfo;
@@ -172,10 +171,6 @@ abstract class AttachApiTest {
 	public static void checkTargetPid(TargetManager target) {
 		String targetPid = target.getTargetPid();
 		Assert.assertTrue((null != targetPid) && !targetPid.equalsIgnoreCase("failed"), "target attach API failed to launch");
-	}
-
-	protected static Optional<String> search(String needle, List<String> haystack) {
-		return haystack.stream().filter(s -> s.contains(needle)).findFirst();
 	}
 
 	protected boolean checkLoadAgentOutput(String errOutput,

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -23,9 +23,7 @@ package org.openj9.test.attachAPI;
 
 import static org.openj9.test.attachAPI.TestConstants.TARGET_VM_CLASS;
 import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -34,6 +32,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.openj9.test.util.PlatformInfo;
+import org.openj9.test.util.StringUtilities;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -54,9 +53,9 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommand();
-		assertTrue(TEST_PROCESS_ID_MISSING, search(vmId, jpsOutput).isPresent());
-		assertTrue("jps is missing", search(JPS_Class, jpsOutput).isPresent()); //$NON-NLS-1$
-		assertTrue(CHILD_IS_MISSING, search(tgtMgr.targetId, jpsOutput).isPresent());
+		assertTrue(TEST_PROCESS_ID_MISSING, StringUtilities.searchSubstring(vmId, jpsOutput).isPresent());
+		assertTrue("jps is missing", StringUtilities.searchSubstring(JPS_Class, jpsOutput).isPresent()); //$NON-NLS-1$
+		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());
 		tgtMgr.terminateTarget();
 	}
 
@@ -66,7 +65,7 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommand(Collections.singletonList("-l")); //$NON-NLS-1$
-		Optional<String> searchResult = search(tgtMgr.targetId, jpsOutput);
+		Optional<String> searchResult = StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
 		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
 		assertTrue(WRONG_PKG_NAME + searchResult.get(), searchResult.get().contains(TargetVM.class.getPackage().getName()));
 		tgtMgr.terminateTarget();
@@ -74,25 +73,21 @@ public class TestJps extends AttachApiTest {
 
 	@Test(groups = { "level.extended" })
 	public void testJpsIdOnly() throws IOException {
-		final String SPURIOUS_OUTPUT = "Spurious output: "; //$NON-NLS-1$
 		TargetManager tgtMgr1 = new TargetManager(TARGET_VM_CLASS, null);
 		TargetManager tgtMgr2 = new TargetManager(TARGET_VM_CLASS, "SomeRandomId"); //$NON-NLS-1$
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr1.syncWithTarget());
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr2.syncWithTarget());
 		List<String> jpsOutput = runCommand(Collections.singletonList("-q")); //$NON-NLS-1$
 		
-		Optional<String> searchResult = search(vmId, jpsOutput);
-		assertTrue(TEST_PROCESS_ID_MISSING, searchResult.isPresent());
-		assertEquals(SPURIOUS_OUTPUT, vmId, searchResult.get());
+		boolean searchResult = StringUtilities.contains(vmId, jpsOutput);
+		assertTrue(TEST_PROCESS_ID_MISSING + ": " + vmId, searchResult); //$NON-NLS-1$
 		
-		searchResult = search(tgtMgr1.targetId, jpsOutput);
-		assertTrue(CHILD_IS_MISSING, search(tgtMgr1.targetId, jpsOutput).isPresent());
-		assertEquals(SPURIOUS_OUTPUT, tgtMgr1.targetId, searchResult.get());
+		searchResult = StringUtilities.contains(tgtMgr1.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING + ": " + tgtMgr1.targetId, searchResult); //$NON-NLS-1$
 		
 		/* now try with non-default vm ID */
-		searchResult = search(tgtMgr2.targetId, jpsOutput);
-		assertTrue(CHILD_IS_MISSING, search(tgtMgr2.targetId, jpsOutput).isPresent());
-		assertEquals(SPURIOUS_OUTPUT, tgtMgr2.targetId, searchResult.get());
+		searchResult = StringUtilities.contains(tgtMgr2.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING + ": " + tgtMgr2.targetId, searchResult); //$NON-NLS-1$
 		
 		tgtMgr1.terminateTarget();
 		tgtMgr2.terminateTarget();
@@ -104,8 +99,8 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, targetArgs);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommand(Collections.singletonList("-m")); //$NON-NLS-1$
-		Optional<String> searchResult =  search(tgtMgr.targetId, jpsOutput);
-		assertTrue(CHILD_IS_MISSING, search(tgtMgr.targetId, jpsOutput).isPresent());
+		Optional<String> searchResult =  StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());
 		for (String a: targetArgs) {
 			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));
 		}
@@ -118,8 +113,8 @@ public class TestJps extends AttachApiTest {
 		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, null, vmArgs, null);
 		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
 		List<String> jpsOutput = runCommand(Collections.singletonList("-v")); //$NON-NLS-1$
-		Optional<String> searchResult =  search(tgtMgr.targetId, jpsOutput);
-		assertTrue(CHILD_IS_MISSING, search(tgtMgr.targetId, jpsOutput).isPresent());
+		Optional<String> searchResult =  StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, StringUtilities.searchSubstring(tgtMgr.targetId, jpsOutput).isPresent());
 		for (String a: vmArgs) {
 			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));
 		}
@@ -137,22 +132,8 @@ public class TestJps extends AttachApiTest {
 	 */
 	@BeforeSuite
 	void setupSuite() {
-		assertTrue("This test is valid only on OpenJ9",  //$NON-NLS-1$
-				System.getProperty("java.vm.vendor").contains("OpenJ9"));  //$NON-NLS-1$//$NON-NLS-2$
-		char fs = java.io.File.separatorChar;
-		final String jpsCommandWithSuffix = 
-				PlatformInfo.isWindows() ? JPS_COMMAND + ".exe": JPS_COMMAND; //$NON-NLS-1$
-		String binDir = System.getProperty("java.home") + fs + "bin" + fs; //$NON-NLS-1$ //$NON-NLS-2$
-		commandName = binDir + jpsCommandWithSuffix;
-		File  commandFile = new File(commandName);
-		if (!commandFile.exists()) { /* Java 8 has 2 bin directories, and JAVA_HOME is probably pointing at jre/bin */
-			log("Did not find jps in "+binDir); //$NON-NLS-1$
-			binDir = System.getProperty("java.home") + fs + ".." + fs + "bin" + fs; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			commandName = binDir + jpsCommandWithSuffix;
-			commandFile = new File(commandName);
-			assertTrue("Did not find " + jpsCommandWithSuffix //$NON-NLS-1$
-					+ " in " + binDir, commandFile.exists()); //$NON-NLS-1$
-		}
+		assertTrue("This test is valid only on OpenJ9",PlatformInfo.isOpenJ9()); //$NON-NLS-1$
+		getJdkUtilityPath(JPS_COMMAND);
 		assertTrue("Attach API failed to launch", TargetManager.waitForAttachApiInitialization()); //$NON-NLS-1$
 		vmId = TargetManager.getVmId();
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstack.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstack.java
@@ -24,7 +24,6 @@ package org.openj9.test.attachAPI;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -38,7 +37,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import org.openj9.test.util.PlatformInfo;
 import org.openj9.test.util.StringPrintStream;
+import org.openj9.test.util.StringUtilities;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -120,7 +121,7 @@ public class TestJstack extends AttachApiTest {
 			buff.append("\n"); //$NON-NLS-1$
 		});
 		log(buff.toString());
-		Optional<String> searchResult = search(testName, jpsOutput);
+		Optional<String> searchResult = StringUtilities.searchSubstring(testName, jpsOutput);
 		assertTrue(searchResult.isPresent(), "Method name missing"); //$NON-NLS-1$
 	}
 
@@ -137,7 +138,7 @@ public class TestJstack extends AttachApiTest {
 			buff.append("\n"); //$NON-NLS-1$
 		});
 		log(buff.toString());
-		Optional<String> searchResult = search(testName, jpsOutput);
+		Optional<String> searchResult = StringUtilities.searchSubstring(testName, jpsOutput);
 		assertTrue(searchResult.isPresent(), "Method name missing"); //$NON-NLS-1$
 	}
 
@@ -158,7 +159,7 @@ public class TestJstack extends AttachApiTest {
 			buff.append("\n"); //$NON-NLS-1$
 		});
 		log(buff.toString());
-		Optional<String> searchResult = search(TEST_VALUE, jpsOutput);
+		Optional<String> searchResult = StringUtilities.searchSubstring(TEST_VALUE, jpsOutput);
 		assertTrue(searchResult.isPresent(), TEST_PROPERTY + " missing"); //$NON-NLS-1$
 	}
 
@@ -170,8 +171,7 @@ public class TestJstack extends AttachApiTest {
 
 	@BeforeSuite
 	protected void setupSuite() {
-		assertTrue("This test is valid only on OpenJ9", //$NON-NLS-1$
-				System.getProperty("java.vm.vendor").contains("OpenJ9")); //$NON-NLS-1$//$NON-NLS-2$
+		assertTrue(PlatformInfo.isOpenJ9(), "This test is valid only on OpenJ9"); //$NON-NLS-1$
 		getJdkUtilityPath(JSTACK_COMMAND);
 	}
 

--- a/test/functional/TestUtilities/src/org/openj9/test/util/StringUtilities.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/StringUtilities.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.util;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Utility methods for String input and output.
+ *
+ */
+public class StringUtilities {
+
+	/**
+	 * Find the first occurrence of a substring in a list of Strings.
+	 * @param needle pattern for which to search
+	 * @param haystack list of Strings to search
+	 * @return Optional which is either empty or contains matching string 
+	 */
+	public static Optional<String> searchSubstring(String needle, List<String> haystack) {
+		return haystack.stream().filter(s -> s.contains(needle)).findFirst();
+	}
+	
+
+	/**
+	 * Determine if a pattern (needle) matches exactly  in a list of Strings.
+	 * @param needle pattern for which to search
+	 * @param haystack list of Strings to search
+	 * @return true if at least one member of haystack equals needle 
+	 */
+	public static boolean contains(String needle, List<String> haystack) {
+		return haystack.stream().anyMatch(s -> s.equals(needle));
+	}
+}


### PR DESCRIPTION
Rename search() to searchSubstring() and move it to a common utility class.
Add a method to do exact string comparison in  a list.  Update TestJps to use
exact comparison where appropriate.

Minor cleanup: replace ad-hoc setup code with common utilities.

Fixes https://github.com/eclipse/openj9/issues/5569.

[ci skip]

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>