### PR TITLE
Properly align doubleStaticAddress for 32bit systems

### DIFF
--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -192,7 +192,8 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 
 #if !defined(J9VM_ENV_DATA64)
 		if (0 != ((UDATA)doubleStaticAddress & (sizeof(U_64) - 1))) {
-			doubleStaticAddress += 1;
+			/* Increment by a U_32 to ensure 64 bit aligned */
+			doubleStaticAddress = (U_64*)(((U_32*)doubleStaticAddress) + 1);
 		}
 #endif
 


### PR DESCRIPTION
When refactoring ramClass->static initialization, I changed
the pointer definition from being a U_32* to a U_64* and
missed updating the `+1`.

The +1 is necessary in the case where the double/long statics
wouldn't begin on a properly aligned boundary.

Issue only seen on 32 bit systems

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>