### PR TITLE
Fix assumption that object header size is one slot

### DIFF
--- a/runtime/gc_glue_java/MixedObjectModel.hpp
+++ b/runtime/gc_glue_java/MixedObjectModel.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "modron.h"
+#include "objectdescription.h"
 
 #include "Bits.hpp"
 
@@ -83,6 +84,17 @@ public:
 	getSizeInBytesWithHeader(J9Object *objectPtr)
 	{
 		return getSizeInBytesWithoutHeader(objectPtr) + sizeof(J9Object);
+	}
+	
+	/**
+	* Returns an address of first data slot of the object
+	* @param objectPtr Pointer to the object
+	* @return Address of first data slot of the object
+	*/
+	MMINLINE fomrobject_t *
+	getHeadlessObject(J9Object *objectPtr)
+	{
+		return (fomrobject_t *)((uint8_t*)objectPtr + getHeaderSize(objectPtr));
 	}
 	
 	/**

--- a/runtime/gc_glue_java/MixedObjectScanner.hpp
+++ b/runtime/gc_glue_java/MixedObjectScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,8 +63,8 @@ protected:
 	 * @param[in] flags Scanning context flags
 	 */
 	MMINLINE GC_MixedObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, uintptr_t flags)
-		: GC_ObjectScanner(env, objectPtr, (fomrobject_t *)(objectPtr + 1), 0, flags, J9GC_J9OBJECT_CLAZZ(objectPtr)->instanceHotFieldDescription)
-		, _endPtr((fomrobject_t *)((uint8_t*)_scanPtr + J9GC_J9OBJECT_CLAZZ(objectPtr)->totalInstanceSize))
+		: GC_ObjectScanner(env, objectPtr, env->getExtensions()->mixedObjectModel.getHeadlessObject(objectPtr), 0, flags, J9GC_J9OBJECT_CLAZZ(objectPtr)->instanceHotFieldDescription)
+		, _endPtr((fomrobject_t *)((uint8_t*)_scanPtr + env->getExtensions()->mixedObjectModel.getSizeInBytesWithoutHeader(objectPtr)))
 		, _mapPtr(_scanPtr)
 		, _descriptionPtr(NULL)
 #if defined(J9VM_GC_LEAF_BITS)

--- a/runtime/gc_glue_java/ObjectIterator.hpp
+++ b/runtime/gc_glue_java/ObjectIterator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2014 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ public:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
 		case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
-			return _mixedObjectIterator.initialize(objectPtr);
+			return _mixedObjectIterator.initialize(_omrVM, objectPtr);
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
 			return _pointerContiguousArrayIterator.initialize(objectPtr);
 		case GC_ObjectModel::SCAN_PRIMITIVE_ARRAY_OBJECT:

--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -722,7 +722,7 @@ MM_RealtimeMarkingScheme::scanMixedObject(MM_EnvironmentRealtime *env, J9Object 
 {
 	/* Object slots */
 
-	fj9object_t *scanPtr = (fj9object_t*)( objectPtr + 1 );
+	fj9object_t *scanPtr = _gcExtensions->mixedObjectModel.getHeadlessObject(objectPtr);
 	UDATA objectSize = _gcExtensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
 	fj9object_t *endScanPtr = (fj9object_t*)(((U_8 *)objectPtr) + objectSize);
 	UDATA *descriptionPtr;
@@ -793,7 +793,7 @@ MM_RealtimeMarkingScheme::scanMixedObject(MM_EnvironmentRealtime *env, J9Object 
 MMINLINE UDATA
 MM_RealtimeMarkingScheme::scanReferenceMixedObject(MM_EnvironmentRealtime *env, J9Object *objectPtr)
 {
-	fj9object_t *scanPtr = (fj9object_t*)( objectPtr + 1 );
+	fj9object_t *scanPtr = _gcExtensions->mixedObjectModel.getHeadlessObject(objectPtr);
 	UDATA objectSize = _gcExtensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
 	fj9object_t *endScanPtr = (fj9object_t*)(((U_8 *)objectPtr) + objectSize);
 	UDATA *descriptionPtr;

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -499,7 +499,7 @@ MM_GlobalMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obje
 	markObjectClass(env, objectPtr);
 
 	/* Object slots */
-	volatile fj9object_t *scanPtr = (fj9object_t*)( objectPtr + 1 );
+	volatile fj9object_t *scanPtr = _extensions->mixedObjectModel.getHeadlessObject(objectPtr);
 	UDATA objectSize = _extensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
 
 	updateScanStats(env, objectSize, reason);
@@ -510,7 +510,7 @@ MM_GlobalMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obje
 	leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr)->instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 
-	if(((UDATA)descriptionPtr) & 1) {
+	if (((UDATA)descriptionPtr) & 1) {
 		descriptionBits = ((UDATA)descriptionPtr) >> 1;
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits = ((UDATA)leafPtr) >> 1;
@@ -523,7 +523,7 @@ MM_GlobalMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obje
 	}
 	descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 
-	while(scanPtr < endScanPtr) {
+	while (scanPtr < endScanPtr) {
 		/* Determine if the slot should be processed */
 		if(descriptionBits & 1) {
 			/* As this function can be invoked during concurent mark the slot is
@@ -546,7 +546,7 @@ MM_GlobalMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obje
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits >>= 1;
 #endif /* J9VM_GC_LEAF_BITS */
-		if(descriptionIndex-- == 0) {
+		if (descriptionIndex-- == 0) {
 			descriptionBits = *descriptionPtr++;
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits = *leafPtr++;
@@ -615,7 +615,7 @@ MM_GlobalMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Obj
 		}
 	}
 
-	volatile fj9object_t * scanPtr = (fj9object_t*)( objectPtr + 1 );
+	volatile fj9object_t * scanPtr = _extensions->mixedObjectModel.getHeadlessObject(objectPtr);
 	UDATA objectSize = _extensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
 	endScanPtr = (fj9object_t*)(((U_8 *)objectPtr) + objectSize);
 

--- a/runtime/gc_vlhgc/PartialMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.cpp
@@ -486,7 +486,7 @@ MM_PartialMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obj
 	markObjectClass(env, objectPtr);
 	
 	/* Object slots */
-	volatile fj9object_t* scanPtr = (fj9object_t*)( objectPtr + 1 );
+	volatile fj9object_t* scanPtr = _extensions->mixedObjectModel.getHeadlessObject(objectPtr);
 	UDATA objectSize = _extensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
 
 	updateScanStats(env, objectSize, reason);
@@ -497,7 +497,7 @@ MM_PartialMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obj
 	leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr)->instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 
-	if(((UDATA)descriptionPtr) & 1) {
+	if (((UDATA)descriptionPtr) & 1) {
 		descriptionBits = ((UDATA)descriptionPtr) >> 1;
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits = ((UDATA)leafPtr) >> 1;
@@ -510,7 +510,7 @@ MM_PartialMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obj
 	}
 	descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 
-	while(scanPtr < endScanPtr) {
+	while (scanPtr < endScanPtr) {
 		/* Determine if the slot should be processed */
 		if (descriptionBits & 1) {
 			/* As this function can be invoked during concurent mark the slot is
@@ -533,7 +533,7 @@ MM_PartialMarkingScheme::scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *obj
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits >>= 1;
 #endif /* J9VM_GC_LEAF_BITS */
-		if(descriptionIndex-- == 0) {
+		if (descriptionIndex-- == 0) {
 			descriptionBits = *descriptionPtr++;
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits = *leafPtr++;
@@ -605,7 +605,7 @@ MM_PartialMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Ob
 		}
 	}
 
-	volatile fj9object_t* scanPtr = (fj9object_t*)( objectPtr + 1 );
+	volatile fj9object_t* scanPtr = _extensions->mixedObjectModel.getHeadlessObject(objectPtr);
 	UDATA objectSize = _extensions->mixedObjectModel.getSizeInBytesWithHeader(objectPtr);
 	endScanPtr = (fj9object_t*)(((U_8 *)objectPtr) + objectSize);
 
@@ -616,7 +616,7 @@ MM_PartialMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Ob
 	leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr)->instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 
-	if(((UDATA)descriptionPtr) & 1) {
+	if (((UDATA)descriptionPtr) & 1) {
 		descriptionBits = ((UDATA)descriptionPtr) >> 1;
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits = ((UDATA)leafPtr) >> 1;
@@ -629,9 +629,9 @@ MM_PartialMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Ob
 	}
 	descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 
-	while(scanPtr < endScanPtr) {
+	while (scanPtr < endScanPtr) {
 		/* Determine if the slot should be processed */
-		if((descriptionBits & 1) && ((scanPtr != referentPtr.readAddressFromSlot()) || referentMustBeMarked)) {
+		if ((descriptionBits & 1) && ((scanPtr != referentPtr.readAddressFromSlot()) || referentMustBeMarked)) {
 			/* As this function can be invoked during concurrent mark the slot is
 			 * volatile so we must ensure that the compiler generates the correct
 			 * code if markObject() is inlined.
@@ -652,7 +652,7 @@ MM_PartialMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Ob
 #if defined(J9VM_GC_LEAF_BITS)
 		leafBits >>= 1;
 #endif /* J9VM_GC_LEAF_BITS */
-		if(descriptionIndex-- == 0) {
+		if (descriptionIndex-- == 0) {
 			descriptionBits = *descriptionPtr++;
 #if defined(J9VM_GC_LEAF_BITS)
 			leafBits = *leafPtr++;


### PR DESCRIPTION
In GC_MixedObjectScanner constructor object header size is hard coded to
one slot. Technically it is not correct because object header size can
be changed. This code should request MixedObjectModel for value.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>