### PR TITLE
Purge cached data of clients that suddenly disconnected

### DIFF
--- a/runtime/compiler/runtime/StatisticsThread.cpp
+++ b/runtime/compiler/runtime/StatisticsThread.cpp
@@ -81,6 +81,11 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
          crtTime = j9time_current_time_millis();
          persistentInfo->setElapsedTime(crtTime - persistentInfo->getStartTime());
 
+            {
+            OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
+            compInfo->getClientSessionHT()->purgeOldDataIfNeeded();
+            }
+
          if ((statisticsThread->getStatisticsFrequency() != 0) && ((crtTime - lastStatistics) > statisticsThread->getStatisticsFrequency()))
             {
             int32_t cpuUsage = 0, avgCpuUsage = 0, vmCpuUsage = 0;


### PR DESCRIPTION
When client suddenly terminates, it will not send a final
message to the server that indicates the end of session,
thus the server doesn't know that ClientSessionData should
be purged, and leaks persistent memory.
To fix that, periodically check if client data should be
purged from statistics thread.