### PR TITLE
z/TPF Root VPATH Rename

### DIFF
--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -75,7 +75,7 @@ ZASM_SCRIPT?=$(JIT_SCRIPT_DIR)/s390m4check.pl
 
 # Set up z/TPF directories and flags
 # Note: -isystem $(TPF_ROOT) is used for a2e calls to opensource functions
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/gnu/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit
 
 TPF_INCLUDES := $(foreach d,$(TPF_ROOT),-I$d/base/a2e/headers)
 TPF_INCLUDES += $(foreach d,$(TPF_ROOT),-I$d/base/include)

--- a/runtime/makelib/targets.mk.ztpf.inc.ftl
+++ b/runtime/makelib/targets.mk.ztpf.inc.ftl
@@ -58,7 +58,7 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 	-o $@ $(UMA_EXE_POSTFIX_FLAGS)
 </#assign>
 
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/gnu/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit
 
 ifndef j9vm_env_data64
   J9M31 = -m31


### PR DESCRIPTION
Very minor update for one of the vpaths used during z/TPF only builds.
The directory path change and we didn't correctly update the path to
reflect the correct name.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>