### PR TITLE
Declare J9RAMVirtualMethodRef methodIndexAndArgCount as volatile

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2097,8 +2097,8 @@ typedef struct J9RAMStaticMethodRef {
 } J9RAMStaticMethodRef;
 
 typedef struct J9RAMVirtualMethodRef {
-	UDATA methodIndexAndArgCount;
-	struct J9Method* method;
+	UDATA volatile methodIndexAndArgCount;
+	struct J9Method *volatile method;
 } J9RAMVirtualMethodRef;
 
 typedef struct J9RAMMethodTypeRef {


### PR DESCRIPTION
Declare `J9RAMVirtualMethodRef methodIndexAndArgCount` as `volatile`

Declaring `J9RAMVirtualMethodRef.methodIndexAndArgCount` as `volatile` instructs the compiler to generate assembly code that writes to the field atomically.
This fixes the segment error due to `zero methodIndex` which seems due to separated writes to the field, first one is `argCount`, and the second one is `methodIndex`.
In addition, the field `J9RAMVirtualMethodRef.method` is declared as `volatile` as well.

More background info is at https://github.com/eclipse/openj9/issues/4778#issuecomment-490673548
Note: Refetch `ramCPEntry` via CP index in `resolvesupport.cpp:resolveVirtualMethodRefInto()` probably can be removed now. The refactoring will be done in a separated PR.

closes: #4053, closes: #4054, closes: #4125, closes: #4126, closes: #4737, closes: #4772, closes: #4778, closes: #5088, closes: #5140 

Reviewer: @gacholio 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>