### PR TITLE
Use OMR build flags in OpenJ9

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2063,11 +2063,11 @@ impl_jitReferenceArrayCopy(J9VMThread *currentThread, UDATA lengthInBytes)
 		(J9IndexableObject*)currentThread->floatTemp2,
 		(fj9object_t*)currentThread->floatTemp3,
 		(fj9object_t*)currentThread->floatTemp4,
-#if defined(J9VM_GC_COMPRESSED_POINTERS) || !defined(J9VM_ENV_DATA64)
+#if defined(OMR_GC_COMPRESSED_POINTERS) || !defined(J9VM_ENV_DATA64)
 		(I_32)(lengthInBytes >> 2)
 #else
 		(I_32)(lengthInBytes >> 3)
-#endif /* J9VM_GC_COMPRESSED_POINTERS || !J9VM_ENV_DATA64 */
+#endif /* OMR_GC_COMPRESSED_POINTERS || !J9VM_ENV_DATA64 */
 	)) {
 		exception = (void*)-1;
 	}

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -119,7 +119,7 @@ TR::Instruction *OMR::ARM::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGen
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg->fe());
    uintptrj_t mask = TR::Compiler->om.maskOfObjectVftField();
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    bool isCompressed = true;
 #else
    bool isCompressed = false;

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -357,7 +357,7 @@ ifeq ($(HOST_ARCH),z)
             M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
         endif
         ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
-            M4_DEFINES+=J9VM_GC_COMPRESSED_POINTERS
+            M4_DEFINES+=OMR_GC_COMPRESSED_POINTERS
         endif
     endif
 

--- a/runtime/compiler/build/toolcfg/zos-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/zos-xlc/common.mk
@@ -192,7 +192,7 @@ ifeq ($(HOST_BITS),64)
     endif
 
     ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
-        M4_DEFINES+=J9VM_GC_COMPRESSED_POINTERS
+        M4_DEFINES+=OMR_GC_COMPRESSED_POINTERS
     endif
 endif
 

--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -207,7 +207,7 @@ ifeq ($(HOST_ARCH),z)
             M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
         endif
         ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
-            M4_DEFINES+=J9VM_GC_COMPRESSED_POINTERS
+            M4_DEFINES+=OMR_GC_COMPRESSED_POINTERS
         endif
     endif
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -304,7 +304,7 @@ qualifiedSize(UDATA *byteSize, char **qualifier)
 bool
 J9::Options::useCompressedPointers()
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    return true;
 #else
    return false;

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -91,7 +91,7 @@ J9::ObjectModel::initialize()
 int32_t
 J9::ObjectModel::sizeofReferenceField()
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    return sizeof(fj9object_t);
 #else
    return sizeof(uintptrj_t);
@@ -113,7 +113,7 @@ J9::ObjectModel::getSizeOfArrayElement(TR::Node * node)
 
    if (node->getOpCodeValue() == TR::anewarray)
       {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
       return TR::Compiler->om.sizeofReferenceField();
 #else
       return TR::Symbol::convertTypeToSize(TR::Address);
@@ -225,7 +225,7 @@ J9::ObjectModel::nativeAddressesCanChangeSize()
 bool
 J9::ObjectModel::generateCompressedObjectHeaders()
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    return true;
 #else
    return false;
@@ -306,7 +306,7 @@ J9::ObjectModel::compressedReferenceShiftOffset()
 int32_t
 J9::ObjectModel::compressedReferenceShift()
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    J9JavaVM *javaVM = TR::Compiler->javaVM;
    if (!javaVM)
       return 0;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3146,7 +3146,7 @@ TR_J9ByteCodeIlGenerator::calculateArrayElementAddress(TR::DataType dataType, bo
    // since each element of an reference array is a compressed pointer,
    // modify the width accordingly, so the stride is 4bytes instead of 8
    //
-   // J9VM_GC_COMPRESSED_POINTERS
+   // OMR_GC_COMPRESSED_POINTERS
    //
    if (comp()->useCompressedPointers() && dataType == TR::Address)
       {

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -2258,7 +2258,7 @@ static uint8_t* initializeCCPreLoadedObjectAlloc(uint8_t *buffer, void **CCPreLo
 
    TR::Instruction *entry = generateLabelInstruction(cg, TR::InstOpCode::label, n, entryLabel);
    TR::Instruction *cursor = entry;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    const TR::InstOpCode::Mnemonic Op_stclass = TR::InstOpCode::stw;
 #else
    const TR::InstOpCode::Mnemonic Op_stclass =TR::InstOpCode::Op_st;
@@ -2475,7 +2475,7 @@ static uint8_t* initializeCCPreLoadedArrayAlloc(uint8_t *buffer, void **CCPreLoa
 
    TR::Instruction *entry = generateLabelInstruction(cg, TR::InstOpCode::label, n, entryLabel);
    TR::Instruction *cursor = entry;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    const TR::InstOpCode::Mnemonic Op_stclass = TR::InstOpCode::stw;
 #else
    const TR::InstOpCode::Mnemonic Op_stclass =TR::InstOpCode::Op_st;
@@ -2749,7 +2749,7 @@ static uint8_t* initializeCCPreLoadedWriteBarrier(uint8_t *buffer, void **CCPreL
    helperTrampolineLabel->setCodeLocation((uint8_t *)TR::CodeCacheManager::instance()->findHelperTrampoline(TR_writeBarrierStoreGenerational, buffer));
    TR::Instruction *entry = generateLabelInstruction(cg, TR::InstOpCode::label, n, entryLabel);
    TR::Instruction *cursor = entry;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    const TR::InstOpCode::Mnemonic Op_lclass = TR::InstOpCode::lwz;
 #else
    const TR::InstOpCode::Mnemonic Op_lclass =TR::InstOpCode::Op_load;
@@ -2851,7 +2851,7 @@ static uint8_t* initializeCCPreLoadedWriteBarrierAndCardMark(uint8_t *buffer, vo
    helperTrampolineLabel->setCodeLocation((uint8_t *)TR::CodeCacheManager::instance()->findHelperTrampoline(TR_writeBarrierStoreGenerationalAndConcurrentMark, buffer));
    TR::Instruction *entry = generateLabelInstruction(cg, TR::InstOpCode::label, n, entryLabel);
    TR::Instruction *cursor = entry;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    const TR::InstOpCode::Mnemonic Op_lclass = TR::InstOpCode::lwz;
 #else
    const TR::InstOpCode::Mnemonic Op_lclass =TR::InstOpCode::Op_load;
@@ -3066,7 +3066,7 @@ static uint8_t* initializeCCPreLoadedArrayStoreCHK(uint8_t *buffer, void **CCPre
    helperTrampolineLabel->setCodeLocation((uint8_t *)TR::CodeCacheManager::instance()->findHelperTrampoline(TR_typeCheckArrayStore, buffer));
    TR::Instruction *entry = generateLabelInstruction(cg, TR::InstOpCode::label, n, entryLabel);
    TR::Instruction *cursor = entry;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    const TR::InstOpCode::Mnemonic Op_lclass = TR::InstOpCode::lwz;
 #else
    const TR::InstOpCode::Mnemonic Op_lclass =TR::InstOpCode::Op_load;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -475,7 +475,7 @@ TR::Register *outlinedHelperWrtbarEvaluator(TR::Node *node, TR::CodeGenerator *c
 static int32_t getOffsetOfJ9ObjectFlags()
    {
 #if defined(J9VM_INTERP_FLAGS_IN_CLASS_SLOT)
-#if defined(TR_TARGET_64BIT) && !defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(TR_TARGET_64BIT) && defined(OMR_GC_FULL_POINTERS)
 #if defined(__LITTLE_ENDIAN__)
    return TMP_OFFSETOF_J9OBJECT_CLAZZ;
 #else
@@ -2935,7 +2935,7 @@ TR::Instruction *J9::Power::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGe
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg->fe());
    uintptrj_t mask = TR::Compiler->om.maskOfObjectVftField();
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    bool isCompressed = true;
 #else
    bool isCompressed = false;
@@ -2963,7 +2963,7 @@ static TR::Instruction *genTestIsSuper(TR::Node *node, TR::Register *objClassReg
    TR::Compilation* comp = cg->comp();
    int32_t superClassOffset = castClassDepth * TR::Compiler->om.sizeofReferenceAddress();
    bool outOfBound = (!depthInReg2 && (superClassOffset > UPPER_IMMED || superClassOffset < LOWER_IMMED)) ? true : false;
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // objClassReg contains the class offset so we may need to generate code
    // to convert from class offset to real J9Class pointer
 #endif
@@ -2992,7 +2992,7 @@ static TR::Instruction *genTestIsSuper(TR::Node *node, TR::Register *objClassReg
       else
          cursor = generateShiftLeftImmediate(cg, node, scratch2Reg, scratch2Reg, 2, cursor);
       }
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // objClassReg contains the class offset so we may need to generate code
    // to convert from class offset to real J9Class pointer
 #endif
@@ -3009,7 +3009,7 @@ static TR::Instruction *genTestIsSuper(TR::Node *node, TR::Register *objClassReg
       cursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, scratch1Reg,
             new (cg->trHeapMemory()) TR::MemoryReference(scratch1Reg, superClassOffset, TR::Compiler->om.sizeofReferenceAddress(), cg), cursor);
       }
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // castClassReg has a class offset and scratch1Reg contains a J9Class pointer
    // May need to convert the J9Class pointer to a class offset
 #endif
@@ -3023,7 +3023,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *src, TR::Regi
    TR::Compilation * comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg->fe());
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // must read only 32 bits
    generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, t1Reg,
          new (cg->trHeapMemory()) TR::MemoryReference(dst, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
@@ -3091,7 +3091,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *src, TR::Regi
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, toWB, cndReg);
       }
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // For the following two instructions
    // we may need to convert the class offset from t1Reg into J9Class
 #endif
@@ -3869,7 +3869,7 @@ TR::Register *J9::Power::TreeEvaluator::VMcheckcastEvaluator2(TR::Node *node, TR
             TR_ASSERT(!objectClassReg, "Object class already loaded");
             objectClassReg = srm->findOrCreateScratchRegister();
             generateTrg1MemInstruction(cg,
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
                                        TR::InstOpCode::lwz,
 #else
                                        TR::InstOpCode::Op_load,
@@ -4039,7 +4039,7 @@ TR::Register *J9::Power::TreeEvaluator::VMinstanceOfEvaluator2(TR::Node *node, T
             TR_ASSERT(!objectClassReg, "Object class already loaded");
             objectClassReg = srm->findOrCreateScratchRegister();
             generateTrg1MemInstruction(cg,
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
                                        TR::InstOpCode::lwz,
 #else
                                        TR::InstOpCode::Op_load,
@@ -4315,7 +4315,7 @@ TR::Register *J9::Power::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR:
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, doneLabel, cndReg);
       }
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // read only 32 bits
    generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, objClassReg,
          new (cg->trHeapMemory()) TR::MemoryReference(objReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
@@ -4852,7 +4852,7 @@ TR::Register * J9::Power::TreeEvaluator::VMgenCoreInstanceofEvaluator(TR::Node *
 
    if (testEqualClass || testCache || testCastClassIsSuper)
       {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // read only 32 bits
       iCursor = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, objClassReg,
             new (cg->trHeapMemory()) TR::MemoryReference(objectReg,
@@ -5317,7 +5317,7 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
       objectClassReg = cg->allocateRegister();
       condReg = cg->allocateRegister(TR_CCR);
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // must read only 32 bits
       generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, objectClassReg,
             new (cg->trHeapMemory()) TR::MemoryReference(objReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
@@ -6447,7 +6447,7 @@ static void genInitObjectHeader(TR::Node *node, TR::Instruction *&iCursor, TR_Op
          iCursor = loadConstant(cg, node, (int32_t) clazz | (int32_t) orFlag, temp1Reg, iCursor);
 #endif /* TR_TARGET_64BIT */
          }
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // must store only 32 bits
       iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node,
             new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), 4, cg),
@@ -6463,7 +6463,7 @@ static void genInitObjectHeader(TR::Node *node, TR::Instruction *&iCursor, TR_Op
          {
          iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ori, node, clzReg, clzReg, orFlag, iCursor);
          }
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // must store only 32 bits
       iCursor = generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node,
             new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfObjectVftField(), 4, cg),
@@ -7781,7 +7781,7 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
    TR::InstOpCode::Mnemonic loadOpCode;
    if (nextTopNode->getOpCodeValue() == TR::aloadi && TR::Compiler->target.is64Bit())
       {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       if (nextTopNode->getSymbol()->isClassObject())
          {
          tempMR = new (cg->trHeapMemory()) TR::MemoryReference(nextTopNode, 4, cg);
@@ -7975,7 +7975,7 @@ TR::Register *J9::Power::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Co
       objectClassReg = cg->allocateRegister();
       condReg = cg->allocateRegister(TR_CCR);
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // must read only 32 bits
       generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, objectClassReg,
             new (cg->trHeapMemory()) TR::MemoryReference(objReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
@@ -8331,7 +8331,7 @@ TR::Register *J9::Power::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR
    //
    if (!node->isArrayChkPrimitiveArray1() && !node->isArrayChkReferenceArray1() && !node->isArrayChkPrimitiveArray2() && !node->isArrayChkReferenceArray2())
       {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tmp1Reg,
             new (cg->trHeapMemory()) TR::MemoryReference(obj1Reg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
 #else
@@ -8354,7 +8354,7 @@ TR::Register *J9::Power::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR
 
    // One of the object is array. Test equality of two objects' classes.
    //
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // must read only 32 bits
    generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tmp2Reg,
          new (cg->trHeapMemory()) TR::MemoryReference(obj2Reg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
@@ -8394,7 +8394,7 @@ TR::Register *J9::Power::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR
          {
 
          // Loading the Class Pointer -> classDepthandFlags
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tmp1Reg,
                new (cg->trHeapMemory()) TR::MemoryReference(obj1Reg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
 #else
@@ -8426,7 +8426,7 @@ TR::Register *J9::Power::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR
       // Object2 must be of reference component type array, otherwise throw exception
       if (!node->isArrayChkReferenceArray2())
          {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tmp1Reg,
                new (cg->trHeapMemory()) TR::MemoryReference(obj2Reg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), 4, cg));
 #else
@@ -9430,7 +9430,7 @@ static TR::Register *inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8
          scratchRegister = cg->allocateCollectedReferenceRegister();
          TR::Register *memRefRegister = scratchRegister;
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          // read only 32 bits
          generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, memRefRegister,
                new (cg->trHeapMemory()) TR::MemoryReference(valueReg, arrayFieldOffset, 4, cg));
@@ -9951,7 +9951,7 @@ static TR::Register *inlineAtomicOperation(TR::Node *node, TR::CodeGenerator *cg
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(valueReg, arrayFieldOffset, size, cg);
       scratchReg = cg->allocateCollectedReferenceRegister();
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // read only 32 bits
       generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, scratchReg,
             new (cg->trHeapMemory()) TR::MemoryReference(valueReg, arrayFieldOffset, 4, cg));

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -64,7 +64,7 @@
 #define maskVFT(reg)    rlwinm reg, reg, 0, 0, 31-J9TR_RequiredClassAlignmentInBits
 #endif
 
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS)
 /* extract isolated field address in TenantDataxxx
    MT_ComputeIsoaltedFieldAddress(32/64/obj, element_shift size 2/3)
    assume
@@ -1403,7 +1403,7 @@ MTUnresolvedInt32Load:
 .MTUnresolvedInt32Load:
 #endif
 	startproc.MTUnresolvedInt32Load:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 	#include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1442,7 +1442,7 @@ MTUnresolvedInt64Load:
 .MTUnresolvedInt64Load:
 #endif
 	startproc.MTUnresolvedInt64Load:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1481,7 +1481,7 @@ MTUnresolvedFloatLoad:
 .MTUnresolvedFloatLoad:
 #endif
 	startproc.MTUnresolvedFloatLoad:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1520,7 +1520,7 @@ MTUnresolvedDoubleLoad:
 .MTUnresolvedDoubleLoad:
 #endif
 	startproc.MTUnresolvedDoubleLoad:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1558,7 +1558,7 @@ MTUnresolvedAddressLoad:
 .MTUnresolvedAddressLoad:
 #endif
 	startproc.MTUnresolvedAddressLoad:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1599,7 +1599,7 @@ MTUnresolvedInt32Store:
 .MTUnresolvedInt32Store:
 #endif
 	startproc.MTUnresolvedInt32Store:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1640,7 +1640,7 @@ MTUnresolvedInt64Store:
 .MTUnresolvedInt64Store:
 #endif
 	startproc.MTUnresolvedInt64Store:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1681,7 +1681,7 @@ MTUnresolvedFloatStore:
 .MTUnresolvedFloatStore:
 #endif
 	startproc.MTUnresolvedFloatStore:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1722,7 +1722,7 @@ MTUnresolvedDoubleStore:
 .MTUnresolvedDoubleStore:
 #endif
 	startproc.MTUnresolvedDoubleStore:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -1762,7 +1762,7 @@ MTUnresolvedAddressStore:
 .MTUnresolvedAddressStore:
 #endif
 	startproc.MTUnresolvedAddressStore:
-#if defined(TR_HOST_64BIT) && defined(J9VM_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
+#if defined(TR_HOST_64BIT) && defined(OMR_GC_COMPRESSED_POINTERS) && defined(J9VM_OPT_TENANT)
 #include "p/runtime/SaveGPRs.inc"
 	mfcr    r0
 	stw     r0,-4(J9SP)					! Save CR also
@@ -2702,7 +2702,7 @@ _virtualUnresolvedHelper:
 .L.directDispatch:							! J9SP-96,r5(offset),r11,RTOC
 	laddr	r3, 7*ALen(J9SP)					! Restore object ptr: this
 	laddr	r0, VirtualRAOffset(r11)				! Load code cache RA
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
         lwz     r6, J9TR_J9Object_class(r3)                                               ! Load class offset
         ! may need to convert class offset to J9Class
 #else
@@ -2824,7 +2824,7 @@ _interfaceCallHelper:
 	laddr	r5, jitLookupInterfaceMethod@got(RTOC)		! Load the callee address
 #endif
 	mtspr	CTR, r5						! Prepare for long jump
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r3, J9TR_J9Object_class(r4)				! Load the class offset
 #else
 	laddr	r3, J9TR_J9Object_class(r4)				! Load the class
@@ -2884,7 +2884,7 @@ _interfaceCallHelper:
 	mtspr	CTR, r5						! Prepare for long jump
 	mr	r5, r11						! Load code cache RA
 	addi	r4, r11, 3*ALen					! Address of interface table&slot number
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r3, J9TR_J9Object_class(r6)				! Load the class offset
 #else
 	laddr	r3, J9TR_J9Object_class(r6)				! Load the class
@@ -2892,7 +2892,7 @@ _interfaceCallHelper:
 	maskVFT(r3)
 	bcctrl	BO_ALWAYS, CR0_LT					! Call to look up method
 	laddr	r5, 7*ALen(J9SP)					! Load:  this
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r6, J9TR_J9Object_class(r5)				! Load the class offset
 	! may need to convert class offset to J9Class
 #else
@@ -2945,7 +2945,7 @@ _interfaceCallHelper:
 	bl	.__refreshHelper					! save:	RTOC, r6, r10, r11
 #endif
 	laddr	r4, 5*ALen(r11)					! Load slot1 class
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
         ! may need to convert class offset to J9Class pointer
 #endif
 	laddr	r5, 3*ALen(r11)					! Resolved class
@@ -2959,7 +2959,7 @@ _interfaceCallHelper:
 	neg	r4, r3
 	addi	r12, r4,J9TR_InterpVTableOffset			! Must set it up in r12
 	laddr	r3, 7*ALen(J9SP)					! Restore "this"
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r5, J9TR_J9Object_class(r3)				! class offset
         ! may need to convert class offset to J9Class pointer
 #else
@@ -3013,7 +3013,7 @@ _interfaceCompeteSlot2:
 	laddr	r5, jitLookupInterfaceMethod@got(RTOC)		! Load the callee address
 #endif
 	laddr	r6, 7*ALen(J9SP)					! Load "this"
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r3, J9TR_J9Object_class(r6)				! Load the class offset
 #else
 	laddr	r3, J9TR_J9Object_class(r6)				! Load the class
@@ -3024,7 +3024,7 @@ _interfaceCompeteSlot2:
 	mr	r5, r11						! Load code cache RA
 	bcctrl	BO_ALWAYS, CR0_LT					! Call to look up
 	laddr	r5, 7*ALen(J9SP)					! Load:  this
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r6, J9TR_J9Object_class(r5)				! Load the class offset
         ! may need to convert class offset to J9Class
 #else
@@ -3081,7 +3081,7 @@ _interfaceCompeteSlot2:
 #endif
 	or	r3, r6, r6					! Restore r3
 	laddr	r4, 7*ALen(r11)					! Load slot2 class
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
         ! may need to convert class offset to J9Class pointer
 #endif
 	laddr	r5, 3*ALen(r11)					! Resolved class
@@ -3151,7 +3151,7 @@ _interfaceSlotsUnavailable:
 #ifndef NO_HELPER_LASTITABLE_CHECK
         ! Before going to the VM helper, check if the receiver class lastITable matches the interface class
         ! of the method being called and if so, use it to quickly look up the vtable offset and make the call
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
         lwz     r10, J9TR_J9Object_class(r3)                    ! Load class
 #else  
         laddr   r10, J9TR_J9Object_class(r3)                    ! Load class
@@ -3196,7 +3196,7 @@ _interfaceSlotsUnavailable:
 #else
 	laddr	r5, jitLookupInterfaceMethod@got(RTOC)		! Load address of final helper
 #endif
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	lwz	r3, J9TR_J9Object_class(r3)				! Load class
 #else
 	laddr	r3, J9TR_J9Object_class(r3)				! Load class

--- a/runtime/compiler/ras/kca_offsets_generator.cpp
+++ b/runtime/compiler/ras/kca_offsets_generator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,7 @@ J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
    char szCMPRSS[8];
    char szRT[4];
 
-   #if defined(J9VM_GC_COMPRESSED_POINTERS)
+   #if defined(OMR_GC_COMPRESSED_POINTERS)
    strcpy( szCMPRSS, "_CMPRSS" );
    #else
    szCMPRSS[0]='\0';
@@ -173,7 +173,7 @@ J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
       fprintf( file, "#define VM_JITCONFIG               (%d)\n", offsetof(J9JavaVM,jitConfig) );
       fprintf( file, "#define VM_BOOLARRAYCLASS          (%d)\n", offsetof(J9JavaVM,booleanArrayClass) );
       fprintf( file, "#define VM_CMPRSS_DISPLACEMENT     (%d)\n", 0 );
-      #if defined(J9VM_GC_COMPRESSED_POINTERS)
+      #if defined(OMR_GC_COMPRESSED_POINTERS)
       fprintf( file, "#define VM_CMPRSS_SHIFT            (%d)\n", offsetof(J9JavaVM,compressedPointersShift) );
       #else
       fprintf( file, "#define VM_CMPRSS_SHIFT            (%d)\n", 0 );

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -4304,18 +4304,18 @@ TR_IPHashedCallSite::operator new (size_t size) throw()
 inline
 uintptrj_t CallSiteProfileInfo::getClazz(int index)
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS) //compressed references
+#if defined(OMR_GC_COMPRESSED_POINTERS) //compressed references
    //support for convert code, when it is implemented, "uncompress"
    return (uintptrj_t)TR::Compiler->cls.convertClassOffsetToClassPtr((TR_OpaqueClassBlock *)(uintptrj_t)_clazz[index]);
 #else
    return (uintptrj_t)_clazz[index]; //things are just stored as regular pointers otherwise
-#endif //J9VM_GC_COMPRESSED_POINTERS
+#endif //OMR_GC_COMPRESSED_POINTERS
    }
 
 inline
 void CallSiteProfileInfo::setClazz(int index, uintptrj_t clazzPointer)
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS) //compressed references
+#if defined(OMR_GC_COMPRESSED_POINTERS) //compressed references
    //support for convert code, when it is implemented, do compression
    TR_OpaqueClassBlock * compressedOffset = J9JitMemory::convertClassPtrToClassOffset((J9Class *)clazzPointer); //compressed 32bit pointer
    //if we end up with something in the top 32bits, our compression is no good...
@@ -4323,7 +4323,7 @@ void CallSiteProfileInfo::setClazz(int index, uintptrj_t clazzPointer)
    _clazz[index] = (uint32_t)((uintptrj_t)compressedOffset); //ditch the top zeros
 #else
    _clazz[index] = (uintptrj_t)clazzPointer;
-#endif //J9VM_GC_COMPRESSED_POINTERS
+#endif //OMR_GC_COMPRESSED_POINTERS
    }
 
 

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,11 +132,11 @@ public:
    void setClazz(int index, uintptrj_t clazzPtr);
 
 private:
-#if defined(J9VM_GC_COMPRESSED_POINTERS) //compressed references
+#if defined(OMR_GC_COMPRESSED_POINTERS) //compressed references
    uint32_t _clazz[NUM_CS_SLOTS]; // store them in 32bits
 #else
    uintptrj_t _clazz[NUM_CS_SLOTS]; // store them in either 64 or 32 bits
-#endif //J9VM_GC_COMPRESSED_POINTERS
+#endif //OMR_GC_COMPRESSED_POINTERS
    };
 
 #define TR_IPBCD_FOUR_BYTES  1
@@ -379,11 +379,11 @@ public:
    void * operator new (size_t size) throw();
    void * operator new (size_t size, void * placement) {return placement;}
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS) //compressed references
+#if defined(OMR_GC_COMPRESSED_POINTERS) //compressed references
    static const uint32_t IPROFILING_INVALID = ~0; //only take up the bottom 32, class compression issue
 #else
    static const uintptrj_t IPROFILING_INVALID = ~0;
-#endif //J9VM_GC_COMPRESSED_POINTERS
+#endif //OMR_GC_COMPRESSED_POINTERS
 
    virtual uintptrj_t getData(TR::Compilation *comp = NULL);
    virtual CallSiteProfileInfo* getCGData() { return &_csInfo; } // overloaded

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -642,7 +642,7 @@ void J9FASTCALL _jitProfileStringValue(uintptrj_t value, int32_t charsOffset, in
       {
       readValues = true;
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
       J9JavaVM *jvm = jitConfig->javaVM;
       if (!jvm)
          return;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1024,13 +1024,13 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(J9JavaVM *pjavaVM, TR_FrontEn
          incompatibleCache(J9NLS_RELOCATABLE_CODE_PROCESSING_COMPATIBILITY_FAILURE,
                            "AOT header validation failed: incompatible arraylet size");
          }
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
       else if ( hdrInCache->compressedPointerShift != TR::Compiler->om.compressedReferenceShift())
          {
          incompatibleCache(J9NLS_RELOCATABLE_CODE_PROCESSING_COMPATIBILITY_FAILURE,
                            "AOT header validation failed: incompatible compressed pointer shift");
          }
-#endif // J9VM_GC_COMPRESSED_POINTERS
+#endif // OMR_GC_COMPRESSED_POINTERS
       else
          {
          static_cast<TR_JitPrivateConfig *>(jitConfig()->privateConfig)->aotValidHeader = TR_yes;
@@ -1079,7 +1079,7 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(J9JavaVM *pjavaVM, TR_FrontEnd 
       aotHeader->processorSignature = TR::Compiler->target.cpu.id();
       aotHeader->gcPolicyFlag = javaVM()->memoryManagerFunctions->j9gc_modron_getWriteBarrierType(javaVM());
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(pjavaVM);
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
 #else
       aotHeader->compressedPointerShift = 0;

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -131,7 +131,7 @@ uint8_t *
 TR_RelocationTarget::loadClassAddressForHeader(uint8_t *reloLocation)
    {
    // reloLocation points at the start of the address, so just need to dereference as uint8_t *
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    return (uint8_t *) (uintptr_t) loadUnsigned32b(reloLocation);
 #else
    return (uint8_t *) loadPointer(reloLocation);
@@ -142,7 +142,7 @@ void
 TR_RelocationTarget::storeClassAddressForHeader(uint8_t *clazz, uint8_t *reloLocation)
    {
    // reloLocation points at the start of the address, so just store the uint8_t * at reloLocation
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    uintptr_t clazzPtr = (uintptr_t)clazz;
    storeUnsigned32b((uint32_t)clazzPtr, reloLocation);
 #else

--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -431,7 +431,7 @@ bool ppcCodePatching(void *method, void *callSite, void *currentPC, void *curren
 
          const intptrj_t *obj = *(intptrj_t **)((intptrj_t)extra + sizeof(intptrj_t));
          // Discard high order 32 bits via cast to uint32_t to avoid shifting and masking when using compressed refs
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
          intptrj_t currentReceiverJ9Class = *(uint32_t *)((int8_t *)obj + TMP_OFFSETOF_J9OBJECT_CLAZZ);
 #else
          intptrj_t currentReceiverJ9Class = *(intptrj_t *)((int8_t *)obj + TMP_OFFSETOF_J9OBJECT_CLAZZ);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -4787,7 +4787,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
       objectClassReg = cg->allocateRegister();
       numDeps++;
       TR::X86RegMemInstruction *instr;
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       instr = generateRegMemInstruction(L4RegMem, node, objectClassReg, objectClassMR, cg);
 #else
       instr = generateRegMemInstruction(LRegMem(), node, objectClassReg, objectClassMR, cg);
@@ -5291,7 +5291,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
       {
       TR::MemoryReference *objectClassMR = generateX86MemoryReference(objectReg, TMP_OFFSETOF_J9OBJECT_CLAZZ, cg);
       objectClassReg = cg->allocateRegister();
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       TR::Instruction *instr = generateRegMemInstruction(L4RegMem, node, objectClassReg, objectClassMR, cg);
 #else
       TR::Instruction *instr = generateRegMemInstruction(LRegMem(), node, objectClassReg, objectClassMR, cg);
@@ -8165,7 +8165,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
 
       TR::Instruction* instr;
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // FIXME: Add check for hint when doing the arraystore check as below when class pointer compression
       // is enabled.
 
@@ -8184,7 +8184,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
 
       if (TR::Compiler->target.is64Bit())
          {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          TR_ASSERT((((uintptr_t)objectClass) >> 32) == 0, "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
          instr = generateRegImmInstruction(CMP4RegImm4, node, destComponentClassReg, (uint32_t) ((uint64_t) objectClass), cg);
 
@@ -8289,7 +8289,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
 
       if (TR::Compiler->target.is64Bit())
          {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          TR_ASSERT((((uintptr_t)objectClass) >> 32) == 0, "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
          instr = generateRegImmInstruction(CMP4RegImm4, node, destComponentClassReg, (uint32_t) ((uint64_t) objectClass), cg);
 
@@ -8334,7 +8334,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
          TR_OpaqueClassBlock *arrayComponentClass = (TR_OpaqueClassBlock *) node->getArrayComponentClassInNode();
          if (TR::Compiler->target.is64Bit())
             {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
             TR_ASSERT((((uintptr_t)arrayComponentClass) >> 32) == 0, "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
             instr = generateRegImmInstruction(CMP4RegImm4, node, destComponentClassReg, (uint32_t) ((uint64_t) arrayComponentClass), cg);
 
@@ -8378,7 +8378,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
 
 
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // destComponentClassReg contains the class offset so we may need to generate code
    // to convert from class offset to real J9Class pointer
 #endif
@@ -8433,7 +8433,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
             }
          }
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // temp2 contains the class offset so we may need to generate code
    // to convert from class offset to real J9Class pointer
 #endif
@@ -8504,7 +8504,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
          scratchRegisterManager->reclaimScratchRegister(sourceClassDepthReg);
 
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // destComponentClassReg contains the class offset so we may need to generate code
    // to convert from class offset to real J9Class pointer
 #endif
@@ -8538,7 +8538,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
       TR::MemoryReference *leaMR =
          generateX86MemoryReference(sourceSuperClassReg, destComponentClassDepthReg, logBase2(sizeof(uintptrj_t)), 0, cg);
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // leaMR is a memory reference to a J9Class
       // destComponentClassReg contains a TR_OpaqueClassBlock
       // We may need to convert superClass to a class offset before doing the comparison
@@ -8547,7 +8547,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
       if (TR::Compiler->target.is32Bit())
          {
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          TR_ASSERT(0, "Unexpected 32-bit ArrayStoreCHK path");
 #endif
 
@@ -8638,7 +8638,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
       else
          testOpCode = TEST4MemImm4;
 
-      #ifdef J9VM_GC_COMPRESSED_POINTERS
+      #ifdef OMR_GC_COMPRESSED_POINTERS
          generateRegMemInstruction(L4RegMem, node, tempReg, generateX86MemoryReference(object1Reg,  TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
       #else
          generateRegMemInstruction(LRegMem(), node, tempReg, generateX86MemoryReference(object1Reg,  TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
@@ -8694,7 +8694,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
       if (!node->isArrayChkReferenceArray1())
          {
 
-         #ifdef J9VM_GC_COMPRESSED_POINTERS
+         #ifdef OMR_GC_COMPRESSED_POINTERS
             generateRegMemInstruction(L4RegMem, node, tempReg, generateX86MemoryReference(object1Reg,  TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
          #else
             generateRegMemInstruction(LRegMem(), node, tempReg, generateX86MemoryReference(object1Reg,  TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
@@ -8730,7 +8730,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
 
          // Check that object 2 is an array. If not, throw exception.
          //
-         #ifdef J9VM_GC_COMPRESSED_POINTERS
+         #ifdef OMR_GC_COMPRESSED_POINTERS
             generateRegMemInstruction(L4RegMem, node, tempReg, generateX86MemoryReference(object2Reg,  TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
          #else
             generateRegMemInstruction(LRegMem(), node, tempReg, generateX86MemoryReference(object2Reg,  TR::Compiler->om.offsetOfObjectVftField(), cg), cg);

--- a/runtime/compiler/x/runtime/X86Codert.nasm
+++ b/runtime/compiler/x/runtime/X86Codert.nasm
@@ -26,7 +26,7 @@ eq_floats_Offset              equ 128
 eq_gprs_Offset                equ 0
 
 eq_gpr_size                   equ 8
-%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+%ifdef ASM_OMR_GC_COMPRESSED_POINTERS
    eq_vft_pointer_size        equ 4
 %else
    eq_vft_pointer_size        equ 8

--- a/runtime/compiler/x/runtime/X86LockReservation.nasm
+++ b/runtime/compiler/x/runtime/X86LockReservation.nasm
@@ -60,7 +60,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFF05h
 ; this stupidness is required because masm2gas can't handle
 ; ifdef on definitions
 
-%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+%ifdef ASM_OMR_GC_COMPRESSED_POINTERS
 eq_J9Monitor_LockWord         equ 04h
 %else
 eq_J9Monitor_LockWord         equ 08h
@@ -76,7 +76,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
 ; lockword value   => _rax
 %macro ObtainLockWordHelper 1 ; args: ObjAddr
     %ifdef ASM_J9VM_THR_LOCK_NURSERY
-        %ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+        %ifdef ASM_OMR_GC_COMPRESSED_POINTERS
             mov  eax, [%1 + J9TR_J9Object_class]        ; receiver class
         %else
             mov _rax, [%1 + J9TR_J9Object_class]         ; receiver class
@@ -87,7 +87,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
     %else
         lea _rcx, [%1 + eq_J9Monitor_LockWord]           ; load the address of object lock word
     %endif
-    %ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+    %ifdef ASM_OMR_GC_COMPRESSED_POINTERS
         mov  eax, [_rcx]
     %else
         mov _rax, [_rcx]
@@ -125,7 +125,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
 %endif
 %endif
 
-%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+%ifdef ASM_OMR_GC_COMPRESSED_POINTERS
     lock cmpxchg [_rcx],  ebp                       ; try taking the lock
 %else
     lock cmpxchg [_rcx], _rbp                       ; try taking the lock

--- a/runtime/compiler/x/runtime/X86PicBuilder.inc
+++ b/runtime/compiler/x/runtime/X86PicBuilder.inc
@@ -103,7 +103,7 @@ eq_IPicData_j2iThunk           equ 22h    ; only present if direct invoke is pos
 ; ClassPtrReg32 must be the lower part of ClassPtrReg64
 ;
 %macro LoadClassPointerFromObjectHeader 3 ;ObjectReg, ClassPtrReg64, ClassPtrReg32
-%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+%ifdef ASM_OMR_GC_COMPRESSED_POINTERS
         mov     %3, dword [%1 + J9TR_J9Object_class] ; read only 32 bits and zero extend
         and     %3, eq_ObjectClassMask
 %else

--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -929,7 +929,7 @@ retn
       %include "jilconsts.inc"
       %include "X86PicBuilder.inc"
 
-%ifdef ASM_J9VM_GC_COMPRESSED_POINTERS
+%ifdef ASM_OMR_GC_COMPRESSED_POINTERS
 eq_offsetof_J9Object_clazz equ   8        ; offset of class pointer in a J9Object
 %else
 eq_offsetof_J9Object_clazz equ   16       ; offset of class pointer in a J9Object

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1131,7 +1131,7 @@ extern void TEMPORARY_initJ9S390TreeEvaluatorTable(TR::CodeGenerator *cg)
 TR::Instruction *
 J9::Z::TreeEvaluator::genLoadForObjectHeaders(TR::CodeGenerator *cg, TR::Node *node, TR::Register *reg, TR::MemoryReference *tempMR, TR::Instruction *iCursor)
    {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    return generateRXInstruction(cg, TR::InstOpCode::LLGF, node, reg, tempMR, iCursor);
 #else
    return generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, reg, tempMR, iCursor);
@@ -1146,7 +1146,7 @@ J9::Z::TreeEvaluator::genLoadForObjectHeadersMasked(TR::CodeGenerator *cg, TR::N
    TR::Compilation *comp = cg->comp();
    bool disabled = comp->getOption(TR_DisableZ13) || comp->getOption(TR_DisableZ13LoadAndMask);
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z13) && !disabled)
       {
       iCursor = generateRXInstruction(cg, TR::InstOpCode::LLZRGF, node, reg, tempMR, iCursor);
@@ -1213,7 +1213,7 @@ genTestIsSuper(TR::CodeGenerator * cg, TR::Node * node,
    bool eliminateSuperClassArraySizeCheck = (!dynamicCastClass && (castClassDepth < cg->comp()->getOptions()->_minimumSuperclassArraySize));
 
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // objClassReg contains the class offset, so we may need to
    // convert this offset to a real J9Class pointer
 #endif
@@ -1347,7 +1347,7 @@ genTestIsSuper(TR::CodeGenerator * cg, TR::Node * node,
       {
       cursor = generateRIInstruction(cg, TR::InstOpCode::LHI, node, resultReg, 1, cursor);
       }
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    // objClassReg contains the class offset, so we may need to
    // convert this offset to a real J9Class pointer
 #endif
@@ -1364,7 +1364,7 @@ genTestIsSuper(TR::CodeGenerator * cg, TR::Node * node,
          {
          cursor = generateRSInstruction(cg, TR::InstOpCode::SLL, node, scratch2Reg, 2, cursor);
          }
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // castClassReg contains the class offset, but the memory reference below will
       // generate a J9Class pointer. We may need to convert this pointer to an offset
 #endif
@@ -1373,7 +1373,7 @@ genTestIsSuper(TR::CodeGenerator * cg, TR::Node * node,
       }
    else
       {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // castClassReg contains the class offset, but the memory reference below will
       // generate a J9Class pointer. We may need to convert this pointer to an offset
 #endif
@@ -1836,7 +1836,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
       // inline checking remembered bit for generational or (gencon+cardmarking is inlined).
       static_assert(J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST <= 0xFF, "The constant is too big");
       int32_t offsetToAgeBits =  TR::Compiler->om.offsetOfHeaderFlags() + 3;
-#if defined(J9VM_INTERP_FLAGS_IN_CLASS_SLOT) && defined(TR_TARGET_64BIT) && !defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(J9VM_INTERP_FLAGS_IN_CLASS_SLOT) && defined(TR_TARGET_64BIT) && defined(OMR_GC_FULL_POINTERS)
       offsetToAgeBits += 4;
 #endif
       TR::MemoryReference * tempMR = generateS390MemoryReference(owningObjectReg, offsetToAgeBits, cg);
@@ -3984,7 +3984,7 @@ VMarrayStoreCHKEvaluator(
    cursor = generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, t1Reg, generateS390MemoryReference(owningObjectRegVal, (int32_t) offsetof(J9ArrayClass, componentType), cg));
 
    // check if obj.class(in t1Reg) == array.componentClass in t2Reg
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CR, node, t1Reg, srcRegVal, TR::InstOpCode::COND_BER, wbLabel, false, false);
 #else
    cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpLogicalRegOpCode(), node, t1Reg, srcRegVal, TR::InstOpCode::COND_BE, wbLabel, false, false);
@@ -4037,7 +4037,7 @@ VMarrayStoreCHKEvaluator(
             genLoadAddressConstantInSnippet(cg, node, (intptr_t)objectClass, t2Reg, cursor, conditions, litPoolBaseReg, true);
             }
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          generateRRInstruction(cg, TR::InstOpCode::CR, node, t1Reg, t2Reg);
 #else
          generateRRInstruction(cg, TR::InstOpCode::getCmpLogicalRegOpCode(), node, t1Reg, t2Reg);
@@ -4787,7 +4787,7 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator(TR::Node * node, TR::CodeGene
 
       TR::LabelSymbol * doneTestCacheLabel  = generateLabelSymbol(cg);
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // For the memory reference below, we may need to convert the
       // class offset from objClassReg into a J9Class pointer
 #endif
@@ -4817,7 +4817,7 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator(TR::Node * node, TR::CodeGene
          generateRRInstruction(cg, TR::InstOpCode::getAndRegOpCode(), node, scratch1Reg, scratch2Reg);
          }
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // May need to convert the J9Class pointer from scratch1Reg
       // into a class offset
 #endif
@@ -6981,7 +6981,7 @@ J9::Z::TreeEvaluator::VMcheckcastEvaluator(TR::Node * node, TR::CodeGenerator * 
       // compare and we will take the slow path.
 
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
       // for the following two instructions we may need to convert the
       // class offset from scratch1Reg into a J9Class pointer and
       // offset from castClassReg into a J9Pointer. Then we can compare
@@ -7243,7 +7243,7 @@ J9::Z::TreeEvaluator::VMmonentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
          TR::MemoryReference * temp2MR = generateS390MemoryReference(cg->getMethodMetaDataRealRegister(), lookupOffsetReg, offsetOfMonitorLookupCache, cg);
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
          generateRXInstruction(cg, TR::InstOpCode::LLGF, node, tempRegister, temp2MR, NULL);
          startICF = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, tempRegister, NULLVALUE, TR::InstOpCode::COND_BE, helperCallLabel, false, true);
 #else
@@ -7676,7 +7676,7 @@ J9::Z::TreeEvaluator::VMmonexitEvaluator(TR::Node * node, TR::CodeGenerator * cg
          // TODO No Need to use Memory Reference Here. Combine it with generateRXInstruction
          TR::MemoryReference * temp2MR = generateS390MemoryReference(cg->getMethodMetaDataRealRegister(), lookupOffsetReg, offsetOfMonitorLookupCache, cg);
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
          generateRXInstruction(cg, TR::InstOpCode::LLGF, node, tempRegister, temp2MR, NULL);
          startICF = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, tempRegister, NULLVALUE, TR::InstOpCode::COND_BE, helperCallLabel, false, true);
 #else
@@ -8290,7 +8290,7 @@ genInitObjectHeader(TR::Node * node, TR::Instruction *& iCursor, TR_OpaqueClassB
             iCursor = genLoadAddressConstantInSnippet(cg, node, (intptr_t) classAddress | (intptrj_t)orFlag, temp1Reg, iCursor, conditions, litPoolBaseReg, true);
             if (orFlag != 0)
                {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
                iCursor = generateS390ImmOp(cg, TR::InstOpCode::O, node, temp1Reg, temp1Reg, (int32_t)orFlag, conditions, litPoolBaseReg);
 #else
                if (TR::Compiler->target.is64Bit())
@@ -8324,7 +8324,7 @@ genInitObjectHeader(TR::Node * node, TR::Instruction *& iCursor, TR_OpaqueClassB
             }
          else
             {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
             // must store just 32 bits (class offset)
 
             iCursor = generateRXInstruction(cg, TR::InstOpCode::ST, node, temp1Reg,
@@ -8337,7 +8337,7 @@ genInitObjectHeader(TR::Node * node, TR::Instruction *& iCursor, TR_OpaqueClassB
          }
       else
          {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
          // must store just 32 bits (class offset)
          iCursor = generateRXInstruction(cg, TR::InstOpCode::ST, node, clzReg,
                generateS390MemoryReference(resReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), cg), iCursor);
@@ -8491,7 +8491,7 @@ genInitArrayHeader(TR::Node * node, TR::Instruction *& iCursor, bool isVariableL
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    bool canUseIIHF= false;
    if (!comp->compileRelocatableCode() && (node->getOpCodeValue() == TR::newarray || node->getOpCodeValue() == TR::anewarray)
-#ifndef J9VM_GC_COMPRESSED_POINTERS
+#ifndef OMR_GC_COMPRESSED_POINTERS
          && TR::Compiler->target.is32Bit()
 #endif
 #ifndef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
@@ -9319,7 +9319,7 @@ J9::Z::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::CodeGenerator *c
    //
    TR::TreeEvaluator::genLoadForObjectHeaders(cg, node, tempReg, generateS390MemoryReference(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), NULL);
 
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
    generateRXInstruction(cg, TR::InstOpCode::X, node, tempReg, generateS390MemoryReference(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg));
 #else
    generateRXInstruction(cg, TR::InstOpCode::getXOROpCode(), node, tempReg, generateS390MemoryReference(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg));

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1181,7 +1181,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     LR_GPR  r0,r14
     BASR    r14,rEP                      # Call jitResolvedStaticField
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     LHI     r1,2                                 # shift for addr
 ],[dnl
     LHI     r1,3                                 # shift for addr
@@ -1192,7 +1192,7 @@ ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
     JZ      LMTStaticAddressLoadNoneIsolated
 
     MTComputeStaticAddress(AddressLoad,Obj)
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     LLGF    r3,0(,r2)                        # load comprssed val
     SLLG    r3,r3,0(r1)                       # decompress
     STG     r3,(2*PTR_SIZE)(,r5)             # store val into r2
@@ -1350,7 +1350,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     LG      r1,28(,r14)               # load CP word
     LG      r7,(PTR_SIZE)(,r5)        # load JIT r1, obj to store
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     SLLG    r2,r2,2                   # col offset, data size
     SLLG    r6,r6,2                   # row offset, compressed
     LLGF    r3,8(r6,r3)               # tenantData[row]
@@ -1883,7 +1883,7 @@ LABEL(LcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)  # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load lookup class offset
     LLGFR   r1,r1
@@ -1900,7 +1900,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
     LR_GPR  r14,r0
 ZZ                                  # return interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)  # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -1918,7 +1918,7 @@ LABEL(LcommonJitDispatch)         # interpVtable offset in r2
     LNR_GPR r2,r2                 # negative the interpVtable offset
     AHI_GPR r2,J9TR_InterpVTableOffset
     LR_GPR  r0,r2                 # J9 requires the offset in R0
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -1988,7 +1988,7 @@ LABEL(ifCH1LcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load lookup class offset
     LLGFR   r1,r1
@@ -2005,7 +2005,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
 
 ZZ                                # return interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -2018,7 +2018,7 @@ ZZ # Load the addr of the lookup class
     TM   eq_methodCompiledFlagOffset(r3),J9TR_MethodNotCompiledBit
     JNZ     ifCH1LcommonJitDispatch
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r2,r2
@@ -2068,7 +2068,7 @@ ZZ For zos rEP(r15) is not clobbered, hense not saved
 
     L       CARG2,J9TR_J9Class_classLoader(r2)
 
-ZZ  for J9VM_GC_COMPRESSED_POINTERS
+ZZ  for OMR_GC_COMPRESSED_POINTERS
 ZZ  may need to convert r2 to J9Class
 
     L       CARG1,eq_intfAddr_inInterfaceSnippet(,r14)
@@ -2162,7 +2162,7 @@ LABEL(ifCH1LcommonJitDispatch)      # interpVtable offset in rEP
     AHI_GPR rEP,J9TR_InterpVTableOffset
     LR_GPR  r0,rEP                  # J9 requires the offset in R0
     L_GPR   r1,(2*PTR_SIZE)(J9SP)   # Restore "this"
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of lookup class
     LLGFR   r3,r3
@@ -2231,7 +2231,7 @@ LABEL(ifCHMLcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load offset of lookup class
     LLGFR   r1,r1
@@ -2248,7 +2248,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
 
 ZZ                          # returned interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -2263,7 +2263,7 @@ ZZ # Load the address of the lookup class
     JNZ     ifCHMLcommonJitDispatch
 
 ZZ  #Load reciving object classPtr in R2
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r2,r2
@@ -2327,7 +2327,7 @@ LABEL(ifCHMLoopTillUpdate)
 
 ZZ  current slot is now updated,
 ZZ  Lets see if it has same classPtr as we are trying to store
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r0,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r0,r0
@@ -2349,7 +2349,7 @@ ZZ slot we contended for last time
 LABEL(ifCHMUpdateCacheSlot)
 ZZ store class pointer and method EP in the current empty slot
     ST_GPR  r3,PTR_SIZE(,r1)
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     ST  r2,0(,r1)
 ],[dnl
     ST_GPR  r2,0(,r1)
@@ -2363,7 +2363,7 @@ ZZ  Load pic address as second address
     L_GPR   r0,J9TR_J9Class_classLoader(CARG1)
 
 ZZ  Load class pointer as first argument
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       CARG1,0(CARG2)   # May need to convert offset to J9Class
     LLGFR   CARG1,CARG1
 ],[dnl
@@ -2447,7 +2447,7 @@ LABEL(ifCHMLcommonJitDispatch)    # interpVtable offset in rEP
     AHI_GPR rEP,J9TR_InterpVTableOffset
     LR_GPR  r0,rEP                # J9 requires the offset in R0
     L_GPR   r1,(2*PTR_SIZE)(J9SP) # Restore "this"
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3

--- a/runtime/compiler/z/runtime/Recompilation.m4
+++ b/runtime/compiler/z/runtime/Recompilation.m4
@@ -958,7 +958,7 @@ ZZ            rEP - new method Entry Point
 
 ZZ Get the lastCacheSlot pointer into r3.
     L_GPR     r3,eq_lastCachedSlotField_inInterfaceSnippet(r2)
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
 ZZ Load the class offset (32 bits)
     L         r0,J9TR_J9Object_class(,r1)
     LLGFR     r0,r0
@@ -978,7 +978,7 @@ ZZ slots or slots are uninitialized.
     JL        LJumpToNewRoutine
 
 ZZ Compare our class pointer with the class pointer in current slot
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     CL        r0,0(,r3)
 ],[dnl
     CL_GPR    r0,0(,r3)

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -540,7 +540,7 @@ define(MTComputeStaticAddress,[dnl
     NILH    r2,0                      # get col index
     SLLG    r2,r2,0(r1)               # col offset, data size
 
-ifdef([J9VM_GC_COMPRESSED_POINTERS],[dnl
+ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     LGR     r14,r0                    # restore r14
     LG      r1,28(,r14)               # load CP word
     SRLG    r1,r1,8                   # shift amount

--- a/runtime/gc_api/HeapIteratorAPI.cpp
+++ b/runtime/gc_api/HeapIteratorAPI.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2019 IBM Corp. and others
  *
@@ -175,11 +174,11 @@ j9mm_iterate_spaces(
 		spaceDesc.classPointerOffset = TMP_OFFSETOF_J9OBJECT_CLAZZ;
 		spaceDesc.classPointerSize = sizeof(j9objectclass_t);
 		spaceDesc.fobjectPointerDisplacement = 0;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		spaceDesc.fobjectPointerScale = (UDATA)1 << vm->compressedPointersShift;
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		spaceDesc.fobjectPointerScale = 1;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 		spaceDesc.fobjectSize = sizeof(fj9object_t);
 		spaceDesc.memorySpace = defaultMemorySpace;
 

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -50,7 +50,7 @@ MM_ObjectAccessBarrier::initialize(MM_EnvironmentBase *env)
 	J9JavaVM *vm = (J9JavaVM*)env->getOmrVM()->_language_vm;
 	OMR_VM *omrVM = env->getOmrVM();
 	
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 
 #if defined(J9VM_GC_REALTIME)
 	/*
@@ -69,7 +69,7 @@ MM_ObjectAccessBarrier::initialize(MM_EnvironmentBase *env)
 	_compressedPointersShift = omrVM->_compressedPointersShift;
 	vm->compressedPointersShift = omrVM->_compressedPointersShift;
 	Trc_MM_CompressedAccessBarrierInitialized(env->getLanguageVMThread(), 0, _compressedPointersShift);
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 	vm->objectAlignmentInBytes = omrVM->_objectAlignmentInBytes;
 	vm->objectAlignmentShift = omrVM->_objectAlignmentShift;
@@ -1567,7 +1567,7 @@ MM_ObjectAccessBarrier::compareAndSwapObject(J9VMThread *vmThread, J9Object *des
 		preObjectStore(vmThread, destObject, actualDestAddress, swapObject, true);
 		protectIfVolatileBefore(vmThread, true, false, false);
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		result = ((U_32)(UDATA)compareValue == MM_AtomicOperations::lockCompareExchangeU32((U_32 *)actualDestAddress, (U_32)(UDATA)compareValue, (U_32)(UDATA)swapValue));
 #else
 		result = ((UDATA)compareValue == MM_AtomicOperations::lockCompareExchange((UDATA *)actualDestAddress, (UDATA)compareValue, (UDATA)swapValue));
@@ -1715,7 +1715,7 @@ MM_ObjectAccessBarrier::compareAndExchangeObject(J9VMThread *vmThread, J9Object 
 		preObjectStore(vmThread, destObject, actualDestAddress, swapObject, true);
 		protectIfVolatileBefore(vmThread, true, false, false);
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		J9Object *result = (J9Object *)(UDATA)MM_AtomicOperations::lockCompareExchangeU32((U_32 *)actualDestAddress, (U_32)(UDATA)compareValue, (U_32)(UDATA)swapValue);
 #else
 		J9Object *result = (J9Object *)MM_AtomicOperations::lockCompareExchange((UDATA *)actualDestAddress, (UDATA)compareValue, (UDATA)swapValue);

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2019 IBM Corp. and others
  *
@@ -54,9 +53,9 @@ private:
 protected:
 	MM_GCExtensions *_extensions; 
 	MM_Heap *_heap;
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	UDATA _compressedPointersShift; /**< the number of bits to shift by when converting between the compressed pointers heap and real heap */
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	UDATA _referenceLinkOffset; /** Offset within java/lang/ref/Reference of the reference link field */
 	UDATA _ownableSynchronizerLinkOffset; /** Offset within java/util/concurrent/locks/AbstractOwnableSynchronizer of the ownable synchronizer link field */
 public:
@@ -305,11 +304,11 @@ public:
 	MMINLINE mm_j9object_t 
 	convertPointerFromToken(fj9object_t token)
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return (mm_j9object_t)((UDATA)token << compressedPointersShift());
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return (mm_j9object_t)token;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	}
 	
 	/**
@@ -321,11 +320,11 @@ public:
 	MMINLINE fj9object_t 
 	convertTokenFromPointer(mm_j9object_t pointer)
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return (fj9object_t)((UDATA)pointer >> compressedPointersShift());
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return (fj9object_t)pointer;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	}
 
 	/**
@@ -338,11 +337,11 @@ public:
 	MMINLINE UDATA 
 	compressedPointersShift()
 	{ 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return _compressedPointersShift;
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return 0;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */ 
+#endif /* OMR_GC_COMPRESSED_POINTERS */ 
 	}
 
 	virtual UDATA compressedPointersShadowHeapBase(J9VMThread *vmThread);
@@ -535,9 +534,9 @@ public:
 	MM_ObjectAccessBarrier(MM_EnvironmentBase *env) : MM_BaseVirtual()
 		, _extensions(NULL) 
 		, _heap(NULL)
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		, _compressedPointersShift(0)
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 		, _referenceLinkOffset(UDATA_MAX)
 		, _ownableSynchronizerLinkOffset(UDATA_MAX)
 	{

--- a/runtime/gc_base/ScavengerForwardedHeader.cpp
+++ b/runtime/gc_base/ScavengerForwardedHeader.cpp
@@ -31,9 +31,9 @@
 void
 MM_ScavengerForwardedHeader::validateAssumptions()
 {
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	Assert_MM_true(offsetof(J9IndexableObjectContiguous, size) == offsetof(MutableHeaderFields, overlap));
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 }
 
 /**
@@ -56,7 +56,7 @@ MM_ScavengerForwardedHeader::setForwardedObject(omrobjectptr_t destinationObject
 	volatile MutableHeaderFields* objectHeader = (volatile MutableHeaderFields *)_objectPtr;
 	UDATA oldValue = *(UDATA *)&_preserved.clazz;
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN)
+#if defined (OMR_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN)
 	/*
 	 *  Forwarded tag should be in low bits of the pointer and at the same time be in class slot
 	 * To get it for compressed big endian just swap halves of pointer
@@ -66,12 +66,12 @@ MM_ScavengerForwardedHeader::setForwardedObject(omrobjectptr_t destinationObject
 	/* add a high half */
 	newValue |= ((UDATA)destinationObjectPtr | FORWARDED_TAG) << 32;
 
-#else /* defined (J9VM_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
+#else /* defined (OMR_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
 
 	/* little endian or not compressed - write UDATA bytes straight */
 	UDATA newValue = (UDATA)destinationObjectPtr | FORWARDED_TAG;
 
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
 
 	if (MM_AtomicOperations::lockCompareExchange((volatile UDATA*)&objectHeader->clazz, oldValue, newValue) != oldValue) {
 		MM_ScavengerForwardedHeader forwardedObject(_objectPtr);

--- a/runtime/gc_base/ScavengerForwardedHeader.hpp
+++ b/runtime/gc_base/ScavengerForwardedHeader.hpp
@@ -61,13 +61,13 @@ protected:
 		/* class slot must be always aligned to UDATA */
 		j9objectclass_t clazz;
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		/*
 		 * this field is used indirectly by extending of clazz field (8 bytes starting from &MutableHeaderFields.clazz)
 		 * must be here to reserve space if clazz field is 4 bytes long
 		 */
 		U_32 overlap;
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 	};
 	
 	omrobjectptr_t _objectPtr; /**< the object on which to act */
@@ -313,25 +313,25 @@ public:
 		/* restore class slot from local copy, change age flags in low bits of class slot at the same time */
 		newHeader->clazz = (j9objectclass_t)(((UDATA)_preserved.clazz & ~OBJECT_HEADER_AGE_MASK) | newAge);
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		/* first object slot is destroyed, must be restored from local copy as well */
 		newHeader->overlap = _preserved.overlap;
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 	}
 
 	MMINLINE U_32
 	getPreservedIndexableSize()
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		/* in compressed headers, the size of the object is stored in the other half of the UDATA read when we read clazz
 		 * so read it from there instead of the heap (since the heap copy would have been over-written by the forwarding
 		 * pointer if another thread copied the object underneath us).
 		 * In non-compressed, this field should still be readable out of the heap.
 		 */
 		U_32 size = _preserved.overlap;
-#else /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#else /* defined (OMR_GC_COMPRESSED_POINTERS) */
 		U_32 size = ((J9IndexableObjectContiguous *)_objectPtr)->size;
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 #if defined(J9VM_GC_HYBRID_ARRAYLETS)
 		if (0 == size) {
 			/* Discontiguous */
@@ -373,18 +373,18 @@ protected:
 	{
 		Assert_MM_true(isForwardedPointer());
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN)
+#if defined (OMR_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN)
 		/* compressed big endian - read two halves separately */
 		U_32 low = _preserved.clazz & ~ALL_TAGS;
 		U_32 high = _preserved.overlap;
 		omrobjectptr_t forwardedObject = (omrobjectptr_t)((U_64)low | ((U_64)high << 32));
 
-#else /* defined (J9VM_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
+#else /* defined (OMR_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
 
 		/* Little endian or not compressed - read all UDATA bytes at once */
 		omrobjectptr_t forwardedObject = (omrobjectptr_t)(*(UDATA *)(&_preserved.clazz) & ~ALL_TAGS);
 
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) && !defined(J9VM_ENV_LITTLE_ENDIAN) */
 
 		return forwardedObject;
 	}

--- a/runtime/gc_base/modron.h
+++ b/runtime/gc_base/modron.h
@@ -102,7 +102,7 @@
 #define J9GC_CLASS_SHAPE(ramClass)		(J9CLASS_SHAPE(ramClass))
 #define J9GC_CLASS_IS_ARRAY(ramClass)	(J9CLASS_IS_ARRAY(ramClass))
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 
 extern "C" mm_j9object_t j9gc_objaccess_pointerFromToken(J9VMThread *vmThread, fj9object_t token);
 extern "C" fj9object_t j9gc_objaccess_tokenFromPointer(J9VMThread *vmThread, mm_j9object_t object);
@@ -113,12 +113,12 @@ extern "C" fj9object_t j9gc_objaccess_tokenFromPointer(J9VMThread *vmThread, mm_
 /* The size of the reserved area at the beginning of the compressed pointer heap */
 #define J9GC_COMPRESSED_POINTER_NULL_REGION_SIZE 4096
 
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 
 #define mmPointerFromToken(vmThread, token) ((mm_j9object_t)(token))
 #define mmTokenFromPointer(vmThread, object) ((fj9object_t)(object))
 
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 #if defined(J9VM_GC_REALTIME)
 /* Note that the "reserved" index is used for 2 different purposes with the

--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2019 IBM Corp. and others
  *
@@ -1535,11 +1534,11 @@ isPointerInRange(void *pointer, void *start, void *end)
 static J9Object* 
 convertPointerFromToken(J9JavaVM* vm, fj9object_t token)
 {
-#if defined(J9VM_GC_COMPRESSED_POINTERS)	
+#if defined(OMR_GC_COMPRESSED_POINTERS)	
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vm)->accessBarrier;
 	return barrier->convertPointerFromToken(token);
 #else 
 	return (J9Object*)token;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 }
 #endif /* J9VM_GC_ARRAYLETS && !J9VM_GC_HYBRID_ARRAYLETS */

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,7 +131,7 @@ public:
 	{
 		bool needAlignment = false;
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		/* Compressed pointers require that each leaf starts at 8 aligned address.
 		 * Otherwise compressed leaf pointers will not work with shift value of 3.
 		 */

--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -51,9 +51,9 @@
 #include "ObjectModel.hpp"
 #include "ParallelGlobalGC.hpp"
 #include "ParallelHeapWalker.hpp"
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 #include "ReadBarrierVerifier.hpp"
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 #include "ReferenceChainWalkerMarkMap.hpp"
 #include "ReferenceObjectList.hpp"
 #include "ScavengerJavaStats.hpp"
@@ -101,11 +101,11 @@ MM_GlobalCollectorDelegate::initialize(MM_EnvironmentBase *env, MM_GlobalCollect
 	/* Balanced and realtime polices will instantiate their own access barrier */
 	if (_extensions->isStandardGC()) {
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 		if (1 == _extensions->fvtest_enableReadBarrierVerification) {
 			_extensions->accessBarrier = MM_ReadBarrierVerifier::newInstance(env);
 		} else
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 		{
 			_extensions->accessBarrier = MM_StandardAccessBarrier::newInstance(env);
 		}
@@ -311,7 +311,7 @@ MM_GlobalCollectorDelegate::prepareHeapForWalk(MM_EnvironmentBase *env)
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 }
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 void
 MM_GlobalCollectorDelegate::poisonSlots(MM_EnvironmentBase *env)
 {
@@ -323,7 +323,7 @@ MM_GlobalCollectorDelegate::healSlots(MM_EnvironmentBase *env)
 {
 	((MM_ReadBarrierVerifier *)_extensions->accessBarrier)->healSlots(env);
 }
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 bool
 MM_GlobalCollectorDelegate::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress)

--- a/runtime/gc_glue_java/GlobalCollectorDelegate.hpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,10 +86,10 @@ public:
 	bool isAllowUserHeapWalk();
 	void prepareHeapForWalk(MM_EnvironmentBase *env);
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	void poisonSlots(MM_EnvironmentBase *env);
 	void healSlots(MM_EnvironmentBase *env);
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress);
 	bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);

--- a/runtime/gc_glue_java/ObjectModelDelegate.hpp
+++ b/runtime/gc_glue_java/ObjectModelDelegate.hpp
@@ -320,7 +320,7 @@ public:
 		J9Class* clazz = (J9Class *)(preservedSlot & ~(UDATA)_delegateHeaderSlotFlagsMask);
 
 		if (J9GC_CLASS_IS_ARRAY(clazz)) {
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 			uintptr_t elements = forwardedHeader->getPreservedOverlap();
 #else /* defined (OMR_GC_COMPRESSED_POINTERS) */
 			uintptr_t elements = ((J9IndexableObjectContiguous *)forwardedHeader->getObject())->size;

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -87,9 +87,9 @@
 #include "ParallelHeapWalker.hpp"
 #include "ParallelSweepScheme.hpp"
 #include "PointerArrayObjectScanner.hpp"
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 #include "ReadBarrierVerifier.hpp"
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 #include "ReferenceChainWalkerMarkMap.hpp"
 #include "ReferenceObjectBuffer.hpp"
 #include "ReferenceObjectList.hpp"
@@ -514,12 +514,12 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 		}
 		extensions->objectModel.setObjectClassAndFlags(objectPtr, forwardedClass, forwardedFlags);
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		/* Restore destroyed overlapped slot in the original object. This slot might need to be reversed
 		 * as well or it may be already reversed - such fixup will be completed at in a later pass.
 		 */
 		originalForwardedHeader->restoreDestroyedOverlap();
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 
 		MM_ObjectAccessBarrier* barrier = extensions->accessBarrier;
 
@@ -546,7 +546,7 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 	}
 }
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 void
 MM_ScavengerDelegate::fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *originalForwardedHeader, MM_MemorySubSpaceSemiSpace *subSpaceNew)
 {
@@ -584,7 +584,7 @@ MM_ScavengerDelegate::fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHe
 		}
 	}
 }
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 
 void
 MM_ScavengerDelegate::private_addOwnableSynchronizerObjectInList(MM_EnvironmentStandard *env, omrobjectptr_t object)
@@ -671,10 +671,10 @@ MM_ScavengerDelegate::switchConcurrentForThread(MM_EnvironmentBase *env)
 		 */
 		vmThread->readBarrierRangeCheckBase = (UDATA)base;
 		vmThread->readBarrierRangeCheckTop = (UDATA)top - 1;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		vmThread->readBarrierRangeCheckBaseCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckBase);
 		vmThread->readBarrierRangeCheckTopCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckTop);
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 		vmThread->privateFlags |= J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE;
 
 		if (_extensions->isConcurrentScavengerHWSupported()) {
@@ -713,7 +713,7 @@ MM_ScavengerDelegate::switchConcurrentForThread(MM_EnvironmentBase *env)
 		vmThread->privateFlags &= ~J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE;
 		vmThread->readBarrierRangeCheckBase = UDATA_MAX;
 		vmThread->readBarrierRangeCheckTop = 0;
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 		vmThread->readBarrierRangeCheckBaseCompressed = U_32_MAX;
 		vmThread->readBarrierRangeCheckTopCompressed = 0;
 #endif
@@ -721,7 +721,7 @@ MM_ScavengerDelegate::switchConcurrentForThread(MM_EnvironmentBase *env)
 }
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 void
 MM_ScavengerDelegate::poisonSlots(MM_EnvironmentBase *env)
 {
@@ -733,7 +733,7 @@ MM_ScavengerDelegate::healSlots(MM_EnvironmentBase *env)
 {
 	((MM_ReadBarrierVerifier *)_extensions->accessBarrier)->healSlots(env);
 }
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 MM_ScavengerDelegate::MM_ScavengerDelegate(MM_EnvironmentBase* env)
 	: _omrVM(MM_GCExtensions::getExtensions(env)->getOmrVM())

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -118,9 +118,9 @@ public:
 	void backOutIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	void backOutIndirectObjects(MM_EnvironmentStandard *env);
 	void reverseForwardedObject(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject);
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	void fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject, MM_MemorySubSpaceSemiSpace *subSpaceNew);
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	void switchConcurrentForThread(MM_EnvironmentBase *env);
@@ -141,10 +141,10 @@ public:
 	bool getFinalizationRequired(void) { return _finalizationRequired; }
 #endif /* J9VM_GC_FINALIZATION */
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	void poisonSlots(MM_EnvironmentBase *env);
 	void healSlots(MM_EnvironmentBase *env);
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);

--- a/runtime/gc_glue_java/objectdescription.h
+++ b/runtime/gc_glue_java/objectdescription.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ typedef J9Object* languageobjectptr_t;
 typedef J9Object* omrobjectptr_t;
 typedef J9IndexableObject* omrarrayptr_t;
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 typedef U_32 fomrobject_t;
 typedef U_32 fomrarray_t;
 #else

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -47,9 +47,9 @@ protected:
 private:
 	const UDATA _writeBarrierType;
 	const UDATA _readBarrierType;
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	const UDATA _compressedPointersShift;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 /* Methods */
 public:
@@ -60,9 +60,9 @@ public:
 	MM_ObjectAccessBarrierAPI(J9VMThread *currentThread)
 		: _writeBarrierType(currentThread->javaVM->gcWriteBarrierType)
 		, _readBarrierType(currentThread->javaVM->gcReadBarrierType)
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		, _compressedPointersShift(currentThread->javaVM->compressedPointersShift)
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	{}
 
 	static VMINLINE void
@@ -1977,11 +1977,11 @@ public:
 	static VMINLINE fj9object_t
 	convertTokenFromPointer(j9object_t pointer, UDATA compressedPointersShift)
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return (fj9object_t)((UDATA)pointer >> compressedPointersShift);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return (fj9object_t)pointer;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	}
 
 	/**
@@ -1993,11 +1993,11 @@ public:
 	static VMINLINE j9object_t
 	convertPointerFromToken(fj9object_t token, UDATA compressedPointersShift)
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return (mm_j9object_t)((UDATA)token << compressedPointersShift);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return (mm_j9object_t)token;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	}
 
 	/* Return an j9object_t that can be stored in the constantpool.
@@ -2603,11 +2603,11 @@ protected:
 	VMINLINE fj9object_t
 	internalConvertTokenFromPointer(j9object_t pointer)
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return convertTokenFromPointer(pointer, _compressedPointersShift);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return (fj9object_t)pointer;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	}
 
 	/**
@@ -2619,11 +2619,11 @@ protected:
 	VMINLINE j9object_t
 	internalConvertPointerFromToken(fj9object_t token)
 	{
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		return convertPointerFromToken(token, _compressedPointersShift);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		return (mm_j9object_t)token;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	}
 
 private:
@@ -2909,11 +2909,11 @@ private:
 			}
 			newFlags = (oldFlags & ~J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_CLEAR) | J9_OBJECT_HEADER_REMEMBERED_BITS_TO_SET;
 		}
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		while (oldFlags != VM_AtomicSupport::lockCompareExchangeU32(flagsPtr, oldFlags, newFlags));
-#else /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		while (oldFlags != VM_AtomicSupport::lockCompareExchange(flagsPtr, (UDATA)oldFlags, (UDATA)newFlags));
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 		return result;
 	}

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@
 #include "Scavenger.hpp"
 #include "SublistFragment.hpp"
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 
 MM_ReadBarrierVerifier *
 MM_ReadBarrierVerifier::newInstance(MM_EnvironmentBase *env)
@@ -249,5 +249,5 @@ MM_ReadBarrierVerifier::preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAdd
 	return true;
 }
 
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@
 
 #include "StandardAccessBarrier.hpp"
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 
 /**
  * Access barrier for Modron collector.
@@ -79,7 +79,7 @@ public:
 
 
 };
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 #endif /* ReadBarrierVerifier_HPP_ */
 

--- a/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 #include "ObjectAccessBarrier.hpp"
 #include "RootScannerReadBarrierVerifier.hpp"
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 
 void
 MM_RootScannerReadBarrierVerifier::doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator)
@@ -112,4 +112,4 @@ MM_RootScannerReadBarrierVerifier::doClassStaticSlots(omrobjectptr_t *slotPtr)
 	}
 }
 
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */

--- a/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.hpp
+++ b/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 #include "j9.h"
 #include "RootScanner.hpp"
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 
 class MM_RootScannerReadBarrierVerifier : public MM_RootScanner
 {
@@ -57,7 +57,7 @@ class MM_RootScannerReadBarrierVerifier : public MM_RootScanner
 
 };
 
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 #endif /* RootScannerReadBarrierVerifier_HPP_ */
 

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1100,7 +1100,7 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 	extensions->memoryMax = MM_Math::roundToFloor(extensions->regionSize, extensions->memoryMax);
 	extensions->maxSizeDefaultMemorySpace = MM_Math::roundToFloor(extensions->regionSize, extensions->maxSizeDefaultMemorySpace);
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	if (extensions->shouldAllowShiftingCompression) {
 		if (extensions->shouldForceSpecifiedShiftingCompression) {
 			extensions->heapCeiling = NON_SCALING_LOW_MEMORY_HEAP_CEILING << extensions->forcedShiftingCompressionAmount;
@@ -1150,7 +1150,7 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, displayXmxOrMaxRAMPercentage(memoryParameters));
 		return JNI_ERR;
 	}
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 
 	/* Verify Xmx is too small */
 	if (extensions->memoryMax < minimumSizeValue) {
@@ -1538,10 +1538,10 @@ independentMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		extensions->allocationIncrement = MM_Math::roundToCeiling(extensions->regionSize, extensions->allocationIncrement);
 	}
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	/* Align the Xmcrs if necessary */
 	extensions->suballocatorInitialSize = MM_Math::roundToCeiling(SUBALLOCATOR_ALIGNMENT, extensions->suballocatorInitialSize);
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 	return JNI_OK;
 

--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1451,7 +1451,7 @@ gcParseCommandLineAndInitializeWithValues(J9JavaVM *vm, IDATA *memoryParameters)
 		goto _error;
 	}
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)	/* This should be J9VM_GC_COMPRESSED_POINTERS */
+#if defined(OMR_GC_COMPRESSED_POINTERS)	/* This should be OMR_GC_COMPRESSED_POINTERS */
 	if (-1 != index) {
 		extensions->suballocatorInitialSize = optionValue;
 	}
@@ -1464,7 +1464,7 @@ gcParseCommandLineAndInitializeWithValues(J9JavaVM *vm, IDATA *memoryParameters)
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_OVERFLOWED, OPT_XMCRS);
 			return JNI_EINVAL;
 	}
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 	memoryParameters[opt_Xmcrs] = index;
 

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -242,7 +242,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 		}
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		/* see if we are to force disable shifting in compressed refs */
 		if (try_scan(&scan_start, "noShiftingCompression")) {
 			extensions->shouldAllowShiftingCompression = false;
@@ -264,7 +264,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 
 			continue;
 		}
-#endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 
 #if defined (J9VM_GC_VLHGC)
 		/* parse the maximum age a region can have to be included in the nursery set, if specified */
@@ -1151,7 +1151,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 		if (try_scan(&scan_start, "fvtest_enableReadBarrierVerification=")) {
 			extensions->fvtest_enableReadBarrierVerification = 0;
 
@@ -1175,7 +1175,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			}
 			continue;
 		}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 		if (try_scan(&scan_start, "fvtest_forceReferenceChainWalkerMarkMapCommitFailure=")) {
 			if(!scan_udata_helper(vm, &scan_start, &(extensions->fvtest_forceReferenceChainWalkerMarkMapCommitFailure), "fvtest_forceReferenceChainWalkerMarkMapCommitFailure=")) {

--- a/runtime/gc_verbose_java/VerboseJava.cpp
+++ b/runtime/gc_verbose_java/VerboseJava.cpp
@@ -229,11 +229,11 @@ gcDumpMemorySizes(J9JavaVM *javaVM)
 	gcDumpQualifiedSize(PORTLIB, javaVM->ramClassAllocationIncrement, "-Xmca", J9NLS_GC_VERB_SIZES_XMCA);
 	gcDumpQualifiedSize(PORTLIB, javaVM->romClassAllocationIncrement, "-Xmco", J9NLS_GC_VERB_SIZES_XMCO);
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)	/* This should be J9VM_GC_COMPRESSED_POINTERS */
+#if defined(OMR_GC_COMPRESSED_POINTERS)	/* This should be OMR_GC_COMPRESSED_POINTERS */
 	gcDumpQualifiedSize(PORTLIB, extensions->suballocatorInitialSize, "-Xmcrs", J9NLS_GC_VERB_SIZES_XMCRS);
-#else /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	gcDumpQualifiedSize(PORTLIB, 0, "-Xmcrs", J9NLS_GC_VERB_SIZES_XMCRS);
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 	if (extensions->isVLHGC()) {
 #if defined (J9VM_GC_VLHGC)

--- a/runtime/gc_verbose_old_events/VerboseEventGCInitialized.cpp
+++ b/runtime/gc_verbose_old_events/VerboseEventGCInitialized.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,13 +73,13 @@ MM_VerboseEventGCInitialized::formattedOutput(MM_VerboseOutputAgent *agent)
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"gcPolicy\" value=\"%s\" />", _event.gcPolicy);
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", _event.maxHeapSize);
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"initialHeapSize\" value=\"0x%zx\" />", _event.initialHeapSize);
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"compressedRefs\" value=\"true\" />");
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"compressedRefsDisplacement\" value=\"0x%zx\" />", 0);
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"compressedRefsShift\" value=\"0x%zx\" />", _event.compressedPointersShift);
-#else /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"compressedRefs\" value=\"false\" />");
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"pageSize\" value=\"0x%zx\" />", _event.heapPageSize);
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"pageType\" value=\"%s\" />", _event.heapPageType);
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), indentLevel + 1, "<attribute name=\"requestedPageSize\" value=\"0x%zx\" />", _event.heapRequestedPageSize);

--- a/runtime/gc_vlhgc/InterRegionRememberedSet.cpp
+++ b/runtime/gc_vlhgc/InterRegionRememberedSet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -265,7 +265,7 @@ MM_InterRegionRememberedSet::initialize(MM_EnvironmentVLHGC* env)
 	_regionTable = _heapRegionManager->_regionTable;
 	_tableDescriptorSize = _heapRegionManager->_tableDescriptorSize;
 	UDATA baseOfHeap = (UDATA) (_heapRegionManager->_regionTable)->getLowAddress();
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	_cardToRegionShift = _heapRegionManager->_regionShift - CARD_SIZE_SHIFT;
 	_cardToRegionDisplacement = baseOfHeap >> CARD_SIZE_SHIFT;
 #else

--- a/runtime/gc_vlhgc/InterRegionRememberedSet.hpp
+++ b/runtime/gc_vlhgc/InterRegionRememberedSet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -380,7 +380,7 @@ public:
 	convertRememberedSetCardFromHeapAddress(void* address)
 	{
 		MM_RememberedSetCard card = 0;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		card = (MM_RememberedSetCard)((UDATA)address >> CARD_SIZE_SHIFT);
 #else
 		card = (MM_RememberedSetCard) address;	
@@ -397,7 +397,7 @@ public:
 	convertHeapAddressFromRememberedSetCard(MM_RememberedSetCard card)
 	{
 		void *address = NULL;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		address = (void *)((UDATA)card << CARD_SIZE_SHIFT);
 #else
 		address = (void *) card;
@@ -413,7 +413,7 @@ public:
 	 */
 	MMINLINE Card *rememberedSetCardToCardAddr(MM_EnvironmentVLHGC *env, MM_RememberedSetCard card)
 	{
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		Card *virtualStart = _cardTable->getCardTableVirtualStart();
 		return virtualStart + card;
 #else

--- a/runtime/gc_vlhgc/RememberedSetCardBucket.hpp
+++ b/runtime/gc_vlhgc/RememberedSetCardBucket.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,13 +32,13 @@
 #include "EnvironmentVLHGC.hpp"
 #include "GCExtensions.hpp"
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 /* Compresses a heap address by shifting right by CARD_SIZE_SHIFT */
 typedef U_32 MM_RememberedSetCard; 
 #else
 /* Just a heap address */
 typedef UDATA MM_RememberedSetCard;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 class MM_RememberedSetCardList;
 

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -131,7 +131,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 	osarch = j9sysinfo_get_CPU_architecture();
 
 #ifdef J9VM_ENV_DATA64
-	#ifdef J9VM_GC_COMPRESSED_POINTERS
+	#ifdef OMR_GC_COMPRESSED_POINTERS
 		#define MEM_INFO "-64-Bit Compressed References "
 	#else
 		#define MEM_INFO "-64-Bit "

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -297,9 +297,9 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_INTERP_SMALL_MONITOR_SLOT", 1) |
 #endif /* J9VM_INTERP_SMALL_MONITOR_SLOT */
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
-			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_GC_COMPRESSED_POINTERS", 1) |
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+			writeConstant(OMRPORTLIB, fd, "ASM_OMR_GC_COMPRESSED_POINTERS", 1) |
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 #if defined(J9VM_GC_TLH_PREFETCH_FTA)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_GC_TLH_PREFETCH_FTA", 1) |
 #endif /* J9VM_GC_TLH_PREFETCH_FTA */
@@ -482,9 +482,9 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #if defined(J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_jitTOC", offsetof(J9JavaVM, jitTOC)) |
 #endif /* J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE */
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_compressedPointersShift", offsetof(J9JavaVM, compressedPointersShift)) |
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9MemoryManagerFunctions_J9ReadBarrier", offsetof(J9MemoryManagerFunctions, J9ReadBarrier)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9MemoryManagerFunctions_referenceArrayCopy", offsetof(J9MemoryManagerFunctions, referenceArrayCopy)) |
 			/* J9VMEntryLocalStorage */

--- a/runtime/oti/ObjectHash.hpp
+++ b/runtime/oti/ObjectHash.hpp
@@ -53,11 +53,11 @@ private:
 			oldFlags = *flagsPtr;
 			newFlags = oldFlags | OBJECT_HEADER_HAS_BEEN_HASHED_IN_CLASS;
 		}
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		while (oldFlags != VM_AtomicSupport::lockCompareExchangeU32(flagsPtr, oldFlags, newFlags));
-#else /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		while (oldFlags != VM_AtomicSupport::lockCompareExchange(flagsPtr, (UDATA)oldFlags, (UDATA)newFlags));
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	}
 
 	static VMINLINE U_32

--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -216,11 +216,11 @@ done:
 	static VMINLINE j9objectmonitor_t
 	compareAndSwapLockword(j9objectmonitor_t volatile *lockEA, j9objectmonitor_t oldValue, j9objectmonitor_t newValue, bool readBeforeCAS = false)
 	{
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		j9objectmonitor_t contents = VM_AtomicSupport::lockCompareExchangeU32(lockEA, oldValue, newValue, readBeforeCAS);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		j9objectmonitor_t contents = VM_AtomicSupport::lockCompareExchange(lockEA, oldValue, newValue, readBeforeCAS);
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 		return contents;
 	}
 

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -29,20 +29,20 @@
 /*
  * Define type used to represent the class in the 'clazz' slot of an object's header
  */
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 typedef U_32 j9objectclass_t;
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 typedef UDATA j9objectclass_t;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 /*
  * Define type used to represent the lock in the 'monitor' slot of an object's header
  */
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 typedef U_32 j9objectmonitor_t;
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 typedef UDATA j9objectmonitor_t;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 /*
  * Define the type system for object pointers.
@@ -67,7 +67,7 @@ typedef struct J9IndexableObject* j9array_t;
  * Object reference fields that point to other objects require a different type from root references.  
  * In concrete terms (compressed pointers), this is the 32 bit representation of a pointer.
  */
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 typedef U_32 fj9object_t;
 typedef U_32 fj9array_t;
 #else
@@ -96,7 +96,7 @@ typedef struct J9IndexableObject* mm_j9array_t;
 #define J9JAVAVM_VMTHREAD(javaVM) (javaVM->internalVMFunctions->currentVMThread(javaVM))
 
 /* Internal macro - Do not use J9_CONVERT_POINTER_FROM_TOKEN__ or J9_CONVERT_POINTER_TO_TOKEN__! */
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(J9VM_OUT_OF_PROCESS)
 #define J9_CONVERT_POINTER_FROM_TOKEN_VM__(javaVM, pointer) ((void *) ((UDATA)(pointer) << dbgReadUDATA((UDATA*)&(javaVM->compressedPointersShift))))
 #define J9_CONVERT_POINTER_FROM_TOKEN__(vmThread, pointer) J9_CONVERT_POINTER_FROM_TOKEN_VM__(J9VMTHREAD_JAVAVM(vmThread),pointer)
@@ -108,12 +108,12 @@ typedef struct J9IndexableObject* mm_j9array_t;
 #define J9_CONVERT_POINTER_TO_TOKEN_VM__(javaVM, pointer) ((fj9object_t) ((UDATA)(pointer) >> javaVM->compressedPointersShift))
 #define J9_CONVERT_POINTER_TO_TOKEN__(vmThread, pointer) J9_CONVERT_POINTER_TO_TOKEN_VM__(J9VMTHREAD_JAVAVM(vmThread),pointer)
 #endif /* J9VM_OUT_OF_PROCESS */
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 #define J9_CONVERT_POINTER_FROM_TOKEN__(vmThread, pointer) ((void *) (pointer))
 #define J9_CONVERT_POINTER_FROM_TOKEN_VM__(javaVM, pointer) ((void *) (pointer))
 #define J9_CONVERT_POINTER_TO_TOKEN__(vmThread, pointer) ((fj9object_t)(UDATA)(pointer))
 #define J9_CONVERT_POINTER_TO_TOKEN_VM__(javaVM, pointer) ((fj9object_t)(UDATA)(pointer))
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 #if defined(J9VM_OUT_OF_PROCESS)
 #define J9JAVAARRAYDISCONTIGUOUS_EA(vmThread, array, index, elemType) (&(((elemType*)J9_CONVERT_POINTER_FROM_TOKEN__(vmThread, dbgReadPrimitiveType((UDATA)&(((fj9object_t*)((J9IndexableObjectDiscontiguous *)array + 1))[((U_32)index)/(dbgReadUDATA((UDATA*)&(J9VMTHREAD_JAVAVM(vmThread)->arrayletLeafSize))/sizeof(elemType))]), sizeof(fj9object_t))))[((U_32)index)%(dbgReadUDATA((UDATA*)&(J9VMTHREAD_JAVAVM(vmThread)->arrayletLeafSize))/sizeof(elemType))]))
@@ -641,7 +641,7 @@ typedef struct J9IndexableObject* mm_j9array_t;
 /*
  * Macros for accessing object header fields
  */
-#if defined (J9VM_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
+#if defined (OMR_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
 #define J9OBJECT_CLAZZ(vmThread, object) ((void)0, (struct J9Class*)((UDATA)J9OBJECT_U32_LOAD(vmThread, object, offsetof(J9Object,clazz)) & ~((UDATA)(J9_REQUIRED_CLASS_ALIGNMENT - 1))))
 #define J9OBJECT_CLAZZ_VM(javaVM, object) ((void)0, (struct J9Class*)((UDATA)J9OBJECT_U32_LOAD_VM(javaVM, object, offsetof(J9Object,clazz)) & ~((UDATA)(J9_REQUIRED_CLASS_ALIGNMENT - 1))))
 #define J9OBJECT_FLAGS_FROM_CLAZZ(vmThread, object) ((void)0, ((UDATA)J9OBJECT_U32_LOAD(vmThread, object, offsetof(J9Object,clazz)) & ((UDATA)(J9_REQUIRED_CLASS_ALIGNMENT - 1))))
@@ -667,7 +667,7 @@ typedef struct J9IndexableObject* mm_j9array_t;
 #define J9OBJECT_MONITOR_OFFSET(vmThread,object) offsetof(J9Object,monitor)
 #endif
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
+#if defined (OMR_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
 #define J9OBJECT_MONITOR(vmThread, object) ((void)0, (j9objectmonitor_t)J9OBJECT_U32_LOAD(vmThread, object, J9OBJECT_MONITOR_OFFSET(vmThread,object)))
 #define J9OBJECT_SET_MONITOR(vmThread, object, value) ((void)0, J9OBJECT_U32_STORE(vmThread, object,J9OBJECT_MONITOR_OFFSET(vmThread,object), value))
 #else
@@ -676,7 +676,7 @@ typedef struct J9IndexableObject* mm_j9array_t;
 #endif
 
 #if defined( J9VM_THR_LOCK_NURSERY )
-#if defined (J9VM_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
+#if defined (OMR_GC_COMPRESSED_POINTERS) || !defined (J9VM_ENV_DATA64)
 #define TMP_LOCKWORD_OFFSET(object) (dbgReadUDATA((UDATA*)((U_8*)(((UDATA)(dbgReadU32((U_32*)(((U_8*)object) + offsetof(J9Object, clazz))))& ~((UDATA)(J9_REQUIRED_CLASS_ALIGNMENT - 1)))+ offsetof(J9Class,lockOffset)))))
 #else
 #define TMP_LOCKWORD_OFFSET(object) (dbgReadUDATA((UDATA*)((U_8*)(((UDATA)(dbgReadU64((U_64*)(((U_8*)object) + offsetof(J9Object, clazz))))& ~((UDATA)(J9_REQUIRED_CLASS_ALIGNMENT - 1)))+ offsetof(J9Class,lockOffset)))))

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2809,18 +2809,18 @@ typedef struct J9IndexableObject {
 typedef struct J9IndexableObjectContiguous {
 	j9objectclass_t clazz;
 	U_32 size;
-#if defined(J9VM_ENV_DATA64) && !defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(J9VM_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	U_32 padding;
-#endif /* J9VM_ENV_DATA64 && !J9VM_GC_COMPRESSED_POINTERS */
+#endif /* J9VM_ENV_DATA64 && !OMR_GC_COMPRESSED_POINTERS */
 } J9IndexableObjectContiguous;
 
 typedef struct J9IndexableObjectDiscontiguous {
 	j9objectclass_t clazz;
 	U_32 mustBeZero;
 	U_32 size;
-#if defined(J9VM_GC_COMPRESSED_POINTERS) || !defined(J9VM_ENV_DATA64)
+#if defined(OMR_GC_COMPRESSED_POINTERS) || !defined(J9VM_ENV_DATA64)
 	U_32 padding;
-#endif /* J9VM_GC_COMPRESSED_POINTERS || !J9VM_ENV_DATA64 */
+#endif /* OMR_GC_COMPRESSED_POINTERS || !J9VM_ENV_DATA64 */
 } J9IndexableObjectDiscontiguous;
 
 typedef struct J9InitializerMethods {
@@ -4910,10 +4910,10 @@ typedef struct J9VMThread {
 	struct J9GSParameters gsParameters;
 	UDATA readBarrierRangeCheckBase;
 	UDATA readBarrierRangeCheckTop;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	U_32 readBarrierRangeCheckBaseCompressed;
 	U_32 readBarrierRangeCheckTopCompressed;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	UDATA safePointCount;
 } J9VMThread;
@@ -5266,9 +5266,9 @@ typedef struct J9JavaVM {
 	struct J9CheckJNIData checkJNIData;
 	void* j9rasdumpGlobalStorage;
 	struct J9HashTable* contendedLoadTable;
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	UDATA compressedPointersShift;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 	void ( *invokeJ9ReadBarrier)(struct J9VMThread *currentThread);
 #endif

--- a/runtime/tests/shared/SharedCacheAPITest.cpp
+++ b/runtime/tests/shared/SharedCacheAPITest.cpp
@@ -217,11 +217,11 @@ validateSharedCacheCallback(J9JavaVM *vm, J9SharedCacheInfo *cacheInfo, void *us
 
 	cacheCount++;
 
-#if defined(J9VM_ENV_DATA64) && defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(J9VM_ENV_DATA64) && defined(OMR_GC_COMPRESSED_POINTERS)
 	addrMode |= COM_IBM_ITERATE_SHARED_CACHES_COMPRESSED_POINTERS_MODE;
 #else
 	addrMode |= COM_IBM_ITERATE_SHARED_CACHES_NON_COMPRESSED_POINTERS_MODE;
-#endif /* defined(J9VM_ENV_DATA64) && defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(J9VM_ENV_DATA64) && defined(OMR_GC_COMPRESSED_POINTERS) */
 
 	/* calculate cache size for empty cache */
 	if (J9PORT_SHR_CACHE_TYPE_PERSISTENT == cacheInfo->cacheType) {

--- a/runtime/tests/thread/thrstate/runtest.c
+++ b/runtime/tests/thread/thrstate/runtest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -586,7 +586,7 @@ signalProtectedMain(struct J9PortLibrary *portLibrary, void *arg)
 		/*Soft realtime options*/
 		|| (vmOptionsTableAddOption(&vmOptionsTable, "-Xgcpolicy:metronome", NULL) != J9CMDLINE_OK)
 #endif /* defined (J9VM_GC_REALTIME) */
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		|| (vmOptionsTableAddOption(&vmOptionsTable, "-Xcompressedrefs", NULL) != J9CMDLINE_OK)
 #else
 		|| (vmOptionsTableAddOption(&vmOptionsTable, "-Xnocompressedrefs", NULL) != J9CMDLINE_OK)

--- a/runtime/util/shchelp_j9.c
+++ b/runtime/util/shchelp_j9.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,11 +57,11 @@ getJVMFeature(J9JavaVM *vm)
 	U_32 ret = J9SH_FEATURE_DEFAULT;
 
 #if defined(J9VM_ENV_DATA64)
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	ret |= J9SH_FEATURE_COMPRESSED_POINTERS;
 #else 	
 	ret |= J9SH_FEATURE_NON_COMPRESSED_POINTERS;
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 #endif /* defined(J9VM_ENV_DATA64) */
 	return ret;
 }

--- a/runtime/util/thrinfo.c
+++ b/runtime/util/thrinfo.c
@@ -28,7 +28,7 @@
 #define READU_ADDR(fieldAddr) dbgReadUDATA((UDATA *)(fieldAddr))
 #define READP(field) ((void *)READU(field))
 #define READP_ADDR(fieldAddr) ((void *)READU_ADDR(fieldAddr))
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 #define READMON(field) dbgReadU32((U_32 *)&(field))
 #define READMON_ADDR(fieldAddr) dbgReadU32((U_32 *)(fieldAddr))
 #else
@@ -39,7 +39,7 @@
 #define LOCAL_TO_TARGET(addr) dbgLocalToTarget(addr)
 
 /* This explicit conversion breaks the GC abstraction. Don't use this for in-process code. */
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 #define J9OBJECT_FROM_FJ9OBJECT(vm, fobj) ((j9object_t)(((UDATA)(fobj)) << (vm)->compressedPointersShift))
 #else
 #define J9OBJECT_FROM_FJ9OBJECT(vm, fobj) ((j9object_t)(UDATA)(fobj))

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -320,7 +320,7 @@ cancelLockReservation(J9VMThread* vmStruct)
 					Assert_VM_true(J9_FLATLOCK_COUNT(oldLock) == 0);
 				}
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 				compareAndSwapU32(lockEA, oldLock, newLock);
 #else
 				compareAndSwapUDATA(lockEA, oldLock, newLock);

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -110,7 +110,7 @@ cacheObjectMonitorForLookup(J9JavaVM* vm, J9VMThread* vmStruct, J9ObjectMonitor*
 static J9HashTable*
 createMonitorTable(J9JavaVM *vm, char *tableName) {
 
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 #define MONTABLE_FLAGS J9HASH_TABLE_ALLOCATE_ELEMENTS_USING_MALLOC32
 #else
 #define MONTABLE_FLAGS 0

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -426,7 +426,7 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 	}
 }
 
-#if !defined(J9ZOS390) && !defined(J9ZTPF) && defined(J9VM_GC_COMPRESSED_POINTERS)
+#if !defined(J9ZOS390) && !defined(J9ZTPF) && defined(OMR_GC_COMPRESSED_POINTERS)
 #define ALLOCATE_RAS_DATA_IN_SUBALLOCATOR
 #endif
 

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -130,11 +130,11 @@ void freeMemorySegment(J9JavaVM *javaVM, J9MemorySegment *segment, BOOLEAN freeD
 		} else if ((useAdvise) && (MEMORY_TYPE_JIT_SCRATCH_SPACE & segment->type)) {
 			j9mem_advise_and_free_memory(segment->baseAddress);
 		} else if (segment->type & (MEMORY_TYPE_RAM_CLASS | MEMORY_TYPE_UNDEAD_CLASS)) {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 			j9mem_free_memory32(segment->baseAddress);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 			j9mem_free_memory(segment->baseAddress);
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 		} else {
 			j9mem_free_memory(segment->baseAddress);
 		}
@@ -229,11 +229,11 @@ allocateMemoryForSegment(J9JavaVM *javaVM,J9MemorySegment *segment, J9PortVmemPa
 		tmpAddr = j9vmem_reserve_memory_ex(&segment->vmemIdentifier, vmemParams);
 		Trc_VM_virtualRAMClassAlloc(tmpAddr);
 	} else if (J9_ARE_ALL_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS)) {
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 		tmpAddr = j9mem_allocate_memory32(segment->size, memoryCategory);
-#else /* J9VM_GC_COMPRESSED_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
 		tmpAddr = j9mem_allocate_memory(segment->size, memoryCategory);
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 	} else {
 		tmpAddr = j9mem_allocate_memory(segment->size, memoryCategory);
 	}

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -100,7 +100,7 @@ void freeVMThread(J9JavaVM *vm, J9VMThread *vmThread)
 		j9mem_free_memory(vmThread->riParameters);
 	}
 #endif /* defined(J9VM_PORT_RUNTIME_INSTRUMENTATION) */
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 	j9mem_free_memory32(vmThread->startOfMemoryBlock);
 #else
 	j9mem_free_memory(vmThread->startOfMemoryBlock);

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -117,7 +117,7 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 		/* Create the vmThread */
 		void *startOfMemoryBlock = NULL;
 		UDATA vmThreadAllocationSize = J9VMTHREAD_ALIGNMENT + ROUND_TO(sizeof(UDATA), vm->vmThreadSize);
-#if defined(J9VM_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		startOfMemoryBlock = (void *)j9mem_allocate_memory32(vmThreadAllocationSize, OMRMEM_CATEGORY_THREADS);
 #else
 		startOfMemoryBlock = (void *)j9mem_allocate_memory(vmThreadAllocationSize, OMRMEM_CATEGORY_THREADS);
@@ -214,10 +214,10 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 	/* Initialize fields used by Concurrent Scavenger */
 	newThread->readBarrierRangeCheckBase = UDATA_MAX;
 	newThread->readBarrierRangeCheckTop = 0;
-#ifdef J9VM_GC_COMPRESSED_POINTERS
+#ifdef OMR_GC_COMPRESSED_POINTERS
 	newThread->readBarrierRangeCheckBaseCompressed = U_32_MAX;
 	newThread->readBarrierRangeCheckTopCompressed = 0;
-#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	/* Attach the thread to OMR */
@@ -1384,7 +1384,7 @@ allocateJavaStack(J9JavaVM * vm, UDATA stackSize, J9JavaStack * previousStack)
 	 */
 
 	mallocSize = J9_STACK_OVERFLOW_AND_HEADER_SIZE + (stackSize + sizeof(UDATA)) + vm->thrStaggerMax;
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	stack = (J9JavaStack*)j9mem_allocate_memory32(mallocSize, OMRMEM_CATEGORY_THREADS_RUNTIME_STACK);
 #else
 	stack = (J9JavaStack*)j9mem_allocate_memory(mallocSize, OMRMEM_CATEGORY_THREADS_RUNTIME_STACK);
@@ -1437,7 +1437,7 @@ freeJavaStack(J9JavaVM * vm, J9JavaStack * stack)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-#if defined (J9VM_GC_COMPRESSED_POINTERS)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	j9mem_free_memory32(stack);			
 #else
 	j9mem_free_memory(stack);

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -194,7 +194,7 @@ PLACE_LABEL(L_GS_CALL_HELPER)
 
 dnl Load the updated object pointer into CARG2
     LG CARG1,J9TR_VMThread_gsParameters_operandAddr(J9VMTHREAD)
-ifdef({ASM_J9VM_GC_COMPRESSED_POINTERS},{
+ifdef({ASM_OMR_GC_COMPRESSED_POINTERS},{
 dnl Some objects may be stored in a decompressed format on the heap.
 dnl A typical example of this may be static objects. For such objects
 dnl we must not decompress via the compressedPointersShift value. To


### PR DESCRIPTION
Replace uses of J9VM_ flags for compressed refs with OMR_ versions. The
flags must necessarily be in sync, and this makes search/replace easier.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>