### PR TITLE
(v0.14.2) Fix the duplicated NLS messages when SH_OSCache::getCacheDir() failed.

### DIFF
--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -178,11 +178,12 @@ SH_OSCache::removeCacheVersionAndGen(char* buffer, UDATA bufferSize, UDATA versi
  * @param [out] buffer  The buffer to write the result into
  * @param [in] bufferSize  The size of the buffer in bytes
  * @param [in] cacheType  The Type of cache
+ * @param [in] allowVerbose Whether to allow verbose message.
  *
  * @return 0 on success or -1 for failure  
  */
 IDATA
-SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType)
+SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType, bool allowVerbose)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	IDATA rc;
@@ -212,8 +213,10 @@ SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDA
 	rc = j9shmem_getDir(ctrlDirName, flags, buffer, bufferSize);
 
 	if (rc < 0) {
-		if (0 != vm->sharedCacheAPI->verboseFlags) {
-			switch(rc) {
+		if (allowVerbose
+			&& J9_ARE_ANY_BITS_SET(vm->sharedCacheAPI->verboseFlags, J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_DEFAULT | J9SHR_VERBOSEFLAG_ENABLE_VERBOSE)
+		) {
+		switch(rc) {
 			case J9PORT_ERROR_SHMEM_GET_DIR_BUF_OVERFLOW:
 				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_SHRC_GET_DIR_BUF_OVERFLOW);
 				break;

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -187,7 +187,7 @@ public:
 
 	static UDATA getRequiredConstrBytes(void);
 	
-	static IDATA getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType);
+	static IDATA getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType, bool allowVerbose = true);
 	
 	static IDATA createCacheDir(J9PortLibrary* portLibrary, char* cacheDirName, UDATA cacheDirPerm, bool cleanMemorySegments);
 

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -4908,7 +4908,8 @@ isFreeDiskSpaceLow(J9JavaVM *vm, U_64* maxsize)
 	bool ret = true;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	if (-1 == SH_OSCache::getCacheDir(vm, vm->sharedCacheAPI->ctrlDirName, cacheDirName, J9SH_MAXPATH, J9PORT_SHR_CACHE_TYPE_PERSISTENT)) {
+	if (-1 == j9shr_getCacheDir(vm, vm->sharedCacheAPI->ctrlDirName, cacheDirName, J9SH_MAXPATH, J9PORT_SHR_CACHE_TYPE_PERSISTENT)) {
+		/* use j9shr_getCacheDir() instead of SH_OSCache::getCacheDir() to avoid dupliated NLS message if SH_OSCache::getCacheDir() failed */
 		Trc_SHR_INIT_isFreeDiskSpaceLow_getDirFailed();
 		goto done;
 	}
@@ -5140,7 +5141,7 @@ j9shr_findGCHints(J9VMThread* currentThread, UDATA *heapSize1, UDATA *heapSize2)
 IDATA
 j9shr_getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType)
 {
-	return SH_OSCache::getCacheDir(vm, ctrlDirName, buffer, bufferSize, cacheType);
+	return SH_OSCache::getCacheDir(vm, ctrlDirName, buffer, bufferSize, cacheType, false);
 }
 
 } /* extern "C" */


### PR DESCRIPTION
Add a new input parameter "allowVerbose" to SH_OSCache::getCacheDir()
Always call SH_OSCache::getCacheDir() with allowVerbose = false in
j9shr_getCacheDir().

Port of #5263

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>