### PR TITLE
Initialize per-compilation caches to NULL

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3718,6 +3718,16 @@ ClientSessionData::updateMaxReceivedSeqNo(uint32_t seqNo)
    }
 
 
+TR::CompilationInfoPerThreadRemote::CompilationInfoPerThreadRemote(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread)
+   : CompilationInfoPerThread(compInfo, jitConfig, id, isDiagnosticThread),
+   _recompilationMethodInfo(NULL),
+   _seqNo(0),
+   _waitToBeNotified(false),
+   _methodIPDataPerComp(NULL),
+   _resolvedMethodInfoMap(NULL),
+   _resolvedMirrorMethodsPersistIPInfo(NULL)
+   {}
+
 // waitForMyTurn needs to be exeuted with sequencingMonitor in hand
 void
 TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSession, TR_MethodToBeCompiled &entry)

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -275,9 +275,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    {
    public:
       friend class TR::CompilationInfo;
-      CompilationInfoPerThreadRemote(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread)
-         :CompilationInfoPerThread(compInfo, jitConfig, id, isDiagnosticThread), 
-         _recompilationMethodInfo(NULL), _seqNo(0), _waitToBeNotified(false) {}
+      CompilationInfoPerThreadRemote(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread);
       virtual void processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider) override;
       TR_PersistentMethodInfo *getRecompilationMethodInfo() { return _recompilationMethodInfo; }
       uint32_t getSeqNo() const { return _seqNo; }; // for ordering requests at the server


### PR DESCRIPTION
Caches in `CompilationInfoPerThreadRemote`
were not initialized to NULL.
Didn't seem to cause any problems, but should
still set them to NULL in the constructor.