### PR TITLE
(v0.14.2) Add back the `_WIN32` case to JNIEXPORT definition

### DIFF
--- a/runtime/include/jniport.h
+++ b/runtime/include/jniport.h
@@ -23,19 +23,19 @@
 #ifndef jniport_h
 #define jniport_h
 
-#if defined(WIN32)
+#if defined(WIN32) || defined(_WIN32)
 
 #define JNIEXPORT __declspec(dllexport)
 #define JNICALL __stdcall
 typedef __int64 jlong;
 
-#else /* WIN32 */
+#else /* WIN32 || _WIN32 */
 
 #define JNIEXPORT 
 
 typedef long long jlong;
 
-#endif /* WIN32 */
+#endif /* WIN32 || _WIN32 */
 
 #ifndef JNICALL
 #define JNICALL


### PR DESCRIPTION
The previous PR `Commonize definitions of jint & jbyte` #4680
cleaned up too many defines.

Not having this resulted in missing exports on natives compiled
on windows.

Backport: #5643 

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>