### PR TITLE
No module related hashtable creation for JDK8

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -81,19 +81,21 @@ MM_RootScanner::doClassLoader(J9ClassLoader *classLoader)
 void
 MM_RootScanner::scanModularityObjects(J9ClassLoader * classLoader)
 {
-	J9HashTableState moduleWalkState;
-	J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
-	while (NULL != modulePtr) {
-		J9Module * const module = *modulePtr;
+	if (NULL != classLoader->moduleHashTable) {
+		J9HashTableState moduleWalkState;
+		J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
+		while (NULL != modulePtr) {
+			J9Module * const module = *modulePtr;
 
-		doSlot(&module->moduleObject);
-		if (NULL != module->moduleName) {
-			doSlot(&module->moduleName);
+			doSlot(&module->moduleObject);
+			if (NULL != module->moduleName) {
+				doSlot(&module->moduleName);
+			}
+			if (NULL != module->version) {
+				doSlot(&module->version);
+			}
+			modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 		}
-		if (NULL != module->version) {
-			doSlot(&module->version);
-		}
-		modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 	}
 }
 

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -430,23 +430,24 @@ MM_ConcurrentMarkingDelegate::concurrentClassMark(MM_EnvironmentBase *env, bool 
 					clazz = _javaVM->internalVMFunctions->hashClassTableNextDo(&walkState);
 				}
 
-				Assert_MM_true(NULL != classLoader->moduleHashTable);
-				J9HashTableState moduleWalkState;
-				J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
-				while (NULL != modulePtr) {
-					J9Module * const module = *modulePtr;
+				if (NULL != classLoader->moduleHashTable) {
+					J9HashTableState moduleWalkState;
+					J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
+					while (NULL != modulePtr) {
+						J9Module * const module = *modulePtr;
 
-					_markingScheme->markObject(env, (j9object_t)module->moduleObject);
-					if (NULL != module->moduleName) {
-						_markingScheme->markObject(env, (j9object_t)module->moduleName);
+						_markingScheme->markObject(env, (j9object_t)module->moduleObject);
+						if (NULL != module->moduleName) {
+							_markingScheme->markObject(env, (j9object_t)module->moduleName);
+						}
+						if (NULL != module->version) {
+							_markingScheme->markObject(env, (j9object_t)module->version);
+						}
+						if (env->isExclusiveAccessRequestWaiting()) {	/* interrupt if exclusive access request is waiting */
+							goto quitConcurrentClassMark;
+						}
+						modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 					}
-					if (NULL != module->version) {
-						_markingScheme->markObject(env, (j9object_t)module->version);
-					}
-					if (env->isExclusiveAccessRequestWaiting()) {	/* interrupt if exclusive access request is waiting */
-						goto quitConcurrentClassMark;
-					}
-					modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 				}
 
 				classLoader->gcFlags |= J9_GC_CLASS_LOADER_SCANNED;

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -322,20 +322,21 @@ MM_MarkingDelegate::completeMarking(MM_EnvironmentBase *env)
 									clazz = javaVM->internalVMFunctions->hashClassTableNextDo(&walkState);
 								}
 
-								Assert_MM_true(NULL != classLoader->moduleHashTable);
-								J9HashTableState moduleWalkState;
-								J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
-								while (NULL != modulePtr) {
-									J9Module * const module = *modulePtr;
+								if (NULL != classLoader->moduleHashTable) {
+									J9HashTableState moduleWalkState;
+									J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
+									while (NULL != modulePtr) {
+										J9Module * const module = *modulePtr;
 
-									_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->moduleObject);
-									if (NULL != module->moduleName) {
-										_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->moduleName);
+										_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->moduleObject);
+										if (NULL != module->moduleName) {
+											_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->moduleName);
+										}
+										if (NULL != module->version) {
+											_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->version);
+										}
+										modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 									}
-									if (NULL != module->version) {
-										_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->version);
-									}
-									modulePtr = (J9Module**)hashTableNextDo(&moduleWalkState);
 								}
 							}
 						}

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -986,15 +986,16 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 					 */
 					hashTableResetFlag(classLoader->classHashTable, J9HASH_TABLE_DO_NOT_REHASH);
 
-					Assert_MM_true(NULL != classLoader->moduleHashTable);
-					J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-					while (NULL != modulePtr) {
-						J9Module * const module = *modulePtr;
+					if (NULL != classLoader->moduleHashTable) {
+						J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+						while (NULL != modulePtr) {
+							J9Module * const module = *modulePtr;
 
-						didWork |= _markingScheme->markObject(env, module->moduleObject);
-						didWork |= _markingScheme->markObject(env, module->moduleName);
-						didWork |= _markingScheme->markObject(env, module->version);
-						modulePtr = (J9Module**)hashTableNextDo(&walkState);
+							didWork |= _markingScheme->markObject(env, module->moduleObject);
+							didWork |= _markingScheme->markObject(env, module->moduleName);
+							didWork |= _markingScheme->markObject(env, module->version);
+							modulePtr = (J9Module**)hashTableNextDo(&walkState);
+						}
 					}
 				}
 			}

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2718,23 +2718,24 @@ MM_CopyForwardScheme::scanClassLoaderObjectSlots(MM_EnvironmentVLHGC *env, MM_Al
 				success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(clazz->classObject));
 			}
 
-			Assert_MM_true(NULL != classLoader->moduleHashTable);
-			J9HashTableState walkState;
-			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-			while (success && (NULL != modulePtr)) {
-				J9Module * const module = *modulePtr;
-				success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->moduleObject));
-				if (success) {
-					if (NULL != module->moduleName) {
-						success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->moduleName));
+			if (NULL != classLoader->moduleHashTable) {
+				J9HashTableState walkState;
+				J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+				while (success && (NULL != modulePtr)) {
+					J9Module * const module = *modulePtr;
+					success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->moduleObject));
+					if (success) {
+						if (NULL != module->moduleName) {
+							success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->moduleName));
+						}
 					}
-				}
-				if (success) {
-					if (NULL != module->version) {
-						success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->version));
+					if (success) {
+						if (NULL != module->version) {
+							success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->version));
+						}
 					}
+					modulePtr = (J9Module**)hashTableNextDo(&walkState);
 				}
-				modulePtr = (J9Module**)hashTableNextDo(&walkState);
 			}
 		}
 	}
@@ -4378,23 +4379,24 @@ MM_CopyForwardScheme::scanRoots(MM_EnvironmentVLHGC* env)
 									success = copyAndForward(env, clazzContext, (J9Object **)&(clazz->classObject));
 								}
 
-								Assert_MM_true(NULL != classLoader->moduleHashTable);
-								J9HashTableState walkState;
-								J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-								while (success && (NULL != modulePtr)) {
-									J9Module * const module = *modulePtr;
-									success = copyAndForward(env, getContextForHeapAddress(module->moduleObject), (J9Object **)&(module->moduleObject));
-									if (success) {
-										if (NULL != module->moduleName) {
-											success = copyAndForward(env, getContextForHeapAddress(module->moduleName), (J9Object **)&(module->moduleName));
+								if (NULL != classLoader->moduleHashTable) {
+									J9HashTableState walkState;
+									J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+									while (success && (NULL != modulePtr)) {
+										J9Module * const module = *modulePtr;
+										success = copyAndForward(env, getContextForHeapAddress(module->moduleObject), (J9Object **)&(module->moduleObject));
+										if (success) {
+											if (NULL != module->moduleName) {
+												success = copyAndForward(env, getContextForHeapAddress(module->moduleName), (J9Object **)&(module->moduleName));
+											}
 										}
-									}
-									if (success) {
-										if (NULL != module->version) {
-											success = copyAndForward(env, getContextForHeapAddress(module->version), (J9Object **)&(module->version));
+										if (success) {
+											if (NULL != module->version) {
+												success = copyAndForward(env, getContextForHeapAddress(module->version), (J9Object **)&(module->version));
+											}
 										}
+										modulePtr = (J9Module**)hashTableNextDo(&walkState);
 									}
-									modulePtr = (J9Module**)hashTableNextDo(&walkState);
 								}
 							}
 						}

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -236,20 +236,21 @@ MM_GlobalMarkCardScrubber::scrubClassLoaderObject(MM_EnvironmentVLHGC *env, J9Ob
 			doScrub = mayScrubReference(env, classLoaderObject, classObject);
 		}
 
-		Assert_MM_true(NULL != classLoader->moduleHashTable);
-		J9HashTableState walkState;
-		J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-		while (doScrub && (NULL != modulePtr)) {
-			J9Module * const module = *modulePtr;
-			Assert_MM_true(NULL != module->moduleObject);
-			doScrub = mayScrubReference(env, classLoaderObject, module->moduleObject);
-			if (doScrub) {
-				doScrub = mayScrubReference(env, classLoaderObject, module->moduleName);
+		if (NULL != classLoader->moduleHashTable) {
+			J9HashTableState walkState;
+			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+			while (doScrub && (NULL != modulePtr)) {
+				J9Module * const module = *modulePtr;
+				Assert_MM_true(NULL != module->moduleObject);
+				doScrub = mayScrubReference(env, classLoaderObject, module->moduleObject);
+				if (doScrub) {
+					doScrub = mayScrubReference(env, classLoaderObject, module->moduleName);
+				}
+				if (doScrub) {
+					doScrub = mayScrubReference(env, classLoaderObject, module->version);
+				}
+				modulePtr = (J9Module**)hashTableNextDo(&walkState);
 			}
-			if (doScrub) {
-				doScrub = mayScrubReference(env, classLoaderObject, module->version);
-			}
-			modulePtr = (J9Module**)hashTableNextDo(&walkState);
 		}
 	}
 	

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -808,23 +808,24 @@ MM_GlobalMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object
 		}
 		GC_VMInterface::unlockClasses(_extensions);
 
-		Assert_MM_true(NULL != classLoader->moduleHashTable);
-		J9HashTableState walkState;
-		J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-		while (NULL != modulePtr) {
-			J9Module * const module = *modulePtr;
-			Assert_MM_true(NULL != module->moduleObject);
-			markObject(env, module->moduleObject);
-			rememberReferenceIfRequired(env, classLoaderObject, module->moduleObject);
-			if (NULL != module->moduleName) {
-				markObject(env, module->moduleName);
-				rememberReferenceIfRequired(env, classLoaderObject, module->moduleName);
+		if (NULL != classLoader->moduleHashTable) {
+			J9HashTableState walkState;
+			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+			while (NULL != modulePtr) {
+				J9Module * const module = *modulePtr;
+				Assert_MM_true(NULL != module->moduleObject);
+				markObject(env, module->moduleObject);
+				rememberReferenceIfRequired(env, classLoaderObject, module->moduleObject);
+				if (NULL != module->moduleName) {
+					markObject(env, module->moduleName);
+					rememberReferenceIfRequired(env, classLoaderObject, module->moduleName);
+				}
+				if (NULL != module->version) {
+					markObject(env, module->version);
+					rememberReferenceIfRequired(env, classLoaderObject, module->version);
+				}
+				modulePtr = (J9Module**)hashTableNextDo(&walkState);
 			}
-			if (NULL != module->version) {			
-				markObject(env, module->version);
-				rememberReferenceIfRequired(env, classLoaderObject, module->version);
-			}
-			modulePtr = (J9Module**)hashTableNextDo(&walkState);
 		}
 	}
 }

--- a/runtime/gc_vlhgc/PartialMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.cpp
@@ -800,23 +800,24 @@ MM_PartialMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Objec
 			rememberReferenceIfRequired(env, classLoaderObject, classObject);
 		}
 
-		Assert_MM_true(NULL != classLoader->moduleHashTable);
-		J9HashTableState walkState;
-		J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-		while (NULL != modulePtr) {
-			J9Module * const module = *modulePtr;
-			Assert_MM_true(NULL != module->moduleObject);
-			markObject(env, module->moduleObject);
-			rememberReferenceIfRequired(env, classLoaderObject, module->moduleObject);
-			if (NULL != module->moduleName) {
-				markObject(env, module->moduleName);
-				rememberReferenceIfRequired(env, classLoaderObject, module->moduleName);
+		if (NULL != classLoader->moduleHashTable) {
+			J9HashTableState walkState;
+			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+			while (NULL != modulePtr) {
+				J9Module * const module = *modulePtr;
+				Assert_MM_true(NULL != module->moduleObject);
+				markObject(env, module->moduleObject);
+				rememberReferenceIfRequired(env, classLoaderObject, module->moduleObject);
+				if (NULL != module->moduleName) {
+					markObject(env, module->moduleName);
+					rememberReferenceIfRequired(env, classLoaderObject, module->moduleName);
+				}
+				if (NULL != module->version) {
+					markObject(env, module->version);
+					rememberReferenceIfRequired(env, classLoaderObject, module->version);
+				}
+				modulePtr = (J9Module**)hashTableNextDo(&walkState);
 			}
-			if (NULL != module->version) {
-				markObject(env, module->version);
-				rememberReferenceIfRequired(env, classLoaderObject, module->version);
-			}
-			modulePtr = (J9Module**)hashTableNextDo(&walkState);
 		}
 	}
 }
@@ -843,20 +844,21 @@ MM_PartialMarkingScheme::scanClassLoaderSlots(MM_EnvironmentVLHGC *env, J9ClassL
 				markObject(env, (J9Object *) clazz->classObject);
 			}
 
-			Assert_MM_true(NULL != classLoader->moduleHashTable);
-			J9HashTableState walkState;
-			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
-			while (NULL != modulePtr) {
-				J9Module * const module = *modulePtr;
-				Assert_MM_true(NULL != module->moduleObject);
-				markObject(env, module->moduleObject);
-				if (NULL != module->moduleName) {
-					markObject(env, module->moduleName);
+			if (NULL != classLoader->moduleHashTable) {
+				J9HashTableState walkState;
+				J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
+				while (NULL != modulePtr) {
+					J9Module * const module = *modulePtr;
+					Assert_MM_true(NULL != module->moduleObject);
+					markObject(env, module->moduleObject);
+					if (NULL != module->moduleName) {
+						markObject(env, module->moduleName);
+					}
+					if (NULL != module->version) {
+						markObject(env, module->version);
+					} 
+					modulePtr = (J9Module**)hashTableNextDo(&walkState);
 				}
-				if (NULL != module->version) {
-					markObject(env, module->version);
-				} 
-				modulePtr = (J9Module**)hashTableNextDo(&walkState);
 			}
 		}
 	}

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -168,12 +168,14 @@ allocateClassLoader(J9JavaVM *javaVM)
 
 	classLoader = pool_newElement(javaVM->classLoaderBlocks);
 
-	if (classLoader != NULL) {
+	if (NULL != classLoader) {
 		/* memset not required as the classLoaderBlocks pool returns zero'd memory */
 
 		classLoader->classHashTable = hashClassTableNew(javaVM, INITIAL_CLASSHASHTABLE_SIZE);
+#if JAVA_SPEC_VERSION > 8
 		classLoader->moduleHashTable = hashModuleNameTableNew(javaVM, INITIAL_MODULE_HASHTABLE_SIZE);
 		classLoader->packageHashTable = hashPackageTableNew(javaVM, INITIAL_PACKAGE_HASHTABLE_SIZE);
+#endif /* JAVA_SPEC_VERSION > 8 */
 		/* Allocate classLocationHashTable only for bootloader which is the first classloader to be allocated.
 		 * The classLoader being allocated must be the bootloader if javaVM->systemClassLoader is NULL.
 		 */
@@ -181,9 +183,11 @@ allocateClassLoader(J9JavaVM *javaVM)
 			classLoader->classLocationHashTable = hashClassLocationTableNew(javaVM, INITIAL_CLASSLOCATION_HASHTABLE_SIZE);
 		}
 
-		if ((NULL == classLoader->classHashTable) 
-			|| (NULL == classLoader->moduleHashTable) 
+		if ((NULL == classLoader->classHashTable)
+#if JAVA_SPEC_VERSION > 8
+			|| (NULL == classLoader->moduleHashTable)
 			|| (NULL == classLoader->packageHashTable)
+#endif /* JAVA_SPEC_VERSION > 8 */
 			|| ((NULL == javaVM->systemClassLoader) && (NULL == classLoader->classLocationHashTable))
 		) {
 			freeClassLoader(classLoader, javaVM, NULL, TRUE);


### PR DESCRIPTION
No module related `hashtable` creation for `JDK8`

`Module` is a feature available for `JDK11+`, `classLoader->moduleHashTable` & `packageHashTable` should not be created in `JDK8`.
Added compile time check against `JAVA_SPEC_VERSION` to avoid such `hashtable` creation.

Note: this is related to https://github.com/eclipse/openj9/pull/5891, verified that a `JVM` with PR doesn't produce a `javacore` entry like `+--Modules: 3,264 bytes / 16 allocations` because there is no such allocations any more.
Probably more modularity code can be decorated with either compile or runtime check to reduce the `JDK8` overhead, would like leave that to another PR instead.


Reviewer: @DanHeidinga  

Signed-off-by: Jason Feng <fengj@ca.ibm.com>