### PR TITLE
Configure Jenkins scm to pull based on params

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -183,6 +183,8 @@ def cancel_running_builds(JOB_NAME, BUILD_IDENTIFIER) {
 
 def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SETUP_LABEL, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, CUSTOM_DESCRIPTION, ghprbPullId, ghprbCommentBody, ghprbTargetBranch) {
     stage ("${BUILD_JOB_NAME}") {
+        SCM_BRANCH = (ghprbPullId) ? "origin/pr/${ghprbPullId}/merge" : 'refs/heads/master'
+        SCM_REFSPEC = (ghprbPullId) ? "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge" : ''
         return build_with_slack(BUILD_JOB_NAME, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER,
             [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
             string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH),
@@ -208,7 +210,9 @@ def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO
             string(name: 'ghprbPullId', value: ghprbPullId),
             string(name: 'ghprbGhRepository', value: ghprbGhRepository),
             string(name: 'ghprbCommentBody', value: ghprbCommentBody),
-            string(name: 'ghprbTargetBranch', value: ghprbTargetBranch)])
+            string(name: 'ghprbTargetBranch', value: ghprbTargetBranch),
+            string(name: 'SCM_BRANCH', value: SCM_BRANCH),
+            string(name: 'SCM_REFSPEC', value: SCM_REFSPEC)])
     }
 }
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -291,6 +291,8 @@ try {
 
 def build(JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, AUTOMATIC_GENERATION, CUSTOM_DESCRIPTION) {
     stage ("${JOB_NAME}") {
+        SCM_BRANCH = (ghprbPullId) ? "origin/pr/${ghprbPullId}/merge" : 'refs/heads/master'
+        SCM_REFSPEC = (ghprbPullId) ? "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge" : ''
         JOB = build job: JOB_NAME,
                 parameters: [
                     string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
@@ -328,7 +330,9 @@ def build(JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRAN
                     string(name: 'ghprbGhRepository', value: ghprbGhRepository),
                     string(name: 'ghprbCommentBody', value: ghprbCommentBody),
                     string(name: 'ghprbTargetBranch', value: ghprbTargetBranch),
-                    string(name: 'ghprbActualCommit', value: ghprbActualCommit)]
+                    string(name: 'ghprbActualCommit', value: ghprbActualCommit),
+                    string(name: 'SCM_BRANCH', value: SCM_BRANCH),
+                    string(name: 'SCM_REFSPEC', value: SCM_REFSPEC)]
         return JOB
     }
 }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -27,10 +27,9 @@ if (!binding.hasVariable('VENDOR_REPO_DEFAULT')) VENDOR_REPO_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_BRANCH_DEFAULT')) VENDOR_BRANCH_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID_DEFAULT = ''
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
-if (!binding.hasVariable('GIT_URI')) GIT_URI = 'https://github.com/eclipse/openj9.git'
-if (!binding.hasVariable('SOURCE_BRANCH')) SOURCE_BRANCH = 'refs/heads/master'
-if (!binding.hasVariable('GIT_REFSPEC')) GIT_REFSPEC = ''
-if (!binding.hasVariable('LIGHTWEIGHT_CHECKOUT')) LIGHTWEIGHT_CHECKOUT = true
+if (!binding.hasVariable('SCM_URL')) SCM_URL = 'https://github.com/eclipse/openj9.git'
+if (!binding.hasVariable('SCM_BRANCH')) SCM_BRANCH = 'refs/heads/master'
+if (!binding.hasVariable('LIGHTWEIGHT_CHECKOUT')) LIGHTWEIGHT_CHECKOUT = false
 
 if (jobType == 'build') {
     pipelineScript = 'buildenv/jenkins/jobs/builds/Build-Test-Any-Platform'
@@ -47,10 +46,10 @@ pipelineJob("$JOB_NAME") {
             scm {
                 git {
                     remote {
-                        url(GIT_URI)
-                        refspec(GIT_REFSPEC)
+                        url(SCM_URL)
+                        refspec('$SCM_REFSPEC')
                     }
-                    branch("${SOURCE_BRANCH}")
+                    branch('$SCM_BRANCH')
                     extensions {
                         cleanBeforeCheckout()
                     }
@@ -94,6 +93,8 @@ pipelineJob("$JOB_NAME") {
         stringParam('OPENJDK_CLONE_DIR')
         stringParam('PERSONAL_BUILD')
         stringParam('CUSTOM_DESCRIPTION')
+        stringParam('SCM_BRANCH', SCM_BRANCH)
+        stringParam('SCM_REFSPEC')
 
         if (jobType == 'pipeline'){
             stringParam('TESTS_TARGETS')


### PR DESCRIPTION
- Add params SCM_BRANCH and SCM_REFSPEC to the pipeline and build jobs.
- Set default SCM_BRANCH to refs/heads/master.
- Set default SCM_REFSPEC to blank.
- Set LIGHTWEIGHT_CHECKOUT to false in order to allow non-default refspecs
- Allows PR builds to pass non-default values in order to clone
  pipeline materials directly from the PR merge ref.

[skip ci]
Fixes #4443

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>