### PR TITLE
Check for NULL before using target_method

### DIFF
--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -889,6 +889,13 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
                   continue;
                /* call getResolvedMethod again to generate the validation records */
                TR_ResolvedMethod* target_method = getResolvedMethod (tempreceiverClass);
+
+               /* it is possible for getResolvedMethod to return NULL, since there might be
+                * a problem when generating validation records
+                */
+               if (!target_method)
+                  continue;
+
                TR_OpaqueClassBlock *classOfMethod = target_method->classOfMethod();
                SVM_ASSERT_ALREADY_VALIDATED(comp()->getSymbolValidationManager(), classOfMethod);
                }


### PR DESCRIPTION
When the inliner finds a profiled receiver, under AOT, the receiver
class and, if the method is inherited, the base class need to be
validated. However, because this involves validation, it is possible for
getResolvedMethod to return NULL. Therefore, a NULL check is required.