### PR TITLE
Fix grammar/spelling

### DIFF
--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -406,7 +406,7 @@ MM_Scheduler::waitForMutatorsToStop(MM_EnvironmentRealtime *env)
 	 * exclusive access for itself.
 	 * requestExclusiveVMAccess is invoked atomically with _mode being set to WAKING_GC
 	 * under masterThreadMonitor (see continueGC). Therefore, we check here if mode is not
-	 * WAKING_GC, and only than when we request exclusive assess for ourselves.
+	 * WAKING_GC, and only then we request exclusive assess for ourselves.
 	 * TODO: This approach is just to fix some timing holes in shutdown. Consider removing this
 	 * "if" statement and fix alarm thread not to die before requesting exclusive access for us.
 	 */
@@ -1055,4 +1055,3 @@ j9gc_startGCIfTimeExpired(OMR_VMThread* vmThread)
 }
 
 }
-

--- a/test/functional/Java8andUp/src/org/openj9/test/management/AllocationGenerator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/management/AllocationGenerator.java
@@ -156,7 +156,7 @@ public class AllocationGenerator extends Thread {
 
        		if ((i < (long)largeAllocStart[sizeIndex] * keyCount)
        				|| (i > (long)largeAllocStop[sizeIndex] * keyCount)) {
-       			// this i ugly: we are not replacing old Index; reset back tha counter 
+       			// this is ugly: we are not replacing old Index; revert back that counter
      	        if (null != oldRecord) {
      	        	largeAllocCount[sizeIndex] += 1;
      	        }

--- a/test/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/nogc/Allocator.java
@@ -135,7 +135,7 @@ public class Allocator extends Thread {
 
 			if ((i < (long) largeAllocStart[sizeIndex] * keyCount)
 					|| (i > (long) largeAllocStop[sizeIndex] * keyCount)) {
-				// this i ugly: we are not replacing old Index; reset back tha counter
+				// this is ugly: we are not replacing old Index; revert back that counter
 				if (null != oldRecord) {
 					largeAllocCount[sizeIndex] += 1;
 				}


### PR DESCRIPTION
* revet was changed to reset; should have been revert
* than -> then