### PR TITLE
Add test for JVMTI Exception event

### DIFF
--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -134,6 +134,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "soae001", soae001, "com.ibm.jvmti.tests.samplingObjectAllocation.soae001", "Test JEP331 low-overhead sampling heap object allocation" },
 #endif /* JAVA_SPEC_VERSION >= 11 */
 	{ "gsp001", gsp001, "com.ibm.jvmti.tests.getSystemProperty.gsp001", "Ensure JVMTI GetSystemProperty can retrieve certain system properties at early phrase" },
+	{ "ee001", ee001, "com.ibm.jvmti.tests.eventException.ee001", "Ensure only single JVMTI Exception event gets generated with JNI frame before handler" },
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -245,5 +245,6 @@ jint JNICALL nmr001(agentEnv * agent_env, char * args);
 jint JNICALL snmp001(agentEnv * agent_env, char * args);
 jint JNICALL soae001(agentEnv * agent_env, char * args);
 jint JNICALL gsp001(agentEnv *agent_env, char *args);
+jint JNICALL ee001(agentEnv *agent_env, char *args);
 
 #endif /*JVMTI_TEST_H_*/

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -201,6 +201,8 @@
 		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat" />
 		<export name="Java_com_ibm_jvmti_tests_getSystemProperty_gsp001_getSystemProperty" />
 		<export name="Java_com_ibm_jvmti_tests_getSystemProperty_gsp001_cleanup" />
+		<export name="Java_com_ibm_jvmti_tests_eventException_ee001_invoke" />
+		<export name="Java_com_ibm_jvmti_tests_eventException_ee001_check" />
 	</exports>
 		
 	<exports group="jdk9">

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -173,6 +173,8 @@ add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
 	
 	com/ibm/jvmti/tests/getSystemProperty/gsp001.c
+
+	com/ibm/jvmti/tests/eventException/ee001.c
 )
 
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.c
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <string.h>
+
+#include "jvmti_test.h"
+
+#define EXCEPTION_METHOD "generateException"
+
+static agentEnv * env;
+
+static void JNICALL exceptionThrowCB(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread, jmethodID method, jlocation location, jobject exception, jmethodID catch_method, jlocation catch_location);
+
+static jboolean exceptionEventFired;
+
+jint JNICALL
+ee001(agentEnv * agent_env, char * args)
+{
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+	jvmtiEventCallbacks callbacks;
+    jvmtiCapabilities capabilities;
+	jvmtiError err;
+
+	env = agent_env;
+
+	exceptionEventFired = JNI_FALSE;
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_generate_exception_events = 1;
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to add capabilities");
+		return JNI_ERR;
+	}
+
+	/* Set the CompiledMethodLoad event callback */
+	memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
+	callbacks.Exception = exceptionThrowCB;
+	err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to set callback for Exception events");
+		return JNI_ERR;
+	}
+
+	/* Enable the JVMTI_EVENT_EXCEPTION callback */
+	err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to enable Exception event");
+		return JNI_ERR;
+	} 
+
+	return JNI_OK;
+}
+
+static void JNICALL
+exceptionThrowCB(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread, jmethodID method, jlocation location, jobject exception, jmethodID catch_method, jlocation catch_location)
+{
+    char *name_ptr;
+    jvmtiError err = (*jvmti_env)->GetMethodName(jvmti_env, method, &name_ptr, NULL, NULL);
+    if (err != JVMTI_ERROR_NONE) {
+        error(env, err, "Failed to GetMethodName");
+        return;
+    }
+    if (0 == strcmp(name_ptr, EXCEPTION_METHOD)) {
+        if (JNI_FALSE == exceptionEventFired) {
+            exceptionEventFired = JNI_TRUE;
+        } else {
+            error(env, JVMTI_ERROR_INTERNAL, "Failed to avoid duplicate event callback for Exception event");
+        }
+    }
+	
+	return;	
+}
+
+
+void JNICALL
+Java_com_ibm_jvmti_tests_eventException_ee001_invoke(JNIEnv *jni_env, jclass cls, jstring method)
+{
+    jmethodID mid = (*jni_env)->GetStaticMethodID(jni_env, cls, EXCEPTION_METHOD, "()V");
+    (*jni_env)->CallStaticVoidMethod(jni_env, cls, mid);
+}
+
+jboolean JNICALL
+Java_com_ibm_jvmti_tests_eventException_ee001_check(JNIEnv *jni_env, jclass cls, jstring method)
+{
+    return exceptionEventFired;
+}

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,40 +34,40 @@ static jboolean exceptionEventFired;
 jint JNICALL
 ee001(agentEnv * agent_env, char * args)
 {
-	JVMTI_ACCESS_FROM_AGENT(agent_env);
-	jvmtiEventCallbacks callbacks;
+    JVMTI_ACCESS_FROM_AGENT(agent_env);
+    jvmtiEventCallbacks callbacks;
     jvmtiCapabilities capabilities;
-	jvmtiError err;
+    jvmtiError err;
 
-	env = agent_env;
+    env = agent_env;
 
-	exceptionEventFired = JNI_FALSE;
+    exceptionEventFired = JNI_FALSE;
 
-	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
-	capabilities.can_generate_exception_events = 1;
-	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
-	if (err != JVMTI_ERROR_NONE) {
-		error(env, err, "Failed to add capabilities");
-		return JNI_ERR;
-	}
+    memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+    capabilities.can_generate_exception_events = 1;
+    err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+    if (err != JVMTI_ERROR_NONE) {
+        error(env, err, "Failed to add capabilities");
+        return JNI_ERR;
+    }
 
-	/* Set the CompiledMethodLoad event callback */
-	memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
-	callbacks.Exception = exceptionThrowCB;
-	err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
-	if (err != JVMTI_ERROR_NONE) {
-		error(env, err, "Failed to set callback for Exception events");
-		return JNI_ERR;
-	}
+    /* Set the Exception event callback */
+    memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
+    callbacks.Exception = exceptionThrowCB;
+    err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
+    if (err != JVMTI_ERROR_NONE) {
+        error(env, err, "Failed to set callback for Exception events");
+        return JNI_ERR;
+    }
 
-	/* Enable the JVMTI_EVENT_EXCEPTION callback */
-	err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL);
-	if (err != JVMTI_ERROR_NONE) {
-		error(env, err, "Failed to enable Exception event");
-		return JNI_ERR;
-	} 
+    /* Enable the JVMTI_EVENT_EXCEPTION callback */
+    err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL);
+    if (err != JVMTI_ERROR_NONE) {
+        error(env, err, "Failed to enable Exception event");
+        return JNI_ERR;
+    } 
 
-	return JNI_OK;
+    return JNI_OK;
 }
 
 static void JNICALL
@@ -86,20 +86,20 @@ exceptionThrowCB(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread, jmethodID
             error(env, JVMTI_ERROR_INTERNAL, "Failed to avoid duplicate event callback for Exception event");
         }
     }
-	
-	return;	
+    
+    return;	
 }
 
 
 void JNICALL
-Java_com_ibm_jvmti_tests_eventException_ee001_invoke(JNIEnv *jni_env, jclass cls, jstring method)
+Java_com_ibm_jvmti_tests_eventException_ee001_invoke(JNIEnv *jni_env, jclass cls, jobject method)
 {
-    jmethodID mid = (*jni_env)->GetStaticMethodID(jni_env, cls, EXCEPTION_METHOD, "()V");
+    jmethodID mid = (*jni_env)->FromReflectedMethod(jni_env, method);
     (*jni_env)->CallStaticVoidMethod(jni_env, cls, mid);
 }
 
 jboolean JNICALL
-Java_com_ibm_jvmti_tests_eventException_ee001_check(JNIEnv *jni_env, jclass cls, jstring method)
+Java_com_ibm_jvmti_tests_eventException_ee001_check(JNIEnv *jni_env, jclass cls)
 {
     return exceptionEventFired;
 }

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -422,4 +422,8 @@
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:gsp001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
+	<test id="ee001">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:ee001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
 </suite>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.eventException;
+
+public class ee001 
+{
+    public native static void invoke();
+    public native static boolean check();
+	
+	public String helpException()
+	{
+		return "Test only single exception event gets thrown with JNI frame before handler";
+	}
+    
+    public static void generateException() throws Exception {
+        throw new Exception();
+    }
+
+	public boolean testException()
+	{
+        boolean exceptionCaught = false;
+        try {
+            invoke();
+        } catch (Exception e) {
+            exceptionCaught = true;
+        }
+
+        return exceptionCaught && check();
+    }
+}

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/eventException/ee001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,25 +21,29 @@
  *******************************************************************************/
 package com.ibm.jvmti.tests.eventException;
 
+import java.lang.reflect.Method;
+
 public class ee001 
 {
-    public native static void invoke();
+    public native static void invoke(Method m);
     public native static boolean check();
-	
-	public String helpException()
-	{
-		return "Test only single exception event gets thrown with JNI frame before handler";
-	}
     
-    public static void generateException() throws Exception {
+    public String helpException()
+    {
+        return "Test only single exception event gets thrown with JNI frame before handler";
+    }
+    
+    public static void generateException() throws Exception
+    {
         throw new Exception();
     }
 
-	public boolean testException()
-	{
+    public boolean testException() throws Exception
+    {
         boolean exceptionCaught = false;
+        Method m = ee001.class.getMethod("generateException");
         try {
-            invoke();
+            invoke(m);
         } catch (Exception e) {
             exceptionCaught = true;
         }


### PR DESCRIPTION
- Ensure only single JVMTI Exception event gets generated with
	JNI frame before handler

Related: #5784 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>