### PR TITLE
Fold bndsChkNeedsLiteralFromPool in OMR and OpenJ9

### DIFF
--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -406,7 +406,7 @@ bool TR_DynamicLiteralPool::transformNeeded(TR::Node *grandParent, TR::Node *par
    // TR::arraytranslateAndTest may throw AIOB, but that is taken care of by the evaluator.  Also, the
    // iconst may be the character to search.
    if (parentOpCode.isBndCheck() && parentOpCodeValue != TR::arraytranslateAndTest)
-      return (cg()->bndsChkNeedsLiteralFromPool(child));
+      return false;
 
    // TR::arrayset evaluator expects to see const child, and it's evaluated
    // specially. Don't modify const children of TR::arrayset. See 74553


### PR DESCRIPTION
The `OMR::CodeGenerator` has a function `bndsChkNeedsLiteralFromPool` that
is only returning false. See the [comment section](https://github.com/eclipse/openj9/pull/5880). Thus, fold the function as `false`.

Issue: eclipse/omr#1872
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com