### PR TITLE
Pass reportByteCodeInfoAtCatchBlock to the server

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7676,7 +7676,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          if (that->_methodBeingCompiled->_clientOptions != NULL)
             {
             TR_ASSERT(that->_methodBeingCompiled->isOutOfProcessCompReq(), "Options are already provided only for JITaaS server");
-            options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, that, p->trMemory());
+            options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, that, vm, p->trMemory());
             options->setLogFileForClientOptions();
             }
          else

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2860,7 +2860,7 @@ J9::Options::packOptions(TR::Options *origOptions)
    }
 
 TR::Options *
-J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_Memory *trMemory)
+J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_J9VMBase *fe, TR_Memory *trMemory)
    {
    TR::Options *options = (TR::Options *)trMemory->allocateHeapMemory(clientOptionsSize);
    memcpy(options, clientOptions, clientOptionsSize);
@@ -2882,6 +2882,8 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::Co
    // On JITaaS server, we store this value for each client in ClientSessionData
    bool rtResolve = (bool) *((uint8_t *) options + clientOptionsSize - sizeof(bool));
    compInfoPT->getClientData()->setRtResolve(rtResolve);
+
+   _reportByteCodeInfoAtCatchBlock = fe->getReportByteCodeInfoAtCatchBlock();
 
    unpackRegex(options->_disabledOptTransformations);
    unpackRegex(options->_disabledInlineSites);

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -337,7 +337,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static const size_t FILENAME_MAX_SIZE = 1025;
    static std::string packOptions(TR::Options *origOptions);
-   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_Memory *trMemory);
+   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_J9VMBase *fe, TR_Memory *trMemory);
    static uint8_t *appendContent(char * &charPtr, uint8_t * curPos, size_t length);
    static std::string packLogFile(TR::FILE *fp);
    void setLogFileForClientOptions(int doubleCompile = 0);

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -440,6 +440,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._stringCompressionEnabled = fe->isStringCompressionEnabledVM();
          vmInfo._hasSharedClassCache = TR::Options::sharedClassCache();
          vmInfo._elgibleForPersistIprofileInfo = vmInfo._isIProfilerEnabled ? fe->getIProfiler()->elgibleForPersistIprofileInfo(comp) : NULL;
+         vmInfo._reportByteCodeInfoAtCatchBlock = comp->getOptions()->getReportByteCodeInfoAtCatchBlock();
          for (int32_t i = 0; i <= 7; i++)
             {
             vmInfo._arrayTypeClasses[i] = fe->getClassFromNewArrayTypeNonNull(i + 4);

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -136,6 +136,7 @@ class ClientSessionData
       bool _hasSharedClassCache;
       bool _elgibleForPersistIprofileInfo;
       TR_OpaqueClassBlock *_arrayTypeClasses[8];
+      bool _reportByteCodeInfoAtCatchBlock;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6073,6 +6073,12 @@ TR_J9VMBase::getClassFromNewArrayTypeNonNull(int32_t arrayType)
    return clazz;
    }
 
+bool
+TR_J9VMBase::getReportByteCodeInfoAtCatchBlock()
+   {
+   return _compInfoPT->getCompilation()->getOptions()->getReportByteCodeInfoAtCatchBlock();
+   }
+
 /////////////////////////////////////////////////////
 // TR_J9VM
 /////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -938,6 +938,7 @@ public:
    virtual int64_t getCpuTimeSpentInCompThread(TR::Compilation * comp); // resolution is 0.5 sec or worse. Returns -1 if unavailable
 
    virtual void *             getClassLoader(TR_OpaqueClassBlock * classPointer);
+   virtual bool getReportByteCodeInfoAtCatchBlock();
 
    J9VMThread *            _vmThread;
    J9PortLibrary *         _portLibrary;

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1516,6 +1516,13 @@ TR_J9ServerVM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    }
 
 bool
+TR_J9ServerVM::getReportByteCodeInfoAtCatchBlock()
+   {
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   return _compInfoPT->getClientData()->getOrCacheVMInfo(stream)->_reportByteCodeInfoAtCatchBlock;
+   }
+
+bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
    TR_ASSERT(vettedForAOT, "The TR_J9SharedCacheServerVM version of this method is expected to be called only from isClassLibraryMethod.\n"

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -172,6 +172,7 @@ public:
    virtual bool isStringCompressionEnabledVM() override;
    virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp) override;
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
+   virtual bool getReportByteCodeInfoAtCatchBlock() override;
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);


### PR DESCRIPTION
This option is a static variable and thus it is not
serialized in `J9::Options::packOptions`.
Since it is VM global, can add it to `VMInfo` and fetch
it with the rest of that struct.
This fixes a crash in `cmdLineTester_decompilationTests_1`.