### PR TITLE
Implement opt pass for generic static final field folding

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -56,6 +56,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/optimizer/SignExtendLoads.cpp \
     compiler/optimizer/SPMDParallelizer.cpp \
     compiler/optimizer/SPMDPreCheck.cpp \
+    compiler/optimizer/StaticFinalFieldFolding.cpp \
     compiler/optimizer/StringBuilderTransformer.cpp \
     compiler/optimizer/StringPeepholes.cpp \
     compiler/optimizer/UnsafeFastPath.cpp \

--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -61,7 +61,8 @@ j9jit_files(
 	optimizer/SignExtendLoads.cpp
 	optimizer/SPMDParallelizer.cpp
 	optimizer/SPMDPreCheck.cpp
-	optimizer/StringBuilderTransformer.cpp
+        optimizer/StaticFinalFieldFolding.cpp
+        optimizer/StringBuilderTransformer.cpp
 	optimizer/StringPeepholes.cpp
 	optimizer/UnsafeFastPath.cpp
 	optimizer/VarHandleTransformer.cpp

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -75,6 +75,7 @@
 #include "runtime/J9Profiler.hpp"
 #include "optimizer/UnsafeFastPath.hpp"
 #include "optimizer/VarHandleTransformer.hpp"
+#include "optimizer/StaticFinalFieldFolding.hpp"
 
 
 static const OptimizationStrategy J9EarlyGlobalOpts[] =
@@ -83,6 +84,7 @@ static const OptimizationStrategy J9EarlyGlobalOpts[] =
    { OMR::stringPeepholes                      }, // need stringpeepholes to catch bigdecimal patterns
    { OMR::methodHandleInvokeInliningGroup,  OMR::IfMethodHandleInvokes },
    { OMR::inlining                             },
+   { OMR::staticFinalFieldFolding,             },
    { OMR::osrGuardInsertion,                OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                       }, // most inlining is done by now
    { OMR::jProfilingBlock                      },
@@ -299,6 +301,7 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::stringPeepholes                                                       }, // need stringpeepholes to catch bigdecimal patterns
    { OMR::methodHandleInvokeInliningGroup,                OMR::IfMethodHandleInvokes },
    { OMR::inlining                                                              },
+   { OMR::staticFinalFieldFolding,                                              },
    { OMR::osrGuardInsertion,                         OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                       }, // most inlining is done by now
    { OMR::jProfilingBlock                                                       },
@@ -379,6 +382,7 @@ static const OptimizationStrategy warmStrategyOpts[] =
 static const OptimizationStrategy reducedWarmStrategyOpts[] =
    {
    { OMR::inlining                                                              },
+   { OMR::staticFinalFieldFolding,                                              },
    { OMR::osrGuardInsertion,                         OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                                               }, // most inlining is done by now
    { OMR::jProfilingBlock                                                       },
@@ -641,6 +645,7 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::stringPeepholes                                                       }, // need stringpeepholes to catch bigdecimal patterns
    { OMR::methodHandleInvokeInliningGroup,           OMR::IfMethodHandleInvokes      },
    { OMR::inlining                                                              },
+   { OMR::staticFinalFieldFolding,                                              },
    { OMR::osrGuardInsertion,                         OMR::IfVoluntaryOSR       },
    { OMR::osrExceptionEdgeRemoval                                               }, // most inlining is done by now
    { OMR::jProfilingBlock                                                       },
@@ -804,6 +809,8 @@ J9::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *method
       new (comp->allocator()) TR::OptimizationManager(self(), TR_JProfilingRecompLoopTest::create, OMR::jProfilingRecompLoopTest);
    _opts[OMR::jProfilingValue] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_JProfilingValue::create, OMR::jProfilingValue);
+   _opts[OMR::staticFinalFieldFolding] =
+         new (comp->allocator()) TR::OptimizationManager(self(), TR_StaticFinalFieldFolding::create, OMR::staticFinalFieldFolding);
    // NOTE: Please add new J9 optimizations here!
 
    // initialize additional J9 optimization groups

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -40,6 +40,7 @@
 #include "j9.h"
 #include "optimizer/OMROptimization_inlines.hpp"
 #include "optimizer/Structure.hpp"
+#include "optimizer/HCRGuardAnalysis.hpp"
 
 /**
  * Walks the TR_RegionStructure counting loops to get the nesting depth of the block
@@ -897,6 +898,19 @@ J9::TransformUtil::transformIndirectLoad(TR::Compilation *comp, TR::Node *node)
    return NULL;
    }
 
+/** \brief
+ *     Entry point for folding whitelist'd static final fields.
+ *     These typically belong to fundamental system/bootstrap classes.
+ *
+ *  \param comp
+ *     The compilation object.
+ *
+ *  \param node
+ *     The node which is a load of a static final field.
+ *
+ *  \return
+ *    True if the field is folded.
+*/
 bool
 J9::TransformUtil::foldReliableStaticFinalField(TR::Compilation *comp, TR::Node *node)
    {
@@ -933,6 +947,20 @@ J9::TransformUtil::foldStaticFinalFieldAssumingProtection(TR::Compilation *comp,
    return false;
    }
 
+/** \brief
+ *     Compile time query that answers if a direct load for static can be folded by compiler.
+ *
+ *  \param comp
+ *     The compilation object.
+ *
+ *  \param node
+ *     The node which is a load of a static final field.
+ *
+ *  \return
+ *    True TR_yes if the field is whitelisted and can be folded.
+ *    True TR_maybe if the field is a generic static final and can be folded with protection.
+ *    True TR_no if the field is cannot be folded due to being unresolved, already been written post initialization, or owning class uninitialized, etc.
+ */
 TR_YesNoMaybe
 J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node)
    {
@@ -967,6 +995,267 @@ J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node
       return TR_yes;
 
    return TR_maybe;
+   }
+
+static bool isTakenSideOfAVirtualGuard(TR::Compilation* comp, TR::Block* block)
+   {
+   // First block can never be taken side
+   if (block == comp->getStartTree()->getEnclosingBlock())
+      return false;
+
+   for (auto edge = block->getPredecessors().begin(), end = block->getPredecessors().end(); edge != end; ++edge)
+      {
+      TR::Block *pred = toBlock((*edge)->getFrom());
+      TR::Node* predLastRealNode = pred->getLastRealTreeTop()->getNode();
+
+      if (predLastRealNode
+          && predLastRealNode->isTheVirtualGuardForAGuardedInlinedCall()
+          && predLastRealNode->getBranchDestination()->getEnclosingBlock() == block)
+         return true;
+
+      }
+
+   return false;
+   }
+
+static bool skipFinalFieldFoldingInBlock(TR::Compilation* comp, TR::Block* block)
+   {
+   if (block->isCold()
+       || block->isOSRCatchBlock()
+       || block->isOSRCodeBlock()
+       || isTakenSideOfAVirtualGuard(comp, block))
+      return true;
+
+   return false;
+   }
+
+// This is a place holder for when we may want to run HCR guard analysis.
+// Currently the analysis is skipped due to concern of added computation/footprint cost at compile-time.
+static TR_HCRGuardAnalysis* runHCRGuardAnalysisIfPossible()
+   {
+   return NULL;
+   }
+
+// Do not add fear point in a frame that doesn't support OSR
+static bool cannotAttemptOSRDuring(TR::Compilation* comp, int32_t callerIndex)
+   {
+   TR::ResolvedMethodSymbol *method = callerIndex == -1 ?
+      comp->getJittedMethodSymbol() : comp->getInlinedResolvedMethodSymbol(callerIndex);
+
+   return method->cannotAttemptOSRDuring(callerIndex, comp, false);
+   }
+
+static TR_YesNoMaybe safeToAddFearPointAt(TR::Optimization* opt, TR::TreeTop* tt)
+   {
+   TR::Compilation* comp = opt->comp();
+   if (opt->trace())
+      {
+      traceMsg(comp, "Checking if it is safe to add fear point at n%dn\n", tt->getNode()->getGlobalIndex());
+      }
+
+   int32_t callerIndex = tt->getNode()->getByteCodeInfo().getCallerIndex();
+   if (!cannotAttemptOSRDuring(comp, callerIndex) && !comp->isOSRProhibitedOverRangeOfTrees())
+      {
+      if (opt->trace())
+         {
+         traceMsg(comp, "Safe to add fear point because there is no OSR prohibition\n");
+         }
+      return TR_yes;
+      }
+
+   // Look for an OSR point dominating tt in block
+   TR::Block* block = tt->getEnclosingBlock();
+   TR::TreeTop* firstTT = block->getEntry();
+   while (tt != firstTT)
+      {
+      if (comp->isPotentialOSRPoint(tt->getNode()))
+         {
+         TR_YesNoMaybe result = comp->isPotentialOSRPointWithSupport(tt) ? TR_yes : TR_no;
+         if (opt->trace())
+            {
+            traceMsg(comp, "Found %s potential OSR point n%dn, %s to add fear point\n",
+                     result == TR_yes ? "supported" : "unsupported",
+                     tt->getNode()->getGlobalIndex(),
+                     result == TR_yes ? "Safe" : "Not safe");
+            }
+
+         return result;
+         }
+      tt = tt->getPrevTreeTop();
+      }
+
+   TR_HCRGuardAnalysis* guardAnalysis = runHCRGuardAnalysisIfPossible();
+   if (guardAnalysis)
+      {
+      TR_YesNoMaybe result = guardAnalysis->_blockAnalysisInfo[block->getNumber()]->isEmpty() ? TR_yes : TR_no;
+      if (opt->trace())
+         {
+         traceMsg(comp, "%s to add fear point based on HCRGuardAnalysis\n", result == TR_yes ? "Safe" : "Not safe");
+         }
+
+      return result;
+      }
+
+   if (opt->trace())
+      {
+      traceMsg(comp, "Cannot determine if it is safe to add fear point at n%dn\n", tt->getNode()->getGlobalIndex());
+      }
+   return TR_maybe;
+   }
+
+static bool isVarHandleFolding(TR::Compilation* comp, TR_OpaqueClassBlock* declaringClass, char* fieldSignature, int32_t fieldSigLength)
+   {
+   if (comp->getMethodSymbol()->hasMethodHandleInvokes()
+       && !TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
+      {
+      if (fieldSigLength == 28 && !strncmp(fieldSignature, "Ljava/lang/invoke/VarHandle;", 28))
+         return true;
+      }
+
+   return false;
+   }
+
+/** \brief
+ *     Try to fold var handle static final field with protection
+ *
+ *  \param opt
+ *     The current optimization object.
+ *
+ *  \param currentTree
+ *     The tree with the load of static final field.
+ *
+ *  \param node
+ *     The node which is a load of a static final field.
+ */
+bool J9::TransformUtil::attemptVarHandleStaticFinalFieldFolding(TR::Optimization* opt, TR::TreeTop * currentTree, TR::Node *node)
+   {
+   return J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(opt, currentTree, node, true);
+   }
+
+/** \brief
+ *     Try to fold generic static final field with protection
+ *
+ *  \param opt
+ *     The current optimization object.
+ *
+ *  \param currentTree
+ *     The tree with the load of static final field.
+ *
+ *  \param node
+ *     The node which is a load of a static final field.
+ */
+bool J9::TransformUtil::attemptGenericStaticFinalFieldFolding(TR::Optimization* opt, TR::TreeTop * currentTree, TR::Node *node)
+   {
+   return J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(opt, currentTree, node, false);
+   }
+
+/** \brief
+ *     Try to fold static final field with protection
+ *
+ *  \param opt
+ *     The current optimization object.
+ *
+ *  \param currentTree
+ *     The tree with the load of static final field.
+ *
+ *  \param node
+ *     The node which is a load of a static final field.
+ *
+ *  \param varHandleOnly
+ *     True if only folding varHandle static final fields.
+ *     Faslse if folding all static final fileds.
+ */
+bool J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(TR::Optimization* opt, TR::TreeTop * currentTree, TR::Node *node, bool varHandleOnly)
+   {
+   TR::Compilation* comp = opt->comp();
+   // first attempt folding reliable fields
+   if (J9::TransformUtil::foldReliableStaticFinalField(comp, node))
+      {
+      if (opt->trace())
+         traceMsg(comp, "SFFF fold reliable at node %p\n", node);
+      return true;
+      }
+
+   // try folding regular static final fields
+   TR::SymbolReference* symRef = node->getSymbolReference();
+   if (symRef->hasKnownObjectIndex())
+      {
+      return false;
+      }
+
+   if (comp->getOption(TR_DisableGuardedStaticFinalFieldFolding))
+      {
+      return false;
+      }
+
+   if (!comp->supportsInduceOSR()
+       || !comp->isOSRTransitionTarget(TR::postExecutionOSR)
+       || comp->getOSRMode() != TR::voluntaryOSR)
+      {
+      return false;
+      }
+
+   if (skipFinalFieldFoldingInBlock(comp, currentTree->getEnclosingBlock())
+       || J9::TransformUtil::canFoldStaticFinalField(comp, node) != TR_maybe
+       || safeToAddFearPointAt(opt, currentTree) != TR_yes)
+      {
+      return false;
+      }
+
+   int32_t cpIndex = symRef->getCPIndex();
+   TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp)->getClassFromFieldOrStatic(comp, cpIndex);
+   int32_t fieldNameLen;
+   char* fieldName = symRef->getOwningMethod(comp)->fieldName(cpIndex, fieldNameLen, comp->trMemory(), stackAlloc);
+   int32_t fieldSigLength;
+   char* fieldSignature = symRef->getOwningMethod(comp)->staticSignatureChars(cpIndex, fieldSigLength);
+
+   if (opt->trace())
+      {
+      traceMsg(comp,
+              "Looking at static final field n%dn %.*s declared in class %p\n",
+              node->getGlobalIndex(), fieldNameLen, fieldName, declaringClass);
+      }
+   if (!varHandleOnly || isVarHandleFolding(comp, declaringClass, fieldSignature, fieldSigLength))
+      {
+      if (J9::TransformUtil::foldStaticFinalFieldAssumingProtection(comp, node))
+         {
+         // Add class to assumption table
+         comp->addClassForStaticFinalFieldModification(declaringClass);
+         // Insert osrFearPointHelper call
+         TR::TreeTop* helperTree = TR::TreeTop::create(comp, TR::Node::create(node, TR::treetop, 1, TR::Node::createOSRFearPointHelperCall(node)));
+         currentTree->insertBefore(helperTree);
+
+         if (opt->trace())
+            {
+            traceMsg(comp,
+                    "Static final field n%dn is folded with OSRFearPointHelper call tree n%dn  helper tree n%dn\n",
+                    node->getGlobalIndex(), currentTree->getNode()->getGlobalIndex(), helperTree->getNode()->getGlobalIndex());
+            }
+
+         TR::DebugCounter::prependDebugCounter(comp,
+                                            TR::DebugCounter::debugCounterName(comp,
+                                                                               "staticFinalFieldFolding/success/(field %.*s)/(%s %s)",
+                                                                               fieldNameLen,
+                                                                               fieldName,
+                                                                               comp->signature(),
+                                                                               comp->getHotnessName(comp->getMethodHotness())),
+                                                                               currentTree->getNextTreeTop());
+         return true;
+         }
+      }
+   else
+      {
+      TR::DebugCounter::prependDebugCounter(comp,
+                                            TR::DebugCounter::debugCounterName(comp,
+                                                                               "staticFinalFieldFolding/notFolded/(field %.*s)/(%s %s)",
+                                                                               fieldNameLen,
+                                                                               fieldName,
+                                                                               comp->signature(),
+                                                                               comp->getHotnessName(comp->getMethodHotness())),
+                                                                               currentTree->getNextTreeTop());
+      }
+
+   return false;
    }
 
 /*

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -56,6 +56,7 @@ public:
    
    static TR::Node *transformIndirectLoad(TR::Compilation *, TR::Node *node);
    static bool transformDirectLoad(TR::Compilation *, TR::Node *node);
+
    /**
     * \brief
     *    Fold direct load of a reliable static final field. A reliable static final field
@@ -74,6 +75,7 @@ public:
     * \return
     *    True if the field has been folded
     */
+
    static bool foldReliableStaticFinalField(TR::Compilation *, TR::Node *node);
    /**
     * \brief
@@ -92,6 +94,34 @@ public:
     *    True if the field has been folded
     */
    static bool foldStaticFinalFieldAssumingProtection(TR::Compilation *, TR::Node *node);
+
+   /** \brief
+    *     Try to fold var handle static final field with protection
+    *
+    *  \param opt
+    *     The current optimization object.
+    *
+    *  \param currentTree
+    *     The tree with the load of static final field.
+    *
+    *  \param node
+    *     The node which is a load of a static final field.
+    */
+   static bool attemptVarHandleStaticFinalFieldFolding(TR::Optimization* opt, TR::TreeTop * currentTree, TR::Node *node);
+
+   /** \brief
+    *     Try to fold generic static final field with protection
+    *
+    *  \param opt
+    *     The current optimization object.
+    *
+    *  \param currentTree
+    *     The tree with the load of static final field.
+    *
+    *  \param node
+    *     The node which is a load of a static final field.
+    */
+   static bool attemptGenericStaticFinalFieldFolding(TR::Optimization* opt, TR::TreeTop * currentTree, TR::Node *node);
 
    /**
     * \brief
@@ -165,6 +195,23 @@ protected:
     */
    static bool foldStaticFinalFieldImpl(TR::Compilation *, TR::Node *node);
 
+   /** \brief
+    *     Try to fold static final field with protection
+    *
+    *  \param opt
+    *     The current optimization object.
+    *
+    *  \param currentTree
+    *     The tree with the load of static final field.
+    *
+    *  \param node
+    *     The node which is a load of a static final field.
+    *
+    *  \param varHandleOnly
+    *     True if only folding varHandle static final fields.
+    *     Faslse if folding all static final fileds.
+    */
+   static bool attemptStaticFinalFieldFoldingImpl(TR::Optimization* opt, TR::TreeTop * currentTree, TR::Node *node, bool varHandleOnly);
    };
 
 }

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1188,38 +1188,6 @@ J9::ValuePropagation::getParmValues()
    TR_ASSERT(parmIterator->atEnd() && parmIndex == numParms, "Bad signature for owning method");
    }
 
-static bool isTakenSideOfAVirtualGuard(TR::Compilation* comp, TR::Block* block)
-   {
-   // First block can never be taken side
-   if (block == comp->getMethodSymbol()->getFirstTreeTop()->getEnclosingBlock())
-      return false;
-
-   for (auto edge = block->getPredecessors().begin(); edge != block->getPredecessors().end(); ++edge)
-      {
-      TR::Block *pred = toBlock((*edge)->getFrom());
-      TR::Node* predLastRealNode = pred->getLastRealTreeTop()->getNode();
-
-      if (predLastRealNode
-          && predLastRealNode->isTheVirtualGuardForAGuardedInlinedCall()
-          && predLastRealNode->getBranchDestination()->getEnclosingBlock() == block)
-         return true;
-
-      }
-
-   return false;
-   }
-
-static bool skipFinalFieldFoldingInBlock(TR::Compilation* comp, TR::Block* block)
-   {
-   if (block->isCold()
-       || block->isOSRCatchBlock()
-       || block->isOSRCodeBlock()
-       || isTakenSideOfAVirtualGuard(comp, block))
-      return true;
-
-   return false;
-   }
-
 static bool isStaticFinalFieldWorthFolding(TR::Compilation* comp, TR_OpaqueClassBlock* declaringClass, char* fieldSignature, int32_t fieldSigLength)
    {
    if (comp->getMethodSymbol()->hasMethodHandleInvokes()
@@ -1232,194 +1200,21 @@ static bool isStaticFinalFieldWorthFolding(TR::Compilation* comp, TR_OpaqueClass
    return false;
    }
 
-
-// Do not add fear point in a frame that doesn't support OSR
-static bool cannotAttemptOSRDuring(TR::Compilation* comp, int32_t callerIndex)
-   {
-   TR::ResolvedMethodSymbol *method = callerIndex == -1 ?
-      comp->getJittedMethodSymbol() : comp->getInlinedResolvedMethodSymbol(callerIndex);
-
-   return method->cannotAttemptOSRDuring(callerIndex, comp, false);
-   }
-
 bool J9::ValuePropagation::transformDirectLoad(TR::Node* node)
    {
-   // Allow OMR to fold reliable static final field first
+   // Allow OMR to fold reliable static final field
    if (OMR::ValuePropagation::transformDirectLoad(node))
       return true;
 
+   // Limited to varhandle folding only in VP
    if (node->isLoadOfStaticFinalField() &&
-       tryFoldStaticFinalFieldAt(_curTree, node))
+          TR::TransformUtil::attemptVarHandleStaticFinalFieldFolding(this, _curTree, node))
       {
       return true;
       }
 
    return false;
    }
-
-
-static TR_HCRGuardAnalysis* runHCRGuardAnalysisIfPossible()
-   {
-   return NULL;
-   }
-
-TR_YesNoMaybe J9::ValuePropagation::safeToAddFearPointAt(TR::TreeTop* tt)
-   {
-   if (trace())
-      {
-      traceMsg(comp(), "Checking if it is safe to add fear point at n%dn\n", tt->getNode()->getGlobalIndex());
-      }
-
-   int32_t callerIndex = tt->getNode()->getByteCodeInfo().getCallerIndex();
-   if (!cannotAttemptOSRDuring(comp(), callerIndex) && !comp()->isOSRProhibitedOverRangeOfTrees())
-      {
-      if (trace())
-         {
-         traceMsg(comp(), "Safe to add fear point because there is no OSR prohibition\n");
-         }
-      return TR_yes;
-      }
-
-   // Look for an OSR point dominating tt in block
-   TR::Block* block = tt->getEnclosingBlock();
-   TR::TreeTop* firstTT = block->getEntry();
-   while (tt != firstTT)
-      {
-      if (comp()->isPotentialOSRPoint(tt->getNode()))
-         {
-         TR_YesNoMaybe result = comp()->isPotentialOSRPointWithSupport(tt) ? TR_yes : TR_no;
-         if (trace())
-            {
-            traceMsg(comp(), "Found %s potential OSR point n%dn, %s to add fear point\n",
-                     result == TR_yes ? "supported" : "unsupported",
-                     tt->getNode()->getGlobalIndex(),
-                     result == TR_yes ? "Safe" : "Not safe");
-            }
-
-         return result;
-         }
-      tt = tt->getPrevTreeTop();
-      }
-
-   TR_HCRGuardAnalysis* guardAnalysis = runHCRGuardAnalysisIfPossible();
-   if (guardAnalysis)
-      {
-      TR_YesNoMaybe result = guardAnalysis->_blockAnalysisInfo[block->getNumber()]->isEmpty() ? TR_yes : TR_no;
-      if (trace())
-         {
-         traceMsg(comp(), "%s to add fear point based on HCRGuardAnalysis\n", result == TR_yes ? "Safe" : "Not safe");
-         }
-
-      return result;
-      }
-
-   if (trace())
-      {
-      traceMsg(comp(), "Cannot determine if it is safe\n");
-      }
-   return TR_maybe;
-   }
-
-/** \brief
- *     Try to fold static final field
- *
- *  \param tree
- *     The tree with the load of static final field.
- *
- *  \param fieldNode
- *     The node which is a load of a static final field.
- */
-bool J9::ValuePropagation::tryFoldStaticFinalFieldAt(TR::TreeTop* tree, TR::Node* fieldNode)
-   {
-   TR_ASSERT(fieldNode->isLoadOfStaticFinalField(), "Node n%dn %p has to be a load of a static final field", fieldNode->getGlobalIndex(), fieldNode);
-
-   if (comp()->getOption(TR_DisableGuardedStaticFinalFieldFolding))
-      {
-      return false;
-      }
-
-   if (!comp()->supportsInduceOSR()
-       || !comp()->isOSRTransitionTarget(TR::postExecutionOSR)
-       || comp()->getOSRMode() != TR::voluntaryOSR)
-      {
-      return false;
-      }
-
-   if (skipFinalFieldFoldingInBlock(comp(), tree->getEnclosingBlock())
-       || safeToAddFearPointAt(tree) != TR_yes
-       || TR::TransformUtil::canFoldStaticFinalField(comp(), fieldNode) != TR_maybe)
-      {
-      return false;
-      }
-
-   TR::SymbolReference* symRef = fieldNode->getSymbolReference();
-   if (symRef->hasKnownObjectIndex())
-      {
-      return false;
-      }
-
-   int32_t cpIndex = symRef->getCPIndex();
-   TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp())->getClassFromFieldOrStatic(comp(), cpIndex);
-   int32_t fieldNameLen;
-   char* fieldName = symRef->getOwningMethod(comp())->fieldName(cpIndex, fieldNameLen, comp()->trMemory(), stackAlloc);
-   int32_t fieldSigLength;
-   char* fieldSignature = symRef->getOwningMethod(comp())->staticSignatureChars(cpIndex, fieldSigLength);
-
-   if (trace())
-      {
-      traceMsg(comp(),
-              "Looking at static final field n%dn %.*s declared in class %p\n",
-              fieldNode->getGlobalIndex(), fieldNameLen, fieldName, declaringClass);
-      }
-
-   if (isStaticFinalFieldWorthFolding(comp(), declaringClass, fieldSignature, fieldSigLength))
-      {
-      if (TR::TransformUtil::foldStaticFinalFieldAssumingProtection(comp(), fieldNode))
-         {
-         // Add class to assumption table
-         comp()->addClassForStaticFinalFieldModification(declaringClass);
-         // Insert osrFearPointHelper call
-         TR::TreeTop* helperTree = TR::TreeTop::create(comp(),
-                                                       TR::Node::create(fieldNode,
-                                                                        TR::treetop,
-                                                                        1,
-                                                                        TR::Node::createOSRFearPointHelperCall(fieldNode)));
-         tree->insertBefore(helperTree);
-
-         if (trace())
-            {
-            traceMsg(comp(),
-                    "Static final field n%dn is folded with OSRFearPointHelper call tree n%dn  helper tree n%dn\n",
-                    fieldNode->getGlobalIndex(), tree->getNode()->getGlobalIndex(), helperTree->getNode()->getGlobalIndex());
-            }
-
-         TR::DebugCounter::prependDebugCounter(comp(),
-                                               TR::DebugCounter::debugCounterName(comp(),
-                                                                                  "staticFinalFieldFolding/success/(field %.*s)/(%s %s)",
-                                                                                  fieldNameLen,
-                                                                                  fieldName,
-                                                                                  comp()->signature(),
-                                                                                  comp()->getHotnessName(comp()->getMethodHotness())),
-                                                                                  tree->getNextTreeTop());
-
-         return true;
-         }
-      }
-   else
-      {
-      TR::DebugCounter::prependDebugCounter(comp(),
-                                            TR::DebugCounter::debugCounterName(comp(),
-                                                                               "staticFinalFieldFolding/notWorthFolding/(field %.*s)/(%s %s)",
-                                                                               fieldNameLen,
-                                                                               fieldName,
-                                                                               comp()->signature(),
-                                                                               comp()->getHotnessName(comp()->getMethodHotness())),
-                                                                               tree->getNextTreeTop());
-      }
-
-   return false;
-   }
-
 
 static void getHelperSymRefs(OMR::ValuePropagation *vp, TR::Node *curCallNode, TR::SymbolReference *&getHelpersSymRef, TR::SymbolReference *&helperSymRef, char *helperSig, int32_t helperSigLen, TR::MethodSymbol::Kinds helperCallKind)
    {

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -50,7 +50,6 @@ class ValuePropagation : public OMR::ValuePropagation
 
    virtual void constrainRecognizedMethod(TR::Node *node);
    virtual bool transformDirectLoad(TR::Node *node);
-   bool tryFoldStaticFinalFieldAt(TR::TreeTop* tree, TR::Node* fieldNode);
    virtual void doDelayedTransformations();
    void transformCallToIconstWithHCRGuard(TR::TreeTop *callTree, int32_t result);
    void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true);
@@ -72,8 +71,6 @@ class ValuePropagation : public OMR::ValuePropagation
    virtual TR::Node *innerConstrainAcall(TR::Node *node);
 
    private:
-
-   TR_YesNoMaybe safeToAddFearPointAt(TR::TreeTop* tt);
 
    struct TreeIntResultPair {
       TR_ALLOC(TR_Memory::ValuePropagation)

--- a/runtime/compiler/optimizer/StaticFinalFieldFolding.cpp
+++ b/runtime/compiler/optimizer/StaticFinalFieldFolding.cpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "optimizer/StaticFinalFieldFolding.hpp"
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Options.hpp"
+#include "control/Options_inlines.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/IO.hpp"
+#include "env/VMJ9.h"
+#include "env/j9method.h"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Checklist.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "optimizer/J9TransformUtil.hpp"
+
+void TR_StaticFinalFieldFolding::visitNode(TR::TreeTop * currentTree, TR::Node *node)
+   {
+   if (!_checklist->contains(node))
+      {
+      _checklist->add(node);
+      uint16_t childCount = node->getNumChildren();
+      for (int i = childCount; i>0; i--)
+         {
+         visitNode(currentTree, node->getChild(i-1));
+         }
+      if (node->getOpCode().isLoadVarDirect() && node->isLoadOfStaticFinalField())
+         {
+         TR_ASSERT_FATAL(childCount == 0, "Direct load node for static final field should have no child");
+         J9::TransformUtil::attemptGenericStaticFinalFieldFolding(this, currentTree, node);
+         }      
+      }
+   }
+
+/**
+ *
+ * Fold static final fields based on certain criteria
+ */
+int32_t TR_StaticFinalFieldFolding::perform()
+   {
+   if (comp()->getOSRMode() == TR::involuntaryOSR)
+      {
+      if (trace())
+         traceMsg(comp(), "Static final field folding disabled due to involuntary OSR\n");
+      return 0;
+      }
+
+   if (comp()->getOption(TR_DisableOSR))
+      {
+      if (trace())
+         traceMsg(comp(), "Static final field folding disabled due to disabled OSR\n");
+      return 0;
+      }
+
+   if (comp()->getOption(TR_EnableFieldWatch))
+      {
+      if (trace())
+         traceMsg(comp(), "Static final field folding disabled due to field watch\n");
+      return 0;
+      }
+
+   if (comp()->getOption(TR_MimicInterpreterFrameShape))
+      {
+      if (trace())
+         traceMsg(comp(), "Static final field folding disabled due to mimic interpreter frame shape\n");
+      return 0;
+      }
+
+   _checklist = new (trStackMemory()) TR::NodeChecklist(comp());
+
+   for (TR::TreeTop * tt = comp()->getStartTree(); tt != NULL; tt = tt->getNextTreeTop())
+      {
+      TR::Node *node = tt->getNode();
+      visitNode(tt, node);
+      }
+   return 0;
+   }
+
+const char *
+TR_StaticFinalFieldFolding::optDetailString() const throw()
+   {
+   return "O^O STATIC FINAL FIELD FOLDING: ";
+   }

--- a/runtime/compiler/optimizer/StaticFinalFieldFolding.hpp
+++ b/runtime/compiler/optimizer/StaticFinalFieldFolding.hpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef STATICFINALFIELDFOLDING_INCL
+#define STATICFINALFIELDFOLDING_INCL
+
+#include <stdint.h>
+#include "il/Node.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
+
+namespace TR { class NodeChecklist; }
+
+class TR_StaticFinalFieldFolding : public TR::Optimization
+   {
+   TR::NodeChecklist *_checklist;
+   void visitNode(TR::TreeTop * currentTree, TR::Node *node);
+
+   public:
+
+   TR_StaticFinalFieldFolding(TR::OptimizationManager *manager)
+      : TR::Optimization(manager)
+      {}
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) TR_StaticFinalFieldFolding(manager);
+      }
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   };
+#endif


### PR DESCRIPTION
Insert a new opt pass named StaticFinalFieldFolding inbetween inlining and
osrGuardInsertion, which performs generic static final field folding with
fear point insertion. For now, VP continues to do folding for varHandle
only. Existing logic is refactored into J9::TransformUtil to be shared
with new pass and VP.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>