### PR TITLE
(v0.14.2) Declare J9RAMVirtualMethodRef methodIndexAndArgCount as volatile

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2098,8 +2098,8 @@ typedef struct J9RAMStaticMethodRef {
 } J9RAMStaticMethodRef;
 
 typedef struct J9RAMVirtualMethodRef {
-	UDATA methodIndexAndArgCount;
-	struct J9Method* method;
+	UDATA volatile methodIndexAndArgCount;
+	struct J9Method *volatile method;
 } J9RAMVirtualMethodRef;
 
 typedef struct J9RAMMethodTypeRef {


### PR DESCRIPTION
Declare `J9RAMVirtualMethodRef methodIndexAndArgCount` as `volatile`

Declaring `J9RAMVirtualMethodRef.methodIndexAndArgCount` as `volatile` instructs the compiler to generate assembly code that writes to the field atomically.
This fixes the segment error due to `zero methodIndex` which seems due to separated writes to the field, first one is `argCount`, and the second one is `methodIndex`.
In addition, the field `J9RAMVirtualMethodRef.method` is declared as `volatile` as well.

More background info is at https://github.com/eclipse/openj9/issues/4778#issuecomment-490673548

Backported from https://github.com/eclipse/openj9/pull/5694

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>