### PR TITLE
Fix queries for HW and SW read barrier on z

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -77,7 +77,6 @@ J9::ObjectModel::initialize()
       _arrayLetLeafLogSize = 0;
       }
 
-   _shouldReplaceGuardedLoadWithSoftwareReadBarrier = mmf->j9gc_software_read_barrier_enabled(vm);
    _readBarrierType  = (MM_GCReadBarrierType) mmf->j9gc_modron_getReadBarrierType(vm);
    _writeBarrierType = (MM_GCWriteBarrierType)mmf->j9gc_modron_getWriteBarrierType(vm);
    if (_writeBarrierType == gc_modron_wrtbar_satb_and_oldcheck)

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -53,8 +53,7 @@ public:
       _arrayLetLeafSize(0),
       _arrayLetLeafLogSize(0),
       _readBarrierType(gc_modron_readbar_none),
-      _writeBarrierType(gc_modron_wrtbar_none),
-      _shouldReplaceGuardedLoadWithSoftwareReadBarrier(false)
+      _writeBarrierType(gc_modron_wrtbar_none)
    {}
 
    void initialize();
@@ -122,14 +121,6 @@ public:
    */
    MM_GCWriteBarrierType writeBarrierType() { return _writeBarrierType; }
 
-   /**
-    * \brief Determine whether to replace guarded loads with software read barrier sequence
-    *
-    * \return
-    *     true if debug gc option -XXgc:softwareRangeCheckReadBarrier is used
-    */
-   bool shouldReplaceGuardedLoadWithSoftwareReadBarrier() { return _shouldReplaceGuardedLoadWithSoftwareReadBarrier; }
-
 private:
 
    bool                  _usesDiscontiguousArraylets;
@@ -137,7 +128,6 @@ private:
    int32_t               _arrayLetLeafLogSize;
    MM_GCReadBarrierType  _readBarrierType;
    MM_GCWriteBarrierType _writeBarrierType;
-   bool                  _shouldReplaceGuardedLoadWithSoftwareReadBarrier;
    };
 
 }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1270,10 +1270,15 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
 #endif
 
    if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none)
+      {
       featureFlags |= TR_FeatureFlag_ConcurrentScavenge;
 
-   if (TR::Compiler->om.shouldReplaceGuardedLoadWithSoftwareReadBarrier())
-      featureFlags |= TR_FeatureFlag_SoftwareReadBarrier;
+#ifdef TR_TARGET_S390
+      if (!TR::Compiler->target.cpu.getSupportsGuardedStorageFacility())
+         featureFlags |= TR_FeatureFlag_SoftwareReadBarrier;
+#endif
+      }
+
 
    if (fej9->isAsyncCompilation())
       featureFlags |= TR_FeatureFlag_AsyncCompilation;

--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -276,7 +276,9 @@ CPU::initializeS390ProcessorFeatures()
 
       if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE))
          {
-         TR::Compiler->target.cpu.setSupportsGuardedStorageFacility(true);
+         // turn off GS facility if GC has -XXgc:softwareRangeCheckReadBarrier
+         J9MemoryManagerFunctions * mmf = TR::Compiler->javaVM->memoryManagerFunctions;
+         TR::Compiler->target.cpu.setSupportsGuardedStorageFacility(!(mmf->j9gc_software_read_barrier_enabled(TR::Compiler->javaVM)));
          }
       }
 


### PR DESCRIPTION
Fix queries used to emit HW and SW read barrier instructions so that
correct instructions are emitted for HW and SW CS. This ensures that
z13 and below gets software-based CS and z14 gets hardware CS whenever
-Xgc:concurrentScavenge is enabled, and that HW CS can be turned into SW CS 
when -XXgc:softwareRangeCheckReadBarrier is supplied.


Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>