### PR TITLE
(v0.14.2-release) Create two module hashtables with module name/pointer as key

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -204,7 +204,7 @@ createPackage(J9VMThread * currentThread, J9Module * fromModule, const char *pac
 			freePackage(currentThread, j9package);
 			return retval;
 		}
-		j9package->exportsHashTable = vmFuncs->hashModuleTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
+		j9package->exportsHashTable = vmFuncs->hashModulePointerTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
 		if (NULL != j9package->exportsHashTable) {
 			retval = j9package;
 		}
@@ -263,7 +263,7 @@ createModule(J9VMThread * currentThread, j9object_t moduleObject, J9ClassLoader 
 	if (NULL != j9mod) {
 		j9mod->moduleName = moduleName;
 
-		j9mod->readAccessHashTable = vmFuncs->hashModuleTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
+		j9mod->readAccessHashTable = vmFuncs->hashModulePointerTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
 
 		if (NULL != j9mod->readAccessHashTable) {
 			j9mod->classLoader = classLoader;
@@ -666,7 +666,7 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
 				 * at the same time.
 				 */
 				if (NULL == fromModule->removeAccessHashTable) {
-					fromModule->removeAccessHashTable = vm->internalVMFunctions->hashModuleTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
+					fromModule->removeAccessHashTable = vm->internalVMFunctions->hashModulePointerTableNew(vm, INITIAL_INTERNAL_MODULE_HASHTABLE_SIZE);
 				}
 				if (NULL != fromModule->removeAccessHashTable) {
 					Trc_MODULE_invokeHashTableAtPut(currentThread, "allowReadAccessToModule(removeAccessHashTable)", fromModule, fromModule->removeAccessHashTable, &toModule, toModule, "false");

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4681,7 +4681,8 @@ typedef struct J9InternalVMFunctions {
 	void  ( *internalEnterVMFromJNI)(struct J9VMThread * currentThread) ;
 	void  ( *internalExitVMToJNI)(struct J9VMThread * currentThread) ;
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-	struct J9HashTable* ( *hashModuleTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
+	struct J9HashTable* ( *hashModuleNameTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
+	struct J9HashTable* ( *hashModulePointerTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashPackageTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashModuleExtraInfoTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashClassLocationTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1775,12 +1775,28 @@ findClassLocationForClass(J9VMThread *currentThread, J9Class *clazz);
 /* ---------------- ModularityHashTables.c ---------------- */
 
 /**
- * @brief Create the module definition hash table
+ * Used by classLoader->moduleHashTable which doesn't allow multiple modules with same module name.
+ * Create a new J9HashTable with hashFn (moduleNameHashFn) and hashEqualFn (moduleNameHashEqualFn).
+ * Using module name as the key can determine if two modules are same based on their module names.
+ *
+ * @param javaVM A java VM 
  * @param initialSize initial size
- * @return Pointer to new hash table
+ * @return an initialized J9HashTable on success, otherwise NULL.
  */
 J9HashTable *
-hashModuleTableNew(J9JavaVM *javaVM, U_32 initialSize);
+hashModuleNameTableNew(J9JavaVM *javaVM, U_32 initialSize);
+
+/**
+ * Used by J9Package->exportsHashTable, J9Module->readAccessHashTable, and J9Module->removeAccessHashTable
+ * which might contain modules loaded by different classloader but with same module names.
+ * Create a new J9HashTable with hashFn (modulePointerHashFn) and hashEqualFn (modulePointerHashEqualFn).
+ * Using J9Module pointer as the key can differentiate modules loaded by different classloader with same module name.
+ * @param javaVM A java VM 
+ * @param initialSize initial size
+ * @return an initialized J9HashTable on success, otherwise NULL.
+ */
+J9HashTable *
+hashModulePointerTableNew(J9JavaVM *javaVM, U_32 initialSize);
 
 /**
  * @brief Create the package definition hash table

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -172,7 +172,7 @@ allocateClassLoader(J9JavaVM *javaVM)
 		/* memset not required as the classLoaderBlocks pool returns zero'd memory */
 
 		classLoader->classHashTable = hashClassTableNew(javaVM, INITIAL_CLASSHASHTABLE_SIZE);
-		classLoader->moduleHashTable = hashModuleTableNew(javaVM, INITIAL_MODULE_HASHTABLE_SIZE);
+		classLoader->moduleHashTable = hashModuleNameTableNew(javaVM, INITIAL_MODULE_HASHTABLE_SIZE);
 		classLoader->packageHashTable = hashPackageTableNew(javaVM, INITIAL_PACKAGE_HASHTABLE_SIZE);
 		/* Allocate classLocationHashTable only for bootloader which is the first classloader to be allocated.
 		 * The classLoader being allocated must be the bootloader if javaVM->systemClassLoader is NULL.

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -338,7 +338,8 @@ J9InternalVMFunctions J9InternalFunctions = {
 	internalEnterVMFromJNI,
 	internalExitVMToJNI,
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-	hashModuleTableNew,
+	hashModuleNameTableNew,
+	hashModulePointerTableNew,
 	hashPackageTableNew,
 	hashModuleExtraInfoTableNew,
 	hashClassLocationTableNew,


### PR DESCRIPTION
Create two `module hashtables` with `module name/pointer` as `key`

`classLoader->moduleHashTable` doesn't allow multiple modules with same module name. Added `hashModuleNameTableNew()` with `moduleNameHashFn` as `hashFn` and `moduleNameHashEqualFn` as `hashEqualFn` such that two modules are determined to be same or not based on their module names.

`J9Package->exportsHashTable`, `J9Module->readAccessHashTable`, and `J9Module->removeAccessHashTable` might contain modules loaded by different `classloader` but with same module names. Added `hashModulePointerTableNew()` which uses `J9Module` pointer as the key to
differentiate such modules.

Verified that this PR passes internal tests and https://github.com/eclipse/openj9/issues/4921.

Cherry-Pick from https://github.com/eclipse/openj9/pull/5566.

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>