### PR TITLE
Relocate the CodeGenerator::createOrFindClonedNode function from OMR

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -39,6 +39,7 @@ namespace J9 { typedef J9::CodeGenerator CodeGeneratorConnector; }
 #include "env/IO.hpp"
 #include "env/jittypes.h"
 #include "infra/List.hpp"
+#include "infra/HashTab.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
@@ -152,6 +153,7 @@ public:
    bool needRelocationsForStatics();
 
    // ----------------------------------------
+   TR::Node *createOrFindClonedNode(TR::Node *node, int32_t numChildren);
 
    void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction);
 
@@ -267,6 +269,8 @@ public:
    TR_BitVector *setLiveMonitors(TR_BitVector *v) {return (_liveMonitors = v);}
 
 private:
+
+   TR_HashTabInt _uncommonedNodes;               // uncommoned nodes keyed by the original nodes
 
    uint16_t changeParmLoadsToRegLoads(TR::Node*node, TR::Node **regLoads, TR_BitVector *globalRegsWithRegLoad, TR_BitVector &killedParms, vcount_t visitCount); // returns number of RegLoad nodes created
 


### PR DESCRIPTION
`TR::Node *createOrFindClonedNode` function in `OMR::CodeGenerator` has only relevance to the OpenJ9 project. Therefore, remove it from OMR and relocate it to the `J9::CodeGenerator` instead. In addition, fix the spelling mistake on `_uncommonedNodes` and relocate it from OMR to J9.

Issue: eclipse/omr#2068
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>