### PR TITLE
Fix behaviour of XX:IdleTuningCompactOnIdle

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -482,7 +482,7 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 	}
 
 #if defined(J9VM_GC_IDLE_HEAP_MANAGER)
-	if (extensions->gcOnIdle || extensions->compactOnIdle) {
+	if (extensions->gcOnIdle) {
 		/* Enable idle tuning only for gencon policy */
 		if (gc_policy_gencon == extensions->configurationOptions._gcPolicy) {
 			extensions->idleGCManager = MM_IdleGCManager::newInstance(&env);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1874,20 +1874,23 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				}
 				if (TRUE == enableGcOnIdle) {
 					vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_GC_ON_IDLE;
+					/*
+ 					 * 
+				  	 * CompactOnIdle is enabled only if XX:+IdleTuningGcOnIdle is set and:
+				  	 * 1. -XX:+IdleTuningCompactOnIdle is set, or
+				  	 * 2. running in container
+				  	 *
+				  	 * Setting Xtune:virtualized on java versions 9 or above does not enable CompactOnIdle.
+				  	 */
+					if ((argIndexCompactOnIdleEnable > argIndexCompactOnIdleDisable)
+					|| ((-1 == argIndexCompactOnIdleDisable) && inContainer)
+					) {
+						vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_COMPACT_ON_IDLE;
+					} else {
+						vm->vmRuntimeStateListener.idleTuningFlags &= ~(UDATA)J9_IDLE_TUNING_COMPACT_ON_IDLE;
+					}
 				} else {
 					vm->vmRuntimeStateListener.idleTuningFlags &= ~(UDATA)J9_IDLE_TUNING_GC_ON_IDLE;
-				}
-				/*
-				 * CompactOnIdle is enabled only if:
-				 * 1. -XX:+IdleTuningCompactOnIdle is set, or
-				 * 2. running in container
-				 */
-				if ((argIndexCompactOnIdleEnable > argIndexCompactOnIdleDisable)
-				|| ((-1 == argIndexCompactOnIdleDisable) && inContainer)
-				) {
-					vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_COMPACT_ON_IDLE;
-				} else {
-					vm->vmRuntimeStateListener.idleTuningFlags &= ~(UDATA)J9_IDLE_TUNING_COMPACT_ON_IDLE;
 				}
 				/* default ignore if idle tuning options not supported */
 				vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_IGNORE_UNRECOGNIZED_OPTIONS;


### PR DESCRIPTION
Currently, idle GC still happens in a container even when XX:-IdleTuningGcOnIdle
is passed. This is because compactOnIdle is enabled by default, and its behaviour
is to still perform idle GC, with added compaction.

Changed the behaviour to make sure that idle GC only happens when gcOnIdle is enabled,
otherwise, it is silently ignored.

[Related issue](https://github.com/eclipse/openj9/issues/5374)

[Doc changes](https://github.com/eclipse/openj9-docs/pull/276) 

Signed-off-by: Shishir Halaharvi <shishir.neo95@gmail.com>