### PR TITLE
Fix pthread_spinlock_t error in musl

### DIFF
--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -43,6 +43,10 @@
 #include <unistd.h>
 #endif
 
+#if defined(LINUX) && !defined(J9ZTPF)
+#include <pthread.h>
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
+
 /**
  * @name Port library access
  * @anchor PortAccess


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #5658

In musl environment the OpenJ9 build fails with : 

```
../../../oti/j9port.h:292:9: error: 'pthread_spinlock_t' does not name a type; did you mean 'pthread_sigmask'?
 typedef pthread_spinlock_t spinlock_t;
         ^~~~~~~~~~~~~~~~~~
         pthread_sigmask
```
**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>