### PR TITLE
Restore Escape Analysis refinement

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2371,8 +2371,16 @@ bool TR_EscapeAnalysis::checkAllNewsOnRHSInLoopWithAliasing(int32_t defIndex, TR
 
          for (Candidate *otherAllocNode = _candidates.getFirst(); otherAllocNode; otherAllocNode = otherAllocNode->getNext())
             {
+            // A reaching definition that is an allocation node for a candidate
+            // for stack allocation is harmless.  Also, a reaching definition
+            // that has the value number of a candidate allocation, other than the
+            // current candidate, is harmless.  The added restriction in the
+            // second case avoids allowing the current candidate through from a
+            // a previous loop iteration. 
             if (otherAllocNode->_node == firstChild
-                || _valueNumberInfo->getValueNumber(otherAllocNode->_node) == _valueNumberInfo->getValueNumber(firstChild))
+                   || (candidate->_node != otherAllocNode->_node
+                       && _valueNumberInfo->getValueNumber(otherAllocNode->_node)
+                            == _valueNumberInfo->getValueNumber(firstChild)))
                {
                rhsIsHarmless = true;
                break;

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -584,7 +584,8 @@ class TR_EscapeAnalysis : public TR::Optimization
    TR_UseDefInfo             *_useDefInfo;
    bool                      _invalidateUseDefInfo;
    TR_BitVector              *_otherDefsForLoopAllocation;
-   TR_BitVector              *_localObjectsValueNumbers;
+   TR_BitVector              *_nonColdLocalObjectsValueNumbers;
+   TR_BitVector              *_allLocalObjectsValueNumbers;
    TR_BitVector              *_notOptimizableLocalObjectsValueNumbers;
    TR_BitVector              *_notOptimizableLocalStringObjectsValueNumbers;
    TR_BitVector              *_blocksWithFlushOnEntry;


### PR DESCRIPTION
This pull request restores a refinement to Escape Analysis (EA) that Andrew Craik @andrewcraik had prototyped, and adds a fix for problem it encountered.  That refinement had been reverted under pull request #5421 as a fix for issue #5379.

The problem described in issue #5379 can be reproduced with the following test, which will end up throwing a `RuntimeException` after EA runs, if https://github.com/eclipse/openj9/commit/e6991e539d1437dbfe734abe46826a43f2383434 is applied.  That's because EA allocates the array that is assigned to `z` below on the stack, though it shouldn't be stack allocated, as an instance of `z` allocated in one iteration of the `do-while` loop escapes to the next iteration - that is, two instances of the array assigned to `z` might be defined and referenced during a single iteration of the `do-while` loop.

```
public class Experiment {
    public static final void main(String[] args) {
        for (long i = 0; i < 10000000; i++) {
            tryIt();
        }
    }

    public static int tryIt() {
        int[] y = new int[] {1,2,3,4,5};
        int sum = 0;
        int prevsum = -1;

        do {
            if (prevsum == sum) throw new RuntimeException("Wrong!");

            prevsum = sum;
            int[] z = new int[5];
            for (int i = 0; i < z.length; i++) z[i] = y[i % y.length] * 2;
            for (int i = 0; i < y.length; i++) sum = sum + y[i];
            y = z;
        } while (sum < 10000000);

        return prevsum;
    }
}
```

The problem lies with [this condition in `EscapeAnalysis.cpp`](https://github.com/eclipse/openj9/blob/c2eb8ed7f2ebc2f9d45d6d7c852027f0843747c1/runtime/compiler/optimizer/EscapeAnalysis.cpp#L2375).  In the process of looking at all reaching definitions for a particular use of a candidate for stack allocation, the code is deciding whether those reaching definitions are "harmless."  One case that's considered harmless is a reaching definition that is itself a candidate for stack allocation.

Previously, the check for whether a definition was a candidate checked whether the definition was a reference to the candidate's allocation node.  Commit c2eb8ed7f2ebc2f9d45d6d7c852027f0843747c1 expanded that to allow the value number of the definition to match the candidate's allocation node.

The problem is that, if the current candidate is the allocation that appears in the declaration of `z`, that allows the definition of `y` from the assignment `y = z` that reaches references to `y` to be considered harmless.  That's because the value number of the RHS in that assignment is equal to the value number of the current candidate's allocation node.

The fix in commit https://github.com/eclipse/openj9/commit/eb5edefe6e2600655bf56164f64e8ccb48aaae18 avoids that by only considering value numbers of candidate allocation nodes other than the candidate that's currently under consideration.