### PR TITLE
Add libfontconfig1-dev to JDK 8 Dockerfiles

### DIFF
--- a/buildenv/docker/jdk8/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/ppc64le/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,7 @@ RUN apt-get update \
     libcups2-dev \
     libdwarf-dev \
     libelf-dev \
-    libfontconfig \
+    libfontconfig1-dev \
     libfreetype6-dev \
     libnuma-dev \
     libx11-dev \

--- a/buildenv/docker/jdk8/ppc64le/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/ppc64le/ubuntu18/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@ RUN apt-get update \
 	  libcups2-dev \
 	  libdwarf-dev \
 	  libelf-dev \
+	  libfontconfig1-dev \
 	  libfreetype6-dev \
 	  libnuma-dev \
 	  libx11-dev \

--- a/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ RUN apt-get update \
     libcups2-dev \
     libdwarf-dev \
     libelf-dev \
-    libfontconfig \
+    libfontconfig1-dev \
     libfreetype6-dev \
     libx11-dev \
     libxext-dev \

--- a/buildenv/docker/jdk8/s390x/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu18/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@ RUN apt-get update \
 	  libcups2-dev \
 	  libdwarf-dev \
 	  libelf-dev \
+	  libfontconfig1-dev \
 	  libfreetype6-dev \
 	  libx11-dev \
 	  libxext-dev \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,7 @@ RUN apt-get update \
     libcups2-dev \
     libdwarf-dev \
     libelf-dev \
-    libfontconfig \
+    libfontconfig1-dev \
     libfreetype6-dev \
     libnuma-dev \
     libx11-dev \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@ RUN apt-get update \
 	  libcups2-dev \
 	  libdwarf-dev \
 	  libelf-dev \
+	  libfontconfig1-dev \
 	  libfreetype6-dev \
 	  libnuma-dev \
 	  libx11-dev \


### PR DESCRIPTION
At some point, the JDK 8 extensions repo made a change to its
dependencies and now requires the libfontconfig1-dev package to be
installed. The JDK 8 Dockerfiles in the OpenJ9 repo were never updated
to match this change in dependencies, resulting in Docker builds failing
when running the configuration script. This has now been corrected and
the JDK 8 Dockerfiles should work correctly again.

Signed-off-by: Ben Thomas <ben@benthomas.ca>