### PR TITLE
Prepare to remove OMR::ResolvedMethodSymbol::isNoTemps

### DIFF
--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1841,7 +1841,6 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
          static char *disableHoist = feGetEnv("TR_disableHoist");
          if (!disableHoist &&
              comp->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-             !comp->getJittedMethodSymbol()->isNoTemps() &&
              comp->cg()->isMaterialized(constValueNode))
             {
             TR::Block *block = prevTreeTop->getEnclosingBlock();


### PR DESCRIPTION
This flag is never set.  Remove and fold code assuming it is always
false.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>