### PR TITLE
Fix logic that determines when to do load without rdbar

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12934,7 +12934,8 @@ void J9::X86::TreeEvaluator::rdbarSideEffectsEvaluator(TR::Node *node, TR::CodeG
 TR::Register *J9::X86::TreeEvaluator::irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::rdbarSideEffectsEvaluator(node, cg);
-   if (TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none)
+   // Perform regular load if no rdbar required.
+   if (TR::Compiler->om.readBarrierType() == gc_modron_readbar_none)
       return TR::TreeEvaluator::iloadEvaluator(node, cg);
 
    //sequence for Concurrent Scavenge
@@ -12979,7 +12980,8 @@ TR::Register *J9::X86::TreeEvaluator::drdbarEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *J9::X86::TreeEvaluator::ardbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::rdbarSideEffectsEvaluator(node, cg);
-   if (TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none)
+   // Perform regular load if no rdbar required.
+   if (TR::Compiler->om.readBarrierType() == gc_modron_readbar_none)
       return TR::TreeEvaluator::aloadEvaluator(node, cg);
 
    //sequence for Concurrent Scavenge


### PR DESCRIPTION
Use `gc_modron_readbar_none` as condition to check when rdbar needs
to be involved or a simple regular load is needed. Fixes assert on IA32 where 
we erroneously get into rdbar code.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>