### PR TITLE
Don't check classfiles >= 51 for JSRs with -Xverify:none

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2668,9 +2668,13 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 			return result;
 		}
 	} else {
-		/* special checking to look for jsr's if -noverify - the verifyFunction normally scans and tags 
-			for inlining methods and classes that contain jsr's */
-		hasRET = checkForJsrs(classfile);
+		/* Special checking to look for jsr's if -noverify - the verifyFunction normally scans and tags
+		 * for inlining methods and classes that contain jsr's unless the class file version is 51 or
+		 * greater as jsr / ret are always illegal in that case
+		 */
+		if (classfile->majorVersion < 51) {
+			hasRET = checkForJsrs(classfile);
+		}
 	}
 	VERBOSE_END(ParseClassFileVerifyClass);
 


### PR DESCRIPTION
Classes of version 51 or greater are not allowed to continue JSR/RET
bytecodes.  If running with -Xverify:none, then we don't need to do
the check for them.  Any issues would be reported by enabling the
verifier.

Currently, verification isn't enabled for the bootclasspath so this
change should improve startup for bootclasspath classes

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>