### PR TITLE
Make DecimalFormatHelper optional

### DIFF
--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -452,7 +452,10 @@ void TR_StringPeepholes::processBlock(TR::Block *block)
                }
             }
 
-         if (comp()->isOutermostMethod() && !optimizer()->isIlGenOpt() && !comp()->getOption(TR_DisableDecimalFormatPeephole))
+         // check that the helper class is available before invoking the matcher
+         TR_OpaqueClassBlock *DFHClass = fe()->getClassFromSignature("com/ibm/jit/DecimalFormatHelper", 31, comp()->getCurrentMethod());
+         if (comp()->isOutermostMethod() && !optimizer()->isIlGenOpt() && !comp()->getOption(TR_DisableDecimalFormatPeephole) &&
+            DFHClass != NULL)
             {
             TR::TreeTop *newTree = detectFormatPattern(tt, exit, callNode);
             if (newTree)


### PR DESCRIPTION
By checking if the decimal format helper class is available before
running the decimalFormatPeephole optimisation we can make the JIT
tolerate the absence of the class, effectively making the opt switchable
by adding or removing the helper class. This improves flexibility for
deployment and serviceability.