### PR TITLE
Take only 7 chars of SHA

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/omrMirror
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror
@@ -52,12 +52,13 @@ timestamps {
                                 ).trim()
                             currentBuild.description = "${LAST_COMMIT}"
 
-                            current_sha = LAST_COMMIT.split()[0]
+                            current_sha = LAST_COMMIT.take(7)
 
                             // if there were changes, launch an acceptance build
                             copyArtifacts optional: true, projectName: JOB_NAME, selector: lastSuccessful()
                             def default_sha = [omr_sha: 'Default']
                             def previous = readProperties defaults: default_sha, file: "${ARCHIVE_FILE}"
+                            echo "Previous SHA:${previous.omr_sha}\nCurrent SHA:${current_sha}"
                             if ( previous.omr_sha != current_sha ) {
                                 build job: 'Pipeline-OMR-Acceptance', propagate: false, wait: false
                                 writeFile file: "${ARCHIVE_FILE}", text: "omr_sha=${current_sha}"


### PR DESCRIPTION
- Some git versions only produce 7 by default

[skip ci]
Originally fixed in #4819
Reintroduced by #5652

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>