### PR TITLE
fix configure fail Xrander.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ addons:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
+      - libxrandr-dev
       - make
       - nasm
       - pkg-config


### PR DESCRIPTION
Currently the Travis `RUN_BUILD=yes RUN_LINT=no` build fails at the configure stage.