### PR TITLE
Replaced JAVA_BIN with TEST_JDK_HOME in several tests

### DIFF
--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -64,7 +64,7 @@
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/commons-exec.jar" />
-						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
+						<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
 					</classpath>
 				</javac>
 			</then>

--- a/test/functional/Java11andUp/build.xml
+++ b/test/functional/Java11andUp/build.xml
@@ -45,7 +45,7 @@
 	<target name="compile_generator" depends="init" description="Compile CondyGenerator">
 		<echo>Compiling CondyTest helpers</echo>
 		<echo>Ant version is ${ant.version}"</echo>
-		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<property name="compiler.javac" value="${TEST_JDK_HOME}/bin/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
@@ -62,7 +62,7 @@
 	</target>
 
 	<target name="generate_condy" depends="compile_generator" description="Run Condugenerator to generate bytecode" >
-		<property name="javaexecutable.java" value="${JAVA_BIN}/java" />
+		<property name="javaexecutable.java" value="${TEST_JDK_HOME}/bin/java" />
 		<echo>Running CondyGenerator</echo>
 		<java classname="org.openj9.test.condy.CondyGenerator" fork="true" failonerror="true" logError="true" jvm="${javaexecutable.java}">
 			<jvmarg value="-Xverify:none" />

--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -163,7 +163,7 @@
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar" />
-						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
+						<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/commons-cli.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/javassist.jar" />
 					</classpath>
@@ -253,10 +253,10 @@
 	<target name="jasm_generator" depends="init" description="prepare jasm files">
 		<property name="jasm_class_destination" location="${build}/j9vm/test/invoker" />
 		<mkdir dir="${jasm_class_destination}" />
-		<exec executable="${JAVA_BIN}/java" dir="${jasm_class_destination}">
+		<exec executable="${TEST_JDK_HOME}/bin/java" dir="${jasm_class_destination}">
 			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jasm ${src}/j9vm/test/invoker/NodeClass.jasm"/>
 		</exec>
-		<exec executable="${JAVA_BIN}/java" dir="${jasm_class_destination}">
+		<exec executable="${TEST_JDK_HOME}/bin/java" dir="${jasm_class_destination}">
 			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jasm ${src}/j9vm/test/invoker/NodeInterface.jasm"/>
 		</exec>
 	</target>

--- a/test/functional/Java9andUp/build.xml
+++ b/test/functional/Java9andUp/build.xml
@@ -118,7 +118,7 @@
 				</javac>
 			</sequential>
 		</for>
-		<exec executable="${JAVA_BIN}/java" failonerror="true">
+		<exec executable="${TEST_JDK_HOME}/bin/java" failonerror="true">
 			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jasm -d ${module_bin_root}/${MODULE_NAME_ROOT}.testerModule ${module_src_root}/${MODULE_NAME_ROOT}.testerModule/${MODULE_PATH_ROOT}/tests/MethodHandleTester.jasm" />
 		</exec>
 	</target>


### PR DESCRIPTION
- replaced path JAVA_BIN with new TEST_JDK_HOME variable in tests of JLM, Java8andUp, Java9andUp, Java11andUp.
[ci skip]

Signed-off-by: Longyu <longyu.zhang@ibm.com>