### PR TITLE
Remove deprecated SSL_CTX_set_ecdh_auto calls

### DIFF
--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -62,12 +62,14 @@ void J9ClientStream::static_init(TR::PersistentInfo *info)
       exit(1);
       }
 
+#if OPENSSL_VERSION_NUMBER < 0x010100000L
    if (SSL_CTX_set_ecdh_auto(ctx, 1) != 1)
       {
       perror("failed to configure SSL ecdh");
       ERR_print_errors_fp(stderr);
       exit(1);
       }
+#endif
 
    auto &sslKeys = info->getJITaaSSslKeys();
    auto &sslCerts = info->getJITaaSSslCerts();

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -108,12 +108,14 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
 
    SSL_CTX_set_session_id_context(ctx, (const unsigned char*) "JITaaS", 6);
 
+#if OPENSSL_VERSION_NUMBER < 0x010100000L
    if (SSL_CTX_set_ecdh_auto(ctx, 1) != 1)
       {
       perror("failed to configure SSL ecdh");
       ERR_print_errors_fp(stderr);
       exit(1);
       }
+#endif
 
    auto &sslKeys = info->getJITaaSSslKeys();
    auto &sslCerts = info->getJITaaSSslCerts();


### PR DESCRIPTION
JITaaS clients and servers use this openssl api which has been deprecated

Issue: #5746
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>