### PR TITLE
Divert CMake specs to regular test builds

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -455,6 +455,7 @@ def get_build_job_name(spec, version, identifier) {
 }
 
 def get_test_job_name(targetName, spec, version, identifier) {
+    spec = strip_cmake_specs(spec)
     id = convert_build_identifier(identifier)
     return "Test_openjdk${version}_j9_${targetName}_${spec}_${id}"
 }
@@ -575,13 +576,14 @@ def generate_test_jobs(TARGET_NAMES, SPEC, ARTIFACTORY_SERVER, ARTIFACTORY_REPO)
     levels.unique(true)
     groups.unique(true)
 
+    spec = strip_cmake_specs(SPEC)
     if (levels && groups) {
         def parameters = [
             string(name: 'LEVELS', value: levels.join(',')),
             string(name: 'GROUPS', value: groups.join(',')),
             string(name: 'JDK_VERSIONS', value: SDK_VERSION),
             string(name: 'SUFFIX', value: "_${convert_build_identifier(BUILD_IDENTIFIER)}"),
-            string(name: 'ARCH_OS_LIST', value: SPEC),
+            string(name: 'ARCH_OS_LIST', value: spec),
             string(name: 'JDK_IMPL', value: 'openj9'),
             string(name: 'ARTIFACTORY_SERVER', value: ARTIFACTORY_SERVER),
             string(name: 'ARTIFACTORY_REPO', value: ARTIFACTORY_REPO),
@@ -685,4 +687,11 @@ def setup_pull_request() {
     PERSONAL_BUILD = 'true'
 }
 
+def strip_cmake_specs(spec) {
+    // Strip off cmake from SPEC name
+    // Since cmake is a method for how the SDK is built,
+    // from a test perspective it is the same sdk. Therefore
+    // we will reuse the same test jobs as the non-cmake specs.
+    return spec - 'cm'
+}
 return this

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -692,6 +692,6 @@ def strip_cmake_specs(spec) {
     // Since cmake is a method for how the SDK is built,
     // from a test perspective it is the same sdk. Therefore
     // we will reuse the same test jobs as the non-cmake specs.
-    return spec - 'cm'
+    return spec - '_cm'
 }
 return this

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -289,15 +289,6 @@ x86-64_linux_cm:
       11: 'source /opt/rh/devtoolset-7/enable'
       12: 'source /opt/rh/devtoolset-7/enable'
       next: 'source /opt/rh/devtoolset-7/enable'
-  excluded_tests:
-    8:
-      <<: *defaultTests
-    11:
-      <<: *defaultTests
-    12:
-      <<: *defaultTests
-    next:
-      <<: *defaultTests
 #========================================#
 # Linux x86 64bits Large Heap
 #========================================#


### PR DESCRIPTION
- Since cmake is a method for how the SDK is built,
  from a test perspective it is the same sdk. Therefore
  we will reuse the same test jobs as the non-cmake specs.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>