### PR TITLE
Make findField accessible outside of VM

### DIFF
--- a/runtime/jit_vm/ctsupport.c
+++ b/runtime/jit_vm/ctsupport.c
@@ -404,7 +404,7 @@ jitResetAllMethodsAtStartupHelper(J9VMThread *vmStruct, J9Class *root)
  * @return pointer cast to UDATA 
  */
 static UDATA
-findField(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA index, BOOLEAN isStatic, J9Class **declaringClass)
+jitFindField(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA index, BOOLEAN isStatic, J9Class **declaringClass)
 {
 	J9JavaVM *javaVM = vmStruct->javaVM;
 	J9ROMFieldRef *romRef; 
@@ -496,10 +496,10 @@ jitFieldsAreIdentical (J9VMThread *vmStruct, J9ConstantPool *cp1, UDATA index1, 
 	}
 	if (compareFields) {
 		J9Class *c1 = NULL;
-		UDATA f1 = findField(vmStruct, cp1, index1, isStatic, &c1);
+		UDATA f1 = jitFindField(vmStruct, cp1, index1, isStatic, &c1);
 		if (0 != f1) {
 			J9Class *c2 = NULL;
-			UDATA f2 = findField(vmStruct, cp2, index2, isStatic, &c2);
+			UDATA f2 = jitFindField(vmStruct, cp2, index2, isStatic, &c2);
 			if (0 != f2) {
 					identical = ((f1 == f2) && (c1 == c2));
 			}

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1135,6 +1135,7 @@ extern J9_CFUNC UDATA jitGetRealCPIndex(J9VMThread *currentThread, J9ROMClass *r
 extern J9_CFUNC struct J9Method* jitGetJ9MethodUsingIndex(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpOrSplitIndex);
 extern J9_CFUNC struct J9Method* jitResolveStaticMethodRef(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpOrSplitIndex, UDATA resolveFlags);
 extern J9_CFUNC struct J9Method* jitResolveSpecialMethodRef(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpOrSplitIndex, UDATA resolveFlags);
+extern J9_CFUNC UDATA jitFindField(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA index, BOOLEAN isStatic, J9Class **declaringClass);
 
 #endif /* J9VM_INTERP_NATIVE_SUPPORT*/
 #endif /* _J9VMJITNATIVECOMPILESUPPORT_ */


### PR DESCRIPTION
Rename `findField` to `jitFindField` and
add it to `j9protos.h`, so that it can be accessed
from the compiler.
The reason is because a downstream project (JITaaS)
would benefit from being able to directly call this function.

Required for: #5634