### PR TITLE
Add a #include in J9WatchedStaticFieldSnippet.cpp

### DIFF
--- a/runtime/compiler/codegen/J9WatchedStaticFieldSnippet.cpp
+++ b/runtime/compiler/codegen/J9WatchedStaticFieldSnippet.cpp
@@ -22,6 +22,7 @@
 
 #include "codegen/J9WatchedStaticFieldSnippet.hpp"
 #include "codegen/Relocation.hpp"
+#include "il/SymbolReference.hpp"
 
 TR::J9WatchedStaticFieldSnippet::J9WatchedStaticFieldSnippet(TR::CodeGenerator *cg, TR::Node *node, J9Method *m, UDATA loc, void *fieldAddress, J9Class *fieldClass)
    : TR::Snippet(cg, node, generateLabelSymbol(cg), false)


### PR DESCRIPTION
This commit adds a line for including a header file for SymbolReference
to J9WatchedStaticFieldSnippet.cpp, for resolving a compilation error
in AArch64 build.

Signed-off-by: knn-k <konno@jp.ibm.com>