### PR TITLE
Fix java executable path in OnOutOfMemoryError test

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
@@ -34,7 +34,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
     <variable name="ONOUTOFMEMORYERROR_EQUALS" value="-XX:OnOutOfMemoryError="/>
     <variable name="ONOUTOFMEMORYERROR_JAR" value="-cp $Q$$JARPATH$$Q$ OnOutOfMemoryErrorTest"/>
     <variable name="JAVALANGOUTOFMEMORYERROR" value="java.lang.OutOfMemoryError:"/>
-    <variable name="JVMREQUESTINGTOOLDUMP" value="JVM Requesting Tool dump using 'java -version'"/>
 
     <test id="Verify Generate a javacore to STDOUT">
         <command>$EXE$ -Xdump:java:events=vmstart,file=/STDOUT/</command>
@@ -67,9 +66,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
     </test>
 
     <test id="test -XX:OnOutOfMemoryError=">
-        <command>$EXE$ $JVM_HEAP_LIMIT$ $ONOUTOFMEMORYERROR_EQUALS$"java -version" $ONOUTOFMEMORYERROR_JAR$</command>
+        <command>$EXE$ $JVM_HEAP_LIMIT$ $ONOUTOFMEMORYERROR_EQUALS$"$EXE$ -version" $ONOUTOFMEMORYERROR_JAR$</command>
         <output type="success" caseSensitive="yes" regex="no">$JAVALANGOUTOFMEMORYERROR$</output>
-        <output type="required" caseSensitive="yes" regex="no">$JVMREQUESTINGTOOLDUMP$</output>
+        <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">java (.)* -version</output>
         <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
     </test>
 </suite>


### PR DESCRIPTION
Internal test revealed bug in `test -XX:OnOutOfMemoryError=` in `cmdLineTest_J9test_extended`, where the `java` command cannot be found when running the test.

This likely occurs if `JAVA_HOME`/`JAVA_BIN` isn't set on the test machine. By using the full path to the `java` command in the test command, we can avoid this failure.

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>