### PR TITLE
Delete _compressedRefs references from OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2972,7 +2972,6 @@ J9::CodeGenerator::compressedReferenceRematerialization()
          node = tt->getNode();
          if (node->getOpCodeValue() == TR::BBStart && !node->getBlock()->isExtensionOfPreviousBlock())
             {
-            _compressedRefs.clear();
 
             ListIterator<TR::Node> nodesIt(&rematerializedNodes);
             for (TR::Node * rematNode = nodesIt.getFirst(); rematNode != NULL; rematNode = nodesIt.getNext())
@@ -2990,7 +2989,6 @@ J9::CodeGenerator::compressedReferenceRematerialization()
            {
            if (node->getFirstChild()->getVisitCount() == visitCount)
               alreadyVisitedFirstChild = true;
-           _compressedRefs.push_front(node->getFirstChild());
            }
 
          self()->rematerializeCompressedRefs(autoSymRef, tt, NULL, -1, node, visitCount, &rematerializedNodes);


### PR DESCRIPTION
`OMR::CodeGenerator` has field `compressedRefs` that does not do anything. Therefore, remove the field by first deleting the references in OpenJ9. Then remove the initialization in OMR.

Issue: eclipse/omr#1896
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>