### PR TITLE
Disable PPCHWProfiler on IBM i current releases.

### DIFF
--- a/runtime/compiler/build/files/host/p.mk
+++ b/runtime/compiler/build/files/host/p.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,11 +45,7 @@ ifeq ($(OS),aix)
     PPC_HW_PROFILER=compiler/p/runtime/PPCHWProfilerAIX.cpp
     PPC_LM_GUARDED_STORAGE=compiler/p/runtime/PPCLMGuardedStorageAIX.cpp
 
-    ifeq ($(I5_VERSION),I5_V6R1)
-        PPC_HW_PROFILER=
-        PPC_LM_GUARDED_STORAGE=
-    endif
-    ifeq ($(I5_VERSION),I5_V7R2)
+    ifneq ($(findstring $(I5_VERSION),I5_V6R1 I5_V7R2 I5_V7R3 I5_V7R4),)
         PPC_HW_PROFILER=
         PPC_LM_GUARDED_STORAGE=
     endif


### PR DESCRIPTION
Disable build PPCHWProfiler related codes on IBM i current releases.