### PR TITLE
Fix JNI check to properly handle atomic-free

### DIFF
--- a/runtime/jnichk/jnichk_internal.h
+++ b/runtime/jnichk/jnichk_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,9 +102,27 @@ typedef struct JNICHK_GREF_HASHENTRY {
 
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 
-#define enterVM(currentThread) enterVMFromJNI(currentThread)
-
-#define exitVM(currentThread) exitVMToJNI(currentThread)
+#define enterVM(currentThread) \
+	BOOLEAN hasNoVMAccess = J9_ARE_NO_BITS_SET((currentThread)->publicFlags, J9_PUBLIC_FLAGS_VM_ACCESS); \
+	UDATA inNative = (currentThread)->inNative; \
+	do { \
+		if (inNative) { \
+			enterVMFromJNI(currentThread); \
+		} else { \
+			if (hasNoVMAccess) { \
+				acquireVMAccess(currentThread); \
+			} \
+		} \
+	} while(0)
+		
+#define exitVM(currentThread) \
+	do { \
+		if (inNative) { \
+			exitVMToJNI(currentThread); \
+		} else if (hasNoVMAccess) { \
+			releaseVMAccess(currentThread); \
+		} \
+	} while(0)
 
 #else /* J9VM_INTERP_ATOMIC_FREE_JNI */
 


### PR DESCRIPTION
When atomic-free was introduced, JNI check was modified to enter/exit
the VM instead of acquire/release VM access. This is incorrect in some
cases (particularly, the method exit hook which is called from inside
the VM with VM access).

The end result is that JNI check might incorrectly mark a thread as
being in a native when it is in fact running in the VM, resulting in
assertions or crashes.

Fix JNI check to differentiate between being called from JNI code, or
called internally from the VM.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>