### PR TITLE
Remove "// *this swipeable for debug" comments

### DIFF
--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -324,7 +324,6 @@ uint32_t TR::ARMCallSnippet::getLength(int32_t estimatedSnippetStart)
 
 uint8_t *TR::ARMUnresolvedCallSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg()->fe());
    uint8_t *cursor = TR::ARMCallSnippet::emitSnippetBody();
 
@@ -388,13 +387,11 @@ uint8_t *TR::ARMUnresolvedCallSnippet::emitSnippetBody()
 
 uint32_t TR::ARMUnresolvedCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this   swipeable for debugger
    return TR::ARMCallSnippet::getLength(estimatedSnippetStart) + 8;
    }
 
 uint8_t *TR::ARMVirtualUnresolvedSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t            *cursor = cg()->getBinaryBufferCursor();
    TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
    TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMvirtualUnresolvedHelper, false, false, false);
@@ -439,7 +436,6 @@ uint32_t TR::ARMVirtualUnresolvedSnippet::getLength(int32_t estimatedSnippetStar
 
 uint8_t *TR::ARMInterfaceCallSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t            *cursor = cg()->getBinaryBufferCursor();
    TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
    TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMinterfaceCallHelper, false, false, false);

--- a/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,6 @@ J9::ARM::UnresolvedDataSnippet::getHelper()
 uint8_t *
 J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t            *cursor = cg()->getBinaryBufferCursor();
 
    getSnippetLabel()->setCodeLocation(cursor);
@@ -126,7 +125,6 @@ J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
 uint32_t
 J9::ARM::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this   swipeable for debugger
    return 6 * 4;
    }
 

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -336,7 +336,6 @@ TR_RuntimeHelper TR::PPCCallSnippet::getInterpretedDispatchHelper(
 uint8_t *TR::PPCCallSnippet::emitSnippetBody()
    {
 
-   // *this   swipeable for debugger
    uint8_t       *cursor = cg()->getBinaryBufferCursor();
    TR::Node       *callNode = getNode();
    TR::SymbolReference *methodSymRef = (_realMethodSymbolReference)?_realMethodSymbolReference:callNode->getSymbolReference();
@@ -448,7 +447,6 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
 uint32_t TR::PPCCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
    TR::Compilation* comp = cg()->comp();
-   // *this   swipeable for debugger
    return((instructionCountForArguments(getNode(), cg())*4) + 2*TR::Compiler->om.sizeofReferenceAddress() + 8);
    }
 
@@ -456,7 +454,6 @@ uint8_t *TR::PPCUnresolvedCallSnippet::emitSnippetBody()
    {
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
-   // *this   swipeable for debugger
    uint8_t *cursor = TR::PPCCallSnippet::emitSnippetBody();
 
    TR::SymbolReference *methodSymRef = (_realMethodSymbolReference)?_realMethodSymbolReference:getNode()->getSymbolReference();
@@ -519,13 +516,11 @@ uint8_t *TR::PPCUnresolvedCallSnippet::emitSnippetBody()
 uint32_t TR::PPCUnresolvedCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
    TR::Compilation* comp = cg()->comp();
-   // *this   swipeable for debugger
    return TR::PPCCallSnippet::getLength(estimatedSnippetStart) + 8 + TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint8_t *TR::PPCVirtualSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    return(NULL);
    }
 
@@ -536,7 +531,6 @@ uint32_t TR::PPCVirtualSnippet::getLength(int32_t estimatedSnippetStart)
 
 uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t       *cursor = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
@@ -654,7 +648,6 @@ uint32_t TR::PPCVirtualUnresolvedSnippet::getLength(int32_t estimatedSnippetStar
 
 uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t       *cursor = cg()->getBinaryBufferCursor();
    uint8_t       *blAddress;
    TR::Node       *callNode = getNode();
@@ -831,7 +824,6 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
 
 uint32_t TR::PPCInterfaceCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this   swipeable for debugger
    /*
     * 4 = Code alignment may add 4 to the length. To be conservative it is always part of the estimate.
     * 8 = Two instructions. One bl and one b instruction.
@@ -1439,7 +1431,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCCallSnippet * snippet)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCUnresolvedCallSnippet * snippet)
    {
-   // *this   swipeable for debugger
    uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation() + snippet->getLength(0) - (8+sizeof(intptrj_t));
 
    TR::SymbolReference *methodSymRef = snippet->getNode()->getSymbolReference();
@@ -1485,13 +1476,11 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCUnresolvedCallSnippet * snippet)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCVirtualSnippet * snippet)
    {
-   // *this   swipeable for debugger
    }
 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCVirtualUnresolvedSnippet * snippet)
    {
-   // *this   swipeable for debugger
    uint8_t            *cursor   = snippet->getSnippetLabel()->getCodeLocation();
    TR::Node            *callNode = snippet->getNode();
 
@@ -1541,7 +1530,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCVirtualUnresolvedSnippet * snippet)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCInterfaceCallSnippet * snippet)
    {
-   // *this   swipeable for debugger
    uint8_t            *cursor   = snippet->getSnippetLabel()->getCodeLocation();
    TR::Node            *callNode = snippet->getNode();
 

--- a/runtime/compiler/p/codegen/InterfaceCastSnippet.cpp
+++ b/runtime/compiler/p/codegen/InterfaceCastSnippet.cpp
@@ -402,7 +402,6 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::PPCInterfaceCastSnippet * snippet)
    {
-   // *this  swipeable for debugger
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
    uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation();
    bool     checkcast = snippet->isCheckCast();

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -69,7 +69,6 @@ J9::Power::UnresolvedDataSnippet::UnresolvedDataSnippet(
 
 uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t *cursor = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
@@ -259,8 +258,6 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
    {
-
-   // *this  swipeable for debugger
    uint8_t            *cursor = snippet->getSnippetLabel()->getCodeLocation();
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Unresolved Data Snippet");
@@ -360,7 +357,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
 
 uint32_t J9::Power::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   // *this   swipeable for debugger
    TR::Compilation* comp = cg()->comp();
    return 28+2*TR::Compiler->om.sizeofReferenceAddress();
    }

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -35,7 +35,6 @@
 uint8_t *
 TR::S390ForceRecompilationSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(cursor);
    TR::Compilation *comp = cg()->comp();

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -824,7 +824,6 @@ TR::S390PrivateLinkage::mapStack(TR::ResolvedMethodSymbol * method)
 void
 TR::S390PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
    {
-   // *this    swipeable for debugging purposeso
 
    mapSingleAutomatic(p, p->getRoundedSize(), stackIndex);
    }

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -415,7 +415,6 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
 uint32_t
 J9::Z::UnresolvedDataSnippet::getLength(int32_t  estimatedSnippetStart)
    {
-   // *this   swipeable for debugger
    uint32_t length = (TR::Compiler->target.is64Bit() ? (14 + 5 * sizeof(uintptrj_t)) : (12 + 5 * sizeof(uintptrj_t)));
    // For instance snippets, we have the out-of-line sequence
    if (isInstanceData())
@@ -432,7 +431,6 @@ J9::Z::UnresolvedDataSnippet::getLength(int32_t  estimatedSnippetStart)
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
    {
-   // *this   swipeable for debugger
 
    uint8_t * bufferPos = snippet->getSnippetLabel()->getCodeLocation();
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Unresolved Data Snippet");

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -253,7 +253,6 @@ TR::S390J9CallSnippet::emitSnippetBody()
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
-   // *this   swipeable for debugger
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Node * callNode = getNode();
    TR::SymbolReference * methodSymRef =  getRealMethodSymbolReference();
@@ -390,7 +389,6 @@ TR::S390UnresolvedCallSnippet::emitSnippetBody()
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
-   // *this   swipeable for debugger
    uint8_t * cursor = TR::S390J9CallSnippet::emitSnippetBody();
 
    TR::SymbolReference * methodSymRef = getNode()->getSymbolReference();
@@ -481,14 +479,12 @@ TR::S390UnresolvedCallSnippet::emitSnippetBody()
 uint32_t
 TR::S390UnresolvedCallSnippet::getLength(int32_t  estimatedSnippetStart)
    {
-   // *this   swipeable for debugger
    return TR::S390CallSnippet::getLength(estimatedSnippetStart) + sizeof(uintptrj_t) + sizeof(int32_t);
    }
 
 uint8_t *
 TR::S390VirtualSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    return NULL;
    }
 
@@ -501,7 +497,6 @@ TR::S390VirtualSnippet::getLength(int32_t  estimatedSnippetStart)
 uint8_t *
 TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Node * callNode = getNode();
    TR::Compilation *comp = cg()->comp();
@@ -615,7 +610,6 @@ TR::S390InterfaceCallSnippet::S390InterfaceCallSnippet(
 uint8_t *
 TR::S390InterfaceCallSnippet::emitSnippetBody()
    {
-   // *this   swipeable for debugger
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(cursor);
    TR::Compilation *comp = cg()->comp();


### PR DESCRIPTION
The comments were originally used in debugging and have already been
removed from omr. This commit removes these comments in openj9.

Signed-off-by: Andrew Gao <andrewgao98@gmail.com>