### PR TITLE
Add null check to cancel_running_builds

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -173,7 +173,7 @@ def cancel_running_builds(JOB_NAME, BUILD_IDENTIFIER) {
         // get all runs/jobs from the build
         // Class org.jenkinsci.plugins.workflow.job.WorkflowRun
         // Only look for running jobs with matching BUILD_IDENTIFIER
-        if ((run.isBuilding()) && (run.getEnvironment().get('BUILD_IDENTIFIER') == "${BUILD_IDENTIFIER}")) {
+        if ((run) && (run.isBuilding()) && (run.getEnvironment().get('BUILD_IDENTIFIER') == "${BUILD_IDENTIFIER}")) {
             echo "Cancelling Job:'${run}'"
             run.doStop()
         }


### PR DESCRIPTION
- Sometimes the loop fails with
  NPE: Cannot invoke method isBuilding() on null object
- It seems to be intermittent and hard to reproduce.
- The idea is to at least catch it and not fail the build

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>