### PR TITLE
Relocate JniCallSites to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -75,7 +75,8 @@ J9::CodeGenerator::CodeGenerator() :
    _stackLimitOffsetInMetaData(self()->comp()->fej9()->thisThreadGetStackLimitOffset()),
    _uncommonedNodes(self()->comp()->trMemory(), stackAlloc),
    _liveMonitors(NULL),
-   _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator()))
+   _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
+   _jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(TR::comp()->allocator()))
    {
    }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -86,6 +86,8 @@ public:
 
    void createReferenceReadBarrier(TR::TreeTop* treeTop, TR::Node* parent);
 
+   TR::list<TR_Pair<TR_ResolvedMethod,TR::Instruction> *> &getJNICallSites() { return _jniCallSites; }  // registerAssumptions()
+
    // OSR, not code generator
    void populateOSRBuffer();
 
@@ -273,6 +275,8 @@ private:
    TR_HashTabInt _uncommonedNodes;               // uncommoned nodes keyed by the original nodes
    
    TR::list<TR::Node*> _nodesSpineCheckedList;
+   
+   TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> _jniCallSites; // list of instrutions representing direct jni call sites
 
    uint16_t changeParmLoadsToRegLoads(TR::Node*node, TR::Node **regLoads, TR_BitVector *globalRegsWithRegLoad, TR_BitVector &killedParms, vcount_t visitCount); // returns number of RegLoad nodes created
 


### PR DESCRIPTION
The `OMR::CodeGenerator` has field `JniCallSites` that has only relevance in
OpenJ9. Therefore, move it to `J9::CodeGenerator`. This commit add `_JniCallSites` into OpenJ9.

Issue: eclipse/omr#1894
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>