### PR TITLE
Remove ' from comment in ppc .spp file to avoid xlC error

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -706,7 +706,7 @@ _interpreterUnresolvedInstanceDataGlue:
 	bc	BO_IF_NOT, CR0_EQ, .L_pTOC_update		! Is pTOC case?
 	lwz     r9, 4(r6)                                       ! load the second instr from memory reference sequence in the code cache
 	andis.  r29, r29, IS_32BitLong                          ! Mask off all bits but the IS_32BitLong bit
-	andc.   r8, r29, r26                                    ! if IS_32BitLong and it isn't really a volatile then
+	andc.   r8, r29, r26                                    ! if IS_32BitLong and it isnt really a volatile then
 	beq     .L_LoadTemplateInstruction                      ! dont branch,
 	cmpi    cr0, 0, r28, 0                                  ! and check if we are in a load sequence.
         lis     r9, lwz_r3_high                                 ! if so then use lwz r3,0(r11)
@@ -728,7 +728,7 @@ _interpreterUnresolvedInstanceDataGlue:
 
         lwz     r9,1*ALen(r7)                                   ! Load cp index for this field
 	andis.  r9, r9, IS_32BitLong                            ! Mask off all bits but the IS_32BitLong bit
-        andc.   r9, r9, r26                                     ! if IS_32BitLong and it isn't really a volatile then
+        andc.   r9, r9, r26                                     ! if IS_32BitLong and it isnt really a volatile then
         beq     .L_Skip2ndMemRefInstruction                     ! dont branch,
         cmpi    cr0, 0, r28, 0                                  ! and check if we are in a load sequence.
         lis     r9, lwz_r4_high                                 ! if so then use lwz r4,0(r11)


### PR DESCRIPTION
#5806 changed isnt to isn't in ppc .spp file comment, which caused xlC
errors:
"/tmp/bld_416956/bld_aix_ppc-64_cmprssptrs/compiler/../compiler/p/runtime/PicBuilder.spp",
line 709.118: 1506-209 (S) Character constants must end before the end
of a line.
"/tmp/bld_416956/bld_aix_ppc-64_cmprssptrs/compiler/../compiler/p/runtime/PicBuilder.spp",
line 731.118: 1506-209 (S) Character constants must end before the end
of a line.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>