### PR TITLE
Disable addJavaPropertiesOptions() in OpenJ9 builds.

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1862,29 +1862,31 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		}
 		/* now add implicit VM arguments */
 		if (
-				/* Add the default options file */
-				(0 != addOptionsDefaultFile(&j9portLibrary, &vmArgumentsList, optionsDefaultFileLocation, localVerboseLevel))
-				|| (0 != addXjcl(&j9portLibrary, &vmArgumentsList, J2SE_CURRENT_VERSION))
-				|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dcom.ibm.oti.vm.bootstrap.library.path=",
-						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
-				|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dsun.boot.library.path=",
-						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
-				|| (0 != addJavaLibraryPath(&j9portLibrary, &vmArgumentsList, argEncoding, jvmInSubdir,
-						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer),
-						libpathValue, ldLibraryPathValue))
-				|| (0 != addJavaHome(&j9portLibrary, &vmArgumentsList, altJavaHomeSpecified, jvmBufferData(j9libBuffer)))
-				|| (doAddExtDir && (0 != addExtDir(&j9portLibrary, &vmArgumentsList, jvmBufferData(j9libBuffer), args, J2SE_CURRENT_VERSION)))
-				|| (0 != addUserDir(&j9portLibrary, &vmArgumentsList, cwd))
-				|| (0 != addJavaPropertiesOptions(&j9portLibrary, &vmArgumentsList, localVerboseLevel))
-				|| (0 != addJarArguments(&j9portLibrary, &vmArgumentsList, specialArgs.executableJarPath, zipFuncs, localVerboseLevel))
-				|| (0 != addEnvironmentVariables(&j9portLibrary, args, &vmArgumentsList, localVerboseLevel))
-				|| (0 != addLauncherArgs(&j9portLibrary, args, launcherArgumentsSize, &vmArgumentsList,
-						&xServiceBuffer, argEncoding, localVerboseLevel))
+			/* Add the default options file */
+			(0 != addOptionsDefaultFile(&j9portLibrary, &vmArgumentsList, optionsDefaultFileLocation, localVerboseLevel))
+			|| (0 != addXjcl(&j9portLibrary, &vmArgumentsList, J2SE_CURRENT_VERSION))
+			|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dcom.ibm.oti.vm.bootstrap.library.path=",
+					jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
+			|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dsun.boot.library.path=",
+					jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
+			|| (0 != addJavaLibraryPath(&j9portLibrary, &vmArgumentsList, argEncoding, jvmInSubdir,
+					jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer),
+					libpathValue, ldLibraryPathValue))
+			|| (0 != addJavaHome(&j9portLibrary, &vmArgumentsList, altJavaHomeSpecified, jvmBufferData(j9libBuffer)))
+			|| (doAddExtDir && (0 != addExtDir(&j9portLibrary, &vmArgumentsList, jvmBufferData(j9libBuffer), args, J2SE_CURRENT_VERSION)))
+			|| (0 != addUserDir(&j9portLibrary, &vmArgumentsList, cwd))
+#if !defined(OPENJ9_BUILD)
+			|| (0 != addJavaPropertiesOptions(&j9portLibrary, &vmArgumentsList, localVerboseLevel))
+#endif /* defined(OPENJ9_BUILD) */
+			|| (0 != addJarArguments(&j9portLibrary, &vmArgumentsList, specialArgs.executableJarPath, zipFuncs, localVerboseLevel))
+			|| (0 != addEnvironmentVariables(&j9portLibrary, args, &vmArgumentsList, localVerboseLevel))
+			|| (0 != addLauncherArgs(&j9portLibrary, args, launcherArgumentsSize, &vmArgumentsList,
+					&xServiceBuffer, argEncoding, localVerboseLevel))
 #ifdef J9VM_OPT_HARMONY
-				/* pass in the Harmony library */
-				|| (0 != addHarmonyPortLibrary(&j9portLibrary, &vmArgumentsList, localVerboseLevel))
+			/* pass in the Harmony library */
+			|| (0 != addHarmonyPortLibrary(&j9portLibrary, &vmArgumentsList, localVerboseLevel))
 #endif /* J9VM_OPT_HARMONY */
-				|| (0 != addXserviceArgs(&j9portLibrary, &vmArgumentsList, xServiceBuffer, localVerboseLevel))
+			|| (0 != addXserviceArgs(&j9portLibrary, &vmArgumentsList, xServiceBuffer, localVerboseLevel))
 		) {
 			result = JNI_ERR;
 			goto exit;

--- a/runtime/oti/vmargs_api.h
+++ b/runtime/oti/vmargs_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/vmargs_api.h
+++ b/runtime/oti/vmargs_api.h
@@ -193,6 +193,7 @@ addExtDir(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jr
 IDATA
 addUserDir(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *cwd);
 
+#if !defined(OPENJ9_BUILD)
 /**
  * Add -D options to define java properties
  * @param portLib port library
@@ -202,6 +203,7 @@ addUserDir(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *
  */
 IDATA
 addJavaPropertiesOptions(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags);
+#endif /* !defined(OPENJ9_BUILD) */
 
 /**
  * Open the executable JAR file and add arguments from the manifest file.

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -1069,6 +1069,13 @@ addUserDir(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *
 
 }
 
+#if !defined(OPENJ9_BUILD)
+/* Function reads the J9NLS_J2SE_EXTRA_OPTIONS to get a -D define to set the IBM java version.
+ * This isn't needed in OpenJ9 and using this is one of the items that forces the NLS message
+ * catalogs to be parsed  early in startup
+ *
+ * Disable for OpenJ9 but leave in place for IBM to be handled in a separate cleanup item
+ */
 IDATA
 addJavaPropertiesOptions(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags)
 {
@@ -1112,6 +1119,7 @@ addJavaPropertiesOptions(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumen
 	}
 	return 0;
 }
+#endif /* !OPENJ9_BUILD */
 
 /*
  * parseOptionsFileText() removes tabs and spaces following a newline.


### PR DESCRIPTION
Leave the function in place under a define that excludes it
from OpenJ9 builds until IBM has had a chance to clean up their
builds to not rely on it.

The changes to runtime/j9vm/jvm.c are mostly whitespace as I decreased an overly indented block there to improve the readability of the code

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>