### PR TITLE
Implement JIT fields cache

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -72,6 +72,9 @@ struct ClassUnloadedData
    bool _cached;
    };
 
+using TR_JitFieldsCacheEntry = std::pair<J9Class *, UDATA>;
+using TR_JitFieldsCache = PersistentUnorderedMap<int32_t, TR_JitFieldsCacheEntry>;
+
 class ClientSessionData
    {
    public:
@@ -106,6 +109,7 @@ class ClientSessionData
       TR_FieldAttributesCache *_fieldAttributesCacheAOT;
       TR_FieldAttributesCache *_staticAttributesCacheAOT;
       J9ConstantPool *_constantPool;
+      TR_JitFieldsCache *_jitFieldsCache;
       };
 
    struct J9MethodInfo

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -176,6 +176,8 @@ public:
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);
+   bool getCachedField(J9Class *ramClass, int32_t cpIndex, J9Class **declaringClass, UDATA *field);
+   void cacheField(J9Class *ramClass, int32_t cpIndex, J9Class *declaringClass, UDATA field);
    };
 
 class TR_J9SharedCacheServerVM: public TR_J9ServerVM


### PR DESCRIPTION
`TR_J9ServerVM::jitFieldsAreSame` compares 2 fields from classes
at given CP indices, and returns true if they are the same,
false otherwise.
We cache the declaring class and value of a field per RAM class,
which enables us to significantly reduce the number of remote calls
made to the client.