### PR TITLE
Fix some spelling mis-corrections

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -918,7 +918,7 @@ public static Map<String, String> getenv() {
  * @return the Console or null
  */
 public static Console console() {
-	/*[PR CMVC 114090] System.console does not return null in subprocesss */
+	/*[PR CMVC 114090] System.console does not return null in subprocess */
 	/*[PR CMVC 114119] Console exists when stdin, stdout are redirected */
 	if (consoleInitialized) return console;
 	synchronized(System.class) {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2443,7 +2443,7 @@ TR_J9ByteCodeIlGenerator::saveStack(int32_t targetIndex, bool anchorLoads)
 // Bad code results if code following saveStack generated stores
 // attempts to load from one of the saved PPS slots. Two obvious
 // examples arise. For the first example see the comment before
-// TR_J9ByteCodeIlGenerator::genIfImp. Second, consider a treetop precedeing a
+// TR_J9ByteCodeIlGenerator::genIfImp. Second, consider a treetop preceding a
 // decompilation point. Nodes loaded from the PPS save region (i.e that
 // were live on entry to the block) may be referred to by treetops on
 // both sides of the decompilation point and thus may be killed by the

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -161,7 +161,7 @@ J9::Recompilation::fixUpMethodCode(void * startPC)
    else
       {
       // Will overwrite the first instruction of the body--this should be a store of the link reg
-      // ie ST r14,4(r5).  Note that there will be precedeing loads for the args for the interpreter
+      // ie ST r14,4(r5).  Note that there will be preceding loads for the args for the interpreter
       // entry point and these vary depending on # args, hence add adjustment for jitEntryOffset
       int32_t jitEntryOffset = getJitEntryOffset(linkageInfo);
       int32_t * jitEntry = (int32_t *) ((uint8_t *) startPC + jitEntryOffset);

--- a/runtime/rastrace/trclog.c
+++ b/runtime/rastrace/trclog.c
@@ -1644,7 +1644,7 @@ traceV(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, const char *
 		 *  Handle sequence counter wrap
 		 *
 		 *  It's not a problem if the sequence counter write is aborted/discarded
-		 *  by nodynamic because it applies to the *precedeing* tracepoints and
+		 *  by nodynamic because it applies to the *preceding* tracepoints and
 		 *  they'll have been discarded as well.
 		 */
 		if (lastSequence != (int32_t)(trcBuf->record.sequence>>32)) {


### PR DESCRIPTION
* precedeing -> preceding
* subprocesss -> subprocess