### PR TITLE
Convert static initialization into a single loop

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -182,7 +182,8 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	_isClassContended(false),
 	_isClassUnmodifiable(context->isClassUnmodifiable()),
-	_isInnerClass(false)
+	_isInnerClass(false),
+	_needsStaticConstantInit(false)
 {
 	Trc_BCU_Assert_NotEquals( classFile, NULL );
 
@@ -296,6 +297,7 @@ ClassFileOracle::walkFields()
 
 		if (isStatic) {
 			if (NULL != field->constantValueAttribute) {
+				_needsStaticConstantInit = true;
 				U_16 constantValueIndex = field->constantValueAttribute->constantValueIndex;
 				if (CFR_CONSTANT_String == _classFile->constantPool[constantValueIndex].tag) {
 					markStringAsReferenced(constantValueIndex);

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -924,6 +924,10 @@ class NameAndTypeIterator
 	bool annotationRefersDoubleSlotEntry() const { return _annotationRefersDoubleSlotEntry; }
 	bool isInnerClass() const { return _isInnerClass; }
 
+	bool needsStaticConstantInit() const {
+		return _needsStaticConstantInit;
+	}
+
 	U_8 constantDynamicType(U_16 cpIndex) const
 	{
 		J9CfrConstantPoolInfo* nas = &_classFile->constantPool[_classFile->constantPool[cpIndex].slot2];
@@ -996,6 +1000,7 @@ private:
 	bool _hasClinit;
 	bool _annotationRefersDoubleSlotEntry;
 	bool _isInnerClass;
+	bool _needsStaticConstantInit;
 
 	FieldInfo *_fieldsInfo;
 	MethodInfo *_methodsInfo;

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -923,10 +923,7 @@ class NameAndTypeIterator
 	bool hasClinit() const { return _hasClinit; }
 	bool annotationRefersDoubleSlotEntry() const { return _annotationRefersDoubleSlotEntry; }
 	bool isInnerClass() const { return _isInnerClass; }
-
-	bool needsStaticConstantInit() const {
-		return _needsStaticConstantInit;
-	}
+	bool needsStaticConstantInit() const { return _needsStaticConstantInit; }
 
 	U_8 constantDynamicType(U_16 cpIndex) const
 	{

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -1077,7 +1077,7 @@ ROMClassBuilder::finishPrepareAndLaydown(
  *                      + AccClassInnerClass
  *                     + UNUSED
  *
- *                   + UNUSED
+ *                   + AccClassNeedsStaticConstantInit
  *                  + AccClassIntermediateDataIsClassfile
  *                 + AccClassUnsafe
  *                + AccClassAnnnotionRefersDoubleSlotEntry
@@ -1203,6 +1203,10 @@ ROMClassBuilder::computeExtraModifiers(ClassFileOracle *classFileOracle, ROMClas
 
 	if (classFileOracle->isInnerClass()) {
 		modifiers |= J9AccClassInnerClass;
+	}
+
+	if (classFileOracle->needsStaticConstantInit()) {
+		modifiers |= J9AccClassNeedsStaticConstantInit;
 	}
 
 	return modifiers;

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -54,6 +54,7 @@
 #define J9AccClassHasVerifyData 0x800000
 #define J9AccClassHotSwappedOut 0x4000000
 #define J9AccClassInnerClass 0x4000
+#define J9AccClassNeedsStaticConstantInit 0x10000
 #define J9AccClassIntermediateDataIsClassfile 0x20000
 #define J9AccClassInternalPrimitiveType 0x20000
 #define J9AccClassIsContended 0x1000000

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -182,7 +182,7 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 		Trc_VM_performVerification_noVerify(currentThread);
 	}
 
-	{
+	if (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassNeedsStaticConstantInit)) {
 		/* Prepare the class - the event is sent after the class init status has been updated */
 		Trc_VM_performVerification_prepareClass(currentThread);
 		romClass = clazz->romClass;

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -186,64 +186,57 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 		/* Prepare the class - the event is sent after the class init status has been updated */
 		Trc_VM_performVerification_prepareClass(currentThread);
 		romClass = clazz->romClass;
-		UDATA *staticAddress = clazz->ramStatics;
+		UDATA *objectStaticAddress = clazz->ramStatics;
+		UDATA *singleStaticAddress = objectStaticAddress + romClass->objectStaticCount;
+		U_64 *doubleStaticAddress = (U_64*)(singleStaticAddress + romClass->singleScalarStaticCount);
+
+#if !defined(J9VM_ENV_DATA64)
+		if (0 != ((UDATA)doubleStaticAddress & (sizeof(U_64) - 1))) {
+			doubleStaticAddress += 1;
+		}
+#endif
+
 		/* initialize object slots first */
 		J9ROMFieldWalkState fieldWalkState;
 		J9ROMFieldShape *field = romFieldsStartDo(romClass, &fieldWalkState);
 		while (field != NULL) {
 			U_32 modifiers = field->modifiers;
-			if (J9_ARE_ALL_BITS_SET(modifiers, (J9AccStatic | J9FieldFlagObject))) {
-				if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagConstant)) {
-					U_32 index = *(U_32*)romFieldInitialValueAddress(field);
-					J9ConstantPool *ramConstantPool = J9_CP_FROM_CLASS(clazz);
-					J9RAMStringRef *ramCPEntry = ((J9RAMStringRef*)ramConstantPool) + index;
-					j9object_t stringObject = ramCPEntry->stringObject;
-					if (NULL == stringObject) {
-						resolveStringRef(currentThread, ramConstantPool, index, J9_RESOLVE_FLAG_RUNTIME_RESOLVE);
-						clazz = VM_VMHelpers::currentClass(clazz);
-						if (VM_VMHelpers::exceptionPending(currentThread)) {
-							goto done;
+			if (J9_ARE_ALL_BITS_SET(modifiers, J9AccStatic)) {
+				const bool hasConstantValue = J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagConstant);
+			
+				if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagObject)) {
+					if (hasConstantValue) {
+						U_32 index = *(U_32*)romFieldInitialValueAddress(field);
+						J9ConstantPool *ramConstantPool = J9_CP_FROM_CLASS(clazz);
+						J9RAMStringRef *ramCPEntry = ((J9RAMStringRef*)ramConstantPool) + index;
+						j9object_t stringObject = ramCPEntry->stringObject;
+						if (NULL == stringObject) {
+							resolveStringRef(currentThread, ramConstantPool, index, J9_RESOLVE_FLAG_RUNTIME_RESOLVE);
+							clazz = VM_VMHelpers::currentClass(clazz);
+							if (VM_VMHelpers::exceptionPending(currentThread)) {
+								goto done;
+							}
+							stringObject = ramCPEntry->stringObject;
 						}
-						stringObject = ramCPEntry->stringObject;
+						J9STATIC_OBJECT_STORE(currentThread, clazz, (j9object_t*)objectStaticAddress, stringObject);
+						/* Overwriting NULL with a string that is in immortal, so no exception can occur */
 					}
-					J9STATIC_OBJECT_STORE(currentThread, clazz, (j9object_t*)staticAddress, stringObject);
-					/* Overwriting NULL with a string that is in immortal, so no exception can occur */
-				}
-				staticAddress += 1;
-			}
-			field = romFieldsNextDo(&fieldWalkState);
-		}
-		/* initialize single scalar slots next */
-		field = romFieldsStartDo(romClass, &fieldWalkState);
-		while (field != NULL) {
-			U_32 modifiers = field->modifiers;
-			if (J9AccStatic == (modifiers & (J9AccStatic | J9FieldFlagObject | J9FieldSizeDouble))) {
-				if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagConstant)) {
-					*(U_32*)staticAddress = *(U_32*)romFieldInitialValueAddress(field);
-				}
-				staticAddress += 1;
-			}
-			field = romFieldsNextDo(&fieldWalkState);
-		}
-		/* initialize double scalar slots last - 8-align the storage before starting */
-#if !defined(J9VM_ENV_DATA64)
-		if (0 != ((UDATA)staticAddress & (sizeof(U_64) - 1))) {
-			staticAddress += 1;
-		}
-#endif
-		{
-			U_64 *doubleStaticAddress = (U_64*)staticAddress;
-			field = romFieldsStartDo(romClass, &fieldWalkState);
-			while (field != NULL) {
-				U_32 modifiers = field->modifiers;
-				if (J9_ARE_ALL_BITS_SET(modifiers, (J9AccStatic | J9FieldSizeDouble))) {
-					if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagConstant)) {
+					objectStaticAddress += 1;
+				} else if (0 == (modifiers & (J9FieldFlagObject | J9FieldSizeDouble))) {
+					if (hasConstantValue) {
+						*(U_32*)singleStaticAddress = *(U_32*)romFieldInitialValueAddress(field);
+					}
+					singleStaticAddress += 1;
+				} else if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldSizeDouble)) {
+					if (hasConstantValue) {
 						*doubleStaticAddress = *(U_64*)romFieldInitialValueAddress(field);
 					}
 					doubleStaticAddress += 1;
+				} else {
+					// Can't happen now - maybe in the future with valuetypes?
 				}
-				field = romFieldsNextDo(&fieldWalkState);
 			}
+			field = romFieldsNextDo(&fieldWalkState);
 		}
 	}
 done:


### PR DESCRIPTION
The code needs to loop over the static fields and initialize any
of them that have a constant value (J9FieldFlagConstant).  Original
code use three loops - one to process objects, one to process single
slot statics, one to process double slot statics - which meant
iterating over the romClass fields 3 times.

The new algorithm uses the counts in the J9ROMClass to figure out
the starting area for each of the 3 kinds of static fields.  This
saves two iterations over the fields (an expensive operation!)
while still maintaining the same layout of object/singles/doubles.

Keep track of whether the class being processed has static
fields with constantValueAttributes.  These fields require
extra work when initializing the class to ensure that the
constant values are copied into the J9Class->ramStatics.

Having this info allows optimizing class initialization to
skip this processing if the class doesn't have the field
