### PR TITLE
(v0.14.2-release) Init system property java.vm.specification.version via native

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -398,8 +398,6 @@ private static void ensureProperties(boolean isInitialization) {
 
 /*[IF Java12]*/
 	java.lang.VersionProps.init(initializedProperties);
-	/* VersionProps.init(systemProperties) above sets java.specification.version value which is used to set java.vm.specification.version. */
-	initializedProperties.put("java.vm.specification.version", initializedProperties.get("java.specification.version")); //$NON-NLS-1$ //$NON-NLS-2$
 /*[ELSE]
 	/* VersionProps.init requires systemProperties to be set */
 	systemProperties = initializedProperties;

--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -51,6 +51,7 @@
 #define JAVA_VM_VENDOR "Eclipse OpenJ9"
 #define JAVA_VM_NAME "Eclipse OpenJ9 VM"
 
+#if JAVA_SPEC_VERSION < 12
 /* Pre-JDK12 versions use following defines to set system properties
  * java.vendor and java.vendor.url within vmprop.c:initializeSystemProperties(vm).
  * JDK12 (assuming future versions as well) sets these properties via java.lang.VersionProps.init(systemProperties) 
@@ -58,5 +59,6 @@
  */
 #define JAVA_VENDOR "Eclipse OpenJ9"
 #define JAVA_VENDOR_URL "http://www.eclipse.org/openj9"
+#endif /* JAVA_SPEC_VERSION < 12 */
 
 #endif     /* vendor_version_h */

--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -49,8 +49,8 @@
 #define VENDOR_SHORT_NAME "OpenJ9"
 
 #define JAVA_VM_VENDOR "Eclipse OpenJ9"
+#define JAVA_VM_NAME "Eclipse OpenJ9 VM"
 
-#if JAVA_SPEC_VERSION < 12
 /* Pre-JDK12 versions use following defines to set system properties
  * java.vendor and java.vendor.url within vmprop.c:initializeSystemProperties(vm).
  * JDK12 (assuming future versions as well) sets these properties via java.lang.VersionProps.init(systemProperties) 
@@ -58,8 +58,5 @@
  */
 #define JAVA_VENDOR "Eclipse OpenJ9"
 #define JAVA_VENDOR_URL "http://www.eclipse.org/openj9"
-#endif /* JAVA_SPEC_VERSION < 12 */
-
-#define JAVA_VM_NAME "Eclipse OpenJ9 VM"
 
 #endif     /* vendor_version_h */

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -539,6 +539,7 @@ initializeSystemProperties(J9JavaVM * vm)
 	UDATA j2seVersion = J2SE_VERSION(vm);
 	const char* propValue = NULL;
 	UDATA rc = J9SYSPROP_ERROR_NONE;
+	const char *specificationVersion = NULL;
 
 	if (omrthread_monitor_init(&(vm->systemPropertiesMutex), 0) != 0) {
 		return J9SYSPROP_ERROR_OUT_OF_MEMORY;
@@ -572,35 +573,34 @@ initializeSystemProperties(J9JavaVM * vm)
 		}
 	}
 
-#if JAVA_SPEC_VERSION < 12
-	/* Following system properties are defined via java.lang.VersionProps.init(systemProperties) and following settings within System.ensureProperties() */
-	{
-		const char *classVersion = NULL;
-		const char *specificationVersion = NULL;
-
-		/* Properties that always exist */
-		switch (j2seVersion) {
-		case J2SE_18:
-			classVersion = "52.0";
-			specificationVersion = "1.8";
-			break;
-		case J2SE_V11:
-		default:
-			classVersion = "55.0";
-			specificationVersion = "11";
-			break;
-		}
-		rc = addSystemProperty(vm, "java.class.version", classVersion, 0);
-		if (J9SYSPROP_ERROR_NONE != rc) {
-			goto fail;
-		}
-
+	if (JAVA_SPEC_VERSION == 8) {
+		specificationVersion = "1.8";
+	} else {
+#define J9_STR_(x) #x
+#define J9_STR(x) J9_STR_(x)
+		specificationVersion = J9_STR(JAVA_SPEC_VERSION);
+	}
+	if (JAVA_SPEC_VERSION < 12) {
+		/* System property "java.specification.version" is defined via java.lang.VersionProps.init(systemProperties) within System.ensureProperties() */
 		rc = addSystemProperty(vm, "java.specification.version", specificationVersion, 0);
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
 		}
-
-		rc = addSystemProperty(vm, "java.vm.specification.version", specificationVersion, 0);
+	}
+	rc = addSystemProperty(vm, "java.vm.specification.version", specificationVersion, 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
+	
+	if (JAVA_SPEC_VERSION < 12) {
+		/* Following system properties are defined via java.lang.VersionProps.init(systemProperties) within System.ensureProperties() */
+		const char *classVersion = NULL;
+		if (JAVA_SPEC_VERSION == 8) {
+			classVersion = "52.0";
+		} else {
+			classVersion = "55.0";	/* Java 11 */
+		}
+		rc = addSystemProperty(vm, "java.class.version", classVersion, 0);
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
 		}
@@ -614,9 +614,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		if (J9SYSPROP_ERROR_NONE != rc) {
 			goto fail;
 		}
-
 	}
-#endif /* JAVA_SPEC_VERSION < 12 */
 
 	rc = addSystemProperty(vm, "java.vm.vendor", JAVA_VM_VENDOR, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {


### PR DESCRIPTION
Init system property `java.vm.specification.version` via native

There is a need to retrieve the system property `java.vm.specification.version` via `JVMTI API` in an early phase before Java code `java.lang.VersionProps.init(systemProperties)` running.
Removed the Java code (Java 12+) setting the property;
Get the property value via `JAVA_SPEC_VERSION` and set it within `vmprops.c:initializeSystemProperties()`;

Verified that the system property `java.vm.specification.version` has correct value.

Cherry-Pick from https://github.com/eclipse/openj9/pull/5576

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>