### PR TITLE
Remove all references to `installJitBytecodes()`

### DIFF
--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -130,8 +130,6 @@ static void codertOnBootstrap(J9HookInterface * * hookInterface, UDATA eventNum,
       javaVM->jitGetOwnedObjectMonitors = jitGetOwnedObjectMonitors;
       }
 
-   /* Poke the new return bytecodes into the bytecode table */
-   javaVM->internalVMFunctions->installJitBytecodes(javaVM);
    return;
    }
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4465,7 +4465,6 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_IVE_ROM_IMAGE_HELPERS) || (defined(J9VM_OPT_DYNAMIC_LOAD_SUPPORT) && defined(J9VM_OPT_ROM_IMAGE_SUPPORT))
 	struct J9MemorySegment*  ( *romImageNewSegment)(struct J9JavaVM *vm, struct J9ROMImageHeader *header, UDATA isBaseType, struct J9ClassLoader *classLoader ) ;
 #endif /* J9VM_IVE_ROM_IMAGE_HELPERS || (J9VM_OPT_DYNAMIC_LOAD_SUPPORT && J9VM_OPT_ROM_IMAGE_SUPPORT) */
-	void  ( *installJitBytecodes)(struct J9JavaVM *javaVM) ;
 	void  (JNICALL *runCallInMethod)(JNIEnv *env, jobject receiver, jclass clazz, jmethodID methodID, void* args) ;
 	j9object_t  ( *catUtfToString4)(struct J9VMThread * vmThread, const U_8 *data1, UDATA length1, const U_8 *data2, UDATA length2, const U_8 *data3, UDATA length3, const U_8 *data4, UDATA length4) ;
 	struct J9MemorySegmentList*  ( *allocateMemorySegmentList)(struct J9JavaVM * javaVM, U_32 numberOfMemorySegments, U_32 memoryCategory) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1068,7 +1068,6 @@ extern J9_CFUNC void  helperInitializeFPU (void);
 #ifndef _J9VMINITIALIZEVM_
 #define _J9VMINITIALIZEVM_
 extern J9_CFUNC void  initializeExecutionModel (J9VMThread *currentThread);
-extern J9_CFUNC void  installJitBytecodes (J9JavaVM *javaVM);
 #endif /* _J9VMINITIALIZEVM_ */
 
 /* J9VMMethodUtils*/

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -123,7 +123,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if defined(J9VM_IVE_ROM_IMAGE_HELPERS) || (defined(J9VM_OPT_DYNAMIC_LOAD_SUPPORT) && defined(J9VM_OPT_ROM_IMAGE_SUPPORT))
 	romImageNewSegment,
 #endif /* J9VM_IVE_ROM_IMAGE_HELPERS || (J9VM_OPT_DYNAMIC_LOAD_SUPPORT && J9VM_OPT_ROM_IMAGE_SUPPORT) */
-	installJitBytecodes,
 	runCallInMethod,
 	catUtfToString4,
 	allocateMemorySegmentList,

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6808,12 +6808,6 @@ isPPC64bit() {
 #endif /* (AIXPPC || LINUXPPC) && !J9OS_I5 */
 
 void
-installJitBytecodes(J9JavaVM *javaVM)
-{
-}
-
-
-void
 initializeExecutionModel(J9VMThread *currentThread)
 {
 	/* Build initial call-out frame. */


### PR DESCRIPTION
installJitBytecodes() is left over from the old builder based
interpreter using a bytecode table rather than the current
switch / computed goto based interpreter.

Removing all references to the function saves an indirect
cross-dll call from startup.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>