### PR TITLE
Change to ghprbPullId for PR check

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -96,7 +96,8 @@ def get_sources() {
     }
 
     // Check if this build is a PR
-    if (params.ghprbGhRepository) {
+    // Only PR builds (old and new) pass ghprbPullId
+    if (params.ghprbPullId) {
         // Look for dependent changes and checkout PR(s)
         checkout_pullrequest()
     } else {


### PR DESCRIPTION
- Current check uses ghprbGhRepository which is now used for non-pr builds
- Change to pull id as this param is only passed for old and new style pr builds

Related #2836
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>