### PR TITLE
Fixed Assert for Debug Test

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3059,6 +3059,11 @@ ClientSessionData::cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byt
       IPTable_t *iProfilerMap = it->second._IPData;
       if (!iProfilerMap)
          {
+         // Check and update if method is compiled when collecting profiling data
+         bool isCompiled = TR::CompilationInfo::isCompiled((J9Method*)method);
+         if(isCompiled)
+            it->second._isCompiledWhenProfiling = true;
+
          // allocate a new iProfiler map
          iProfilerMap = new (PERSISTENT_NEW) IPTable_t(IPTable_t::allocator_type(TR::Compiler->persistentAllocator()));
          if (iProfilerMap)
@@ -3431,7 +3436,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    for (uint32_t i = 0; i < numMethods; i++)
       {
       clientSessionData->getJ9MethodMap().insert({&methods[i], 
-            {romMethod, NULL, static_cast<bool>(methodTracingInfo[i]), (TR_OpaqueClassBlock *)clazz} });
+            {romMethod, NULL, static_cast<bool>(methodTracingInfo[i]), (TR_OpaqueClassBlock *)clazz, false}});
       romMethod = nextROMMethod(romMethod);
       }
    }

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -116,6 +116,7 @@ class ClientSessionData
       IPTable_t *_IPData;
       bool _isMethodTracingEnabled;
       TR_OpaqueClassBlock * _owningClass;
+      bool _isCompiledWhenProfiling; // To record if the method is compiled when doing Profiling
       };
 
    // This struct contains information about VM that does not change during its lifetime.

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -78,7 +78,7 @@ protected:
    virtual bool invalidateEntryIfInconsistent(TR_IPBytecodeHashTableEntry *entry) override;
 
 private:
-   void validateCachedIPEntry(TR_IPBytecodeHashTableEntry *entry, TR_IPBCDataStorageHeader *clientData, uintptrj_t methodStart, bool isMethodBeingCompiled, TR_OpaqueMethodBlock *method);
+   void validateCachedIPEntry(TR_IPBytecodeHashTableEntry *entry, TR_IPBCDataStorageHeader *clientData, uintptrj_t methodStart, bool isMethodBeingCompiled, TR_OpaqueMethodBlock *method, bool fromPerCompilationCache, bool isCompiledWhenProfiling);
    bool _useCaching;
    // Statistics
    uint32_t _statsIProfilerInfoFromCache;  // IP cache answered the query


### PR DESCRIPTION
[skip ci]
Fixed assert for Mismatch dominant
class for persistent profiling data.

-Added a field in the persistent cache in
 J9MethodInfo to indicate whether or not the
 method was compiled at the time we collected
 the profiling data
-If it was not compiled at the time we collected
 the profiling data, we do not check the assert

Closes: #5631
Signed-off-by: caohaley <haleycao88@hotmail.com>