### PR TITLE
Create new protobuf message for resolved methods

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1595,7 +1595,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) j9method, vTableSlot, mirror, fe, trMemory);
 
          // Collect AOT stats
-         TR_ResolvedJ9Method *resolvedMethod = std::get<0>(methodInfo).remoteMirror;
+         TR_ResolvedJ9Method *resolvedMethod = methodInfo.remoteMirror;
 
          isRomClassForMethodInSC = TR::CompilationInfo::get(fe->_jitConfig)->isRomClassForMethodInSharedCache(j9method, fe->_jitConfig->javaVM);
 

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -99,29 +99,7 @@ private:
 
 using TR_FieldAttributesCache = PersistentUnorderedMap<int32_t, TR_J9MethodFieldAttributes>;
 
-struct
-TR_ResolvedJ9JITaaSServerMethodInfoStruct
-   {
-   TR_ResolvedJ9Method *remoteMirror;
-   J9RAMConstantPoolItem *literals;
-   J9Class *ramClass;
-   uint64_t methodIndex;
-   uintptrj_t jniProperties;
-   void *jniTargetAddress;
-   bool isInterpreted;
-   bool isJNINative;
-   bool isMethodInValidLibrary;
-   TR::RecognizedMethod mandatoryRm;
-   TR::RecognizedMethod rm;
-   void *startAddressForJittedMethod;
-   bool virtualMethodIsOverridden;
-   void *addressContainingIsOverriddenBit;
-   J9ClassLoader *classLoader;
-   };
-
-
-// The last 3 strings are serialized versions of jittedBodyInfo, persistentMethodInfo and TR_ContiguousIPMethodHashTableInfo
-using TR_ResolvedJ9JITaaSServerMethodInfo = std::tuple<TR_ResolvedJ9JITaaSServerMethodInfoStruct, std::string, std::string, std::string>;
+using TR_ResolvedJ9JITaaSServerMethodInfo = JITaaS::TR_ResolvedMethodInfoWrapper;
 
 struct
 TR_RemoteROMStringKey

--- a/runtime/compiler/rpc/ProtobufTypeConvert.hpp
+++ b/runtime/compiler/rpc/ProtobufTypeConvert.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <type_traits>
 #include "StreamTypes.hpp"
+#include "ProtobufWrappers.hpp"
 
 namespace JITaaS
    {
@@ -117,6 +118,22 @@ namespace JITaaS
          msg->set_bytes_v(strVal);
          }
       static inline Any::TypeCase typeCase() { return Any::kBytesV; }
+      };
+   // TR_ResolvedMethodInfoWrapper
+   template <> struct AnyPrimitive<const TR_ResolvedMethodInfoWrapper>
+      {
+      static inline TR_ResolvedMethodInfoWrapper read(const Any *msg)
+         {
+         const ResolvedMethodInfo &data = msg->method_info_v();
+         TR_ResolvedMethodInfoWrapper methodInfo(data);
+         return methodInfo;
+         }
+      static inline void write(Any *msg, const TR_ResolvedMethodInfoWrapper &val)
+         {
+         ResolvedMethodInfo *resolvedMsg = msg->mutable_method_info_v();
+         val.serialize(resolvedMsg);
+         }
+      static inline Any::TypeCase typeCase() { return Any::kMethodInfoV; }
       };
    // vector
    template <typename T> struct AnyPrimitive<T, typename std::enable_if<std::is_same<T, std::vector<typename T::value_type>>::value>::type>
@@ -227,6 +244,8 @@ namespace JITaaS
       {
       static_assert(!std::is_same<T, bool>::value, "ProtobufTypeConvert for vector of bools (non-contiguous in standard)");
       };
+
+   template <> struct ProtobufTypeConvert<TR_ResolvedMethodInfoWrapper> : PrimitiveTypeConvert<const TR_ResolvedMethodInfoWrapper> { };
 
 
    // setArgs fills out a protobuf AnyData message with values from a variadic argument list.

--- a/runtime/compiler/rpc/ProtobufWrappers.hpp
+++ b/runtime/compiler/rpc/ProtobufWrappers.hpp
@@ -1,0 +1,115 @@
+
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "rpc/gen/compile.pb.h"
+
+#ifndef PROTOBUF_WRAPPERS_H
+#define PROTOBUF_WRAPPERS_H
+
+#include "j9.h"
+#include "env/jittypes.h"
+#include "codegen/RecognizedMethods.hpp"
+
+
+using namespace google::protobuf;
+class TR_ResolvedJ9Method;
+
+namespace JITaaS
+{
+struct
+TR_ResolvedMethodInfoWrapper
+   {
+   TR_ResolvedMethodInfoWrapper()
+      {
+      }
+
+   TR_ResolvedMethodInfoWrapper(const ResolvedMethodInfo &serializedInfo)
+      {
+      deserialize(serializedInfo);
+      }
+
+   void deserialize(const ResolvedMethodInfo &serializedInfo)
+      {
+      remoteMirror = (TR_ResolvedJ9Method *) serializedInfo.remotemirror();
+      literals = (J9RAMConstantPoolItem *) serializedInfo.literals();
+      ramClass = (J9Class *) serializedInfo.ramclass();
+      methodIndex = serializedInfo.methodindex();
+      jniProperties = (uintptrj_t) serializedInfo.jniproperties();
+      jniTargetAddress = (void *) serializedInfo.jnitargetaddress();
+      isInterpreted = serializedInfo.isinterpreted();
+      isJNINative = serializedInfo.isjninative();
+      isMethodInValidLibrary = serializedInfo.ismethodinvalidlibrary();
+      mandatoryRm = (TR::RecognizedMethod) serializedInfo.mandatoryrm();
+      rm = (TR::RecognizedMethod) serializedInfo.rm();
+      startAddressForJittedMethod = (void *) serializedInfo.startaddressforjittedmethod();
+      virtualMethodIsOverridden = serializedInfo.virtualmethodisoverridden();
+      addressContainingIsOverriddenBit = (void *) serializedInfo.addresscontainingisoverriddenbit();
+      classLoader = (J9ClassLoader *) serializedInfo.classloader();
+      bodyInfoStr = serializedInfo.bodyinfostr();
+      methodInfoStr = serializedInfo.methodinfostr();
+      entryStr = serializedInfo.entrystr();
+      }
+
+   void serialize(ResolvedMethodInfo *serializedInfo) const
+      {
+      serializedInfo->set_remotemirror((uint64) remoteMirror);
+      serializedInfo->set_literals((uint64) literals);
+      serializedInfo->set_ramclass((uint64) ramClass);
+      serializedInfo->set_methodindex(methodIndex);
+      serializedInfo->set_jniproperties((uint64) jniProperties);
+      serializedInfo->set_jnitargetaddress((uint64) jniTargetAddress);
+      serializedInfo->set_isinterpreted(isInterpreted);
+      serializedInfo->set_isjninative(isJNINative);
+      serializedInfo->set_ismethodinvalidlibrary(isMethodInValidLibrary);
+      serializedInfo->set_mandatoryrm((int32) mandatoryRm);
+      serializedInfo->set_rm((int32) rm);
+      serializedInfo->set_startaddressforjittedmethod((uint64) startAddressForJittedMethod);
+      serializedInfo->set_virtualmethodisoverridden(virtualMethodIsOverridden);
+      serializedInfo->set_addresscontainingisoverriddenbit((uint64) addressContainingIsOverriddenBit);
+      serializedInfo->set_classloader((uint64) classLoader);
+      serializedInfo->set_bodyinfostr(bodyInfoStr);
+      serializedInfo->set_methodinfostr(methodInfoStr);
+      serializedInfo->set_entrystr(entryStr);
+      }
+
+   TR_ResolvedJ9Method *remoteMirror;
+   J9RAMConstantPoolItem *literals;
+   J9Class *ramClass;
+   uint64_t methodIndex;
+   uintptrj_t jniProperties;
+   void *jniTargetAddress;
+   bool isInterpreted;
+   bool isJNINative;
+   bool isMethodInValidLibrary;
+   TR::RecognizedMethod mandatoryRm;
+   TR::RecognizedMethod rm;
+   void *startAddressForJittedMethod;
+   bool virtualMethodIsOverridden;
+   void *addressContainingIsOverriddenBit;
+   J9ClassLoader *classLoader;
+   std::string bodyInfoStr;
+   std::string methodInfoStr;
+   std::string entryStr;
+   };
+}
+#endif // PROTOBUF_WRAPPERS_H

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -36,12 +36,35 @@ message Any
       bytes bytes_v = 6;
       bool bool_v = 7;
       AnyData vector_v = 8;
+      ResolvedMethodInfo method_info_v = 9;
       }
    }
 
 message AnyData
    {
    repeated Any data = 1;
+   }
+
+message ResolvedMethodInfo
+   {
+   uint64 remoteMirror = 1;
+   uint64 literals = 2;
+   uint64 ramClass = 3;
+   uint64 methodIndex = 4;
+   uint64 jniProperties = 5;
+   uint64 jniTargetAddress = 6;
+   bool isINterpreted = 7;
+   bool isJNINative = 8;
+   bool isMethodInValidLibrary = 9;
+   int32 mandatoryRm = 10;
+   int32 rm = 11;
+   uint64 startAddressForJittedMethod = 12;
+   bool virtualMethodIsOverridden = 13;
+   uint64 addressContainingIsOverriddenBit = 14;
+   uint64 classLoader = 15;
+   bytes bodyInfoStr = 16;
+   bytes methodInfoStr = 17;
+   bytes entryStr = 18;
    }
 
 enum J9ServerMessageType


### PR DESCRIPTION
One problem with how we process regular protobuf messages
is that we cannot send non-trivially copyable structs/classes
over protobuf, i.e. structs containing strings, vectors, maps.
This leads to awkward workarounds, such as putting all primitive
attributes in a struct, and then wrapping it in a tuple
with variable length attributes.
One way to overcome this limitation is by defining a new protobuf message
for a non-trivially copyable struct, then writing
serialization/deserialization code from/to JIT internal struct to/from class generated by protobuf.
This is what I've done for `TR_ResolvedJ9JITaaSServerMethodInfo`.

Another solution would be to not define a new protobuf message, and
instead write code to directly serialize/deserialize JIT internal struct
to/from an array of bytes.