### PR TITLE
CMake: Add headers for DDR

### DIFF
--- a/runtime/codert_vm/CMakeLists.txt
+++ b/runtime/codert_vm/CMakeLists.txt
@@ -72,3 +72,8 @@ target_link_libraries(j9codert_vm
 		j9vm_interface
 		j9vm_compiler_defines
 )
+
+target_enable_ddr(j9codert_vm j9ddr)
+set_property(TARGET j9codert_vm APPEND PROPERTY DDR_HEADERS
+	${j9vm_SOURCE_DIR}/oti/stackwalk.h
+)

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -276,6 +276,11 @@ elseif(OMR_OS_WINDOWS)
 endif()
 set_property(TARGET j9jit PROPERTY LINKER_LANGUAGE CXX)
 
+target_enable_ddr(j9jit j9ddr)
+set_property(TARGET j9jit PROPERTY DDR_HEADERS
+	runtime/MethodMetaData.h
+)
+
 install(
 	TARGETS j9jit
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}

--- a/runtime/gc_base/CMakeLists.txt
+++ b/runtime/gc_base/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,3 +62,15 @@ target_link_libraries(j9gcbase
 		omrgc
 )
 
+target_enable_ddr(j9gcbase j9ddr)
+set_property(TARGET j9gcbase PROPERTY DDR_HEADERS
+	FinalizerSupport.hpp
+	modron.h
+	ScavengerForwardedHeader.hpp
+
+	${j9vm_SOURCE_DIR}/gc_include/j9modron.h
+	${j9vm_SOURCE_DIR}/gc_include/HeapIteratorAPI.h
+	${j9vm_SOURCE_DIR}/gc_include/ResourceManagedSupport.h
+	${j9vm_SOURCE_DIR}/gc_glue_java/ObjectModel.hpp
+	${j9vm_SOURCE_DIR}/gc_glue_java/sizeclasses.h
+)

--- a/runtime/gc_realtime/CMakeLists.txt
+++ b/runtime/gc_realtime/CMakeLists.txt
@@ -62,3 +62,8 @@ target_link_libraries(j9realtime
 if(OMR_OS_WINDOWS)
 	target_link_libraries(j9realtime PRIVATE winmm.lib)
 endif()
+
+target_enable_ddr(j9realtime j9ddr)
+set_property(TARGET j9realtime PROPERTY DDR_HEADERS
+	Metronome.hpp
+)

--- a/runtime/rasdump/CMakeLists.txt
+++ b/runtime/rasdump/CMakeLists.txt
@@ -68,6 +68,12 @@ omr_add_exports(j9dmp
 	J9VMDllMain
 )
 
+target_enable_ddr(j9dmp j9ddr)
+set_property(TARGET j9dmp APPEND PROPERTY DDR_HEADERS
+	rasdump_internal.h
+	dmpsup.h
+)
+
 install(
 	TARGETS j9dmp
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}

--- a/runtime/rastrace/CMakeLists.txt
+++ b/runtime/rastrace/CMakeLists.txt
@@ -74,6 +74,16 @@ omr_add_exports(j9trc
 )
 
 target_enable_ddr(j9trc j9ddr)
+set_property(TARGET j9trc APPEND PROPERTY DDR_HEADERS
+	j9rastrace.h
+	rastrace_internal.h
+	trcqueue.h
+	trctrigger.h
+
+	${j9vm_SOURCE_DIR}/include/rastrace_external.h
+	${j9vm_SOURCE_DIR}/include/ute.h
+	${j9vm_SOURCE_DIR}/oti/j9trace.h
+)
 
 install(
 	TARGETS j9trc

--- a/runtime/shared_common/CMakeLists.txt
+++ b/runtime/shared_common/CMakeLists.txt
@@ -67,3 +67,11 @@ target_link_libraries(j9shrcommon
 		j9utilcore
 		j9util
 )
+
+target_enable_ddr(j9shrcommon j9ddr)
+file(GLOB cpp_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
+set_property(TARGET j9shrcommon APPEND PROPERTY DDR_HEADERS
+	${cpp_headers}
+	shrinit.h
+	sharedconsts.h
+)

--- a/runtime/thread/CMakeLists.txt
+++ b/runtime/thread/CMakeLists.txt
@@ -47,6 +47,9 @@ omr_add_exports(j9thr ${thread_exports})
 # Note: we need to pass EARLY_SOURCE_EVAL because the ddr logic chokes on
 # $<TARGET_OBJECTS:j9thr_obj> on older versions of cmake
 target_enable_ddr(j9thr j9ddr EARLY_SOURCE_EVAL)
+set_property(TARGET j9thr APPEND PROPERTY DDR_HEADERS
+	${j9vm_SOURCE_DIR}/oti/j9thread.h
+)
 
 install(
 	TARGETS j9thr

--- a/runtime/util/CMakeLists.txt
+++ b/runtime/util/CMakeLists.txt
@@ -133,3 +133,8 @@ target_link_libraries(j9util
 		j9simplepool
 		j9stackmap
 )
+
+target_enable_ddr(j9util j9ddr)
+set_property(TARGET j9util APPEND PROPERTY DDR_HEADERS
+	filecache.h
+)

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -213,6 +213,9 @@ if(J9VM_INTERP_TRACING)
 endif()
 
 target_enable_ddr(j9vm j9ddr)
+set_property(TARGET j9vm APPEND PROPERTY DDR_HEADERS
+	vm_internal.h
+)
 
 install(
 	TARGETS j9vm


### PR DESCRIPTION
Specify headers needed for ddrgen to extract macro information

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>