### PR TITLE
AArch64: Add FlushICache

### DIFF
--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -23,6 +23,7 @@
 j9jit_files(
 	${omr_SOURCE_DIR}/compiler/aarch64/runtime/CodeSync.cpp
 	${omr_SOURCE_DIR}/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+	aarch64/runtime/FlushICache.spp
 	aarch64/runtime/PicBuilder.spp
 	aarch64/runtime/Recomp.cpp
 	aarch64/runtime/Recompilation.spp

--- a/runtime/compiler/aarch64/runtime/FlushICache.spp
+++ b/runtime/compiler/aarch64/runtime/FlushICache.spp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+	.globl	flushICache
+
+// in:  x0 = start address to flush
+//      x1 = # of bytes to flush
+//
+// trash: none
+//
+flushICache:
+	stp	x0, x1, [sp, #-144]! // save volatile registers
+	stp	x2, x3, [sp, #16]
+	stp	x4, x5, [sp, #32]
+	stp	x6, x7, [sp, #48]
+	stp	x8, x9, [sp, #64]
+	stp	x10, x11, [sp, #80]
+	stp	x12, x13, [sp, #96]
+	stp	x14, x15, [sp, #112]
+	str	x30, [sp, #128]
+	add	x1, x0, x1
+#if defined(__GNUC__)
+	// GCC built-in function in libgcc
+	// void __clear_cache(char *begin, char *end);
+	bl	 __clear_cache
+#else
+#error Not supported yet
+#endif
+	ldp	x0, x1, [sp, #0] // restore volatile registers
+	ldp	x2, x3, [sp, #16]
+	ldp	x4, x5, [sp, #32]
+	ldp	x6, x7, [sp, #48]
+	ldp	x8, x9, [sp, #64]
+	ldp	x10, x11, [sp, #80]
+	ldp	x12, x13, [sp, #96]
+	ldp	x14, x15, [sp, #112]
+	ldr	x30, [sp, #128]
+	add	sp, sp, #144
+	ret

--- a/runtime/compiler/build/files/host/aarch64.mk
+++ b/runtime/compiler/build/files/host/aarch64.mk
@@ -23,6 +23,7 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
 
 JIT_PRODUCT_SOURCE_FILES+= \
+    compiler/aarch64/runtime/FlushICache.spp \
     compiler/aarch64/runtime/PicBuilder.spp \
     compiler/aarch64/runtime/Recomp.cpp \
     compiler/aarch64/runtime/Recompilation.spp


### PR DESCRIPTION
This commit adds a file for flushICache, a utility function that flushes
the specified length of instructions at specified address from the cache.
It saves and restores volatile registers.

Signed-off-by: knn-k <konno@jp.ibm.com>