### PR TITLE
Miscellaneous updates specific to z/TPF

### DIFF
--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -75,7 +75,7 @@ ZASM_SCRIPT?=$(JIT_SCRIPT_DIR)/s390m4check.pl
 
 # Set up z/TPF directories and flags
 # Note: -isystem $(TPF_ROOT) is used for a2e calls to opensource functions
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/redhat/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/gnu/all /ztpf/commit
 
 TPF_INCLUDES := $(foreach d,$(TPF_ROOT),-I$d/base/a2e/headers)
 TPF_INCLUDES += $(foreach d,$(TPF_ROOT),-I$d/base/include)
@@ -270,6 +270,7 @@ SOLINK_EXTRA_ARGS+=-Wl,-soname=libj9jit29.so
 SOLINK_EXTRA_ARGS+=-Wl,--as-needed
 SOLINK_EXTRA_ARGS+=-Wl,--eh-frame-hdr
 SOLINK_EXTRA_ARGS+=$(foreach d,$(TPF_ROOT),-L$d/base/lib)
+SOLINK_EXTRA_ARGS+=$(foreach d,$(TPF_ROOT),-L$d/base/stdlib)
 SOLINK_EXTRA_ARGS+=$(foreach d,$(TPF_ROOT),-L$d/opensource/stdlib)
 
 SOLINK_FLAGS+=$(SOLINK_FLAGS_EXTRA)

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -357,7 +357,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; qemu-aarch64 -r '9' ./j9ddrgen" type="all">
 				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild"/>
 			</command>
-			<command line="cd $(UMA_PATH_TO_ROOT); if [ -x ../build_j9ddrgen.sh ] &amp;&amp; [ ! -e ../j9ddrgen.completed ] ; then ../build_j9ddrgen.sh ; fi" type="all">
+			<command line="sleep 20;cd $(UMA_PATH_TO_ROOT); if [ -x ../build_j9ddrgen.sh ] &amp;&amp; [ ! -e ../j9ddrgen.completed ] ; then ../build_j9ddrgen.sh ; fi" type="all">
 				<include-if condition="spec.linux_ztpf.*"/>
 			</command>
 		</commands>

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -493,7 +493,7 @@ static void freeGlobals(void)
 {
 	free(newPath);
 	newPath = NULL;
-	
+
 	free(j9binBuffer);
 	j9binBuffer = NULL;
 
@@ -505,7 +505,7 @@ static void freeGlobals(void)
 
 	free(j9libvmBuffer);
 	j9libvmBuffer = NULL;
-	
+
 	free(j9Buffer);
 	j9Buffer = NULL;
 }
@@ -583,8 +583,8 @@ jint JNICALL DestroyJavaVM(JavaVM * javaVM)
 
 		BFUjavaVM = NULL;
 	} else {
-		/* We are not shutting down the  port library but we still 
-		 * need to make sure memcheck gets a chance to print its 
+		/* We are not shutting down the  port library but we still
+		 * need to make sure memcheck gets a chance to print its
 		 * report.
 		 */
 		memoryCheck_print_report(&j9portLibrary);
@@ -624,7 +624,7 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserv
 }
 
 
-static BOOLEAN 
+static BOOLEAN
 preloadLibraries(void)
 {
 	char* tempchar = 0;
@@ -643,7 +643,7 @@ preloadLibraries(void)
 		return TRUE;
 	}
 	beenRun = TRUE;
-	
+
 	unicodeDLLNameLength = GetModuleFileNameW(jvm_dllHandle, unicodeDLLName, (J9_MAX_PATH + 1));
 	/* Don't use truncated path */
 	if (unicodeDLLNameLength > (DWORD)J9_MAX_PATH) {
@@ -708,7 +708,7 @@ preloadLibraries(void)
 	DBG_MSG(("j9libBuffer   = <%s>\n", jvmBufferData(j9libBuffer)));
 	DBG_MSG(("j9libvmBuffer = <%s>\n", jvmBufferData(j9libvmBuffer)));
 	DBG_MSG(("j9Buffer      = <%s>\n", jvmBufferData(j9Buffer)));
-	
+
 #if !CALL_BUNDLED_FUNCTIONS_DIRECTLY
 	vmDLL = (HINSTANCE) preloadLibrary(vmDllName, TRUE);
 	preloadLibrary(J9_HOOKABLE_DLL_NAME, TRUE);
@@ -765,7 +765,7 @@ preloadLibraries(void)
 	preloadLibrary(J9_ZIP_DLL_NAME, TRUE);
 
 #ifdef J9_CLEAR_VM_INTERFACE_DLL_NAME
-	/* CMVC 142575: Harmony JDWP sits apart for the JVM natives including the vmi.  
+	/* CMVC 142575: Harmony JDWP sits apart for the JVM natives including the vmi.
 	 * We must preload the library so that it can be found when JDWP tries to load it. */
 	preloadLibrary(J9_CLEAR_VM_INTERFACE_DLL_NAME, TRUE);
 #endif
@@ -1007,7 +1007,7 @@ removeSuffix(char *string, const char *suffix)
 #endif /* JAVA_SPEC_VERSION == 8 */
 
 #if defined(J9UNIX) || defined(J9ZOS390)
-static BOOLEAN 
+static BOOLEAN
 preloadLibraries(void)
 {
 	void *vmDLL, *threadDLL, *portDLL;
@@ -1205,7 +1205,7 @@ preloadLibraries(void)
 	}
 
 #ifdef J9_CLEAR_VM_INTERFACE_DLL_NAME
-	/* CMVC 142575: Harmony JDWP sits apart for the JVM natives including the vmi.  
+	/* CMVC 142575: Harmony JDWP sits apart for the JVM natives including the vmi.
 	 * We must preload the library so that it can be found when JDWP tries to load it. */
 	preloadLibrary(J9_CLEAR_VM_INTERFACE_DLL_NAME, TRUE);
 #endif /* J9_CLEAR_VM_INTERFACE_DLL_NAME */
@@ -1303,7 +1303,7 @@ typedef struct J9SpecialArguments {
  * and return the total size required for the strings
  */
 static UDATA
-initialArgumentScan(JavaVMInitArgs *args, J9SpecialArguments *specialArgs) 
+initialArgumentScan(JavaVMInitArgs *args, J9SpecialArguments *specialArgs)
 {
 	BOOLEAN xCheckFound = FALSE;
 	const char *xCheckString = "-Xcheck";
@@ -1663,7 +1663,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 
 	/* no tracing for this function, since it's unlikely to be used once the VM is running and the trace engine is initialized */
 	preloadLibraries();
-	
+
 #ifdef WIN32
 	if (GetCurrentDirectoryW(J9_MAX_PATH, unicodeTemp) == 0) {
 		strcpy(cwd, "\\");
@@ -1701,11 +1701,11 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 #if defined(J9ZOS390)
 	/*
 	 * When we init the port lib, the 'Signal Reporter' thread will be spawned.
-	 * On z/OS, we need to know whether this thread should be spawned as a medium 
+	 * On z/OS, we need to know whether this thread should be spawned as a medium
 	 * or heavy weight thread. We do this here but we will only take into
 	 * account JAVA_THREAD_MODEL - i.e., if the customer is using '-Xthr:tw=heavy'
-	 * instead of the env var, the 'Signal Reporter' thread will still be launched 
-	 * as a medium weight thread (see PR100512). 
+	 * instead of the env var, the 'Signal Reporter' thread will still be launched
+	 * as a medium weight thread (see PR100512).
 	 */
 	if (!setZOSThrWeight()) {
 		return JNI_ERR;
@@ -1823,7 +1823,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		 * The catalog has already been set above. */
 		memoryCheck_initialize(&j9portLibrary, "all", NULL);
 	}
-	
+
 	{
 		char *optionsDefaultFileLocation = NULL;
 		BOOLEAN doAddExtDir = FALSE;
@@ -1933,7 +1933,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 
 #if CALL_BUNDLED_FUNCTIONS_DIRECTLY
 	result = J9_CreateJavaVM((JavaVM**)&BFUjavaVM, penv, &createParams);
-#else 
+#else
 	result = globalCreateVM((JavaVM**)&BFUjavaVM, penv, &createParams);
 #endif /* CALL_BUNDLED_FUNCTIONS_DIRECTLY  */
 
@@ -2094,7 +2094,7 @@ JNI_GetCreatedJavaVMs(JavaVM **vmBuf, jsize bufLen, jsize *nVMs)
 
 jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args) {
 	UDATA requestedVersion = (UDATA)((JDK1_1InitArgs *)vm_args)->version;
-	
+
 	switch (requestedVersion) {
 	case JNI_VERSION_1_2:
 	case JNI_VERSION_1_4:
@@ -2108,8 +2108,8 @@ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args) {
 #endif /* JAVA_SPEC_VERSION >= 10 */
 		return JNI_OK;
 	}
-	
-	return JNI_EVERSION;	
+
+	return JNI_EVERSION;
 }
 
 
@@ -4000,11 +4000,11 @@ JVM_Open(const char* filename, jint flags, jint mode)
 #endif
 
 #if defined(J9UNIX) || defined(J9ZOS390)
-#if defined(OSX)
+#if defined(OSX) || defined(J9ZTPF)
 #define EXTRA_OPEN_FLAGS 0
 #else
 #define EXTRA_OPEN_FLAGS O_LARGEFILE
-#endif /* defined(OSX) */
+#endif /* defined(OSX) || defined(J9ZTPF) */
 
 #ifndef O_DSYNC
 #define O_DSYNC O_SYNC
@@ -5047,7 +5047,7 @@ JVM_Socket(jint domain, jint type, jint protocol)
  *
  * @param descriptor socket file descriptor
  * @param result the number of bytes that can be read without blocking
- * 
+ *
  * @return result of this JVM method, 0 for failure, 1 (or non-zero value) for success
  */
 jint JNICALL
@@ -5127,7 +5127,7 @@ JVM_Timeout(jint descriptor, jint timeout)
 #endif
 
 #if defined(J9UNIX) || defined(J9ZOS390)
-	jint returnVal = 0; 
+	jint returnVal = 0;
 	jint crazyCntr = 10;
 	fd_set fdset;
 #endif /* defined(J9UNIX) || defined(J9ZOS390) */
@@ -5979,12 +5979,12 @@ setZOSThrWeight(void)
 }
 
 /**
- * @return ZOS_THR_WEIGHT_HEAVY or ZOS_THR_WEIGHT_MEDIUM if the customer is 
+ * @return ZOS_THR_WEIGHT_HEAVY or ZOS_THR_WEIGHT_MEDIUM if the customer is
  * explicitly requesting heavy or medium weight threads via the
- * JAVA_THREAD_MODEL env var. Otherwise, it returns 
+ * JAVA_THREAD_MODEL env var. Otherwise, it returns
  * ZOS_THR_WEIGHT_NOT_FOUND.
  */
-static UDATA 
+static UDATA
 checkZOSThrWeightEnvVar(void)
 {
 	UDATA retVal = ZOS_THR_WEIGHT_NOT_FOUND;
@@ -5995,7 +5995,7 @@ checkZOSThrWeightEnvVar(void)
 	if (NULL != val) {
 		/*
 		 * If the customer did not request heavy weight, assume medium.
-		 * Note that the goal here is not to properly parse the env 
+		 * Note that the goal here is not to properly parse the env
 		 * var. This is done in threadParseArguments() and it will flag
 		 * if the customer attempts to pass a bad value in the env var.
 		 */

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -108,7 +108,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<command line="cd $(UMA_PATH_TO_ROOT) &amp;&amp; qemu-aarch64 -r '9' ./constgen" type="all">
 				<include-if condition="spec.linux_aarch64.* and spec.flags.env_crossbuild" />
 			</command>
-			<command line="cd $(UMA_PATH_TO_ROOT); if [ -x ../build_constgen.sh ] &amp;&amp; [ ! -e ../constgen.completed ] ; then ../build_constgen.sh ; fi" type="all">
+			<command line="sleep 20;cd $(UMA_PATH_TO_ROOT); if [ -x ../build_constgen.sh ] &amp;&amp; [ ! -e ../constgen.completed ] ; then ../build_constgen.sh ; fi" type="all">
 				<include-if condition="spec.linux_ztpf.*"/>
 			</command>
 		</commands>

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -191,6 +191,7 @@ CXXFLAGS+=$(UMA_C_INCLUDES)
 CPPFLAGS+=$(UMA_C_INCLUDES)
 
 UMA_LINK_PATH += $(foreach d,$(TPF_ROOT),-L$d/base/lib)
+UMA_LINK_PATH += $(foreach d,$(TPF_ROOT),-L$d/base/stdlib)
 UMA_LINK_PATH += $(foreach d,$(TPF_ROOT),-L$d/opensource/stdlib)
 
 </#if>

--- a/runtime/makelib/targets.mk.ztpf.inc.ftl
+++ b/runtime/makelib/targets.mk.ztpf.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2018 IBM Corp. and others
+Copyright (c) 1998, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 	-o $@ $(UMA_EXE_POSTFIX_FLAGS)
 </#assign>
 
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/redhat/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/gnu/all /ztpf/commit
 
 ifndef j9vm_env_data64
   J9M31 = -m31
@@ -114,9 +114,9 @@ ifdef j9vm_uma_supportsIpv6
   CPPFLAGS +=
 endif
 
-CFLAGS += $(J9M31) -DS390 -D_LONG_LONG -DJ9VM_TIERED_CODE_CACHE -fno-strict-aliasing
-CXXFLAGS += $(J9M31) -DS390 -D_LONG_LONG -DJ9VM_TIERED_CODE_CACHE -fno-strict-aliasing
-CPPFLAGS += -DS390 -D_LONG_LONG -DJ9VM_TIERED_CODE_CACHE
+CFLAGS += $(J9M31) -DS390 -D_LONG_LONG -DJ9VM_TIERED_CODE_CACHE -DIBMLOCKS -fno-strict-aliasing
+CXXFLAGS += $(J9M31) -DS390 -D_LONG_LONG -DJ9VM_TIERED_CODE_CACHE -DIBMLOCKS -fno-strict-aliasing
+CPPFLAGS += -DS390 -D_LONG_LONG -DJ9VM_TIERED_CODE_CACHE -DIBMLOCKS
 ifdef j9vm_env_data64
   CFLAGS += -DS39064
   CXXFLAGS += -DS39064

--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -23,7 +23,7 @@
 -->
 
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-        
+
 	<exports group="all">
 		<export name="j9port_allocate_library" />
 		<export name="j9port_create_library" />
@@ -40,14 +40,14 @@
 			<xi:include href="vendor_port_default.xml"></xi:include>
 		</xi:fallback>
 	</xi:include>
-	
+
 	<!-- ri_support.xml can contain the RI support on z/OS-->
 	<xi:include href="ri_support.xml">
 		<xi:fallback>
 			<xi:include href="ri_support_default.xml"></xi:include>
 		</xi:fallback>
 	</xi:include>
-	
+
 	<objects group="all">
 		<object name="j9csrsi">
 			<include-if condition="spec.zos_390.*"/>
@@ -135,7 +135,7 @@
 		</object>
 		<object name="ut_j9prt" />
 	</objects>
-	
+
 	<!-- vendor_port_flags.xml can contain vendor specific configuration -->
 	<xi:include href="vendor_port_flags.xml">
 		<xi:fallback>
@@ -218,7 +218,7 @@
 			<include path="j9oti"/>
 			<include path="j9include"/>
 		</includes>
-		
+
 		<makefilestubs>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1">
 				<exclude-if condition="spec.linux_ppc.*"/>
@@ -227,7 +227,7 @@
 				<exclude-if condition="spec.linux_390.*" />
 				<exclude-if condition="spec.linux_390-64.*" />
 			</makefilestub>
-			
+
 			<makefilestub data="OMRPORT_SRCDIR=$(OMR_DIR)/port/" />
 
 			<makefilestub data="ifdef I5_VERSION">
@@ -294,11 +294,11 @@
 				<include-if condition="spec.linux_390.*"/>
 				<include-if condition="spec.linux_ztpf.*"/>
 			</vpath>
-			
+
 			<vpath pattern="%" path="ztpf" augmentIncludes="true" type="relativepath">
 				<include-if condition="spec.linux_ztpf.*"/>
 			</vpath>
-			
+
 			<vpath pattern="%" path="linuxarm" augmentIncludes="true" type="relativepath">
 				<include-if condition="spec.linux_arm.*"/>
 			</vpath>
@@ -340,11 +340,11 @@
 			<library name="j9thr"/>
 			<library name="j9utilcore"/>
 			<library name="j9avl" type="external"/>
-			<library name="j9hashtable" type="external"/>						
+			<library name="j9hashtable" type="external"/>
 			<library name="omrsig">
 				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
 			</library>
-			<library name="socket" type="macro"/>			
+			<library name="socket" type="macro"/>
 			<library name="j9pool" type="external"/>
 			<library name="omrglue" type="external"/>
 			<library name="iconv" type="system">
@@ -353,6 +353,7 @@
 			</library>
 			<library name="rt" type="system">
 				<include-if condition="spec.linux_.*"/>
+				<exclude-if condition="spec.linux_ztpf.*"/>
 			</library>
 			<library name="perfstat" type="system">
 				<include-if condition="spec.aix_.*"/>

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -84,6 +84,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<library name="dl" type="system">
 				<exclude-if condition="spec.win_.*"/>
 				<exclude-if condition="spec.zos_.*"/>
+				<exclude-if condition="spec.linux_ztpf.*"/>
 			</library>
 		</libraries>
 	</artifact>


### PR DESCRIPTION
z/TPF had a build path change which needs to be propagated to the
build (redhat subpath is now gnu).  Additionally, a sleep needed
to be added as part of the z/TPF specific ddrgen and codegen to
allow for some build services to complete.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>