### PR TITLE
Deprecate ILProp4::PackedArithmeticSelect and J9::Node bcdFlags

### DIFF
--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,14 +110,6 @@ public:
    int32_t getStorageReferenceSize();
    int32_t getStorageReferenceSourceSize();
 #endif
-
-   inline void setBCDNodeOverflow();
-   inline bool getBCDNodeOverflow();
-   inline void resetBCDNodeOverflow();
-
-   inline void setBCDNodeRounding();
-   inline bool getBCDNodeRounding();
-   inline void resetBCDNodeRounding();
 
    bool         isEvenPrecision();
    bool         isOddPrecision();
@@ -403,7 +395,6 @@ protected:
       // eventually should replace by exclusive representation (eg. enum)
       DecimalInfo _decimalInfo;    ///< hasDecimalInfo()
       // overflow/rounding option
-      uint8_t     _bcdFlags;       ///< hasBCDFlags()
       UnionPropertyB()
          {
          memset(this, 0, sizeof(UnionPropertyB)); ///< in C++11 notation: _unionPropertyB = {0};

--- a/runtime/compiler/il/J9Node_inlines.hpp
+++ b/runtime/compiler/il/J9Node_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,48 +25,6 @@
 
 #include "il/J9Node.hpp"
 #include "il/OMRNode_inlines.hpp"
-
-void
-J9::Node::setBCDNodeOverflow()
-   {
-   TR_ASSERT(self()->hasBCDFlags(), "attempting to access _bcdFlags field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   _unionPropertyB._bcdFlags |= 0x01;
-   }
-
-void
-J9::Node::resetBCDNodeOverflow()
-   {
-   TR_ASSERT(self()->hasBCDFlags(), "attempting to access _bcdFlags field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   _unionPropertyB._bcdFlags &= 0xFE;
-   }
-
-bool
-J9::Node::getBCDNodeOverflow()
-   {
-   TR_ASSERT(self()->hasBCDFlags(), "attempting to access _bcdFlags field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   return _unionPropertyB._bcdFlags & 0x01;
-   }
-
-void
-J9::Node::setBCDNodeRounding()
-   {
-   TR_ASSERT(self()->hasBCDFlags(), "attempting to access _bcdFlags field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   _unionPropertyB._bcdFlags |= 0x02;
-   }
-
-void
-J9::Node::resetBCDNodeRounding()
-   {
-   TR_ASSERT(self()->hasBCDFlags(), "attempting to access _bcdFlags field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   _unionPropertyB._bcdFlags &= 0xFD;
-   }
-
-bool
-J9::Node::getBCDNodeRounding()
-   {
-   TR_ASSERT(self()->hasBCDFlags(), "attempting to access _bcdFlags field for node %s %p that does not have it", self()->getOpCode().getName(), this);
-   return (_unionPropertyB._bcdFlags & 0x02) == 0 ? false : true;
-   }
 
 float
 J9::Node::getFloat()

--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -1270,11 +1270,6 @@ bool TR_DataAccessAccelerator::generateI2PD(TR::TreeTop* treeTop, TR::Node* call
          // correctly compute a new CP to relocate DAA OOL calls.
          bcdchkNode->setInlinedSiteIndex(callNode->getInlinedSiteIndex());
 
-         if (errorCheckingNode->getInt())
-            bcdchkNode->setBCDNodeOverflow();
-         else
-            bcdchkNode->resetBCDNodeOverflow();
-
          pdstore = TR::Node::create(op, 2, storeAddressNode, pdshlNode);
          }
       else
@@ -1676,11 +1671,6 @@ TR_DataAccessAccelerator::generatePD2IConstantParameter(TR::TreeTop* treeTop, TR
       // Replacing TT with BCDCHK, so losing one reference.
       callNode->decReferenceCount();
 
-      if (overflow)
-         bcdchk->setBCDNodeOverflow();
-      else
-         bcdchk->resetBCDNodeOverflow();
-
       //create pd2i:
       pd2iNode = callNode;
       pd2iNode->setNumChildren(1);
@@ -1985,15 +1975,6 @@ bool TR_DataAccessAccelerator::genArithmeticIntrinsic(TR::TreeTop* treeTop, TR::
 
       TR::TreeTop * ttPdstore = TR::TreeTop::create(comp(), pdstore);
 
-      if (isCheckOverflow)
-         {
-         bcdchk->setBCDNodeOverflow();
-         }
-      else
-         {
-         bcdchk->resetBCDNodeOverflow();
-         }
-
       // Join treetops:
       TR::TreeTop * nextTT = treeTop->getNextTreeTop();
       TR::TreeTop * prevTT = treeTop->getPrevTreeTop();
@@ -2091,16 +2072,6 @@ bool TR_DataAccessAccelerator::genShiftRightIntrinsic(TR::TreeTop* treeTop, TR::
    // Set inlined site index to make sure AOT TR_RelocationRecordConstantPool::computeNewConstantPool() API can
    // correctly compute a new CP to relocate DAA OOL calls.
    bcdchkNode->setInlinedSiteIndex(callNode->getInlinedSiteIndex());
-
-   if (isCheckOverflow)
-      bcdchkNode->setBCDNodeOverflow();
-   else
-      bcdchkNode->resetBCDNodeOverflow();
-
-   if (isRound)
-      bcdchkNode->setBCDNodeRounding();
-   else
-      bcdchkNode->resetBCDNodeRounding();
 
    TR::ILOpCodes op = comp()->il.opCodeForIndirectStore(TR::PackedDecimal);
    TR::SymbolReference * symRefPdstore = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::PackedDecimal, outOfLineCopyBackAddr, 8, fe());
@@ -2203,7 +2174,6 @@ bool TR_DataAccessAccelerator::genShiftLeftIntrinsic(TR::TreeTop* treeTop, TR::N
    // Set inlined site index to make sure AOT TR_RelocationRecordConstantPool::computeNewConstantPool() API can
    // correctly compute a new CP to relocate DAA OOL calls.
    bcdchkNode->setInlinedSiteIndex(callNode->getInlinedSiteIndex());
-   bcdchkNode->setBCDNodeOverflow();
 
    //following pdstore
    TR::ILOpCodes op = comp()->il.opCodeForIndirectStore(TR::PackedDecimal);


### PR DESCRIPTION
Also fold away any dead code that results from the removal of these two identifiers.

Signed-off-by: simonameng <simonameng97@gmail.com>