### PR TITLE
Convert offlineNodes to an array of nodes with hyperlinks

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes
+++ b/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes
@@ -224,7 +224,7 @@ timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNITS) {
 
                     if (aComputer.isOffline()) {
                         echo "Node: ${JENKINS_URL}${aComputer.getUrl()} - Status: offline - Cause: ${aComputer.getOfflineCause().toString()}"
-                        offlineNodes.add(aComputer.getDisplayName())
+                        offlineNodes.add("<${JENKINS_URL}${aComputer.getUrl()}|${aComputer.getDisplayName()}>")
                     }
                 }
             }


### PR DESCRIPTION
When a Slack meesage lists offline nodes, it would be useful
if the names were hyperlinks to the machine page on Jenkins.
This change will store the machine url with the name in
the offlineNodes array which is the format Slack expects for links.

[skip ci]
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>