### PR TITLE
Use global name space for shared semaphores on Windows

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Advertisement.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Advertisement.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ public final class Advertisement {
 	private static final String KEY_VERSION = "version"; //$NON-NLS-1$
 	private static final String KEY_PROCESS_ID = "processId"; //$NON-NLS-1$
 	private static final String ADVERT_FILENAME = "attachInfo"; //$NON-NLS-1$
+	private static final String GLOBAL_SEMAPHORE = "globalSemaphore"; //$NON-NLS-1$
 	private Properties props;
 	private final long pid, uid;
 
@@ -81,7 +82,7 @@ public final class Advertisement {
 	 * Factory method to read the data from an advertisement file
 	 * @param advertStream InputStream to an open file
 	 * @return Advertisement object containing the data from the file.
-	 * @throws IOException 
+	 * @throws IOException if file cannot be read
 	 */
 	public static Advertisement readAdvertisementFile(InputStream advertStream) throws IOException {
 		Advertisement advert = null;
@@ -109,7 +110,7 @@ public final class Advertisement {
 		addKeyValue(contentBuffer, KEY_VM_ID, vmId);
 		addKeyValue(contentBuffer, KEY_DISPLAY_NAME, (((null == displayName) || (displayName.length() == 0))? vmId: displayName));
 		addKeyValue(contentBuffer, KEY_NOTIFIER, CommonDirectory.MASTER_NOTIFIER);
-		
+		addKeyValue(contentBuffer, GLOBAL_SEMAPHORE, Boolean.TRUE.toString());
 		File tmpTargetDirectoryFileObject = TargetDirectory.getTargetDirectoryFileObject();
 		File tmpSyncFileObject = TargetDirectory.getSyncFileObject();
 		
@@ -270,6 +271,14 @@ public final class Advertisement {
 	 */
 	public long getUid() {
 		return uid;
+	}
+
+	/**
+	 * 
+	 * @return true if the target uses the global semaphore (Windows only)
+	 */
+	public boolean isGlobalSemaphore() {
+		return Boolean.parseBoolean(props.getProperty(GLOBAL_SEMAPHORE));
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
@@ -481,7 +481,7 @@ public class AttachHandler extends Thread {
 					 * Therefore, notify myself 
 					 */
 					if (wakeHandler) {
-						CommonDirectory.notifyVm(1); 
+						CommonDirectory.notifyVm(1, true); 
 					}
 					destroySemaphore = true;
 				} else if (wakeHandler) {
@@ -493,7 +493,7 @@ public class AttachHandler extends Thread {
 					 * it wakes up.
 					 */
 					setDoCancelNotify(true); /* get the handler thread to close the semaphore */
-					CommonDirectory.notifyVm(numTargets); 
+					CommonDirectory.notifyVm(numTargets, true); 
 					/* CMVC 162086. add an extra notification since the count won't include this VM: the advertisement directory is already deleted */
 				}
 			} finally {

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -230,7 +230,7 @@ public abstract class CommonDirectory {
 	 */
 	static String openSemaphore() throws IOException {
 		String semName = MASTER_NOTIFIER; /*[PR Jazz 48044] semaphore name is a constant */
-		int status = IPC.openSemaphore(getCommonDirFileObject().getAbsolutePath(), semName);
+		int status = IPC.openSemaphore(getCommonDirFileObject().getAbsolutePath(), semName, true);
 		/*[MSG "K0538", "semaphore {0} status= {1}"]*/
 		if (SEMAPHORE_OKAY != status) {
 			throw new IOException(com.ibm.oti.util.Msg.getString("K0538" , semName, Integer.valueOf(status)));  //$NON-NLS-1$
@@ -246,7 +246,7 @@ public abstract class CommonDirectory {
 		int status = 0;
 		IPC.logMessage("reopenSemaphore"); //$NON-NLS-1$
 		closeSemaphore();
-		status = IPC.openSemaphore(getCommonDirFileObject().getAbsolutePath(), MASTER_NOTIFIER);		
+		status = IPC.openSemaphore(getCommonDirFileObject().getAbsolutePath(), MASTER_NOTIFIER, true);		
 		return status;
 	}
 
@@ -267,22 +267,24 @@ public abstract class CommonDirectory {
 	/**
 	 * Open the semaphore, post to it, and close it
 	 * @param numberOfTargets number of times to post to the semaphore
+	 * @param global Use the global semaphore (Windows only)
 	 * @return 0 on success
 	 */
-	public static int notifyVm(int numberOfTargets) {
+	public static int notifyVm(int numberOfTargets, boolean global) {
 		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("notifyVm ", numberOfTargets, " targets"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		return IPC.notifyVm(getCommonDirFileObject().getAbsolutePath(), MASTER_NOTIFIER, numberOfTargets);
+		return IPC.notifyVm(getCommonDirFileObject().getAbsolutePath(), MASTER_NOTIFIER, numberOfTargets, global);
 	}
 
 	/**
 	 * Open the semaphore, decrement it without blocking to it, and close it
 	 * @param numberOfTargets number of times to decrement to the semaphore
+	 * @param global Use the global semaphore (Windows only)
 	 * @return 0 on success
 	 */
-	public static int cancelNotify(int numberOfTargets) {
-		return IPC.cancelNotify(getCommonDirPath(), MASTER_NOTIFIER, numberOfTargets);
+	public static int cancelNotify(int numberOfTargets, boolean global) {
+		return IPC.cancelNotify(getCommonDirPath(), MASTER_NOTIFIER, numberOfTargets, global);
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -167,15 +167,13 @@ public class IPC {
 		}
 	}
 
-	/*[PR Jazz 30075] setupSemaphore was re-doing what createDirectoryAndSemaphore (now called prepareCommonDirectory) did already */
-
 	/**
-	 * 
+	 * Open a semaphore.  On Windows, use the global namespace if requested.
 	 * @param ctrlDir Location of the control file
 	 * @param SemaphoreName key used to identify the semaphore
 	 * @return non-zero on failure
 	 */
-	native static int openSemaphore(String ctrlDir, String SemaphoreName);
+	native static int openSemaphore(String ctrlDir, String SemaphoreName, boolean global);
 
 	/**
 	 * wait for a post on the semaphore for this VM. Use notify() to do the post
@@ -185,19 +183,25 @@ public class IPC {
 
 	/**
 	 * Open the semaphore, post to it, and close it
+	 * @param ctrlDir directory containing the semaphore
+	 * @param semaphoreName name of the semaphore
 	 * @param numberOfTargets number of times to post to the semaphore
+	 * @param global open the semaphore in the global namespace (Windows only)
 	 * @return 0 on success
 	 */
-	native static int notifyVm(String ctrlDir, String SemaphoreName,
-			int numberOfTargets);
+	native static int notifyVm(String ctrlDir, String semaphoreName,
+			int numberOfTargets, boolean global);
 
 	/**
 	 * Open the semaphore, decrement it without blocking to it, and close it
-	 * @param numberOfTargets number of times to decrement to the semaphore
+	 * @param ctrlDir directory containing the semaphore
+	 * @param semaphoreName name of the semaphore
+	 * @param numberOfTargets number of times to post to the semaphore
+	 * @param global open the semaphore in the global namespace (Windows only)
 	 * @return 0 on success
 	 */
-	static native int cancelNotify(String ctrlDir, String SemaphoreName,
-			int numberOfTargets);
+	static native int cancelNotify(String ctrlDir, String semaphoreName,
+			int numberOfTargets, boolean global);
 
 	/**
 	 * close but do not destroy this VM's notification semaphore.

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/WaitLoop.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/WaitLoop.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,7 +81,7 @@ final class WaitLoop extends Thread {
 				if (LOGGING_DISABLED != loggingStatus) {
 					IPC.logMessage("iteration ", AttachHandler.notificationCount, " waitForNotification cancelNotify"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
-				CommonDirectory.cancelNotify(AttachHandler.getNumberOfTargets());
+				CommonDirectory.cancelNotify(AttachHandler.getNumberOfTargets(), true);
 			}
 			return null;
 		} 
@@ -107,7 +107,7 @@ final class WaitLoop extends Thread {
 						IPC.logMessage("semaphore recovery: send test post"); //$NON-NLS-1$
 						int numTargets = CommonDirectory.countTargetDirectories();
 						AttachHandler.setNumberOfTargets(numTargets);
-						CommonDirectory.notifyVm(numTargets); 
+						CommonDirectory.notifyVm(numTargets, true); 
 						CommonDirectory.releaseMasterLock();
 					}
 					return waitForNotification(false);

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -428,7 +428,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 				} else {
 					lockAllAttachNotificationSyncFiles(vmds);
 					numberOfTargets = CommonDirectory.countTargetDirectories();
-					int status = CommonDirectory.notifyVm(numberOfTargets);
+					int status = CommonDirectory.notifyVm(numberOfTargets, descriptor.isGlobalSemaphore());
 					/*[MSG "K0532", "status={0}"]*/
 					if ((IPC.JNI_OK != status)
 							&& (CommonDirectory.J9PORT_INFO_SHSEM_OPENED_STALE != status)) {
@@ -468,7 +468,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 				}
 				if (numberOfTargets > 0) { /*[PR 48044] if number of targets is 0, then the VM is attaching to itself  and the semaphore was not involved */
 					unlockAllAttachNotificationSyncFiles();
-					CommonDirectory.cancelNotify(numberOfTargets);
+					CommonDirectory.cancelNotify(numberOfTargets, descriptor.isGlobalSemaphore());
 
 					if (numberOfTargets > 2) {
 						try {

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachineDescriptor.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachineDescriptor.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.attacher;
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,7 @@ final class OpenJ9VirtualMachineDescriptor extends VirtualMachineDescriptor {
 	private final String attachSyncFileValue;
 	private final long processId;
 	private final long uid;
+	private final boolean globalSemaphore;
 
 	/**
 	 * @param provider AttachProvider associated with this VM
@@ -70,6 +71,7 @@ final class OpenJ9VirtualMachineDescriptor extends VirtualMachineDescriptor {
 		replyFile = null;
 		processId = 0;
 		uid = 0;
+		globalSemaphore = true;
 	}
 
 	/**
@@ -82,6 +84,7 @@ final class OpenJ9VirtualMachineDescriptor extends VirtualMachineDescriptor {
 		replyFile = null;
 		processId = 0;
 		uid = 0;
+		globalSemaphore = true;
 	}
 
 	/**
@@ -96,6 +99,8 @@ final class OpenJ9VirtualMachineDescriptor extends VirtualMachineDescriptor {
 		attachSyncFileValue = advert.getNotificationSync();
 		processId = advert.getProcessId();
 		uid = advert.getUid();
+		globalSemaphore = advert.isGlobalSemaphore();
+
 	}
 
 	/**
@@ -104,6 +109,14 @@ final class OpenJ9VirtualMachineDescriptor extends VirtualMachineDescriptor {
 	 */
 	long getProcessId() {
 		return processId;
+	}
+
+	/**
+	 * 
+	 * @return true if the target uses the global semaphore (Windows only)
+	 */
+	public boolean isGlobalSemaphore() {
+		return globalSemaphore;
 	}
 
 	/**

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -253,7 +253,8 @@ typedef struct  J9PortShSemParameters {
  	const char* controlFileDir; /* Directory in which to create control files (SysV semaphores only) */
  	uint8_t proj_id; /* parameter used with semName to generate semaphore key */
  	uint32_t deleteBasefile : 1; /* delete the base file (used to generate the semaphore key) when destroying the semaphore */
- } J9PortShSemParameters;
+ 	uint32_t global : 1; /* Windows only: use the global namespace for the sempahore */
+} J9PortShSemParameters;
 /**
  * @name Process Handle
  * J9ProcessHandle is a pointer to the opaque structure J9ProcessHandleStruct.

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -570,7 +570,7 @@ jlong JNICALL Java_com_ibm_jvm_Trace_getMicros(JNIEnv *env, jobject recv);
 
 /* attach API */
 jint JNICALL
-Java_com_ibm_tools_attach_target_IPC_cancelNotify(JNIEnv *env, jclass clazz, jstring ctrlDirName, jstring semaName, jint numberOfDecrements);
+Java_com_ibm_tools_attach_target_IPC_cancelNotify(JNIEnv *env, jclass clazz, jstring ctrlDirName, jstring semaName, jint numberOfDecrements, jboolean global);
 jint JNICALL
 Java_com_ibm_tools_attach_target_IPC_chownFileToTargetUid(JNIEnv *env, jclass clazz, jstring path, jlong uid);
 jlong JNICALL
@@ -592,7 +592,7 @@ Java_com_ibm_tools_attach_target_IPC_setupSemaphore(JNIEnv *env, jclass clazz, j
 jint JNICALL
 Java_com_ibm_tools_attach_target_IPC_openSemaphore(JNIEnv *env, jclass clazz, jstring ctrlDirName, jstring semaName);
 jint JNICALL
-Java_com_ibm_tools_attach_target_IPC_notifyVm(JNIEnv *env, jclass clazz, jstring ctrlDirName, jstring semaName, jint numberOfPosts);
+Java_com_ibm_tools_attach_target_IPC_notifyVm(JNIEnv *env, jclass clazz, jstring ctrlDirName, jstring semaName, jint numberOfPosts, jboolean global);
 jint JNICALL
 Java_com_ibm_tools_attach_target_IPC_waitSemaphore(JNIEnv *env, jclass clazz);
 void JNICALL

--- a/runtime/port/sysvipc/j9shsem.c
+++ b/runtime/port/sysvipc/j9shsem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,6 +71,7 @@ j9shsem_params_init(struct J9PortLibrary *portLibrary, struct J9PortShSemParamet
  	params->controlFileDir = NULL; /* Directory in which to create control files (SysV semaphores only */
  	params->proj_id = 1; /* parameter used with semName to generate semaphore key */
  	params->deleteBasefile = 1; /* set to 0 to retain the basefile when destroying the semaphore. */
+ 	params->global = 0; /* global is used on Windows only */
  	return 0;
 }
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/5533

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>