### PR TITLE
Remove NLS-specific number tags from the default string

### DIFF
--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -1027,7 +1027,7 @@ setClassLoadingConstraintLinkageError(J9VMThread *vmThread, J9Class *methodOrFie
 	const char *nlsTemplate = j9nls_lookup_message(
 			J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
 			J9NLS_JCL_METHODTYPE_CLASS_LOADING_CONSTRAINT,
-			"loading constraint violation: %2$.*1$s not visible from %4$.*3$s");
+			"loading constraint violation: %.*s not visible from %.*s");
 	char * msg = expandNLSTemplate(
 			vmThread,
 			nlsTemplate,

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -1122,7 +1122,7 @@ j9shr_dump_help(J9JavaVM* vm, UDATA more)
 				if (strlen(J9SHAREDCLASSESHELPTEXT[i].option) > 27) {
 				/* Some help text has more than 28 chars, print them in two lines, e.g.
 				 * invalidateAotMethods=<method_specification>[,<method_specification>]
-                 *            Invalidate the AOT method(s) specified by the user.
+				 * Invalidate the AOT method(s) specified by the user.
 				 */
 					j9file_printf(PORTLIB, J9PORT_TTY_OUT, " %s\n", J9SHAREDCLASSESHELPTEXT[i].option);
 					j9file_printf(PORTLIB, J9PORT_TTY_OUT, " %28s", "");

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -939,7 +939,7 @@ defaultMethodConflictExceptionMessage(J9VMThread *currentThread, J9Class *target
 	Assert_VM_true(methodsLength > 1);
 
 	errorMsg = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
-			J9NLS_VM_DEFAULT_METHOD_CONFLICT_LIST, "conflicting default methods for '%2$s%4$s' in %6$s from classes [%7$s]");
+			J9NLS_VM_DEFAULT_METHOD_CONFLICT_LIST, "conflicting default methods for '%*.s%*.s' in %*.s from classes [%s]");
 	
 	/* Construct class list string */
 	for (i = 0; i < methodsLength; i++) {


### PR DESCRIPTION
Remove NLS-specific number tags from the default string

Adapt the default string to correctly handle J9UTF8, non-zero
terminated strings