### PR TITLE
RAM Class Flags Cache on Server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3600,7 +3600,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct._staticAttributesCacheAOT = NULL;
    classInfoStruct._constantPool = (J9ConstantPool *)std::get<18>(classInfo);
    classInfoStruct._jitFieldsCache = NULL;
-
+   classInfoStruct.classFlags = std::get<19>(classInfo);
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 
    uint32_t numMethods = romClass->romMethodCount;
@@ -3684,7 +3684,8 @@ JITaaSHelpers::packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_M
    TR_OpaqueClassBlock * arrayClass = fe->getArrayClassFromComponentClass((TR_OpaqueClassBlock *)clazz);
    uintptrj_t totalInstanceSize = clazz->totalInstanceSize;
    uintptrj_t cp = fe->getConstantPoolFromClass((TR_OpaqueClassBlock *)clazz);
-   return std::make_tuple(packROMClass(clazz->romClass, trMemory), methodsOfClass, baseClass, numDims, parentClass, TR::Compiler->cls.getITable((TR_OpaqueClassBlock *) clazz), methodTracingInfo, classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass, classLoader, hostClass, componentClass, arrayClass, totalInstanceSize, clazz->romClass, cp);
+   uintptrj_t classFlags = fe->getClassFlagsValue((TR_OpaqueClassBlock *)clazz);
+   return std::make_tuple(packROMClass(clazz->romClass, trMemory), methodsOfClass, baseClass, numDims, parentClass, TR::Compiler->cls.getITable((TR_OpaqueClassBlock *) clazz), methodTracingInfo, classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass, classLoader, hostClass, componentClass, arrayClass, totalInstanceSize, clazz->romClass, cp, classFlags);
    }
 
 J9ROMClass *
@@ -3866,6 +3867,11 @@ JITaaSHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo, Cl
       case CLASSINFO_REMOTE_ROM_CLASS :
          {
          *(J9ROMClass **)data = classInfo.remoteRomClass;
+         }
+         break;
+      case CLASSINFO_CLASS_FLAGS :
+         {
+         *(uintptrj_t *)data = classInfo.classFlags;
          }
          break;
       default :

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -110,6 +110,7 @@ class ClientSessionData
       TR_FieldAttributesCache *_staticAttributesCacheAOT;
       J9ConstantPool *_constantPool;
       TR_JitFieldsCache *_jitFieldsCache;
+      uintptrj_t classFlags;
       };
 
    struct J9MethodInfo
@@ -397,10 +398,23 @@ class JITaaSHelpers
       CLASSINFO_TOTAL_INSTANCE_SIZE,
       CLASSINFO_CLASS_OF_STATIC_CACHE,
       CLASSINFO_REMOTE_ROM_CLASS,
+      CLASSINFO_CLASS_FLAGS,
       };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
-   using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<uint8_t>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t, J9ROMClass *, uintptrj_t>;
+   using ClassInfoTuple = std::tuple
+      <
+      std::string, J9Method *,                                       // 0: string                  1: methodsOfClass
+      TR_OpaqueClassBlock *, int32_t,                                // 2: baseComponentClass      3: numDimensions
+      TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>,     // 4: parentClass             5: tmpInterfaces
+      std::vector<uint8_t>, bool,                                    // 6: methodTracingInfo       7: classHasFinalFields
+      uintptrj_t, bool,                                              // 8: classDepthAndFlags      9: classInitialized
+      uint32_t, TR_OpaqueClassBlock *,                               // 10: byteOffsetToLockword   11: leafComponentClass
+      void *, TR_OpaqueClassBlock *,                                 // 12: classLoader            13: hostClass
+      TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: componentClass         15: arrayClass
+      uintptrj_t, J9ROMClass *,                                      // 16: totalInstanceSize      17: remoteRomClass
+      uintptrj_t, uintptrj_t                                         // 18: _constantPool          19: classFlags
+      >;
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -58,6 +58,7 @@ public:
    J9Class *convertClassOffsetToClassPtr(TR_OpaqueClassBlock *clazzOffset);
 
    uintptrj_t classFlagsValue(TR_OpaqueClassBlock * classPointer);
+   uintptrj_t classFlagReservableWorldInitValue(TR_OpaqueClassBlock * classPointer);
    uintptrj_t classDepthOf(TR_OpaqueClassBlock *clazzPointer);
    uintptrj_t classInstanceSize(TR_OpaqueClassBlock * clazzPointer);
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -260,6 +260,7 @@ public:
    virtual bool isGetImplInliningSupported();
 
    virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
+   virtual uintptrj_t getClassFlagsValue(TR_OpaqueClassBlock * classPointer);
 
    virtual bool isAbstractClass(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isCloneable(TR_OpaqueClassBlock *);
@@ -1167,6 +1168,7 @@ public:
    virtual bool               isPublicClass(TR_OpaqueClassBlock *clazz);
    virtual bool               hasFinalizer(TR_OpaqueClassBlock * classPointer);
    virtual uintptrj_t         getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
+   virtual uintptrj_t         getClassFlagsValue(TR_OpaqueClassBlock * classPointer);
    virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, char *, char *, TR_OpaqueClassBlock * = NULL);
    virtual bool               isPrimitiveClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1109,6 +1109,14 @@ TR_J9ServerVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz)
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
+uintptrj_t
+TR_J9ServerVM::getClassFlagsValue(TR_OpaqueClassBlock *clazz)
+   {
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITaaS::J9ServerMessageType::ClassEnv_classFlagsValue, clazz);
+   return std::get<0>(stream->read<uintptrj_t>());
+   }
+
 TR_OpaqueMethodBlock *
 TR_J9ServerVM::getMethodFromName(char *className, char *methodName, char *signature)
    {
@@ -2147,6 +2155,27 @@ TR_J9SharedCacheServerVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * class
 
    if (validated)
       return classDepthFlags;
+   else
+      return 0;
+   }
+
+uintptrj_t
+TR_J9SharedCacheServerVM::getClassFlagsValue(TR_OpaqueClassBlock * classPointer)
+   {
+   TR::Compilation* comp = _compInfoPT->getCompilation();
+   TR_ASSERT(comp, "Should be called only within a compilation");
+
+   bool validated = false;
+   uintptrj_t classFlags = TR_J9ServerVM::getClassFlagsValue(classPointer);
+   
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(comp->getSymbolValidationManager(), classPointer);
+      validated = true;
+      }
+
+   if (validated)
+      return classFlags;
    else
       return 0;
    }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -131,6 +131,7 @@ public:
    virtual int32_t getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, bool &hashCodeComputed) override;
    virtual bool hasFinalizer(TR_OpaqueClassBlock *clazz) override;
    virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz) override;
+   virtual uintptrj_t getClassFlagsValue(TR_OpaqueClassBlock * clazz) override;
    virtual TR_OpaqueMethodBlock *getMethodFromName(char *className, char *methodName, char *signature) override;
    virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass) override;
    virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
@@ -240,6 +241,7 @@ public:
    virtual bool isPublicClass(TR_OpaqueClassBlock *clazz) override;
    virtual bool hasFinalizer(TR_OpaqueClassBlock * classPointer) override;
    virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer) override;
+   virtual uintptrj_t getClassFlagsValue(TR_OpaqueClassBlock * classPointer) override;
    virtual bool isPrimitiveClass(TR_OpaqueClassBlock *clazzPointer) override;
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass) override;
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6874,7 +6874,7 @@ static void genInitObjectHeader(TR::Node             *node,
       }
    else
       {
-      bool initReservable = TR::Compiler->cls.classFlagsValue(clazz) & J9ClassReservableLockWordInit;
+      bool initReservable = TR::Compiler->cls.classFlagReservableWorldInitValue(clazz);
       if (!isZeroInitialized || initReservable)
          {
          bool initLw = (node->getOpCodeValue() != TR::New) || initReservable;


### PR DESCRIPTION
Cache RAM Class Flags on Server

RAM class flags was obtained by remote call, this change adds cache for these flags.
Edit function J9::ClassEnv::classFlagsValue and revalent class definitions.
Follow cache implementation in J9::ClassEnv::classDepthOf.
Add assertion to check if the class flags from remote call and cached version are equivalent.

Resolves: #5584