### PR TITLE
(v0.14.2-release) Add a VMLangAccess method to create threads

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -11,7 +11,7 @@ import sun.reflect.ConstantPool;
 
 
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,4 +155,18 @@ public interface VMLangAccess {
 	public void addPackageToList(Class<?> newClass, ClassLoader loader);
 	/*[ENDIF] Sidecar19-SE */
 
+	/**
+	 * Create a thread that it has runnable as its run object, has threadName as its name, has contextClassLoader as its context ClassLoader,
+	 * has an option to be part of system thread group, has an option to inherit ThreadLocals or not, and has an option to set isDaemon.
+	 * 
+	 * @param       runnable                A java.lang.Runnable whose method <code>run</code> will be executed by the new Thread
+	 * @param       threadName              Name for the Thread being created
+	 * @param       isSystemThreadGroup     A boolean indicating whether the thread to be created belongs to the system thread group
+	 * @param       inheritThreadLocals     A boolean indicating whether to inherit initial values for inheritable thread-local variables
+	 * @param       isDaemon                Indicates whether or not the Thread being created is a daemon thread
+	 * @param       contextClassLoader      The context ClassLoader
+	 * 
+	 * @return      A java.lang.Thread created
+	 */
+	public Thread createThread(Runnable runnable, String threadName, boolean isSystemThreadGroup, boolean inheritThreadLocals, boolean isDaemon, ClassLoader contextClassLoader);
 }

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -347,6 +347,12 @@ public Thread(ThreadGroup group, Runnable runnable, String threadName, long stac
  */
 public Thread(ThreadGroup group, Runnable runnable, String threadName) {
 	this(group, runnable, threadName, null, true);
+}
+
+Thread(Runnable runnable, String threadName, boolean isSystemThreadGroup, boolean inheritThreadLocals, boolean isDaemon, ClassLoader contextClassLoader) {
+	this(isSystemThreadGroup ? systemThreadGroup : null, runnable, threadName, null, inheritThreadLocals);
+	this.isDaemon = isDaemon;
+	this.contextClassLoader = contextClassLoader;
 }
 
 private Thread(ThreadGroup group, Runnable runnable, String threadName, AccessControlContext acc, boolean inheritThreadLocals) {

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -216,4 +216,8 @@ final class VMAccess implements VMLangAccess {
 	}
 	/*[ENDIF] Sidecar19-SE */
 
+	@Override
+	public Thread createThread(Runnable runnable, String threadName, boolean isSystemThreadGroup, boolean inheritThreadLocals, boolean isDaemon, ClassLoader contextClassLoader) {
+		return new Thread(runnable, threadName, isSystemThreadGroup, inheritThreadLocals, isDaemon, contextClassLoader);
+	}
 }


### PR DESCRIPTION
Add a `VMLangAccess` method to create threads

Added a package access method `java.lang.Thread:Thread(Runnable runnable, String threadName, boolean isSystemThreadGroup, boolean inheritThreadLocals, boolean isDaemon, ClassLoader contextClassLoader)` which allows callers outside of `java.lang` package to create threads with such options via `VMLangAccess` interface.
Specifically this supports `java.io.ClassCache` to create a thread that belongs to the system thread group, and not inherit `ThreadLocals`.

Back-ported from https://github.com/eclipse/openj9/pull/5778

Reviewer: @pshipton 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>