### PR TITLE
Use JIT_COMPILE rather than AOT_LOAD resolve flag

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1124,7 +1124,7 @@ TR_RelocationRecordConstantPoolWithIndex::getSpecialMethodFromCP(TR_RelocationRu
    TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
 
    J9VMThread *vmThread = reloRuntime->currentThread();
-   TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *) jitResolveSpecialMethodRef(vmThread, cp, cpIndex, J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+   TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *) jitResolveSpecialMethodRef(vmThread, cp, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
    RELO_LOG(reloLogger, 6, "\tgetMethodFromCP: found special method %p\n", method);
    return method;
    }
@@ -1143,7 +1143,7 @@ TR_RelocationRecordConstantPoolWithIndex::getVirtualMethodFromCP(TR_RelocationRu
       UDATA vTableOffset = javaVM->internalVMFunctions->resolveVirtualMethodRefInto(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                                    cp,
                                                                                    cpIndex,
-                                                                                   J9_RESOLVE_FLAG_AOT_LOAD_TIME,
+                                                                                   J9_RESOLVE_FLAG_JIT_COMPILE_TIME,
                                                                                    &method,
                                                                                    NULL);
       }
@@ -1175,7 +1175,7 @@ TR_RelocationRecordConstantPoolWithIndex::getStaticMethodFromCP(TR_RelocationRun
    TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *) jitResolveStaticMethodRef(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                                      cp,
                                                                                      cpIndex,
-                                                                                     J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+                                                                                     J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
    RELO_LOG(reloLogger, 6, "\tgetMethodFromCP: found static method %p\n", method);
    return method;
    }
@@ -1199,7 +1199,7 @@ TR_RelocationRecordConstantPoolWithIndex::getInterfaceMethodFromCP(TR_Relocation
       interfaceClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(reloRuntime->currentThread(),
                                                                                             cp,
                                                                                             romMethodRef->classRefCPIndex,
-                                                                                            J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+                                                                                            J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
       }
 
    TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
@@ -1250,12 +1250,12 @@ TR_RelocationRecordConstantPoolWithIndex::getAbstractMethodFromCP(TR_RelocationR
       abstractClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(reloRuntime->currentThread(),
                                                                                             cp,
                                                                                             romMethodRef->classRefCPIndex,
-                                                                                            J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+                                                                                            J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
 
       vTableOffset = javaVM->internalVMFunctions->resolveVirtualMethodRefInto(reloRuntime->currentThread(),
                                                                               cp,
                                                                               cpIndex,
-                                                                              J9_RESOLVE_FLAG_AOT_LOAD_TIME,
+                                                                              J9_RESOLVE_FLAG_JIT_COMPILE_TIME,
                                                                               &method,
                                                                               NULL);
       }
@@ -1652,7 +1652,7 @@ TR_RelocationRecordClassAddress::computeNewClassAddress(TR_RelocationRuntime *re
 
       {
       TR::VMAccessCriticalSection computeNewClassObject(reloRuntime->fej9());
-      resolvedClass = javaVM->internalVMFunctions->resolveClassRef(vmThread, (J9ConstantPool *)newConstantPool, cpIndex, J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+      resolvedClass = javaVM->internalVMFunctions->resolveClassRef(vmThread, (J9ConstantPool *)newConstantPool, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
       }
 
    RELO_LOG(reloRuntime->reloLogger(), 6,"\tcomputeNewClassObject: resolvedClass %p\n", resolvedClass);
@@ -2036,7 +2036,7 @@ TR_RelocationRecordInlinedAllocation::preparePrivateData(TR_RelocationRuntime *r
       clazz = javaVM->internalVMFunctions->resolveClassRef(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                     newConstantPool,
                                                                     cpIndex(reloTarget),
-                                                                    J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+                                                                    J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
       }
 
    bool inlinedCodeIsOkay = false;
@@ -3131,7 +3131,7 @@ TR_RelocationRecordValidateClass::getClassFromCP(TR_RelocationRuntime *reloRunti
       definingClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                                            (J9ConstantPool *) void_cp,
                                                                                            cpIndex(reloTarget),
-                                                                                           J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+                                                                                           J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
       }
 
    return definingClass;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1217,7 +1217,7 @@ TR_SharedCacheRelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9JavaVM *
    /* Get the class.  Stop immediately if an exception occurs. */
    J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&constantPool->romConstantPool[cpIndex];
 
-   J9Class *resolvedClass = javaVM()->internalVMFunctions->resolveClassRef(vmThread, constantPool, romFieldRef->classRefCPIndex, J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+   J9Class *resolvedClass = javaVM()->internalVMFunctions->resolveClassRef(vmThread, constantPool, romFieldRef->classRefCPIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
 
    if (resolvedClass == NULL)
       return NULL;


### PR DESCRIPTION
The compiler uses J9_RESOLVE_FLAG_AOT_LOAD_TIME for compile time resolve
when doing an AOT load. However, semantically, this should be the same
as J9_RESOLVE_FLAG_JIT_COMPILE_TIME as an AOT compile is, form an
external (to the compiler) point of view, the same as a JIT compile.
Therefore, having semantics in the load of a body than what was used to
generate the body is probably not a good idea. This commit replaces all
uses of the AOT_LOAD resolve flag with the JIT_COMPILE resolve flag.

As an aside, it turns out the AOT_LOAD resolve flag dates back to a time
when the JVM supported simple AOT loads from JXEs; in that mode,
the JIT wasn't necessarily loaded.

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>