### PR TITLE
Remove dependency on the environment at build time

### DIFF
--- a/runtime/compiler/build/toolcfg/common.mk
+++ b/runtime/compiler/build/toolcfg/common.mk
@@ -20,7 +20,6 @@
 
 J9_VERSION?=29
 J9LIBS = j9jit_vm j9codert_vm j9util j9utilcore j9pool j9avl j9stackmap j9hashtable
-VERSION_MAJOR?=9
 
 OMR_DIR ?= $(J9SRC)/omr
 -include $(OMR_DIR)/omrmakefiles/jitinclude.mk

--- a/runtime/makelib/mkconstants.mk.ftl
+++ b/runtime/makelib/mkconstants.mk.ftl
@@ -24,16 +24,7 @@
 </#list>
 
 # Define the Java Version we are compiling
-ifndef VERSION_MAJOR
-$(error VERSION_MAJOR is not set from extensions code)
-endif
-export VERSION_MAJOR
-
-# Define full Java Version
-ifndef OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
-$(error OPENJDK_VERSION_NUMBER_FOUR_POSITIONS is not set from extensions code)
-endif
-export OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
+export VERSION_MAJOR := ${uma.spec.properties.JAVA_SPEC_VERSION.value}
 
 # Define a default target of the root directory for all targets.
 ifndef UMA_TARGET_PATH

--- a/sourcetools/com.ibm.uma/com/ibm/j9/uma/platform/PlatformWindows.java
+++ b/sourcetools/com.ibm.uma/com/ibm/j9/uma/platform/PlatformWindows.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,10 +174,21 @@ public class PlatformWindows extends PlatformImplementation {
 				);
 		fa.writeToDisk();
 	}
-	
+
+	private static void checkVersion() throws UMAException {
+		if (OPENJDK_VERSION_NUMBER_FOUR_POSITIONS == null) {
+			throw new UMAException("OPENJDK_VERSION_NUMBER_FOUR_POSITIONS is not defined in the environment");
+		}
+	}
+
 	// TODO: move to template
 	void writeExecutableResourceFile(Artifact artifact) throws UMAException {
-		if ( artifact.getType() != Artifact.TYPE_EXECUTABLE ) return;
+		if (artifact.getType() != Artifact.TYPE_EXECUTABLE) {
+			return;
+		}
+
+		checkVersion();
+
 		GregorianCalendar calendar = new GregorianCalendar();
 		String filename = UMA.getUma().getRootDirectory() + artifact.getContainingModule().getFullName() + "/" + artifact.getTargetNameWithScope() + ".rc";
 		FileAssistant fa = new FileAssistant(filename);
@@ -196,8 +207,8 @@ public class PlatformWindows extends PlatformImplementation {
 				"#include \"j9version.h\"\n" +
 				"\n" +
 				"VS_VERSION_INFO VERSIONINFO\n" +
-				" FILEVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
-				" PRODUCTVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
+				" FILEVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace('.', ',') + "\n" +
+				" PRODUCTVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace('.', ',') + "\n" +
 				" FILEFLAGSMASK 0x3fL\n" +
 				" FILEFLAGS 0x0L\n" +
 				" FILEOS VOS_NT_WINDOWS32\n" +
@@ -493,7 +504,12 @@ public class PlatformWindows extends PlatformImplementation {
 
 	// TODO: move to template file
 	void writeSharedLibResourceFile(Artifact artifact) throws UMAException {
-		if ( artifact.getType() != Artifact.TYPE_SHARED && artifact.getType() != Artifact.TYPE_BUNDLE ) return;
+		if (artifact.getType() != Artifact.TYPE_SHARED && artifact.getType() != Artifact.TYPE_BUNDLE) {
+			return;
+		}
+
+		checkVersion();
+
 		GregorianCalendar calendar = new GregorianCalendar();
 		String filename = UMA.getUma().getRootDirectory() + artifact.getContainingModule().getFullName() + "/" + artifact.getTargetNameWithScope() + ".rc";
 		FileAssistant fa = new FileAssistant(filename);
@@ -512,8 +528,8 @@ public class PlatformWindows extends PlatformImplementation {
 				"#include \"j9version.h\"\n" +
 				"\n" +
 				"VS_VERSION_INFO VERSIONINFO\n" +
-				" FILEVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
-				" PRODUCTVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
+				" FILEVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace('.', ',') + "\n" +
+				" PRODUCTVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace('.', ',') + "\n" +
 				" FILEFLAGSMASK 0x3fL\n" +
 				" FILEFLAGS 0x0L\n" +
 				" FILEOS VOS_NT_WINDOWS32\n" +
@@ -541,7 +557,6 @@ public class PlatformWindows extends PlatformImplementation {
 				"END\n"
 		);
 		fa.writeToDisk();
-
 	}
 	
 	@Override


### PR DESCRIPTION
* VERSION_MAJOR is known to UMA; it can write that value directly in the generated makefile
* OPENJDK_VERSION_NUMBER_FOUR_POSITIONS is needed only by UMA and can safely be omitted from the generated makefile

* improve robustness of UMA - throw a more helpful UMAException if the environment doesn't define OPENJDK_VERSION_NUMBER_FOUR_POSITIONS

* remove useless (and incorrect) definition of VERSION_MAJOR

This should have no effect on normal builds, but will enable developers to go to an arbitrary build directory and from there invoke make without needing to set those environment variables.