### PR TITLE
Change tabs to spaces in echo messages for build.xml files

### DIFF
--- a/test/TestConfig/src/build_envInfo.xml
+++ b/test/TestConfig/src/build_envInfo.xml
@@ -37,8 +37,8 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===debug:				on</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===debug:                        on</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${JAVAC}" includeAntRuntime="false" encoding="ISO-8859-1"/>
 	</target>
 

--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -52,10 +52,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:       yes</echo>
-		<echo>===executable: ${compiler.javac}</echo>
-		<echo>===debug:      on</echo>
-		<echo>===destdir:    ${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${transformerListener}" />

--- a/test/functional/IllegalAccessError_for_protected_method/build.xml
+++ b/test/functional/IllegalAccessError_for_protected_method/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<classpath>

--- a/test/functional/InstrumentationAgent/build.xml
+++ b/test/functional/InstrumentationAgent/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,10 +43,10 @@
 	<target name="compile" depends="init" description="using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 				</javac>

--- a/test/functional/JIT_Test/build.xml
+++ b/test/functional/JIT_Test/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${transformerListener}" />

--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@
 
 	<target name="compile" depends="init" description="using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
-		<echo>========COMPILER SETTINGS========</echo>
+		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>

--- a/test/functional/Java10andUp/build.xml
+++ b/test/functional/Java10andUp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,10 +46,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}"/>

--- a/test/functional/Java11andUp/build.xml
+++ b/test/functional/Java11andUp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,10 +47,10 @@
 		<echo>Ant version is ${ant.version}"</echo>
 		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:		${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:			${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<include name="**/condy/BootstrapMethods.java" />
@@ -82,10 +82,10 @@
 	<target name="compile" depends="generate_condy" description="Using java ${JDK_VERSION} to compile the source" >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:		${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:			${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>

--- a/test/functional/Java12andUp/build.xml
+++ b/test/functional/Java12andUp/build.xml
@@ -44,10 +44,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source" >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:		${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:			${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>

--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -143,10 +143,10 @@
 	<target name="compile" depends="jasm_generator" description="using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:		${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:			${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>

--- a/test/functional/Java9andUp/build.xml
+++ b/test/functional/Java9andUp/build.xml
@@ -52,10 +52,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />

--- a/test/functional/JavaAgentTest/build.xml
+++ b/test/functional/JavaAgentTest/build.xml
@@ -41,9 +41,10 @@
 	</target>
 
 	<target name="compile" depends="init" description="compile the source " >
-		<echo>===Ant version: ${ant.version}</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<matches string="${JDK_VERSION}" pattern="^(8|9|10|11)$$" />
 			<then>

--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,10 +53,10 @@
 		<echo>Ant version is ${ant.version}</echo>
 		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<include name="**/indyn/BootstrapMethods.java" />
@@ -107,10 +107,10 @@
 		<echo>Ant version is ${ant.version}</echo>
 		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>
@@ -141,10 +141,10 @@
 	<target name="compile" depends="compile_bootstrap, generate_indyn" description="compile the test source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>

--- a/test/functional/Jsr335/build.xml
+++ b/test/functional/Jsr335/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${transformerListener}" />

--- a/test/functional/Jsr335_interfaceStaticMethod/build.xml
+++ b/test/functional/Jsr335_interfaceStaticMethod/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,10 @@
 	<target name="compile.generator" depends="init" description="Compile SimpleInvokeStaticGenerator">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<echo>Compiling Everything but InvokeStaticTest and classes where they are referenced</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false"
 				excludes="org/openj9/test/jsr335/interfaceStaticMethod/InvokeStaticTest*" encoding="ISO-8859-1">
@@ -81,10 +81,10 @@
 	<target name="compile" depends="generate.invokeStatic" description="Compile InvokeStaticTest" >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<echo>Compiling InvokeStaticTest and classes where they are referenced</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"
 			includes="org/openj9/test/jsr335/interfaceStaticMethod/InvokeStaticTest*">

--- a/test/functional/NativeTest/jniargtests/build.xml
+++ b/test/functional/NativeTest/jniargtests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-   Copyright (c) 2006, 2018 IBM Corp. and others
+   Copyright (c) 2006, 2019 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,16 +37,16 @@
 		<mkdir dir="${build}" />
 	</target>
 	<target name="compile" depends="init" description="compile the source " >
-			<echo>Ant version is ${ant.version}</echo>
-			<echo>============COMPILER SETTINGS============</echo>
-			<echo>===fork:				yes</echo>
-			<echo>===executable:			${compiler.javac}</echo>
-			<echo>===debug:				on</echo>
-			<echo>===destdir:				${DEST}</echo>
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		
-			<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-				<src path="${src}" />
-			</javac>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+		</javac>
 	</target>
 	<target name="dist" depends="compile" description="generate the distribution" >
 		<jar jarfile="${DEST}/jniargtests.jar" filesonly="true">

--- a/test/functional/OpenJ9_Jsr_292_API/build.xml
+++ b/test/functional/OpenJ9_Jsr_292_API/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-   Copyright (c) 2017, 2018 IBM Corp. and others
+   Copyright (c) 2017, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,10 +63,10 @@
 		<echo>Ant version is ${ant.version}</echo>
 		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
@@ -86,10 +86,10 @@
 		<echo>Ant version is ${ant.version}</echo>
 		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
@@ -109,10 +109,10 @@
 		<echo>Ant version is ${ant.version}</echo>
 		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
@@ -131,10 +131,10 @@
 		<echo>Compiling the test source code</echo>
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>

--- a/test/functional/Panama/build.xml
+++ b/test/functional/Panama/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,10 +51,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
 				<src path="${src}"/>
 				<src path="${transformerListener}" />

--- a/test/functional/SharedCPEntryInvokerTests/build.xml
+++ b/test/functional/SharedCPEntryInvokerTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,10 +43,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<!-- Compile agent first, then tests -->
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
     			<src path="${redefineclassagent}"/>

--- a/test/functional/TestExample/build.xml
+++ b/test/functional/TestExample/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 			<src path="${transformerListener}" />

--- a/test/functional/UnsafeTest/build.xml
+++ b/test/functional/UnsafeTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,10 +47,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>

--- a/test/functional/VM_Test/build.xml
+++ b/test/functional/VM_Test/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,10 +63,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<javac srcdir="${data}/InvalidClasspathResource1" destdir="${databin}/InvalidClasspathResource1" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" />
 		<javac srcdir="${data}/InvalidClasspathResource2" destdir="${databin}/InvalidClasspathResource2" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" />

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,10 +47,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${transformerListener}" />

--- a/test/functional/cmdLineTests/J9security/build.xml
+++ b/test/functional/cmdLineTests/J9security/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 	
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />

--- a/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,10 +50,10 @@
 	<target name="compile" depends="init" description="Compile the source" >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>	
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<!--
 		1.) Copy URLClassLoaderTests xml and script files ...

--- a/test/functional/cmdLineTests/gcRegressionTests/build.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 	
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />

--- a/test/functional/cmdLineTests/javaAssertions/build.xml
+++ b/test/functional/cmdLineTests/javaAssertions/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2018, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 		</javac>
 	</target>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<classpath>
 				<pathelement location="${JAVA_BIN}/../../lib/tools.jar" /><!-- tools.jar is only used for Java8 compiler-->

--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,7 +45,7 @@
 
 	<target name="compile" depends="init" description="compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
-		<echo>========COMPILER SETTINGS========</echo>
+		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>

--- a/test/functional/cmdLineTests/lazyClassLoadingTest/build.xml
+++ b/test/functional/cmdLineTests/lazyClassLoadingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 	</target>
 

--- a/test/functional/cmdLineTests/libpathTest/build.xml
+++ b/test/functional/cmdLineTests/libpathTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 	</target>
 

--- a/test/functional/cmdLineTests/loadLibraryTest/build.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 	</target>
 

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>

--- a/test/functional/cmdLineTests/openssl/build.xml
+++ b/test/functional/cmdLineTests/openssl/build.xml
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"/>
 	</target>

--- a/test/functional/cmdLineTests/proxyFieldAccess/build.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,10 +36,10 @@
 	<target name="compile" description="using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:		${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:			${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<if>
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 			<then>

--- a/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
 		</javac>

--- a/test/functional/cmdLineTests/shareClassTests/DataHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/DataHelperTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Compile the source" >	
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<!--
 		1.) Copy config files and java ...

--- a/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,10 +43,10 @@
 	<target name="compile" depends="init" description="Compile the source" >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" debuglevel="lines,vars,source" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 	</target>
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Compile the source" >	
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>	
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<copy todir="${build}">
 			<fileset dir="${src}" includes="*.bat,*.sh,*.xml,*.pl" excludes="playlist.xml" />

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatibilityTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatibilityTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,10 +53,10 @@
 	<target name="compile" depends="init,AddTestClassesToPackage,AddBatchAndScriptFilesToPackage" description="Compile the source" >	
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>	
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<copy todir="${build}">
 			<fileset dir="${src}" includes="*.xml,*.java" excludes="playlist.xml" />

--- a/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,10 @@
 	<target name="compile" depends="init" description="Compile the source" >	
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>		
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
 			<src path="${src}" />

--- a/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,10 +44,10 @@
 	<target name="compile" depends="init" description="Compile the source" >	
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>	
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		
 		<!--
 		1.) APITests directory ...

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,10 +57,10 @@
 	<target name="compile" depends="init,AddTestClassesToPackage, AddBatchAndScriptFilesToPackage"  description="compile the source">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>	
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 		<!--
 		1.) Copy config files ...

--- a/test/functional/cmdLineTests/utils/build.xml
+++ b/test/functional/cmdLineTests/utils/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 	</target>
 

--- a/test/functional/cmdLineTests/vmRuntimeState/build.xml
+++ b/test/functional/cmdLineTests/vmRuntimeState/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
 			<src path="${src}" />
 		</javac>

--- a/test/functional/cmdline_options_tester/build.xml
+++ b/test/functional/cmdline_options_tester/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,10 +46,10 @@
 	<target name="compile" depends="init" description="compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${j9exclude_file_support}"/>

--- a/test/functional/cmdline_options_testresources/build.xml
+++ b/test/functional/cmdline_options_testresources/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,10 @@
 	<target name="compile" depends="init" description="compile the source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
-		<echo>===fork:				yes</echo>
-		<echo>===executable:			${compiler.javac}</echo>
-		<echo>===debug:				on</echo>
-		<echo>===destdir:				${DEST}</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
 
 
 		<if>


### PR DESCRIPTION
"echo" messages in the compile target for build.xml should contain spaces instead of tabs. 
These messages in build.xml files in the `test` directory have been updated to contain only spaces.

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>