### PR TITLE
Revert "Enhance the handling of indexOf in ValuePropagation"

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4305,8 +4305,6 @@ static bool foldFinalFieldsIn(char *className, int32_t classNameLength, TR::Comp
       return true;
    else if (classNameLength >= 38 && !strncmp(className, "java/util/concurrent/ThreadLocalRandom", 38))
       return true;
-   else if (classNameLength == 16 && !strncmp(className, "java/lang/String", 16))
-      return true;
    else
       return false;
    }

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -50,7 +50,7 @@
 J9::ValuePropagation::ValuePropagation(TR::OptimizationManager *manager)
    : OMR::ValuePropagation(manager),
      _bcdSignConstraints(NULL),
-     _callsToBeFoldedToNode(trMemory())
+     _callsToBeFoldedToIconst(trMemory())
    {
    }
 
@@ -98,13 +98,13 @@ TR::VP_BCDSign **J9::ValuePropagation::getBCDSignConstraints(TR::DataType dt)
  *    The constant used to replace the call in the fast path.
  */
 void
-J9::ValuePropagation::transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR::Node *result)
+J9::ValuePropagation::transformCallToIconstWithHCRGuard(TR::TreeTop *callTree, int32_t result)
    {
    static const char *disableHCRGuards = feGetEnv("TR_DisableHCRGuards");
    TR_ASSERT(!disableHCRGuards && comp()->getHCRMode() != TR::none, "foldCallToConstantInHCRMode should be called in HCR mode");
 
    TR::Node * callNode = callTree->getNode()->getFirstChild();
-   TR_ASSERT(callNode->getSymbol()->isResolvedMethod(), "Expecting resolved call in transformCallToNodeWithHCRGuard");
+   TR_ASSERT(callNode->getSymbol()->isResolvedMethod(), "Expecting resolved call in transformCallToIconstWithHCRGuard");
 
    TR::ResolvedMethodSymbol *calleeSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
 
@@ -126,8 +126,7 @@ J9::ValuePropagation::transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR:
    ifTree->getNode()->getFirstChild()->setIsTheVirtualCallNodeForAGuardedInlinedCall();
    // resultNode is the inlined node, should have the correct callee index
    // Pass compareNode as the originatingByteCodeNode so that the resultNode has the correct callee index
-   TR::Node *resultNode = result;
-   result->setByteCodeInfo(compareNode->getByteCodeInfo());
+   TR::Node *resultNode = TR::Node::iconst(compareNode, result);
    TR::TreeTop *elseTree = TR::TreeTop::create(comp(), TR::Node::create(callNode, TR::treetop, 1, resultNode));
    J9::TransformUtil::createDiamondForCall(this, callTree, compareTree, ifTree, elseTree, false /*changeBlockExtensions*/, true /*markCold*/);
    comp()->decInlineDepth();
@@ -179,14 +178,13 @@ J9::ValuePropagation::getObjectLocationFromConstraint(TR::VPConstraint *constrai
  *   If true, fold the call in place. Otherwise in delayed transformations.
  */
 void
-J9::ValuePropagation::transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop* callTree, int32_t result, bool isGlobal, bool inPlace, bool requiresGuard)
+J9::ValuePropagation::transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop* callTree, int32_t result, bool isGlobal, bool inPlace)
    {
     TR::Node * callNode = callTree->getNode()->getFirstChild();
     TR_Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
     const char *signature = calledMethod->signature(comp()->trMemory(), stackAlloc);
     if (inPlace)
        {
-       TR_ASSERT_FATAL(!requiresGuard, "An in place tranformation cannot be done with a guard!");
        if (trace())
           traceMsg(comp(), "Fold the call to %s on node %p to %d\n", signature, callNode, result);
        replaceByConstant(callNode, TR::VPIntConst::create(this, result), isGlobal);
@@ -195,20 +193,10 @@ J9::ValuePropagation::transformCallToIconstInPlaceOrInDelayedTransformations(TR:
        {
        if (trace())
           traceMsg(comp(), "The call to %s on node %p will be folded to %d in delayed transformations\n", signature, callNode, result);
-       _callsToBeFoldedToNode.add(new (trStackMemory()) TreeNodeResultPair(callTree, TR::Node::iconst(callTree->getNode()->getFirstChild(), result), requiresGuard));
+       _callsToBeFoldedToIconst.add(new (trStackMemory()) TreeIntResultPair(callTree, result));
        }
-   }
+  }
 
-void
-J9::ValuePropagation::transformCallToNodeDelayedTransformations(TR::TreeTop *callTree, TR::Node *result, bool requiresGuard)
-   {
-   TR::Node * callNode = callTree->getNode()->getFirstChild();
-   TR_Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
-   const char *signature = calledMethod->signature(comp()->trMemory(), stackAlloc);
-   if (trace())
-          traceMsg(comp(), "The call to %s on node %p will be folded in delayed transformations\n", signature, callNode, result);
-   _callsToBeFoldedToNode.add(new (trStackMemory()) TreeNodeResultPair(callTree, result, requiresGuard));
-   }
 /**
  * \brief
  *    Check if the given constraint is for a java/lang/String object.
@@ -304,7 +292,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
              && receiverChildConstraint->getClassType()->asFixedClass())
             {
             int32_t isInterface = TR::Compiler->cls.isInterfaceClass(comp(), receiverChildConstraint->getClass());
-            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, isInterface, receiverChildGlobal, transformNonnativeMethodInPlace, !transformNonnativeMethodInPlace);
+            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, isInterface, receiverChildGlobal, transformNonnativeMethodInPlace);
             TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
             return;
             }
@@ -330,7 +318,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                   traceMsg(comp(), "Cannot get access to the String object, quit transforming String.hashCode\n");
                break;
                }
-            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, hashCode, receiverChildGlobal, transformNonnativeMethodInPlace, !transformNonnativeMethodInPlace);
+            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, hashCode, receiverChildGlobal, transformNonnativeMethodInPlace);
             TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
             return;
             }
@@ -354,7 +342,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             // According to java doc, String.equals returns false when the argument object is null
             if (objectChildConstraint->isNullObject())
                {
-               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, 0, receiverChildGlobal && objectChildGlobal, transformNonnativeMethodInPlace, !transformNonnativeMethodInPlace);
+               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, 0, receiverChildGlobal && objectChildGlobal, transformNonnativeMethodInPlace);
                TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
                return;
                }
@@ -369,7 +357,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                }
             else if (isObjectString == TR_no)
                {
-               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, 0, receiverChildGlobal && objectChildGlobal, transformNonnativeMethodInPlace, !transformNonnativeMethodInPlace);
+               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, 0, receiverChildGlobal && objectChildGlobal, transformNonnativeMethodInPlace);
                TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
                return;
                }
@@ -391,7 +379,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                         traceMsg(comp(), "Does not have VM access, cannot tell whether %p and %p are equal\n", receiverChild, objectChild);
                      break;
                      }
-                  transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, result, receiverChildGlobal && objectChildGlobal, transformNonnativeMethodInPlace, !transformNonnativeMethodInPlace);
+                  transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, result, receiverChildGlobal && objectChildGlobal, transformNonnativeMethodInPlace);
                   TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
                   return;
                   }
@@ -424,7 +412,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             len = comp()->fej9()->getStringLength(stringObject);
             }
             // java/lang/String.lengthInternal is used internally and HCR guards can be skipped for calls to it.
-            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, len, receiverChildGlobal, transformNonnativeMethodInPlace || rm == TR::java_lang_String_lengthInternal, !(transformNonnativeMethodInPlace || rm == TR::java_lang_String_lengthInternal));
+            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, len, receiverChildGlobal, transformNonnativeMethodInPlace || rm == TR::java_lang_String_lengthInternal);
             TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
             return;
             }
@@ -444,7 +432,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             bool success = comp()->fej9()->javaLangClassGetModifiersImpl(classChildConstraint->getClass(), modifiersForClass);
             if (!success)
                break;
-            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, modifiersForClass, classChildGlobal, true, false);
+            transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, modifiersForClass, classChildGlobal, true);
             TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
             return;
             }
@@ -491,7 +479,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                   else if (isInstanceOfResult == TR_yes)
                      assignable = 1;
                   }
-               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, assignable, firstClassChildGlobal && secondClassChildGlobal, true, false);
+               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, assignable, firstClassChildGlobal && secondClassChildGlobal, true);
                TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
                return;
                }
@@ -514,7 +502,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
             int32_t hashCodeForClass = comp()->fej9()->getJavaLangClassHashCode(comp(), classChildConstraint->getClass(), hashCodeWasComputed);
             if (hashCodeWasComputed)
                {
-               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, hashCodeForClass, classChildGlobal, true, false);
+               transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, hashCodeForClass, classChildGlobal, true);
                TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
                return;
                }
@@ -648,67 +636,6 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                invalidateValueNumberInfo();
                TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));
                return;
-               }
-            }
-         break;
-         }
-      case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
-         {
-         TR::Node *array = node->getSecondChild();
-         bool isGlobal;
-         TR::VPConstraint *arrayConstraint = getConstraint(array, isGlobal);
-         if (!arrayConstraint)
-            break;
-
-         TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-         TR::VPKnownObject *kobj = arrayConstraint->getKnownObject();
-         if (knot && kobj)
-            {
-            TR_OpaqueClassBlock *klazz = kobj->getClass();
-            if (comp()->fej9()->isPrimitiveArray(klazz)
-                || comp()->fej9()->isReferenceArray(klazz))
-               {
-               TR::VMAccessCriticalSection constrainArraylengthCriticalSection(comp(),
-                           TR::VMAccessCriticalSection::tryToAcquireVMAccess);
-               if (constrainArraylengthCriticalSection.hasVMAccess())
-                  {
-                  uintptrj_t array = knot->getPointer(kobj->getIndex());
-                  uintptrj_t length = comp()->fej9()->getArrayLengthInElements(array);
-                  if (length == 0)
-                     {
-                     replaceByConstant(node, TR::VPIntConst::create(this, -1), isGlobal);
-                     return;
-                     }
-                  else if (length == 1)
-                     {
-                     bool offsetIsGlobal;
-                     TR::VPConstraint *offsetConstraint = getConstraint(node->getChild(3), offsetIsGlobal);
-                     if (offsetConstraint && offsetConstraint->asIntConst())
-                        {
-                        uintptrj_t element = TR::Compiler->om.getAddressOfElement(comp(), array, offsetConstraint->asIntConst()->getInt() + TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
-                        char ch  = *((char*)element);
-                        bool searchIsGlobal;
-                        TR::VPConstraint *searchCharConstraint = getConstraint(node->getChild(2), searchIsGlobal);
-                        if (searchCharConstraint && searchCharConstraint->asShortConst())
-                           {
-                           replaceByConstant(node, TR::VPIntConst::create(this, ch == ((char)searchCharConstraint->asShortConst()->getShort()) ? 0 : -1), isGlobal && offsetIsGlobal && searchIsGlobal);
-                           }
-                        else
-                           {
-                           transformCallToNodeDelayedTransformations(_curTree, 
-                              TR::Node::create(node, TR::isub, 2,
-                                 TR::Node::create(node, TR::icmpeq, 2,
-                                    node->getChild(2),
-                                    TR::Node::iconst(node, ch)
-                                 ),
-                                 TR::Node::iconst(node, 1)
-                              )
-                              , false);
-                           }
-                        return;
-                        }
-                     }
-                  }
                }
             }
          break;
@@ -992,29 +919,23 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 void
 J9::ValuePropagation::doDelayedTransformations()
    {
-   ListIterator<TreeNodeResultPair> callsToBeFoldedToNode(&_callsToBeFoldedToNode);
-   for (TreeNodeResultPair *it = callsToBeFoldedToNode.getFirst();
+   ListIterator<TreeIntResultPair> callsToBeFoldedToIconst(&_callsToBeFoldedToIconst);
+   for (TreeIntResultPair *it = callsToBeFoldedToIconst.getFirst();
         it;
-        it = callsToBeFoldedToNode.getNext())
+        it = callsToBeFoldedToIconst.getNext())
       {
       TR::TreeTop *callTree = it->_tree;
-      TR::Node *result = it->_result;
+      int32_t result = it->_result;
       TR::Node * callNode = callTree->getNode()->getFirstChild();
-      traceMsg(comp(), "Doing delayed call transformaiton on call node n%dn\n", callNode->getGlobalIndex());
+      TR_Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
+      const char *signature = calledMethod->signature(comp()->trMemory(), stackAlloc);
 
-      if (!performTransformation(comp(), "%sTransforming call node %p on tree %p to node %p\n", OPT_DETAILS, callNode, callTree, result))
+      if (!performTransformation(comp(), "%sTransforming call %s on node %p on tree %p to iconst %d\n", OPT_DETAILS, signature, callNode, callTree, result))
          break;
 
-      if (it->_requiresHCRGuard)
-         {
-         transformCallToNodeWithHCRGuard(callTree, result);
-         }
-      else
-         {
-         TR::TransformUtil::transformCallNodeToPassThrough(this, callNode, callTree, result);
-         }
+      transformCallToIconstWithHCRGuard(callTree, result);
       }
-   _callsToBeFoldedToNode.deleteAll();
+   _callsToBeFoldedToIconst.deleteAll();
 
    OMR::ValuePropagation::doDelayedTransformations();
    }

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -52,9 +52,8 @@ class ValuePropagation : public OMR::ValuePropagation
    virtual bool transformDirectLoad(TR::Node *node);
    bool tryFoldStaticFinalFieldAt(TR::TreeTop* tree, TR::Node* fieldNode);
    virtual void doDelayedTransformations();
-   void transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR::Node *result);
-   void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true, bool requiresGuard = false);
-   void transformCallToNodeDelayedTransformations(TR::TreeTop *callTree, TR::Node *result, bool requiresGuard = false);
+   void transformCallToIconstWithHCRGuard(TR::TreeTop *callTree, int32_t result);
+   void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true);
    uintptrj_t* getObjectLocationFromConstraint(TR::VPConstraint *constraint);
    bool isKnownStringObject(TR::VPConstraint *constraint);
    TR_YesNoMaybe isStringObject(TR::VPConstraint *constraint);
@@ -65,17 +64,15 @@ class ValuePropagation : public OMR::ValuePropagation
 
    TR_YesNoMaybe safeToAddFearPointAt(TR::TreeTop* tt);
 
-   struct TreeNodeResultPair {
+   struct TreeIntResultPair {
       TR_ALLOC(TR_Memory::ValuePropagation)
       TR::TreeTop *_tree;
-      TR::Node *_result;
-      bool _requiresHCRGuard;
-      TreeNodeResultPair(TR::TreeTop *tree, TR::Node *result, bool requiresHCRGuard) 
-         : _tree(tree), _result(result), _requiresHCRGuard(requiresHCRGuard) {}
+      int32_t _result;
+      TreeIntResultPair(TR::TreeTop *tree, int32_t result) : _tree(tree), _result(result) {}
    };
 
    TR::VP_BCDSign **_bcdSignConstraints;
-   List<TreeNodeResultPair> _callsToBeFoldedToNode;
+   List<TreeIntResultPair> _callsToBeFoldedToIconst;
    };
 
 


### PR DESCRIPTION
Reverts eclipse/openj9#5444

The change seems to be causing some test failures so I'm reverting it.
```
j> 22:03:24 java.lang.IllegalArgumentException: protocol = null host = null
j> 22:03:24 	at sun.net.spi.DefaultProxySelector.select(DefaultProxySelector.java:189)
j> 22:03:24 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:395)
j> 22:03:24 	at java.net.Socket.connect(Socket.java:666)
j> 22:03:24 	at com.ibm.jsse2.av.connect(av.java:35)
j> 22:03:24 	at com.ibm.jsse2.av.<init>(av.java:580)
j> 22:03:24 	at com.ibm.jsse2.SSLSocketFactoryImpl.createSocket(SSLSocketFactoryImpl.java:16)
j> 22:03:24 	at org.apache.harmony.xnet.tests.javax.net.ssl.HandshakeCompletedEventTest.setUp(HandshakeCompletedEventTest.java:62)
```