### PR TITLE
Relax monitor read barrier assert

### DIFF
--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -764,7 +764,8 @@ MM_StandardAccessBarrier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object
 			forwardHeader.copyOrWait(forwardPtr);
 			*srcAddress = forwardPtr;
 		} else {
-			Assert_MM_unreachable();
+			Assert_GC_true_with_message2(env, forwardHeader.isSelfForwardedPointer(),
+				"Monitor object, not forwarded, in Evacuate: slot %llx object %llx\n", srcAddress, object);
 			/* A typical usage of this barrier is to update monitor table slot for blocking object (blockingEnterObject).
 			 * Such object is a hard root, hence copied during initial roots scanning. We should never need to copy it via this barrier.
 			 * If this assert eventually triggers it means the barrier is used for some other objects that are not hard roots


### PR DESCRIPTION
Read barrier for monitor object slot that asserts object in Evacuate
must be forwarded, needs also to account for self-forwarded object.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>