### PR TITLE
Initialize interface class method ordering

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2753,9 +2753,10 @@ fail:
 				ramClass->initializeStatus = J9ClassInitSucceeded;
 			}
 
-			/* If the class is an interface, fill in the iTableMethodCount */
+			/* If the class is an interface, fill in the iTableMethodCount and method ordering table */
 			if (J9ROMCLASS_IS_INTERFACE(romClass)) {
 				J9INTERFACECLASS_SET_ITABLEMETHODCOUNT(ramClass, iTableMethodCount);
+				J9INTERFACECLASS_SET_METHODORDERING(ramClass, NULL);
 			}
 
 			Trc_VM_initializeRAMClass_End(vmThread, J9UTF8_LENGTH(className), J9UTF8_DATA(className), classSize, classLoader);


### PR DESCRIPTION
The method ordering re-uses the finalizeLinkOffset field, which is
usually 0 for interface classes, but not always. Explicitly initialize
the ordering to NULL when an interface class is created.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>