### PR TITLE
Move _dummyTempStorageRefNode to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -76,7 +76,8 @@ J9::CodeGenerator::CodeGenerator() :
    _uncommonedNodes(self()->comp()->trMemory(), stackAlloc),
    _liveMonitors(NULL),
    _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
-   _jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(TR::comp()->allocator()))
+   _jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(TR::comp()->allocator())),
+   _dummyTempStorageRefNode(NULL)
    {
    }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -331,6 +331,11 @@ private:
 
    TR_BitVector *_liveMonitors;
 
+protected:
+
+   // isTemporaryBased storageReferences just have a symRef but some other routines expect a node so use the below to fill in this symRef on this node
+   TR::Node *_dummyTempStorageRefNode;
+
 public:
 
    static bool wantToPatchClassPointer(TR::Compilation *comp,


### PR DESCRIPTION
Move initialization and declaration of variable `_dummyTempStorageRefNode` to `J9::CodeGenerator`.

Issue: eclipse/omr#1897
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>