### PR TITLE
 Cache resolved methods inside heuristic regions 

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -4344,7 +4344,20 @@ TR::CompilationInfoPerThreadRemote::getCachedResolvedMethod(TR_ResolvedMethodKey
          
       if (*resolvedMethod)
          {
-         if (unresolvedInCP) *unresolvedInCP = false;
+         if (comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager) && !comp->getSymbolValidationManager()->inHeuristicRegion())
+            {
+            auto serverMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(*resolvedMethod);
+            if(!serverMethod->addValidationRecordForCachedResolvedMethod(key))
+               {
+               // Could not add a validation record
+               *resolvedMethod = NULL;
+               if (unresolvedInCP) *unresolvedInCP = true;
+               }
+            }
+         else
+            {
+            if (unresolvedInCP) *unresolvedInCP = false;
+            }
          return true;
          }
       else

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -273,6 +273,7 @@ public:
    bool inROMClass(void *address);
    static void createResolvedMethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
+   bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key);
 
 protected:
    JITaaS::J9ServerStream *_stream;


### PR DESCRIPTION
If a resolved method is created and cached inside heuristic
region, validation record will not be created.
However, when resolved method is retrieved from the cache
outisde of heuristic region, we need to add validation record,
which is what this change implements