### PR TITLE
Add @loader_path/.. to dylib rpath on OSX

### DIFF
--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2018 IBM Corp. and others
+Copyright (c) 1998, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,7 +123,7 @@ endif
 
 # https://stackoverflow.com/questions/21907504/how-to-compile-shared-lib-with-clang-on-osx
 UMA_DLL_LINK_FLAGS += -shared -undefined dynamic_lookup -install_name @rpath/lib$(UMA_LIB_NAME).dylib
-UMA_DLL_LINK_FLAGS += -Xlinker -rpath -Xlinker @loader_path
+UMA_DLL_LINK_FLAGS += -Xlinker -rpath -Xlinker @loader_path -Xlinker -rpath -Xlinker @loader_path/..
 
 UMA_DLL_LINK_POSTFLAGS += $(UMA_LINK_STATIC_LIBRARIES)
 UMA_DLL_LINK_POSTFLAGS += $(UMA_LINK_SHARED_LIBRARIES)


### PR DESCRIPTION
The libraries built in OpenJ9 are put into lib/compressedrefs, and
since the rpath of those libraries is '@loader_path', any dynamic
loading done through these libraries (mainly port library) only looks
in lib/compressedrefs and misses everything in lib/. Thus we add an
extra rpath '@loader_path/..' to the libraries we build.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/1056

Reviewer: @DanHeidinga 