### PR TITLE
Add MemoryReference forward declaration

### DIFF
--- a/runtime/compiler/arm/codegen/ARMJNILinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@
 #include "infra/Assert.hpp"
 
 namespace TR { class ARMMemoryArgument; }
+namespace TR { class MemoryReference; }
 namespace TR { class Node; }
 namespace TR { class Register; }
 namespace TR { class RegisterDependencyConditions; }


### PR DESCRIPTION
No longer declared once CodeGenerator include is removed upstream.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>