### PR TITLE
Fix for JIT starvation detection logic

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -994,7 +994,12 @@ TR_YesNoMaybe TR::CompilationInfo::detectCompThreadStarvation()
 
    // If there are idle cycles on the CPU set where this JVM can run
    // then the compilation threads should be able to use those cycles
-   // (if (idle > 10%) return 0
+   // The following is just an approximation because we look at idle
+   // cyles on the entire machine
+   if (getCpuUtil()->isFunctional() &&
+      getCpuUtil()->getCpuIdle() > 5 && // This is for the entire machine
+      getCpuUtil()->getVmCpuUsage() + 10 < getJvmCpuEntitlement()) // at least 10% unutilized by this JVM
+      return TR_no;
 
    // Large queue and small CPU utilization for the compilation thread
    // is a sign of compilation thread starvation


### PR DESCRIPTION
The JIT has some logic that attempts to detect when compilation threads
are starved due to competition from (potantially many) application
threads. This logic looks at compilation backlog, at CPU utilization
of the JVM and at CPU utilization of the compilation threads.
In some cases though, the CPU utilization of the compilation threads
is low because of other factors, the most common example being
when compilations are performed out-of-process and there is a large
waiting time for compilation results.
In this PR we amend the starvation detection logic such that, if
the JVM does not consume its entire CPU allowance and there are idle
cycles on the machine as well, the JIT cannot be starved (it should be
able to consume those remaining CPU cycles)

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>