### PR TITLE
Replaced JAVA_BIN to corresponding Test_JDK_HOME in Test

### DIFF
--- a/test/TestConfig/openj9Settings.mk
+++ b/test/TestConfig/openj9Settings.mk
@@ -41,7 +41,7 @@ endif
 # Set JAVA_SHARED_LIBRARIES_DIR  and VM_SUBDIR for tests which need native library.
 # Set ADD_JVM_LIB_DIR_TO_LIBPATH as tests on some platforms need LIBPATH containing VM directory
 #######################################
-JAVA_LIB_DIR:=$(JAVA_BIN)$(D)..$(D)lib
+JAVA_LIB_DIR:=$(TEST_JDK_HOME)$(D)lib
 VM_SUBDIR=default
 ifneq (,$(findstring cmprssptrs,$(SPEC)))
 VM_SUBDIR=compressedrefs
@@ -73,26 +73,26 @@ endif
 # otherwise, native test libs are under NATIVE_TEST_LIBS
 ifneq (, $(findstring current, $(JCL_VERSION)))
 	ifneq (,$(findstring win,$(SPEC)))
-		JAVA_SHARED_LIBRARIES_DIR:=$(JAVA_BIN)$(D)$(VM_SUBDIR)
-		J9VM_PATH=$(JAVA_BIN)$(D)j9vm
+		JAVA_SHARED_LIBRARIES_DIR:=$(TEST_JDK_HOME)$(D)bin$(D)$(VM_SUBDIR)
+		J9VM_PATH=$(TEST_JDK_HOME)$(D)bin$(D)j9vm
 	else
 		JAVA_SHARED_LIBRARIES_DIR:=$(JAVA_LIB_DIR)$(D)$(ARCH_DIR)$(D)$(VM_SUBDIR)
 		J9VM_PATH=$(JAVA_LIB_DIR)$(D)$(ARCH_DIR)$(D)j9vm
 	endif
-	ADD_JVM_LIB_DIR_TO_LIBPATH:=export LIBPATH=$(Q)$(LIBPATH)$(P)$(JAVA_LIB_DIR)$(D)$(VM_SUBDIR)$(P)$(JAVA_SHARED_LIBRARIES_DIR)$(P)$(JAVA_BIN)$(D)j9vm$(Q);
+	ADD_JVM_LIB_DIR_TO_LIBPATH:=export LIBPATH=$(Q)$(LIBPATH)$(P)$(JAVA_LIB_DIR)$(D)$(VM_SUBDIR)$(P)$(JAVA_SHARED_LIBRARIES_DIR)$(P)$(TEST_JDK_HOME)$(D)bin$(D)j9vm$(Q);
 else
 	ifneq (, $(findstring 8, $(JDK_VERSION)))
 		ifneq (,$(findstring win,$(SPEC)))
-			VM_SUBDIR_PATH=$(JAVA_BIN)$(D)$(VM_SUBDIR)
-			J9VM_PATH=$(JAVA_BIN)$(D)j9vm
+			VM_SUBDIR_PATH=$(TEST_JDK_HOME)$(D)jre$(D)bin$(D)$(VM_SUBDIR)
+			J9VM_PATH=$(TEST_JDK_HOME)$(D)jre$(D)bin$(D)j9vm
 		else
-			VM_SUBDIR_PATH=$(JAVA_LIB_DIR)$(D)$(ARCH_DIR)$(D)$(VM_SUBDIR)
-			J9VM_PATH=$(JAVA_LIB_DIR)$(D)$(ARCH_DIR)$(D)j9vm
+			VM_SUBDIR_PATH=$(JAVA_LIB_DIR)$(D)..$(D)jre$(D)lib$(D)$(ARCH_DIR)$(D)$(VM_SUBDIR)
+			J9VM_PATH=$(JAVA_LIB_DIR)$(D)..$(D)jre$(D)lib$(D)$(ARCH_DIR)$(D)j9vm
 		endif
 	else
 		ifneq (,$(findstring win,$(SPEC))) 
-			VM_SUBDIR_PATH=$(JAVA_BIN)$(D)$(VM_SUBDIR)
-			J9VM_PATH=$(JAVA_BIN)$(D)j9vm
+			VM_SUBDIR_PATH=$(TEST_JDK_HOME)$(D)bin$(D)$(VM_SUBDIR)
+			J9VM_PATH=$(TEST_JDK_HOME)$(D)bin$(D)j9vm
 		else
 			VM_SUBDIR_PATH=$(JAVA_LIB_DIR)$(D)$(VM_SUBDIR)
 			J9VM_PATH=$(JAVA_LIB_DIR)$(D)j9vm

--- a/test/TestConfig/scripts/build_test.xml
+++ b/test/TestConfig/scripts/build_test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,16 +32,8 @@
 	<property name="ascii.test.dir" value="${BUILD_ROOT}" />
 	<property name="JDK_VERSION" value=""/>
 	<property name="JAVA_BIN" value="${JAVA_BIN}" />
-	<echo> JAVA_BIN is ${JAVA_BIN} </echo>
-	<if>
-		<equals arg1="${JDK_VERSION}" arg2="8"/>
-		<then>
-			<property name="JAVAC" value="${JAVA_BIN}/../../bin/javac" />
-		</then>
-		<else>
-			<property name="JAVAC" value="${JAVA_BIN}/javac" />
-		</else>
-	</if>
+	<property name="JAVAC" value="${TEST_JDK_HOME}/bin/javac" />
+	<echo> JAVAC is ${JAVAC} </echo>
 
 	<var name="build.list" value= "" />
 	<if>

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -188,7 +188,7 @@ ifneq ($(DEBUG),)
 $(info DEFAULT_EXCLUDE is set to $(DEFAULT_EXCLUDE))
 endif
 
-JAVA_COMMAND:=$(Q)$(JAVA_BIN)$(D)java$(Q)
+JAVA_COMMAND:=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)java$(Q)
 
 #######################################
 # common dir and jars
@@ -348,4 +348,3 @@ rmResultFile:
 
 resultsSummary:
 	@perl $(Q)$(TEST_ROOT)$(D)TestConfig$(D)scripts$(D)testKitGen$(D)resultsSummary$(D)resultsSum.pl$(Q) --failuremk=$(Q)$(FAILEDTARGETS)$(Q) --resultFile=$(Q)$(TEMPRESULTFILE)$(Q) --tapFile=$(Q)$(TAPRESULTFILE)$(Q) --diagnostic=$(DIAGNOSTICLEVEL)
-

--- a/test/TestConfig/testEnv.mk
+++ b/test/TestConfig/testEnv.mk
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2018, 2018 IBM Corp. and others
+#  Copyright (c) 2018, 2019 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,10 +27,10 @@ testEnvTeardown:
 
 ifneq (,$(findstring JITAAS,$(TEST_FLAG)))
 testEnvSetup:
-	$(JAVA_BIN)$(D)java -XX:JITaaSServer &
+	$(TEST_JDK_HOME)$(D)bin$(D)java -XX:JITaaSServer &
 
 testEnvTeardown:
-	pkill -9 -xf "$(JAVA_BIN)$(D)java -XX:JITaaSServer"; true
+	pkill -9 -xf "$(TEST_JDK_HOME)$(D)bin$(D)java -XX:JITaaSServer"; true
 
 RESERVED_OPTIONS += -XX:JITaaSClient
 endif

--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -51,7 +51,7 @@
 	<target name="compile_generator" depends="init" description="Compile SimpleIndyGenerator">
 		<echo>Compiling Everything but IndyTest and ComplexIndyTest</echo>
 		<echo>Ant version is ${ant.version}</echo>
-		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<property name="compiler.javac" value="${TEST_JDK_HOME}/bin/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
@@ -72,7 +72,7 @@
 	</target>
 	
 	<target name="generate_indyn" depends="compile_generator" description="Run SimpleIndyGenerator to generate bytecode" > 
-		<property name="javaexecutable.java" value="${JAVA_BIN}/java" />
+		<property name="javaexecutable.java" value="${TEST_JDK_HOME}/bin/java" />
 		<echo>Running SimpleIndyGenerator</echo>
 		<java classname="com.ibm.j9.jsr292.indyn.SimpleIndyGenerator" failonerror="true" fork="true" logError="true" 
 				jvm="${javaexecutable.java}">
@@ -105,7 +105,7 @@
 	
 	<target name="compile_bootstrap" depends="init" description="compile the bootstrap source " >
 		<echo>Ant version is ${ant.version}</echo>
-		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<property name="compiler.javac" value="${TEST_JDK_HOME}/bin/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>

--- a/test/functional/Jsr335_interfaceStaticMethod/build.xml
+++ b/test/functional/Jsr335_interfaceStaticMethod/build.xml
@@ -64,7 +64,7 @@
 
 	<target name="generate.invokeStatic" depends="compile.generator" description="Run SimpleInvokeStaticGenerator to generate bytecode" >
 		<echo>Running SimpleInvokeStaticGenerator</echo>
-		<property name="build.javaexecutable.java" value="${JAVA_BIN}/java" />
+		<property name="build.javaexecutable.java" value="${TEST_JDK_HOME}/bin/java" />
 		<java classname="org.openj9.test.jsr335.interfaceStaticMethod.SimpleInvokeStaticGenerator" failonerror="true" fork="true" logError="true"
 				jvm="${build.javaexecutable.java}">
 			<classpath>

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -197,7 +197,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.linux</platformRequirements>
@@ -222,7 +222,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.zos</platformRequirements>
@@ -247,7 +247,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all aix ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -271,7 +271,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)$(SQ) $(SQ)-Xbootclasspath/a:$(Q)dummy1$(P)dummy2$(P)dummy3$(Q)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.win</platformRequirements>
@@ -296,7 +296,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.linux</platformRequirements>
@@ -320,7 +320,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.zos</platformRequirements>
@@ -344,7 +344,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all aix ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -367,7 +367,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)$(SQ) ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.win</platformRequirements>
@@ -390,7 +390,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)$(SQ) -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
 	$(TEST_STATUS)
 	</command>
 		<levels>
@@ -404,6 +404,27 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</types>
 		<subsets>
 			<subset>8</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>thrstatetest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)$(SQ) -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
+	$(TEST_STATUS)
+	</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<subsets>
 			<subset>9</subset>
 			<subset>11+</subset>
 		</subsets>
@@ -419,7 +440,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>Mode551</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)vmLifecyleTests$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(JAVA_BIN)$(D)..$(D)$(SQ) -Dibm.java9.forceCommonCleanerShutdown=true ; \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)vmLifecyleTests$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)$(SQ) -Dibm.java9.forceCommonCleanerShutdown=true ; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -432,6 +453,32 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</types>
 		<subsets>
 			<subset>8</subset>
+		</subsets>
+		<disabled>https://github.com/eclipse/openj9/issues/3561</disabled>
+	</test>
+	<test>
+		<testCaseName>vmLifecyleTests</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+			<variation>Mode301</variation>
+			<variation>Mode351</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)vmLifecyleTests$(SQ) $(JVM_OPTIONS) -Djava.home=$(SQ)$(TEST_JDK_HOME)$(D)$(SQ) -Dibm.java9.forceCommonCleanerShutdown=true ; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<subsets>
 			<subset>9</subset>
 			<subset>11+</subset>
 		</subsets>

--- a/test/functional/OpenJ9_Jsr_292_API/build.xml
+++ b/test/functional/OpenJ9_Jsr_292_API/build.xml
@@ -61,7 +61,7 @@
 	<target name="compile_modulec" depends="init" description="Compile the module files in mods.modulec">
 		<echo>Compiling the module files in mods.modulec</echo>
 		<echo>Ant version is ${ant.version}</echo>
-		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<property name="compiler.javac" value="${TEST_JDK_HOME}/bin/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
@@ -84,7 +84,7 @@
 	<target name="compile_moduleb" depends="init" description="Compile the module files in mods.moduleb">
 		<echo>Compiling the module files in mods.moduleb</echo>
 		<echo>Ant version is ${ant.version}</echo>
-		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<property name="compiler.javac" value="${TEST_JDK_HOME}/bin/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
@@ -107,7 +107,7 @@
 	<target name="compile_modulea" depends="init,compile_moduleb,compile_modulec" description="Compile the module files in mods.modulea">
 		<echo>Compiling the module files in mods.modulea</echo>
 		<echo>Ant version is ${ant.version}</echo>
-		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<property name="compiler.javac" value="${TEST_JDK_HOME}/bin/javac" />
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>

--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -36,7 +36,7 @@
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -Xint \
 	-cp $(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
-	j9vm.runner.Menu A -exe=$(SQ)$(JAVA_BIN)$(D)java $(JVM_OPTIONS) -Xdump$(SQ) -version=$(JDK_VERSION) -jar=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) -xlist=$(Q)$(TEST_RESROOT)$(D)j9vm.xml$(Q) \
+	j9vm.runner.Menu A -exe=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)java $(JVM_OPTIONS) -Xdump$(SQ) -version=$(JDK_VERSION) -jar=$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) -xlist=$(Q)$(TEST_RESROOT)$(D)j9vm.xml$(Q) \
 	-xids=all,$(PLATFORM); \
 	$(TEST_STATUS)</command>
 		<levels>
@@ -92,7 +92,7 @@
 	<test>
 		<testCaseName>SharedClassesSysVTesting</testCaseName>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-	cd $(JAVA_BIN) ; \
+	cd $(TEST_JDK_HOME)$(D)bin ; \
 	perl $(TEST_RESROOT)$(D)SharedClassesSysVTesting$(D)testSC_SysV_Java7_Tests.pl linux ; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,^arch.390</platformRequirements>
@@ -102,6 +102,11 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>9</subset>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>recreateClassTest</testCaseName>

--- a/test/functional/cmdLineTests/gptest/playlist.xml
+++ b/test/functional/cmdLineTests/gptest/playlist.xml
@@ -32,10 +32,10 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
-	-DJAVA_EXECUTABLE_DIR=$(Q)$(JAVA_BIN)$(Q) \
+	-DJAVA_EXECUTABLE_DIR=$(Q)$(TEST_JDK_HOME)$(D)bin$(Q) \
 	-DUTILS_DIR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(Q) \
 	-DGLAUNCH=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)glaunch$(Q) \
-	-DJVMLIBPATH=$(Q)$(JAVA_BIN)$(D)j9vm$(Q) \
+	-DJVMLIBPATH=$(Q)$(TEST_JDK_HOME)$(D)jre$(D)bin$(D)j9vm$(Q) \
 	-DFIBTARGET=$(Q)VMBench$(D)FibBench$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-Xint -jar $(CMDLINETESTER_JAR) \
@@ -51,5 +51,41 @@
 		<types>
 			<type>native</type>
 		</types>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>cmdLineTest_gpTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-DJAVA_EXECUTABLE_DIR=$(Q)$(TEST_JDK_HOME)$(D)bin$(Q) \
+	-DUTILS_DIR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(Q) \
+	-DGLAUNCH=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)glaunch$(Q) \
+	-DJVMLIBPATH=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)j9vm$(Q) \
+	-DFIBTARGET=$(Q)VMBench$(D)FibBench$(Q) \
+	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+	-Xint -jar $(CMDLINETESTER_JAR) \
+	-config  $(Q)$(TEST_RESROOT)$(D)gptests.xml$(Q) -verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}	</command>
+		<platformRequirements>^os.win</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<subsets>
+			<subset>9</subset>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
@@ -48,7 +48,7 @@
 		<echo>===destdir:                      ${DEST}</echo>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<classpath>
-				<pathelement location="${JAVA_BIN}/../../lib/tools.jar" /><!-- tools.jar is only used for Java8 compiler-->
+				<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" /><!-- tools.jar is only used for Java8 compiler-->
 			</classpath>
 		</javac>
 	</target>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -26,7 +26,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
 	-DJAVATEST_ROOT=$(Q)$(JAVATEST_ROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
-	-DJAVA_EXECUTABLE_DIR=$(Q)$(JAVA_BIN)$(Q) \
+	-DJAVA_EXECUTABLE_DIR=$(Q)$(TEST_JDK_HOME)$(D)bin$(Q) \
 	-DSTATLNKJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)jep178staticLinkingTest$(D)jep178staticLinkingTest.jar$(Q) \
 	-DTESTJEP178_STATIC=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)testjep178_static$(Q) \
 	-DTESTJEP178_DYNAMIC=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)testjep178_dynamic$(Q) \
@@ -35,7 +35,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
 	-DJEPTESTCLASS=$(Q)com/ibm/j9/tests/jeptests/StaticLinking$(Q) \
 	-DJVMTITESTCLASS=$(Q)com/ibm/j9/tests/jeptests/StaticAgents$(Q) \
-	-DATTACHTOOLSJAR=$(Q)$(JAVA_BIN)$(D)..$(D)..$(D)lib$(D)tools.jar$(Q) \
+	-DATTACHTOOLSJAR=$(Q)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)jep178.xml$(Q) \
@@ -61,7 +61,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
 	-DJAVATEST_ROOT=$(Q)$(JAVATEST_ROOT)$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
-	-DJAVA_EXECUTABLE_DIR=$(Q)$(JAVA_BIN)$(Q) \
+	-DJAVA_EXECUTABLE_DIR=$(Q)$(TEST_JDK_HOME)$(D)bin$(Q) \
 	-DSTATLNKJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)jep178staticLinkingTest$(D)jep178staticLinkingTest.jar$(Q) \
 	-DTESTJEP178_STATIC=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)testjep178_static$(Q) \
 	-DTESTJEP178_DYNAMIC=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)testjep178_dynamic$(Q) \
@@ -70,7 +70,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
 	-DJEPTESTCLASS=$(Q)com/ibm/j9/tests/jeptests/StaticLinking$(Q) \
 	-DJVMTITESTCLASS=$(Q)com/ibm/j9/tests/jeptests/StaticAgents$(Q) \
-	-DATTACHTOOLSJAR=$(Q)$(JAVA_BIN)$(D)..$(D)lib$(D)tools.jar$(Q) \
+	-DATTACHTOOLSJAR=$(Q)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(Q) \
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)jep178.xml$(Q) \

--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -59,7 +59,7 @@
 					<src path="${src_80}"/>
 					<classpath>
 						<pathelement location="${asm.jar}" />
-						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
+						<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
 					</classpath>
 				</javac>
 			</then>

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -79,7 +79,7 @@
 	</target>
 
 	<target name="generateTestClass" depends="compile" description="Generate test class files ">
-		<property name="build.javaexecutable" value="${JAVA_BIN}/java"/>
+		<property name="build.javaexecutable" value="${TEST_JDK_HOME}/bin/java"/>
 		<java classname="IntLongObjectAlignmentTestGenerator" failonerror="true" fork="true" logError="true" jvm="${build.javaexecutable}">
 			<classpath>
 				<pathelement path="${build}"/>

--- a/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
@@ -28,7 +28,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -DEXEP=$(Q)$(JAVA_BIN)$(D)..$(D)..$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) -DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) -DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>
@@ -46,7 +46,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) --add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED$(SQ) -DEXEP=$(Q)$(JAVA_BIN)$(D)javap$(Q) -DOLWMODE=standard -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) -DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) --add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED$(SQ) -DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) -DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>

--- a/test/functional/cmdLineTests/openssl/playlist.xml
+++ b/test/functional/cmdLineTests/openssl/playlist.xml
@@ -31,6 +31,29 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(TEST_JDK_HOME)$(D)jre$(D)bin$(D)java $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)openssl.xml$(Q) \
+		-verbose -explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_CryptoTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
 		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)openssl.xml$(Q) \
 		-verbose -explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
@@ -43,6 +66,10 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<subsets>
+			<subset>9</subset>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 
 </playlist>

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption14.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption14.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,14 +34,14 @@ use strict;
 use warnings;
 
 sub nameOption14test{
-	my ($java_bin,$cache_max_len_string)=@_;
+	my ($java_exe,$cache_max_len_string)=@_;
 	my $user_name = get_user_name();
 	my $test_name = "nameOption14";
 	
 	my $append_token=get_short_string_for_user( ); 
 	my $expanded_token=$user_name;
 	
-	cache_name_with_fixed_length_test( $java_bin, $test_name, $cache_max_len_string, $append_token, 
+	cache_name_with_fixed_length_test( $java_exe, $test_name, $cache_max_len_string, $append_token, 
 		$expanded_token);
 }		
 	

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption15.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption15.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 
 sub nameOption15test{
-	my ($java_bin,$cache_max_len_string)=@_;
+	my ($java_exe,$cache_max_len_string)=@_;
 	my $test_name = "nameOption15";
 
 	my $append_token=get_short_string_for_group();
@@ -44,12 +44,12 @@ sub nameOption15test{
 	if (is_windows_OS( )){
 		my $error_msg = "Escape character g not valid for cache name";
 		$expanded_token= "  "; #  dummy string with the same length as append_token
-		long_cache_name_fail_cases_test($java_bin, $test_name, $cache_max_len_string, $error_msg,
+		long_cache_name_fail_cases_test($java_exe, $test_name, $cache_max_len_string, $error_msg,
 			$append_token, $expanded_token);
 	}else {
 		my $group_name=get_group_name();
 		$expanded_token = $group_name;
-		cache_name_with_fixed_length_test($java_bin, $test_name, $cache_max_len_string, $append_token, 
+		cache_name_with_fixed_length_test($java_exe, $test_name, $cache_max_len_string, $append_token, 
 			$expanded_token);
 	}
 }		

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption16.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption16.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,9 +33,9 @@ use strict;
 use warnings;
 
 sub nameOption16test{
-	my ($java_bin, $cache_max_len_string)=@_;
+	my ($java_exe, $cache_max_len_string)=@_;
 	my $test_name = "nameOption16";
-	cache_name_with_fixed_length_test( $java_bin, $test_name, $cache_max_len_string);
+	cache_name_with_fixed_length_test( $java_exe, $test_name, $cache_max_len_string);
 }		
 	
 nameOption16test((@ARGV));

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption17.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption17.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,13 +33,13 @@ use strict;
 use warnings;
 
 sub nameOption17test{
-	my ($java_bin, $cache_max_len_string)=@_;
+	my ($java_exe, $cache_max_len_string)=@_;
 	my $test_name = "nameOption17";
 
 	my $new_cache_len = ($cache_max_len_string + 0 ) + 1;
 	my $new_cache_len_string = ($new_cache_len . '');
 	my $error_msg = long_cache_name_err_msg();
-	long_cache_name_fail_cases_test($java_bin, $test_name, $new_cache_len_string, $error_msg);
+	long_cache_name_fail_cases_test($java_exe, $test_name, $new_cache_len_string, $error_msg);
 }		
 	
 nameOption17test((@ARGV));

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption18.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption18.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ use strict;
 use warnings;
 
 sub nameOption18test{
-	my ($java_bin, $cache_max_len_string)=@_;
+	my ($java_exe, $cache_max_len_string)=@_;
 
 	my $test_name = "nameOption18";	
 	my $user_name=get_user_name();
@@ -44,7 +44,7 @@ sub nameOption18test{
 	# increment the length by 1 and convert to string 
 	my $new_cache_len = ($cache_max_len_string + 0 ) + 1;
     my $new_cache_len_string = $new_cache_len . ' ';
-	long_cache_name_fail_cases_test( $java_bin, $test_name, $new_cache_len_string,
+	long_cache_name_fail_cases_test( $java_exe, $test_name, $new_cache_len_string,
 		$error_msg, $append_token, $expanded_token);
 }		
 	

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption19.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption19.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2018 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ use strict;
 use warnings;
 
 sub nameOption19test{
-	my ($java_bin, $cache_max_len_string)=@_;
+	my ($java_exe, $cache_max_len_string)=@_;
 	my $test_name = "nameOption19";
 	my $append_token=get_short_string_for_group();
 #   expanded_token contains the expansion of chars stored in append_token
@@ -45,13 +45,13 @@ sub nameOption19test{
 	if (is_windows_OS( )){
 		$error_msg = long_cache_name_err_msg( );
 		$expanded_token= "  "; #  dummy string with the same length as append_token
-		long_cache_name_fail_cases_test($java_bin, $test_name, $new_cache_len_string, $error_msg,
+		long_cache_name_fail_cases_test($java_exe, $test_name, $new_cache_len_string, $error_msg,
 			$append_token, $expanded_token);
 	} else {
 		my $group_name=get_group_name();
 		$expanded_token=$group_name;
 		$error_msg=copy_groupname_err_msg( ); 
-		long_cache_name_fail_cases_test($java_bin, $test_name, $new_cache_len_string, $error_msg,
+		long_cache_name_fail_cases_test($java_exe, $test_name, $new_cache_len_string, $error_msg,
 			$append_token, $expanded_token);
 	}
 }			

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
@@ -163,11 +163,11 @@ sub read_lines_from_file {
 
 # get the command to list all caches
 sub get_listAllCaches_command{
-	my ($java_bin,$test_name) = @_;
+	my ($java_exe,$test_name) = @_;
 	my $postfix_string="";
 	my $cmd_to_execute="";
 	my $dump_file = get_dump_file($test_name) ;
-	my $cmd = "$java_bin -Xshareclasses:listAllCaches";
+	my $cmd = "$java_exe -Xshareclasses:listAllCaches";
 
 	$postfix_string = get_postfix_string(1,1, $dump_file);
 	$cmd_to_execute=$cmd . $postfix_string;
@@ -177,11 +177,11 @@ sub get_listAllCaches_command{
 
 # get the command to create cache
 sub get_createCache_command {
-	my ($java_bin,$cache_name,$test_name,$is_err_stream_needed,$is_output_stream_needed) = @_;
+	my ($java_exe,$cache_name,$test_name,$is_err_stream_needed,$is_output_stream_needed) = @_;
 	my $postfix_string="";
 	my $cmd_to_execute="";
 	my $dump_file = get_dump_file($test_name);
-	my $cmd = $java_bin;
+	my $cmd = $java_exe;
 
 	$cmd = $cmd . " -Xshareclasses:name=$cache_name HelloWorld ";
 
@@ -193,13 +193,13 @@ sub get_createCache_command {
 
 # get the command to print cache stats
 sub get_printStats_command {
-	my ($java_bin,$cache_name,$test_name) = @_;
+	my ($java_exe,$cache_name,$test_name) = @_;
 	my $postfix_string="";
 	my $cmd_to_execute="";
 	my $is_output_stream_needed = 1;
   	my $is_err_stream_needed = 1;
 	my $dump_file = get_dump_file($test_name) ;
-	my $cmd = "$java_bin -Xshareclasses:name=$cache_name,printStats ";
+	my $cmd = "$java_exe -Xshareclasses:name=$cache_name,printStats ";
 
 	$postfix_string = get_postfix_string($is_output_stream_needed, $is_err_stream_needed, $dump_file);
 	$cmd_to_execute=$cmd . $postfix_string;
@@ -209,13 +209,13 @@ sub get_printStats_command {
 
 # create a cache with the given cache_name
 sub do_create_cache {
-	my ($java_bin,$cache_name,$test_name,$is_err_stream_needed,$is_output_stream_needed) = @_;
+	my ($java_exe,$cache_name,$test_name,$is_err_stream_needed,$is_output_stream_needed) = @_;
 	my @lines = undef;
 	my $dump_file = get_dump_file($test_name);
 
 	my $cmd_to_execute = " ";
 
-	$cmd_to_execute = get_createCache_command($java_bin,$cache_name,
+	$cmd_to_execute = get_createCache_command($java_exe,$cache_name,
 						$test_name,$is_err_stream_needed
 						,$is_output_stream_needed);
 
@@ -238,16 +238,16 @@ sub do_create_cache {
 
 # destroy the specified shared class cache
 sub do_destroy_cache {
-	my ($java_bin,$test_name, $cache_name) = @_;
-	my $cmd = "$java_bin -Xshareclasses:name=$cache_name,destroy " . " > "  . get_dump_file($test_name) . " 2>&1";
+	my ($java_exe,$test_name, $cache_name) = @_;
+	my $cmd = "$java_exe -Xshareclasses:name=$cache_name,destroy " . " > "  . get_dump_file($test_name) . " 2>&1";
 
 	`$cmd`;
 }
 
 # returns true if a shared class cache name is present
 sub is_cache_present {
-	my ($java_bin,$cache_name,$test_name) = @_;
-	my $cmd_to_execute = get_listAllCaches_command($java_bin, $test_name);
+	my ($java_exe,$cache_name,$test_name) = @_;
+	my $cmd_to_execute = get_listAllCaches_command($java_exe, $test_name);
 	my $dump_file = get_dump_file($test_name);
 
 	remove_file_if_not_writable($dump_file);
@@ -259,8 +259,8 @@ sub is_cache_present {
 
 # returns true if a shared class cache name is no more in the list of available caches.
 sub is_cache_absent{
-	my ($java_bin,$cache_name,$test_name) = @_;
-	my $cmd_to_execute = get_printStats_command($java_bin,$cache_name, $test_name);
+	my ($java_exe,$cache_name,$test_name) = @_;
+	my $cmd_to_execute = get_printStats_command($java_exe,$cache_name, $test_name);
 	my $dump_file = get_dump_file($test_name);
 
 	remove_file_if_not_writable($dump_file);
@@ -288,15 +288,15 @@ sub get_path_separator {
 # Given a cache name it validates that the fact creating the cache with the given name
 # fails with the error message specified in the argument list
 sub test_unsuccessful_cache_creation {
-	my ($java_bin, $test_name, $cache_name, $error_msg)=@_;
-	$java_bin =~ s/\\/\\\\/g;
+	my ($java_exe, $test_name, $cache_name, $error_msg)=@_;
+	$java_exe =~ s/\\/\\\\/g;
 	my $return_status;
 	my $create_status;
 	my $destroy_status;
 	my $dump_file = get_dump_file($test_name);
 	my $is_create_failed=0;
 
-	do_create_cache($java_bin, $cache_name, $test_name, 1, 1);
+	do_create_cache($java_exe, $cache_name, $test_name, 1, 1);
 
 	$is_create_failed =words_grep_from_file($dump_file, $error_msg, 1);
 
@@ -313,19 +313,19 @@ sub test_unsuccessful_cache_creation {
 
 # Given a cache name it checks for the creation of the cache and declares pass/fail.
 sub test_successful_cache_creation {
-	my ($java_bin, $test_name, $cache_name, $cache_grep_name)=@_;
-	$java_bin =~ s/\\/\\\\/g;
+	my ($java_exe, $test_name, $cache_name, $cache_grep_name)=@_;
+	$java_exe =~ s/\\/\\\\/g;
 	my $return_status=0;
 	my $create_status=0;
 	my $destroy_status=0;
 
-	do_create_cache($java_bin, $cache_name,$test_name, 1, 0);
+	do_create_cache($java_exe, $cache_name,$test_name, 1, 0);
 
-	$create_status=is_cache_present($java_bin, $cache_grep_name,$test_name);
+	$create_status=is_cache_present($java_exe, $cache_grep_name,$test_name);
 
 	if ($create_status) {
-		do_destroy_cache($java_bin, $test_name, $cache_name) ;
-		$destroy_status = is_cache_absent($java_bin, $cache_name,$test_name);
+		do_destroy_cache($java_exe, $test_name, $cache_name) ;
+		$destroy_status = is_cache_absent($java_exe, $cache_name,$test_name);
 	}
 
 	if ($create_status && $destroy_status) {
@@ -393,7 +393,7 @@ sub get_cache_name {
 # test successful cache creation/deletion scenario where cache name is equal to the
 # length of cache_name_len passed in as arg.
 sub cache_name_with_fixed_length_test {
-	my ($java_bin, $test_name, $cache_max_len_string, $add_token, $expanded_token) = @_;
+	my ($java_exe, $test_name, $cache_max_len_string, $add_token, $expanded_token) = @_;
 
 	my $specified_cache_name = "" ;
 	my $expanded_cache_name = "" ;
@@ -414,12 +414,12 @@ sub cache_name_with_fixed_length_test {
 	$expanded_cache_name = $arr[1];
 
 	print "cache name to create: " . $specified_cache_name . ":to grep: " . "$expanded_cache_name  \n";
-	test_successful_cache_creation ($java_bin , $test_name, $specified_cache_name, $expanded_cache_name);
+	test_successful_cache_creation ($java_exe , $test_name, $specified_cache_name, $expanded_cache_name);
 }
 
 # tests the failures in cache creation where cache name exceeds the max length
 sub long_cache_name_fail_cases_test {
-	my ($java_bin, $test_name, $cache_max_len_string, $error_msg, $add_token, $expanded_token) = @_;
+	my ($java_exe, $test_name, $cache_max_len_string, $error_msg, $add_token, $expanded_token) = @_;
 
 	my $specified_cache_name = "" ;
 	my $cache_max_len = 0;
@@ -443,7 +443,7 @@ sub long_cache_name_fail_cases_test {
 
 	#leaving debug messages commented
 	#printf "\ncache name to create & grep :$arr[0]:  grep:$arr[1]\n";
-	test_unsuccessful_cache_creation ($java_bin , $test_name, $specified_cache_name, $error_msg);
+	test_unsuccessful_cache_creation ($java_exe , $test_name, $specified_cache_name, $error_msg);
 }
 
 # error msg to indicate cache name is too long


### PR DESCRIPTION
- Replaced JAVA_BIN to corresponding TEST_JDK_HOME to avoid ambiguity in test
- makefile, build_test, and settings.mk will be changed later along with JAVA_BIN in OpenJDK.
- Merged codes which were used to handle different jdk versions but not needed now
- Split codes which need to handle different jdk version due to removal of JAVA_BIN
[ci skip]

Signed-off-by: Longyu <longyu.zhang@ibm.com>