### PR TITLE
Make PassThrough x86 NULLCHKs implicit

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3354,9 +3354,10 @@ J9::CodeGenerator::rematerializeCompressedRefs(
       TR::Node *child = node->getChild(i);
       self()->rematerializeCompressedRefs(autoSymRef, tt, node, i, child, visitCount, rematerializedNodes);
       }
-
+   
+   static bool disableBranchlessPassThroughNULLCHK = feGetEnv("TR_disableBranchlessPassThroughNULLCHK") != NULL;
    if (node->getOpCode().isNullCheck() && reference &&
-          (!isLowMemHeap || self()->performsChecksExplicitly() || (node->getFirstChild()->getOpCodeValue() == TR::PassThrough)) &&
+          (!isLowMemHeap || self()->performsChecksExplicitly() || (disableBranchlessPassThroughNULLCHK && node->getFirstChild()->getOpCodeValue() == TR::PassThrough)) &&
           ((node->getFirstChild()->getOpCodeValue() == TR::l2a) ||
            (reference->getOpCodeValue() == TR::l2a)) &&
          performTransformation(self()->comp(), "%sTransforming null check reference %p in null check node %p to be checked explicitly\n", OPT_DETAILS, reference, node))


### PR DESCRIPTION
Currently a NULLCHK with a PassThrough will evaluate into test and
branch sequences. This change switches the sequence to simply touch
the memory of the value being NULLCHK'd. A trap will result in the
appropriate null pointer exception and saves a branch at the cost of
some potential cache pollution.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>