### PR TITLE
Spelling comments j..n

### DIFF
--- a/debugtools/DDR_VM/generate.properties
+++ b/debugtools/DDR_VM/generate.properties
@@ -31,7 +31,7 @@ J9Class=true,false
 # This is required to ensure that where a change in a pointer is detected such that a new vX (e.g. v1)
 # version of the field is required, this is always done in the same order.
 
-#TODO: lpgnuyen Don't forget to remove combo specs from here after we delete them
+#TODO: lpnguyen Don't forget to remove combo specs from here after we delete them
 #ddr.order=aix_ppc-64,aix_ppc-64_cmprssptrs,aix_ppc-64_cmprssptrs_tarok,aix_ppc-64_tarok,aix_ppc,\
 linux_390-64,linux_390-64_cmprssptrs,linux_390-64_cmprssptrs_tarok,linux_390-64_tarok,linux_390,\
 linux_ppc-64,linux_ppc-64_cmprssptrs,linux_ppc-64_cmprssptrs_tarok,linux_ppc-64_tarok,linux_ppc,\

--- a/debugtools/DDR_VM/generate.properties
+++ b/debugtools/DDR_VM/generate.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2017 IBM Corp. and others
+# Copyright (c) 2013, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/LibraryCollector.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/LibraryCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/LibraryCollector.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/LibraryCollector.java
@@ -41,7 +41,7 @@ import java.util.logging.SimpleFormatter;
 
 public class LibraryCollector {
 	/**
-	 * Used to indicated the overall outcome when invoking the libary collection process
+	 * Used to indicated the overall outcome when invoking the library collection process
 	 * @author Adam Pilkington
 	 *
 	 */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
@@ -316,7 +316,7 @@ public class ModularityHelper {
 	 *
 	 * @param    out            The printstream that will be provided to outputter
 	 * @param    filter         Used to determine whether a class will be output.
-	 *                          Will be run on all loaaded classes owned by the module.
+	 *                          Will be run on all loaded classes owned by the module.
 	 * @param    outputter      Used to output details about a class that was matched
 	 *                          by the filter. Will be run on any class that filter
 	 *                          returns true for.

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/ImageProcessComparator.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/ImageProcessComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/ImageProcessComparator.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/ImageProcessComparator.java
@@ -50,7 +50,7 @@ public class ImageProcessComparator extends DTFJComparator {
 	// getPointerSize()
 	// getRuntiems()
 	// getSignalName()
-	// getSignalNuumber()
+	// getSignalNumber()
 	// getThreads()
 	
 	public void testEquals(Object ddrObject, Object jextractObject, int members) {

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/JavaMethodComparator.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/JavaMethodComparator.java
@@ -66,7 +66,7 @@ public class JavaMethodComparator extends DTFJComparator {
 	// DDR handles these sections properly so may return more sections than jextract.
 	
 	// When number of returned values are the same test that they are all the same.
-	// If the number siffer, remove all cold sections from DDR output and make sure remainders
+	// If the numbers differ, remove all cold sections from DDR output and make sure remainders
 	// match jextract output.  In this scenerio we must ignore the size of the jextract output since
 	// it too is incorrect
 	

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/DTFJUnitTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/DTFJUnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/DTFJUnitTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/DTFJUnitTest.java
@@ -95,7 +95,7 @@ public abstract class DTFJUnitTest {
 	// Clones of DDR Objects to test.  These should pass equals test
 	static List<Object> ddrClonedObjects;
 
-	// Jxtract reference objects
+	// jextract reference objects
 	static List<Object> jextractTestObjects;
 	
 	public static class InvalidObjectException extends Exception {

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -524,7 +524,7 @@ final class J9VMInternals {
 	
 	/**
 	 * Format a message to be used when creating a NoSuchMethodException from the VM.
-	 * On failure returns methodSig ie the old style of NoSuchMethoException message
+	 * On failure returns methodSig ie the old style of NoSuchMethodException message
 	 * @param methodSig String representation of the signature of the called method
 	 * @param clazz1 The calling class, 
 	 * @param classPath1 Classpath used to load calling class. Only set when class is loaded by bootstrap loader

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1326,7 +1326,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// the byte[] value of two Strings. In such cases we extract the String.value fields before entering the operation loop.
 	// However if chatAt is used inside the loop then the JIT will anchor the load of the value byte[] inside of the loop thus
 	// causing us to load the String.value on every iteration. This is very suboptimal and breaks some of the common idioms
-	// that we recognize. The most prominent one is the regionMathes arraycmp idiom that is not recognized unless this method
+	// that we recognize. The most prominent one is the regionMatches arraycmp idiom that is not recognized unless this method
 	// is being used.
 	char charAtInternal(int index, byte[] value) {
 		// Check if the String is compressed
@@ -5277,7 +5277,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	// the byte[] value of two Strings. In such cases we extract the String.value fields before entering the operation loop.
 	// However if chatAt is used inside the loop then the JIT will anchor the load of the value byte[] inside of the loop thus
 	// causing us to load the String.value on every iteration. This is very suboptimal and breaks some of the common idioms
-	// that we recognize. The most prominent one is the regionMathes arraycmp idiom that is not recognized unless this method
+	// that we recognize. The most prominent one is the regionMatches arraycmp idiom that is not recognized unless this method
 	// is being used.
 	char charAtInternal(int index, char[] value) {
 		// Check if the String is compressed

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2415,7 +2415,7 @@ public class MethodHandles {
 	 * and the third will be the item to write into the array
 	 * 
 	 * @param arrayType - the type of the array
-	 * @return a MehtodHandle able to write into the array
+	 * @return a MethodHandle able to write into the array
 	 * @throws IllegalArgumentException - if arrayType is not actually an array
 	 */
 	public static MethodHandle arrayElementSetter(Class<?> arrayType) throws IllegalArgumentException {

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -250,7 +250,7 @@ public class ThreadInfo {
 	 * If thread contention monitoring is supported and enabled, returns the
 	 * total amount of time that the thread represented by this
 	 * <code>ThreadInfo</code> has spent blocked on any monitor objects. The
-	 * time is measued in milliseconds and will be measured over the time period
+	 * time is measured in milliseconds and will be measured over the time period
 	 * since thread contention was most recently enabled.
 	 * 
 	 * @return if thread contention monitoring is currently enabled, the number

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaHeap.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaHeap.java
@@ -243,7 +243,7 @@ class PHDJavaHeap implements JavaHeap {
 		/** Largest address - used to find if a JavaObject at a particular address might be in this chunk. */
 		final long maxAddress;
 		/**
-		 * Construct the metadeta for a chunk.
+		 * Construct the metadata for a chunk.
 		 * @param index
 		 * @param size
 		 * @param nextIndex

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaHeap.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaHeap.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/PluginManagerLocator.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/PluginManagerLocator.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/PluginManagerLocator.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/plugins/PluginManagerLocator.java
@@ -36,7 +36,7 @@ import com.ibm.java.diagnostics.utils.DTFJContext;
 
 /**
  * Locator class to hide the ASM classloading shimming that occurs when using 
- * the plugin mangager, allowing this to be shared by different plugin architectures
+ * the plugin manager, allowing this to be shared by different plugin architectures
  * rather than just the DTFJ based ones.
  * 
  * @author adam

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecordExternal.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecordExternal.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecordExternal.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecordExternal.java
@@ -125,7 +125,7 @@ final public class TraceRecordExternal extends TraceRecord {
                 if ( buffer[entry+2]==0 && buffer[entry+1]==0 ) {
                      Util.Debug.println("Entry with data length > 256");
 
-                     // remember the ID and lenght of the special entry
+                     // remember the ID and length of the special entry
                      longEntryID     = buffer[entry+3];
                      longEntryLength = Util.constructUnsignedByte(buffer,entry);
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -309,8 +309,8 @@ set(CMAKE_SHARED_LIBRARY_SUFFIX "${J9VM_SHARED_LIBRARY_SUFFIX}")
 ###
 ### Begin the definitions of our modules
 ###
-# TODO: a few subdirectories still neeed to be implemented (currently commented out)
-# TODO: most libriaries still need to be gated with if() statements
+# TODO: a few subdirectories still need to be implemented (currently commented out)
+# TODO: most libraries still need to be gated with if() statements
 
 if(J9VM_MODULE_BCUTIL)
 	add_subdirectory(bcutil)

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -550,7 +550,7 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 					&& ((U_8 *)existingROMClass == context->intermediateClassData())
 				) {
 					/* 'existingROMClass' is same as the ROMClass corresponding to intermediate class data.
-					 * Based on the assumption that an agent is actually modifing the class file
+					 * Based on the assumption that an agent is actually modifying the class file
 					 * instead of just returning a copy of the classbytes it recieves,
 					 * this comparison can be avoided.
 					 */

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -472,7 +472,7 @@ convertToOSFilename (J9JavaVM * javaVM, U_8 * dir, UDATA dirLength, U_8 * module
 
 /* 
 	Verify that the internal dynamic loader buffers used to hold the Sun class file are large enough
-	to accommodate @sunClassFileSize bytes.  Grow buffers if neccessary.
+	to accommodate @sunClassFileSize bytes.  Grow buffers if necessary.
 
 	Return 0 on success, non-zero on error.
 */

--- a/runtime/cmake/platform.cmake
+++ b/runtime/cmake/platform.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/cmake/platform.cmake
+++ b/runtime/cmake/platform.cmake
@@ -21,7 +21,7 @@
 ################################################################################
 
 #TODO alot of this should really just be inherited from the OMR config
-#TODO we are assuming liunx at the moment
+#TODO we are assuming Linux at the moment
 if(CMAKE_CXX_COMPILER_ID STREQUAL "XL")
     set(OMR_TOOLCONFIG "xlc")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -q64 -qalias=noansi")

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -928,7 +928,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Co
    cg->addSnippet(snippet);
    doneLabel->setEndInternalControlFlow();
 #else
-   // Branch directly to jitMontiorExit
+   // Branch directly to jitMonitorExit
    TR::SymbolReference *symRef = node->getSymbolReference();
    instr = generateImmSymInstruction(cg, ARMOp_bl, node, (uint32_t)symRef->getMethodAddress(), deps, symRef);
    instr->setConditionCode(ARMConditionCodeNE);

--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -55,7 +55,7 @@ PERL?=perl
 
 #
 # z/Architecture arch and tune level
-# z/TPF uses z10 as minminum supported z/Architecture.
+# z/TPF uses z10 as minimum supported z/Architecture.
 # mtune of z9-109 allows builtin versions of memcpy, etc.
 # instead of calling "arch-optimized" glibc functions.
 #

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4677,7 +4677,7 @@ J9::CodeGenerator::generateCatchBlockBBStartPrologue(
       {
       // Note we should not use `fenceInstruction` here because it is not the first instruction in this BB. The first
       // instruction is a label that incoming branches will target. We will use this label (first instruction in the
-      // block) in `createMethodMetaData` to populate a list of non-mergable GC maps so as to ensure the GC map at the
+      // block) in `createMethodMetaData` to populate a list of non-mergeable GC maps so as to ensure the GC map at the
       // catch block entry is always present if requested.
       node->getBlock()->getFirstInstruction()->setNeedsGCMap();
       }

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -838,7 +838,7 @@ public:
    /**
    * @brief Compute free physical memory taking into account container limits
    *
-   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered mmeory couldn't be read
+   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered memory couldn't be read
    * @return                 A value representing the free physicalMemory
                              or OMRPORT_MEMINFO_NOT_AVAILABLE in case of error
    */
@@ -851,7 +851,7 @@ public:
    * only refreshes it if more than "updatePeriodMs" have passed since the last update
    * If updatePeriodMs==-1, then updatePeriodMs uses a default value of 500 ms
    *
-   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered mmeory couldn't be read
+   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered memory couldn't be read
    * @param updatePeriodMs   Indicates how often the cached values are refreshed
    * @return                 A value representing the free physicalMemory 
                              or OMRPORT_MEMINFO_NOT_AVAILABLE in case of error

--- a/runtime/compiler/control/CompilationTracingFacility.hpp
+++ b/runtime/compiler/control/CompilationTracingFacility.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/control/CompilationTracingFacility.hpp
+++ b/runtime/compiler/control/CompilationTracingFacility.hpp
@@ -40,7 +40,7 @@ struct J9VMThread;
 struct TR_CompilationTracingEntry
    {
    TR_PERSISTENT_ALLOC(TR_Memory::OptimizationPlan) // lie about the type as this is for debug only
-   uint16_t _J9VMThreadId; // last meaningfull bits from the vm thread pointer
+   uint16_t _J9VMThreadId; // last meaningful bits from the vm thread pointer
    uint8_t  _operation;
    uint8_t  _otherData;
    }; // TR_CompilationTracingEntry

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2944,7 +2944,7 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
          classPair = (J9JITRedefinedClass *) ((char *) classPair->methodList + (classPair->methodCount * sizeof(struct J9JITMethodEquivalence)));
          }
       }
-   //for extended HCR under FSD, all the methods in code cache neeeds to be
+   //for extended HCR under FSD, all the methods in code cache needs to be
    //discarded because of inlining
    else
       {

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -75,7 +75,7 @@ J9::Recompilation::setupMethodInfo()
          }
 
       // During compilation methodInfo->nextOptLevel is the current optlevel
-      // ie. we pretend that the previous (non-extistent) compile has set this up
+      // ie. we pretend that the previous (nonexistent) compile has set this up
       // for us.  Mark this as a non-profiling compile.  Only sampleMethod
       // even enables profiling.
       //

--- a/runtime/compiler/il/J9IL.cpp
+++ b/runtime/compiler/il/J9IL.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/J9IL.cpp
+++ b/runtime/compiler/il/J9IL.cpp
@@ -34,7 +34,7 @@ TR::ILOpCodes J9::IL::opCodesForConst[] =
    TR::BadILOp,    // TR::PackedDecimal
    TR::BadILOp,    // TR::ZonedDecimal
    TR::BadILOp,    // TR::ZonedDecimalSignLeadingEmbedded
-   TR::BadILOp,    // TR::ZonedDecimalSignLeingSeparate
+   TR::BadILOp,    // TR::ZonedDecimalSignLeadingSeparate
    TR::BadILOp,    // TR::ZonedDecimalSignTrailingSeparate
    TR::BadILOp,    // TR::UnicodeDecimal
    TR::BadILOp,    // TR::UnicodeDecimalSignLeading
@@ -139,7 +139,7 @@ TR::ILOpCodes J9::IL::opCodesForRegisterLoad[] =
    TR::BadILOp,    // TR::PackedDecimal
    TR::BadILOp,    // TR::ZonedDecimal
    TR::BadILOp,    // TR::ZonedDecimalSignLeadingEmbedded
-   TR::BadILOp,    // TR::ZonedDecimalSignLeangSeparate
+   TR::BadILOp,    // TR::ZonedDecimalSignLeadingSeparate
    TR::BadILOp,    // TR::ZonedDecimalSignTrailingSeparate
    TR::BadILOp,    // TR::UnicodeDecimal
    TR::BadILOp,    // TR::UnicodeDecimalSignLeading
@@ -154,7 +154,7 @@ TR::ILOpCodes J9::IL::opCodesForRegisterStore[] =
    TR::BadILOp,    // TR::PackedDecimal
    TR::BadILOp,    // TR::ZonedDecimal
    TR::BadILOp,    // TR::ZonedDecimalSignLeadingEmbedded
-   TR::BadILOp,    // TR::ZonedDecimalSignLeangSeparate
+   TR::BadILOp,    // TR::ZonedDecimalSignLeadingSeparate
    TR::BadILOp,    // TR::ZonedDecimalSignTrailingSeparate
    TR::BadILOp,    // TR::UnicodeDecimal
    TR::BadILOp,    // TR::UnicodeDecimalSignLeading

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -197,7 +197,7 @@ ChangeAlignmentOfRegion(TR_CISCTransformer *trans)
    if (!lastNode) return changed;   // the last node of the peeling region
    TR_CISCNode *foundNode = lastNode->getSucc(0);
 
-   // Find the last non-neglible node
+   // Find the last non-negligible node
    if (lastNode->isNegligible())
       {
       TR_CISCNode *lastNonNegligble = NULL;

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -139,7 +139,7 @@ static bool isFinalFieldPointingAtRepresentableNativeStruct(TR::SymbolReference 
       case TR::SymbolReferenceTable::classFromJavaLangClassSymbol:
       case TR::SymbolReferenceTable::classFromJavaLangClassAsPrimitiveSymbol:
          // Note: We could also do vftSymbol, except replacing those with
-         // loadaddres mucks up indirect loads in ways the optimizer/codegen
+         // loadaddr mucks up indirect loads in ways the optimizer/codegen
          // isn't expecting yet
          TR_ASSERT(symRef->getSymbol()->isShadow(), "isFinalFieldPointingAtRepresentableNativeStruct expected shadow symbol");
          return true;

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -59,7 +59,7 @@ public:
    /**
     * \brief
     *    Fold direct load of a reliable static final field. A reliable static final field
-    *    is a field on which midification after initialization is not expected because it's
+    *    is a field on which modification after initialization is not expected because it's
     *    initial value critical to VM functionality and performance.
     *
     *    See J9::TransformUtil::canFoldStaticFinalField for the list of reliable static final

--- a/runtime/compiler/p/runtime/J9PPCArrayTranslate.spp
+++ b/runtime/compiler/p/runtime/J9PPCArrayTranslate.spp
@@ -1495,7 +1495,7 @@ __arrayTranslateTROT:
 ! Legends:
 !      ...   No data
 !      .PP   Partial block (missing a part at head)
-!      .P.   Partial block (imssing a part at both head and tail)
+!      .P.   Partial block (missing a part at both head and tail)
 !      PP.   Partial block (missing a part at tail)
 !      BBBB+ One or more 4x unrolled blocks
 !      BB    A pair of blocks

--- a/runtime/compiler/runtime/DataCache.cpp
+++ b/runtime/compiler/runtime/DataCache.cpp
@@ -522,7 +522,7 @@ void TR_DataCacheManager::fillDataCacheHeader(J9JITDataCacheHeader *hdr, uint32_
 // header of the record
 // The data cache does not have to be reserved
 // size may be rounded for alignment
-// There is a similar methos in J9VMBase. That one is supposed to be called
+// There is a similar methods in J9VMBase. That one is supposed to be called
 // from within a compilation. This method is supposed to be called outside a
 // compilation and when we don't need contiguous allocation.
 //----------------------------------------------------------------------------

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -27,7 +27,7 @@
  * \page Iprofiling Interpreter Profiling 
  * 
  * The Interpreter Profiler, or IProfiler, is a mechanism created to extract 
- * knowlege from the interpreter to feed into our first compilation. 
+ * knowledge from the interpreter to feed into our first compilation. 
  *
  * Structurally, the IProfiler consists of three main components: 
  *

--- a/runtime/compiler/runtime/J9ValueProfiler.hpp
+++ b/runtime/compiler/runtime/J9ValueProfiler.hpp
@@ -640,7 +640,7 @@ TR_HashTableProfilerInfo<T>::dumpInfo(TR::FILE *logFile)
 
 /**
  * Determine whether the table should be reset or not, due to a selection
- * of bad values. Will reset the table if necesssary.
+ * of bad values. Will reset the table if necessary.
  *
  * \return True if the table was reset.
  */

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -188,7 +188,7 @@ J9JITConfig * codert_onload(J9JavaVM * javaVM)
       }
    #endif
 
-   // Attempt to allocate a table of mutices
+   // Attempt to allocate a table of mutexes
    if (!TR::MonitorTable::init(privatePortLibrary, javaVM))
       goto _abort;
 

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -160,7 +160,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(
 
    if (getProperties().getCallerCleanup() && memoryArgSize > 0)
       {
-      // adjust sp is neccessary, because for java, the stack is native stack, not java stack.
+      // adjust sp is necessary, because for java, the stack is native stack, not java stack.
       // we need to restore native stack sp properly to the correct place.
       TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
       TR_X86OpCodes op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? ADDRegImms() : ADDRegImm4();

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -815,7 +815,7 @@ int32_t TR::AMD64PrivateLinkage::argAreaSize(TR::Node *callNode)
    // TODO: We only need this function because unresolved calls don't have a
    // TR::ResolvedMethodSymbol, and only TR::ResolvedMethodSymbol has
    // getParameterList().  If getParameterList() ever moves to TR::MethodSymbol,
-   // then this function becomes unneccessary.
+   // then this function becomes unnecessary.
    //
    TR::Node *child;
    int32_t  i;

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -212,7 +212,7 @@ void TR_X86Recompilation::setMethodReturnInfoBits()
    if (!couldBeCompiledAgain())
       return;
 
-   // Sets up bits inside the likage info field of the method.  Linkage info
+   // Sets up bits inside the linkage info field of the method.  Linkage info
    // is the dword immediately before the startPC
    //
    // The bits contain information about a) what kind of method header this

--- a/runtime/compiler/x/runtime/X86LockReservation.nasm
+++ b/runtime/compiler/x/runtime/X86LockReservation.nasm
@@ -167,7 +167,7 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
   .fallback:
 %endmacro
 
-; This code is called when we need to exit reserved montior with couple of possible
+; This code is called when we need to exit reserved monitor with couple of possible
 ; scenarios:
 ;   - more than one level of recursion
 ;   - FLC or INF are set

--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -132,7 +132,7 @@ interpreterUnresolvedStaticGlue:
       btr         eax, 0
       ; Load the resolved RAM method into EDI so that the caller doesn't have to re-run patched code
       xchg        edi, eax
-      ; Skip code patching if the interpreter low-tag the RAM mathod
+      ; Skip code patching if the interpreter low-tag the RAM method
       jc          .skippatching
 
       ; Patch the call that brought us here into a load of the resolved RAM method into EDI.
@@ -1038,7 +1038,7 @@ interpreterUnresolvedStaticGlue:
       btr         rax, 0
       ; Load the resolved RAM method into RDI so that the caller doesn't have to re-run patched code
       mov         rdi, rax
-      ; Skip code patching if the interpreter low-tag the RAM mathod 
+      ; Skip code patching if the interpreter low-tag the RAM method 
       jc          .skippatching
 
       ; Patch the call that brought us here into a load of the resolved RAM method into RDI.

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -7267,7 +7267,7 @@ J9::Z::TreeEvaluator::pdshiftEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
       {
       if (srcPrecision > resultPrecision)
          {
-         /* Packed decimal narrrowing with exception handling:
+         /* Packed decimal narrowing with exception handling:
           *
           * If the narrowing operation truncates non-zero digits (e.g. shift "123C" by 0 digts and keep 2 digits yields "23C")
           * and the 'checkOverflow' parameter is true, the JIT'ed sequence should trigger HW exception and

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -3355,7 +3355,7 @@ TR::S390PrivateLinkage::buildIndirectDispatch(TR::Node * callNode)
 ////////////////////////////////////////////////////////////////////////////////
 // TR::S390PrivateLinkage::mapIncomingParms - maps parameters onto the stack for the given method.
 //   This function iterates over the parameters, mapping them onto the stack, either right
-//   to left, or left to right, depending on S390Linakge properties.
+//   to left, or left to right, depending on S390Linkage properties.
 //   This code was removed from TR::S390PrivateLinkage::mapStack as it is common code that
 //   is now called by TR::S390PrivateLinkage::mapCompactedStack as well.
 ////////////////////////////////////////////////////////////////////////////////

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -5108,7 +5108,7 @@ reservationLockEnter(TR::Node *node, int32_t lwOffset, TR::Register *objectClass
    callLabel = generateLabelSymbol(cg);
    doneLabel = generateLabelSymbol(cg);
 
-   // TODO - primitive monitores are disabled. Enable it after testing
+   // TODO - primitive monitors are disabled. Enable it after testing
    //TR::TreeEvaluator::isPrimitiveMonitor(node, cg);
    //
    TR::LabelSymbol *helperReturnOOLLabel, *doneOOLLabel = NULL;
@@ -12232,7 +12232,7 @@ J9::Z::TreeEvaluator::forwardArrayCopySequenceGenerator(TR::Node *node, TR::Code
                                          node->getArrayCopyElementType() == TR::Address;
    if (mustGenerateOOLGuardedLoadPath)
       {
-      // It might be possible that we have constant byte lenght load and it is forward array copy.
+      // It might be possible that we have constant byte length load and it is forward array copy.
       // In this case if we need to do guarded Load then need to evaluate byteLenNode.
       if (byteLenReg == NULL)
          byteLenReg = cg->gprClobberEvaluate(byteLenNode);

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -554,7 +554,7 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
 
    // Field used by nestmate private calls
    // J2I thunk address
-   // No explicit call to `addExternalReloation` because its relocation info is passed to CP_addr `addExternalReloation` call.
+   // No explicit call to `addExternalRelocation` because its relocation info is passed to CP_addr `addExternalRelocation` call.
    *(uintptrj_t *) cursor = (uintptrj_t) thunkAddress;
    j2iRelocInfo->data3 = (uintptrj_t)cursor - cpAddrPosition;    // data3 is the offset of CP_addr to J2I thunk
    AOTcgDiag1(comp, "add TR_J2IVirtualThunkPointer cursor=%x\n", cursor);
@@ -1077,7 +1077,7 @@ TR::J9S390InterfaceCallDataSnippet::emitSnippetBody()
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
    // J2I thunk address.
-   // Note that J2I thunk relocation is associated with CP addr and the call to `addExternalReloation` uses CP-Addr cursor.
+   // Note that J2I thunk relocation is associated with CP addr and the call to `addExternalRelocation` uses CP-Addr cursor.
    *(intptrj_t *) cursor = (intptrj_t)_thunkAddress;
    j2iRelocInfo->data3 = (uintptrj_t)cursor - cpAddrPosition;  // data3 is the offset of CP_addr to J2I thunk
 

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1733,7 +1733,7 @@ ZZ zLinux
 ])dnl
 
     LR_GPR  r1,r2
-    NR_GPR  r1,r0          # Remove low-tag of J9Metod ptr
+    NR_GPR  r1,r0          # Remove low-tag of J9Method ptr
     LR_GPR  r3,r14         # free up r14 for RA
     L_GPR   r14,eq_privateRA_inVUCallSnippet(r14) #load RA
     TM      eq_methodCompiledFlagOffset(r1),J9TR_MethodNotCompiledBit
@@ -2482,7 +2482,7 @@ LABEL(ifCHMLTypeCheckIFCPrivate)
 ZZ  Call fast_jitInstanceOf
 ZZ  with three args: VMthread, object, and castClass.
 ZZ
-ZZ  The call to this helper follows J9S390CHelperLinakge except
+ZZ  The call to this helper follows J9S390CHelperLinkage except
 ZZ  that all volatiles are saved here.
 ZZ  instance of result is indicated in return reg
 ZZ
@@ -2549,7 +2549,7 @@ ZZ zLinux
     LHI_GPR r2,~J9TR_J9_ITABLE_OFFSET_DIRECT
 ])dnl
 
-    NR_GPR  r1,r2         # Remove low-tag of J9Metod ptr
+    NR_GPR  r1,r2         # Remove low-tag of J9Method ptr
     L_GPR   r14,eq_codeRA_inInterfaceSnippet(r14)    #load RA
     TM      eq_methodCompiledFlagOffset(r1),J9TR_MethodNotCompiledBit
     JZ      L_jitted_private

--- a/runtime/compiler/z/runtime/Recompilation.m4
+++ b/runtime/compiler/z/runtime/Recompilation.m4
@@ -987,7 +987,7 @@ ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     AHI_GPR   r3,-2*PTR_SIZE    ZZ Otherwise, we move to previous slot
     J LSearchInterfaceSlotToPatch
 
-ZZ If we find a slot that mathces the same class pointer,
+ZZ If we find a slot that matches the same class pointer,
 ZZ we would patch the method entry point
 LABEL(LPatchInterfaceSlot)
     ST_GPR    rEP,PTR_SIZE(r3)

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -300,9 +300,9 @@ ZZ  # derive base pointer into table
     CONST_4BYTE(000000FF) # lshmask1 for patching
     CONST_4BYTE(0000FFFF) # lshmask2 for patching
     CONST_4BYTE(00FFFFFF) # lshmask3 for patching
-    CONST_4BYTE(FF000000) # mshmaks1 for patching
-    CONST_4BYTE(FFFF0000) # mshmaks2 for patching
-    CONST_4BYTE(FFFFFF00) # mshmaks3 for patching
+    CONST_4BYTE(FF000000) # mshmask1 for patching
+    CONST_4BYTE(FFFF0000) # mshmask2 for patching
+    CONST_4BYTE(FFFFFF00) # mshmask3 for patching
 
 LABEL($1PatchLbl0)
 

--- a/runtime/ddrext/ddrJniRegistration.c
+++ b/runtime/ddrext/ddrJniRegistration.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/ddrext/ddrJniRegistration.c
+++ b/runtime/ddrext/ddrJniRegistration.c
@@ -88,7 +88,7 @@ static JNINativeMethod jniOutputStreamMemoryMethods[] = {
  * native methods with the class.
  * @param env java env
  * @param class Java class name.
- * @param mathods array of native methods
+ * @param methods array of native methods
  * @param nMethods size of array
  */
 static BOOLEAN

--- a/runtime/exelib/common/memcheck.c
+++ b/runtime/exelib/common/memcheck.c
@@ -951,7 +951,7 @@ static void memoryCheck_fill_bytes(OMRPortLibrary *portLib, U_8 *fillAddress, UD
 
 
 
-/* @internal	The portLibray passed on to other functions  must be the memCheckPortLib. */
+/* @internal	The portLibrary passed on to other functions  must be the memCheckPortLib. */
 static void 
 memoryCheck_free_memory(OMRPortLibrary *portLib, void *memoryPointer)
 {
@@ -2876,7 +2876,7 @@ memoryCheck_control(OMRPortLibrary *portLib, const char* key, UDATA value)
   *
   * @param portLibrary 
   * @param node J9MEMAVLTreeNode to print callSite information for
-  * @internal	The portLibray passed in should be the memCheckPortLib->
+  * @internal	The portLibrary passed in should be the memCheckPortLib->
   *
   */
 static void 
@@ -2927,7 +2927,7 @@ memoryCheck_dump_callSites(OMRPortLibrary *portLibrary, J9AVLTree *tree)
  *
  * @parm portLib OMRPortLibrary used to access the memory functions
  * @param tree J9AVLTree storing the callSite information
- * @internal	The portLibray passed in should be the memCheckPortLib.
+ * @internal	The portLibrary passed in should be the memCheckPortLib.
  */
 static void 
 memoryCheck_free_AVLTree(OMRPortLibrary *portLib, J9AVLTree *tree)
@@ -2948,7 +2948,7 @@ memoryCheck_free_AVLTree(OMRPortLibrary *portLib, J9AVLTree *tree)
  *
  * @parm portLib OMRPortLibrary used to access the memory functions
  * @param tree J9AVLTreeNode the node to free
- * @internal	The portLibray passed in should be the memCheckPortLib.
+ * @internal	The portLibrary passed in should be the memCheckPortLib.
  */
 static void 
 memoryCheck_free_AVLTreeNode(OMRPortLibrary *portLib, J9AVLTreeNode *node)
@@ -3177,7 +3177,7 @@ memoryCheck_print_stats_callSite_small(OMRPortLibrary *portLib, J9MEMAVLTreeNode
   *
   * @param portLibrary 
   * @param tree J9AVLTree storing the callSite information
-  * @internal	The portLibray passed in should be the memCheckPortLib->
+  * @internal	The portLibrary passed in should be the memCheckPortLib->
   *
   */
 static void 
@@ -3204,7 +3204,7 @@ memoryCheck_dump_callSites_small(OMRPortLibrary *portLibrary, J9AVLTree *tree)
   *
   * @param portLibrary 
   * @param node J9MEMAVLTreeNode to print callSite information for
-  * @internal	The portLibray passed in should be the memCheckPortLib.
+  * @internal	The portLibrary passed in should be the memCheckPortLib.
   */
 static void 
 memoryCheck_dump_callSite_small(OMRPortLibrary *portLibrary, J9AVLTreeNode *node)

--- a/runtime/gc_base/FinalizeListManager.hpp
+++ b/runtime/gc_base/FinalizeListManager.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_base/FinalizeListManager.hpp
+++ b/runtime/gc_base/FinalizeListManager.hpp
@@ -300,7 +300,7 @@ public:
 	/**
 	 * Pop the first classloader on this off that has a non NULL gcThreadNotification
 	 * 
-	 * @return classLoader the first class loader on the list with a non NULL gcThreadNotifcation or NULL
+	 * @return classLoader the first class loader on the list with a non NULL gcThreadNotification or NULL
 	 */
 	J9ClassLoader *popRequiredClassLoaderForForcedClassLoaderUnload();
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */

--- a/runtime/gc_check/CheckCycle.cpp
+++ b/runtime/gc_check/CheckCycle.cpp
@@ -453,7 +453,7 @@ GC_CheckCycle::run(GCCheckInvokedBy invokedBy, UDATA filterFlags)
  * pointer is unaligned, ie low_tagged.
  * 
  * This is not necessary if the Object Map is available as we can perform the
- * necessary check by calling the memeory manager j9gc_ext_is_liveObject() function
+ * necessary check by calling the memory manager j9gc_ext_is_liveObject() function
  * 
  */
 void

--- a/runtime/gc_doc/DoxygenConfig.txt
+++ b/runtime/gc_doc/DoxygenConfig.txt
@@ -257,7 +257,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # extension. Doxygen has a built-in mapping, but you can override or extend it 
 # using this tag. The format is ext=language, where ext is a file extension, 
 # and language is one of the parsers supported by doxygen: IDL, Java, 
-# Javascript, CSharp, C, C++, D, PHP, Objective-C, Python, Fortran, VHDL, C, 
+# JavaScript, CSharp, C, C++, D, PHP, Objective-C, Python, Fortran, VHDL, C, 
 # C++. For instance to make doxygen treat .inc files as Fortran files (default 
 # is PHP), and .f files as C (default is Fortran), use: inc=Fortran f=C. Note 
 # that for custom extensions you also need to set FILE_PATTERNS otherwise the 
@@ -1242,7 +1242,7 @@ FORMULA_FONTSIZE       = 10
 FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax 
-# (see http://www.mathjax.org) which uses client side Javascript for the 
+# (see http://www.mathjax.org) which uses client side JavaScript for the 
 # rendering instead of using prerendered bitmaps. Use this if you do not 
 # have LaTeX installed or if you want to formulas look prettier in the HTML 
 # output. When enabled you may also need to install MathJax separately and 
@@ -1284,7 +1284,7 @@ MATHJAX_EXTENSIONS     =
 SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be 
-# implemented using a web server instead of a web client using Javascript. 
+# implemented using a web server instead of a web client using JavaScript. 
 # There are two flavours of web server based search depending on the 
 # EXTERNAL_SEARCH setting. When disabled, doxygen will generate a PHP script for 
 # searching and an index file used by the script. When EXTERNAL_SEARCH is 
@@ -1780,7 +1780,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the 
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS 
 # threshold limits the number of items for each type to make the size more 
-# managable. Set this to 0 for no limit. Note that the threshold may be 
+# manageable. Set this to 0 for no limit. Note that the threshold may be 
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -245,7 +245,7 @@ public:
 	/**
 	 * We can't use memcpy because it may be not atomic for pointers, use this function instead
 	 * Copy data in UDATA words
-	 * If lenght is not times of UDATA one more word is copied
+	 * If length is not times of UDATA one more word is copied
 	 * @param destAddr address copy to
 	 * @param sourceAddr address copy from
 	 * @param lengthInBytes requested size in bytes

--- a/runtime/gc_modron_startup/mmparse.h
+++ b/runtime/gc_modron_startup/mmparse.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_modron_startup/mmparse.h
+++ b/runtime/gc_modron_startup/mmparse.h
@@ -57,7 +57,7 @@ typedef enum {
 } gcMemoryParameters;
 
 /* When displaying, maximum number of characters required, plus the "-" i.e. -Xmox */
-#define MAXIMUM_GC_MEMORY_PARAMETER_LENGTH 8 /* -Xsoftmx is longer than the others (Lenght 5) */
+#define MAXIMUM_GC_MEMORY_PARAMETER_LENGTH 8 /* -Xsoftmx is longer than the others (length 5) */
 
 /**
  * Manipulate GC memory parameters.

--- a/runtime/gc_realtime/RealtimeMarkingSchemeRootClearer.hpp
+++ b/runtime/gc_realtime/RealtimeMarkingSchemeRootClearer.hpp
@@ -42,7 +42,7 @@
  */
 class MM_RealtimeMarkingSchemeRootClearer : public MM_RealtimeRootScanner
 {
-/* Data memebers / types */
+/* Data members / types */
 public:
 protected:
 private:

--- a/runtime/gc_realtime/RealtimeMarkingSchemeRootMarker.hpp
+++ b/runtime/gc_realtime/RealtimeMarkingSchemeRootMarker.hpp
@@ -44,7 +44,7 @@
  */
 class MM_RealtimeMarkingSchemeRootMarker : public MM_RealtimeRootScanner
 {
-/* Data memebers / types */
+/* Data members / types */
 public:
 protected:
 private:

--- a/runtime/gc_trace/TgcHeap.cpp
+++ b/runtime/gc_trace/TgcHeap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_trace_standard/TgcFreeListSummary.cpp
+++ b/runtime/gc_trace_standard/TgcFreeListSummary.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_trace_standard/TgcFreeListSummary.cpp
+++ b/runtime/gc_trace_standard/TgcFreeListSummary.cpp
@@ -45,7 +45,7 @@
 
 /*
  * Free List Summary is organized as a array of counters. Each counter represents number of holes in pool with size in particular range.
- * First element represents number of holes smaller then FIRST_ELEMENT_THRESHOLD bytes (but larger then dark metter threshold - 512 bytes default)
+ * First element represents number of holes smaller then FIRST_ELEMENT_THRESHOLD bytes (but larger then dark matter threshold - 512 bytes default)
  * Second element represents number of holes smaller then 2 * FIRST_ELEMENT_THRESHOLD but larger then FIRST_ELEMENT_THRESHOLD.
  * Each next element has a doubled threshold, except last one which represents number of holes larger then previous threshold.
  * The table of thresholds for FIRST_ELEMENT_THRESHOLD = 1024 and number of elements = 22 is below: 

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -1029,7 +1029,7 @@ MM_MemorySubSpaceTarok::performContract(MM_EnvironmentBase *env, MM_AllocateDesc
 	 */
 	maximumContractSize = getAvailableContractionSize(env, allocDescription);  
 	
-	/* round down to muliple of heap alignment */
+	/* round down to multiple of heap alignment */
 	maximumContractSize= MM_Math::roundToFloor(_extensions->heapAlignment, maximumContractSize);
 	
 	/* Decide by how much to contract */

--- a/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
+++ b/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
+++ b/runtime/gc_vlhgc/SweepHeapSectioningVLHGC.cpp
@@ -38,7 +38,7 @@
  * Called during initialization, this routine looks at the maximum size of the heap and expected
  * configuration (generations, regions, etc) and determines the approximate maximum number of chunks
  * that will be required for a sweep at any given time.  It is safe to underestimate the number of chunks,
- * as the sweep sectioning mechnanism will compensate, but the the expectation is that by having all
+ * as the sweep sectioning mechanism will compensate, but the the expectation is that by having all
  * chunk memory allocated in one go will keep the data localized and fragment system memory less.
  * @return estimated upper bound number of chunks that will be required by the system.
  */

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1346,7 +1346,7 @@ initialArgumentScan(JavaVMInitArgs *args, J9SpecialArguments *specialArgs)
 	}
 
 	if (TRUE == xCheckFound) {
-		/* scan backwards for -Xcheck:memory.  There may be multiple -Xcheck options, so check them all, stop when we hit -Xcheck:memeory */
+		/* scan backwards for -Xcheck:memory.  There may be multiple -Xcheck options, so check them all, stop when we hit -Xcheck:memory */
 		for( argCursor = args->nOptions - 1 ; argCursor >= 0; argCursor-- ) {
 			char* memcheckArgs[2];
 
@@ -3181,8 +3181,8 @@ testBackupAndRestoreLibpath(void)
 		failed++;
 	}
 
-	/* The backup path is prefixed by mulitiple colons */
-	printf("TESTCASE_31: The backup path is prefixed by mulitiple colons\n");
+	/* The backup path is prefixed by multiple colons */
+	printf("TESTCASE_31: The backup path is prefixed by multiple colons\n");
 	setLibpath(":::abc");
 	backupLibpath(&bkp, strlen("abc"));
 	setLibpath("abc");
@@ -4661,7 +4661,7 @@ JVM_RawMonitorDestroy(void* mon)
 
 
 /**
- * Moniter enter
+ * Monitor enter
  *
  * @param mon pointer of the monitor
  * @return 0

--- a/runtime/jcl/common/mgmtmemory.c
+++ b/runtime/jcl/common/mgmtmemory.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jcl/common/mgmtmemory.c
+++ b/runtime/jcl/common/mgmtmemory.c
@@ -758,7 +758,7 @@ Java_com_ibm_lang_management_internal_MemoryNotificationThread_processNotificati
 void JNICALL
 Java_com_ibm_lang_management_internal_MemoryNotificationThreadShutdown_sendShutdownNotification(JNIEnv *env, jobject instance)
 {
-	/* currently, the only queue is the heap usage notfication queue */
+	/* currently, the only queue is the heap usage notification queue */
 	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	J9MemoryNotification *notification = NULL;

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -121,7 +121,7 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 
 	memset(&rv_capabilities, 0, sizeof(jvmtiCapabilities));
 
-	/* Get the JVMTI mutex to ensure to prevent multple agents acquiring capabilities that can only be held by one agent at a time */
+	/* Get the JVMTI mutex to ensure to prevent multiple agents acquiring capabilities that can only be held by one agent at a time */
 
 	omrthread_monitor_enter(jvmtiData->mutex);
 
@@ -330,7 +330,7 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 		rc = JVMTI_ERROR_NOT_AVAILABLE;
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
-		/* Get the JVMTI mutex to ensure to prevent multple agents acquiring capabilities that can only be held by one agent at a time */
+		/* Get the JVMTI mutex to ensure to prevent multiple agents acquiring capabilities that can only be held by one agent at a time */
 
 		omrthread_monitor_enter(jvmtiData->mutex);
 
@@ -453,7 +453,7 @@ jvmtiRelinquishCapabilities(jvmtiEnv* env,
 
 	ENSURE_NON_NULL(capabilities_ptr);
 
-	/* Get the JVMTI mutex to ensure to prevent multple agents releasing capabilities that can only be held by one agent at a time */
+	/* Get the JVMTI mutex to ensure to prevent multiple agents releasing capabilities that can only be held by one agent at a time */
 	/* Also prevents multiple threads from releasing capabilities in the same agent */
 
 	omrthread_monitor_enter(jvmtiData->mutex);

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -471,7 +471,7 @@ javaOffloadSwitchOff(J9JVMTIEnv * j9env, J9VMThread * currentThread, UDATA event
 	vm = currentThread->javaVM;
 
 	/* There are two cases for zAAP switching:
-	 * 1) The agent libary (most likely created by customer) calls GetEnv() at any time when required 
+	 * 1) The agent library (most likely created by customer) calls GetEnv() at any time when required 
 	 *    but doesn't need to call GetEnv() in Agent_OnLoad. Thus, it may be possible for j9env->library 
 	 *    to be NULL if JVMTI is used directly by the VM.
 	 * 2) The flag in J9NativeLibrary->doSwitching requires it to do zAAP switching.

--- a/runtime/nls/exel/exelib.nls
+++ b/runtime/nls/exel/exelib.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/exel/exelib.nls
+++ b/runtime/nls/exel/exelib.nls
@@ -417,7 +417,7 @@ J9NLS_EXELIB_CMDLINE_CP_WARN.system_action=
 J9NLS_EXELIB_CMDLINE_CP_WARN.user_response=
 # END NON-TRANSLATABLE
 
-#J9SourceExeLibArgumentsParsing - cmdline_prepend_internal_WARN/cmdline_perpend_numberic1024_WARN
+#J9SourceExeLibArgumentsParsing - cmdline_prepend_internal_WARN/cmdline_perpend_numeric1024_WARN
 J9NLS_EXELIB_CMDLINE_PREPEND_WARN=\nWARNING: The command line argument \"%s\" has been deprecated.\nWARNING: Use the -X equivalent.
 # START NON-TRANSLATABLE
 J9NLS_EXELIB_CMDLINE_PREPEND_WARN.sample_input_1=-mca:

--- a/runtime/oti/bcutil_api.h
+++ b/runtime/oti/bcutil_api.h
@@ -245,7 +245,7 @@ internalLoadROMClass(J9VMThread *vmThread, J9LoadROMClassData *loadData, J9Trans
 * @param vmThread pointer to J9VMThread
 * @param moduleName name of the module containing the class; can be NULL
 * @param className name of the class to be located
-* @param classNameLength lenght of className
+* @param classNameLength length of className
 * @param classLoader pointer to J9ClassLoader loading the class
 * @param classPath pointer to class path entries
 * @param classPathEntryCount number of class path entries in classPath

--- a/runtime/oti/helpers.m4
+++ b/runtime/oti/helpers.m4
@@ -91,7 +91,7 @@ define([get_function_arg_size], [eval(get_function_arg_size_impl($@))])
 
 # decorate_impl(func_name, ignored, ignored, ignored, ARGS ...)
 # Given a function name and a list of C-style argument strings, get the decorated function name.
-# This uses Microsft-style C name mangling for stdcall functions.
+# This uses Microsoft-style C name mangling for stdcall functions.
 # see https://docs.microsoft.com/en-us/cpp/build/reference/decorated-names#FormatC
 # ex: decorate_impl("foo", ignored, ignored,ignored, "int foo", "int bar") => "_foo@8"
 define([decorate_impl], [_$1@get_function_arg_size(mshift(4,$@))])

--- a/runtime/oti/helpers.m4
+++ b/runtime/oti/helpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2018, 2018 IBM Corp. and others
+dnl Copyright (c) 2018, 2019 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -285,7 +285,7 @@ static const struct { \
 #define internalExitVMToJNI internalReleaseVMAccess
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI */
 
-/* Move marcro MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_xxx from redirector.c in order to be referenced from IBM i series */
+/* Move macro MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_xxx from redirector.c in order to be referenced from IBM i series */
 #define MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_COMPRESSEDREFS	((U_64)57 * 1024 * 1024 * 1024)
 #define MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_3BIT_SHIFT_COMPRESSEDREFS	((U_64)25 * 1024 * 1024 * 1024)
 

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -45,7 +45,7 @@ extern "C" {
 /*	JVM feature bit flag(s)	*/
 /*
  * if there is a need for double digit features such as 10
- * version string leng is going to increase by 1
+ * version string length is going to increase by 1
  * J9SH_VERSION_STRING_LEN need to be changed accordingly *
  */
 #define J9SH_FEATURE_DEFAULT 0x0

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1769,13 +1769,13 @@ J9HashTable *
 hashClassLocationTableNew(J9JavaVM *javaVM, U_32 initialSize);
 
 /**
- * @brief Locates and returns a structure containing load locatioin for the given class 
+ * @brief Locates and returns a structure containing load location for the given class 
  * Caller must acquire classLoaderModuleAndLocationMutex before making the call
  *
  * @param currentThread current thread pointer
  * @param clazz J9Class for which load location is to be searched
  *
- * @return pointer to J9ClassLocatioin for the given class, or NULL if not found
+ * @return pointer to J9ClassLocation for the given class, or NULL if not found
  */
 J9ClassLocation *
 findClassLocationForClass(J9VMThread *currentThread, J9Class *clazz);

--- a/runtime/oti/vmargs_core_api.h
+++ b/runtime/oti/vmargs_core_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/vmargs_core_api.h
+++ b/runtime/oti/vmargs_core_api.h
@@ -104,7 +104,7 @@ parseOptionsFileText(J9PortLibrary* portLibrary, const char* fileText, J9JavaVMA
  * Parses the Hypervisor Environment Variable string into a J9JavaVMArgInfoList list
  * removing leading and trailing quotes
  *
- * @param[in]	portLib 	The portLibary
+ * @param[in]	portLib 	The portLibrary
  * @param[in]	argBuffer 	pointer to the env var ENVVAR_IBM_JAVA_HYPERVISOR_SETTINGS
  * @param[in]	hypervisorArgumentsList	pointer to the parsed option strings
  *

--- a/runtime/port/common/j9shmem.c
+++ b/runtime/port/common/j9shmem.c
@@ -312,7 +312,7 @@ j9shmem_statDeprecated(struct J9PortLibrary *portLibrary, const char* cacheDirNa
  * \arg J9PORT_INFO_SHMEM_STAT_PASSED			Success - Successfully retrieved stats of the shared memory
  * \arg J9PORT_ERROR_SHMEM_HANDLE_INVALID 		Failure - 'handle' is NULL
  * \arg J9PORT_ERROR_SHMEM_STAT_BUFFER_INVALID	Failure - 'statbuf' is NULL
- * \arg J9PORT_ERROR_SHMEM_STAT_FAILED			Failure - Error in retrieving stats of the shared memroy
+ * \arg J9PORT_ERROR_SHMEM_STAT_FAILED			Failure - Error in retrieving stats of the shared memory
  */
 intptr_t
 j9shmem_handle_stat(struct J9PortLibrary *portLibrary, struct j9shmem_handle *handle, struct J9PortShmemStatistic *statbuf)
@@ -418,7 +418,7 @@ j9shmem_protect(struct J9PortLibrary *portLibrary, const char* cacheDirName, uin
 }
  
 /**
- * Returns the minumum granularity in bytes on which permissions can be set for a memory region containing the address provided.
+ * Returns the minimum granularity in bytes on which permissions can be set for a memory region containing the address provided.
  *
  * @param[in] portLibrary the Port Library.
  * @param[in] cacheDirName The name of the cache directory

--- a/runtime/rastrace/method_trigger.c
+++ b/runtime/rastrace/method_trigger.c
@@ -70,7 +70,7 @@ static const StackTraceFormattingFunction stackTraceFormattingFunctions[] = {
  *               rules (one of these exists for each method(...) clause
  *               specified by the user in the trigger property)
  *
- *               if any matches are found, the macthing method(s) need to
+ *               if any matches are found, the matching method(s) need to
  *               be traced.  addMethodBlockEntry is called to adds these
  *               methods to the triggerOnMethodBlocks chain and to flick
  *               their methodblock flag bits to say "trigger on entry to or
@@ -878,7 +878,7 @@ err:
 }
 
 /**************************************************************************
- * name        - doTriggerActionJstacktrace
+ * name        - doTriggerActionJStacktrace
  * description - generate java stack trace when trigger action met
  * parameters  - thr
  * returns     - void

--- a/runtime/runtimetools/migration/MigrationAgent.cpp
+++ b/runtime/runtimetools/migration/MigrationAgent.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/runtimetools/migration/MigrationAgent.cpp
+++ b/runtime/runtimetools/migration/MigrationAgent.cpp
@@ -27,7 +27,7 @@ static MigrationAgent* migrationAgent;
 
 
 /*
- * default timein millisconds that we wait after a check signal before deciding we are not likely to migrate after all
+ * default timein milliseconds that we wait after a check signal before deciding we are not likely to migrate after all
  * The number is currently quite high because the obervered times are quite high
  */
 #define DEFAULT_MIGRATE_WAIT_INTERVAL 200000

--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -653,7 +653,7 @@ j9shr_destroy_all_snapshot(struct J9JavaVM* vm, const char* ctrlDirName, UDATA g
 
 	if (-1 == SH_OSCache::getCacheDir(vm, ctrlDirName, cacheDir, J9SH_MAXPATH, J9PORT_SHR_CACHE_TYPE_SNAPSHOT)) {
 		Trc_SHR_CLM_j9shr_destroy_all_snapshot_getCacheDirFailed();
-		/* NLS meesge has been printed out inside SH_OSCache::getCacheDir() if verbose flag is not 0 */
+		/* NLS message has been printed out inside SH_OSCache::getCacheDir() if verbose flag is not 0 */
 		return -1;
 	}
 	j9tty_printf(PORTLIB, "\n");

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -1600,7 +1600,7 @@ SH_CacheMap::runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCac
  * @param [in] currentThread the thread calling this function
  * @param [in] sizes Size of the ROMClass, and its parts.
  * @param [in] pieces The results of successfully calling this method.
- * @param [in] classnameLength lenth of the class name
+ * @param [in] classnameLength length of the class name
  * @param [in] classnameData class name data
  * @param [in] cpw classpath wrapper
  * @param [in] partitionInCache partition info
@@ -1706,7 +1706,7 @@ SH_CacheMap::allocateROMClass(J9VMThread* currentThread, const J9RomClassRequire
  *
  * @param [in] currentThread the thread calling this function
  * @param [in] sizeToAlloc size in bytes of the new ROMClass to allocate
- * @param [in] classnameLength lenth of the class name
+ * @param [in] classnameLength length of the class name
  * @param [in] classnameData class name data
  * @param [in] cpw classpath wrapper
  * @param [in] partitionInCache partition info

--- a/runtime/shared_common/ClassDebugDataProvider.cpp
+++ b/runtime/shared_common/ClassDebugDataProvider.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/shared_common/ClassDebugDataProvider.cpp
+++ b/runtime/shared_common/ClassDebugDataProvider.cpp
@@ -693,7 +693,7 @@ ClassDebugDataProvider::setPermission(J9VMThread* currentThread, AbstractMemoryP
 
 		if ( lntProtectHigh == lvtProtectLow) {
 			/* The whole debug area will be memory protected after the next call to setRegionPermissions().
-			 * Only new data is mportected, it is assumed the rest was protected earlier.
+			 * Only new data is mprotected, it is assumed the rest was protected earlier.
 			 */
 			UDATA startMprotect = ROUND_DOWN_TO(pageSize, (UDATA)lntProtectLow);
 			UDATA endMprotect = ROUND_UP_TO(pageSize, (UDATA)lvtProtectHigh);

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -6454,7 +6454,7 @@ SH_CompositeCacheImpl::tryAdjustMinMaxSizes(J9VMThread *currentThread, bool isJC
 		I_32 freeDebugBytes = (I_32)(_theca->localVariableTableNextSRP - _theca->lineNumberTableNextSRP);
 		U_32 maxUsedBytes = (maxLimit < (totalBytes - freeDebugBytes - J9SHR_MIN_GAP_BEFORE_METADATA)) ? maxLimit : (totalBytes - freeDebugBytes - J9SHR_MIN_GAP_BEFORE_METADATA);
 		/* The reserved AOT/JIT data space can only come from space between updateSRP and segmentSRP, so free space in debug area should be subtracted.
-		 * Leave at leaset J9SHR_MIN_GAP_BEFORE_METADATA, so J9SHR_MIN_GAP_BEFORE_METADATA should also be subtracted.
+		 * Leave at least J9SHR_MIN_GAP_BEFORE_METADATA, so J9SHR_MIN_GAP_BEFORE_METADATA should also be subtracted.
 		 */
 		if ((usedAOTBytesAfter - usedAOTBytesBefore + usedJITBytesAfter - usedJIBytesBefore + usedBytesBefore) > maxUsedBytes) {
 			CC_WARNING_TRACE(J9NLS_SHRC_CC_TOTAL_USED_BYTES_GRTHAN_MAXLIMIT, isJCLCall);

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -749,10 +749,10 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 		} else if (lockID == J9SH_OSCACHE_MMAP_LOCKID_WRITELOCK) {
 			/*	CMVC 153095: Case 3
 			 * Another thread:
-			 *	- Owns RW monintor, and is waiting on (or owns) the RW lock.
+			 *	- Owns RW monitor, and is waiting on (or owns) the RW lock.
 			 * 
 			 * Current thread:
-			 *	- Owns W monintor, and gets EDEADLK on W lock.
+			 *	- Owns W monitor, and gets EDEADLK on W lock.
 			 *	
 			 * Note:
 			 *  - If the 'call stack' ends up here then it is known the current thread 

--- a/runtime/shared_common/SCImplementedAPI.cpp
+++ b/runtime/shared_common/SCImplementedAPI.cpp
@@ -992,7 +992,7 @@ j9shr_classStoreTransaction_updateSharedClassSize(void * tobj, U_32 sizeUsed)
 }
 
 /**
- * Called by JCL natives, this function updates the metadtata (e.g. classpath info) for a shared ROMClass.
+ * Called by JCL natives, this function updates the metadata (e.g. classpath info) for a shared ROMClass.
  *
  * @param [in] currentThread thread calling this function
  * @param [in] classloader

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -2496,7 +2496,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 	case RESULT_DO_REVALIDATE_AOT_METHODS_EQUALS:
 	case RESULT_DO_FIND_AOT_METHODS_EQUALS:
 		if (0 == strcmp(vm->sharedCacheAPI->methodSpecs, SUB_OPTION_AOT_METHODS_OPERATION_HELP)) {
-			/* User has passed in findAotMethdos/invalidateAotMethods/revalidateAotMethods=help" */
+			/* User has passed in findAotMethods/invalidateAotMethods/revalidateAotMethods=help" */
 			const char* option = OPTION_FIND_AOT_METHODS_EQUALS;
 			if (RESULT_DO_INVALIDATE_AOT_METHODS_EQUALS == command) {
 				option = OPTION_INVALIDATE_AOT_METHODS_EQUALS;

--- a/runtime/tests/algorithm/srphashtabletest.c
+++ b/runtime/tests/algorithm/srphashtabletest.c
@@ -176,7 +176,7 @@ userCheckIntegrityFn(void *in, void *userData) {
  * It runs userCheckIntegrityFn for every element in the SRPHashTable.
  * It also tries to find every element user passed by data array.
  * It fails if it is not supposed to find/not find the element.
- * First dataLenth elements of data array should be found in SRPHashtable
+ * First dataLength elements of data array should be found in SRPHashtable
  * and test fails if any of these elements can not be found.
  * Any element after the first dataLength elements of data array should not be found in SRPHashTable.
  * If any is found, then test fails.

--- a/runtime/tests/cutest/XMLBenchOutputWriter.cpp
+++ b/runtime/tests/cutest/XMLBenchOutputWriter.cpp
@@ -109,7 +109,7 @@ void XMLBenchOutputWriter::endCharts()
  * @param chartName the name to be associated with the chart
  * @param chartImage the name of the file containing the chart
  * @param xAxisLabel the label for the X axis
- * @param yAxisLable the label for the Y axis
+ * @param yAxisLabel the label for the Y axis
  * @param xAxisLog true if the X axis should be logarithmic
  * @param yAxisLog true if the Y axis should be logarithmic
  */

--- a/runtime/tests/cutest/XMLBenchOutputWriter.hpp
+++ b/runtime/tests/cutest/XMLBenchOutputWriter.hpp
@@ -100,7 +100,7 @@ public:
 	 * @param chartName the name to be associated with the chart
 	 * @param chartImage the name of the file containing the chart
 	 * @param xAxisLabel the label for the X axis
-	 * @param yAxisLable the label for the Y axis
+	 * @param yAxisLabel the label for the Y axis
 	 * @param xAxisLog true if the X axis should be logarithmic
 	 * @param yAxisLog true if the Y axis should be logarithmic
 	 */

--- a/runtime/tests/cutest/XMLBenchOutputWriter.hpp
+++ b/runtime/tests/cutest/XMLBenchOutputWriter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2014 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9errorTest.c
+++ b/runtime/tests/port/j9errorTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9errorTest.c
+++ b/runtime/tests/port/j9errorTest.c
@@ -65,7 +65,7 @@ j9error_test0(struct J9PortLibrary *portLibrary)
 	/* Verify that the error handling function pointers are non NULL */
 	
 	/* Not tested, implementation dependent.  No known functionality.
-	 * Startup is private to the portlibary, it is not re-entrant safe
+	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
 	if (NULL == OMRPORT_FROM_J9PORT(PORTLIB)->error_startup) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->error_startup is NULL\n");

--- a/runtime/tests/port/j9fileTest.c
+++ b/runtime/tests/port/j9fileTest.c
@@ -233,7 +233,7 @@ j9file_test0(struct J9PortLibrary *portLibrary)
 		}
 
 		/* Not tested, implementation dependent.  No known functionality.
-		 * Startup is private to the portlibary, it is not re-entrant safe
+		 * Startup is private to the portlibrary, it is not re-entrant safe
 		 */
 		if (NULL == OMRPORT_FROM_J9PORT(PORTLIB)->file_startup) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->file_startup is NULL\n");
@@ -283,7 +283,7 @@ j9file_test0(struct J9PortLibrary *portLibrary)
 		}
 
 		/* Not tested, implementation dependent.  No known functionality.
-		 * Startup is private to the portlibary, it is not re-entrant safe
+		 * Startup is private to the portlibrary, it is not re-entrant safe
 		 */
 		if (NULL == OMRPORT_FROM_J9PORT(PORTLIB)->file_blockingasync_startup) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->file_blockingasync_startup is NULL\n");
@@ -752,7 +752,7 @@ j9file_test5(struct J9PortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "%s() returned valid file handle expected -1\n", FILE_OPEN_FUNCTION_NAME);
 	}
 
-	/* try to close a non existant file, should fail */
+	/* try to close a nonexistent file, should fail */
 	rc = FILE_CLOSE_FUNCTION(portLibrary, -1);
 	if (0 == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "%s() returned %d expected %d\n", FILE_CLOSE_FUNCTION_NAME, rc, -1);
@@ -1666,7 +1666,7 @@ j9file_test12(struct J9PortLibrary *portLibrary)
 		goto exit;
 	}
 
-	/* try unlinking a non-existant file */
+	/* try unlinking a nonexistent file */
 	rc = j9file_unlink("rubbish");
 	if (-1 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9file_unlink() returned %d expected -1\n", rc);
@@ -1695,7 +1695,7 @@ j9file_test12(struct J9PortLibrary *portLibrary)
 		goto exit;
 	}
 
-	/* try unlinkdir of non-existant directory */
+	/* try unlinkdir of nonexistent directory */
 	rc = j9file_unlinkdir("rubbish");
 	if (0 == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9file_unlinkdir() returned %d expected -1\n", rc);

--- a/runtime/tests/port/j9memTest.c
+++ b/runtime/tests/port/j9memTest.c
@@ -184,7 +184,7 @@ j9mem_test0(struct J9PortLibrary *portLibrary)
 	/* Verify that the memory management function pointers are non NULL */
 	
 	/* Not tested, implementation dependent.  No known functionality.
-	 * Startup is private to the portlibary, it is not re-entrant safe
+	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
 	if (NULL == OMRPORT_FROM_J9PORT(PORTLIB)->mem_startup) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->mem_startup is NULL\n");

--- a/runtime/tests/port/j9portTest.c
+++ b/runtime/tests/port/j9portTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9portTest.c
+++ b/runtime/tests/port/j9portTest.c
@@ -36,7 +36,7 @@
  * by the port library and are not in the actual port library table, however there
  * are a few.
  * 
- * @note port library maintenace operations are not optional in the port library table.
+ * @note port library maintenance operations are not optional in the port library table.
  */
 #include <stdlib.h>
 #include <string.h>

--- a/runtime/tests/port/j9shsem_deprecatedTest.c
+++ b/runtime/tests/port/j9shsem_deprecatedTest.c
@@ -626,7 +626,7 @@ cleanup:
 #if defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
 /*Note:
  * This is more than one test. The first test that fails blocks the rest of the test. The test should not fail :-) 
- * This test is meant to exercise the race conditions that can occur when mutliple vm's create sysv obj
+ * This test is meant to exercise the race conditions that can occur when multiple vm's create sysv obj
  * at the same time.
  */
 int
@@ -685,7 +685,7 @@ j9shsem_deprecated_test7(J9PortLibrary *portLibrary, char* argv0)
 	 	j9file_unlink(mybaseFilePath);
 	}
 
-	/*This test starts multuple process we use a semaphore to synchronize the launch*/
+	/*This test starts multiple process we use a semaphore to synchronize the launch*/
 	launchSemaphore = openLaunchSemaphore(PORTLIB, LAUNCH_CONTROL_SEMAPHORE, J9SHSEM_TEST4_CHILDCOUNT);
 	if(-1 == launchSemaphore) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Cannot open launch semaphore");

--- a/runtime/tests/port/j9strTest.c
+++ b/runtime/tests/port/j9strTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9strTest.c
+++ b/runtime/tests/port/j9strTest.c
@@ -333,7 +333,7 @@ j9str_test0(struct J9PortLibrary *portLibrary)
 	/* Verify that the string function pointers are non NULL */
 	
 	/* Not tested, implementation dependent.  No known functionality.
-	 * Startup is private to the portlibary, it is not re-entrant safe
+	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
 	if (NULL == OMRPORT_FROM_J9PORT(portLibrary)->str_startup) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->str_startup is NULL\n");

--- a/runtime/tests/port/j9timeTest.c
+++ b/runtime/tests/port/j9timeTest.c
@@ -88,7 +88,7 @@ j9time_test0(struct J9PortLibrary *portLibrary)
 	/* Verify that the time function pointers are non NULL */
 	
 	/* Not tested, implementation dependent.  No known functionality.
-	 * Startup is private to the portlibary, it is not re-entrant safe
+	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
 	if (NULL == OMRPORT_FROM_J9PORT(portLibrary)->time_startup) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->time_startup is NULL\n");

--- a/runtime/tests/port/j9ttyTest.c
+++ b/runtime/tests/port/j9ttyTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/j9ttyTest.c
+++ b/runtime/tests/port/j9ttyTest.c
@@ -208,7 +208,7 @@ j9tty_test0(struct J9PortLibrary *portLibrary)
 	/* Verify that the TTY function pointers are non NULL */
 
 	/* Not tested, implementation dependent.  No known functionality.
-	 * Startup is private to the portlibary, it is not re-entrant safe
+	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
 	if (NULL == OMRPORT_FROM_J9PORT(portLibrary)->tty_startup) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->tty_startup is NULL\n");

--- a/runtime/tests/port/j9vmemTest.c
+++ b/runtime/tests/port/j9vmemTest.c
@@ -170,7 +170,7 @@ j9vmem_verify_functiontable_slots(struct J9PortLibrary *portLibrary)
 	/* Verify that the memory management function pointers are non NULL */
 	
 	/* Not tested, implementation dependent.  No known functionality.
-	 * Startup is private to the portlibary, it is not re-entrant safe
+	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
 	if (NULL == OMRPORT_FROM_J9PORT(portLibrary)->vmem_startup) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->vmem_startup is NULL\n");

--- a/runtime/tests/port/shmem.c
+++ b/runtime/tests/port/shmem.c
@@ -1493,7 +1493,7 @@ exit:
 #if defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
 /*Note:
  * This is more than one test. The first test that fails blocks the rest of the test. The test should not fail :-) 
- * This test is meant to exercise the race conditions that can occur when mutliple vm's create sysv obj
+ * This test is meant to exercise the race conditions that can occur when multiple vm's create sysv obj
  * at the same time.
  */
 int
@@ -1551,7 +1551,7 @@ j9shmem_test15(J9PortLibrary *portLibrary, char* argv0)
 		}
 	}
 
-	/*This test starts multuple process we use a semaphore to synchronize the launch*/
+	/*This test starts multiple process we use a semaphore to synchronize the launch*/
 	launchSemaphore = openLaunchSemaphore(PORTLIB, TEST15_LAUNCH_SEM_NAME, 1);
 	if(-1 == launchSemaphore) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Cannot open launch semaphore");

--- a/runtime/tests/port/socket.c
+++ b/runtime/tests/port/socket.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/port/socket.c
+++ b/runtime/tests/port/socket.c
@@ -279,7 +279,7 @@ testTCPserver(struct J9PortLibrary *portLibrary,char *host, U_16 port)
 	rc=startupIP(PORTLIB,&socket, &netPipe, &addr, host, J9SOCK_STREAM, port);
 	if(rc!=0){
 		j9tty_printf(PORTLIB,"  Error starting up server: %d\n",rc);
-		goto shutdown;		/*return rc;*/	/*should still shutdown, you knwo*/
+		goto shutdown;		/*return rc;*/	/*should still shutdown, you know*/
 	}
 
 	j9tty_printf(PORTLIB,"  Server waiting on port %d...\n",port);
@@ -371,13 +371,13 @@ testTCPclient(struct J9PortLibrary *portLibrary,char *host, U_16 port)
 	rc=startupIP(PORTLIB,&socket, NULL, &addr, host, J9SOCK_STREAM, port);
 	if(rc!=0){
 		j9tty_printf(PORTLIB,"  Error starting up client: %d\n",rc);
-		goto shutdown;	/*return rc;*/	/*should still shutdown, you knwo*/
+		goto shutdown;	/*return rc;*/	/*should still shutdown, you know*/
 	}
 
 	rc=j9sock_connect(socket, addr);
 	if(rc!=0){
 		j9tty_printf(PORTLIB,"  Error connecting to %s:%d (%d)\n",host,port,rc);
-		goto shutdown;	/*return rc;*/	/*should still shutdown, you knwo*/
+		goto shutdown;	/*return rc;*/	/*should still shutdown, you know*/
 	}
 	j9tty_printf(PORTLIB,"  connected to %s on port %d...\n",host,port);
 

--- a/runtime/tests/shared/CompositeCacheTest.cpp
+++ b/runtime/tests/shared/CompositeCacheTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/shared/CompositeCacheTest.cpp
+++ b/runtime/tests/shared/CompositeCacheTest.cpp
@@ -908,7 +908,7 @@ CompositeCacheTest::writeHashTest(J9JavaVM* vm, IDATA testCacheSize, SH_Composit
 	if (cc1a->testAndSetWriteHash(currentThread, 999) != 1) {
 		return 5;
 	}
-	/* muliple calls should return same result */
+	/* multiple calls should return same result */
 	if (cc1a->testAndSetWriteHash(currentThread, 999) != 1) {
 		return 6;
 	}

--- a/runtime/tests/shared/main.c
+++ b/runtime/tests/shared/main.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/shared/main.c
+++ b/runtime/tests/shared/main.c
@@ -310,7 +310,7 @@ signalProtectedMain(struct J9PortLibrary *portLibrary, void * vargs)
 	HEADING(PORTLIB, "Compiled Method Test");
 	rc |= testCompiledMethod(vm);
 
-	/* TODO: Temporarily disable due to problems with Manager statics and muliple CacheMaps */
+	/* TODO: Temporarily disable due to problems with Manager statics and multiple CacheMaps */
 #if defined(REMOVED_FOR_NOW)
 	HEADING(PORTLIB, "Byte Data Test");
 	rc |= testByteDataManager(vm);

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2292,7 +2292,7 @@ outOfMemory:
 			/* In non-fastHCR case when class is being redefined, the classLocation of original class
 			 * should now point to redefined class.
 			 * Get the classLocation for the original class, remove it from the hashtable
-			 * and a new classLoation with redefined class as the key.
+			 * and a new classLocation with redefined class as the key.
 			 */
 			J9ClassLocation *classLocation = NULL;
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2384,7 +2384,7 @@ done:;
 				ffi_raw_call(cif, FFI_FN(function), returnStorage, values_raw);
 #else /* FFI_NATIVE_RAW_API */
 				ffi_call(cif, FFI_FN(function), returnStorage, values);
-#endif /* FFI_NATOVE_RAW_API */
+#endif /* FFI_NATIVE_RAW_API */
 				ret = ffiSuccess;
 			}
 		}

--- a/runtime/vm/vmbootlib.c
+++ b/runtime/vm/vmbootlib.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/vmbootlib.c
+++ b/runtime/vm/vmbootlib.c
@@ -278,7 +278,7 @@ openNativeLibrary(J9JavaVM* vm, J9ClassLoader * classLoader, const char * libNam
 #endif
 
 	/* No library path specified, just add the extension and try that */
-	/* temp fix.  Remove the second openFunc call once apps like javah have bootLibrayPaths */
+	/* temp fix.  Remove the second openFunc call once apps like javah have bootLibraryPaths */
 	result = openFunction(userData, classLoader, libName, (char *)libName, libraryPtr, errorBuffer, bufferLength, lazy);
 	if(result == J9NATIVELIB_LOAD_ERR_NOT_FOUND) {
 		result = openFunction(userData, classLoader, libName, (char *)libName, libraryPtr, errorBuffer, bufferLength, lazy | J9PORT_SLOPEN_DECORATE);

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
@@ -881,7 +881,7 @@ public class ConfigObject {
 	}
 
 	/**
-	 * Returns the numbe of sources defined for this ConfigObject.
+	 * Returns the number of sources defined for this ConfigObject.
 	 *
 	 * @return      the number of defined sources
 	 */

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/GenerateCore.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/GenerateCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/GenerateCore.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/GenerateCore.java
@@ -33,7 +33,7 @@ public class GenerateCore {
 	/**
 	 * @param args
 	 *            args[0] -- Java home e.g./bluebird/builds/bld_87583/SDK
-	 *            args[1] -- Optional, core dump locatiion.If not specify, store
+	 *            args[1] -- Optional, core dump location. If not specify, store
 	 *            the core dump to the default location e.g. under current build
 	 *            folder
 	 */

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/MethodForNameOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/MethodForNameOutputParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/MethodForNameOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/MethodForNameOutputParser.java
@@ -52,7 +52,7 @@ public class MethodForNameOutputParser {
 	 * @param methodArguments JVM signature of the arguments to the method, e.g. "JI". 
 	 * 			This must be the full set of arguments or "null" to take the first matching method.
 	 * 
-	 * @return String representation of extracted j9metod address from
+	 * @return String representation of extracted J9Method address from
 	 * !methodforname extension. return null, if any error occurs or address
 	 * can not be found in given !methodforname output.
 	 */

--- a/test/functional/JIT_Test/src/jit/test/jitt/assembler/SwitchTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/assembler/SwitchTest.java
@@ -79,7 +79,7 @@ public class SwitchTest extends jit.test.jitt.Test {
 			Assert.fail("SwitchTest->run: Incorrect result for test #1B!");
 
 
-		//CASE2: Choose Range of largr int case labels
+		//CASE2: Choose Range of large int case labels
 
 		int test2 = 2147483647;
 		int check2 = 0;

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
@@ -385,7 +385,7 @@ public class TestOperatingSystemMXBean {
 			// On Unix, we have two more attributes that the call
 			// mbs.getAttributes() cannot account for.  Check this.
 
-			// for reasons not yet clear, the JMX mechanismm does not
+			// for reasons not yet clear, the JMX mechanism does not
 			// "see" the OperatingSystemMXBean APIs getHardwareModel() and isHardwareEmulated(),
 			// which is why on Windows we see this discrepancy in attribute count.
 			// Should be 19 attributes on non-Unices and 21 (the UnixOperatingSystem bean adds

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Object.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Object.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Object.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Object.java
@@ -73,7 +73,7 @@ public class Test_Object {
 	static int slaveExitCount; // slaves completed ok
 
 	/**
-	 * The static variables below are used by the testNofity3 method
+	 * The static variables below are used by the testNotify3 method
 	 */
 	// Tunable input parameters - teste are the defaults
 	public static int MASTER_SLEEP_SECS3 = 1;

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Bind.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Bind.java
@@ -342,7 +342,7 @@ public class LookupAPITests_Bind {
 	}
 
 	/**
-	 * Negaitve test : Lookup.bind() test with a protected method belonging to a super-class(receiver) that is on a different package than the lookup class.
+	 * Negative test : Lookup.bind() test with a protected method belonging to a super-class(receiver) that is on a different package than the lookup class.
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.extended" })

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Bind.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Bind.java
@@ -13,7 +13,7 @@ import java.util.TreeMap;
 import examples.PackageExamples;
 
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupInTests.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupInTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupInTests.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupInTests.java
@@ -66,7 +66,7 @@ public class LookupInTests {
 	 * ****************************************/
 	
 	/**
-	 * Validates public access mode of a Lookup factory created by a call to MethodHandles.publicLookiup() 
+	 * Validates public access mode of a Lookup factory created by a call to MethodHandles.publicLookup() 
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.extended" })

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/BootstrapMethods.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/BootstrapMethods.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/BootstrapMethods.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/BootstrapMethods.java
@@ -167,7 +167,7 @@ public class BootstrapMethods {
 		return new ConstantCallSite( f0 );
 	}
 	
-	//For Negative test : Bootstrap method that attempts to return a non-existant method
+	//For Negative test : Bootstrap method that attempts to return a nonexistent method
 	public static CallSite bootstrap_call_invalid_method( Lookup lookup, String name, MethodType type ) throws Throwable {
 		MethodHandle mh = lookup.findStatic( String.class, "valueO", MethodType.methodType( String.class,Object.class ) );
 		return new ConstantCallSite( mh );

--- a/test/functional/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
+++ b/test/functional/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
+++ b/test/functional/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
@@ -66,7 +66,7 @@ public class LookupInTests {
 	 * ****************************************/
 	
 	/**
-	 * Validates public access mode of a Lookup factory created by a call to MethodHandles.publicLookiup() 
+	 * Validates public access mode of a Lookup factory created by a call to MethodHandles.publicLookup() 
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.sanity" })

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getThreadState/gts001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getThreadState/gts001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getThreadState/gts001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getThreadState/gts001.java
@@ -154,7 +154,7 @@ public class gts001 {
 	
 	/* this test can only be used when we put a j9thread_sleep(5000) in startJavaThread in
 	 * vmThread.c to widen the window between when the thread is marked started
-	 * and when the vmThread reference is populated.  Remove the RunMaually prefix
+	 * and when the vmThread reference is populated.  Remove the RunManually prefix
 	 * to add the test back to the set that you are running
 	 */
 	public boolean RunManuallytestDistinguishStartingFromTerminated() {

--- a/test/functional/cmdline_options_tester/src/Stopwatch.java
+++ b/test/functional/cmdline_options_tester/src/Stopwatch.java
@@ -29,7 +29,7 @@ import java.text.*;
  * ToDo: Move to System.nanoTime() instead of System.currentTimeMillis() once test source 
  * is built with 1.5 or higher.
  * Currently millisecond calculation entirely depends on OS update of timer values
- * which happens only once in few tens of milliseconds. So getting milliseocnd directly from os may 
+ * which happens only once in few tens of milliseconds. So getting millisecond directly from os may 
  * not be accurate.
  * 
  */

--- a/test/functional/cmdline_options_tester/src/Stopwatch.java
+++ b/test/functional/cmdline_options_tester/src/Stopwatch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdline_options_tester/src/Test.java
+++ b/test/functional/cmdline_options_tester/src/Test.java
@@ -64,7 +64,7 @@ class Test {
 	static final int CORE_COUNT = Integer.getInteger(CORE_COUNT_PROPERTY, 2).intValue();
 	
 	/**
-	 * The time in millisecodns between capturing core files (if CORE_COUNT > 1)
+	 * The time in milliseconds between capturing core files (if CORE_COUNT > 1)
 	 * may be specified via
 	 *   -Dcmdline.coreintervalms=N
 	 * The default is one minute.


### PR DESCRIPTION
This PR should be purely comment changes for words (or families of words) that start w/ `j`..`n`

To make my life easier, these initial comment focused PRs will have 2 commits:
* one which is the fixes
* and one which is the copyright bumping

For more information, see #5722 

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `f` / `fchurn`.