### PR TITLE
Create resolved methods in batches

### DIFF
--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -153,7 +153,7 @@ namespace std
 // Since one cache contains different types of resolved methods, need to uniquely identify
 // each type. Apparently, the same cpIndex may refer to both virtual or special method,
 // for different method calls, so using TR_ResolvedMethodType is necessary.
-enum TR_ResolvedMethodType {VirtualFromCP, VirtualFromOffset, Interface, Static, Special, ImproperInterface};
+enum TR_ResolvedMethodType {VirtualFromCP, VirtualFromOffset, Interface, Static, Special, ImproperInterface, NoType};
 struct
 TR_ResolvedMethodKey
    {
@@ -274,6 +274,7 @@ public:
    static void createResolvedMethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key);
+   void cacheResolvedMethodsCallees();
 
 protected:
    JITaaS::J9ServerStream *_stream;

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+
 syntax = "proto3";
 
 package JITaaS;
@@ -103,6 +104,7 @@ enum J9ServerMessageType
    ResolvedMethod_isUnresolvedString = 148;
    ResolvedMethod_stringConstant = 149;
    ResolvedMethod_getResolvedVirtualMethod = 150;
+   ResolvedMethod_getMultipleResolvedMethods = 151;
 
    ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 160;
    ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 161;


### PR DESCRIPTION
Most of the remote messages creating resolved methods
come from `TR_J9EstimateCodeSize::realEstimateCodeSize`.
The first step of size estimation is to walk through
method bytecodes and create a resolved method for every
invocation bytecode. So this loop will cause many remote
queries.
I merged these queries into one, by iterating through the
bytecodes right before estimator does it, identifying all
bytecodes that require a resolved method, and asking the client
to create them all in one batch, i.e. send only 1 message pair.