### PR TITLE
Fix bug in assumption reclamation

### DIFF
--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -416,11 +416,11 @@ void jitRemoveAllMetaDataForClassLoader(J9VMThread * vmThread, J9ClassLoader * c
 void jitReclaimMarkedAssumptions(bool isEager)
    {
    static char *forceAggressiveRATCleaning = feGetEnv("TR_forceAggressiveRATCleaning");
-   if (isEager || forceAggressiveRATCleaning)
+   if (isEager && forceAggressiveRATCleaning)
       {
       reclaimMarkedAssumptionsFromRAT(-1);
       }
-   else
+   else if (!isEager)
       {
       reclaimMarkedAssumptionsFromRAT(100);
       }


### PR DESCRIPTION
Something went wrong in changeset merging where the jitReclaimMarkedAssumptions
should be doing eager cleanup on if the env var TR_forceAggressiveRATCleaning
is set. Currently aggressive cleaning is always on which is not the intent.
This change fixes this logic bug.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>