### PR TITLE
cache optimization for classByName

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -863,8 +863,7 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
                                    : TR::CompilationInfoPerThreadBase(compInfo, jitConfig, id, true),
                                      _compThreadCPU(_compInfo.persistentMemory()->getPersistentInfo(), jitConfig, 490000000, id),
                                      _thunksToBeRelocated(ThunkVectorAllocator(TR::Compiler->persistentAllocator())),
-                                     _invokeExactThunksToBeRelocated(InvokeExactThunkVectorAllocator(TR::Compiler->persistentAllocator())),
-                                     _customClassByNameMap(decltype(_customClassByNameMap)::allocator_type(TR::Compiler->persistentAllocator()))
+                                     _invokeExactThunksToBeRelocated(InvokeExactThunkVectorAllocator(TR::Compiler->persistentAllocator()))
    {
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
    _initializationSucceeded = false;
@@ -4114,8 +4113,6 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
    // Unpin the class
    if (!entry.isOutOfProcessCompReq())
       compThread->javaVM->internalVMFunctions->j9jni_deleteLocalRef((JNIEnv*)compThread, classObject);
-   else
-      _customClassByNameMap.clear(); // reset before next compilation starts
 
    // Update how many compilation threads are working on hot/scorching methods
    if (entry._hasIncrementedNumCompThreadsCompilingHotterMethods)

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -329,33 +329,6 @@ private:
    }; // CompilationInfoPerThreadBase
 }
 
-struct ClassLoaderStringPair
-   {
-   J9ClassLoader *_classLoader;
-   std::string    _className;
-
-   bool operator==(const ClassLoaderStringPair &other) const
-      {
-      return _classLoader == other._classLoader &&  _className == other._className;
-      }
-   };
-
-
-// custom specialization of std::hash injected in std namespace
-namespace std
-   {
-   template<> struct hash<ClassLoaderStringPair>
-      {
-      typedef ClassLoaderStringPair argument_type;
-      typedef std::size_t result_type;
-      result_type operator()(argument_type const& clsPair) const noexcept
-         {
-         return std::hash<void*>()((void*)(clsPair._classLoader)) ^ std::hash<std::string>()(clsPair._className);
-         }
-      };
-   }
-
-
 //--------------------------------------------------------------------
 // The following class will be use by the separate compilation threads
 // TR::CompilationInfoPerThreadBase will be used by compilation on application thread
@@ -412,7 +385,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    void                   addInvokeExactThunkToBeRelocated(TR_J2IThunk *thunk);
    void                   relocateThunks();
    void                   persistThunksToSCC(const J9JITDataCacheHeader *cacheEntry, uint8_t * existingCode);
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getCustomClassByNameMap() { return _customClassByNameMap; }
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() { return _classesThatShouldNotBeNewlyExtended; }
    uint32_t               getLastLocalGCCounter() { return _lastLocalGCCounter; }
    void                   updateLastLocalGCCounter(); 
@@ -440,7 +412,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    std::vector<TR_J2IThunk *, InvokeExactThunkVectorAllocator> _invokeExactThunksToBeRelocated;
    // The following hastable caches <classLoader,classname> --> <J9Class> mappings
    // The cache only lives during a compilation due to class unloading concerns
-   PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> _customClassByNameMap;
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;
    uint32_t               _lastLocalGCCounter;
 

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2844,7 +2844,7 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _chTableClassMap(decltype(_chTableClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _romClassMap(decltype(_romClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _J9MethodMap(decltype(_J9MethodMap)::allocator_type(TR::Compiler->persistentAllocator())),
-   _systemClassByNameMap(decltype(_systemClassByNameMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classByNameMap(decltype(_classByNameMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _classChainDataMap(decltype(_classChainDataMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _unloadedClassAddresses(NULL),
    _requestUnloadedClasses(true),
@@ -2855,7 +2855,7 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _inUse = 1;
    _numActiveThreads = 0;
    _romMapMonitor = TR::Monitor::create("JIT-JITaaSROMMapMonitor");
-   _systemClassMapMonitor = TR::Monitor::create("JIT-JITaaSSystemClassMapMonitor");
+   _classMapMonitor = TR::Monitor::create("JIT-JITaaSClassMapMonitor");
    _classChainDataMapMonitor = TR::Monitor::create("JIT-JITaaSClassChainDataMapMonitor");
    _sequencingMonitor = TR::Monitor::create("JIT-JITaaSSequencingMonitor");
    _vmInfo = NULL;
@@ -2867,7 +2867,7 @@ ClientSessionData::~ClientSessionData()
    {
    clearCaches();
    _romMapMonitor->destroy();
-   _systemClassMapMonitor->destroy();
+   _classMapMonitor->destroy();
    _classChainDataMapMonitor->destroy();
    _sequencingMonitor->destroy();
    if (_unloadedClassAddresses)
@@ -2885,7 +2885,9 @@ ClientSessionData::processUnloadedClasses(JITaaS::J9ServerStream *stream, const 
    {
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server will process a list of %u unloaded classes for clientUID %llu", (unsigned)classes.size(), (unsigned long long)_clientUID);
-
+   //Vector to hold the list of the unloaded classes and the corresponding data needed for purging the Caches
+   std::vector<ClassUnloadedData> unloadedClasses;
+   unloadedClasses.reserve(classes.size());
    bool updateUnloadedClasses = true;
    if (_requestUnloadedClasses)
       {
@@ -2916,9 +2918,21 @@ ClientSessionData::processUnloadedClasses(JITaaS::J9ServerStream *stream, const 
 
          auto it = _romClassMap.find((J9Class*) clazz);
          if (it == _romClassMap.end())
+            {
+            //Class is not cached so this entry will be used to delete the entry from caches by value.
+            ClassLoaderStringPair key;
+            unloadedClasses.push_back({clazz, key, NULL, false});
             continue; // unloaded class was never cached
-
+            }
          J9ROMClass *romClass = it->second.romClass;
+
+         J9UTF8 *clazzName = NNSRP_GET(romClass->className, J9UTF8 *);
+         std::string className((const char *)clazzName->data, (int32_t)clazzName->length);
+         J9ClassLoader * cl = (J9ClassLoader *)(it->second.classLoader);
+         ClassLoaderStringPair key = {cl, className};
+         //Class is cached, so retain the data to be used for purging the caches.
+         unloadedClasses.push_back({clazz, key, NULL, true});
+
          J9Method *methods = it->second.methodsOfClass;
          // delete all the cached J9Methods belonging to this unloaded class
          for (size_t i = 0; i < romClass->romMethodCount; i++)
@@ -2947,12 +2961,42 @@ ClientSessionData::processUnloadedClasses(JITaaS::J9ServerStream *stream, const 
          _romClassMap.erase(it);
          }
       }
+
+      {
       OMR::CriticalSection processUnloadedClasses(getClassChainDataMapMonitor());
 
       //remove the class chain data from the cache for the unloaded class.
       for (auto clazz : classes)
          _classChainDataMap.erase((J9Class*)clazz);
+      }
 
+      {
+      OMR::CriticalSection classMapCS(getClassMapMonitor());
+      auto it = unloadedClasses.begin();
+      while (it != unloadedClasses.end())
+         {
+         if (it->_cached)
+            {
+            getClassByNameMap().erase(it->_pair);
+            }
+         else
+            {
+            //If the class is not cached this is the place to iterate the cache(Map) for deleting the entry by value rather then key.
+            auto itClass = getClassByNameMap().begin();
+            while (itClass != getClassByNameMap().end())
+               {
+               if (itClass->second == it->_class)
+                  {
+                  getClassByNameMap().erase(itClass);
+                  break;
+                  }
+               ++itClass;
+               }
+            }
+         //DO NOT remove the entry from the unloadedClasses as it will be needed to purge other caches.
+         ++it;
+         }
+      }
 
    }
 
@@ -3113,6 +3157,10 @@ ClientSessionData::getOrCacheVMInfo(JITaaS::J9ServerStream *stream)
 void
 ClientSessionData::clearCaches()
    {
+      {
+      OMR::CriticalSection clearCache(getClassMapMonitor());
+      _classByNameMap.clear();
+      }
    OMR::CriticalSection getRemoteROMClass(getROMMapMonitor());
    // Free memory for all hashtables with IProfiler info
    for (auto it : _J9MethodMap)
@@ -3132,12 +3180,14 @@ ClientSessionData::clearCaches()
          it.second._IPData = NULL;
          }
       }
+
    _J9MethodMap.clear();
    // Free memory for j9class info
    for (auto it : _romClassMap)
       {
       it.second.freeClassInfo();
       }
+
    _romClassMap.clear();
 
    _classChainDataMap.clear();
@@ -4111,7 +4161,6 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
 
    setClientData(NULL); // Reset the pointer to the cached client session data
 
-   _customClassByNameMap.clear(); // reset before next compilation starts
    entry._newStartPC = startPC;
    // Update statistics regarding the compilation status (including compilationOK)
    compInfo->updateCompilationErrorStats((TR_CompilationErrorCode)entry._compErrCode);


### PR DESCRIPTION
Currently there are two cache _systemClassByNameMap and
_customClassByNameMap. Both the cache are merged into a
single cache _classByNameMap. Also the _classByNameMap
is a global cache which give a better cache hit.

For unloaded classes purge the global cache(_classByNameMap).

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>