### PR TITLE
Fix bug in profiled inlined method relocation

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -456,16 +456,16 @@ uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
 
          TR::SymbolReference *callSymRef = guard->getSymbolReference();
          TR_ResolvedMethod *owningMethod = callSymRef->getOwningMethod(comp);
+
+         TR_InlinedCallSite & ics = comp->getInlinedCallSite(inlinedSiteIndex);
+         TR_ResolvedMethod *inlinedMethod = ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod;
+         TR_OpaqueClassBlock *inlinedCodeClass = reinterpret_cast<TR_OpaqueClassBlock *>(inlinedMethod->classOfMethod());
+
          *(uintptrj_t *) cursor = (uintptrj_t) owningMethod->constantPool(); // record constant pool
          cursor += SIZEPOINTER;
 
          *(uintptrj_t*) cursor = (uintptrj_t) callSymRef->getCPIndex(); // record cpIndex
          cursor += SIZEPOINTER;
-
-         TR_OpaqueClassBlock *inlinedCodeClass = guard->getThisClass();
-         int32_t len;
-         char *className = fej9->getClassNameChars(inlinedCodeClass, len);
-         //traceMsg(comp(), "inlined site index is %d, inlined code class is %.*s\n", inlinedSiteIndex, len, className);
 
          void *romClass = (void *) fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass);
          void *romClassOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romClass);
@@ -479,27 +479,8 @@ uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
 
          cursor = self()->emitClassChainOffset(cursor, inlinedCodeClass);
 
-         uintptrj_t offset;
-         TR::MethodSymbol *calleeSymbol = callSymRef->getSymbol()->castToMethodSymbol();
-         if (!TR::Compiler->cls.isInterfaceClass(comp, inlinedCodeClass) && calleeSymbol->isInterface())
-            {
-            int32_t index = owningMethod->getResolvedInterfaceMethodOffset(inlinedCodeClass, callSymRef->getCPIndex());
-            //traceMsg(comp(),"ProfiledGuard offset for interface is %d\n", index);
-            offset = (uintptrj_t) index;
-            if (index < 0)
-               offset = (uintptrj_t) fej9->virtualCallOffsetToVTableSlot(index);
-            //traceMsg(comp(),"ProfiledGuard offset for interface is %d\n", index);
-            }
-         else
-            {
-            offset = (int32_t) callSymRef->getOffset();
-            //traceMsg(comp(),"ProfiledGuard offset for non-interface is %d\n", offset);
-            offset = (uintptrj_t) fej9->virtualCallOffsetToVTableSlot((int32_t) callSymRef->getOffset());
-            //traceMsg(comp(),"ProfiledGuard offset for non-interface is now %d\n", offset);
-            }
-
-         //traceMsg(comp(),"ProfiledGuard offset using %d\n", offset);
-         *(uintptrj_t *) cursor = offset;
+         uintptrj_t methodIndex = fej9->getMethodIndexInClass(inlinedCodeClass, inlinedMethod->getNonPersistentIdentifier());
+         *(uintptrj_t *)cursor = methodIndex;
          cursor += SIZEPOINTER;
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -933,7 +933,7 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                cursor +=56;
                self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
                if (isVerbose)
-                  traceMsg(self()->comp(), "\nProfiled Class Guard: Inlined site index = %d, Constant pool = %x, cpIndex = %x, romClassOffsetInSharedCache=%p, classChainIdentifyingLoaderOffsetInSharedCache=%p, classChainForInlinedMethod %p, vTableSlot %d",
+                  traceMsg(self()->comp(), "\nProfiled Class Guard: Inlined site index = %d, Constant pool = %x, cpIndex = %x, romClassOffsetInSharedCache=%p, classChainIdentifyingLoaderOffsetInSharedCache=%p, classChainForInlinedMethod %p, methodIndex %d",
                                   *(uint64_t *)ep1, *(uint64_t *)ep2, *(uint64_t *)ep3, *(uint64_t *)ep4, *(uint64_t *)ep5, *(uint64_t *)ep6, *(uint64_t *)ep7);
                }
             else

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6451,6 +6451,28 @@ TR_J9VMBase::getNumMethods(TR_OpaqueClassBlock * classPointer)
    return TR::Compiler->cls.romClassOf(classPointer)->romMethodCount;
    }
 
+/* This API takes a J9Class (TR_OpaqueClassBlock) and a J9Method (TR_OpaqueMethodBlock) and returns the
+ * index of the J9Method in the J9Class' array of J9Methods.
+ */
+uintptr_t
+TR_J9VMBase::getMethodIndexInClass(TR_OpaqueClassBlock *classPointer, TR_OpaqueMethodBlock *methodPointer)
+   {
+   void *methodsInClass = getMethods(classPointer);
+   uint32_t numMethods = getNumMethods(classPointer);
+
+   uintptr_t methodOffset = reinterpret_cast<uintptr_t>(methodPointer) - reinterpret_cast<uintptr_t>(methodsInClass);
+   TR_ASSERT_FATAL((methodOffset % sizeof (J9Method)) == 0, "methodOffset %llx isn't a multiple of sizeof(J9Method)\n",
+                                                             static_cast<uint64_t>(methodOffset));
+
+   uintptr_t methodIndex = methodOffset / sizeof (J9Method);
+   TR_ASSERT_FATAL(methodIndex < numMethods, "methodIndex %llx greater than numMethods %llx for method %p in class %p\n",
+                                              static_cast<uint64_t>(methodIndex),
+                                              static_cast<uint64_t>(numMethods),
+                                              methodPointer, classPointer);
+
+   return methodIndex;
+   }
+
 uint32_t
 TR_J9VMBase::getNumInnerClasses(TR_OpaqueClassBlock * classPointer)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -405,6 +405,8 @@ public:
    uint32_t                   getNumInnerClasses(TR_OpaqueClassBlock *classPointer);
    uint32_t                   getNumMethods(TR_OpaqueClassBlock *classPointer);
 
+   uintptr_t                  getMethodIndexInClass(TR_OpaqueClassBlock *classPointer, TR_OpaqueMethodBlock *methodPointer);
+
    virtual uint8_t *          allocateCodeMemory( TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
 
    virtual void               releaseCodeMemory(void *startPC, uint8_t bytesToSaveAtStart);

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -141,8 +141,12 @@ typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedInte
 struct TR_RelocationRecordProfiledInlinedMethodBinaryTemplate : TR_RelocationRecordInlinedMethodBinaryTemplate
    {
    UDATA _classChainIdentifyingLoaderOffsetInSharedCache;
+
+   // Class chain of the defining class of the inlined method
    UDATA _classChainForInlinedMethod;
-   UDATA _vTableSlot;
+
+   // The inlined j9method's index into its defining class' array of j9methods
+   UDATA _methodIndex;
    };
 
 typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledGuardBinaryTemplate;
@@ -1229,12 +1233,15 @@ class TR_RelocationRecordProfiledInlinedMethod : public TR_RelocationRecordInlin
       void setClassChainForInlinedMethod(TR_RelocationTarget *reloTarget, uintptrj_t classChainForInlinedMethod);
       uintptrj_t classChainForInlinedMethod(TR_RelocationTarget *reloTarget);
 
-      void setVTableSlot(TR_RelocationTarget *reloTarget, uintptrj_t vTableSlot);
-      uintptrj_t vTableSlot(TR_RelocationTarget *reloTarget);
+      void setMethodIndex(TR_RelocationTarget *reloTarget, uintptrj_t methodIndex);
+      uintptrj_t methodIndex(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
+      TR_OpaqueMethodBlock *getInlinedMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_OpaqueClassBlock *inlinedCodeClass);
+
    private:
+
       virtual void setupInlinedMethodData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual bool checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass);
       virtual void activateGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation) {}

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -924,7 +924,6 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
       case TR_ProfiledMethodGuardRelocation :
          {
          guard = (TR_VirtualGuard *)relocation->getTargetAddress2();
-         TR_OpaqueClassBlock *inlinedCodeClass = guard->getThisClass();
 
          int32_t inlinedSiteIndex = guard->getCurrentInlinedSiteIndex();
          *(uintptrj_t *)cursor = (uintptrj_t)inlinedSiteIndex;
@@ -932,6 +931,11 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
 
          TR::SymbolReference *callSymRef = guard->getSymbolReference();
          TR_ResolvedMethod *owningMethod = callSymRef->getOwningMethod(self()->comp());
+
+         TR_InlinedCallSite & ics = comp->getInlinedCallSite(inlinedSiteIndex);
+         TR_ResolvedMethod *inlinedMethod = ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod;
+         TR_OpaqueClassBlock *inlinedCodeClass = reinterpret_cast<TR_OpaqueClassBlock *>(inlinedMethod->classOfMethod());
+
          *(uintptrj_t *)cursor = (uintptrj_t)owningMethod->constantPool(); // record constant pool
          cursor += SIZEPOINTER;
 
@@ -947,10 +951,6 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
             }
          cursor += SIZEPOINTER;
 
-         int32_t len;
-         char *className = fej9->getClassNameChars(inlinedCodeClass, len);
-         //traceMsg(comp(), "inlined site index is %d, inlined code class is %.*s\n", inlinedSiteIndex, len, className);
-
          void *romClass = (void *)fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass);
          void *romClassOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romClass);
          traceMsg(self()->comp(), "class is %p, romclass is %p, offset is %p\n", inlinedCodeClass, romClass, romClassOffsetInSharedCache);
@@ -963,27 +963,8 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
 
          cursor = self()->emitClassChainOffset(cursor, inlinedCodeClass);
 
-         uintptrj_t offset;
-         TR::MethodSymbol *calleeSymbol = callSymRef->getSymbol()->castToMethodSymbol();
-         if (!TR::Compiler->cls.isInterfaceClass(self()->comp(), inlinedCodeClass) && calleeSymbol->isInterface())
-            {
-            int32_t index = owningMethod->getResolvedInterfaceMethodOffset(inlinedCodeClass, callSymRef->getCPIndex());
-            //traceMsg(comp(),"ProfiledGuard offset for interface is %d\n", index);
-            offset = (uintptrj_t) index;
-            if (index < 0)
-               offset = (uintptrj_t) fej9->virtualCallOffsetToVTableSlot(index);
-            //traceMsg(comp(),"ProfiledGuard offset for interface is %d\n", index);
-            }
-         else
-            {
-            offset = (int32_t) callSymRef->getOffset();
-            //traceMsg(comp(),"ProfiledGuard offset for non-interface is %d\n", offset);
-            offset = (uintptrj_t) fej9->virtualCallOffsetToVTableSlot((int32_t) callSymRef->getOffset());
-            //traceMsg(comp(),"ProfiledGuard offset for non-interface is now %d\n", offset);
-            }
-
-         //traceMsg(comp(),"ProfiledGuard offset using %d\n", offset);
-         *(uintptrj_t *)cursor =  offset;
+         uintptrj_t methodIndex = fej9->getMethodIndexInClass(inlinedCodeClass, inlinedMethod->getNonPersistentIdentifier());
+         *(uintptrj_t *)cursor = methodIndex;
          cursor += SIZEPOINTER;
          }
          break;


### PR DESCRIPTION
For the TR_RelocationRecordProfiledInlinedMethod and subclass relocation
records, what's stored in the relo header is:

1. The class chain of class specified in the TR_VirtualGuard
2. The class chain of the first class loaded by the classloader that
loaded the class in 1.
3. the VFT offset

The idea was to validate that the receiver was the same, and then to add
the appropriate inlined J9Method into the J9JitExceptionTable's inlined
method table during relocation time. The VFT offset was determined by
using the symref stored in the guard (which is the symref of the
*caller*).

A problem occurs when there is an invokeVirtual called on a method via a
class that implements an interface AND the method being invoked is a
default method of that interface. In other words, the defining class of
the method is an interface class, and the implementing class inherits
this method.

When the compiler creates the profiled guard, the TR_VirtualGuard
contains the J9Class of the defining class; in this case it would be the
interface class. However, the symref contains the VFT offset of a
concrete class. Thus, at load time, the relo infrastructure will
materialize the interface class based on the class chain info in the
relo header, and then try to pull out a J9Method from that class' VFT
using the VFT offset. However, interface classes do not have a VFT. As a
result, this can cause undefined behaviour.

This PR addresses this issue by modifying the relo header to store
the method index from the defining class rather than the VFT offset from
the caller. This involves also now changing the the class chains stored
to:

1. The class chain of the defining class of the inlined method
2. The class chain of the first class loaded by the classloader that
loaded the class in 1.

Because this is a profiled inlined method, whether the guard
is a Method Test, VFT Test, or Removed Guard, this will yield the
correct method to populate in the inlined table of the
J9JITExceptionTable.

One important subtlety though, is that in the case of the VFT Test, the
inlined code might have certain assumptions based on the type. However,the
TR_RelocationRecordProfiledInlinedMethod (and subtypes) primarily
deal with populating the inlined table in the J9JITExceptionTable. The
VFT test will result in a TR_ClassPointer relocation record that will
relocate the class being tested by the VFT test guard.