### PR TITLE
Spelling comments a..b

### DIFF
--- a/buildenv/jenkins/ARTIFACTORY.md
+++ b/buildenv/jenkins/ARTIFACTORY.md
@@ -30,7 +30,7 @@ Download Artifactory from JFrog (https://jfrog.com/open-source/)
 
 `https://api.bintray.com/content/jfrog/artifactory/jfrog-artifactory-oss-$latest.zip;bt_package=jfrog-artifactory-oss-zip`
 
-Once Atifactory is downloaded, unzip the file to a directory.  
+Once Artifactory is downloaded, unzip the file to a directory.  
 
 `unzip jfrog-artifactory-oss-zip -d /home/jenkins/artifactory` 
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
@@ -52,7 +52,7 @@ import com.ibm.j9ddr.corereaders.memory.IProcess;
  * classpath to be equal to the Application class loader's classpath.
  *
  * While the user may replace the application class loader with their own
- * implementation, the applicaton class loader MUST be a subclass of
+ * implementation, the application class loader MUST be a subclass of
  * URLClassLoader.
  */
 public class J9DDRClassLoader extends SecureClassLoader {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -293,7 +293,7 @@ public class StructureReader {
 	}
 
 	/**
-	 * Test to see if a structure has been read in and hence avaialble
+	 * Test to see if a structure has been read in and hence available
 	 * @param name name of the structure to look for
 	 * @return true if the structure exists, false if not
 	 */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/CIE.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/CIE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2014 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/CIE.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/CIE.java
@@ -107,12 +107,12 @@ class CIE {
 			cfiStream.read(initialInstructions, 0, initialInstructions.length);
 //			System.err.printf("Initial instructions: %s\n", Unwind.byteArrayToHexString(initialInstructions));
 			
-			// Advance to finish on a word boundry.
+			// Advance to finish on a word boundary.
 			int remainder = (int)(cfiStream.getStreamPosition() % this.unwind.process.bytesPerPointer());
 			
 			// We don't need to skip but printing 0 nicely
 			// confirms we ended up in the right place.
-//			System.err.printf("Skipping %d bytes to end on word boundry\n", remainder);
+//			System.err.printf("Skipping %d bytes to end on word boundary\n", remainder);
 			cfiStream.read(new byte[remainder], 0, remainder); 
 		}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/FDE.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/FDE.java
@@ -92,9 +92,9 @@ public class FDE {
 //			System.err.printf("Reading %d bytes of initial instructions\n", callFrameInstructions.length);
 			cfiStream.read(callFrameInstructions, 0, callFrameInstructions.length);
 //			System.err.printf("Call frame instructions: %s\n", byteArrayToHexString(callFrameInstructions));
-			// Advance to finish on a word boundry.
+			// Advance to finish on a word boundary.
 			int remainder = (int)(cfiStream.getStreamPosition() % this.unwind.process.bytesPerPointer());
-//			System.err.printf("Skipping %d bytes to end on word boundry\n", remainder);
+//			System.err.printf("Skipping %d bytes to end on word boundary\n", remainder);
 			cfiStream.read(new byte[remainder], 0, remainder); // TODO shouldn't need to skip but printing 0 nicely
 			// confirms we ended up in the right place.
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/FDE.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/FDE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
@@ -148,7 +148,7 @@ public class UnwindInfo {
 		}
 		if( (flags & FLAGS_CHAINED) == FLAGS_CHAINED) {
 			UnwindInfo chainedInfo = getChainedUnwindInfo();
-			//System.err.println("Appling chained info: " + chainedInfo);
+			//System.err.println("Applying chained info: " + chainedInfo);
 			stackPointer = chainedInfo.apply(stackPointer);
 		}
 		return stackPointer;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/DsaStackFrame.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/DsaStackFrame.java
@@ -905,7 +905,7 @@ public class DsaStackFrame {
                         /* state variable locator */
                         if ((ppa1h_flag3 & 0x80) != 0)
                             opt_ptr = opt_ptr + 4;
-                        /* Argumnet Area Length */
+                        /* Argument Area Length */
                         if ((ppa1h_flag3 & 0x40) != 0)
                             opt_ptr = opt_ptr + 4;
                         /* FP reg save area locator */
@@ -1022,7 +1022,7 @@ public class DsaStackFrame {
                 /* state variable locator */
                 if ((ppa1flags3 & 0x80) != 0)
                     ptrnam = ptrnam + 4;
-                /* Argumnet Area Length */
+                /* Argument Area Length */
                 if ((ppa1flags3 & 0x40) != 0)
                     ptrnam = ptrnam + 4;
                 /* FP reg save area locator */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/DsaStackFrame.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/DsaStackFrame.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corp. and others
+ * Copyright (c) 2006, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArgumentConversionHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArgumentConversionHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2009 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArgumentConversionHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArgumentConversionHandle.java
@@ -36,7 +36,7 @@ abstract class ArgumentConversionHandle extends ConvertHandle {
 	protected final ThunkTuple computeThunks(Object nextHandleType) {
 		// To get the type casts right, we must inspect the full signatures of
 		// both the receiver and nextHandleType, but we can upcast the return
-		// type becuse ArgumentConversionHandles are not used to filter return types.
+		// type because ArgumentConversionHandles are not used to filter return types.
 		MethodType thunkableReceiverType = ThunkKey.computeThunkableType(type(), 0);
 		MethodType thunkableNextType     = ThunkKey.computeThunkableType((MethodType)nextHandleType, 0);
 		return thunkTable().get(new ThunkKeyWithObject(thunkableReceiverType, thunkableNextType));

--- a/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
@@ -52,7 +52,7 @@ final class GuardWithTestHandle extends MethodHandle {
 	protected final ThunkTable thunkTable(){ return _thunkTable; }
 
  	protected final ThunkTuple computeThunks(Object guardType) {
- 		// Different thunks accomodate guards with different numbers of parameters
+ 		// Different thunks accommodate guards with different numbers of parameters
  		return thunkTable().get(new ThunkKeyWithObject(ThunkKey.computeThunkableType(type()), ThunkKey.computeThunkableType((MethodType)guardType)));
  	}
  

--- a/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2011 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2562,7 +2562,7 @@ public class MethodHandles {
 	 * If <i>handle</i> has a void return, <i>filter</i> must not take any parameters.
 	 * 
 	 * @param handle - the MethodHandle that will have its return value adapted
-	 * @param filter - the MethodHandle that will do the return adaption.
+	 * @param filter - the MethodHandle that will do the return adaptation.
 	 * @return a MethodHandle that will run the filter handle on the result of handle.
 	 * @throws NullPointerException - if handle or filter is null
 	 * @throws IllegalArgumentException - if the return type of <i>handle</i> differs from the type of the only argument to <i>filter</i>

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1780,7 +1780,7 @@ public final class Unsafe {
 	/**
 	 * Atomically sets the parameter value at offset in obj if the compare value 
 	 * matches the existing value in the object.
-	 * The get operation has memory semantics of getAquire.
+	 * The get operation has memory semantics of getAcquire.
 	 * The set operation has the memory semantics of set.
 	 *
 	 * @param obj object into which to store the value

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ThreadMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ThreadMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ThreadMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ThreadMXBean.java
@@ -49,7 +49,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean
      * Find the native (operating system assigned) thread identifiers corresponding
      * to a unique TID (as returned by java/lang/Thread.getId()). When querying multiple threadIDs, 
      * consider using getNativeThreadIds(long[]) as it is more efficient than getNativeThreadId().
-     * @param threadId The Java runtime alloted thread identifier.
+     * @param threadId The Java runtime allocated thread identifier.
      * @return Operating system assigned native thread identifier. If the thread corresponding to the
      * 			ID is no longer alive or does not exist, -1 is returned.
      * @throws IllegalArgumentException is thrown if the thread identifier passed is invalid (&lt;=0).

--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
@@ -264,7 +264,7 @@ public final class DecimalData
      * @param precision
      *            number of Packed Decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * 
      * @throws ArrayIndexOutOfBoundsException
@@ -562,7 +562,7 @@ public final class DecimalData
      * @param precision
      *            number of Packed Decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow), otherwise a truncated value is returned
      * 
      * @throws ArrayIndexOutOfBoundsException
@@ -1260,7 +1260,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @return BigInteger the resulting BigIntger
      * 
@@ -1295,7 +1295,7 @@ public final class DecimalData
      * @param scale
      *            scale of the BigDecimal to be returned
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * 
      * @return BigDecimal the resulting BigDecimal
@@ -1696,7 +1696,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value indicating the type of External Decimal
@@ -1746,7 +1746,7 @@ public final class DecimalData
      * @param scale
      *            scale of the BigDecimal
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value that indicates the type of External Decimal
@@ -2163,7 +2163,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value indicating the type of External Decimal
@@ -2213,7 +2213,7 @@ public final class DecimalData
      * @param scale
      *            scale of the returned BigDecimal
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value indicating the type of External Decimal
@@ -2262,7 +2262,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253s
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * 
      * @throws NullPointerException
@@ -2295,7 +2295,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value that indicates the type of External Decimal
@@ -2335,7 +2335,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant indicating the type of External Decimal
@@ -2375,7 +2375,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * 
      * @throws NullPointerException
@@ -2423,7 +2423,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value indicating the External Decimal type
@@ -2478,7 +2478,7 @@ public final class DecimalData
      * @param precision
      *            number of decimal digits. Maximum valid precision is 253
      * @param checkOverflow
-     *            if true an <code>ArithmenticException</code> will be thrown if the decimal value does not fit in the
+     *            if true an <code>ArithmeticException</code> will be thrown if the decimal value does not fit in the
      *            specified precision (overflow)
      * @param decimalType
      *            constant value that indicates the type of External Decimal

--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF DAA]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/builder/IImageBuilder.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/builder/IImageBuilder.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/builder/IImageBuilder.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/builder/IImageBuilder.java
@@ -34,7 +34,7 @@ import com.ibm.dtfj.image.Image;
  * If a javacore contains multiple address spaces, each
  * with its own set of processes and runtimes, it is assumed
  * that some sort of unique ID in the javacore (could be start address
- * of addresspace) is used to distinguish each address space, and that
+ * of address space) is used to distinguish each address space, and that
  * the proper addressSpaceBuilder can be selected throughout the parsing
  * process by parsing a tag in the javacore that contains this id.
  *

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/IDTFJContext.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/IDTFJContext.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/IDTFJContext.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/IDTFJContext.java
@@ -45,7 +45,7 @@ public interface IDTFJContext extends IContext {
 	 * The address space for this context. This may or may not
 	 * contain any processes.
 	 * 
-	 * @return the image adress space
+	 * @return the image address space
 	 */
 	public ImageAddressSpace getAddressSpace();
 	

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceArgs.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceArgs.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceArgs.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceArgs.java
@@ -68,7 +68,7 @@ final public class TraceArgs {
 	override = false;
     }
 
-    /** parses the command line arguements
+    /** parses the command line arguments
      *
      * @param   args      the arguments
      * @throws  UsageException

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -127,7 +127,7 @@ omr_add_hookgen(INPUT oti/zipCachePool.hdf)
 omr_add_hookgen(INPUT gc_include/j9mm.hdf)
 
 # Wrap up the hookgen'd files in a named target
-# This is to work arround the fact that CMake does not do proper dependency tracking
+# This is to work around the fact that CMake does not do proper dependency tracking
 # for generated files across different directories
 add_custom_target(j9vm_hookgen
 	DEPENDS
@@ -176,7 +176,7 @@ add_custom_command(OUTPUT "${J9VM_INCLUDE_DIR}/jni.h"
 	WORKING_DIRECTORY "${J9VM_INCLUDE_DIR}"
 )
 
-# Note we do this here rather than in the redirector directory to work arround
+# Note we do this here rather than in the redirector directory to work around
 # issues in cmake. If we did it there each target which consumed generated.c has
 # its own rule to create it. Which causes a race condition when building in parallel
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"

--- a/runtime/bcutil/AllocationStrategy.hpp
+++ b/runtime/bcutil/AllocationStrategy.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/bcutil/AllocationStrategy.hpp
+++ b/runtime/bcutil/AllocationStrategy.hpp
@@ -45,7 +45,7 @@ public:
 	virtual U_8* allocate(UDATA byteAmount) = 0;
 
 	/* 
-	 * allocate multiple memory regions to accomodate out of line debug information
+	 * allocate multiple memory regions to accommodate out of line debug information
 	 * with sizes as specified by the argument list.
 	 */
 	virtual bool allocateWithOutOfLineData(AllocatedBuffers *allocatedBuffers, UDATA byteAmount, UDATA lineNumberByteAmount, UDATA variableInfoByteAmount) { return false; }

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -472,7 +472,7 @@ convertToOSFilename (J9JavaVM * javaVM, U_8 * dir, UDATA dirLength, U_8 * module
 
 /* 
 	Verify that the internal dynamic loader buffers used to hold the Sun class file are large enough
-	to accomodate @sunClassFileSize bytes.  Grow buffers if neccessary.
+	to accommodate @sunClassFileSize bytes.  Grow buffers if neccessary.
 
 	Return 0 on success, non-zero on error.
 */

--- a/runtime/bcutil/jsrinliner.c
+++ b/runtime/bcutil/jsrinliner.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/bcutil/jsrinliner.c
+++ b/runtime/bcutil/jsrinliner.c
@@ -1036,7 +1036,7 @@ _nextBranch:
 			break;
 
 		/*	START OF DUP CODES */
-		/* DUPS can legally duplicate return adresses */
+		/* DUPS can legally duplicate return addresses */
 
 		case CFR_BC_dup:
 			value = popStack(jsrData);

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -392,7 +392,7 @@ _errorLocation:
 
 
 /* 
-	Walk the bytceodes linearly and verify that the recorded stack maps match.
+	Walk the bytecodes linearly and verify that the recorded stack maps match.
 
 	returns BCV_SUCCESS on success
 	returns BCV_ERR_INTERNAL_ERROR on verification error

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -532,7 +532,7 @@ isClassCompatible(J9BytecodeVerificationData *verifyData, UDATA sourceClass, UDA
 		 */
 		if ((IDATA) TRUE == isInterfaceClass(verifyData, targetName, targetLength, reasonCode)) {
 			/* targetClass must be either java/lang/Cloneable or java/io/Serializable
-			 * in the case when sourceClass is an arary type (sourceArity > 0).
+			 * in the case when sourceClass is an array type (sourceArity > 0).
 			 */
 			if (((CLONEABLE_CLASS_NAME_LENGTH == targetLength) && ((0 == strncmp((const char*)targetName, CLONEABLE_CLASS_NAME, CLONEABLE_CLASS_NAME_LENGTH))))
 			|| ((SERIALIZEABLE_CLASS_NAME_LENGTH == targetLength) && (0 == strncmp((const char*)targetName, SERIALIZEABLE_CLASS_NAME, SERIALIZEABLE_CLASS_NAME_LENGTH)))

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1838,7 +1838,7 @@ osrAllFramesSize(J9VMThread *currentThread, J9JITExceptionTable *metaData, void 
  * Perform an OSR (fill in the OSR buffer) for the frame represented in the stack walk state.
  *
  * Note that the JITted stack frame will be copied to (osrScratchBuffer + osrScratchBufferSize).
- * This function assumes that the buffer has been alllocated large enough.
+ * This function assumes that the buffer has been allocated large enough.
  *
  * @param[in] *currentThread current thread
  * @param[in] *walkState stack walk state (already at the OSR point)

--- a/runtime/codert_vm/jithash.cpp
+++ b/runtime/codert_vm/jithash.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/codert_vm/jithash.cpp
+++ b/runtime/codert_vm/jithash.cpp
@@ -379,7 +379,7 @@ J9JITHashTable* hash_jit_toJ9MemorySegment(J9JITHashTable * table, J9MemorySegme
 	}
 
 	byteCount += sizeof(J9JITHashTable);
-	/* check allignment - currently removed */
+	/* check alignment - currently removed */
 	/*if (LOW_BIT_SET(dataCache->heapAlloc)) 
 		++byteCount;*/
 
@@ -393,9 +393,9 @@ J9JITHashTable* hash_jit_toJ9MemorySegment(J9JITHashTable * table, J9MemorySegme
 
 	allocate += sizeof(J9JITDataCacheHeader);
 
-	/* point buckets to first alligned chunk after the J9JITHashTable structure */
+	/* point buckets to first aligned chunk after the J9JITHashTable structure */
 	dataCacheHashTable = (J9JITHashTable *) allocate;
-	/* check allignment - currently removed */
+	/* check alignment - currently removed */
 	/*if (LOW_BIT_SET(dataCache->heapAlloc))
 		dataCacheHashTable->buckets = (UDATA *) (allocate + sizeof(J9JITHashTable) + 1);
 	else*/

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -57,7 +57,7 @@ set_property(DIRECTORY PROPERTY COMPILE_DEFINITIONS ${compile_defs})
 
 omr_add_tracegen(env/j9jit.tdf)
 
-# this is a workarround because the jit code is inconsistent about how it includes the tracegen files
+# this is a workaround because the jit code is inconsistent about how it includes the tracegen files
 # It only really works if we put it in the source tree
 add_custom_command(
 	OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/env/ut_j9jit.h

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1510,7 +1510,7 @@ J9::SymbolReferenceTable::checkUserField(TR::SymbolReference *symRef)
    static const char *userField = feGetEnv("TR_UserField");
    if (!userField)
       {
-      // In the absense of further analysis, treat everything as user fields
+      // In the absence of further analysis, treat everything as user fields
       setHasUserField(true);
       return;
       }

--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -866,7 +866,7 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
 
                   // secondCriteria looks at hotness over a period of time that is double
                   // than normal (60 samples). This is why we have to increase scaledScorchingThreshold
-                  // by a factor of 2. If we want to become twice as aggressve we need to double
+                  // by a factor of 2. If we want to become twice as aggressive we need to double
                   // scaledScorchingThreshold yet again
                   //
                   bool secondCriteriaScorching = useAggressiveRecompilations &&

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1662,7 +1662,7 @@ void TR::CompilationInfo::invalidateRequestsForUnloadedMethods(TR_OpaqueClassBlo
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
 
       TR_MethodToBeCompiled *methodBeingCompiled = curCompThreadInfoPT->getMethodBeingCompiled();
-      // Mark the method beign compiled that it has been unloaded.
+      // Mark the method being compiled that it has been unloaded.
       // If it is already marked, then there is nothing to do.
       //
       if (methodBeingCompiled && !methodBeingCompiled->_unloadedMethod)
@@ -8280,7 +8280,7 @@ TR::CompilationInfoPerThreadBase::compile(
          // FAR: should we do postpone this copying until after CHTable commit?
          metaData->runtimeAssumptionList = *(compiler->getMetadataAssumptionList());
 
-         // We don't need to delete the metadataAsumptionList from the compilation object,
+         // We don't need to delete the metadataAssumptionList from the compilation object,
          // and in fact it would be wrong to do so because code during chtable.commit is
          // expecting something in the compiler object
          }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5852,7 +5852,7 @@ void getOutOfIdleStates(TR::CompilationInfo::TR_SamplerStates expectedState, TR:
    if (compInfo->getSamplerState() == expectedState)
       {
       J9JavaVM * vm = compInfo->getJITConfig()->javaVM;
-      // Now aquire the monitor and do another test
+      // Now acquire the monitor and do another test
       j9thread_monitor_enter(vm->vmThreadListMutex);
       getOutOfIdleStatesUnlocked(expectedState, compInfo, reason);
       j9thread_monitor_exit(vm->vmThreadListMutex);
@@ -6044,7 +6044,7 @@ void samplerThreadStateLogic(TR::CompilationInfo *compInfo, TR_FrontEnd *fe, int
 /// Change inlining aggressiveness based on 'time' since we last entered
 /// JIT startup phase. Inlining aggressiveness is a number between 100 and 0
 /// with 100 meaning 'be very aggressive' and 0 meaning 'be very conservative'
-/// 'time' is not wall clock time becaue the algorithm would be dependent on
+/// 'time' is not wall clock time because the algorithm would be dependent on
 /// machine speed/capability and load. Instead 'time' can be expressed in
 /// terms of CPU cycles consummed by the JVM or number of samples taken
 /// by application threads. Both are a loose measure of how much work the

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1860,7 +1860,7 @@ J9::Options::fePreProcess(void * base)
    // On big machines we can afford to spend more time compiling
    // (but not on zOS where customers care about CPU or on Xquickstart
    // which should be skimpy on compilation resources).
-   // TR_SuspendEarly is set on zOS becuse test results indicate that
+   // TR_SuspendEarly is set on zOS because test results indicate that
    // it does not benefit much by spending more time compiling.
 #if !defined(J9ZOS390)
    if (!self()->isQuickstartDetected())

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -274,7 +274,7 @@ class TR_PersistentMethodInfo
    void setRecentProfileInfo(TR_PersistentProfileInfo * ppi) { setForSharedInfo(&_recentProfileInfo, ppi); }
 
    // ### IMPORTANT ###
-   // Method info must alway be the first field in this structure
+   // Method info must always be the first field in this structure
    // Flags must always be second
    private:
    TR_OpaqueMethodBlock                  *_methodInfo;

--- a/runtime/compiler/env/ClassTableCriticalSection.hpp
+++ b/runtime/compiler/env/ClassTableCriticalSection.hpp
@@ -42,7 +42,7 @@ class ClassTableCriticalSection
     * @brief Declare the beginning of a critical section, constructing the
     * TR::ClassTableCriticalSection object and acquiring the Class Table Mutex.
     * @param fe The TR_FrontEnd object used to acquire the Class Table Mutex
-    * @param locked An optional parameter to prevent re-acquring the Class Table Mutex if
+    * @param locked An optional parameter to prevent reacquiring the Class Table Mutex if
     * it has already been acquired
     */
    ClassTableCriticalSection(TR_FrontEnd *fe, bool locked = false)

--- a/runtime/compiler/env/ClassTableCriticalSection.hpp
+++ b/runtime/compiler/env/ClassTableCriticalSection.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -321,7 +321,7 @@ int32_t CpuSelfThreadUtilization::computeThreadCpuUtilOverLastNns(int64_t validI
      
       // The interval between crtTimeNs and lastIntervalEndNs is not accounted for; if this interval
       // is larger than the measurement period the thread might have gone to sleep and not
-      // had a chance to update its CPU utilization. Blindely assume a 0% duty cycle
+      // had a chance to update its CPU utilization. Blindly assume a 0% duty cycle
       if (crtTimeNs - lastIntervalEndNs > _minMeasurementIntervalLength)
          {
          totalTime += crtTimeNs - lastIntervalEndNs;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -456,7 +456,7 @@ TR_J9VMBase::releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(TR::Compilation
             //if (*hadClassUnloadMonitor)
             //   TR::MonitorTable::get()->readAcquireClassUnloadMonitor(_compInfoPT->getCompThreadId());
             comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted");
-            // After the exception throw we will release the classUnloadMonitor and re-acquire the VM access
+            // After the exception throw we will release the classUnloadMonitor and reacquire the VM access
             }
          }
       else
@@ -3889,7 +3889,7 @@ TR_J9VMBase::compilationShouldBeInterrupted(TR::Compilation * comp, TR_CallingCo
          }
       if (exitClassUnloadMonitor)
          {
-         // release the classUnloadMonitor and then re-aquire it. This will give GC a chance to cut in.
+         // release the classUnloadMonitor and then reacquire it. This will give GC a chance to cut in.
          persistentMemory(_jitConfig)->getPersistentInfo()->resetGCwillBlockOnClassUnloadMonitor();
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -397,7 +397,7 @@ TR_AnnotationBase::getAnnotationInfoEntry(TR::SymbolReference *symRef,const char
          if(p->getSlot() == slotId) break;
          parmNo++;
          }
-      if(!resolvedSym->isStatic()) --parmNo; // accomodate 'this'
+      if(!resolvedSym->isStatic()) --parmNo; // accommodate 'this'
 
       annotationj9Type |= parmNo << ANNOTATION_PARM_SHIFT;
       memberName = vmSym->nameChars();

--- a/runtime/compiler/env/annotations/TestAnnotation.cpp
+++ b/runtime/compiler/env/annotations/TestAnnotation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/annotations/TestAnnotation.cpp
+++ b/runtime/compiler/env/annotations/TestAnnotation.cpp
@@ -30,7 +30,7 @@
 #include "il/SymbolReference.hpp"
 #include "compile/ResolvedMethod.hpp"
 
-// only purpose of this class is to test that annoations are working.  Will
+// only purpose of this class is to test that annotations are working.  Will
 // expect specific values
 TR_TestAnnotation::TR_TestAnnotation(TR::Compilation *comp,TR::SymbolReference *symRef):
   TR_AnnotationBase(comp)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -373,7 +373,7 @@ public:
     */
    virtual bool                  isUnresolvedConstantDynamic(int32_t cpIndex);
    /** \brief
-    *     Retrieve the adress of the slot containing the constant dynamic.
+    *     Retrieve the address of the slot containing the constant dynamic.
     *
     *  \param cpIndex
     *     The constant pool index of the constant dynamic.

--- a/runtime/compiler/il/symbol/J9StaticSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9StaticSymbol.hpp
@@ -44,7 +44,7 @@ namespace J9
 {
 
 /**
- * A symbol with an adress
+ * A symbol with an address
  */
 class OMR_EXTENSIBLE StaticSymbol : public OMR::StaticSymbolConnector
    {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6515,7 +6515,7 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
                      return;
                      }
                   }
-               // If the primitive condy is unresolved, OR resolved but we fail to accquire VM access,
+               // If the primitive condy is unresolved, OR resolved but we fail to acquire VM access,
                // proceed to generate the loads. Store the type signature info in the symbol so it may be
                // retrieved by optimizer later.
                symbolTypeSig = (char*)comp()->trMemory()->allocateMemory(autoboxClassSigLength, heapAlloc);

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2406,7 +2406,7 @@ bool TR_EscapeAnalysis::checkAllNewsOnRHSInLoopWithAliasing(int32_t defIndex, TR
 
                   // Until we reach otherAllocNode, call visitTree to
                   // ignore nodes in those trees.  After we've reached
-                  // otherAllocNode, call collectAiasesOfAllocations to
+                  // otherAllocNode, call collectAliasesOfAllocations to
                   // track its aliases in _aliasesOfOtherAllocNode
                   if (!collectAliases)
                      {

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -299,7 +299,7 @@ class Candidate : public TR_Link<Candidate>
          FillsInStackTrace            = 0x08000000,
          UsesStackTrace               = 0x04000000,
 
-         // Object that is being allocted inside a loop
+         // Object that is being allocated inside a loop
          //
          InsideALoop                  = 0x02000000,
 

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -5928,7 +5928,7 @@ TR_CISCTransformer::searchPredecessorOfBlock(TR::Block *block)
 
 //*****************************************************************************************
 // It decides whether we generate versioning code and modifies the target blocks.
-// It returns the block that fast code will be appened.
+// It returns the block that fast code will be appended.
 //*****************************************************************************************
 TR::Block *
 TR_CISCTransformer::modifyBlockByVersioningCheck(TR::Block *block, TR::TreeTop *startTop, TR::Node *lengthNode, List<TR::Node> *guardList)
@@ -5961,7 +5961,7 @@ TR_CISCTransformer::modifyBlockByVersioningCheck(TR::Block *block, TR::TreeTop *
 
 //*****************************************************************************************
 // It decides whether we generate versioning code and modifies the target blocks.
-// It returns the block that fast code will be appeneded.
+// It returns the block that fast code will be appended.
 //*****************************************************************************************
 TR::Block *
 TR_CISCTransformer::modifyBlockByVersioningCheck(TR::Block *block, TR::TreeTop *startTop, List<TR::Node> *guardList)
@@ -6144,7 +6144,7 @@ TR_CISCTransformer::isDeadStore(TR::Node *node)
 
 //*****************************************************************************************
 // It basically skips blocks containing only a goto statement.
-// It can aditionally skip nodes for dead stores and the node specified by "ignoreTree"
+// It can additionally skip nodes for dead stores and the node specified by "ignoreTree"
 //*****************************************************************************************
 TR::Block *
 TR_CISCTransformer::skipGoto(TR::Block *block, TR::Node *ignoreTree)

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -104,7 +104,7 @@ static bool avoidTransformingStringLoops(TR::Compilation* comp)
    }
 
 //*****************************************************************************************
-// It partially peels the loop body to aligh the top of the region
+// It partially peels the loop body to align the top of the region
 //*****************************************************************************************
 bool
 ChangeAlignmentOfRegion(TR_CISCTransformer *trans)
@@ -139,7 +139,7 @@ ChangeAlignmentOfRegion(TR_CISCTransformer *trans)
          if (!chk->isOutsideOfLoop())
             {
             if (disptrace) traceMsg(comp, "ChangeAlignmentOfRegion : (t:%d p:%d) no need to change alignment\n",t->getID(),pTop->getID());
-            return changed;        // Find pTop! Already alighed correctly
+            return changed;        // Find pTop! Already aligned correctly
             }
          }
       if (t->getNumSuccs() < 1)

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5892,7 +5892,7 @@ TR_J9InnerPreexistenceInfo::perform(TR::Compilation *comp, TR::Node *guardNode, 
        comp->compileRelocatableCode())
       return false;
 
-   // perform() is a misnomer -- most of the work is alredy done by the constructor
+   // perform() is a misnomer -- most of the work is already done by the constructor
    // at this stage - we just find what is the best way to utilize the information
    //
    if (!comp->performVirtualGuardNOPing())
@@ -5926,7 +5926,7 @@ TR_J9InnerPreexistenceInfo::perform(TR::Compilation *comp, TR::Node *guardNode, 
 
          //_callNode->devirtualizeCall(_callTree);
 
-         // Add an inner assumptoin on the outer guard
+         // Add an inner assumption on the outer guard
          //
          TR_InnerAssumption *a  = new (comp->trHeapMemory()) TR_InnerAssumption(point->_ordinal, virtualGuard);
          ((TR_J9InnerPreexistenceInfo *)point->_callStack->_innerPrexInfo)->addInnerAssumption(a);

--- a/runtime/compiler/optimizer/JProfilingBlock.cpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.cpp
@@ -77,7 +77,7 @@ class AdjacentBlockIterator
             return;
             }
          }
-      // handle the loopback edge from start to end with an artifically high frequency
+      // handle the loopback edge from start to end with an artificially high frequency
       // to make sure the edge is included in the computed MST
       if (cfg->getStart()->asBlock() == _block
           && !_visitedBlocks.contains(cfg->getEnd()->asBlock()))

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -246,7 +246,7 @@ class TR_ActiveMonitor
    // Further info:
    // 1) Do we profile monitor object types?
    // 2) I think we want high false contention scenarios.  This allows TLE to work nicely
-   // 3) No contention (ie single thread using a lock, or there's only one thread ever trying to aquire the lock) is bad.  There's a 3-5 cycle penalty for Tbegin and compareandswap is 1 cycle
+   // 3) No contention (ie single thread using a lock, or there's only one thread ever trying to acquire the lock) is bad.  There's a 3-5 cycle penalty for Tbegin and compareandswap is 1 cycle
    public:
    int32_t                      _numberOfTreeTopsInsideMonitor;
    bool                         _containsCalls;

--- a/runtime/compiler/optimizer/NewInitialization.cpp
+++ b/runtime/compiler/optimizer/NewInitialization.cpp
@@ -554,7 +554,7 @@ bool TR_NewInitialization::findAllocationNode(TR::TreeTop *treeTop, TR::Node *no
 
       size = node->getFirstChild()->getInt();
 
-      // Ignore large arrays so we don't have to worry abount size
+      // Ignore large arrays so we don't have to worry about size
       // overflow. Make sure that illegal sizes are not inlined.
       //
       if (size < 0 || size > 10000)

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -1846,7 +1846,7 @@ TR::TreeTop *TR_StringPeepholes::detectPattern(TR::Block *block, TR::TreeTop *tt
    if (stringCount > MAX_STRINGS)
       return 0;
    if (stringCount == 2 && !findSymRefForOptMethod(SPH_String_init_SS))
-      return 0; // cannot do it because we do not have the appropiate constructor
+      return 0; // cannot do it because we do not have the appropriate constructor
    if (stringCount == 3 && !findSymRefForOptMethod(SPH_String_init_SSS))
       return 0; // same as above
 

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -788,7 +788,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    *(intptrj_t *)(cursor+2*TR::Compiler->om.sizeofReferenceAddress()) = -1;
    *(intptrj_t *)(cursor+3*TR::Compiler->om.sizeofReferenceAddress()) = (intptrj_t)blAddress;
 
-   // Register for relation of the 1st target addess
+   // Register for relation of the 1st target address
    cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
          __FILE__, __LINE__, callNode);
 

--- a/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
@@ -1938,7 +1938,7 @@ extern TR::Register *inlineBigDecimalUnaryOp(
       }
    else // handles all 32-bit, except dxex
       {
-      // Alocate temporary memory
+      // Allocate temporary memory
       temp = cg->allocateLocalTemp(TR::Int64);
       tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, temp, 8, cg);
 
@@ -2316,7 +2316,7 @@ extern TR::Register *inlineBigDecimalUnscaledValue(
       }
    else // 32-bit or if no direct move support
       {
-      // Alocate temporary memory
+      // Allocate temporary memory
       TR::SymbolReference * tempSymRef = cg->allocateLocalTemp(TR::Int64);
       TR::MemoryReference * tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, tempSymRef, 8, cg);
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -582,7 +582,7 @@ static void VMnonNullSrcWrtBarCardCheckEvaluator(TR::Node *node, TR::Register *s
                   new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, privateFlags), TR::Compiler->om.sizeofReferenceAddress(), cg));
 
             // The value for J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE is a generated value when VM code is created
-            // At the moment we are safe here, but it is better to be careful and avoid any unexpected behavoiur
+            // At the moment we are safe here, but it is better to be careful and avoid any unexpected behaviour
             // Make sure this falls within the scope of andis
             //
             TR_ASSERT(J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >= 0x00010000 && J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE <= 0x80000000,
@@ -743,7 +743,7 @@ static void VMCardCheckEvaluator(TR::Node *node, TR::Register *dstReg, TR::Regis
                new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, privateFlags), TR::Compiler->om.sizeofReferenceAddress(), cg));
 
          // The value for J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE is a generated value when VM code is created
-         // At the moment we are safe here, but it is better to be careful and avoid any unexpected behavoiur
+         // At the moment we are safe here, but it is better to be careful and avoid any unexpected behaviour
          // Make sure this falls within the scope of andis
          //
          TR_ASSERT(J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >= 0x00010000 && J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE <= 0x80000000,
@@ -2510,7 +2510,7 @@ TR::Register *J9::Power::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *no
          // If the constant arraylength is non-zero then it will pass the spine check (hence its
          // a contiguous array) and the BNDCHK can be done inline with no OOL path.
          //
-         // If the constant arraylenth is zero then we will always go OOL.
+         // If the constant arraylength is zero then we will always go OOL.
          //
          // TODO: in the future there shouldn't be an OOL path because any valid access must be
          //       on a discontiguous array.

--- a/runtime/compiler/runtime/DataCache.cpp
+++ b/runtime/compiler/runtime/DataCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/DataCache.cpp
+++ b/runtime/compiler/runtime/DataCache.cpp
@@ -309,7 +309,7 @@ TR_DataCache* TR_DataCacheManager::allocateNewDataCache(uint32_t minimumSize)
 //       Pointer to TR_DataCache that can be used exclusively by this thread
 //       or NULL if cannot get any dataCache
 // Side efects:
-//       Aquires/releases dataCache mutex internally
+//       Acquires/releases dataCache mutex internally
 //----------------------------------------------------------------------------
 TR_DataCache* TR_DataCacheManager::reserveAvailableDataCache(J9VMThread *vmThread, uint32_t sizeHint)
    {
@@ -367,7 +367,7 @@ TR_DataCache* TR_DataCacheManager::reserveAvailableDataCache(J9VMThread *vmThrea
 //---------------------------- makeDataCacheAvailable ------------------------
 // Put the designated dataCache back into the list of available data caches
 // Side efects:
-//       Aquires/releases dataCache mutex internally
+//       Acquires/releases dataCache mutex internally
 //----------------------------------------------------------------------------
 void TR_DataCacheManager::makeDataCacheAvailable(TR_DataCache *dataCache)
    {
@@ -454,7 +454,7 @@ uint8_t* TR_DataCache::allocateDataCacheSpace(int32_t size)
 // Ret value:
 //      pointer to allocated space
 // Side efects:
-//       Aquires/releases dataCache mutex internally
+//       Acquires/releases dataCache mutex internally
 //-----------------------------------------------------------------------------
 uint8_t* TR_DataCacheManager::allocateDataCacheSpace(uint32_t size)
 {

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3879,7 +3879,7 @@ void TR_IProfiler::processWorkingQueue()
 
 extern "C" void stopInterpreterProfiling(J9JITConfig *jitConfig);
 
-/* Lower value will more aggressivly skip samples as the number of unloaded classes increasses */
+/* Lower value will more aggressively skip samples as the number of unloaded classes increasses */
 static const int IP_THROTTLE = 32;
 
 #if defined(NETWORK_ORDER_BYTECODE)
@@ -4582,7 +4582,7 @@ void TR_AggregationHT::sortByNameAndPrint(TR_J9VMBase *fe)
 // This method will be executing on a single thread and it will acquire VM access as needed
 // to prevent the GC from modifying the BC hashtable as we walk.
 // Application threads may add new data to the IProfiler hashtable, but this is not an impediment.
-// Temporary data structures will be allocated using persistent memory which will be dealocated
+// Temporary data structures will be allocated using persistent memory which will be deallocated
 // at the end.
 // Parameter: the vmThread it is executing on.
 void TR_IProfiler::dumpIPBCDataCallGraph(J9VMThread* vmThread)

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -941,7 +941,7 @@ int32_t TR::AMD64PrivateLinkage::buildPrivateLinkageArgs(TR::Node               
    // we're going to align the stack depend on the alignment property
    // adjust = something
    // allocateSize = parmAreaSize + adjust;
-   // then subtract stackpointer with alocateSize
+   // then subtract stackpointer with allocateSize
    uint32_t alignedParmAreaSize = parmAreaSize;
 
    if (!getProperties().getReservesOutgoingArgsInPrologue() && !callNode->getSymbol()->castToMethodSymbol()->isHelper())

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12655,7 +12655,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
 
    /*
     * For reporting field write, reference to the valueNode is needed so we need to store
-    * the value on to a stack location first and pass the stack location address as an arguement
+    * the value on to a stack location first and pass the stack location address as an argument
     * to the VM helper
     */
    if (isWrite)

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1322,7 +1322,7 @@ void TR::X86CallSite::computeProfiledTargets()
 
          // PMR 05447,379,000 getTopValue may return array length profile data instead of a class pointer
          // (when the virtual call feeds an arraycopy method length parameter). We need to defend this case to
-         // avoid attempting to use the length as a pointer, so use asAdressInfo() to gate assignment of topValue.
+         // avoid attempting to use the length as a pointer, so use asAddressInfo() to gate assignment of topValue.
          uintptrj_t topValue = (valueInfo) ? valueInfo->getTopValue() : 0;
 
          // if the call to hashcode is a virtual call node, the top value was already inlined.

--- a/runtime/compiler/x/runtime/X86Codert.nasm
+++ b/runtime/compiler/x/runtime/X86Codert.nasm
@@ -389,7 +389,7 @@ dremloop:
 
 
 ; The assumption is that this thunk method would be called from a 32-bit runtime only.
-; Otherwise, the stack offsets will have to change to accomodate the correct size of return
+; Otherwise, the stack offsets will have to change to accommodate the correct size of return
 ; address.
 ;
         align 16
@@ -406,7 +406,7 @@ SSEfloatRemainderIA32Thunk:
 
 
 ; The assumption is that this thunk method would be called from a 32-bit runtime only.
-; Otherwise, the stack offsets will have to change to accomodate the correct size of return
+; Otherwise, the stack offsets will have to change to accommodate the correct size of return
 ; address.
 ;
         align 16

--- a/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
@@ -85,7 +85,7 @@ const int32_t len = 22;
 /*
  *  No need to stopUsingRegister(FPR) because the RA does
  *  not check for liveliness of these regs on zSeries (yet).
- *  But we'll do it anways.
+ *  But we'll do it anyways.
  */
 
 /*

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -7353,7 +7353,7 @@ J9::Z::TreeEvaluator::pdshiftEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
             needExtraShift = true;
             }
 
-         // Allocate enough temporary space to accomodate the amount of left shifts.
+         // Allocate enough temporary space to accommodate the amount of left shifts.
          tmpResultByteSize += (shiftAmount + 1)/2;
          }
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -465,7 +465,7 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelS2HeadPartMatch);
 
       // Starting from the beginning of the partial match, load the next 16 bytes from s1 and redo s2 header search.
-      // This implies that the partial match will be re-matched by the next VSTRS. This can potentially benifit string
+      // This implies that the partial match will be re-matched by the next VSTRS. This can potentially benefit string
       // search cases where s2 is shorter than 16 bytes. For short s2 strings, string search can potentially be done in
       // the next VSTRS and can we avoid residue matching which requires several index adjustments that do not provide
       // performance benefits.
@@ -1987,7 +1987,7 @@ VMwrtbarEvaluator(
       TR::SymbolReference * wbRef = NULL;
       if (gcMode == gc_modron_wrtbar_always)
          wbRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreSymbolRef();
-      else // use jitWriteBarrierStoreGenerational for both generational and gencon, becaues we inline card marking.
+      else // use jitWriteBarrierStoreGenerational for both generational and gencon, because we inline card marking.
          {
          static char *disable = feGetEnv("TR_disableGenWrtBar");
          wbRef = disable ?
@@ -3094,7 +3094,7 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          {
          // Any constValue <= MAX_UNSIGNED_IMMEDIATE_VAL is taken here.
          // The length is assumed to be non-negative and is within [0, max_uint32] range.
-         // The index can be negative or [0, max_uint32]. An unconditional bransh is generated if it's negative.
+         // The index can be negative or [0, max_uint32]. An unconditional branch is generated if it's negative.
          // No need to use unconditional BRC because it requires a proceeding NO-OP instruction for proper signal
          // handling. And NOP+BRC is of the same length as CLFIT.
          TR::Register * testRegister = cg->evaluate(nonConstNode);
@@ -4054,7 +4054,7 @@ VMarrayStoreCHKEvaluator(
       }
 
    // Bringing back tests from outlined keeping only helper call in outlined section
-   // TODO Attching helper call predependency to BRASL instruction and combine ICF conditions with post dependency conditions of
+   // TODO Attaching helper call predependency to BRASL instruction and combine ICF conditions with post dependency conditions of
    // helper call should fix the issue of unnecessary spillings in ICF. Currently bringing the tests back to main line here but
    // check performance of both case.
    cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, wbLabel);
@@ -4364,7 +4364,7 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
       }
 
    // Store for case where we have a NULL ptr detected at runtime and
-   // branchec around the wrtbar
+   // branches around the wrtbar
    //
    // For the non-NULL case we chose to simply exec the ST twice as this is
    // cheaper than branching around the a single ST inst.
@@ -5729,7 +5729,7 @@ bool genInstanceOfOrCheckcastSuperClassTest(TR::Node *node, TR::CodeGenerator *c
  *
  *  \details
  *     Note that if this function returns <c>false</c> the appropriate null test condition code will be set and the
- *     callee is responsible for generating the branh instruction to act on the condition code.
+ *     callee is responsible for generating the branch instruction to act on the condition code.
  */
 static
 bool genInstanceOfOrCheckCastNullTest(TR::Node* node, TR::CodeGenerator* cg, TR::Register* objectReg)
@@ -6119,7 +6119,7 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
             cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOfStats/(%s)/Equality", comp->signature()),1,TR::DebugCounter::Undetermined);
              /*   #IF NextTest = GoToFalse
               *      branchCond = ifInstanceOf ? (!trueFallThrough ? COND_BE : COND_BNE ) : (init=true ? COND_BE : COND_BNE )
-              *      brnachLabel = ifInstanceOf ? (!trueFallThrough ? trueLabel : falseLabel ) : doneLabel
+              *      branchLabel = ifInstanceOf ? (!trueFallThrough ? trueLabel : falseLabel ) : doneLabel
               *      CGRJ castClassReg, objClassReg, branchCond, branchLabel
               *   #ELSE
               *      CGRJ castClassReg, objClassReg, COND_BE, trueLabel
@@ -8877,7 +8877,7 @@ J9::Z::TreeEvaluator::VMnewEvaluator(TR::Node * node, TR::CodeGenerator * cg)
                   debugObj->addInstructionComment(cursor, "Denotes start of OOL for allocating zero size arrays");
 
                   /* using TR::Compiler->om.discontiguousArrayHeaderSizeInBytes() - TR::Compiler->om.contiguousArrayHeaderSizeInBytes()
-                   * for byte size for discontinous 0 size arrays becasue later instructions do ( + 15 & -8) to round it to object size header and adding a j9 class header
+                   * for byte size for discontinous 0 size arrays because later instructions do ( + 15 & -8) to round it to object size header and adding a j9 class header
                    *
                    *
                    ----------- OOL: Beginning of out-of-line code section ---------------

--- a/runtime/compiler/z/codegen/UncommonBCDCHKAddressNode.hpp
+++ b/runtime/compiler/z/codegen/UncommonBCDCHKAddressNode.hpp
@@ -59,7 +59,7 @@
  * decimal overflow exception.
  *
  * We make a function call in the out-of-line section to the original DAA API function to handle exceptions in the mainline.
- * To achive this, we make use of the addressNode and the callParam-x nodes attached to the BCDCHK node.
+ * To achieve this, we make use of the addressNode and the callParam-x nodes attached to the BCDCHK node.
  * In OOL section evaluation, we make a callNode with callParam 1-n attached to it; after the call, the correct pdOpNode
  * results need to be copied from the addressNode location to the pdOpNode storage reference. This copying makes
  * sure its following pdstorei (usually right after the BCDCHK node) is copying the correct content; and is only done correctly

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -260,7 +260,7 @@ ZZ             DC <Const Pool Indx> // Constant Pool Index
 ZZ ===================================================================
 ZZ
 ZZ ===================================================================
-ZZ PICBuider routine _interpreterUnresolvedSpecialGlue
+ZZ PICBuilder routine _interpreterUnresolvedSpecialGlue
 ZZ
 ZZ Exports:
 ZZ   _interpreterUnresolvedSpecialGlue
@@ -312,7 +312,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveSpecialMethod)
     END_FUNC(_interpreterUnresolvedSpecialGlue,intpUnrSpG,12)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedStaticGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedStaticGlue
 ZZ
 ZZ ===================================================================
 
@@ -337,7 +337,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveStaticMethod)
     END_FUNC(_interpreterUnresolvedStaticGlue,intpUnrStG,12)
 
 ZZ ===================================================================
-ZZ PICBuider routine _interpreterUnresolvedDirectVirtualGlue
+ZZ PICBuilder routine _interpreterUnresolvedDirectVirtualGlue
 ZZ
 ZZ ===================================================================
 
@@ -504,7 +504,7 @@ ZZ   Go through j2iTransition
 
 
 ZZ ===================================================================
-ZZ PICBuider routine _interpreterVoidStaticGlue
+ZZ PICBuilder routine _interpreterVoidStaticGlue
 ZZ
 ZZ ===================================================================
 
@@ -522,7 +522,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStatic0)
     END_FUNC(_interpreterVoidStaticGlue,intpVStG,10)
 
 ZZ ===================================================================
-ZZ PICBuider routine _interpreterSyncVoidStaticGlue
+ZZ PICBuilder routine _interpreterSyncVoidStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterSyncVoidStaticGlue,intpSVStG)
@@ -539,7 +539,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSync0)
     END_FUNC(_interpreterSyncVoidStaticGlue,intpSVStG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterIntStaticGlue
+ZZ  PICBuilder routine - _interpreterIntStaticGlue
 ZZ
 ZZ ===================================================================
 
@@ -557,7 +557,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStatic1)
     END_FUNC(_interpreterIntStaticGlue,intpIStG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterSyncIntStaticGlue
+ZZ  PICBuilder routine - _interpreterSyncIntStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterSyncIntStaticGlue,intpSIStG)
@@ -574,7 +574,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSync1)
     END_FUNC(_interpreterSyncIntStaticGlue,intpSIStG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterLongStaticGlue
+ZZ  PICBuilder routine - _interpreterLongStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterLongStaticGlue,intpLStG)
@@ -591,7 +591,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSyncJ)
     END_FUNC(_interpreterLongStaticGlue,intpLStG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterSyncLongStaticGlue
+ZZ  PICBuilder routine - _interpreterSyncLongStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterSyncLongStaticGlue,intpSLStG)
@@ -608,7 +608,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSyncJ)
     END_FUNC(_interpreterSyncLongStaticGlue,intpSLStG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterFloatStaticGlue
+ZZ  PICBuilder routine - _interpreterFloatStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterFloatStaticGlue,intpFStG)
@@ -625,7 +625,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSyncF)
     END_FUNC(_interpreterFloatStaticGlue,intpFStG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterSyncFloatStaticGlue
+ZZ  PICBuilder routine - _interpreterSyncFloatStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterSyncFloatStaticGlue,intpSFStG)
@@ -642,7 +642,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSyncF)
     END_FUNC(_interpreterSyncFloatStaticGlue,intpSFStG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterDoubleStaticGlue
+ZZ  PICBuilder routine - _interpreterDoubleStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterDoubleStaticGlue,intpDStG)
@@ -659,7 +659,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_icallVMprJavaSendStaticSyncD)
     END_FUNC(_interpreterDoubleStaticGlue,intpDStG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterSyncDoubleStaticGlue
+ZZ  PICBuilder routine - _interpreterSyncDoubleStaticGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterSyncDoubleStaticGlue,intpSDStG)
@@ -823,7 +823,7 @@ ZZ End of LStaticGlueCallFixer
     END_FUNC(_interpreterSyncDoubleStaticGlue,intpSDStG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _nativeStaticHelper
+ZZ  PICBuilder routine - _nativeStaticHelper
 ZZ
 ZZ ===================================================================
 
@@ -851,7 +851,7 @@ ZZ
 ZZ This glue function is called by an unresolved call data snippet.
 ZZ It in turn calls a VM routine (i.e. jitResolve{Class,ClassFrom-
 ZZ StaticField,StaticField,StaticFieldSetter}) to resolve an
-ZZ unresolved class/field, stores the resolved adderss in the literal
+ZZ unresolved class/field, stores the resolved address in the literal
 ZZ pool, patches mainline code, and returns to the point
 ZZ where the call was originally made in the code cache.
 ZZ
@@ -896,7 +896,7 @@ ZZ properly.
 ZZ ===================================================================
 ZZ
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedClassGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedClassGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedClassGlue,intpUCG)
@@ -919,7 +919,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveClass)
     END_FUNC(_interpreterUnresolvedClassGlue,intpUCG,9)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedClassGlue2
+ZZ  PICBuilder routine - _interpreterUnresolvedClassGlue2
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedClassGlue2,intpUCG2)
@@ -942,7 +942,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveClassFromStaticField)
     END_FUNC(_interpreterUnresolvedClassGlue2,intpUCG2,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedStringGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedStringGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedStringGlue,intpUSG)
@@ -965,7 +965,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveString)
     END_FUNC(_interpreterUnresolvedStringGlue,intpUSG,9)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedMethodTypeGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedMethodTypeGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedMethodTypeGlue,intpUMTG)
@@ -988,7 +988,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveMethodType)
     END_FUNC(_interpreterUnresolvedMethodTypeGlue,intpUMTG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedMethodHandleGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedMethodHandleGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedMethodHandleGlue,intpUMHG)
@@ -1011,7 +1011,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveMethodHandle)
     END_FUNC(_interpreterUnresolvedMethodHandleGlue,intpUMHG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedCallSiteTableEntryGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedCallSiteTableEntryGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedCallSiteTableEntryGlue,intpUCSG)
@@ -1034,7 +1034,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveInvokeDynamic)
     END_FUNC(_interpreterUnresolvedCallSiteTableEntryGlue,intpUCSG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedMethodTypeTableEntryGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedMethodTypeTableEntryGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedMethodTypeTableEntryGlue,intpUMT)
@@ -1057,7 +1057,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveHandleMethod)
     END_FUNC(_interpreterUnresolvedMethodTypeTableEntryGlue,intpUMT,9)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedInt32Load
+ZZ  PICBuilder routine - MTUnresolvedInt32Load
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedInt32Load,intpMTI32L)
@@ -1084,7 +1084,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     END_FUNC(MTUnresolvedInt32Load,intpMTI32L,12)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedInt64Load
+ZZ  PICBuilder routine - MTUnresolvedInt64Load
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedInt64Load,intpMTI64L)
@@ -1111,7 +1111,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     END_FUNC(MTUnresolvedInt64Load,intpMTI64L,12)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedFloatLoad
+ZZ  PICBuilder routine - MTUnresolvedFloatLoad
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedFloatLoad,intpMTFL)
@@ -1138,7 +1138,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     END_FUNC(MTUnresolvedFloatLoad,intpMTFL,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedDoubleLoad
+ZZ  PICBuilder routine - MTUnresolvedDoubleLoad
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedDoubleLoad,intpMTDL)
@@ -1165,7 +1165,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     END_FUNC(MTUnresolvedDoubleLoad,intpMTDL,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedAddressLoad
+ZZ  PICBuilder routine - MTUnresolvedAddressLoad
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedAddressLoad,intpMTAL)
@@ -1212,7 +1212,7 @@ LABEL(LMTStaticAddressLoadBRANCHEND)
     END_FUNC(MTUnresolvedAddressLoad,intpMTAL,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedInt32Store
+ZZ  PICBuilder routine - MTUnresolvedInt32Store
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedInt32Store,intpMTI32S)
@@ -1239,7 +1239,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     END_FUNC(MTUnresolvedInt32Store,intpMTI32S,12)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedInt64Store
+ZZ  PICBuilder routine - MTUnresolvedInt64Store
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedInt64Store,intpMTI64S)
@@ -1266,7 +1266,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     END_FUNC(MTUnresolvedInt64Store,intpMTI64S,12)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedFloatStore
+ZZ  PICBuilder routine - MTUnresolvedFloatStore
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedFloatStore,intpMTFS)
@@ -1293,7 +1293,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     END_FUNC(MTUnresolvedFloatStore,intpMTFS,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedDoubleStore
+ZZ  PICBuilder routine - MTUnresolvedDoubleStore
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedDoubleStore,intpMTDS)
@@ -1320,7 +1320,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     END_FUNC(MTUnresolvedDoubleStore,intpMTDS,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - MTUnresolvedAddressStore
+ZZ  PICBuilder routine - MTUnresolvedAddressStore
 ZZ
 ZZ ===================================================================
     START_FUNC(MTUnresolvedAddressStore,intpMTAS)
@@ -1387,7 +1387,7 @@ LABEL(LMTUnresolvedAddressStoreNonIsolated)
     END_FUNC(MTUnresolvedAddressStore,intpMTAS,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedStaticDataGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedStaticDataGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedStaticDataGlue,intpUStDG)
@@ -1410,7 +1410,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     END_FUNC(_interpreterUnresolvedStaticDataGlue,intpUStDG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedStaticDataStoreGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedStaticDataStoreGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedStaticDataStoreGlue,intpUStDSG)
@@ -1454,7 +1454,7 @@ ZZ  at the end, otherwise, we would be loading off the wrong
 ZZ  and unaligned address!
 LABEL(LPatchData)
     TML     r2,HEX(0001)    # data is masked for clinit?
-    JZ      LPatchLitPool   # if no, jump accordinly
+    JZ      LPatchLitPool   # if no, jump accordingly
     LR_GPR  r0,r2           # save the resolved data in r0
     NILL    r2,HEX(FFFE)    # mask off the lower bit
 
@@ -1508,7 +1508,7 @@ ZZ Now we jump back to mainline code.
     END_FUNC(_interpreterUnresolvedStaticDataStoreGlue,intpUStDSG,12)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedInstanceDataGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedInstanceDataGlue
 ZZ
 ZZ ===================================================================
 
@@ -1533,7 +1533,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveField)
     END_FUNC(_interpreterUnresolvedInstanceDataGlue,intpUIDG,10)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interpreterUnresolvedInstanceDataStoreGlue
+ZZ  PICBuilder routine - _interpreterUnresolvedInstanceDataStoreGlue
 ZZ
 ZZ ===================================================================
     START_FUNC(_interpreterUnresolvedInstanceDataStoreGlue,intpUIDSG)
@@ -1630,7 +1630,7 @@ LABEL(LDataOOLExit)
     END_FUNC(_interpreterUnresolvedInstanceDataStoreGlue,intpUIDSG,11)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _virtualUnresolvedHelper
+ZZ  PICBuilder routine - _virtualUnresolvedHelper
 ZZ  Handles unresolved virtual and unresolved nestmate private methods
 ZZ
 ZZ  For unresolved virtual call targets, this routine calls VM helper
@@ -1832,7 +1832,7 @@ ZZ Branch instruction in mainline will be patched here with NOP
     END_FUNC(_jitResolveConstantDynamic,jRCD,6)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interfaceCallHelper
+ZZ  PICBuilder routine - _interfaceCallHelper
 ZZ
 ZZ ===================================================================
     START_FUNC(_interfaceCallHelper,ifCH)
@@ -1937,7 +1937,7 @@ ZZ # Load address of the lookup class
     END_FUNC(_interfaceCallHelper,ifCH,6)
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interfaceCallHelperSingleDynamicSlot
+ZZ  PICBuilder routine - _interfaceCallHelperSingleDynamicSlot
 ZZ
 ZZ ===================================================================
     START_FUNC(_interfaceCallHelperSingleDynamicSlot,ifCH1)
@@ -2181,7 +2181,7 @@ ZZ # Load the address of lookup class
 
 
 ZZ ===================================================================
-ZZ  PICBuider routine - _interfaceCallHelperMultiSlots
+ZZ  PICBuilder routine - _interfaceCallHelperMultiSlots
 ZZ
 ZZ ===================================================================
     START_FUNC(_interfaceCallHelperMultiSlots,ifCHM)
@@ -2300,7 +2300,7 @@ ZZ  so just dispatch
     JZ      ifCHMLcommonJitDispatch
 
 ZZ Try to atomically update lastCachedSlot
-ZZ value to be stored(r1) begining with firstSlot
+ZZ value to be stored(r1) beginning with firstSlot
     L_GPR   r0,eq_firstSlotField_inInterfaceSnippet(r14)
     AHI_GPR r0,-2*PTR_SIZE
 LABEL(ifCHMCSLoopBegin)

--- a/runtime/compiler/z/runtime/Recompilation.m4
+++ b/runtime/compiler/z/runtime/Recompilation.m4
@@ -109,7 +109,7 @@ ZZ Snippet Base Register
 SETVAL(sbase,r11)
 SETVAL(eq_JitCompilerAddr,0)
 ZZ previous field only 4 bytes big, but compiler aligns
-ZZ to double word boundry on 64 bit
+ZZ to double word boundary on 64 bit
 SETVAL(eq_BodyInfo_MethodInfo,PTR_SIZE)
 SETVAL(eq_VMMethodInfo_j9Method,0)
 

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -312,7 +312,7 @@ ZZ  # is the dest. word aligned?
     JNZ       $1PatchLbl1 # no, process accordingly
 
 ZZ
-ZZ 4-bytes patching in word aligneded address.
+ZZ 4-bytes patching in word aligned address.
 ZZ Doing so is straightforward.
 ZZ
     ST        r1,0(r2)              # replace the value

--- a/runtime/exelib/common/memcheck.c
+++ b/runtime/exelib/common/memcheck.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/exelib/common/memcheck.c
+++ b/runtime/exelib/common/memcheck.c
@@ -2974,7 +2974,7 @@ memoryCheck_free_AVLTreeNode(OMRPortLibrary *portLib, J9AVLTreeNode *node)
  * @param insertNode The node which will be inserted into the tree
  * @param walk The current search position in the tree
  *
- * @return IDATA the difference bewtween the two strings alphabetically
+ * @return IDATA the difference between the two strings alphabetically
  *
  */
 static IDATA 
@@ -3020,7 +3020,7 @@ memoryCheck_print_stats_callSite(OMRPortLibrary *portLib, J9MEMAVLTreeNode *node
  * @param search The char * to search for
  * @param walk The current search position in the tree
  *
- * @return IDATA the difference bewtween the two strings alphabetically
+ * @return IDATA the difference between the two strings alphabetically
  *
  */
 static IDATA 

--- a/runtime/gc_check/CheckCycle.cpp
+++ b/runtime/gc_check/CheckCycle.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_check/CheckCycle.cpp
+++ b/runtime/gc_check/CheckCycle.cpp
@@ -452,7 +452,7 @@ GC_CheckCycle::run(GCCheckInvokedBy invokedBy, UDATA filterFlags)
  * method can identify dead objects by virtue of the fact that their class
  * pointer is unaligned, ie low_tagged.
  * 
- * This is not necessary if the Object Map is avaialable as we can perform the
+ * This is not necessary if the Object Map is available as we can perform the
  * necessary check by calling the memeory manager j9gc_ext_is_liveObject() fucntion
  * 
  */

--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -115,7 +115,7 @@ public:
 	void acquireVMAccess();
 
 	/**
-	 * Release shared VM acccess.
+	 * Release shared VM access.
 	 */
 	void releaseVMAccess();
 
@@ -137,7 +137,7 @@ public:
 	void acquireExclusiveVMAccess();
 
 	/**
-	 * Release exclusive VM acccess. If no other thread is waiting for exclusive VM access
+	 * Release exclusive VM access. If no other thread is waiting for exclusive VM access
 	 * this method will notify all threads waiting for shared VM access to continue and
 	 * acquire shared VM access.
 	 */

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -956,7 +956,7 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 						/**
 						 * Jazz103 55784: We cannot rehash the table in the middle of iteration and the Space-opt hashtable cannot grow if
 						 * J9HASH_TABLE_DO_NOT_REHASH is enabled. Don't yield if the hashtable is space-optimized because we run the
-						 * risk of the mutator not being able to grow to accomodate new elements.
+						 * risk of the mutator not being able to grow to accommodate new elements.
 						 */
 						if (!hashTableIsSpaceOptimized(classLoader->classHashTable)) {
 							_realtimeGC->condYield(env, 0);

--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1228,7 +1228,7 @@ _error:
  * Wrapper for scan_udata, that provides readable error messages.
  * @param cursor address of the pointer to the string to parse for the udata
  * @param value address of the storage for the udata to be read
- * @param argName string containing the arguement name to be used in error reporting
+ * @param argName string containing the argument name to be used in error reporting
  * @return true if parsing was successful, false otherwise.
  */
 bool
@@ -1254,7 +1254,7 @@ scan_udata_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, const char *arg
  * Wrapper for scan_udata, that provides readable error messages.
  * @param cursor address of the pointer to the string to parse for the udata
  * @param value address of the storage for the udata to be read
- * @param argName string containing the arguement name to be used in error reporting
+ * @param argName string containing the argument name to be used in error reporting
  * @return true if parsing was successful, false otherwise.
  */
 bool
@@ -1280,7 +1280,7 @@ scan_u32_helper(J9JavaVM *javaVM, char **cursor, U_32 *value, const char *argNam
  * Wrapper for scan_long, that provides readable error messages.
  * @param cursor address of the pointer to the string to parse for the u_64
  * @param value address of the storage for the U_64 to be read
- * @param argName string containing the arguement name to be used in error reporting
+ * @param argName string containing the argument name to be used in error reporting
  * @return true if parsing was successful, false otherwise.
  */
 bool
@@ -1306,7 +1306,7 @@ scan_u64_helper(J9JavaVM *javaVM, char **cursor, U_64 *value, const char *argNam
  * Wrapper for scan_hex, that provides readable error messages.
  * @param cursor address of the pointer to the string to parse for the hex value
  * @param value address of the storage for the hex value to be read
- * @param argName string containing the arguement name to be used in error reporting
+ * @param argName string containing the argument name to be used in error reporting
  * @return true if parsing was successful, false otherwise.
  */
 bool

--- a/runtime/gc_realtime/IncrementalParallelTask.cpp
+++ b/runtime/gc_realtime/IncrementalParallelTask.cpp
@@ -181,7 +181,7 @@ MM_IncrementalParallelTask::releaseSynchronizedGCThreads(MM_EnvironmentBase *env
 	
 	if(env->isMasterThread()) {
 		/* sync/release sequence actually takes time (excluding the work within the sync/release pair).
-		 * Take adventage of the fact the all slaves are blocked to check if it is time to yield */
+		 * Take advantage of the fact the all slaves are blocked to check if it is time to yield */
 		((MM_Scheduler*)_dispatcher)->condYieldFromGC(env);
 		
 		/* Could not have gotten here unless all other threads are sync'd - don't check, just release */

--- a/runtime/gc_realtime/MemorySubSpaceMetronome.cpp
+++ b/runtime/gc_realtime/MemorySubSpaceMetronome.cpp
@@ -126,7 +126,7 @@ MM_MemorySubSpaceMetronome::allocateMixedObjectOrArraylet(MM_EnvironmentBase *en
 		return result;
 	}
 	
-	/* Still failed to allocate so try an agressive synchronous GC */
+	/* Still failed to allocate so try an aggressive synchronous GC */
 	collectOnOOM(envRealtime, MM_GCCode(J9MMCONSTANT_IMPLICIT_GC_AGGRESSIVE), allocDescription);
 	
 	result = allocate(envRealtime, allocDescription, allocType);

--- a/runtime/gc_realtime/Metronome.hpp
+++ b/runtime/gc_realtime/Metronome.hpp
@@ -36,7 +36,7 @@
 
 #define CLOCK_SWITCH_TICK_THRESHOLD 1000000
 #define INTER_YIELD_WARNING_THRESHOLD_NS 80000
-/* INTER_YIELD_WARNING_THRESHOLD_NS indicates that 80 usec for inter-yield checks is alreaady considered large.
+/* INTER_YIELD_WARNING_THRESHOLD_NS indicates that 80 usec for inter-yield checks is already considered large.
  * The largest interval between yield checks should be bounded by 500 usec, which is a HardRT quanta.
  */
 #define INTER_YIELD_MAX_NS 500000

--- a/runtime/gc_realtime/RealtimeAccessBarrier.hpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.hpp
@@ -45,7 +45,7 @@ class MM_RealtimeGC;
  * new location. This is implemented using a forwarding pointer in each object
  * that normally points to the object itself, but after an object has been
  * moved, points to the new location. This class also implements the snapshot
- * at the beggining barrier that remembers overwritten values.
+ * at the beginning barrier that remembers overwritten values.
  */
 
 class MM_RealtimeAccessBarrier : public MM_ObjectAccessBarrier

--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -282,7 +282,7 @@ MM_Scheduler::continueGC(MM_EnvironmentRealtime *env, GCReason reason, uintptr_t
 
 	/* Wake up only the master thread -- it is responsible for
 	 * waking up any slaves.
-	 * Make sure _completeCurrentGCSynchronously and _mode are atomicly changed.
+	 * Make sure _completeCurrentGCSynchronously and _mode are atomically changed.
 	 */
 	omrthread_monitor_enter(_masterThreadMonitor);
 	switch(reason) {

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -113,7 +113,7 @@ public:
 	uintptr_t _gcPhaseSet;
 	/* requests (typically by a mutator) to complete GC synchronously */
 	bool _completeCurrentGCSynchronously;
-	/* copy of the request made by Master Thread at the begining of very next GC increment */
+	/* copy of the request made by Master Thread at the beginning of very next GC increment */
 	bool _completeCurrentGCSynchronouslyMasterThreadCopy;
 	GCReason _completeCurrentGCSynchronouslyReason;
 	uintptr_t _completeCurrentGCSynchronouslyReasonParameter;

--- a/runtime/gc_realtime/UtilizationTracker.cpp
+++ b/runtime/gc_realtime/UtilizationTracker.cpp
@@ -127,7 +127,7 @@ MM_UtilizationTracker::compactTimeSliceWindowAndUpdateCurrentUtil(MM_Environment
 }
 
 /**
- * Adds a time slice.  Calling this method acknoeledges that a certain
+ * Adds a time slice.  Calling this method acknowledges that a certain
  * amount of time has elapsed and is being charged to the GC or mutator.
  * 
  * @note Synchronization must be provided externally when calling this method.

--- a/runtime/gc_trace/Tgc.cpp
+++ b/runtime/gc_trace/Tgc.cpp
@@ -90,7 +90,7 @@ tgcInstantiateExtensions(J9JavaVM *javaVM)
 }
 
 /**
- * Consume arguments found in the -Xtgc: (tgc_colon) arguement list.
+ * Consume arguments found in the -Xtgc: (tgc_colon) argument list.
  * @return true if parsing was successful, 0 otherwise.
  */
 bool

--- a/runtime/gc_verbose_old_events/VerboseEventMetronomeSynchronousGCEnd.cpp
+++ b/runtime/gc_verbose_old_events/VerboseEventMetronomeSynchronousGCEnd.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_verbose_old_events/VerboseEventMetronomeSynchronousGCEnd.cpp
+++ b/runtime/gc_verbose_old_events/VerboseEventMetronomeSynchronousGCEnd.cpp
@@ -74,7 +74,7 @@ MM_VerboseEventMetronomeSynchronousGCEnd::consumeEvents(void)
 
 	/* Find previous (matching) SyncGC start event */
 	if (NULL != (eventSyncGCStart = (MM_VerboseEventMetronomeSynchronousGCStart *)eventStream->returnEvent(J9HOOK_MM_PRIVATE_METRONOME_SYNCHRONOUS_GC_START, _manager->getPrivateHookInterface(), (MM_VerboseEvent *)this))){
-		/* Copy over all relevant atributes from SyncGC start event, to be used later in formattedOutput */
+		/* Copy over all relevant attributes from SyncGC start event, to be used later in formattedOutput */
 		_heapFreeBefore = eventSyncGCStart->getHeapFree();
 		_startTime = eventSyncGCStart->getTimeStamp();
 		strncpy(_timestamp, eventSyncGCStart->getTimestamp(), 32);		

--- a/runtime/gc_vlhgc/AllocationContextBalanced.hpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/AllocationContextBalanced.hpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.hpp
@@ -66,7 +66,7 @@ private:
 	MM_AllocationContextBalanced *_nextSibling; /**< Instances of the receiver are built into a circular linked-list.  This points to the next adjacent downstream neighbour in this list (may be pointing to this if there is only one context in the node) */
 	MM_AllocationContextBalanced *_cachedReplenishPoint;	/**< The sibling context which most recently replenished the receiver */
 	MM_AllocationContextBalanced *_stealingCousin;	/**< A context in the "next" node which the receiver will use for spilling memory requests across NUMA nodes.  Points back at the receiver if this is non-NUMA */
-	MM_AllocationContextBalanced *_nextToSteal;	/**< A pointer to the next context we will try to steal from (we steal in a round-robin to try to distribute the heap's assymetry).  Points back at the receiver if this is non-NUMA */
+	MM_AllocationContextBalanced *_nextToSteal;	/**< A pointer to the next context we will try to steal from (we steal in a round-robin to try to distribute the heap's asymmetry).  Points back at the receiver if this is non-NUMA */
 	MM_HeapRegionManager *_heapRegionManager; /**< A cached pointer to the HeapRegionManager */
 	UDATA *_freeProcessorNodes;	/**< The array listing all the NUMA node numbers which account for the nodes with processors but no memory plus an empty slot for each context to use (element 0 is used by this context) - this is used when setting affinity */
 	UDATA _freeProcessorNodeCount;	/**< The length, in elements, of the _freeProcessorNodes array (always at least 1 after startup) */

--- a/runtime/gc_vlhgc/CompressedCardTable.hpp
+++ b/runtime/gc_vlhgc/CompressedCardTable.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/CompressedCardTable.hpp
+++ b/runtime/gc_vlhgc/CompressedCardTable.hpp
@@ -64,7 +64,7 @@ public:
 	/**
 	 * Set all Compressed Cards correspondent with given heap range dirty for partial collect
 	 * @param startHeapAddress start heap address
-	 * @param endHeapAddress end heap adress
+	 * @param endHeapAddress end heap address
 	 */
 	void setCompressedCardsDirtyForPartialCollect(void *startHeapAddress, void *endHeapAddress);
 
@@ -73,7 +73,7 @@ public:
 	 * Card is going to be marked dirty if original card is dirty for partial collect
 	 * @param env current thread environment
 	 * @param startHeapAddress start heap address
-	 * @param endHeapAddress end heap adress
+	 * @param endHeapAddress end heap address
 	 */
 	void rebuildCompressedCardTableForPartialCollect(MM_EnvironmentBase *env, void *startHeapAddress, void *endHeapAddress);
 
@@ -173,7 +173,7 @@ private:
 	 * @param env current thread environment
 	 * @param cardCleaner given Card Cleaner
 	 * @param startHeapAddress start heap address
-	 * @param endHeapAddress end heap adress
+	 * @param endHeapAddress end heap address
 	 */
 	void cleanCardsInRange(MM_EnvironmentBase *env, MM_CardCleaner *cardCleaner, void *startHeapAddress, void *endHeapAddress);
 };

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -5487,7 +5487,7 @@ MM_CopyForwardScheme::setAllocationAgeForMergedRegion(MM_EnvironmentVLHGC* env, 
 	}
 
 	region->setAge(newAllocationAge, logicalAge);
-	/* reset aging auxilary datea for future usage */
+	/* reset aging auxiliary datea for future usage */
 	region->setAllocationAgeSizeProduct(0.0);
 
 }

--- a/runtime/gc_vlhgc/EnvironmentVLHGC.cpp
+++ b/runtime/gc_vlhgc/EnvironmentVLHGC.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/EnvironmentVLHGC.cpp
+++ b/runtime/gc_vlhgc/EnvironmentVLHGC.cpp
@@ -103,7 +103,7 @@ MM_EnvironmentVLHGC::initializeGCThread()
 	UDATA threadPoolSize = extensions->getHeap()->getHeapRegionManager()->getTableRegionCount();
 	/* Make this thread aware of its RSCL buckets for all regions */
 	_rememberedSetCardBucketPool = &extensions->rememberedSetCardBucketPool[getSlaveID() * threadPoolSize];
-    /* Associate buckets with approprate RSCL (each RSCL maintains a list of its own buckets) */
+    /* Associate buckets with appropriate RSCL (each RSCL maintains a list of its own buckets) */
 	extensions->interRegionRememberedSet->threadLocalInitialize(this);
 }
 

--- a/runtime/gc_vlhgc/InterRegionRememberedSet.cpp
+++ b/runtime/gc_vlhgc/InterRegionRememberedSet.cpp
@@ -124,7 +124,7 @@ MM_InterRegionRememberedSet::flushBuffersForDecommitedRegions(MM_EnvironmentVLHG
 
 		/* At this point there should be no non-empty buffers used by decommitted regions.
 		 * Now, walk the global pool of free buffers, and remove them from the list if they are owned by decommitted region.
-		 * Before that, move all free buffes from thread local pools to the global
+		 * Before that, move all free buffers from thread local pools to the global
 		 */
 
 		releaseCardBufferControlBlockLocalPools(env);

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -899,7 +899,7 @@ MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env)
 
 /**
  * Perform the contraction/expansion based on decisions made by checkResize.
- * Adjustements in contraction size is possible (because compaction might have yielded less then optimal results),
+ * Adjustments in contraction size is possible (because compaction might have yielded less then optimal results),
  * therefore allocDesriptor is still passed.
  * @return the actual amount of resize (having IDATA return result will contain valid value only if contract/expand size is half of maxOfUDATA)
  */

--- a/runtime/gc_vlhgc/RememberedSetCardBucket.hpp
+++ b/runtime/gc_vlhgc/RememberedSetCardBucket.hpp
@@ -107,7 +107,7 @@ public:
 	/**
 	 * If current buffer is full or bucket is empty,
 	 * add a card to a new buffer.
-	 * Handle various misc scenarios when unable to alocate new buffer
+	 * Handle various misc scenarios when unable to allocate new buffer
 	 * or list is already overflowed.
 	 * @param card  card to be remembered
 	 */

--- a/runtime/gc_vlhgc/RememberedSetCardList.hpp
+++ b/runtime/gc_vlhgc/RememberedSetCardList.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/RememberedSetCardList.hpp
+++ b/runtime/gc_vlhgc/RememberedSetCardList.hpp
@@ -162,7 +162,7 @@ public:
 	void releaseBuffers(MM_EnvironmentVLHGC *env);
 
 	/**
-	 * Release buffers only for the bucked assocated with current thread.
+	 * Release buffers only for the bucked associated with current thread.
 	 */
 	void releaseBuffersForCurrentThread(MM_EnvironmentVLHGC *env);
 

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -119,7 +119,7 @@ private:
 	UDATA _threadsWaiting;	/**< The number of threads waiting for work on _workListMonitor */
 	bool _moveFinished;	/**< A flag set when all move work is done to allow all threads waiting for work to exit the monitor */
 	bool _rebuildFinished;	/**< A flag set when all mark map rebuilding work is done to allow all threads waiting for work to exit the monitor */
-	UDATA _lockCount; /**< Number of locks initialized for compact groups, based on NUMA. Stored for control to make sure that we dealocate same number that we allocated in initialize. */
+	UDATA _lockCount; /**< Number of locks initialized for compact groups, based on NUMA. Stored for control to make sure that we deallocate same number that we allocated in initialize. */
 
 	class MM_CompactGroupDestinations {
 		/* Fields */
@@ -175,7 +175,7 @@ private:
 	 * @note inlined in the implementation so this method MUST be private
 	 * @param env[in] A GC thread
 	 * @param objectPtr[in] The pointer to look up to see its new, forwarded, location
-	 * @param cache[in] The cache to use for fast resolve attmpets for objectPtr (may be NULL)
+	 * @param cache[in] The cache to use for fast resolve attempts for objectPtr (may be NULL)
 	 * @return The forwarded location of the given objectPtr
 	 */
 	J9Object *getForwardWrapper(MM_EnvironmentVLHGC *env, J9Object *objectPtr, J9MM_FixupCache *cache);

--- a/runtime/gdb_plugin/plugin-interface.h
+++ b/runtime/gdb_plugin/plugin-interface.h
@@ -116,7 +116,7 @@ struct plugin_service_ops {
   int (*get_thread_list) (gdb_plugin_thread_info * threads, int * count);   
 
   /* Get a list of register names and values. The registers array should be
-	 large enough to accomodate count registers. If registers is null, count
+	 large enough to accommodate count registers. If registers is null, count
 	 will be initialized with the register count and returned. If the
 	 register->name is NULL, a string will be allocated and must be freed
 	 by the user once done. If the passed in register->name is non-null, the

--- a/runtime/gdb_plugin/plugin-interface.h
+++ b/runtime/gdb_plugin/plugin-interface.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2014 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/harmony/thread/hythread.c
+++ b/runtime/harmony/thread/hythread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2014 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/harmony/thread/hythread.c
+++ b/runtime/harmony/thread/hythread.c
@@ -281,7 +281,7 @@ hythread_getSize(struct HyThreadLibraryVersion *version)
 	}
 
 	/* The size of the portLibrary table is determined by the majorVersion number
-	 * and the presence/absense of the HYTHREAD_CAPABILITY_STANDARD capability 
+	 * and the presence/absence of the HYTHREAD_CAPABILITY_STANDARD capability 
 	 */
 	if (0 != (version->capabilities & HYTHREAD_CAPABILITY_STANDARD)) {
 		return sizeof(HyThreadLibrary);

--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -802,7 +802,7 @@ countArguments(const UDATA pattern)
  * Trace method that all other com.ibm.jvm.Trace.trace() methods call through.
  *
  * @param env JNI environment
- * @param handle Application trace handle (returned from registerApplicaton)
+ * @param handle Application trace handle (returned from registerApplication)
  * @param traceId Id of trace point to trace
  * @param methodSignature the signature of the method that supplied the arguments
  *

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -2370,7 +2370,7 @@ jvmtiGetConstantPool_writeConstants(jvmtiGcp_translation *translation, unsigned 
 				GCP_WRITE_U32(constantPoolBufIndex, htEntry->type.longDouble.slot1);
 				GCP_WRITE_U32(constantPoolBufIndex, htEntry->type.longDouble.slot2);
 #endif				
-				/* Skip additional CP entry. See JVM spec v2 section 4.4.5 for the briliant rationale */
+				/* Skip additional CP entry. See JVM spec v2 section 4.4.5 for the brilliant rationale */
 				sunCpIndex++;
 
 				break;

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -2501,7 +2501,7 @@ jvmtiGetMethodAndClassNames_verifyRamMethod(J9JavaVM * vm, J9Method * ramMethod)
  * 	The user is responsible for passing in a ramMethods array containing ram method pointers they wish to query. 
  *	The ramMethodCount argument contains the count of passed in ram method pointers.
  *
- *	The ramMethodDataDescriptors is a buffer large enough to accomodate ramMethodCount number of jvmtiExtensionRamMethodData
+ *	The ramMethodDataDescriptors is a buffer large enough to accommodate ramMethodCount number of jvmtiExtensionRamMethodData
  *	structures. It is written to by this extension as ram method pointers are processed. The first jvmtiExtensionRamMethodData structure
  *	written to the ramMethodDataDescriptors corresponds to the first ram method pointer in the ramMethods array and so on. Ram method
  *	pointers that are detected to be no longer valid (e.g. class has been unloaded) will result in className and methodName pointers being 
@@ -2510,7 +2510,7 @@ jvmtiGetMethodAndClassNames_verifyRamMethod(J9JavaVM * vm, J9Method * ramMethod)
  *
  *	The ramMethodStrings serves as a buffer to copy class, method and package name strings for valid ram method pointers. The 
  *	jvmtiExtensionRamMethodData structures are initialized with pointers into this array. Each string is null terminated. Care should be
- *	taken to pass in a large enough buffer to accomodate strings for all requested ram methods. In case the buffer is not sufficiently 
+ *	taken to pass in a large enough buffer to accommodate strings for all requested ram methods. In case the buffer is not sufficiently 
  *	large, the extension will stop processing any further ram methods pointers and return whatever has been processed up to that point.
  *
  *  ramMethodStringsSize is used by the user to specify the size of ramMethodStrings. If not enough space was provided, this 
@@ -2575,7 +2575,7 @@ jvmtiGetMethodAndClassNames(jvmtiEnv *jvmti_env,  void * ramMethods, jint ramMet
 				   
 				totalStringsLength += length;
 
-				/* got enough space to accomodate this ramMethod's strings? */
+				/* got enough space to accommodate this ramMethod's strings? */
 
 				if (stringsSize >= length) {
 
@@ -2937,7 +2937,7 @@ static void fillInCategoryDeepCounters(jvmtiMemoryCategory * category)
   * JVMTI_ERROR_UNSUPPORTED_VERSION - Unsupported version of jvmtiMemoryCategory
   * JVMTI_ERROR_ILLEGAL_ARGUMENT - Illegal argument (categories_buffer, count_ptr & total_categories_ptr are all NULL)
   * JVMTI_ERROR_INVALID_ENVIRONMENT - Invalid JVMTI environment
-  * JVMTI_ERROR_OUT_OF_MEMORY - Memory category data was truncated becasue category_buffer/max_categories was not large enough
+  * JVMTI_ERROR_OUT_OF_MEMORY - Memory category data was truncated because category_buffer/max_categories was not large enough
   *
   */
 static jvmtiError JNICALL

--- a/runtime/oti/ArrayCopyHelpers.hpp
+++ b/runtime/oti/ArrayCopyHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/ArrayCopyHelpers.hpp
+++ b/runtime/oti/ArrayCopyHelpers.hpp
@@ -161,7 +161,7 @@ private:
 	static VMINLINE void
 	copyForwardU8(U_8 *dest, U_8 *source, UDATA count)
 	{
-		/* Use memmove instead of memcpy becuase memcpy does not work on Ubuntu 10.04 */
+		/* Use memmove instead of memcpy because memcpy does not work on Ubuntu 10.04 */
 		memmove((void *)dest, (void *)source, count);
 	}
 	

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1406,7 +1406,7 @@ exit:
 			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_OSR_SAFE_POINT)) {
 				J9InternalVMFunctions* vmFuncs = vm->internalVMFunctions;
 				vmFuncs->acquireSafePointVMAccess(currentThread);
-				/* check class flag again after aquiring VM access */
+				/* check class flag again after acquiring VM access */
 				if (J9_ARE_NO_BITS_SET(fieldClass->classFlags, J9ClassHasIllegalFinalFieldModifications)) {
 					J9JITConfig* jitConfig = vm->jitConfig;
 					if (NULL != jitConfig) {

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -401,7 +401,7 @@ typedef struct J9ProcessorDesc {
 } J9ProcessorDesc;
 
 /* PowerPC features
- * Auxlliary Vector Hardware Capability (AT_HWCAP) features for PowerPC.
+ * Auxiliary Vector Hardware Capability (AT_HWCAP) features for PowerPC.
  */
 #define J9PORT_PPC_FEATURE_32                    31 /* 32-bit mode.  */
 #define J9PORT_PPC_FEATURE_64                    30 /* 64-bit mode.  */

--- a/runtime/oti/verutil_api.h
+++ b/runtime/oti/verutil_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/verutil_api.h
+++ b/runtime/oti/verutil_api.h
@@ -54,7 +54,7 @@ IDATA verifyFieldSignatureUtf8(U_8* signatureBytes, UDATA signatureLength, UDATA
 /**
  * Check if a string is a well-formed identifier per JVMS java 8 version, section 4.2.
  * String is well-formed if it comprises one or more Unicode characters, with the following exceptions:
- * '/', ';' , '[' and '.' (semicolon, open square backet, and period) are not allowed
+ * '/', ';' , '[' and '.' (semicolon, open square bracket, and period) are not allowed
  * 	@param identifierStart pointer to first character of the signature
  * 	@param identifierLength Length of the signature in bytes
  *	@return TRUE if the string is well formed
@@ -65,7 +65,7 @@ BOOLEAN verifyIdentifierUtf8(U_8* identifierStart, UDATA identifierLength);
 /**
  * Check if a string is a well-formed fully qualified class or interface name per JVMS java 8 version, section 4.2.
  * String is well-formed if it comprises one or more Unicode characters, with the following exceptions:
- * ';' , '[' and '.' (semicolon, open square backet, and period) are not allowed
+ * ';' , '[' and '.' (semicolon, open square bracket, and period) are not allowed
  * '/' is allowed but may not be contiguous with another '/'
  * 	@param identifierStart pointer to first character of the signature
  * 	@param identifierLength Length of the signature in bytes

--- a/runtime/port/common/j9shmem.c
+++ b/runtime/port/common/j9shmem.c
@@ -390,7 +390,7 @@ j9shmem_getFilepath(struct J9PortLibrary* portLibrary, char* cacheDirName, char*
  * Sets the protection as specified by flags for the memory pages containing all or part of the interval address->(address+len).
  * The size of the memory page for a specified memory region can be requested via @ref j9shmem_get_region_granularity
  *
- * The memory region must have been aquired using j9shmap_file
+ * The memory region must have been acquired using j9shmap_file
  *
  * This call has no effect on the protection of other processes.
  *

--- a/runtime/port/linuxs390/j9hypervisor_systemz.c
+++ b/runtime/port/linuxs390/j9hypervisor_systemz.c
@@ -511,7 +511,7 @@ errorout:
  *		files and recreates them with the latest data.
  *		The above operation is very dicey when multiple processes are writing to the update file
  *		and reading from the hypfs files. hypfs also does not allow two writes to the "update"
- *		file within the span of a second. To prevent issues with multiple processes accesing hypfs
+ *		file within the span of a second. To prevent issues with multiple processes accessing hypfs
  *		at the same time, the following protocol is followed
  *		1. check the file write time of the "update" file using stat.
  *		2. If the write has happened within the last second, go to step 5

--- a/runtime/port/win32/j9sock.c
+++ b/runtime/port/win32/j9sock.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/port/win32/j9sock.c
+++ b/runtime/port/win32/j9sock.c
@@ -782,7 +782,7 @@ retry:
 			internalCloseSocket(portLibrary, sock, FALSE );
 		}
 		else {	
-			/* we don't acutally want to close the sockets as connect can be called again on a datagram socket  but we 
+			/* we don't actually want to close the sockets as connect can be called again on a datagram socket  but we 
 			    still need to set the flag that tells us which socket to use */
 			sock->flags = sock->flags | SOCKET_USE_IPV4_MASK;
 		}
@@ -808,7 +808,7 @@ retry:
 		}
 
 		/* for windows it seems to want to have it connect with an IN_ADDR any instead of with an 
-		   UNSPEC familty type so lets be accomodating */
+		   UNSPEC familty type so lets be accommodating */
 
 
 		/* we need to disconnect on both sockets and swallow any expected errors */
@@ -3771,7 +3771,7 @@ addAdapterIpv6(struct J9PortLibrary *portLibrary, struct j9NetworkInterface_stru
 
 	/* now get the interface information */
 
-	/* first count the number of IP addreses and allocate the memory required for the ip address info that will be returned*/
+	/* first count the number of IP addresses and allocate the memory required for the ip address info that will be returned*/
 	numAddresses = 0;
 	currentIPAddress = currentAdapter->FirstUnicastAddress;
 	while(currentIPAddress) {
@@ -3920,7 +3920,7 @@ addAdapterIpv4(struct J9PortLibrary *portLibrary, struct j9NetworkInterface_stru
 
 	/* now get the interface information */
 
-	/* first count the number of IP addreses and allocate the memory required for the ip address info that will be returned*/
+	/* first count the number of IP addresses and allocate the memory required for the ip address info that will be returned*/
 	numAddresses = 0;
 	currentIPAddress = &(currentAdapter->IpAddressList);
 	while(currentIPAddress) {

--- a/runtime/port/zos390/j9csrsi.h
+++ b/runtime/port/zos390/j9csrsi.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/port/zos390/j9csrsi.h
+++ b/runtime/port/zos390/j9csrsi.h
@@ -67,7 +67,7 @@ BOOLEAN j9csrsi_is_vmh(const j9csrsi_t *session);
  *  @param[in] position Number of the entry that should be retrieved
  *  @param[out] buf buffer where vmhpidentifier will be written to. The string
  *  returned is in ASCII
- *  @param[in] len Length of buf. buf must be sufficiently large to accomodate
+ *  @param[in] len Length of buf. buf must be sufficiently large to accommodate
  *  the whole string and a '\0'. Otherwise, an error will be returned.
  *  @return A number greater than 0 in case of success. This is the number
  *  of chars written to buf. Any other return value indicates an error.
@@ -79,7 +79,7 @@ int32_t j9csrsi_get_vmhpidentifier(const j9csrsi_t *session, uint32_t position,
  *  @param[in] session Pointer to j9csrsi session
  *  @param[out] buf buffer where cpctype will be written to. The string
  *  returned is in ASCII
- *  @param[in] len Length of buf. buf must be sufficiently large to accomodate
+ *  @param[in] len Length of buf. buf must be sufficiently large to accommodate
  *  the whole string and a '\0'. Otherwise, an error will be returned.
  *  @return A number greater than 0 in case of success. This is the number
  *  of chars written to buf. Any other return value indicates an error.

--- a/runtime/rasdump/TextFileStream.cpp
+++ b/runtime/rasdump/TextFileStream.cpp
@@ -199,7 +199,7 @@ TextFileStream::writeVPrintf(const char *format, ...)
 {
 	/* Currently, this appears to be the max buffer size needed. We use
 	 * this routine to print 128-bit values and, in this case, we need
-	 * a buffer of at least size 33 in order to accomodate the '\0'. 
+	 * a buffer of at least size 33 in order to accommodate the '\0'. 
 	 */
 	char buffer[35];
 	PORT_ACCESS_FROM_PORT(_PortLibrary);

--- a/runtime/rasdump/heapdump.cpp
+++ b/runtime/rasdump/heapdump.cpp
@@ -90,7 +90,7 @@ public :
 
 	/* Assignment operators... */
 
-	/* Assigment methods... */
+	/* Assignment methods... */
 
 	/* Append operators... */
 	/* Operator for appending another string */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -120,7 +120,7 @@ UDATA handlerIterateStackTrace      (struct J9PortLibrary *, U_32, void *, void 
 UDATA handlerWriteJavaLangThreadInfo(struct J9PortLibrary *, U_32, void *, void *);
 UDATA handlerWriteStacks            (struct J9PortLibrary *, U_32, void *, void *);
 
-/* associated structures for passing arguements are below the JavaCoreDumpWriter declaration */
+/* associated structures for passing arguments are below the JavaCoreDumpWriter declaration */
 }
 
 static IDATA vmthread_comparator(struct J9AVLTree *tree, struct J9AVLTreeNode *insertNode, struct J9AVLTreeNode *walkNode);

--- a/runtime/rastrace/trcformatter.c
+++ b/runtime/rastrace/trcformatter.c
@@ -879,7 +879,7 @@ omr_trc_formatNextTracePoint(UtTracePointIterator *iter, char *buffer, uint32_t 
 		return NULL;
 	}
 
-	/* if this is a circular buffer, that we have alread moved to the end of, and 
+	/* if this is a circular buffer, that we have already moved to the end of, and 
 	 * the current tracepoint length takes us back before where formatting originally
 	 * started in this buffer, then we have found the partially overwritten tracepoint
 	 * that means we have got to the end of this buffer. */

--- a/runtime/rastrace/trcformatter.c
+++ b/runtime/rastrace/trcformatter.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/rastrace/trctrigger.c
+++ b/runtime/rastrace/trctrigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2018 IBM Corp. and others
+ * Copyright (c) 2002, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/rastrace/trctrigger.c
+++ b/runtime/rastrace/trctrigger.c
@@ -52,7 +52,7 @@
  *    action and delay.
  *
  * triggering on methods:
- *    An entry is created in the triggerOnMethods chain, achored off RasGlobalStorage.
+ *    An entry is created in the triggerOnMethods chain, anchored off RasGlobalStorage.
  *    This is known as a method rule.  This contains a RasMethodSpec, as used
  *    in method trace, representing the user entered methodspec.  Whenever a
  *    class is loaded, the classloader calls us.  The class and if necessary its

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -1266,7 +1266,7 @@ SH_CacheMap::getCacheAreaForDataType(J9VMThread* currentThread, UDATA dataType, 
 			}
 		} else {
 			/* Either cachelet is corrupt or there is not enough space to allocate new cachelet.
-			 * In latter case, cache would have alredy been marked full in SH_CompositeCacheImpl::allocate().
+			 * In latter case, cache would have already been marked full in SH_CompositeCacheImpl::allocate().
 			 */
 			return NULL;
 		}
@@ -1417,7 +1417,7 @@ SH_CacheMap::addScopeToCache(J9VMThread* currentThread, const J9UTF8* scope)
 	
 	itemInCache = (ShcItem*)cacheForAllocate->allocateBlock(currentThread, itemPtr, SHC_WORDALIGN, 0);
 	if (itemInCache == NULL) {
-		/* Not enough space in cache to accomodate this item. */
+		/* Not enough space in cache to accommodate this item. */
 		Trc_SHR_CM_addScopeToCache_Exit_Null(currentThread);
 		return NULL;
 	}
@@ -2319,7 +2319,7 @@ SH_CacheMap::commitMetaDataROMClassIfRequired(J9VMThread* currentThread, Classpa
 	itemInCache = (ShcItem*) cacheAreaForAllocate->allocateBlock(currentThread, itemPtr, SHC_WORDALIGN, wrapperSize);
 
 	if (itemInCache == NULL) {
-		/* Not enough space in cache to accomodate this item. */
+		/* Not enough space in cache to accommodate this item. */
 		Trc_SHR_CM_commitMetaDataROMClassIfRequired_Full_Event(currentThread, (UDATA)J9UTF8_LENGTH(romClassName), J9UTF8_DATA(romClassName), (UDATA)romclass);
 		retval = -1;
 		goto done;
@@ -3672,7 +3672,7 @@ SH_CacheMap::addByteDataToCache(J9VMThread* currentThread, SH_Manager* localBDM,
 				}
 			}
 			if ((itemInCache = (ShcItem*)(cacheForAllocate->allocateBlock(currentThread, itemPtr, SHC_WORDALIGN, sizeof(ByteDataWrapper)))) == NULL) {
-				/* Not enough space in cache to accomodate this item. */
+				/* Not enough space in cache to accommodate this item. */
 				return NULL;
 			}
 		} else {
@@ -4993,7 +4993,7 @@ SH_CacheMap::printCacheStats(J9VMThread* currentThread, UDATA showFlags, U_64 ru
 		}
 		CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_META_BYTES_V2, javacoreData.otherBytes);
 		if ((U_32)-1 == javacoreData.softMaxBytes) {
-			/* similarly to the calculation of cache full percentage, take used debug area into accout */
+			/* similarly to the calculation of cache full percentage, take used debug area into account */
 			CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_META_PERCENT_V2, ((javacoreData.otherBytes * 100) / (javacoreData.cacheSize - javacoreData.freeBytes)));
 		} else {
 			/* cache header size is not included in javacoreData.cacheSize, but it is included in softmx as used bytes. To be consistent, subtract cache header size here */ 
@@ -7273,7 +7273,7 @@ SH_CacheMap::tryAdjustMinMaxSizes(J9VMThread* currentThread, bool isJCLCall)
 	return _ccHead->tryAdjustMinMaxSizes(currentThread, isJCLCall);
 }
 
-/* Update the runtime cache full flags accroding to cache full flags in the cache header
+/* Update the runtime cache full flags according to cache full flags in the cache header
  *
  * @param [in] currentThread Pointer to J9VMThread structure for the current thread
  *
@@ -7398,7 +7398,7 @@ SH_CacheMap::updateLocalHintsData(J9VMThread* currentThread, J9SharedLocalStartu
 	} else if (J9_ARE_ALL_BITS_SET(localHints->localStartupHintFlags, J9SHR_LOCAL_STARTUPHINTS_FLAG_STORE_HEAPSIZES)) {
 		if (J9_ARE_NO_BITS_SET(updatedHintsData.flags, J9SHR_STARTUPHINTS_HEAPSIZES_SET)) {
 			Trc_SHR_CM_updateLocalHintsData_WriteHeapSizes(currentThread, localHints->hintsData.heapSize1, localHints->hintsData.heapSize2);
-			/* heapSize1 and heapSize2 have not been set beofore */
+			/* heapSize1 and heapSize2 have not been set before */
 			updatedHintsData.heapSize1 = localHints->hintsData.heapSize1;
 			updatedHintsData.heapSize2 = localHints->hintsData.heapSize2;
 			updatedHintsData.flags |= J9SHR_STARTUPHINTS_HEAPSIZES_SET;

--- a/runtime/shared_common/ClasspathManagerImpl2.cpp
+++ b/runtime/shared_common/ClasspathManagerImpl2.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/shared_common/ClasspathManagerImpl2.cpp
+++ b/runtime/shared_common/ClasspathManagerImpl2.cpp
@@ -974,8 +974,8 @@ SH_ClasspathManagerImpl2::localValidate_CheckAndTimestampManually(J9VMThread* cu
 			 * and running this check, store the stale item (markStale happens later) and return -1
 			 * which will cause the FIND to fail. 
 			 */
-			/* doTryLockJar = false for non-boostrap because we are trying to load from the cache, not from disk, so JARs may not yet be locked by the classloader.
-				Boostrap loader is always helperID==0 and it DOES lock its jars, so this is safe. */
+			/* doTryLockJar = false for non-bootstrap because we are trying to load from the cache, not from disk, so JARs may not yet be locked by the classloader.
+				Bootstrap loader is always helperID==0 and it DOES lock its jars, so this is safe. */
 			if (rc == 1) {
 				Trc_SHR_CMI_localValidate_CheckAndTimestampManually_DetectedStaleCPEI(currentThread, foundItem);
 				if (!(*staleItem)) {
@@ -1109,8 +1109,8 @@ SH_ClasspathManagerImpl2::validate(J9VMThread* currentThread, ROMClassWrapper* f
 				ClasspathEntryItem* foundItem = testCPI->itemAt(i);
 				IDATA tsChangedVal;
 
-				/* doTryLockJar = false for non-boostrap because we are trying to load from the cache, not from disk, so JARs may not yet be locked by the classloader.
-					Boostrap loader is always helperID==0 and it DOES lock its jars, so this is safe. */
+				/* doTryLockJar = false for non-bootstrap because we are trying to load from the cache, not from disk, so JARs may not yet be locked by the classloader.
+					Bootstrap loader is always helperID==0 and it DOES lock its jars, so this is safe. */
 				tsChangedVal = hasTimestampChanged(currentThread, foundItem, NULL, (compareTo->getHelperID()==0));
 				if (tsChangedVal==JAR_LOCKED && i==jarsLockedToIndex+1) {
 					jarsLockedToIndex = i;

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -2817,9 +2817,9 @@ SH_CompositeCacheImpl::allocate(J9VMThread* currentThread, U_8 type, ShcItem* it
 		Trc_SHR_CC_allocate_softMaxBytesReached(currentThread, softMaxValue);
 		if (ALLOCATE_TYPE_BLOCK == type) {
 			/* Similar to the behaviour when setting J9SHR_BLOCK_SPACE_FULL,
-			 * if avalible bytes < CC_MIN_SPACE_BEFORE_CACHE_FULL, J9SHR_AVAILABLE_SPACE_FULL is set in the previous commit. J9SHR_RUNTIMEFLAG_AVAILABLE_SPACE_FULL is checked in 
+			 * if available bytes < CC_MIN_SPACE_BEFORE_CACHE_FULL, J9SHR_AVAILABLE_SPACE_FULL is set in the previous commit. J9SHR_RUNTIMEFLAG_AVAILABLE_SPACE_FULL is checked in 
 			 * higher level APIs in SH_CacheMap. If it is set, higher level APIs will return direcly and we would not reach here. 
-			 * if avalible bytes >= CC_MIN_SPACE_BEFORE_CACHE_FULL, do not set J9SHR_AVAILABLE_SPACE_FULL here as it is above the threshold.
+			 * if available bytes >= CC_MIN_SPACE_BEFORE_CACHE_FULL, do not set J9SHR_AVAILABLE_SPACE_FULL here as it is above the threshold.
 			 */
 			Trc_SHR_Assert_True((softMaxValue - usedBytes) >= CC_MIN_SPACE_BEFORE_CACHE_FULL);
 			/* If allocating block data, we would reach here only when allocating something that requires more than CC_MIN_SPACE_BEFORE_CACHE_FULL bytes. As free available space
@@ -3637,7 +3637,7 @@ SH_CompositeCacheImpl::getFreeBytes(void)
 }
 
 /**
- * Get the number of free availabe bytes within softmx (softmx - usedBytes).
+ * Get the number of free available bytes within softmx (softmx - usedBytes).
  *
  * @return free available bytes in cache (for stats)
  */
@@ -5504,7 +5504,7 @@ SH_CompositeCacheImpl::startupForStats(J9VMThread* currentThread, SH_OSCache * o
 		notifyPagesRead(CASTART(_theca), CAEND(_theca), DIRECTION_FORWARD, true);
 	}
 
-	/* _started is set to true if the write area mutex was entered. Becuase _started 
+	/* _started is set to true if the write area mutex was entered. Because _started 
 	 * is used in ::shutdownForStats() to decide if '::exitWriteMutex()' needs to be called,
 	 * _started will still be set if any of the below code finds the cache to be corrupt.
 	 * 
@@ -6515,7 +6515,7 @@ SH_CompositeCacheImpl::tryAdjustMinMaxSizes(J9VMThread *currentThread, bool isJC
 	protectHeaderReadWriteArea(currentThread, false);
 
 	if (adjustMinJIT || adjustMinAOT || adjustSoftMax) {
-		/* The free block bytes and avaliable bytes (softmx - usedBytes) can be changed if minAOT, minJIT or softmx has been adjusted. fillCacheIfNearlyFull() needs to be called.
+		/* The free block bytes and available bytes (softmx - usedBytes) can be changed if minAOT, minJIT or softmx has been adjusted. fillCacheIfNearlyFull() needs to be called.
 		 */
 		fillCacheIfNearlyFull(currentThread);
 	}
@@ -6536,7 +6536,7 @@ done:
 }
 
 /* Another JVM may have adjusted the softMaxBytes/minAOT/maxAOT/minJIT/maxJIT in the cache header.
- * Update the runtime cache full flags accroding to cache full flags in the cache header
+ * Update the runtime cache full flags according to cache full flags in the cache header
  *
  * @param [in] currentThread Pointer to J9VMThread structure for the current thread
  *

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -109,7 +109,7 @@ typedef struct SH_OSCache_Info {
         UDATA isCompatible; /** Is the cache compatible with this VM */
         UDATA isCorrupt; /** Is set when the cache is found to be corrupt */
         UDATA isJavaCorePopulated; /** Is set when the javacoreData contains valid data */
-        J9SharedClassJavacoreDataDescriptor javacoreData; /** If isCompatible is true, then extra information about the cache is availaible in here*/
+        J9SharedClassJavacoreDataDescriptor javacoreData; /** If isCompatible is true, then extra information about the cache is available in here*/
 } SH_OSCache_Info;
 
 /* DO NOT use UDATA/IDATA in the cache headers so that 32-bit/64-bit JVMs can read each others headers

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -691,7 +691,7 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 			 *	- Owns W monitor, W lock, RW monitor, and gets EDADLK on RW lock
 			 *
 			 * Notes:
-			 *	- This means other JVMs caused EDEADLK becuase they are holding RW, and
+			 *	- This means other JVMs caused EDEADLK because they are holding RW, and
 			 *	  waiting on W in a sequence that gives fcntl the impression of deadlock
 			 *	- If current thread owns the W monitor, it must also own the W lock 
 			 *	  if the call stack ended up here.
@@ -1678,7 +1678,7 @@ SH_OSCachemmap::getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDescripto
 void * 
 SH_OSCachemmap::getAttachedMemory()
 {
-	/* This method should only be called betwen calls to 
+	/* This method should only be called between calls to 
 	 * internalAttach and internalDetach
 	 */
 	return _dataStart;

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -2156,7 +2156,7 @@ SH_OSCachesysv::checkSharedMemoryAccess(LastErrorInfo *lastErrorInfo)
 						Trc_SHR_OSC_Sysv_checkSharedMemoryAccess_GroupAccessRequired(shmid);
 
 						if (statBuf.perm.isGroupWriteable) {
-							/* The shared memory has group read-write permission set, so this process can use it if 'groupAcccess' option is specified. */
+							/* The shared memory has group read-write permission set, so this process can use it if 'groupAccess' option is specified. */
 							shmAccess = J9SH_SHM_ACCESS_GROUP_ACCESS_REQUIRED;
 						} else {
 							/* The shared memory does not have group write permission set, so this process can use it in readonly mode. */

--- a/runtime/shared_common/sharedconsts.h
+++ b/runtime/shared_common/sharedconsts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/shared_common/sharedconsts.h
+++ b/runtime/shared_common/sharedconsts.h
@@ -51,7 +51,7 @@
  *
  * Total chars needed  = 11 + 8 + 64 + 1 + 3 = 87 chars.
  *
- * Add 1 to above length to accomodate NULL char.
+ * Add 1 to above length to accommodate NULL char.
  * Reference:  getCacheVersionAndGen function
  */
 #define CACHE_ROOT_MAXLEN 88

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -27,7 +27,7 @@
 
 /* Notes on string usage:
  * This details what strings are allocated where and which are null-terminated.
- * String data can either come in from JNI in the jcl helpers (shared.c) or from the boostrap loader.
+ * String data can either come in from JNI in the jcl helpers (shared.c) or from the bootstrap loader.
  * Strings we care about are:
  * - Class name
  * 		In the helper API, UTF bytes/length are obtained from the JNI calls. These are only required for the duration of the find/store call so are not copied.
@@ -2863,7 +2863,7 @@ ensureCorrectCacheSizes(J9JavaVM *vm, J9PortLibrary* portlib, U_64 runtimeFlags,
 }
 
 /*
- * Allocates and initiliases SCAbstraceAPI object.
+ * Allocates and initiliases SCAbstractAPI object.
  *
  * @param	vm
  *

--- a/runtime/shared_util/classpathcache.c
+++ b/runtime/shared_util/classpathcache.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/shared_util/classpathcache.c
+++ b/runtime/shared_util/classpathcache.c
@@ -400,7 +400,7 @@ findIdentifiedWithPartition(J9VMThread* currentThread, struct J9ClasspathByIDArr
  * SPEC: Registers a failed match between 2 identified classpaths.
  * This is an optimization that reduces the number of failed classpath matches. 
  * This is particularly useful if the bootstrap classpath is long,
- * as every non-bootstrap FIND will have to first fail the boostrap classpath check.
+ * as every non-bootstrap FIND will have to first fail the bootstrap classpath check.
  * This only works if a ROMClass was found and if both the caller classpath and the cache classpath are identified.
  * The caller classpath ID is callerHelperID and the cache classpath ID is arrayIndex.
  * IndexInCacheHelper is the index of the ROMClass in the cache classpath.

--- a/runtime/stackmap/localmap.c
+++ b/runtime/stackmap/localmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/stackmap/localmap.c
+++ b/runtime/stackmap/localmap.c
@@ -102,7 +102,7 @@ static IDATA mapLocalSet(J9PortLibrary * portLibrary, J9ROMMethod * romMethod, P
 /**
  * Construct a locals map size_of(PARALLEL_TYPE) * 8 slots at a time from 0 to remainingLocals-1.
  * @param portLibrary
- * @param romMethod Method whose byteocdes should be walked.
+ * @param romMethod Method whose bytecodes should be walked.
  * @param unknownsByPC Buffer used to store per-PC metadata (1 PARALLEL_TYPE per PC) + branch stack.
  * @param startPC The PC at which to start mapping.
  * @param resultArrayBase Memory into which the result should be stored.

--- a/runtime/tests/cutest/XMLBenchOutputWriter.cpp
+++ b/runtime/tests/cutest/XMLBenchOutputWriter.cpp
@@ -48,7 +48,7 @@ void XMLBenchOutputWriter::kill()
 /**
  * This method can be used to create an instanced of this class
  *
- * @param portLib the port library that should be assocaited with the class
+ * @param portLib the port library that should be associated with the class
  * @param createOutput set this to true if you want xml output to be created
  */
 XMLBenchOutputWriter* XMLBenchOutputWriter::newInstance(J9PortLibrary* portlib, bool createOutput) {

--- a/runtime/tests/cutest/XMLBenchOutputWriter.cpp
+++ b/runtime/tests/cutest/XMLBenchOutputWriter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2014 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9fileTest.c
+++ b/runtime/tests/port/j9fileTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9fileTest.c
+++ b/runtime/tests/port/j9fileTest.c
@@ -4139,7 +4139,7 @@ j9file_test_long_file_name(struct J9PortLibrary *portLibrary)
 	char *readBufPtr;
 	char *longDirName = "\\abcdefghijklmnopqrstuvwx";
 #define MIN_LENGTH (MAX_PATH + 1)
-#define FILENAME_LENGTH MIN_LENGTH*2 /* double the size to accomodate a file size that is just under twice MIN_LENGTH */
+#define FILENAME_LENGTH MIN_LENGTH*2 /* double the size to accommodate a file size that is just under twice MIN_LENGTH */
 	char filePathName[FILENAME_LENGTH];
 	IDATA fd;
 	char cwd[FILENAME_LENGTH];

--- a/runtime/tests/port/j9mmapTest.c
+++ b/runtime/tests/port/j9mmapTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9mmapTest.c
+++ b/runtime/tests/port/j9mmapTest.c
@@ -1087,7 +1087,7 @@ exit:
 }
 
 /**
- * Verify calling protect on memory aquired using mmap.
+ * Verify calling protect on memory acquired using mmap.
  * 
  * Verify @ref j9mmap.c::j9mmap_protect "j9mmap_protect()" with 
  * J9PORT_PAGE_PROTECT_READ allows the 
@@ -1209,7 +1209,7 @@ exit:
 }
 
 /**
- * Verify calling protect on memory aquired using mmap.
+ * Verify calling protect on memory acquired using mmap.
  * 
  * Verify @ref j9mmap.c::j9mmap_protect "j9mmap_protect()" with 
  * J9PORT_PAGE_PROTECT_READ | J9PORT_PAGE_PROTECT_WRITE allows the 
@@ -1356,7 +1356,7 @@ exit:
 }	
 
 /**
- * Verify calling protect on memory aquired using mmap.
+ * Verify calling protect on memory acquired using mmap.
  * 
  * Verify @ref j9mmap.c::j9mmap_protect "j9mmap_protect()" with 
  * J9PORT_PAGE_PROTECT_READ causes us to crash when writing to the protected region, 

--- a/runtime/tests/port/j9timeTest.c
+++ b/runtime/tests/port/j9timeTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9timeTest.c
+++ b/runtime/tests/port/j9timeTest.c
@@ -504,7 +504,7 @@ j9time_nano_time_direction(struct J9PortLibrary *portLibrary)
 #if defined(WIN32) || defined(WIN64)
 	/**
 	 * On Windows, if QueryPerformanceCounter is used on a multiprocessor computer,
-	 * time might be different accross CPUs. Therefore skip this test and only
+	 * time might be different across CPUs. Therefore skip this test and only
 	 * re-enable if we develop thread affinity support.
 	 */
 	{

--- a/runtime/tests/port/j9vmemTest.c
+++ b/runtime/tests/port/j9vmemTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9vmemTest.c
+++ b/runtime/tests/port/j9vmemTest.c
@@ -251,7 +251,7 @@ exit:
 #if defined(J9ZOS390)
 /**
  * Returns TRUE if the given page size and flags corresponds to new page sizes added in z/OS.
- * z/OS traditionally supports 4K and 1M fixed pages.
+ * z/OS tradditionally supports 4K and 1M fixed pages.
  * 1M pageable and 2G fixed, added recently, are considered new page sizes.
  */
 BOOLEAN

--- a/runtime/tests/port/si.c
+++ b/runtime/tests/port/si.c
@@ -1762,7 +1762,7 @@ j9sysinfo_test_get_tmp4(struct J9PortLibrary *portLibrary)
 #endif /* !defined(WIN32) */
 
 /*
- * Test j9sysinfo_get_cwd when the buffer size == 0, then allocate required ammount of bites and try again.
+ * Test j9sysinfo_get_cwd when the buffer size == 0, then allocate required amount of bites and try again.
  * Expected result size of buffer required
  */
 I_32

--- a/runtime/tests/shared/CacheFullTests.cpp
+++ b/runtime/tests/shared/CacheFullTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/shared/CacheFullTests.cpp
+++ b/runtime/tests/shared/CacheFullTests.cpp
@@ -2810,8 +2810,8 @@ IDATA test9(J9JavaVM* vm)
 
 	/* Try adding a ROMClass so that the cache becomes soft full*/
 	usedBytes = cc->getUsedBytes();
-	/* Make CC_MIN_SPACE_BEFORE_CACHE_FULL > free avalibale space > CC_MIN_SPACE_BEFORE_CACHE_FULL - romClassSize2, so that increasing the softmx according to the
-	 * unstoredBytes in phase 3 can take effect. Otherwise, it has no effect as free avalibale space can still be less than CC_MIN_SPACE_BEFORE_CACHE_FULL. */
+	/* Make CC_MIN_SPACE_BEFORE_CACHE_FULL > free available space > CC_MIN_SPACE_BEFORE_CACHE_FULL - romClassSize2, so that increasing the softmx according to the
+	 * unstoredBytes in phase 3 can take effect. Otherwise, it has no effect as free available space can still be less than CC_MIN_SPACE_BEFORE_CACHE_FULL. */
 	romClassSize = (TEST9_SOFTMX_SIZE - usedBytes - CC_MIN_SPACE_BEFORE_CACHE_FULL + romClassSize2/2);
 	romClassSize = ROUND_UP_TO(sizeof(U_64), romClassSize);
 	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);

--- a/runtime/util/filecache.c
+++ b/runtime/util/filecache.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/util/filecache.c
+++ b/runtime/util/filecache.c
@@ -336,7 +336,7 @@ j9cached_file_open(struct J9PortLibrary *portLibrary, const char *path, I_32 fla
 	}
 	
 	if (alloc_error == TRUE) {
-		/* free up any alocated memory */
+		/* free up any allocated memory */
 		if (handle != (J9CachedFileHandle *) -1) {
 			/* got a handle, so free any cached associated with it */
 			I_8 index;

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3658,13 +3658,13 @@ hshelpUTRegister(J9JavaVM *vm)
  *
  * @param[in]     currentThread
  * @param[in]     jitEventData       event data describing redefined classes
- * @param[in]     extensionsEnabled  specifies if the extensions are enabled, allways true if FSD is on
+ * @param[in]     extensionsEnabled  specifies if the extensions are enabled, always true if FSD is on
  * @return none
  *
  * Notify the JIT of the changes. Enabled extensions mean that the JIT has
  * been initialized in FSD mode. We need to dump the whole code cache in such a case.
  * If the extensions have NOT been enabled we take the smarter code path and ask the
- * jit to patch the compiled code to accound for the redefined classes.
+ * jit to patch the compiled code to account for the redefined classes.
  */
 void
 jitClassRedefineEvent(J9VMThread * currentThread, J9JVMTIHCRJitEventData * jitEventData, UDATA extensionsEnabled)

--- a/runtime/vm/jvmrisup.c
+++ b/runtime/vm/jvmrisup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/jvmrisup.c
+++ b/runtime/vm/jvmrisup.c
@@ -613,7 +613,7 @@ static int JNICALL rasDumpRegister(JNIEnv *env, int (JNICALL *func)(JNIEnv *env2
 	}
 	
 	memset(rda, 0, sizeof(*rda));
-	/* change this to filter on a java core when that facility is avaiable. */
+	/* change this to filter on a java core when that facility is available. */
 	/* for now just run when anything unexpected happens! */
 	rda->nextPtr = NULL;
 	rda->shutdownFn = rasDumpAgentShutdownFn;

--- a/sourcetools/com.ibm.admincache/src/com/ibm/admincache/Main.java
+++ b/sourcetools/com.ibm.admincache/src/com/ibm/admincache/Main.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2017 IBM Corp. and others
+ * Copyright (c) 2006, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/com.ibm.admincache/src/com/ibm/admincache/Main.java
+++ b/sourcetools/com.ibm.admincache/src/com/ibm/admincache/Main.java
@@ -41,7 +41,7 @@
  * Modified on November 15th, 2005 by Marius Lut
  * - add mandatory option -outPath
  * - delete the old logic dealing with backup orig files
- * - add logic that accomodates relative/canonical full path file name
+ * - add logic that accommodates relative/canonical full path file name
  *   passed to jxeinajar
  * - fix the searchPath option problems
  * - if the input file is .zip file make the output file extension .zip too

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2017 IBM Corp. and others
+ * Copyright (c) 1999, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
@@ -293,7 +293,7 @@ public class ConfigObject {
 	}
 
 	/**
-	 * Returns the flags associaetd with this ConfigObject.
+	 * Returns the flags associated with this ConfigObject.
 	 * <p>
 	 * <b>Note:</b> the flagSet isn't completely correct until updateWithDependencies
 	 * is called, when the removes and adding of sets happens
@@ -305,7 +305,7 @@ public class ConfigObject {
 	}
 
 	/**
-	 * Returns the flags associaetd with this ConfigObject.
+	 * Returns the flags associated with this ConfigObject.
 	 * <p>
 	 * <b>Note:</b> the flagSet isn't completely correct until updateWithDependencies
 	 * is called, when the removes and adding of sets happens

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2018 IBM Corp. and others
+ * Copyright (c) 1999, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
@@ -792,7 +792,7 @@ public class JavaPreprocessor {
 
 	/**
 	 * Each preprocessor may use a single instance of this class to replace
-	 * specially-formatted calls to Msg.getString() with appropiate
+	 * specially-formatted calls to Msg.getString() with appropriate
 	 * String-valued expressions at preprocess time.
 	 */
 	private final class MsgCallInliner {

--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -561,7 +561,7 @@ sub writeTargets {
 			print $fhOut "$name: TEST_RESROOT=$jvmtestroot\n";
 
 			my $aotOptions = '';
-			# AOT_OPTIONS only needs to be apended when TEST_FLAG contains AOT and the test is aot applicable.
+			# AOT_OPTIONS only needs to be appended when TEST_FLAG contains AOT and the test is aot applicable.
 			if ( defined $test->{'aot'} ) {
 				if ( $test->{'aot'} eq 'applicable' ) {
 					$aotOptions = '$(AOT_OPTIONS) ';

--- a/test/functional/JIT_Test/src/jit/test/jitt/floats/FloatStaticTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/floats/FloatStaticTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/jitt/floats/FloatStaticTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/floats/FloatStaticTest.java
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 // Test file: FloatStaticTest.java
-// Testing the assigment of static floats and static volatile floats
+// Testing the assignment of static floats and static volatile floats
 
 package jit.test.jitt.floats;
 

--- a/test/functional/JIT_Test/src/jit/test/jitt/math2/IntStaticTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/math2/IntStaticTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/jitt/math2/IntStaticTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/math2/IntStaticTest.java
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 // Test file: IntStaticTest.java
-// Testing the assigment of static integer and static volatile integers
+// Testing the assignment of static integer and static volatile integers
 
 package jit.test.jitt.math2;
 

--- a/test/functional/JIT_Test/src/jit/test/tr/MonitorElimination/LockTestCase.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/MonitorElimination/LockTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2018 IBM Corp. and others
+ * Copyright (c) 2003, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/tr/MonitorElimination/LockTestCase.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/MonitorElimination/LockTestCase.java
@@ -342,7 +342,7 @@ class LockThread extends Thread
       return sum;
       }
 
-   // arrangment of synchronized calls should cause the collectPreds and
+   // arrangement of synchronized calls should cause the collectPreds and
    // collectSuccs to bounce around a bit
    private int testSwitch(LockTestDriver to, int x)
       {

--- a/test/functional/JIT_Test/src/jit/test/tr/liveMonitor/monTests.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/liveMonitor/monTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/tr/liveMonitor/monTests.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/liveMonitor/monTests.java
@@ -357,7 +357,7 @@ public class monTests {
    }
 
    // java "-Xjit:{*testSimple*}(log=tlog,tracefull,optdetails,disableinlining),disableasynccompilation" montests
-   // no ilgen transformation here becuase the method below is not synchronized
+   // no ilgen transformation here because the method below is not synchronized
    //
    private int testSimpleReadMonitorBlock() throws Exception {
       try {

--- a/test/functional/JIT_Test/src/jit/test/tr/newinstance/NewInstanceTests.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/newinstance/NewInstanceTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/tr/newinstance/NewInstanceTests.java
+++ b/test/functional/JIT_Test/src/jit/test/tr/newinstance/NewInstanceTests.java
@@ -54,7 +54,7 @@ public class NewInstanceTests {
 	}
 	
 	/**
-	 * Attemption to create a new instance of a Inner class should raise an instantiation
+	 * Attempt to create a new instance of a Inner class should raise an instantiation
 	 * exception, since the default constructor does not exist (all constructors must take an outer
 	 * instance)
 	 */
@@ -70,7 +70,7 @@ public class NewInstanceTests {
 	}
 		
 	/**
-	 * Attemption to create a new instance of a static inner class should pass 
+	 * Attempt to create a new instance of a static inner class should pass 
 	 */
 	@Test
 	public void test003() {		
@@ -96,7 +96,7 @@ public class NewInstanceTests {
 	}
 	
 	/**
-	 * Attemption to create a new instance of a static inner class with a public constructor
+	 * Attempt to create a new instance of a static inner class with a public constructor
 	 * of a class in another package should fail with an illegal access exception
 	 */
 	@Test
@@ -111,7 +111,7 @@ public class NewInstanceTests {
 	}
 	
 	/**
-	 * Attemption to create a new instance of a static inner class should pass with a private
+	 * Attempt to create a new instance of a static inner class should pass with a private
 	 * constructor by itself should succeed 
 	 */
 	@Test
@@ -130,7 +130,7 @@ public class NewInstanceTests {
 	}
 	
 	/**
-	 * Attemption to create a new instance of an interface should fail with an 
+	 * Attempt to create a new instance of an interface should fail with an 
 	 * InstantiationException
 	 */
 	@Test
@@ -145,7 +145,7 @@ public class NewInstanceTests {
 	}
 	
 	/**
-	 * Attemption to create a new instance of an Abstract class shoudl fail with an
+	 * Attempt to create a new instance of an Abstract class shoudl fail with an
 	 * InstantiationException
 	 */
 	@Test
@@ -160,7 +160,7 @@ public class NewInstanceTests {
 	}
 	
 	/**
-	 * Attemption to create a new instance of an array class should fail with 
+	 * Attempt to create a new instance of an array class should fail with 
 	 * an InstantiationException
 	 */
 	@Test

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -1098,7 +1098,7 @@ public class Test_String {
 		char[] schars = s.toCharArray();
 		// Spec seems to indicate that this should be true, but the JDK does not
 		// return
-		// a buufer of the correct length either.
+		// a buffer of the correct length either.
 		// assertTrue("Returned array is of different size", buf.length !=
 		// schars.length);
 		for (int i = 0; i < s.length(); i++)

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
@@ -1148,7 +1148,7 @@ public class Test_Thread {
 
 		/*
 		 * Thread.stop() implementation is changed from 1.1.7 to the 1.2
-		 * behavour. now stop() doesn't ensure immediate thread death, so we
+		 * behaviour. now stop() doesn't ensure immediate thread death, so we
 		 * have to wait till st thread joins back to curent thread, before
 		 * making an isAlive() check.
 		 */

--- a/test/functional/Java8andUp/src/org/openj9/test/string/StringIndexOfString.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/string/StringIndexOfString.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/string/StringIndexOfString.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/string/StringIndexOfString.java
@@ -89,7 +89,7 @@ public class StringIndexOfString {
 				subStringByteLen = (VECTOR_SIZE - 2);
 				break;
 			case 6:
-				// sub-string head and tail are not alighed to 16B bounary. Its length <
+				// sub-string head and tail are not aligned to 16B boundary. Its length <
 				// VECTOR_SIZE.
 				subStringByteIndex = (VECTOR_SIZE + 2);
 				subStringByteLen = (VECTOR_SIZE - 4);
@@ -132,7 +132,7 @@ public class StringIndexOfString {
 
 			case 13:
 				// 1st char collision
-				// Sub-string is 3*VECTOR_SIZE long, spanning bettween the 4th and 7th 16B
+				// Sub-string is 3*VECTOR_SIZE long, spanning between the 4th and 7th 16B
 				// boundary.
 				subStringByteIndex = VECTOR_SIZE * 3;
 				subStringByteLen = VECTOR_SIZE * 3;

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Find.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Find.java
@@ -1570,7 +1570,7 @@ public class LookupAPITests_Find {
 	}
 	
 	/**
-	 * findVirtual test using a protected overridden method that belogs to the super-class which the lookup class extends.
+	 * findVirtual test using a protected overridden method that belongs to the super-class which the lookup class extends.
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.extended" })

--- a/test/functional/Jsr335/src/org/openj9/test/jsr335/TestLambdaAccessibilityRules.java
+++ b/test/functional/Jsr335/src/org/openj9/test/jsr335/TestLambdaAccessibilityRules.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Jsr335/src/org/openj9/test/jsr335/TestLambdaAccessibilityRules.java
+++ b/test/functional/Jsr335/src/org/openj9/test/jsr335/TestLambdaAccessibilityRules.java
@@ -345,7 +345,7 @@ public class TestLambdaAccessibilityRules {
 		 * lambdaType. The SAM type depends on the value of useSerializable.
 		 *  
 		 * @param testString		The testString to pass into the containing class' method
-		 * @param lambdaType		The accessiblity rule of the method to call
+		 * @param lambdaType		The accessibility rule of the method to call
 		 * @param useSerializable	If true the lambda will be a SAM of the type SerializableCallable<String>,
 		 * 							otherwise it will be a Callable<String>
 		 * @return	The return value of the containing class' method or null if an error occurred
@@ -493,7 +493,7 @@ public class TestLambdaAccessibilityRules {
 		 * outerLambdaType. The SAM type depends on the value of useSerializable.
 		 *  
 		 * @param testString		The testString to pass into the containing class' method
-		 * @param outerLambdaType	The accessiblity rule of the method to call
+		 * @param outerLambdaType	The accessibility rule of the method to call
 		 * @param innerLambdaType	This argument is passed through as the ContainingClassCaller method's lambdaType  
 		 * @param useSerializable	If true the lambda will be a SAM of the type SerializableCallable<String>,
 		 * 							otherwise it will be a Callable<String>

--- a/test/functional/VM_Test/src/com/ibm/j9/offload/tests/library/LibraryTest.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/offload/tests/library/LibraryTest.java
@@ -1,7 +1,7 @@
 package com.ibm.j9.offload.tests.library;
 
 /*******************************************************************************
- * Copyright (c) 2008, 2012 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/VM_Test/src/com/ibm/j9/offload/tests/library/LibraryTest.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/offload/tests/library/LibraryTest.java
@@ -30,7 +30,7 @@ public class LibraryTest extends TestCase {
 	/**
 	 * method that can be used to run the test by itself
 	 * 
-	 * @param args no valid arugments
+	 * @param args no valid arguments
 	 */
 	public static void main (String[] args) {
 		junit.textui.TestRunner.run(suite());

--- a/test/functional/VM_Test/src/j9vm/test/xlp/XlpOptionsTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/xlp/XlpOptionsTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/VM_Test/src/j9vm/test/xlp/XlpOptionsTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/xlp/XlpOptionsTestRunner.java
@@ -564,7 +564,7 @@ public class XlpOptionsTestRunner extends Runner {
 				boolean isVerboseOutputPresent = false;
 				
 				for (String line : outputList) {
-					/* If large page size is supported, -verbose:sizes should display the page size and type used by JVM for heap alloation */
+					/* If large page size is supported, -verbose:sizes should display the page size and type used by JVM for heap allocation */
 					if (line.trim().startsWith("-Xlp:objectheap:pagesize=")) {
 						isVerboseOutputPresent = true;
 						/* Parse -Xlp:objectheap statement to get page size and type used by JVM for heap allocation */

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
@@ -452,12 +452,12 @@ sub long_cache_name_err_msg {
 		. " Cache not created.";
 }
 
-# error msg to indicate that the cache name could not accomodate the expansion of %g
+# error msg to indicate that the cache name could not accommodate the expansion of %g
 sub copy_groupname_err_msg {
 	return "Error copying groupname into cache name";
 }
 
-# error msg to indicate that the cache name could not accomodate the expansion of %u
+# error msg to indicate that the cache name could not accommodate the expansion of %u
 sub copy_username_err_msg {
 	return "The cache name is too long when the user name is included";
 }

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdline_options_tester/src/TestSuite.java
+++ b/test/functional/cmdline_options_tester/src/TestSuite.java
@@ -106,7 +106,7 @@ public class TestSuite {
 	}
 	
 	void printResults() {
-		// print aggegate statistics
+		// print aggregate statistics
 		System.out.println("\n---TEST RESULTS---");
 		System.out.println("Number of PASSED tests: " + _passed.size() + " out of " + (_passed.size() + _failed.size()));
 		System.out.println("Number of FAILED tests: " + _failed.size() + " out of " + (_passed.size() + _failed.size()));

--- a/test/functional/cmdline_options_tester/src/TestSuite.java
+++ b/test/functional/cmdline_options_tester/src/TestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
This PR should be purely comment changes for words (or families of words) that start w/ `a`..`b` -- per @pshipton. 

To make my life easier, these initial comment focused PRs will have 2 commits:
* one which is the fixes
* and one which is the copyright bumping. -- For the copyright bumping, I'm using my own script which is vaguely related to @fjeremic's https://github.com/eclipse/openj9/pull/5722#issuecomment-491355192.

In order to do comment only work, I basically squash the changes for a set together and then do an interactive commit, trying to select only the comments -- this is purely manual and somewhat error-prone. Also, if I'm not awake (which will happen), I may accidentally pull in a comment change that relates to a code change (esp. if a variable is consistently misspelled in both code and comments). I'm sorry if/when that happens and will be happy to fix it.

---
Each project is different. Some projects like to split PRs by module (directories), others by code-type (e.g. docs, comments, apis, local variables, local functions, public functions, others by file-type (e.g. C, Java, ...). 

Once we've finished with comments, we can revisit what to do next.

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `f` / `fchurn`. That branch will grow as I make progress (I've finished `h`). Note that occasionally earlier letters will gain commits as a misspelled token's corrected spelling might be earlier alphabetically than the misspelling itself, but I probably won't go out of my way to amend an existing PR for that as re-selecting >250 hunks out of >350 hunks is a pretty error prone process (I made ~10 errors in my first attempt and don't expect it to be better if I try again). Instead once I get to the end, I'll probably make one additional PR with the remaining comment fixes.

A bit about how I make my initial commits:
1. I create a series of ignore commits which delete files that I don't intend to change (often binaries).
1. For this project, I've also deleted any file which has a copyright header that isn't IBM, since the copyright bot complains when I change those files and that seems like a good heuristic for "not belonging to this project". -- Note that deletions aren't reflected in this PR (or any of my non draft PRs) as I rebase only desired changes into master, deleting just makes it easier for my tooling to work.
1. After this step, I generate a list of `words` (see `f` referenced below).
   * I then review each word, trying to decided if it's a term of art, garbage, or a typo -- often taking advantage of similar unrecognized words to identify which things are misspellings.
1. Each commit I make is a word-family.
   * This lets me drop a word family if it turns out that I'm wrong -- this is especially useful when a project prefers, e.g. `colour` vs. `color` and I guessed wrong.
   * It also makes it much easier for me to rebase my work because if a given commit has conflicts, it's only dealing w/ a single word family, and recreating those fixes isn't a huge problem.
   * And, of course, when I make mistakes (it happens, we're all humans, even when it looks like I'm a bot), fixing things is limited to individual commits.
1. I try to tag commits which I conceive as risky -- especially things that I suspect are `[API]` changes.
1. I try to tag things where I'm less sure `[??]`.
1. Sometimes I will tag brand corrections specifically, e.g. `JavaScript` or `Artifactory` -- although I haven't done that here yet.
1. If a repository is inconsistent about en-US/en-GB, I'll make a guess and tag any commits that are enforcing that guess (again, this makes it easy for me to drop if I guess wrong). -- Fwiw, this repository is somewhat inconsistent, but for the time being, I'm going to try to avoid making a change in either direction.

After the comment cleanup PRs are resolved, I'm likely to sort those last items to the end of my commit chain, and split them off into additional PRs.