### PR TITLE
Add caching for improper resolved methods

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -4407,8 +4407,13 @@ TR::CompilationInfoPerThreadRemote::getCachedResolvedMethod(TR_ResolvedMethodKey
       {
       auto comp = getCompilation();
       auto methodCacheEntry = it->second;
-      auto methodInfo = methodCacheEntry.methodInfo;
       TR_OpaqueMethodBlock *method = methodCacheEntry.method;
+      if (!method)
+         {
+         *resolvedMethod = NULL;
+         return true;
+         }
+      auto methodInfo = methodCacheEntry.methodInfo;
       uint32_t vTableSlot = methodCacheEntry.vTableSlot;
       // Create resolved method from cached method info
       if (key.type != TR_ResolvedMethodType::VirtualFromOffset)

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -153,7 +153,7 @@ namespace std
 // Since one cache contains different types of resolved methods, need to uniquely identify
 // each type. Apparently, the same cpIndex may refer to both virtual or special method,
 // for different method calls, so using TR_ResolvedMethodType is necessary.
-enum TR_ResolvedMethodType {VirtualFromCP, VirtualFromOffset, Interface, Static, Special};
+enum TR_ResolvedMethodType {VirtualFromCP, VirtualFromOffset, Interface, Static, Special, ImproperInterface};
 struct
 TR_ResolvedMethodKey
    {


### PR DESCRIPTION
Add caching for improper resolved methods for
getResolvedImproperInterfaceMethod function.

Resolves: #5582

Signed-off-by: Chris <zichun.chong@mail.utoronto.ca>