### PR TITLE
Improve Escape Analysis under OSR

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -544,6 +544,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
    _fixedVirtualCallSites.setFirst(NULL);
 
    _parms = NULL;
+   _ignoreableUses = NULL;
    _nonColdLocalObjectsValueNumbers = NULL;
    _allLocalObjectsValueNumbers = NULL;
    _visitedNodes = NULL;
@@ -587,6 +588,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
          }
       else
          {
+         _ignoreableUses = new (trStackMemory()) TR_BitVector(0, trMemory(), stackAlloc);
          _nonColdLocalObjectsValueNumbers = new (trStackMemory()) TR_BitVector(_valueNumberInfo->getNumberOfValues(), trMemory(), stackAlloc);
          _allLocalObjectsValueNumbers = new (trStackMemory()) TR_BitVector(_valueNumberInfo->getNumberOfValues(), trMemory(), stackAlloc);
          _notOptimizableLocalObjectsValueNumbers = new (trStackMemory()) TR_BitVector(_valueNumberInfo->getNumberOfValues(), trMemory(), stackAlloc);
@@ -597,6 +599,7 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
    if ( !_candidates.isEmpty())
       {
       findLocalObjectsValueNumbers();
+      findIgnoreableUses();
       }
 
    // Complete the candidate info by finding all uses and defs that are reached
@@ -1261,6 +1264,48 @@ int32_t TR_EscapeAnalysis::performAnalysisOnce()
       }
 
    return cost; // actual cost
+   }
+
+void TR_EscapeAnalysis::findIgnoreableUses()
+   {
+   if (comp()->getOSRMode() != TR::voluntaryOSR)
+      return;
+
+   TR::NodeChecklist visited(comp());
+   bool inOSRCodeBlock = false;
+
+   // Gather all uses under fake prepareForOSR calls - they will be tracked as ignoreable
+   for (TR::TreeTop *treeTop = comp()->getStartTree(); treeTop; treeTop = treeTop->getNextTreeTop())
+       {
+       if (treeTop->getNode()->getOpCodeValue() == TR::BBStart)
+           inOSRCodeBlock = treeTop->getNode()->getBlock()->isOSRCodeBlock();
+       else if (inOSRCodeBlock
+                && treeTop->getNode()->getNumChildren() > 0
+                && treeTop->getNode()->getFirstChild()->getOpCodeValue() == TR::call
+                && treeTop->getNode()->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
+           {
+           TR::Node *callNode = treeTop->getNode()->getFirstChild();
+           for (int i = 0; i < callNode->getNumChildren(); ++i)
+              findIgnoreableUses(callNode->getChild(i), visited);
+           }
+       }
+   }
+
+void TR_EscapeAnalysis::findIgnoreableUses(TR::Node *node, TR::NodeChecklist &visited)
+   {
+   if (visited.contains(node))
+      return;
+   visited.add(node);
+   if (trace())
+      traceMsg(comp(), "Marking n%dn as an ignoreable use\n", node->getGlobalIndex());
+   _ignoreableUses->set(node->getGlobalIndex());
+
+   int32_t i;
+   for (i = 0; i < node->getNumChildren(); i++)
+      {
+      TR::Node *child = node->getChild(i);
+      findIgnoreableUses(child, visited);
+      }
    }
 
 void TR_EscapeAnalysis::findLocalObjectsValueNumbers()
@@ -2307,15 +2352,28 @@ bool TR_EscapeAnalysis::checkDefsAndUses(TR::Node *node, Candidate *candidate)
                   TR::Node *useNode = _useDefInfo->getNode(useIndex+_useDefInfo->getFirstUseIndex());
                   int32_t useNodeVN = _valueNumberInfo->getValueNumber(useNode);
                   int32_t i;
+                  bool valueNumberSeen = false;
+
                   for (i = candidate->_valueNumbers->size()-1; i >= 0; i--)
                      {
                      if (candidate->_valueNumbers->element(i) == useNodeVN)
-                        break;
+                        {
+                        valueNumberSeen = true;
+
+                        // Only add this value number if it's not to be ignored
+                        if (!_ignoreableUses->get(candidate->_valueNumbers->element(i)))
+                           {
+                           break;
+                           }
+                        }
                      }
 
                   if (i < 0)
                      {
-                     candidate->_valueNumbers->add(useNodeVN);
+                     if (!valueNumberSeen)
+                        {
+                        candidate->_valueNumbers->add(useNodeVN);
+                        }
 
                      if (candidate->isInsideALoop())
                         {
@@ -2348,7 +2406,7 @@ bool TR_EscapeAnalysis::checkDefsAndUses(TR::Node *node, Candidate *candidate)
                         else
                            returnValue = false;
                         }
-                     if (!checkDefsAndUses(useNode, candidate))
+                     if (!valueNumberSeen && !checkDefsAndUses(useNode, candidate))
                         returnValue = false;
                      }
                   }
@@ -3911,7 +3969,12 @@ void TR_EscapeAnalysis::checkEscape(TR::TreeTop *firstTree, bool isCold, bool & 
       if (node->getOpCode().isCheck() || node->getOpCodeValue() == TR::treetop)
          node = node->getFirstChild();
       if (node->getOpCode().isCall() && !vnsCall.contains(node))
-         checkEscapeViaCall(node, vnsCall, ignoreRecursion);
+         {
+         if (node->getSymbolReference()->getReferenceNumber() != TR_prepareForOSR
+             || comp()->getOSRMode() != TR::voluntaryOSR
+             ||  _curBlock->isOSRInduceBlock())
+            checkEscapeViaCall(node, vnsCall, ignoreRecursion);
+         }
       }
    }
 

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2350,30 +2350,27 @@ bool TR_EscapeAnalysis::checkDefsAndUses(TR::Node *node, Candidate *candidate)
                   {
                   int32_t useIndex = cursor;
                   TR::Node *useNode = _useDefInfo->getNode(useIndex+_useDefInfo->getFirstUseIndex());
+
+                  // Only add this value number if it's not to be ignored
+                  if (_ignoreableUses->get(useNode->getGlobalIndex()))
+                     {
+                     continue;
+                     }
+
                   int32_t useNodeVN = _valueNumberInfo->getValueNumber(useNode);
                   int32_t i;
-                  bool valueNumberSeen = false;
 
                   for (i = candidate->_valueNumbers->size()-1; i >= 0; i--)
                      {
                      if (candidate->_valueNumbers->element(i) == useNodeVN)
                         {
-                        valueNumberSeen = true;
-
-                        // Only add this value number if it's not to be ignored
-                        if (!_ignoreableUses->get(candidate->_valueNumbers->element(i)))
-                           {
-                           break;
-                           }
+                        break;
                         }
                      }
 
                   if (i < 0)
                      {
-                     if (!valueNumberSeen)
-                        {
-                        candidate->_valueNumbers->add(useNodeVN);
-                        }
+                     candidate->_valueNumbers->add(useNodeVN);
 
                      if (candidate->isInsideALoop())
                         {
@@ -2406,7 +2403,7 @@ bool TR_EscapeAnalysis::checkDefsAndUses(TR::Node *node, Candidate *candidate)
                         else
                            returnValue = false;
                         }
-                     if (!valueNumberSeen && !checkDefsAndUses(useNode, candidate))
+                     if (!checkDefsAndUses(useNode, candidate))
                         returnValue = false;
                      }
                   }

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -452,6 +452,8 @@ class TR_EscapeAnalysis : public TR::Optimization
 
    int32_t  performAnalysisOnce();
    void     findCandidates();
+   void     findIgnoreableUses();
+   void     findIgnoreableUses(TR::Node *node, TR::NodeChecklist& visited);
    void     findLocalObjectsValueNumbers();
    void     findLocalObjectsValueNumbers(TR::Node *node, TR::NodeChecklist& visited);
 
@@ -631,6 +633,7 @@ class TR_EscapeAnalysis : public TR::Optimization
    TR_UseDefInfo             *_useDefInfo;
    bool                      _invalidateUseDefInfo;
    TR_BitVector              *_otherDefsForLoopAllocation;
+   TR_BitVector              *_ignoreableUses;
    TR_BitVector              *_nonColdLocalObjectsValueNumbers;
    TR_BitVector              *_allLocalObjectsValueNumbers;
    TR_BitVector              *_notOptimizableLocalObjectsValueNumbers;


### PR DESCRIPTION
This change defines new optimization passes, `preEscapeAnalysis` and `postEscapeAnalysis`, that help Escape Analysis (EA) do better under voluntary OSR.

The new `preEscapeAnalysis` optimization looks for calls to `OSRInductionHelper` and adds a fake `prepareForOSR` call that references all live auto symrefs and pending pushes.  Any object that ends up as a candidate for stack allocation that appears to be used by such a fake `prepareForOSR` call can be heapified at that point.

During EA itself, those references on `prepareForOSR` calls are marked as ignoreable for the purposes of determining whether an object can be stack allocated.

After EA, the `postEscapeAnalysis` pass will remove the fake calls to `prepareForOSR`.

Submitted on behalf of Andrew Craik <ajcraik@ca.ibm.com>

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>