### PR TITLE
Rename GIT_BRANCH variable to SOURCE_BRANCH in DSL

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -28,7 +28,7 @@ if (!binding.hasVariable('VENDOR_BRANCH_DEFAULT')) VENDOR_BRANCH_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID_DEFAULT = ''
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
 if (!binding.hasVariable('GIT_URI')) GIT_URI = 'https://github.com/eclipse/openj9.git'
-if (!binding.hasVariable('GIT_BRANCH')) GIT_BRANCH = 'refs/heads/master'
+if (!binding.hasVariable('SOURCE_BRANCH')) SOURCE_BRANCH = 'refs/heads/master'
 if (!binding.hasVariable('GIT_REFSPEC')) GIT_REFSPEC = ''
 if (!binding.hasVariable('LIGHTWEIGHT_CHECKOUT')) LIGHTWEIGHT_CHECKOUT = true
 
@@ -50,7 +50,7 @@ pipelineJob("$JOB_NAME") {
                         url(GIT_URI)
                         refspec(GIT_REFSPEC)
                     }
-                    branch("${GIT_BRANCH}")
+                    branch("${SOURCE_BRANCH}")
                     extensions {
                         cleanBeforeCheckout()
                     }


### PR DESCRIPTION
- GIT_BRANCH is passed from Github for PR builds. This
  param was overiding the default value of 'master' in
  PR builds which causes PRs to fail to find the ref.

Related #2836 #4443 #4783
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>