### PR TITLE
Add AOT Feature Flag for Transactional Memory

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1803,6 +1803,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotValidateStringCompressionFailure:
             case compilationSymbolValidationManagerFailure:
             case compilationAOTNoSupportForAOTFailure:
+            case compilationAOTValidateTMFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -197,6 +197,7 @@ char *compilationErrorNames[]={
    "compilationEnforceProfiling", //49
    "compilationSymbolValidationManagerFailure", //50
    "compilationAOTNoSupportForAOTFailure", //51
+   "compilationAOTValidateTMFailure", //52
    "compilationMaxError"
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -75,6 +75,7 @@ typedef enum {
    compilationEnforceProfiling                     = 49,
    compilationSymbolValidationManagerFailure       = 50,
    compilationAOTNoSupportForAOTFailure            = 51,
+   compilationAOTValidateTMFailure                 = 52,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -170,6 +170,7 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_UsesEnableStringCompressionFolding        0x00000008
 #define TR_AOTMethodHeader_StringCompressionEnabled                  0x00000010
 #define TR_AOTMethodHeader_UsesSymbolValidationManager               0x00000020
+#define TR_AOTMethodHeader_TMDisabled                                0x00000040
 
 
 

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1523,6 +1523,11 @@ createMethodMetaData(
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing;
          }
 
+      if (comp->getOption(TR_DisableTM))
+         {
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_TMDisabled;
+         }
+
       // totalAllocated space is in comp object
       TR_ASSERT(comp->getTotalNeededDataCacheSpace() == aotMethodHeaderEntry->compileMethodDataSize, "Size missmatach");
       }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -240,6 +240,12 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
       comp->setOption(TR_UseSymbolValidationManager);
       }
 
+   if ((_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_TMDisabled) && !comp->getOption(TR_DisableTM))
+      {
+      setReturnCode(compilationAOTValidateTMFailure);
+      return NULL;
+      }
+
    _exceptionTableCacheEntry = (J9JITDataCacheHeader *)((uint8_t *)cacheEntry + _aotMethodHeaderEntry->offsetToExceptionTable);
 
    if (_exceptionTableCacheEntry->type == J9_JIT_DCE_EXCEPTION_INFO)

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -936,6 +936,8 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(TR_FrontEnd *fe, TR_AOTHead
       defaultMessage = generateError("AOT header validation failed: Concurrent Scavenge feature mismatch.");
    if ((featureFlags & TR_FeatureFlag_SoftwareReadBarrier) != (hdrInCache->featureFlags & TR_FeatureFlag_SoftwareReadBarrier))
       defaultMessage = generateError("AOT header validation failed: Software Read Barrier feature mismatch.");
+   if ((featureFlags & TR_FeatureFlag_UsesTM) != (hdrInCache->featureFlags & TR_FeatureFlag_UsesTM))
+      defaultMessage = generateError("AOT header validation failed: TM feature mismatch.");
 
    if ((featureFlags & TR_FeatureFlag_SanityCheckEnd) != (hdrInCache->featureFlags & TR_FeatureFlag_SanityCheckEnd))
       defaultMessage = generateError("AOT header validation failed: Trailing sanity bit mismatch.");
@@ -1282,6 +1284,16 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
 
    if (fej9->isAsyncCompilation())
       featureFlags |= TR_FeatureFlag_AsyncCompilation;
+
+
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableTM) &&
+       !TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableTM))
+      {
+      if (TR::Compiler->target.cpu.supportsTransactionalMemoryInstructions())
+         {
+         featureFlags |= TR_FeatureFlag_UsesTM;
+         }
+      }
 
    return featureFlags;
    }

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -80,6 +80,7 @@ typedef enum TR_AOTFeatureFlags
    TR_FeatureFlag_AsyncCompilation              = 0x00000400,     //async compilation - switch to interpreter code NOT generated
    TR_FeatureFlag_ConcurrentScavenge            = 0x00000800,
    TR_FeatureFlag_SoftwareReadBarrier           = 0x00001000,
+   TR_FeatureFlag_UsesTM                        = 0x00002000,
    TR_FeatureFlag_SanityCheckEnd                = 0x80000000
    } TR_AOTFeatureFlags;
 


### PR DESCRIPTION
Currently, the AOT infrastructure does not check to ensure consistency in the compile and load run with regard to transactional memory support. This PR adds this check.

Depends on https://github.com/eclipse/omr/pull/3846