### PR TITLE
Combine `ResolvedMethod_isUnresolvedString` message into `ResolvedMethod_stringConstant`

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1560,6 +1560,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          break;
       case J9ServerMessageType::ResolvedMethod_isUnresolvedString:
          {
+         TR_ASSERT(false, "ResolvedMethod_isUnresolvedString is combined into ResolvedMethod_stringConstant");
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t, bool>();
          auto mirror = std::get<0>(recv);
          auto cpIndex = std::get<1>(recv);
@@ -1572,7 +1573,9 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t>();
          auto mirror = std::get<0>(recv);
          auto cpIndex = std::get<1>(recv);
-         client->write(mirror->stringConstant(cpIndex));
+         client->write(mirror->stringConstant(cpIndex),
+                       mirror->isUnresolvedString(cpIndex, true),
+                       mirror->isUnresolvedString(cpIndex, false));
          }
          break;
       case J9ServerMessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method:

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -305,6 +305,15 @@ private:
    UnorderedMap<TR_ResolvedMethodKey, TR_ResolvedMethodCacheEntry> _resolvedMethodsCache;
    TR_IPMethodHashTableEntry *_iProfilerMethodEntry;
 
+   struct TR_IsUnresolvedString
+      {
+      TR_IsUnresolvedString(bool optimizeForAOTTrueResult, bool optimizeForAOTFalseResult): _optimizeForAOTTrueResult(optimizeForAOTTrueResult),
+                                                                                            _optimizeForAOTFalseResult(optimizeForAOTFalseResult) {}
+      bool _optimizeForAOTTrueResult;
+      bool _optimizeForAOTFalseResult;
+      };
+   UnorderedMap<I_32, TR_IsUnresolvedString> _isUnresolvedStr;
+
    char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    virtual char * fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind = heapAlloc) override;


### PR DESCRIPTION

When sending `stringConstant` info, the client will also send
`isUnresolvedString` info for both `optimizeForAOT` and
not `optimizeForAOT cases.
The server caches the values in a map using cpIndex as the key.

Fixes #5649

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>