### PR TITLE
Relocate OMR::SupportsBigDecimalLongLookasideVersioning to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -335,6 +335,9 @@ public:
 
    bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode);
 
+   bool getSupportsBigDecimalLongLookasideVersioning() { return _flags3.testAny(SupportsBigDecimalLongLookasideVersioning);}
+   void setSupportsBigDecimalLongLookasideVersioning() { _flags3.set(SupportsBigDecimalLongLookasideVersioning);}
+
    // --------------------------------------------------------------------------
    // GPU
    //
@@ -476,12 +479,13 @@ private:
 
    enum // Flags
       {
-      HasFixedFrameC_CallingConvention    = 0x00000001,
-      SupportsMaxPrecisionMilliTime       = 0x00000002,
-      SupportsInlineStringCaseConversion  = 0x00000004, /*! codegen inlining of Java string case conversion */
-      SupportsInlineStringIndexOf         = 0x00000008, /*! codegen inlining of Java string index of */
-      SupportsInlineStringHashCode        = 0x00000010, /*! codegen inlining of Java string hash code */
-      SupportsInlineConcurrentLinkedQueue = 0x00000020,
+      HasFixedFrameC_CallingConvention                    = 0x00000001,
+      SupportsMaxPrecisionMilliTime                       = 0x00000002,
+      SupportsInlineStringCaseConversion                  = 0x00000004, /*! codegen inlining of Java string case conversion */
+      SupportsInlineStringIndexOf                         = 0x00000008, /*! codegen inlining of Java string index of */
+      SupportsInlineStringHashCode                        = 0x00000010, /*! codegen inlining of Java string hash code */
+      SupportsInlineConcurrentLinkedQueue                 = 0x00000020,
+      SupportsBigDecimalLongLookasideVersioning           = 0x00000040, 
       };
 
    flags32_t _j9Flags;


### PR DESCRIPTION
The `OMR::CodeGenerator` class defines
`functionsgetSupportsBigDecimalLongLookasideVersioning` and
`setSupportsBigDecimalLongLookasideVersioning` that are not used in OMR.
They only have relevance in OpenJ9 and should be relocated to the
J9::CodeGenerator class there.

Issue: eclipse/omr#1882
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>