### PR TITLE
Spelling comments r

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -493,7 +493,7 @@ def set_artifactory_config() {
     if (ARTIFACTORY_SERVER) {
         env.ARTIFACTORY_SERVER = ARTIFACTORY_SERVER
         env.ARTIFACTORY_REPO = VARIABLES.artifactory_repo
-        // Set Creds to env so that the parent pipeline can retireve them.
+        // Set Creds to env so that the parent pipeline can retrieve them.
         env.ARTIFACTORY_CREDS = VARIABLES.artifactory_creds
         env.ARTIFACTORY_NUM_ARTIFACTS = VARIABLES.artifactory_num_artifacts
         env.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS = VARIABLES.artifactory_days_to_keep_artifacts // This is being used by the cleanup script

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
@@ -415,7 +415,7 @@ public class Tcb {
 
     /**
      * Return the linkage stack as an array of Lse entries. The length of the array will be zero
-     * if the linkage stack is empty. The top of the stack (as represnted by stcblsdp) is the
+     * if the linkage stack is empty. The top of the stack (as represented by stcblsdp) is the
      * first element in the array and the end of the stack (also sometimes referred to as
      * the first entry, aka stcbestk) is the last element in the array.
      */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/SlidingFileInputStream.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/SlidingFileInputStream.java
@@ -78,7 +78,7 @@ public class SlidingFileInputStream extends InputStream {
 	
 	
 	/**
-	 * Actually closes the underlying stream. The close() method does not close the stream so as to allow its resuse.
+	 * Actually closes the underlying stream. The close() method does not close the stream so as to allow its reuse.
 	 * @throws IOException
 	 */
 	public void disposeStream() throws IOException {

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/ImageProcessComparator.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/comparators/ImageProcessComparator.java
@@ -48,7 +48,7 @@ public class ImageProcessComparator extends DTFJComparator {
 	// getID()
 	// getLibraries()
 	// getPointerSize()
-	// getRuntiems()
+	// getRuntimes()
 	// getSignalName()
 	// getSignalNumber()
 	// getThreads()

--- a/jcl/src/java.base/share/classes/com/ibm/jit/BigDecimalExtension.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/BigDecimalExtension.java
@@ -732,7 +732,7 @@ public class BigDecimalExtension implements java.math.BigDecimal.BigDecimalExten
 
       if (-scale >= -398 && -scale <= 369){
 
-         // If the roundind mode is UNNECESSARY, then we can set
+         // If the rounding mode is UNNECESSARY, then we can set
          // the scale as if we were setting in the previous API
          // i.e. with no concern to rounding (the 3rd parameter)
          if (roundingMode == BigDecimal.ROUND_UNNECESSARY){

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -114,7 +114,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	/* Null check the receiver if the handle isn't for a static method.
 	 * This is the lowest risk change for this failure.
 	 * TODO: Investigate introducing a new handle subclass: 
-	 * NullRecieverBoundHandle as a subclass of RBH that only
+	 * NullReceiverBoundHandle as a subclass of RBH that only
 	 * throws NPE.  We should always know at creation time
 	 * which kind of handle it will be - NRBH or RBH.
 	 * 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/mvs/Tcb.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/mvs/Tcb.java
@@ -358,7 +358,7 @@ public class Tcb {
 
     /**
      * Return the linkage stack as an array of Lse entries. The length of the array will be zero
-     * if the linkage stack is empty. The top of the stack (as represnted by stcblsdp) is the
+     * if the linkage stack is empty. The top of the stack (as represented by stcblsdp) is the
      * first element in the array and the end of the stack (also sometimes referred to as
      * the first entry, aka stcbestk) is the last element in the array.
      */

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/mvs/Tcb.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/mvs/Tcb.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2006, 2017 IBM Corp. and others
+ * Copyright (c) 2006, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImagePointer.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImagePointer.java
@@ -31,7 +31,7 @@ import com.ibm.dtfj.image.MemoryAccessException;
 
 /**
  * @author jmdisher
- * This will have to be revisitted to support z/OS
+ * This will have to be revisited to support z/OS
  */
 public class ImagePointer implements com.ibm.dtfj.image.ImagePointer
 {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImagePointer.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImagePointer.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/JavaObject.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/JavaObject.java
@@ -487,7 +487,7 @@ public class JavaObject implements com.ibm.dtfj.java.JavaObject
 	 */
 	public long getHashcode() throws DataUnavailable, CorruptDataException
 	{
-		//currently, we know no difference between these two kinds of hashcodes (may be revisitted in the future)
+		//currently, we know no difference between these two kinds of hashcodes (may be revisited in the future)
 		return getPersistentHashcode();
 	}
 

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -551,7 +551,7 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 				) {
 					/* 'existingROMClass' is same as the ROMClass corresponding to intermediate class data.
 					 * Based on the assumption that an agent is actually modifying the class file
-					 * instead of just returning a copy of the classbytes it recieves,
+					 * instead of just returning a copy of the classbytes it receives,
 					 * this comparison can be avoided.
 					 */
 					continue;

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1713,7 +1713,7 @@ _illegalPrimitiveReturn:
 
 							/* the lazy evaluation would guarantee reasonCode reflects the first failure.
 							 * In all three functions, returned boolean value would indicate an error occurred and the reasonCode is set to BCV_ERR_INSUFFICIENT_MEMORY in OOM cases.
-							 * Hence, if any of the 3 conditions should fail, if it is not on OOM as readonCode would indicate, it must be a verification error.
+							 * Hence, if any of the 3 conditions should fail, if it is not on OOM as reasonCode would indicate, it must be a verification error.
 							 */
 							if ((FALSE == isClassCompatibleByName(verifyData, classIndex, J9UTF8_DATA(utf8string), J9UTF8_LENGTH(utf8string), &reasonCode))
 							|| (FALSE == isClassCompatible(verifyData, type, classIndex, &reasonCode))

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -1037,7 +1037,7 @@ static void getNameAndLengthFromClassNameList (J9BytecodeVerificationData *verif
 }
 
 /* return BCV_SUCCESS if field is found
- * retrun BCV_NOT_FOUND if field is not found
+ * return BCV_NOT_FOUND if field is not found
  * return BCV_FAIL otherwise
  */
 
@@ -1069,7 +1069,7 @@ static IDATA findFieldFromRamClass (J9Class ** ramClass, J9ROMFieldRef * field, 
 }
 
 /* return BCV_SUCCESS if method is found
- * retrun BCV_NOT_FOUND if method is not found
+ * return BCV_NOT_FOUND if method is not found
  * return BCV_FAIL otherwise
  */
 static IDATA 

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -67,7 +67,7 @@ add_custom_command(
 )
 add_custom_target(j9jit_tracegen DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/env/ut_j9jit.h)
 
-#TODO We should get rid of this, but its still requred by the compiler_support module in omr
+#TODO We should get rid of this, but its still required by the compiler_support module in omr
 set(J9SRC  ${j9vm_SOURCE_DIR})
 
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -615,7 +615,7 @@ J9::SymbolReferenceTable::findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol *
 
       }
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1);
-   // isResovled = true, isUnresolvedInCP = false
+   // isResolved = true, isUnresolvedInCP = false
    initShadowSymbol(owningMethod, symRef, true, type, offset, false);
    return symRef;
    }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3729,7 +3729,7 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
 
       compInfo->debugPrint("\trequeueing interrupted compilation request", details, compThread);
 
-      // After releaseing the monitors and vm access below, we will loop back to the head of the loop, and retry the
+      // After releasing the monitors and vm access below, we will loop back to the head of the loop, and retry the
       // compilation.  Do not put the request back into the pool, instead requeue.
       //
       requeue();

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -325,7 +325,7 @@ class TR_CHTable
      * an exception occurred.
      *
      * This worked perfectly when longjmp was used: when longjmp was issued, the
-     * code is still inside CHTable critical section, and hence reseting/modifying
+     * code is still inside CHTable critical section, and hence resetting/modifying
      * visited status flags was safe.
      *
      * However, this does not work with C++ exception handling and RAII managing
@@ -339,7 +339,7 @@ class TR_CHTable
      * critical section in its constructor and leaves in its destructor. When an
      * exception occurs in Step 2, C++ executes CHTableCriticalSection's destructor
      * before executing the exception handler; and hence the exception handling code
-     * is outside of CHTable critical section. In short, reseting/modifying visited
+     * is outside of CHTable critical section. In short, resetting/modifying visited
      * status flags in the exception handler is NOT safe.
      *
      * To solve the above mentioned issue, VisitTracker is introduced. It resets

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6499,7 +6499,7 @@ TR_ResolvedJ9Method::getResolvedStaticMethod(TR::Compilation * comp, I_32 cpInde
       // ILGen macros currently must be resolved for correctness, or else they
       // are not recognized and expanded.  If we have unresolved calls, we can't
       // tell whether they're ilgen macros because the recognized-method system
-      // only works on resovled methods.
+      // only works on resolved methods.
       //
       if (ramMethod)
          skipForDebugging = false;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3572,7 +3572,7 @@ TR_J9ByteCodeIlGenerator::genIfTwoOperand(TR::ILOpCodes nodeop)
 // handlePendingPushSaveSideEffects is called to promote any such loads
 // to treetops preceding the saveStack generated stores.
 //
-// This API does not generate asynccheck, it's the caller's responsiblity
+// This API does not generate asynccheck, it's the caller's responsibility
 // to ensure one is generated for a backward branch.
 //
 int32_t
@@ -6412,7 +6412,7 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
             // If condy is primitive type and resolved, load the primitive constant;
             // Otherwise, load using a CP symol (for resolved and unresolved object type),
             // and generate subsequent loadi for the unresolved primitive 'value' field if needed (because
-            // for unresolved primitive the resovle helper only returns an autobox'd object).
+            // for unresolved primitive the resolve helper only returns an autobox'd object).
             if (isCondyPrimitive)
                {
                char *autoboxClassSig = NULL;

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -7250,7 +7250,7 @@ bool TR_EscapeAnalysis::devirtualizeCallSites()
             {
             //need to fixup references to the original call
             //store return value to temp (after direct call and after cold call)
-            //load it back (instead of the refereces)
+            //load it back (instead of the references)
 
             TR::DataType dt = callNode->getDataType();
 

--- a/runtime/compiler/optimizer/JProfilingBlock.cpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.cpp
@@ -826,7 +826,7 @@ void TR_JProfilingBlock::dumpCounterDependencies(TR_BitVector **componentCounter
    }
 
 /**
- * Add runtime tests to the start of the method to trigger method reccompilation once the
+ * Add runtime tests to the start of the method to trigger method recompilation once the
  * appropriate number of method entries has occurred as determined by the raw block
  * count of the first block of the method.
  */   

--- a/runtime/compiler/optimizer/SignExtendLoads.hpp
+++ b/runtime/compiler/optimizer/SignExtendLoads.hpp
@@ -57,7 +57,7 @@ class TR_SignExtendLoads : public TR::Optimization
 
    friend struct HashTable;
 
-   // Hash table mapping of nodes to lists of refering nodes
+   // Hash table mapping of nodes to lists of referring nodes
    //
    struct HashTableEntry
       {

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -92,7 +92,7 @@ struct X
 // Method names for unresolved VarHandle access methods
 static X VarHandleMethods[] =
       {
-      // We only get the original method name when the call is unresolved, but recognized method only works for resovled method
+      // We only get the original method name when the call is unresolved, but recognized method only works for resolved method
       // The list for resolved method is in j9method.cpp, any changes in this list must be reflected in the other
       // Notice this list has a tableIndex field to indicate the index of MethodHandle/MethodType of VarHandle access operation
       // in the handleTable/typeTable, check java/lang/invoke/VarHandle.java for the indice of the methods

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -785,7 +785,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
          __FILE__, __LINE__, callNode);
 
-   // Register for relaction of the 2nd target address
+   // Register for relocation of the 2nd target address
    cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+3*TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
          __FILE__, __LINE__, callNode);
 

--- a/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
@@ -1374,7 +1374,7 @@ extern TR::Register *inlineBigDecimalScaledDivide(
    generateTrg1ImmInstruction(cg, TR::InstOpCode::mcrfs, node, crRegister, 0x3); //move FPSCR field 4 (bits 44 to 47)
 
    // assume inexact failed - so we'll load the result for BigDecimal class to test
-   // against an UNNECESSARY rouding mode....
+   // against an UNNECESSARY rounding mode....
    loadConstant(cg, node, 0, retRegister);
 
    generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, labelEND, crRegister);

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2481,7 +2481,7 @@ TR_IProfiler::createIProfilingValueInfo (TR_ByteCodeInfo &bcInfo, TR::Compilatio
                   list->incrementOrCreate(address, &addrOfTotalFrequency, i, weight, &comp->trMemory()->heapMemoryRegion());
                   }
                }
-            // add resudial to last total frequency
+            // add residual to last total frequency
             *addrOfTotalFrequency = (*addrOfTotalFrequency) + csInfo->_residueWeight;
             }
          else

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1030,7 +1030,7 @@ TR_RelocationRecordConstantPool::computeNewConstantPool(TR_RelocationRuntime *re
       // Find CP from inlined method
       // Assume that the inlined call site has already been relocated
       // And assumes that the method is resolved already, otherwise, we would not have properly relocated the
-      // ramMethod for the inlined callsite and trying to retreive stuff from the bogus pointer will result in error
+      // ramMethod for the inlined callsite and trying to retrieve stuff from the bogus pointer will result in error
       TR_InlinedCallSite *inlinedCallSite = (TR_InlinedCallSite *)getInlinedCallSiteArrayElement(reloRuntime->exceptionTable(), thisInlinedSiteIndex);
       J9Method *ramMethod = (J9Method *) inlinedCallSite->_methodInfo;
 

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -188,7 +188,7 @@ TR_PersistentCHTable::classGotUnloadedPost(
       if (scl  && !(scl->hasBeenVisited()))
          {
          scl->removeUnloadedSubClasses();
-         scl->setVisited(); //reseting is done in rossa
+         scl->setVisited(); //resetting is done in rossa
          _trPersistentMemory->getPersistentInfo()->addSuperClass(superClId);
          }
 
@@ -202,7 +202,7 @@ TR_PersistentCHTable::classGotUnloadedPost(
             if (scl && !(scl->hasBeenVisited()))
                {
                scl->removeUnloadedSubClasses();
-               scl->setVisited(); //reseting is done in rossa
+               scl->setVisited(); //resetting is done in rossa
                _trPersistentMemory->getPersistentInfo()->addSuperClass(superClId);
                }
             }

--- a/runtime/compiler/x/codegen/X86Recompilation.hpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.hpp
@@ -43,7 +43,7 @@ class TR_ResolvedMethod;
 // WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 //
 // When changing the prologue or preprologue shape/size, all recompilation-related
-// code must be revisted to make sure it is kept consistent.
+// code must be revisited to make sure it is kept consistent.
 //
 // WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 // WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -375,13 +375,13 @@ patchCmpxchgForLongStore:
 patchMainlineInstructionFromCache:
 
       mov         ecx, dword  [esp + 12]                            ; Load low dword of patch instruction in snippet BEFORE volatile resolution
-      mov         ebx, dword  [esp + 16]                            ; Load high dword of patch instruction in snippet BEFORE volatile resoluion
+      mov         ebx, dword  [esp + 16]                            ; Load high dword of patch instruction in snippet BEFORE volatile resolution
 
 
 patchMainlineInstruction:
 
 
-      mov         esi, dword  [esp]                                 ; Restor RA in mainline code.
+      mov         esi, dword  [esp]                                 ; Restore RA in mainline code.
       mov         edx, dword  [esp + 4]                             ; Restore the call instruction (edx:eax) that should have brought
       mov         eax, dword  [esp + 8]                             ; us to this snippet + the following 3 bytes.
 

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -1900,7 +1900,7 @@ J9::Z::TreeEvaluator::pd2zdVectorEvaluatorHelper(TR::Node * node, TR::CodeGenera
    // 2. creatememoryreference from the StorageREference,
    // 3. Use the memory reference to create VUPKZ instruction
    //
-   // return the allocate PseudoRegister associate the storage refence to the Pseudo register
+   // return the allocate PseudoRegister associate the storage reference to the Pseudo register
    // return this pseudoregister/
    //
    TR_StorageReference *hint = node->getStorageReferenceHint();

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -2120,7 +2120,7 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
                                    TR::Compiler->om.generateCompressedObjectHeaders() // Classes are <2GB on CompressedRefs only.
                                    );
 
-            // Load the interface call data snippet pointer to register is requied for non-CLFI / BRCL sequence.
+            // Load the interface call data snippet pointer to register is required for non-CLFI / BRCL sequence.
             if (!useCLFIandBRCL)
                {
                cursor = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, callNode, snippetReg, ifcSnippet->getDataConstantSnippet(), cg());
@@ -2604,7 +2604,7 @@ void TR::J9S390JNILinkage::acquireVMAccessMask(TR::Node * callNode, TR::Register
    //  As java stack is not yet restored , Make sure that no instruction in this function
    // should use stack.
    // If instruction uses literal pool, it must only be to do load, and such instruction's memory reference should be marked MemRefMustNotSpill
-   // so that in case of long disp, we will resue the target reg as a scratch reg
+   // so that in case of long disp, we will reuse the target reg as a scratch reg
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
    intptrj_t aValue = fej9->constAcquireVMAccessOutOfLineMask();

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -2262,7 +2262,7 @@ ZZ # Load the address of the lookup class
     LR_GPR  r14,r0
     JNZ     ifCHMLcommonJitDispatch
 
-ZZ  #Load reciving object classPtr in R2
+ZZ  #Load receiving object classPtr in R2
 ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset

--- a/runtime/compiler/z/runtime/Recompilation.m4
+++ b/runtime/compiler/z/runtime/Recompilation.m4
@@ -995,10 +995,10 @@ LABEL(LPatchInterfaceSlot)
 
     END_FUNC(_checkAndPatchBrasl,PCHBRSL,9)
 
-ZZ Induce Recompilation asm rountine is just a wrapper to call the C
+ZZ Induce Recompilation asm routine is just a wrapper to call the C
 ZZ function induceRecompilation(VMThread,StartPC), which will patch
 ZZ the startPC in a thread-safe manner.
-ZZ This asm rountine sets up the appropriate parameters and uses the
+ZZ This asm routine sets up the appropriate parameters and uses the
 ZZ jitCallCFunction to invoke the induceRecompilation C routine.
 ZZ
 ZZ _induceRecompilation is called by a ForceRecompilationSnippet

--- a/runtime/exelib/common/memcheck.c
+++ b/runtime/exelib/common/memcheck.c
@@ -2081,7 +2081,7 @@ found_block:
 	memStats.currentBytesAllocated -= topHeader->wrappedBlockSize;
 	memStats.currentBlocksAllocated -= 1;
 
-	/* update the J9MEMAVLTreeNode resposible for this memory block */
+	/* update the J9MEMAVLTreeNode responsible for this memory block */
 	memoryCheck_update_callSites_free(topHeader->node, topHeader->wrappedBlockSize);
 
 	if (!blockWasSkipped && (mode & J9_MCMODE_NEVER_FREE))  {
@@ -2922,7 +2922,7 @@ memoryCheck_dump_callSites(OMRPortLibrary *portLibrary, J9AVLTree *tree)
 
 
 /*
- * This function will start the recusive freeing of the nodes and the free
+ * This function will start the recursive freeing of the nodes and the free
  * the memory for the AVL Tree
  *
  * @parm portLib OMRPortLibrary used to access the memory functions
@@ -2943,7 +2943,7 @@ memoryCheck_free_AVLTree(OMRPortLibrary *portLib, J9AVLTree *tree)
 
 
 /*
- * This function will recusive over the left and right child of the given
+ * This function will recurse over the left and right child of the given
  * node and then free the memory for itself
  *
  * @parm portLib OMRPortLibrary used to access the memory functions

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -835,7 +835,7 @@ MM_MetronomeDelegate::allocateAccessBarrier(MM_EnvironmentBase *env)
 
 /**
  * Iterates over all threads and enables the double barrier for each thread by setting the
- * remebered set fragment index to the reserved index.
+ * remembered set fragment index to the reserved index.
  */
 void
 MM_MetronomeDelegate::enableDoubleBarrier(MM_EnvironmentBase *env)

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -241,7 +241,7 @@ MM_StandardAccessBarrier::postObjectStore(J9VMThread *vmThread, J9Class *destCla
 {
 	j9object_t destObject = J9VM_J9CLASS_TO_HEAPCLASS(destClass);
 
-	/* destObject is guaranteed to be in old space, so the common code path will rememember objects appropriately here */
+	/* destObject is guaranteed to be in old space, so the common code path will remember objects appropriately here */
 	postObjectStoreImpl(vmThread, destObject, value);
 }
 

--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -406,7 +406,7 @@ MM_Scheduler::waitForMutatorsToStop(MM_EnvironmentRealtime *env)
 	 * exclusive access for itself.
 	 * requestExclusiveVMAccess is invoked atomically with _mode being set to WAKING_GC
 	 * under masterThreadMonitor (see continueGC). Therefore, we check here if mode is not
-	 * WAKING_GC, and only than we reqest exclusive assess for ourselves.
+	 * WAKING_GC, and only than when we request exclusive assess for ourselves.
 	 * TODO: This approach is just to fix some timing holes in shutdown. Consider removing this
 	 * "if" statement and fix alarm thread not to die before requesting exclusive access for us.
 	 */
@@ -538,7 +538,7 @@ MM_Scheduler::reportStopGCIncrement(MM_EnvironmentRealtime *env, bool isCycleEnd
 	 */
 	if (isCycleEnd) {
 		if (_completeCurrentGCSynchronously) {
-			/* The reqests for Sync GC made at the very end of
+			/* The requests for Sync GC made at the very end of
 			 * GC cycle might not had a chance to make the local copy
 			 */
 			if (_completeCurrentGCSynchronouslyMasterThreadCopy) {

--- a/runtime/gc_structs/VMThreadIterator.hpp
+++ b/runtime/gc_structs/VMThreadIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_structs/VMThreadIterator.hpp
+++ b/runtime/gc_structs/VMThreadIterator.hpp
@@ -54,7 +54,7 @@ enum {
 
 
 /**
- * Iterate over slots in a VM thread which contain object refereces.
+ * Iterate over slots in a VM thread which contain object references.
  * Internally, uses GC_VMThreadSlotIterator, GC_VMThreadJNISlotIterator, and 
  * GC_VMThreadMonitorRecordSlotIterator on the given thread.
  * @note Does not include references on the thread's stack (see GC_VMThreadStackSlotIterator)

--- a/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanEnd.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanEnd.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanEnd.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanEnd.hpp
@@ -31,7 +31,7 @@
 #include "VerboseEvent.hpp"
 
 /**
- * Stores the data relating to the end of a concurrent remebered set scan
+ * Stores the data relating to the end of a concurrent remembered set scan
  * @ingroup GC_verbose_events
  */
 class MM_VerboseEventConcurrentRSScanEnd : public MM_VerboseEvent

--- a/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanStart.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanStart.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanStart.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventConcurrentRSScanStart.hpp
@@ -31,7 +31,7 @@
 #include "VerboseEvent.hpp"
 
 /**
- * Stores the data relating to the start of a concurrent remebered set scan
+ * Stores the data relating to the start of a concurrent remembered set scan
  * @ingroup GC_verbose_events
  */
 class MM_VerboseEventConcurrentRSScanStart : public MM_VerboseEvent

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1238,8 +1238,8 @@ MM_IncrementalGenerationalGC::partialGarbageCollect(MM_EnvironmentVLHGC *env, MM
 		_schedulingDelegate.setAutomaticDefragmentEmptinessThreshold(optimalEmptinessRegionThreshold);
 	}
 
-	/* For Non CopyForwardHybrid mode, we don't allow any eden rgions with jniCritical for copyforward, if there is any, would switch MarkCompact PGC mode
-	 * For CopyForwardHybrid mode, we do not care about jniCritical eden regions, the eden rgions with jniCritical would be marked instead copyforwarded during collection.*/
+	/* For Non CopyForwardHybrid mode, we don't allow any eden regions with jniCritical for copyforward, if there is any, would switch MarkCompact PGC mode
+	 * For CopyForwardHybrid mode, we do not care about jniCritical eden regions, the eden regions with jniCritical would be marked instead copyforwarded during collection.*/
 	if (!_extensions->tarokEnableCopyForwardHybrid && (0 == _extensions->fvtest_forceCopyForwardHybridRatio)) {
 		if (env->_cycleState->_shouldRunCopyForward) {
 			MM_HeapRegionDescriptorVLHGC *region = NULL;

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -97,7 +97,7 @@ MM_VLHGCAccessBarrier::postObjectStore(J9VMThread *vmThread, J9Class *destClass,
 {
 	j9object_t destObject = J9VM_J9CLASS_TO_HEAPCLASS(destClass);
 
-	/* destObject is guaranteed to be in old space, so the common code path will rememember objects appropriately here */
+	/* destObject is guaranteed to be in old space, so the common code path will remember objects appropriately here */
 	postObjectStoreImpl(vmThread, destObject, value);
 }
 

--- a/runtime/gc_vlhgc/WriteOnceFixupCardCleaner.cpp
+++ b/runtime/gc_vlhgc/WriteOnceFixupCardCleaner.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_vlhgc/WriteOnceFixupCardCleaner.cpp
+++ b/runtime/gc_vlhgc/WriteOnceFixupCardCleaner.cpp
@@ -65,7 +65,7 @@ MM_WriteOnceFixupCardCleaner::clean(MM_EnvironmentBase *envModron, void *lowAddr
 		}
 		break;
 	case CARD_MARK_COMPACT_TRANSITION:
-		/* presently, this state needs to be treated much the same was as PGC_MUST_SCAN but we know that any objects under the card which point to other regions have been rememebered */
+		/* presently, this state needs to be treated much the same was as PGC_MUST_SCAN but we know that any objects under the card which point to other regions have been remembered */
 		rememberedOnly = true;
 	case CARD_PGC_MUST_SCAN:
 		if (_isGlobalMarkPhaseRunning) {

--- a/runtime/jcl/common/extendedosmbean.c
+++ b/runtime/jcl/common/extendedosmbean.c
@@ -222,7 +222,7 @@ Java_com_ibm_lang_management_internal_ExtendedOperatingSystemMXBeanImpl_getTotal
 	/* Now obtain the processor usage statistics on the underlying platform. */
 	rc = getProcessorUsage(env, &procInfo);
 	if (0 != rc) {
-		/* If processor usage statistics retieval failed for some reason, there is already a
+		/* If processor usage statistics retrieval failed for some reason, there is already a
 		 * pending exception. Returning a NULL anyway.
 		 */
 		return NULL;
@@ -287,7 +287,7 @@ Java_com_ibm_lang_management_internal_ExtendedOperatingSystemMXBeanImpl_getProce
 	/* Now obtain the processor usage statistics on the underlying platform. */
 	rc = getProcessorUsage(env, &procInfo);
 	if (0 != rc) {
-		/* If processor usage statistics retieval failed for some reason, there is already a
+		/* If processor usage statistics retrieval failed for some reason, there is already a
 		 * pending exception. Returning a NULL anyway.
 		 */
 		return NULL;
@@ -381,7 +381,7 @@ Java_com_ibm_lang_management_internal_ExtendedOperatingSystemMXBeanImpl_getMemor
 
 	PORT_ACCESS_FROM_ENV(env);
 
-	/* Check whether MemoryUsage class has already been reseolved and cached. If not, do so now.*/
+	/* Check whether MemoryUsage class has already been resolved and cached. If not, do so now.*/
 	if (NULL == JCL_CACHE_GET(env, MID_com_ibm_lang_management_MemoryUsage_updateValues)) {
 		jclass localMemoryUsageRef;
 

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1718,7 +1718,7 @@ done:
 
 
 /** 
- * \brief	Returnt the raw Constant Pool bytes for the specified class
+ * \brief	Return the raw Constant Pool bytes for the specified class
  * \ingroup	jvmtiClass 
  * 
  * 
@@ -1858,7 +1858,7 @@ done:
  *	ISSUES:
  *		The UTF8 and NameAndSignature constants are not stored on the constant pool and
  *		therefore do not have an "index" but rather use SRP references. This call will 
- *		create CP entries and update refering CP items accordingly
+ *		create CP entries and update referring CP items accordingly
  *
  *		The Long and Double type is defined by the spec to take _TWO_ constant pool entries
  *		instead of one. This creates a problem since our bytecode's cp indices have been

--- a/runtime/jvmti/jvmtiModules.c
+++ b/runtime/jvmti/jvmtiModules.c
@@ -411,7 +411,7 @@ done:
  *
  * @param [in] fromModule module containing package
  * @param [in] pkgName name must not contain '/' only '.'
- * @param [in] toModule module recinving access to package
+ * @param [in] toModule module receiving access to package
  *
  * @return JVMTI_ERROR_NONE if successfull, JVMTI_ERROR_INVALID_MODULE if either module is
  * invalid and JVMTI_ERROR_NULL_POINTER if either module is NULL
@@ -427,7 +427,7 @@ jvmtiAddModuleExports(jvmtiEnv* jvmtiEnv, jobject fromModule, const char* pkgNam
  *
  * @param [in] fromModule module containing package
  * @param [in] pkgName name must not contain '/' only '.'
- * @param [in] toModule module recinving access to package
+ * @param [in] toModule module receiving access to package
  *
  * @return JVMTI_ERROR_NONE if successfull, JVMTI_ERROR_INVALID_MODULE if either module is
  * invalid and JVMTI_ERROR_NULL_POINTER if either module is NULL

--- a/runtime/oti/rasdump_api.h
+++ b/runtime/oti/rasdump_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/rasdump_api.h
+++ b/runtime/oti/rasdump_api.h
@@ -410,7 +410,7 @@ triggerOneOffDump(struct J9JavaVM *vm, char *optionString, char *caller, char *f
  * @param *vm VM pointer
  * @param buffer_size Size of the buffer passed in
  * @param *options_buffer pointer to the buffer to be populated with data
- * @param *data_size pointer to integer to recieve the required size of buffer.
+ * @param *data_size pointer to integer to receive the required size of buffer.
  */
 omr_error_t
 queryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer, int* data_size);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3035,7 +3035,7 @@ walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState);
 
 
 /**
-* @brief Print and assert when an invalid reutrn address is detected in a JIT frame.
+* @brief Print and assert when an invalid return address is detected in a JIT frame.
 * @param *walkState
 * @return void
 */
@@ -3132,7 +3132,7 @@ loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options);
  * @param vmThread vmthread token
  * @param nestMember the j9lass requesting the nesthost
  * @param nestHost the actual nest host, this may be NULL
- * @param errorCode the error code represting the exception to throw
+ * @param errorCode the error code representing the exception to throw
  * 	J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR
  * 	J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR
  * 	J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR

--- a/runtime/port/common/j9sock.c
+++ b/runtime/port/common/j9sock.c
@@ -496,7 +496,7 @@ j9sock_gethostname(struct J9PortLibrary *portLibrary, char *buffer, int32_t leng
  * @param[in] sockaddr_size The size of "in_addr"
  * @param[out] name The hostname of the passed address in a preallocated buffer.
  * @param[in] name_length The length of the buffer pointed to by name
- * @param[in] flags Flags on how to form the repsonse (see man pages or doc for getnameinfo)
+ * @param[in] flags Flags on how to form the response (see man pages or doc for getnameinfo)
  *
  * @return	0, if no errors occurred, otherwise the (negative) error code
  *
@@ -1281,7 +1281,7 @@ j9sock_shutdown_output(struct J9PortLibrary *portLibrary, j9socket_t sock)
 	return J9PORT_ERROR_SOCKET_OPFAILED;
 }
 /**
- * Creates a new j9sockaddr, refering to the specified port and address.  The only address family currently supported
+ * Creates a new j9sockaddr, referring to the specified port and address.  The only address family currently supported
  * is AF_INET.
  *
  * @param[in] portLibrary The port library.

--- a/runtime/port/unix/j9sock.c
+++ b/runtime/port/unix/j9sock.c
@@ -1451,7 +1451,7 @@ j9sock_gethostname(struct J9PortLibrary *portLibrary, char *buffer, int32_t leng
  * @param[in] sockaddr_size The size of "in_addr"
  * @param[out] name The hostname of the passed address in a preallocated buffer.
  * @param[in] name_length The length of the buffer pointed to by name
- * @param[in] flags Flags on how to form the repsonse (see man pages or doc for getnameinfo)
+ * @param[in] flags Flags on how to form the response (see man pages or doc for getnameinfo)
  *
  * @return	0, if no errors occurred, otherwise the (negative) error code
  *

--- a/runtime/port/win32/j9shsem_deprecated.c
+++ b/runtime/port/win32/j9shsem_deprecated.c
@@ -251,7 +251,7 @@ j9shsem_deprecated_wait(struct J9PortLibrary *portLibrary, struct j9shsem_handle
 	rc = WaitForSingleObject(handle->semHandles[semset],timeout);
 	
 	switch(rc) {
-	case WAIT_ABANDONED: /* This means someone has crashed but hasn't relase the mutex, we are okay with this */
+	case WAIT_ABANDONED: /* This means someone has crashed but hasn't released the mutex, we are okay with this */
 	case WAIT_OBJECT_0:
 		Trc_PRT_shsem_j9shsem_wait_Exit(0);
 		return 0;

--- a/runtime/port/win32/j9sock.c
+++ b/runtime/port/win32/j9sock.c
@@ -1552,7 +1552,7 @@ j9sock_gethostname(struct J9PortLibrary *portLibrary, char *buffer, int32_t leng
  * @param[in] sockaddr_size The size of "in_addr"
  * @param[out] name The hostname of the passed address in a preallocated buffer.
  * @param[in] name_length The length of the buffer pointed to by name
- * @param[in] flags Flags on how to form the repsonse (see man pages or doc for getnameinfo)
+ * @param[in] flags Flags on how to form the response (see man pages or doc for getnameinfo)
  *
  * @return	0, if no errors occurred, otherwise the (negative) error code
  *
@@ -1952,7 +1952,7 @@ j9sock_getsockname(struct J9PortLibrary *portLibrary, j9socket_t handle, j9socka
 		}
 	}
 
-	/* if both sockets are open we cannot retun the address for either one as whichever one we return it is wrong in some 
+	/* if both sockets are open we cannot return the address for either one as whichever one we return it is wrong in some 
 	   cases. Therefore,  we reset the address to the ANY address and leave the port as is as it should be the same
        for both sockets (bind makes sure that when we open the two sockets we use the same port */
 	if ((handle->flags & SOCKET_IPV4_OPEN_MASK) && (handle->flags & SOCKET_IPV6_OPEN_MASK)) {
@@ -3206,7 +3206,7 @@ j9sock_shutdown_output(struct J9PortLibrary *portLibrary, j9socket_t sock)
 
 
 /**
- * Creates a new j9sockaddr, refering to the specified port and address.  The only address family currently supported
+ * Creates a new j9sockaddr, referring to the specified port and address.  The only address family currently supported
  * is AF_INET.
  *
  * @param[in] portLibrary The port library.

--- a/runtime/runtimetools/balloon/BalloonAgent.cpp
+++ b/runtime/runtimetools/balloon/BalloonAgent.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/runtimetools/balloon/BalloonAgent.cpp
+++ b/runtime/runtimetools/balloon/BalloonAgent.cpp
@@ -50,7 +50,7 @@ Agent_OnUnload(JavaVM * vm)
  * callback invoked by JVMTI when the agent is loaded
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserved for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
@@ -63,7 +63,7 @@ Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
  * callback invoked when an attach is made on the jvm
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserved for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnAttach(JavaVM * vm, char * options, void * reserved)

--- a/runtime/runtimetools/migration/MigrationAgent.cpp
+++ b/runtime/runtimetools/migration/MigrationAgent.cpp
@@ -87,7 +87,7 @@ Agent_OnUnload(JavaVM * vm)
  * callback invoked by JVMTI when the agent is loaded
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserved for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
@@ -111,7 +111,7 @@ Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
  * callback invoked when an attach is made on the jvm
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserverd for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnAttach(JavaVM * vm, char * options, void * reserved)

--- a/runtime/runtimetools/osmemory/OSMemoryAgent.cpp
+++ b/runtime/runtimetools/osmemory/OSMemoryAgent.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/runtimetools/osmemory/OSMemoryAgent.cpp
+++ b/runtime/runtimetools/osmemory/OSMemoryAgent.cpp
@@ -91,7 +91,7 @@ Agent_OnUnload(JavaVM * vm)
  * callback invoked by JVMTI when the agent is loaded
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserverd for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
@@ -104,7 +104,7 @@ Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
  * callback invoked when an attach is made on the jvm
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserverd for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnAttach(JavaVM * vm, char * options, void * reserved)

--- a/runtime/runtimetools/softmxtest/SoftMxTest.cpp
+++ b/runtime/runtimetools/softmxtest/SoftMxTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/runtimetools/softmxtest/SoftMxTest.cpp
+++ b/runtime/runtimetools/softmxtest/SoftMxTest.cpp
@@ -51,7 +51,7 @@ Agent_OnUnload(JavaVM * vm)
  * callback invoked by JVMTI when the agent is loaded
  * @param vm       [ in] jvm that can be used by the agent
  * @param options   [in] options specified on command line for agent
- * @param reserverd [in/out] reserved for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
@@ -64,7 +64,7 @@ Agent_OnLoad(JavaVM * vm, char * options, void * reserved)
  * callback invoked when an attach is made on the jvm
  * @param vm        [in] jvm that can be used by the agent
  * @param options   [in] options specified on command line for agent
- * @param reserverd [in/out] reserved for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnAttach(JavaVM * vm, char * options, void * reserved)

--- a/runtime/runtimetools/vmruntimestateagent/VMRuntimeStateAgent.cpp
+++ b/runtime/runtimetools/vmruntimestateagent/VMRuntimeStateAgent.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/runtimetools/vmruntimestateagent/VMRuntimeStateAgent.cpp
+++ b/runtime/runtimetools/vmruntimestateagent/VMRuntimeStateAgent.cpp
@@ -50,7 +50,7 @@ Agent_OnUnload(JavaVM * vm)
  * callback invoked by JVMTI when the agent is loaded
  * @param vm       [in] jvm that can be used by the agent
  * @param options  [in] options specified on command line for agent
- * @param reserver [in/out] reserved for future use
+ * @param reserved [in/out] reserved for future use
  */
 jint JNICALL
 Agent_OnLoad(JavaVM * vm, char * options, void * reserved)

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -4103,7 +4103,7 @@ SH_CompositeCacheImpl::exitReadWriteAreaMutex(J9VMThread* currentThread, UDATA r
 		}
 
 		/**
-		 * Do assertion checks before relasing the lock to prevent others threads changing the values of
+		 * Do assertion checks before releasing the lock to prevent others threads changing the values of
 		 * _headerProtectCntr and _readWriteProtectCntr
 		 */
 		if (0 != (*_runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_MPROTECT_ALL)) {

--- a/runtime/tests/algorithm/srphashtabletest.c
+++ b/runtime/tests/algorithm/srphashtabletest.c
@@ -491,7 +491,7 @@ runTests(J9PortLibrary *portLib, char * id, J9SRPHashTable **srptable, UDATA *da
  * It has 3 stages.
  * 1. It uses exact required memory size to store all of the elements of data array.
  * 2. It uses 1 byte short memory to store all of the elements of data array.
- * 3. It uses 1000 byte bigger memory size than the size reuired to store all of the elements of data array.
+ * 3. It uses 1000 byte bigger memory size than the size required to store all of the elements of data array.
  *
  * @param 	portLib		Pointer to a port library.
  * @param 	id			Pointer to the test's name.

--- a/runtime/tests/port/j9strTest.c
+++ b/runtime/tests/port/j9strTest.c
@@ -518,7 +518,7 @@ j9str_test2(struct J9PortLibrary *portLibrary)
  * 	2. ime 0 
  * 	3. a known time (February 29th 2004 01:23:45)
  * 	4. Tokens that are not valid for str_ftime but are set by default in j9str_create_tokens. 
- * 		Check that these are not subsituted.
+ * 		Check that these are not substituted.
  *  5. Tokens that are not valid by default anywhere.
  * 
  * 

--- a/runtime/util/fltdmath.c
+++ b/runtime/util/fltdmath.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/util/fltdmath.c
+++ b/runtime/util/fltdmath.c
@@ -2287,7 +2287,7 @@ static CANONICALFP canonicalMultiply( CANONICALFP u, CANONICALFP v ) {
 	presult->sign = pu->sign ^ pv->sign;
 	presult->exponent = pu->exponent + pv->exponent + 2;
 
-	/* If resulting value is too small to be reprented as a
+	/* If resulting value is too small to be represented as a
 	 * floating-point number, just return zero with the correct sign. */
 	if( presult->exponent < -(DPEXPONENT_BIAS+DPFRACTION_LENGTH) ) {
 		presult->exponent = 0;

--- a/runtime/util/mz31/volatile.s
+++ b/runtime/util/mz31/volatile.s
@@ -120,8 +120,8 @@ longVolatileRead_CONSTANTS    DS    0H
         lm   r0,r1,0(r3)
         lr   r3,r1
         lr   r2,r0
-        lm   r4,r15,2048(r4)                      * small frame: restor\
-               e volatile registers (including returnAddress and oldSP)\
+        lm   r4,r15,2048(r4)                     * small frame: restore\
+               volatile registers (including returnAddress and oldSP)\
 
         br   r7
 CODELLONGVOLATILEREAD      EQU *-LONGVOLATILEREAD
@@ -189,8 +189,8 @@ longVolatileWrite_CONSTANTS    DS    0H
         lr   r1,r2
         stm  r0,r1,0(r5)
         bcr ALWAYS,r0 # readwrite barrier
-        lm   r4,r15,2048(r4)                      * small frame: restor\
-               e volatile registers (including returnAddress and oldSP)\
+        lm   r4,r15,2048(r4)                     * small frame: restore\
+               volatile registers (including returnAddress and oldSP)\
 
         br   r7
 CODELLONGVOLATILEWRITE      EQU *-LONGVOLATILEWRITE

--- a/runtime/util/mz31/volatile.s
+++ b/runtime/util/mz31/volatile.s
@@ -1,4 +1,4 @@
-* Copyright (c) 1991, 2017 IBM Corp. and others
+* Copyright (c) 1991, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -193,7 +193,7 @@ _exit:
  * @param vmThread vmthread token
  * @param nestMember the j9lass requesting the nesthost
  * @param nestHost the actual nest host, this may be NULL
- * @param errorCode the error code represting the exception to throw
+ * @param errorCode the error code representing the exception to throw
  * 					J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR
  * 					J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR
  * 					J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Src.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Src.java
@@ -86,7 +86,7 @@ public class Src {
 	}
 
 	/**
-	 * Returns this source's relatiev path.
+	 * Returns this source's relative path.
 	 * 
 	 * @return		the relative path
 	 */

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Src.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Src.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2017 IBM Corp. and others
+ * Copyright (c) 1999, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/objectmodel/com/ibm/j9tools/om/BuildInfo.java
+++ b/sourcetools/objectmodel/com/ibm/j9tools/om/BuildInfo.java
@@ -288,7 +288,7 @@ public class BuildInfo extends OMObject {
 	}
 
 	/**
-	 * Retrives the list of repository keys.
+	 * Retrieves the list of repository keys.
 	 * 
 	 * @return	the repository keys
 	 */

--- a/sourcetools/objectmodel/com/ibm/j9tools/om/BuildInfo.java
+++ b/sourcetools/objectmodel/com/ibm/j9tools/om/BuildInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2011 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/objectmodel/com/ibm/j9tools/om/OMElementException.java
+++ b/sourcetools/objectmodel/com/ibm/j9tools/om/OMElementException.java
@@ -81,7 +81,7 @@ public abstract class OMElementException extends OMException {
 	}
 	
 	/**
-	 * Retrives the column number for this exception.
+	 * Retrieves the column number for this exception.
 	 * 
 	 * @return	the column number
 	 */

--- a/sourcetools/objectmodel/com/ibm/j9tools/om/OMElementException.java
+++ b/sourcetools/objectmodel/com/ibm/j9tools/om/OMElementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2011 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/objectmodel/com/ibm/j9tools/om/ObjectFactory.java
+++ b/sourcetools/objectmodel/com/ibm/j9tools/om/ObjectFactory.java
@@ -707,7 +707,7 @@ public class ObjectFactory {
 	}
 
 	/**
-	 * Retrives the set of valid {@link FeatureDefinition} IDs the factory's config directory.
+	 * Retrieves the set of valid {@link FeatureDefinition} IDs the factory's config directory.
 	 *
 	 * @return	the valid feature definition IDs
 	 */

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxRemoteTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxRemoteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxRemoteTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxRemoteTest.java
@@ -46,7 +46,7 @@ import javax.management.ObjectName;
 import com.ibm.lang.management.MemoryMXBean;
 
 /*
- * Start the RemotTestServer with softmx enabled and jmx enabled before run the test.
+ * Start the RemoteTestServer with softmx enabled and jmx enabled before run the test.
  */
 @Test(groups = { "level.extended" })
 public class SoftmxRemoteTest{

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementFactory.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementFactory.java
@@ -739,7 +739,7 @@ public class TestManagementFactory {
 			AssertJUnit.assertNotNull(stdProxy);
 			AssertJUnit.assertTrue(proxy instanceof NotificationEmitter);
 			NotificationEmitter proxyEmitter = (NotificationEmitter)proxy;
-			// Verify that the notification info can be retreived OK
+			// Verify that the notification info can be retrieved OK
 			MBeanNotificationInfo[] notifications = proxyEmitter.getNotificationInfo();
 			AssertJUnit.assertNotNull(notifications);
 			AssertJUnit.assertTrue(notifications.length > 0);

--- a/test/functional/Java8andUp/src/org/openj9/test/management/AllocationGenerator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/management/AllocationGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/management/AllocationGenerator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/management/AllocationGenerator.java
@@ -156,7 +156,7 @@ public class AllocationGenerator extends Thread {
 
        		if ((i < (long)largeAllocStart[sizeIndex] * keyCount)
        				|| (i > (long)largeAllocStop[sizeIndex] * keyCount)) {
-       			// this i ugly: we are not replacing old Index; revet back tha counter 
+       			// this i ugly: we are not replacing old Index; reset back tha counter 
      	        if (null != oldRecord) {
      	        	largeAllocCount[sizeIndex] += 1;
      	        }

--- a/test/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java
@@ -135,7 +135,7 @@ public class Allocator extends Thread {
 
 			if ((i < (long) largeAllocStart[sizeIndex] * keyCount)
 					|| (i > (long) largeAllocStop[sizeIndex] * keyCount)) {
-				// this i ugly: we are not replacing old Index; revet back tha counter
+				// this i ugly: we are not replacing old Index; reset back tha counter
 				if (null != oldRecord) {
 					largeAllocCount[sizeIndex] += 1;
 				}

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleProxiesTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleProxiesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleProxiesTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleProxiesTest.java
@@ -255,7 +255,7 @@ public class MethodHandleProxiesTest {
 	}
 	
 	/**
-	 * Negative test for verifying target retrival failure for wrapperInstanceTarget method in case of non-wrapper instances.
+	 * Negative test for verifying target retrieval failure for wrapperInstanceTarget method in case of non-wrapper instances.
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.extended" })

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/classModificationAgent/cma001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/classModificationAgent/cma001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/classModificationAgent/cma001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/classModificationAgent/cma001.java
@@ -113,7 +113,7 @@ public class cma001 {
 	 *  - modifies the class bytes to Vj, 
 	 *  - sets current version = Vj.
 	 * 
-	 * cma001 calls RetranformClasses() on cma001_TestClass_V1.
+	 * cma001 calls RetransformClasses() on cma001_TestClass_V1.
 	 * rca001's ClassFileLoadHook callback is invoked that performs following actions:
 	 * 	- verifies bytes received correspond to its expected version i.e. Vi,
 	 *  - modifies the class bytes to Vj, 
@@ -132,7 +132,7 @@ public class cma001 {
 	 *  - modifies the class bytes to Vj, 
 	 *  - sets current version = Vj.
 	 * 
-	 * cma001 calls RetranformClasses() on cma001_TestClass_V1.
+	 * cma001 calls RetransformClasses() on cma001_TestClass_V1.
 	 * rca001's ClassFileLoadHook callback is invoked that performs following actions:
 	 * 	- verifies bytes received correspond to its expected version i.e. Vi,
 	 *  - modifies the class bytes to Vj, 

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -117,7 +117,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<!-- Tests 201 a-d verify shared cache is BCI disabled when only 'cacheRetransfomred is specified -->
+	<!-- Tests 201 a-d verify shared cache is BCI disabled when only 'cacheRetransformed' is specified -->
 	
 	<test id="Test 201-a Verify shared cache is BCI disabled when 'cacheRetransformed' is specified" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,reset,cacheRetransformed -version</command>


### PR DESCRIPTION
This PR should be purely comment changes for words (or families of words) that start w/ `r`

To make my life easier, these initial comment focused PRs will have 2 commits:
* one which is the fixes
* and one which is the copyright bumping

For more information, see #5722 

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `f` / `fchurn`.