### PR TITLE
More runtime checks for compressed refs

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -59,11 +59,20 @@ J9::ObjectModel::initialize()
 
    uintptr_t value;
 
-   // Discontiguous arraylets
-   //
+   // Compressed refs
    uintptr_t result = mmf->j9gc_modron_getConfigurationValueForKey(vm,
                                                                    j9gc_modron_configuration_discontiguousArraylets,
                                                                    &value);
+   if (result == 1 && value == 1)
+      _compressObjectReferences = true;
+   else
+      _compressObjectReferences = false;
+
+   // Discontiguous arraylets
+   //
+   result = mmf->j9gc_modron_getConfigurationValueForKey(vm,
+                                                         j9gc_modron_configuration_discontiguousArraylets,
+                                                         &value);
    if (result == 1 && value == 1)
       {
       _usesDiscontiguousArraylets = true;

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -49,6 +49,7 @@ public:
 
    ObjectModel() :
       OMR::ObjectModelConnector(),
+      _compressObjectReferences(false),
       _usesDiscontiguousArraylets(false),
       _arrayLetLeafSize(0),
       _arrayLetLeafLogSize(0),
@@ -112,17 +113,23 @@ public:
    uintptrj_t offsetOfIndexableSizeField();
 
    /**
-   * @brief: Returns the read barrier type of VM's GC
+   * @brief Returns the read barrier type of VM's GC
    */
    MM_GCReadBarrierType  readBarrierType()  { return _readBarrierType;  }
 
    /**
-   * @brief: Returns the write barrier type of VM's GC
+   * @brief Returns the write barrier type of VM's GC
    */
    MM_GCWriteBarrierType writeBarrierType() { return _writeBarrierType; }
 
+   /**
+   * @brief Returns whether or not object references are compressed
+   */
+   bool compressObjectReferences() { return _compressObjectReferences; }
+
 private:
 
+   bool                  _compressObjectReferences;
    bool                  _usesDiscontiguousArraylets;
    int32_t               _arrayLetLeafSize;
    int32_t               _arrayLetLeafLogSize;

--- a/runtime/gc_base/modron.h
+++ b/runtime/gc_base/modron.h
@@ -107,8 +107,13 @@
 extern "C" mm_j9object_t j9gc_objaccess_pointerFromToken(J9VMThread *vmThread, fj9object_t token);
 extern "C" fj9object_t j9gc_objaccess_tokenFromPointer(J9VMThread *vmThread, mm_j9object_t object);
 
+#if defined (OMR_GC_FULL_POINTERS)
+#define mmPointerFromToken(vmThread, token) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? j9gc_objaccess_pointerFromToken((vmThread), (token)) : ((mm_j9object_t)(token)))
+#define mmTokenFromPointer(vmThread, token) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? j9gc_objaccess_tokenFromPointer((vmThread), (token)) : ((fj9object_t)(object)))
+#else /* defined (OMR_GC_FULL_POINTERS) */
 #define mmPointerFromToken(vmThread, token) (j9gc_objaccess_pointerFromToken((vmThread), (token) ))
 #define mmTokenFromPointer(vmThread, object) (j9gc_objaccess_tokenFromPointer((vmThread), (object) ))
+#endif /* defined (OMR_GC_FULL_POINTERS) */
 
 /* The size of the reserved area at the beginning of the compressed pointer heap */
 #define J9GC_COMPRESSED_POINTER_NULL_REGION_SIZE 4096

--- a/runtime/gc_include/j9modron.h
+++ b/runtime/gc_include/j9modron.h
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,6 +94,7 @@ typedef enum {
 	j9gc_modron_configuration_discontiguousArraylets,  /* a UDATA (TRUE or FALSE) representing whether or not discontiguousArraylets are enabled */
 	j9gc_modron_configuration_gcThreadCount,  /* a UDATA representing the MAX number of GC threads being used */
 	j9gc_modron_configuration_objectAlignment, /* a UDATA representing the alignment of the object in heap */
+	j9gc_modron_configuration_compressObjectReferences, /* a UDATA (TRUE or FALSE) representing whether or not object references are compressed */
 	/* Add new values before this comment */
 	j9gc_modron_configuration_count /* Total number of known configuration keys */
 } J9GCConfigurationKey;

--- a/runtime/gc_modron_startup/mmhelpers.cpp
+++ b/runtime/gc_modron_startup/mmhelpers.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -315,10 +315,14 @@ j9gc_modron_getConfigurationValueForKey(J9JavaVM *javaVM, UDATA key, void *value
 #endif /* J9VM_GC_HYBRID_ARRAYLETS */
 		break;
 	case j9gc_modron_configuration_gcThreadCount:
-		*((UDATA *)value) =  extensions->gcThreadCount;
+		*((UDATA *)value) = extensions->gcThreadCount;
 		keyFound = TRUE;
 		break;
-
+	case j9gc_modron_configuration_compressObjectReferences:
+		*((UDATA *)value) = extensions->compressObjectReferences();
+		keyFound = TRUE;
+		break;
+		
 	default:
 		/* key is either invalid or unknown for this configuration - should not have been requested */
 		Assert_MM_unreachable();

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -71,6 +71,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 	const char *j2se_version_info = NULL;
 	const char *jitEnabled = "";
 	const char *aotEnabled = "";
+	const char *memInfo = NULL;
 #define BUFFER_SIZE 512
 
 	/* The actual allowed BUFFER_SIZE is 512, the extra 1 char is added to check for overflow */
@@ -131,16 +132,12 @@ jint computeFullVersionString(J9JavaVM* vm)
 	osarch = j9sysinfo_get_CPU_architecture();
 
 #ifdef J9VM_ENV_DATA64
-	#ifdef OMR_GC_COMPRESSED_POINTERS
-		#define MEM_INFO "-64-Bit Compressed References "
-	#else
-		#define MEM_INFO "-64-Bit "
-	#endif
+	memInfo = J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? "64-Bit Compressed References": "64-Bit";
 #else
 	#if defined(J9ZOS390) || defined(S390)
-		#define MEM_INFO "-31-Bit "
+		memInfo = "31-Bit";
 	#else
-		#define MEM_INFO "-32-Bit "
+		memInfo = "32-Bit";
 	#endif
 #endif
 
@@ -163,10 +160,11 @@ jint computeFullVersionString(J9JavaVM* vm)
 #endif /* VENDOR_SHORT_NAME && VENDOR_SHA */
 
 	if (BUFFER_SIZE <= j9str_printf(PORTLIB, vminfo, BUFFER_SIZE + 1,
-			"JRE %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
+			"JRE %s %s %s-%s %s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
 			j2se_version_info,
 			(NULL != osname ? osname : " "),
 			osarch,
+			memInfo,
 			EsBuildVersionString,
 			jitEnabled,
 			aotEnabled)) {

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -108,17 +108,14 @@ cacheObjectMonitorForLookup(J9JavaVM* vm, J9VMThread* vmStruct, J9ObjectMonitor*
  * @return an initialized J9HashTable on success, otherwise NULL
  */
 static J9HashTable*
-createMonitorTable(J9JavaVM *vm, char *tableName) {
-
-#if defined(OMR_GC_COMPRESSED_POINTERS)
-#define MONTABLE_FLAGS J9HASH_TABLE_ALLOCATE_ELEMENTS_USING_MALLOC32
-#else
-#define MONTABLE_FLAGS 0
-#endif
-
+createMonitorTable(J9JavaVM *vm, char *tableName)
+{
+	U_32 flags = 0;
+	if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+		flags = J9HASH_TABLE_ALLOCATE_ELEMENTS_USING_MALLOC32;
+	}
 	Assert_VM_false(NULL == tableName);
-	return hashTableNew(OMRPORT_FROM_J9PORT(vm->portLibrary), tableName, 64, sizeof(J9ObjectMonitor), 0, MONTABLE_FLAGS, OMRMEM_CATEGORY_VM, hashMonitorHash, hashMonitorCompare, NULL, vm);
-#undef MONTABLE_FLAGS
+	return hashTableNew(OMRPORT_FROM_J9PORT(vm->portLibrary), tableName, 64, sizeof(J9ObjectMonitor), 0, flags, OMRMEM_CATEGORY_VM, hashMonitorHash, hashMonitorCompare, NULL, vm);
 }
 
 UDATA

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -58,7 +58,7 @@ void J9RASInitialize (J9JavaVM* javaVM);
 void J9RASShutdown (J9JavaVM* javaVM);
 void J9RASCheckDump(J9JavaVM* javaVM);
 void populateRASNetData (J9JavaVM *javaVM, J9RAS *rasStruct);
-static J9RAS* allocateRASStruct(J9PortLibrary* portLib);
+static J9RAS* allocateRASStruct(J9JavaVM *javaVM);
 
 JNIEXPORT struct {
 	union {
@@ -294,7 +294,7 @@ J9RASInitialize(J9JavaVM* javaVM)
 	const char *osarch = j9sysinfo_get_CPU_architecture();
 	const char *osname = j9sysinfo_get_OS_type();
 	const char *osversion = j9sysinfo_get_OS_version();
-	J9RAS *rasStruct = allocateRASStruct(PORTLIB);
+	J9RAS *rasStruct = allocateRASStruct(javaVM);
 
 	memset(rasStruct, 0, sizeof(J9RAS));
 	strcpy((char*)rasStruct->eyecatcher, "J9VMRAS");
@@ -435,7 +435,7 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 #endif
 
 static J9RAS*
-allocateRASStruct(J9PortLibrary* portLib)
+allocateRASStruct(J9JavaVM *javaVM)
 {
 	J9RAS* candidate = (J9RAS*)GLOBAL_DATA(_j9ras_);
 	/*
@@ -450,45 +450,46 @@ allocateRASStruct(J9PortLibrary* portLib)
 	 * Compressed references: the RAS data is relocated to the JVM suballocator once the latter is created.
 	 */
 #if !defined(USE_STATIC_RAS_STRUCT) && !defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR)
+	if (!J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
+		/* if not z/OS or AIX32 */
 
-	/* if not z/OS or AIX32 */
+		J9PortVmemParams params;
+		J9PortVmemIdentifier identifier;
+		J9AllocatedRAS* result = NULL;
+		UDATA pageSize;
+		UDATA roundedSize;
 
-	J9PortVmemParams params;
-	J9PortVmemIdentifier identifier;
-	J9AllocatedRAS* result = NULL;
-	UDATA pageSize;
-	UDATA roundedSize;
+		PORT_ACCESS_FROM_JAVAVM(javaVM);
 
-	PORT_ACCESS_FROM_PORT(portLib);
-
-	pageSize = j9vmem_supported_page_sizes()[0];
-	if (0 == pageSize) { /* problems in the port library */
-		return candidate;
-	}
-	j9vmem_vmem_params_init(&params);
+		pageSize = j9vmem_supported_page_sizes()[0];
+		if (0 == pageSize) { /* problems in the port library */
+			return candidate;
+		}
+		j9vmem_vmem_params_init(&params);
 #if defined (AIXPPC)
-	/* the low 768MB is out of bounds on AIX. Don't even bother trying */
-	params.startAddress = (void *)0x30000000;
+		/* the low 768MB is out of bounds on AIX. Don't even bother trying */
+		params.startAddress = (void *)0x30000000;
 #else /* defined (AIXPPC) */
-	params.startAddress = (void *)pageSize;
+		params.startAddress = (void *)pageSize;
 #endif /* defined (AIXPPC) */
-	params.endAddress = OMR_MIN((void *) candidate, (void *) (UDATA) 0xffffffff); /* don't bother allocating after the static */
-	params.byteAmount = sizeof(J9AllocatedRAS);
-	params.pageSize = pageSize;
-	/* round up byteAmount to pageSize */
-	roundedSize = params.byteAmount + params.pageSize - 1;
-	params.byteAmount = roundedSize - (roundedSize % params.pageSize);
-	params.mode = J9PORT_VMEM_MEMORY_MODE_READ | J9PORT_VMEM_MEMORY_MODE_WRITE | J9PORT_VMEM_MEMORY_MODE_COMMIT;
-	params.options = J9PORT_VMEM_ALLOC_DIR_BOTTOM_UP;
+		params.endAddress = OMR_MIN((void *) candidate, (void *) (UDATA) 0xffffffff); /* don't bother allocating after the static */
+		params.byteAmount = sizeof(J9AllocatedRAS);
+		params.pageSize = pageSize;
+		/* round up byteAmount to pageSize */
+		roundedSize = params.byteAmount + params.pageSize - 1;
+		params.byteAmount = roundedSize - (roundedSize % params.pageSize);
+		params.mode = J9PORT_VMEM_MEMORY_MODE_READ | J9PORT_VMEM_MEMORY_MODE_WRITE | J9PORT_VMEM_MEMORY_MODE_COMMIT;
+		params.options = J9PORT_VMEM_ALLOC_DIR_BOTTOM_UP;
 #if defined(J9ZTPF)
-	params.options |= J9PORT_VMEM_ZTPF_USE_31BIT_MALLOC;
+		params.options |= J9PORT_VMEM_ZTPF_USE_31BIT_MALLOC;
 #endif
-	params.category = OMRMEM_CATEGORY_VM;
+		params.category = OMRMEM_CATEGORY_VM;
 
-	result = j9vmem_reserve_memory_ex(&identifier, &params);
-	if (NULL != result) {
-		memcpy(&result->vmemid, &identifier, sizeof(identifier));
-		candidate = &result->ras;
+		result = j9vmem_reserve_memory_ex(&identifier, &params);
+		if (NULL != result) {
+			memcpy(&result->vmemid, &identifier, sizeof(identifier));
+			candidate = &result->ras;
+		}
 	}
 #endif /* !defined(USE_STATIC_RAS_STRUCT) && !defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR) */
 	return candidate;
@@ -497,28 +498,32 @@ allocateRASStruct(J9PortLibrary* portLib)
 void J9RelocateRASData(J9JavaVM* javaVM) {
 	/* See comments for allocateRASStruct concerning compressed references and z/OS */
 #if !defined(USE_STATIC_RAS_STRUCT) && defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR)
-	PORT_ACCESS_FROM_JAVAVM(javaVM);
-	J9RAS * result = j9mem_allocate_memory32(sizeof(J9RAS), OMRMEM_CATEGORY_VM);
+	if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
+		PORT_ACCESS_FROM_JAVAVM(javaVM);
+		J9RAS * result = j9mem_allocate_memory32(sizeof(J9RAS), OMRMEM_CATEGORY_VM);
 
-	if (NULL != result) {
-		memcpy(result, (J9RAS*)GLOBAL_DATA(_j9ras_), sizeof(J9RAS));
-		javaVM->j9ras = result;
-		memset((J9RAS*)GLOBAL_DATA(_j9ras_), 0, sizeof(J9RAS));
+		if (NULL != result) {
+			memcpy(result, (J9RAS*)GLOBAL_DATA(_j9ras_), sizeof(J9RAS));
+			javaVM->j9ras = result;
+			memset((J9RAS*)GLOBAL_DATA(_j9ras_), 0, sizeof(J9RAS));
+		}
 	}
 #endif /* defined(USE_STATIC_RAS_STRUCT) && defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR) */
 	return;
 }
 
 static void
-freeRASStruct(J9PortLibrary* portLib, J9RAS* rasStruct)
+freeRASStruct(J9JavaVM *javaVM, J9RAS* rasStruct)
 {
 #if !defined(USE_STATIC_RAS_STRUCT)
 	if (rasStruct != GLOBAL_DATA(_j9ras_)) { /* dynamic allocation may have failed */
-		PORT_ACCESS_FROM_PORT(portLib);
+		PORT_ACCESS_FROM_JAVAVM(javaVM);
 
 #if defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR) /* memory was allocated using j9vmem_reserve_memory_ex */
-		j9mem_free_memory32(rasStruct);
-#else
+		if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
+			j9mem_free_memory32(rasStruct);
+		} else
+#endif /* defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR) */
 		{
 			J9AllocatedRAS* allocatedStruct = (J9AllocatedRAS*)rasStruct;
 			J9PortVmemIdentifier identifier;
@@ -532,7 +537,6 @@ freeRASStruct(J9PortLibrary* portLib, J9RAS* rasStruct)
 			memcpy(&identifier, &allocatedStruct->vmemid, sizeof(identifier));
 			j9vmem_free_memory(allocatedStruct, sizeof(J9AllocatedRAS), &identifier);
 		}
-#endif /* defined(ALLOCATE_RAS_DATA_IN_SUBALLOCATOR) */
 	}
 #endif /* defined(USE_STATIC_RAS_STRUCT) */
 }
@@ -563,7 +567,7 @@ J9RASShutdown(J9JavaVM *javaVM)
 		j9mem_free_memory(systemInfo);
 	}
 
-	freeRASStruct(PORTLIB, javaVM->j9ras);
+	freeRASStruct(javaVM, javaVM->j9ras);
 	javaVM->j9ras = NULL;
 }
 

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -130,11 +130,11 @@ void freeMemorySegment(J9JavaVM *javaVM, J9MemorySegment *segment, BOOLEAN freeD
 		} else if ((useAdvise) && (MEMORY_TYPE_JIT_SCRATCH_SPACE & segment->type)) {
 			j9mem_advise_and_free_memory(segment->baseAddress);
 		} else if (segment->type & (MEMORY_TYPE_RAM_CLASS | MEMORY_TYPE_UNDEAD_CLASS)) {
-#ifdef OMR_GC_COMPRESSED_POINTERS
-			j9mem_free_memory32(segment->baseAddress);
-#else /* OMR_GC_COMPRESSED_POINTERS */
-			j9mem_free_memory(segment->baseAddress);
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+			if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+				j9mem_free_memory32(segment->baseAddress);
+			} else {
+				j9mem_free_memory(segment->baseAddress);
+			}
 		} else {
 			j9mem_free_memory(segment->baseAddress);
 		}
@@ -229,11 +229,11 @@ allocateMemoryForSegment(J9JavaVM *javaVM,J9MemorySegment *segment, J9PortVmemPa
 		tmpAddr = j9vmem_reserve_memory_ex(&segment->vmemIdentifier, vmemParams);
 		Trc_VM_virtualRAMClassAlloc(tmpAddr);
 	} else if (J9_ARE_ALL_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS)) {
-#ifdef OMR_GC_COMPRESSED_POINTERS
-		tmpAddr = j9mem_allocate_memory32(segment->size, memoryCategory);
-#else /* OMR_GC_COMPRESSED_POINTERS */
-		tmpAddr = j9mem_allocate_memory(segment->size, memoryCategory);
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+		if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+			tmpAddr = j9mem_allocate_memory32(segment->size, memoryCategory);
+		} else {
+			tmpAddr = j9mem_allocate_memory(segment->size, memoryCategory);
+		}
 	} else {
 		tmpAddr = j9mem_allocate_memory(segment->size, memoryCategory);
 	}

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -100,15 +100,11 @@ void freeVMThread(J9JavaVM *vm, J9VMThread *vmThread)
 		j9mem_free_memory(vmThread->riParameters);
 	}
 #endif /* defined(J9VM_PORT_RUNTIME_INSTRUMENTATION) */
-#if defined(OMR_GC_COMPRESSED_POINTERS)
 	if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
 		j9mem_free_memory32(vmThread->startOfMemoryBlock);
-	}
-#else
-	{
+	} else {
 		j9mem_free_memory(vmThread->startOfMemoryBlock);
 	}
-#endif
 }
 
 void terminateVMThreading(J9JavaVM *vm)


### PR DESCRIPTION
Update some more places in the VM with runtime checks for compressed
mode.

Add a GC configuration query for compressed refs. Add a runtime query
for the JIT in J9ObjectModel.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>