### PR TITLE
Overload incRefCountForOpaquePseudoRegister in OpenJ9

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3528,6 +3528,24 @@ J9::Z::CodeGenerator::incRefCountForOpaquePseudoRegister(TR::Node * node, TR::Co
       }
    }
 
+//AN OVERLOAD OF ABOVE FUNCTION; DOES EXACTLY THE SAME JOB
+void
+J9::Z::CodeGenerator::incRefCountForOpaquePseudoRegister(TR::Node * node)
+   {
+   if (node->getOpaquePseudoRegister())
+      {
+      TR_OpaquePseudoRegister *reg = node->getOpaquePseudoRegister();
+      TR_StorageReference *ref = reg->getStorageReference();
+      if (ref && ref->isNodeBased() && ref->getNodeReferenceCount() > 0)
+         {
+         if (self()->traceBCDCodeGen())
+            self()->comp()->getDebug()->trace("\tnode %s (%p) with storageRef #%d (%s): increment nodeRefCount %d->%d when artificially incrementing ref count\n",
+               node->getOpCode().getName(),node,ref->getReferenceNumber(),self()->comp()->getDebug()->getName(ref->getSymbol()),ref->getNodeReferenceCount(),ref->getNodeReferenceCount()+1);
+         ref->incrementNodeReferenceCount();
+         }
+      }
+   }
+
 TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instruction* cursor, TR::LabelSymbol* vmCallHelperSnippetLabel)
    {
    TR::Compilation* comp = self()->comp();

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -260,6 +260,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 #endif
 
    void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp);
+   //OVERLOAD THE ABOVE FUNCTION
+   void incRefCountForOpaquePseudoRegister(TR::Node * node);
 
    /** \brief
     *     Generates a VM call helper sequence along with the necessary metadata in the instruction stream which when


### PR DESCRIPTION
This patch overloads `J9::Z::CodeGenerator::incRefCountForOpaquePseudoRegister` in
OpenJ9 with less parameters. This is the 2/6 step to simpify function `incRefCountForOpaquePseudoRegister`.

Issue: eclipse/omr#1855
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>