### PR TITLE
Cache resolved methods at the compilation level

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9621,8 +9621,11 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
    TR_DataCache *dataCache = NULL;
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
    if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
-      // end of compilation, clear per-compilation IProfiler cache
+      {
+      // end of compilation, clear per-compilation caches
       ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearIProfilerMap(comp->trMemory());
+      ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearResolvedMethodInfoMap(comp->trMemory());
+      }
 
    if (details.isNewInstanceThunk())
       {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2882,9 +2882,6 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Mem
    if (rtResolve)
       jitConfig->runtimeFlags |= J9JIT_RUNTIME_RESOLVE; // JITaaS FIXME: don't change global flags
 
-   // disable caching of resolved methods if env variable TR_DisableResolvedMethodsCaching is set
-   TR_ResolvedJ9JITaaSServerMethod::_useCaching = !feGetEnv("TR_DisableResolvedMethodsCaching");
-
    unpackRegex(options->_disabledOptTransformations);
    unpackRegex(options->_disabledInlineSites);
    unpackRegex(options->_disabledOpts);

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -248,11 +248,16 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
       void clearIProfilerMap(TR_Memory *trMemory);
       bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
       TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
+      void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo);
+      bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedJ9JITaaSServerMethod *owningMethod, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
+      TR_ResolvedMethodKey getResolvedMethodKey(TR_ResolvedMethodType type, TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_OpaqueClassBlock *classObject=NULL);
+      void clearResolvedMethodInfoMap(TR_Memory *trMemory);
    private:
       TR_PersistentMethodInfo *_recompilationMethodInfo;
       uint32_t _seqNo;
       bool _waitToBeNotified; // accessed with clientSession->_sequencingMonitor in hand
       IPTableHeap_t *_methodIPDataPerComp;
+      TR_ResolvedMethodInfoCache *_resolvedMethodInfoMap;
    };
 }
 


### PR DESCRIPTION
Previously, resolved methods were cached
per resolved method, i.e. each resolved method
stored a map of resolved methods it called.
A slightly more efficient strategy is to store
resolved methods in one per compilation cache,
which is what this commit implements.

The biggest challenge is that a resolved
method, belonging to one RAM class, might have
different owning methods (callers). Thus, we
cannot simply store a pointer to a resolved method.
Instead, we now cache method info struct, from
which a resolved method with an aprropriate owning
method is recreated at cache access.