### PR TITLE
Check and use openssl flags set in JVM build

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -489,3 +489,30 @@ PROTO_CMD?=protoc
 SOLINK_SLINK+=protobuf ssl
 
 CXX_DEFINES+=GOOGLE_PROTOBUF_NO_RTTI
+
+ifneq ($(OPENSSL_CFLAGS),)
+    ADD_OPENSSL_CFLAGS=false
+    # --with-openssl=system, OPENSSL_LIBS looks like "-L/path/to/system/openssllib -lssl -lcrypto"
+    ifneq ($(OPENSSL_LIBS),)
+        SOLINK_LIBPATH+=$(subst -L,,$(firstword $(OPENSSL_LIBS)))
+        ADD_OPENSSL_CFLAGS=true
+    else
+        # --with-openssl=fetched --enable-openssl-bundling
+        ifneq ($(OPENSSL_BUNDLE_LIB_PATH),)
+            SOLINK_LIBPATH+=$(OPENSSL_BUNDLE_LIB_PATH)
+            SOLINK_FLAGS+=-Wl,-rpath,\$$ORIGIN/..
+            ADD_OPENSSL_CFLAGS=true
+        else
+	    # --with-openssl=fetched only
+            ifneq ($(OPENSSL_DIR),)
+                SOLINK_LIBPATH+=$(OPENSSL_DIR)
+                ADD_OPENSSL_CFLAGS=true
+            endif
+        endif
+    endif
+
+    ifeq (true, $(ADD_OPENSSL_CFLAGS))
+        C_INCLUDES+=$(subst -I,,$(OPENSSL_CFLAGS))
+        CXX_INCLUDES+=$(subst -I,,$(OPENSSL_CFLAGS))
+    endif
+endif


### PR DESCRIPTION
[skip ci]
OpenJ9 build supports `--with-openssl=` flag which sets up
openssl include path and library. JITaaS is built by searching
the default places. This change checks and uses
`OPENSSL_DIR`, `OPENSSL_CFLAGS`, `OPENSSL_LIBS`, and
`OPENSSL_BUNDLE_LIB_PATH`, if they are exported in
`CUSTOM_COMPILER_ENV_VARS`.

   - If `--with-openssl=system` is set, JIT will link to OpenSSL lib
     specified by `OPENSSL_LIBS`
   - If `--with-openssl=fetched --enable-openssl-bundling` is set,
     JIT will link to OpenSSL lib specified by `OPENSSL_BUNDLE_LIB_PATH`
   - If `--with-openssl=fetched` is set,  JIT will link to OpenSSL lib
     specified by `OPENSSL_DIR`

Issue #5720

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>