### PR TITLE
Add a method to set allocation sampling interval

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -223,6 +223,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_arraylet_getLeafSize,
 	j9gc_arraylet_getLeafLogSize,
 #endif /* J9VM_GC_ARRAYLETS */
+	j9gc_set_allocation_sampling_interval,
 	j9gc_set_allocation_threshold,
 	j9gc_objaccess_recentlyAllocatedObject,
 	j9gc_objaccess_postStoreClassToClassLoader,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -237,6 +237,7 @@ extern J9_CFUNC void j9gc_set_memoryController(J9VMThread *vmThread, J9Object* o
 extern J9_CFUNC const char* omrgc_get_version(OMR_VM *omrVM);
 extern J9_CFUNC void j9gc_startGCIfTimeExpired(OMR_VMThread* vmThread);
 extern J9_CFUNC void j9gc_allocation_threshold_changed(J9VMThread* currentThread);
+extern J9_CFUNC void j9gc_set_allocation_sampling_interval(J9VMThread* vmThread, UDATA samplingInterval);
 extern J9_CFUNC void j9gc_set_allocation_threshold(J9VMThread* vmThread, UDATA low, UDATA high);
 extern J9_CFUNC void j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread, J9Object *dstObject);
 extern J9_CFUNC void j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass);

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -787,6 +787,32 @@ j9gc_allocation_threshold_changed(J9VMThread *currentThread)
 }
 
 /**
+ * Set the allocation sampling interval to trigger a J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING event
+ * 
+ * Examples:
+ * 	To trigger an event whenever 4K objects have been allocated:
+ *		j9gc_set_allocation_sampling_interval(vmThread, (UDATA)4096);
+ *	To trigger an event for every object allocation:
+ *		j9gc_set_allocation_sampling_interval(vmThread, (UDATA)0);
+ * The initial MM_GCExtensions::oolObjectSamplingBytesGranularity value is 16M
+ * or set by command line option "-Xgc:allocationSamplingGranularity".
+ * By default, the sampling interval is going to be set to 512 KB.
+ * 
+ * @parm[in] vmThread The current VM Thread
+ * @parm[in] samplingInterval The allocation sampling interval.
+ */
+void 
+j9gc_set_allocation_sampling_interval(J9VMThread *vmThread, UDATA samplingInterval)
+{
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(vmThread->javaVM);
+	if (0 == samplingInterval) {
+		/* avoid (env->_oolTraceAllocationBytes) % 0 which could be undefined. */
+		samplingInterval = 1;
+	}
+	extensions->oolObjectSamplingBytesGranularity = samplingInterval;
+}
+
+/**
  * Sets the allocation threshold (VMDESIGN 2006) to trigger a J9HOOK_MM_ALLOCATION_THRESHOLD event
  * whenever an object is allocated on the heap whose is between the lower bound and the upper bound
  * of the allocation threshold range.

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,6 +88,7 @@ UDATA j9gc_get_object_size_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 j9object_t j9gc_get_memoryController(J9VMThread *vmContext, j9object_t objectPtr);
 void j9gc_set_memoryController(J9VMThread *vmThread, j9object_t objectPtr, j9object_t memoryController);
+void j9gc_set_allocation_sampling_interval(J9VMThread *vmThread, UDATA samplingInterval);
 void j9gc_set_allocation_threshold(J9VMThread *vmThread, UDATA low, UDATA high);
 UDATA j9gc_get_bytes_allocated_by_thread(J9VMThread *vmThread);
 void j9gc_get_CPU_times(J9JavaVM *javaVM, U_64 *masterCpuMillis, U_64 *slaveCpuMillis, U_32 *maxThreads, U_32 *currentThreads);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4341,6 +4341,7 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA  ( *j9gc_arraylet_getLeafSize)(struct J9JavaVM* javaVM) ;
 	UDATA  ( *j9gc_arraylet_getLeafLogSize)(struct J9JavaVM* javaVM) ;
 #endif /* J9VM_GC_ARRAYLETS */
+	void  ( *j9gc_set_allocation_sampling_interval)(struct J9VMThread *vmThread, UDATA samplingInterval);
 	void  ( *j9gc_set_allocation_threshold)(struct J9VMThread *vmThread, UDATA low, UDATA high) ;
 	void  ( *j9gc_objaccess_recentlyAllocatedObject)(struct J9VMThread *vmThread, J9Object *dstObject) ;
 	void  ( *j9gc_objaccess_postStoreClassToClassLoader)(struct J9VMThread* vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass) ;


### PR DESCRIPTION
Add a method to set allocation sampling interval

Added a method `j9gc_set_allocation_sampling_interval()` to set a positive value at `MM_GCExtensions::oolObjectSamplingBytesGranularity` which is used to trigger a `J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING` event.

This is a follow-up change of https://github.com/eclipse/openj9/pull/4618 to support [JEP 331](http://openjdk.java.net/jeps/331).

Note: Trace points will be added within caller of `j9gc_set_allocation_sampling_interval()` and [OpenJ9 j9vm.tdf](https://github.ibm.com/runtimes/openj9/blob/ibm_sdk/runtime/vm/j9vm.tdf), otherwise they need to be added to [eclipse/OMR j9mm.tdf](https://github.com/eclipse/omr/blob/master/gc/base/j9mm.tdf) instead.
The test coverage for this method will be provided via [JVMTI jtreg tests]( https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.c).

Reviewer: @charliegracie 
FYI: @DanHeidinga @dmitripivkine 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>