### PR TITLE
Relocate J9::CodeGenerator::_nodesSpineCheckedList to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -74,7 +74,8 @@ J9::CodeGenerator::CodeGenerator() :
    _gpuSymbolMap(self()->comp()->allocator()),
    _stackLimitOffsetInMetaData(self()->comp()->fej9()->thisThreadGetStackLimitOffset()),
    _uncommonedNodes(self()->comp()->trMemory(), stackAlloc),
-   _liveMonitors(NULL)
+   _liveMonitors(NULL),
+   _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator()))
    {
    }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -271,6 +271,8 @@ public:
 private:
 
    TR_HashTabInt _uncommonedNodes;               // uncommoned nodes keyed by the original nodes
+   
+   TR::list<TR::Node*> _nodesSpineCheckedList;
 
    uint16_t changeParmLoadsToRegLoads(TR::Node*node, TR::Node **regLoads, TR_BitVector *globalRegsWithRegLoad, TR_BitVector &killedParms, vcount_t visitCount); // returns number of RegLoad nodes created
 


### PR DESCRIPTION
The `OMR::CodeGenerator` has field `_nodesSpinecheckedList` that has
only relevance to OpenJ9. This commit relocates the field to OpenJ9.

Issue: eclipse/omr#1895
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>