### PR TITLE
Update instructions for running Valhalla tests

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -39,14 +39,13 @@ import org.testng.annotations.BeforeClass;
  * 
  * 1) recompile the JVM with J9VM_OPT_VALHALLA_VALUE_TYPES flag turned on in j9cfg.h.ftl (or j9cfg.h.in when cmake is turned on)
  * 2) cd [openj9-openjdk-dir]/openj9/test/TestConfig
- * 3) export JAVA_BIN=[openj9-openjdk-dir]/build/linux-x86_64-normal-server-release/images/jdk/bin
- * 4) export PATH=$JAVA_BIN:$PATH
- * 5) export JDK_VERSION=Valhalla
- * 6) export SPEC=linux_x86-64_cmprssptrs
- * 7) export BUILD_LIST=functional/Valhalla
- * 8) export AUTO_DETECT=off
- * 9) export JDK_IMPL=openj9
- * 10) make -f run_configure.mk && make compile && make _sanity
+ * 3) export TEST_JDK_HOME=[openj9-openjdk-dir]/build/linux-x86_64-server-release/images/jdk
+ * 4) export JDK_VERSION=Valhalla
+ * 5) export SPEC=linux_x86-64_cmprssptrs
+ * 6) export BUILD_LIST=functional/Valhalla
+ * 7) export AUTO_DETECT=false
+ * 8) export JDK_IMPL=openj9 
+ * 9) make -f run_configure.mk && make compile && make _sanity
  */
 
 @Test(groups = { "level.sanity" })


### PR DESCRIPTION
Following changes are made to ValueTypeTests.java:
    -Define the TEST_JDK_HOME variable so that the user do not to enter it manually
    -Update the AUTO_DETECT from 'off' to 'false'

Changes are made to provide more accurate and easier test instructions for Value Type