### PR TITLE
Spelling comments t..w

### DIFF
--- a/buildenv/docker/jdk10/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk10/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildenv/docker/jdk10/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk10/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -126,7 +126,7 @@ RUN cd /root/debs \
   && cp lib/aarch64-linux-gnu/* ../gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu/aarch64-linux-gnu/libc/lib/ \
   && rm -rf /root/debs
 
-# Env vars set here will be visibile in the running container, so can be
+# Env vars set here will be visible in the running container, so can be
 # used to convey configuration information to the build scripts.
 
 # Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/buildenv/docker/jdk10/armhf_CC/arm-linux-gnueabihf/Dockerfile
+++ b/buildenv/docker/jdk10/armhf_CC/arm-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildenv/docker/jdk10/armhf_CC/arm-linux-gnueabihf/Dockerfile
+++ b/buildenv/docker/jdk10/armhf_CC/arm-linux-gnueabihf/Dockerfile
@@ -127,7 +127,7 @@ RUN cd /root/debs \
   && cp lib/arm-linux-gnueabihf/* ../gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf/arm-linux-gnueabihf/libc/lib/ \
   && rm -rf /root/debs
 
-# Env vars set here will be visibile in the running container, so can be
+# Env vars set here will be visible in the running container, so can be
 # used to convey configuration information to the build scripts.
 
 # Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -130,7 +130,7 @@ RUN cd /root/debs \
   && cp lib/aarch64-linux-gnu/* ../gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu/aarch64-linux-gnu/libc/lib/ \
   && rm -rf /root/debs
 
-# Env vars set here will be visibile in the running container, so can be
+# Env vars set here will be visible in the running container, so can be
 # used to convey configuration information to the build scripts.
 
 # Set environment variable JAVA_HOME, and prepend $JAVA_HOME/bin to PATH

--- a/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -125,7 +125,7 @@ RUN cd /root/debs \
   && cp lib/aarch64-linux-gnu/* ../gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu/aarch64-linux-gnu/libc/lib/ \
   && rm -rf /root/debs
 
-# Env vars set here will be visibile in the running container, so can be
+# Env vars set here will be visible in the running container, so can be
 # used to convey configuration information to the build scripts.
 
 # Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
+++ b/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
+++ b/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
@@ -125,7 +125,7 @@ RUN cd /root/debs \
   && cp lib/arm-linux-gnueabihf/* ../gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf/arm-linux-gnueabihf/libc/lib/ \
   && rm -rf /root/debs
 
-# Env vars set here will be visibile in the running container, so can be
+# Env vars set here will be visible in the running container, so can be
 # used to convey configuration information to the build scripts.
 
 # Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/command/CommandParser.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/command/CommandParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/command/CommandParser.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/command/CommandParser.java
@@ -192,7 +192,7 @@ public class CommandParser {
 		}
 	}
 
-// TokenisinState classes
+// TokenisingState classes
 	
 	/**
 	 * A mini state machine. Each state receives a character and returns the next state.

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/aix/AIXDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/aix/AIXDumpReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/aix/AIXDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/aix/AIXDumpReader.java
@@ -462,7 +462,7 @@ public abstract class AIXDumpReader extends AbstractCoreReader implements ILibra
 	//
 	// // Get the process environment variables
 	// Properties environment = new Properties();
-	// //on AIX, we should truse the env var pointer found in the core and
+	// //on AIX, we should trust the env var pointer found in the core and
 	// ignore whatever the XML told us it is since this internal value is more
 	// likely correct
 	// environment = getEnvironmentVariables(reg5);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
@@ -495,7 +495,7 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			}
 		}
 		
-		// TODO - Sort modules. For the sake of tidyness.
+		// TODO - Sort modules. For the sake of tidiness.
 		_modules.addAll(allModules);
 		ELFFileReader readerForExectuableOnDiskOrAppended = getReaderForModuleOnDiskOrAppended(executableName);
 		_executable = createModuleFromElfReader(executableBaseAddress, executableName, executableELF, readerForExectuableOnDiskOrAppended);
@@ -1280,7 +1280,7 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 							ptr += _process.bytesPerPointer() * getOffsetToIPFromBP();
 							instructionPointer = maskInstructionPointer(_process.getPointerAt(ptr));
 							unwindTable = unwinder.getUnwindTableForInstructionAddress(instructionPointer);
-							// TODO - if we do tranistion back to unwinding with DWARF we need to get the registers right.
+							// TODO - if we do transition back to unwinding with DWARF we need to get the registers right.
 						} else {
 							logger.log(Level.FINER, "Base pointer is zero");
 						}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/ModuleStream.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/ModuleStream.java
@@ -146,7 +146,7 @@ class ModuleStream extends LateInitializedStream
 				IModule module;
 				if( runtimeFunctionList != null ) {
 					module = new UnwindModule(as.getProcesses().iterator().next(),moduleName,symbols,sections, thisModule.imageBaseAddress, properties, runtimeFunctionList);
-					// Uncommend to dump unwind info as we find it. This is very verbose.
+					// Uncomment to dump unwind info as we find it. This is very verbose.
 					// ((UnwindModule)module).dumpUndwindInfo(System.err);
 				} else {
 					module = new Module(as.getProcesses().iterator().next(),moduleName,symbols,sections, thisModule.imageBaseAddress, properties);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
@@ -83,7 +83,7 @@ public class UnwindCode {
 	 * http://msdn.microsoft.com/en-US/library/ck9asaa9%28v=vs.80%29
 	 * The operations marked as untested haven't yet been found in any stack
 	 * (and are quite rare to find in the unwind info for dll's at all) so
-	 * if have found and corrected one please remove the unteseted label.
+	 * if have found and corrected one please remove the untested label.
 	 */
 	public String formatOp() throws CorruptDataException {
 		byte opCode = getOpCode();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/DsaStackFrame.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/le/DsaStackFrame.java
@@ -340,7 +340,7 @@ public class DsaStackFrame {
                 } else {
                     /* 
                      * Check whether this module is a wrapped
-                     * trnsfer vector.                      
+                     * transfer vector.                      
                      *   If the module entry-point + 0 = X'47F0Fxxx'
                      *      (a 'BR xxx(15)' instruction)           
                      *     Calculate the address of the signature:

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/mvs/Tcb.java
@@ -266,7 +266,7 @@ public class Tcb {
             long rbp = tcbrbp();
             long rbsecptr = 0;    /* The last RB read */
             long save2rbptr = 0;  /* The second to last RB read */
-            long save2XsbPtr = 0; /* XSB virutal address */
+            long save2XsbPtr = 0; /* XSB virtual address */
             long saveXsbAddr = 0;
             log.fine("for tcb " + hex(address) + ", rbp = " + hex(rbp));
             int countRbs = 0;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapMapWordIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapMapWordIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapMapWordIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapMapWordIterator.java
@@ -66,7 +66,7 @@ public class GCHeapMapWordIterator extends GCIterator {
 		J9ObjectPointer nextObject = null;
 		
 		if (!_cache.eq(0)) {
-			/* TODO: lpnguyen, Note that numberOfTrailingZeros in java refers == numberOfLeadingZeros in C verison of this.. */
+			/* TODO: lpnguyen, Note that numberOfTrailingZeros in java refers == numberOfLeadingZeros in C version of this.. */
 			int trailingZeros = _cache.numberOfTrailingZeros();
 			long slotsToSkip = (trailingZeros * MM_HeapMap.J9MODRON_HEAP_SLOTS_PER_HEAPMAP_BIT);
 			_heapSlotCurrent = _heapSlotCurrent.add(slotsToSkip);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -834,11 +834,11 @@ public final class MethodType implements Serializable
 	/**
 	 * Wrapper on {@link #methodType(Class, Class[])}.
 	 * <br>
-	 * Return a MethodType with an Object return and only Object parameters.  If isVarags is true, the
+	 * Return a MethodType with an Object return and only Object parameters.  If isVarargs is true, the
 	 * final parameter will be an Object[].  This Object[] parameter is NOT included in the numParameters
 	 * count. 
 	 * 
-	 * @param numParameters - number of parameters not including the isVarags parameter (if requested)
+	 * @param numParameters - number of parameters not including the isVarargs parameter (if requested)
 	 * @param isVarargs - if the Object[] parameter should be added
 	 * @return the requested MethodType object
 	 * @throws IllegalArgumentException if numParameters is less than 0 or greater than the allowed number of arguments (255 or 254 if isVarargs)

--- a/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
@@ -240,7 +240,7 @@ final class SecurityFrameInjector {
 		final MethodType originalMT = potentialInjectFrame.type;
 		
 		// SecurityFrames are always represented as:
-		// 1) VaragsCollectHandle -> AsTypeHandle -> RBH with bound value being an instance of SecurityFrame
+		// 1) VarargsCollectHandle -> AsTypeHandle -> RBH with bound value being an instance of SecurityFrame
 		// 2) AsTypeHandle -> RBH with bound value being an instance of SecurityFrame
 		// 3) RBH with bound value being an instance of SecurityFrame if signature is (Object[])Object
 		boolean mustBeVarags = false;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
@@ -2329,7 +2329,7 @@ public final class DecimalData
      * @param bigIntegerValue
      *            BigInteger value to be converted
      * @param unicodeDecimal
-     *            char array that will hold the Unicde decimal on a successful return
+     *            char array that will hold the Unicode decimal on a successful return
      * @param offset
      *            offset into <code>unicodeDecimal</code> where the Unicode Decimal is expected to be located
      * @param precision

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/le/DsaStackFrame.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/le/DsaStackFrame.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corp. and others
+ * Copyright (c) 2006, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/le/DsaStackFrame.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/le/DsaStackFrame.java
@@ -323,7 +323,7 @@ public class DsaStackFrame {
                 } else {
                     /* 
                      * Check whether this module is a wrapped
-                     * trnsfer vector.                      
+                     * transfer vector.                      
                      *   If the module entry-point + 0 = X'47F0Fxxx'
                      *      (a 'BR xxx(15)' instruction)           
                      *     Calculate the address of the signature:

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/commands/CommandParser.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/commands/CommandParser.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/commands/CommandParser.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/java/diagnostics/utils/commands/CommandParser.java
@@ -193,7 +193,7 @@ public class CommandParser {
 		}
 	}
 
-// TokenisinState classes
+// TokenisingState classes
 	
 	/**
 	 * A mini state machine. Each state receives a character and returns the next state.

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecord50.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecord50.java
@@ -302,7 +302,7 @@ public class TraceRecord50 implements Comparable {
 	/**
 	 * primeRecord readies this UtTraceRecord to have its tracepoint data read.
 	 * 
-	 * Each tracepoint's length field is at the end of the tracepoint, so the traceoints are
+	 * Each tracepoint's length field is at the end of the tracepoint, so the tracepoints are
 	 * formatted backwards out of the record. To enable forward iteration, the whole record 
 	 * must be formatted into a queue, which is then iterated over in reverse order.
 	 * 

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -1370,7 +1370,7 @@ ROMClassWriter::writeMethods(Cursor *cursor, Cursor *lineNumberCursor, Cursor *v
 			if (markAndCountOnly) {
 				/* Following is adding PAD to stackmap size. First round is always markAndCountOnly.
 				 * This logic is very difficult to catch. Cause of the padded stackmapsize, we dont use padding in nextROMMethod() in mthutil.
-				 * Also I find this markAndCountOnly unneccesary and confusing for the following reasons
+				 * Also I find this markAndCountOnly unnecessary and confusing for the following reasons
 				 * 1. It is used partially : See above, we dont use it for the first 6 bytes and we write them down.
 				 * It should be used properly, either always or never.
 				 * 2. Also when it is counting, it is a counting cursor and it actually do not write (see Cursor.hpp).

--- a/runtime/bcutil/jsrinliner.c
+++ b/runtime/bcutil/jsrinliner.c
@@ -843,7 +843,7 @@ _nextBranch:
 			variable8 = (U_8) (bc - CFR_BC_aload_0);
 			if (jsrData && (variable8 < inlineBuffers->maxLocals)) {
 				if (jsrData->locals[variable8]) {
-					/* Jazz 82615: Set the verose error type and the local variable index in the case of illegal load operation */
+					/* Jazz 82615: Set the verbose error type and the local variable index in the case of illegal load operation */
 					inlineBuffers->verboseErrorType = BCV_ERR_JSR_ILLEGAL_LOAD_OPERATION;
 					inlineBuffers->errorLocalIndex = (U_32)variable8;
 					goto _verifyError;
@@ -857,7 +857,7 @@ _nextBranch:
 			NEXT_U8(variable8, bcIndex);
 			if (jsrData && (variable8 < inlineBuffers->maxLocals)) {
 				if (jsrData->locals[variable8]) {
-					/* Jazz 82615: Set the verose error type and the local variable index in the case of illegal load operation */
+					/* Jazz 82615: Set the verbose error type and the local variable index in the case of illegal load operation */
 					inlineBuffers->verboseErrorType = BCV_ERR_JSR_ILLEGAL_LOAD_OPERATION;
 					inlineBuffers->errorLocalIndex = (U_32)variable8;
 					goto _verifyError;
@@ -1303,7 +1303,7 @@ _nextBranch:
 				NEXT_U16(variable16, bcIndex);
 				if (jsrData && ((UDATA) variable16 < inlineBuffers->maxLocals)) {
 					if (jsrData->locals[variable16]) {
-						/* Jazz 82615: Set the verose error type and the local variable index in the case of illegal load operation */
+						/* Jazz 82615: Set the verbose error type and the local variable index in the case of illegal load operation */
 						inlineBuffers->verboseErrorType = BCV_ERR_JSR_ILLEGAL_LOAD_OPERATION;
 						inlineBuffers->errorLocalIndex = (U_32)variable16;
 						goto _verifyError;

--- a/runtime/cmake/version.cmake
+++ b/runtime/cmake/version.cmake
@@ -21,7 +21,7 @@
 ################################################################################
 
 # Set up some default version variables.
-# Note as cache varaiables these can be overridden on the command line when invoking cmake
+# Note as cache variables these can be overridden on the command line when invoking cmake
 # Using the syntax `-D<VAR_NAME>=<VALUE>`
 
 set(JAVA_SPEC_VERSION "9" CACHE STRING "Version of Java to build")

--- a/runtime/compiler/arm/runtime/PicBuilder.armasm
+++ b/runtime/compiler/arm/runtime/PicBuilder.armasm
@@ -118,7 +118,7 @@ J9TR_SCSnippet_method			EQU 4
 J9TR_USCSnippet_CPIndex			EQU 12
 J9TR_USCSnippet_CP			EQU 16
 
-; Unresvoled virtual call snippet
+; Unresolved virtual call snippet
 
 J9TR_UVCSnippet_returnAddress		EQU 0
 J9TR_UVCSnippet_CP			EQU 4
@@ -551,7 +551,7 @@ const_staticGlueTable
 const_nativeStaticHelper
 	DCD	_nativeStaticHelper
 
-; For vitual unresolved call, we generate following instructions
+; For virtual unresolved call, we generate following instructions
 ;  mov   r11, #0
 ;  add   r11, r11, #0 << 8
 ;  add   r11, r11, #0 << 16

--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -437,7 +437,7 @@ TR::DefaultCompilationStrategy::processInterpreterSample(TR_MethodEvent *event)
                {
                // Possible scenario: a long activation method receives a MIL count of 1.
                // The method gets invoked and the count becomes 0 (but the compilation is not
-               // triggerred now, only when the counter would become negative).
+               // triggered now, only when the counter would become negative).
                // The method receives a sample while still being interpreted. We should probably
                // schedule a compilation
                if (logSampling)

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -249,7 +249,7 @@ class TR_JitSampleInfo
 
 // The following class is used for tracking methods that have their invocation
 // count decremented due to a sample in interpreted code. When that happens
-// we add teh method to a list. When a method needs to be compiled we check
+// we add the method to a list. When a method needs to be compiled we check
 // the list and if the method is in the list we delete it and schedule a
 // SamplingJprofiling compilation for the count that has been skipped
 class TR_InterpreterSamplingTracking

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1538,7 +1538,7 @@ TR::CompilationInfo::updateCompQueueAccountingOnDequeue(TR_MethodToBeCompiled *e
       TR_ASSERT(_numQueuedFirstTimeCompilations >= 0, "_numQueuedFirstTimeCompilations is negative : %d", _numQueuedFirstTimeCompilations);
       }
    // Note: queue weight is handled separately because a method that is currently being
-   // compiled is considered as bringing some weigth to the processing backlog
+   // compiled is considered as bringing some weight to the processing backlog
    }
 
 
@@ -4961,7 +4961,7 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
 
    // If compiling on this thread acquire the application thread monitor.
    // This is the monitor that prevents compilation on multiple application
-   // threadsat the same time. It is held for the duration of the compilation.
+   // threads at the same time. It is held for the duration of the compilation.
    //
    if (!useSeparateCompilationThread())
       {

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5430,7 +5430,7 @@ bool CPUThrottleEnabled(TR::CompilationInfo *compInfo, uint64_t crtTime)
       compInfo->getJITConfig()->javaVM->phase != J9VM_PHASE_NOT_STARTUP)
       return false;
 
-   // Maybe the user wants to start throtling only after some time
+   // Maybe the user wants to start throttling only after some time
    if (crtTime < (uint64_t)TR::Options::_startThrottlingTime)
       return false;
 
@@ -5513,7 +5513,7 @@ void CPUThrottleLogic(TR::CompilationInfo *compInfo, uint64_t crtTime)
                             totalCompCPUUtilization > TR::Options::_compThreadCPUEntitlement;
       // We want to avoid situations where we end up throttling and all compilation threads
       // get activated working at full capacity (until, half a second later we discover that we throttle again)
-      // The solution is to go into a trasient state; so from TR_yes we go into TR_maybe and from TR_maybe we go into TR_no
+      // The solution is to go into a transient state; so from TR_yes we go into TR_maybe and from TR_maybe we go into TR_no
       compInfo->setExceedsCompCpuEntitlement(shouldThrottle ? TR_yes : oldThrottleValue == TR_yes ? TR_maybe : TR_no);
       // If the value changed we may want to print a message in the vlog
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance) &&
@@ -6500,7 +6500,7 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
                {
                // Calculate CPU utilization and set throttle flag
                // This code needs to stay  before jitStateLogic because the decision to throttle
-               // application threads (taken in jitStateLogic) depends on the decision to trottle
+               // application threads (taken in jitStateLogic) depends on the decision to throttle
                // the compilation threads
                CalculateOverallCompCPUUtilization(compInfo, crtTime, samplerThread);
                CPUThrottleLogic(compInfo, crtTime);

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -889,7 +889,7 @@ TR_ClassQueries::collectLeafs(TR_PersistentClassInfo *clazz,
    {
    TR::ClassTableCriticalSection collectLeafs(comp->fe(), locked);
 
-   // keep a list of classes that were set visisted so that we can
+   // keep a list of classes that were set visited so that we can
    // easily reset the visited flag later-on
    TR_CHTable::VisitTracker marked(comp->trMemory());
 

--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -106,7 +106,7 @@ private:
    int64_t _prevVmSysTime;      // absolute value (in ns) of time VM spent in kernel space
    int64_t _prevVmUserTime;     // absolute value (in ns) of time VM spent in user space
 
-   CpuUsageCircularBuffer *_cpuUsageCircularBuffer;      // Circular buffer containing timestsamp, system cpu usage sample, and jvm cpu use sample
+   CpuUsageCircularBuffer *_cpuUsageCircularBuffer;      // Circular buffer containing timestamp, system cpu usage sample, and jvm cpu use sample
    int32_t                 _cpuUsageCircularBufferIndex; // Current index of the buffer; contains the oldest data. Subtract 1 to get the most recent data
    int32_t                 _cpuUsageCircularBufferSize;  // Size of the circular buffer
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2373,7 +2373,7 @@ TR_MarkHotField::mark(J9Class * clazz, bool isFixedClass)
 
    if ((*(UDATA *)((char *)clazz + offsetOfHotFields()) & 0x1))
       {
-      // temorary hack: tenure aligned classes can't have
+      // temporary hack: tenure aligned classes can't have
       // hot fields marked, we need another word for this
       if (_comp->getOption(TR_TraceMarkingOfHotFields))
          {
@@ -8261,7 +8261,7 @@ TR_J9VMBase::setInlineThresholds (TR::Compilation *comp, int32_t &callerWeightLi
      }
 
 
-   int32_t _adjustMaxCutOff = 200; //decrease the thershold to make it similar to r11 while we are big app
+   int32_t _adjustMaxCutOff = 200; //decrease the threshold to make it similar to r11 while we are big app
 
    static const char * adjustMaxCutOff = feGetEnv("TR_WarmInlineAdjustMaxCutOff");
 

--- a/runtime/compiler/optimizer/DataAccessAccelerator.hpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.hpp
@@ -190,7 +190,7 @@ class TR_DataAccessAccelerator : public TR::Optimization
     *     basic blocks to form a precision diamond. This disrupts the CFG and invalidates block iterator and
     *     TreeTop iterator that might be in use. As a result of this, it's difficult to inline variable precision
     *     calls while iterating the entire tree. The solution to this problem is to build a list of variable
-    *     precision TreeTops during thetree traversal phase. And after that, go through this list and inline each one of them.
+    *     precision TreeTops during the tree traversal phase. And after that, go through this list and inline each one of them.
     *
     *  \param variableCallTreeTops
     *     A vector of TR::TreeTop*. All variable precision calls listed here will be inlined.

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1942,7 +1942,7 @@ TR_CISCTransformer::isInsideOfFastVersionedLoop(TR_RegionStructure *l)
 
 
 // createLoopCandidates populates the given list with natural loop candidates
-// whcih contains structure information and is not cold.  The return value of
+// which contains structure information and is not cold.  The return value of
 // this call dictates whether we found candidates or not.
 bool
 TR_CISCTransformer::createLoopCandidates(List<TR_RegionStructure> *loopCandidates)

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -887,7 +887,7 @@ indexContainsArrayAccess(TR::Compilation *comp, TR::Node *aXaddNode)
    return false;
    }
 
-// isIndexVaraibleInList checks whether the induction (index) variable symbol(s)
+// isIndexVariableInList checks whether the induction (index) variable symbol(s)
 // from the given 'node' subtree is found inside 'nodeList'.
 //
 // Returns true if

--- a/runtime/compiler/optimizer/J9SimplifierHelpers.cpp
+++ b/runtime/compiler/optimizer/J9SimplifierHelpers.cpp
@@ -127,7 +127,7 @@ TR::Node *removeOperandWidening(TR::Node *node, TR::Node *parent, TR::Block *blo
          bool signWasKnownClean = node->hasKnownCleanSign();
          bool signWasAssumedClean = node->hasAssumedCleanSign();
 
-         node->setDecimalPrecision(maxShiftedPrecision);    // conservatively resets clean sign flags on an a trucation -- but this truncation cannot actually dirty a sign
+         node->setDecimalPrecision(maxShiftedPrecision);    // conservatively resets clean sign flags on a truncation -- but this truncation cannot actually dirty a sign
 
          if (signWasKnownClean)
             node->setHasKnownCleanSign(true);

--- a/runtime/compiler/optimizer/JProfilingRecompLoopTest.cpp
+++ b/runtime/compiler/optimizer/JProfilingRecompLoopTest.cpp
@@ -210,7 +210,7 @@ TR_JProfilingRecompLoopTest::addRecompilationTests(TR::Compilation *comp, Recomp
       // Putting a higher threshold limit to 10K currently to prohibit running profiling body for too long.
       int32_t threshold = recompileThreshold << (depth-1);
       // It is very unlikely that we have a very large depth of the loop which causes above value to become negative
-      // To safeguard this scenario, we also check if threshold is negative or zero we set this thrshold to maxLoopRecompileThreshold
+      // To safeguard this scenario, we also check if threshold is negative or zero we set this threshold to maxLoopRecompileThreshold
       TR::Node *cmpNode = TR::Node::createif(TR::ificmple, root, TR::Node::iconst(node, (threshold > 0 && threshold <= maxLoopRecompilationThreshold) ? threshold : maxLoopRecompilationThreshold), remainingCodeBlock->getEntry());
       TR::TreeTop *cmpFlag = TR::TreeTop::create(comp, cmpNode);
       cmpFlag->getNode()->setIsProfilingCode();

--- a/runtime/compiler/optimizer/SignExtendLoads.cpp
+++ b/runtime/compiler/optimizer/SignExtendLoads.cpp
@@ -711,7 +711,7 @@ void TR_SignExtendLoads::ProcessNodeList(TR_ScratchList<TR::Node> &list,bool isA
                   break;
 
                default:
-                  if (i2lchild->getOpCode().isLong()) // get rid of unceccessary i2l
+                  if (i2lchild->getOpCode().isLong()) // get rid of unnecessary i2l
                      {
                      if (!performTransformation(comp(), "%sRemoving i2l node %p from parent %p\n", OPT_DETAILS, child,parentNode))
                         break;

--- a/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
@@ -329,7 +329,7 @@ static void genStoreDFP(
    TR::Compilation* comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
-   // query the VM for the field offset to wich we are going to store
+   // query the VM for the field offset to which we are going to store
    if (dfpFieldOffset == -1)
       {
       TR_OpaqueClassBlock * bigDClass = NULL;

--- a/runtime/compiler/p/runtime/J9PPCArrayTranslate.spp
+++ b/runtime/compiler/p/runtime/J9PPCArrayTranslate.spp
@@ -1573,7 +1573,7 @@ __arrayTranslateTRTOSimpleVMX:
 	rlwinm	r0,r8,4,28,28		! r0 = (blockCount != 0) << 3			swBlock4Loop << 3
 	neg	r7,r12			! r7 = -trailerCount
 	or	r8,r3,r0	    	! r8 = (swSlowPath << 6) | (swHeader << 4) | (swBlock4Loop << 3) | (blockCount << 1)
-	rlwinm	r9,r7,1,31,31		! r0 = (traileCount != 0) << 0			swTrailer << 0
+	rlwinm	r9,r7,1,31,31		! r0 = (trailerCount != 0) << 0			swTrailer << 0
 	or	r0,r8,r9	    	! r0 = (swSlowPath << 6) | (swHeader << 4) | (swBlock4Loop << 3) | (blockCount << 1) | (swTrailer << 0)
 	mfctr	r7			! Restore maxChar
 

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -595,7 +595,7 @@ _interpreterUnresolvedInstanceDataGlue:
 	bcctrl  BO_ALWAYS, CR0_LT                               ! Call to ask if the field is volatile
 	cmpi	cr0, CmpAddr, r3, 0
 	bne     cr0, .L10.it_is_volatile
-	andis.  r4, r29, IS_32BitLong                           ! was it a potentially volatle long, 32-bit OS sequence?
+	andis.  r4, r29, IS_32BitLong                           ! was it a potentially volatile long, 32-bit OS sequence?
 	bne     cr0, .L.normal_patching
 	andis.	r4, r29, IS_SpecialDouble			! check the special double flag
 	bne	cr0, .L.yankTheCall

--- a/runtime/compiler/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/runtime/CRuntimeImpl.cpp
@@ -113,7 +113,7 @@ void _prepareForOSR(uintptrj_t vmThreadArg, int32_t currentInlinedSiteIndex, int
          TR_VerboseLog::writeLineLocked(TR_Vlog_OSRD, "%X   %d mappings", (int)vmThreadArg, numberOfMappings);
 
       //if there are any symbols sharing slots at this OSR point
-      //SD: With a high probability, this condition is true when the above condition (numSymsThtaShareSlot > 0)
+      //SD: With a high probability, this condition is true when the above condition (numSymsThatShareSlot > 0)
       // is true. So it might be safe to remove the following if statement.
       if (numberOfMappings > 0) // this is a condition that depends on the whole compilation
          {

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -289,7 +289,7 @@ void jitReleaseCodeCollectMetaData(J9JITConfig *jitConfig, J9VMThread *vmThread,
          }
       else
          {
-         // Mark the runtime assumptions so thay can be deleted at the end of the GC cycle.
+         // Mark the runtime assumptions so they can be deleted at the end of the GC cycle.
          // The 3rd parameter to markAssumptionsAndDetach determines whether we mark preprologue assumptions.
          // We should only do that if we are in class unloading and will be reclaiming the entire method body,
          // which means faintCacheBlock is NULL.

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -554,7 +554,7 @@ public:
    void jitProfileParseBuffer(J9VMThread *vmThread);
    uint32_t getIProfilerThreadExitFlag() { return _iprofilerThreadExitFlag; }
    bool postIprofilingBufferToWorkingQueue(J9VMThread * vmThread, const U_8* dataStart, UDATA size);
-   // this is wapper of registered version, for the helper function, from JitRunTime
+   // this is wrapper of registered version, for the helper function, from JitRunTime
 
 private:
 #ifdef J9VM_INTERP_PROFILING_BYTECODES

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -203,7 +203,7 @@ J9::Recompilation::sampleMethod(
       bool newPlanCreated;
       TR_OptimizationPlan *plan = TR::CompilationController::getCompilationStrategy()->processEvent(&event, &newPlanCreated);
       // the plan needs to be created only when async compilation is possible
-      // Otherwise the compilation will be triggerred on next invocation
+      // Otherwise the compilation will be triggered on next invocation
       if (plan)
          {
          bool queued = false;

--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -1129,7 +1129,7 @@ bool s390zOS64CodePatching(void *method, void *callSite, void *currentPC, void *
 
 
 // ZOS390 MCC Support: minimum hookup without callbacks.
-// Default executable space is limited to 2GB: No Trampolinoes required.
+// Default executable space is limited to 2GB: No Trampolines required.
 // Can increase executable space by enabling RMODE64, Trampolines will be required
 void s390zOS64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *numHelpers, int32_t* CCPreLoadedCodeSize)
    {

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1600,7 +1600,7 @@ static bool indirectDispatchWillBuildVirtualGuard(TR::Compilation *comp, TR::X86
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
    // This method is used in vft mask instruction removal in buildIndirectDispatch
-   // if method will generate virutal call guard and build direct call, then skip vft mask instruction.
+   // if method will generate virtual call guard and build direct call, then skip vft mask instruction.
    if (site->getVirtualGuardKind() != TR_NoGuard && fej9->canDevirtualizeDispatch() )
       {
       if (comp->performVirtualGuardNOPing())

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -248,7 +248,7 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
 
       *((uint32_t*)p) = offset;
 
-      // With guarded counting recompilations, we need to fix up the method code regardless of wheter it is
+      // With guarded counting recompilations, we need to fix up the method code regardless of whether it is
       // synchronous or asynchronous
       fixUpMethodCode(oldStartPC);
 

--- a/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
@@ -242,7 +242,7 @@ genStoreDFP(
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    TR::Register * objRegister = cg->evaluate(objAddrNode);
 
-   // query the VM for the field offset to wich we are going to store
+   // query the VM for the field offset to which we are going to store
    if (dfpFieldOffset == -1)
       {
       TR_OpaqueClassBlock * bigDClass = NULL;

--- a/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
@@ -314,7 +314,7 @@ TR::Register * TR::S390CHelperLinkage::buildDirectDispatch(TR::Node * callNode, 
     * #if (fastPathHelper)
     *    STG R5, @(vmThread+offsetOf(J9SP))
     *       #define zOS
-    *       LG DSA, @(vmThraed,offsetOfSSP)
+    *       LG DSA, @(vmThread,offsetOfSSP)
     *       XC offsetOFSSP(vmThread, pointerSize), offsetOfSSP(vmThread)
     *          #define 32Bit
     *          LG CAA, @(DSA+CAAOffset)

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -7352,7 +7352,7 @@ J9::Z::TreeEvaluator::VMcheckcastEvaluator(TR::Node * node, TR::CodeGenerator * 
          TR_OpaqueClassBlock * castClassAddr = TR::TreeEvaluator::getCastClassAddress(castClassNode);
          TR_OpaqueClassBlock * topGuessClassAddr = TR::TreeEvaluator::interpreterProfilingInstanceOfOrCheckCastInfo(cg, node);
          float topProb = TR::TreeEvaluator::interpreterProfilingInstanceOfOrCheckCastTopProb(cg, node);
-         // experimental : set the probability threashold = 50% to enable OOL
+         // experimental : set the probability threshold = 50% to enable OOL
          if (!comp->getOption(TR_DisableOOL) && castClassAddr == topGuessClassAddr && topProb >= 0.5)
             {
             // OOL: Fall through if test passes, else call OOL sequence
@@ -12224,7 +12224,7 @@ J9::Z::TreeEvaluator::tstartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    //                        (  3)      ==>aRegLoad at [0x00000000803f1568] (in &GPR_0048)
 
 
-   // TEBGIN 0(R0),0xFF00
+   // TBEGIN 0(R0),0xFF00
    // BRNEZ  OOL TM                        ; CC0 = success
    // ------ OOL TM ----
    // BRH    Block_Transient_Handler       ; CC2 = transient failure

--- a/runtime/compiler/z/codegen/S390Recompilation.hpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.hpp
@@ -49,7 +49,7 @@ class TR_ResolvedMethod;
  *     The sampling recompilation snippet can be composed of two sub-snippets. Following the sub-snippets mini-
  *     trampolines (BRC instructions) are emitted which branch to the respective snippets (<ffffffec> and <ffffffe8>).
  *     This is done to simplify the patching logic as it keeps the offsets from the interpreter entry point
- *     (<00000000>) to the mini-trampilines constant. Following the mini-trampolines we emit metadata constants for
+ *     (<00000000>) to the mini-trampolines constant. Following the mini-trampolines we emit metadata constants for
  *     patching (<fffffff0>), the body info address (<fffffff4>), and the reserved word (<fffffffc>).
  *
  *     - VM Call Helper Snippet

--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -186,7 +186,7 @@ MM_ReferenceChainWalker::tearDown(MM_EnvironmentBase *env)
  * and adds the slot to queue for scanning.
  * @param slotPtr pointer to the slot
  * @param type root or reference type (J9GC_ROOT_TYPE_* or J9GC_REFERENCE_TYPE_*)
- * @param index an index identifying the slot withing the sourceObj
+ * @param index an index identifying the slot within the sourceObj
  * @param sourceObj the object which contains this slot, or NULL if a root
  */
 void
@@ -215,7 +215,7 @@ MM_ReferenceChainWalker::doSlot(J9Object **slotPtr, IDATA type, IDATA index, J9O
  * and adds the slot to queue for scanning.
  * @param slotPtr pointer to the class slot
  * @param type root or reference type (J9GC_ROOT_TYPE_* or J9GC_REFERENCE_TYPE_*)
- * @param index an index identifying the slot withing the sourceObj
+ * @param index an index identifying the slot within the sourceObj
  * @param sourceObj the object which contains this slot, or NULL if a root
  */
 void
@@ -238,7 +238,7 @@ MM_ReferenceChainWalker::doClassSlot(J9Class **slotPtr, IDATA type, IDATA index,
  * If the slot is modified by the callback, stores the modified value back into the field.
  * @param slotPtr pointer to the field slot
  * @param type root or reference type (J9GC_ROOT_TYPE_* or J9GC_REFERENCE_TYPE_*)
- * @param index an index identifying the slot withing the sourceObj
+ * @param index an index identifying the slot within the sourceObj
  * @param sourceObj the object which contains this slot
  */
 void

--- a/runtime/gc_doc/DoxygenConfig.txt
+++ b/runtime/gc_doc/DoxygenConfig.txt
@@ -973,7 +973,7 @@ HTML_STYLESHEET        =
 # user-defined cascading style sheet that is included after the standard 
 # style sheets created by doxygen. Using this option one can overrule 
 # certain style aspects. This is preferred over using HTML_STYLESHEET 
-# since it does not replace the standard style sheet and is therefor more 
+# since it does not replace the standard style sheet and is therefore more 
 # robust against future updates. Doxygen will copy the style sheet file to 
 # the output directory.
 
@@ -1233,7 +1233,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images 
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images 
 # generated for formulas are transparent PNGs. Transparent PNGs are 
 # not supported properly for IE 6.0, but are supported on all modern browsers. 
 # Note that when changing this option you need to delete any form_*.png files 

--- a/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootClearer.cpp
@@ -248,7 +248,7 @@ MM_MarkingSchemeRootClearer::scanUnfinalizedObjectsComplete(MM_EnvironmentBase *
 		/* ensure that all unfinalized processing is complete before we start marking additional objects */
 		env->_currentTask->synchronizeGCThreads(env, UNIQUE_ID);
 		/* TODO: consider relaxing completeMarking into completeScan (which will skip over 'complete class marking' step).
-		 * This is to avoid potentially unnecessery sync point in class marking step. The class marking step that we do after
+		 * This is to avoid potentially unnecessary sync point in class marking step. The class marking step that we do after
 		 * phantom processing might be sufficient.
 		 */
 		_markingScheme->completeMarking(env);

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1215,7 +1215,7 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 
 	/* Still need to verify the minimum size of Xmx/Xmdx is not less than the required
 	 * minimum subSpace size (oldSpace/NewSpace).  Do this verification after those minimum
-	 * values are verfied.
+	 * values are verified.
 	 */
 	return JNI_OK;
 

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -185,7 +185,7 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 
 #endif /* J9VM_GC_REALTIME */
 
-//todo tempoary option to allow LOA to be enabled for testing with non-default gc policies
+//todo temporary option to allow LOA to be enabled for testing with non-default gc policies
 //Remove once LOA code stable 
 #if defined(J9VM_GC_LARGE_OBJECT_AREA)
 

--- a/runtime/gc_trace/TgcScavenger.cpp
+++ b/runtime/gc_trace/TgcScavenger.cpp
@@ -312,7 +312,7 @@ tgcHookScavengerDiscardedSpace(J9HookInterface** hook, UDATA eventNum, void* eve
 
 	tgcExtensions->printf("\n");
 	/* If _survivorTLHRemainderCount/_tenureTLHRemainderCount gets too high (in 1000s),
-	 * it may indicate that discard threasholds are too low (and possibly causing contention while popping/pushing scan queue
+	 * it may indicate that discard thresholds are too low (and possibly causing contention while popping/pushing scan queue
 	 */
 	tgcExtensions->printf("Scavenger flipped=%zu discard=%zu TLHRemainderReuse=%zu\n", stats->_flipBytes, stats->_flipDiscardBytes, stats->_survivorTLHRemainderCount);
 	tgcExtensions->printf("Scavenger tenured=%zu discard=%zu TLHRemainderReuse=%zu\n", stats->_tenureAggregateBytes, stats->_tenureDiscardBytes, stats->_tenureTLHRemainderCount);

--- a/runtime/gc_vlhgc/RegionBasedOverflowVLHGC.cpp
+++ b/runtime/gc_vlhgc/RegionBasedOverflowVLHGC.cpp
@@ -89,7 +89,7 @@ MM_RegionBasedOverflowVLHGC::tearDown(MM_EnvironmentBase *env)
  * Empty a packet on overflow
  * 
  * Empty a packet to resolve overflow by dirtying the appropriate 
- * cards for each object withing a given packet
+ * cards for each object within a given packet
  * 
  * @param packet - Reference to packet to be emptied
  * @param type - ignored for concurrent collector

--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -745,7 +745,7 @@ MM_SchedulingDelegate::calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, UDATA 
 UDATA
 MM_SchedulingDelegate::initializeKickoffHeadroom(MM_EnvironmentVLHGC *env)
 {
-	/* totoal free memory = total heap size - eden size */
+	/* total free memory = total heap size - eden size */
 	UDATA totalFreeMemory = _regionManager->getTotalHeapSize() - getCurrentEdenSizeInBytes(env);
 	return calculateKickoffHeadroom(env, totalFreeMemory);
 }

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3415,7 +3415,7 @@ JVM_OnExit(void (*func)(void))
  *	Attempts to load the shared library specified by libName.  If
  *	successful, returns the file handle, otherwise returns NULL.
  *
- *	@param libName a null termintated string containing the libName.
+ *	@param libName a null terminated string containing the libName.
  *
  *	@return the shared library's handle if successful, throws java/lang/UnsatisfiedLinkError on failure
  */
@@ -3499,7 +3499,7 @@ JVM_LoadSystemLibrary(const char *libName)
  *	Attempts to load the shared library specified by libName.  If
  *	successful, returns the file handle, otherwise returns NULL.
  *
- *	@param libName a null termintated string containing the libName.
+ *	@param libName a null terminated string containing the libName.
  *
  *	@return the shared library's handle if successful, throws java/lang/UnsatisfiedLinkError on failure
  *

--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -450,7 +450,7 @@ isValidTypeChar(char character)
  * @param *env [in] JNI environment
  * @param templates [in] Array containing templates
  * @param formatStringsArray [out] Pointer to array of strings. Assigned by this method and populated with the UTF version of templates
- * @param callPatternsArray [out] Pointer to array of UDATA. Assigned by thsi method and populated with the call patterns for the templates.
+ * @param callPatternsArray [out] Pointer to array of UDATA. Assigned by this method and populated with the call patterns for the templates.
  * @param tracePointCount [out] Pointer to UDATA to be set to number of trace points (size of templates array)
  */
 static UDATA

--- a/runtime/jcl/common/mgmthypervisor.c
+++ b/runtime/jcl/common/mgmthypervisor.c
@@ -40,7 +40,7 @@
 /**
 * Checks if running on a Virtualized environment or not. i.e On a Hypervisor or not
 *
-* Class:     com_ibm_virtalization_management_internal_HypervisorMXBeanImpl
+* Class:     com_ibm_virtualization_management_internal_HypervisorMXBeanImpl
 * Method:    isEnvironmentVirtual
 *
 * @param[in] env The JNI env.
@@ -67,7 +67,7 @@ Java_com_ibm_virtualization_management_internal_HypervisorMXBeanImpl_isEnvironme
 /**
 * Retrieves the Hypervisor Vendor Name
 *
-* Class:     com_ibm_virtalization_management_internal_HypervisorMXBeanImpl
+* Class:     com_ibm_virtualization_management_internal_HypervisorMXBeanImpl
 * Method:    getVendor
 *
 * @param[in] env The JNI env.

--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -470,7 +470,7 @@ countObjectTags(J9JVMTIObjectTag * entry, J9JVMTIObjectTagMatch * results)
  * @param env             jvmti environment
  * @param heap_filter     tag filter flags used to determine which objects are to be reported
  * @param klass           class filter 
- * @param initial_object  object to start following the references from. Set to null to start witht the Heap Roots
+ * @param initial_object  object to start following the references from. Set to null to start with the Heap Roots
  * @param callbacks       callbacks to be invoked for each reference type
  * @param user_data       user data to be passed back via the callbacks
  * @return                a jvmtiError value

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -2575,7 +2575,7 @@ jvmtiIsModifiableModule(jvmtiEnv* env,
 /* ---------------- suspendhelper.cpp ---------------- */
 /**
 * @brief
-* @param currentThreasd
+* @param currentThread
 * @param thread
 * @param allowNull
 * @param currentThreadSuspended

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -425,7 +425,7 @@ J9NLS_VM_FAILED_TO_ALLOCATE_MONITOR.user_response=Verify that the system has eno
 # END NON-TRANSLATABLE
 
 # argument is the unrecognized command line option
-# this occurs if you pass an unrecongized option to -Xthr. e.g. ./j9 -Xthr:foo
+# this occurs if you pass an unrecognized option to -Xthr. e.g. ./j9 -Xthr:foo
 J9NLS_VM_UNRECOGNIZED_XTHR_OPTION=-Xthr: unrecognized option --> \'%s\'
 # START NON-TRANSLATABLE
 J9NLS_VM_UNRECOGNIZED_XTHR_OPTION.sample_input_1=foo
@@ -514,7 +514,7 @@ J9NLS_VM_JLM_HOLD_TIMES_NOT_SUPPORTED.user_response=
 # END NON-TRANSLATABLE
 
 # argument is the unrecognized command line option
-# this occurs if you pass an unrecongized option to -Xjni. e.g. ./j9 -Xjni:foo
+# this occurs if you pass an unrecognized option to -Xjni. e.g. ./j9 -Xjni:foo
 J9NLS_VM_UNRECOGNIZED_XJNI_OPTION=-Xjni: unrecognized option --> \'%s\'
 # START NON-TRANSLATABLE
 J9NLS_VM_UNRECOGNIZED_XJNI_OPTION.sample_input_1=someoption

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -92,7 +92,7 @@ typedef struct J9ClassLoaderWalkState {
 #define AOT_MINOR_VERSION 0
 
 
-/* temporary hack to ensure that we get the right verison of translate MethodHandle */
+/* temporary hack to ensure that we get the right version of translate MethodHandle */
 #define TRANSLATE_METHODHANDLE_TAKES_FLAGS
 
 /* temporary define to allow JIT work to promote and be enabled at the same time as the vm side */

--- a/runtime/oti/verutil_api.h
+++ b/runtime/oti/verutil_api.h
@@ -192,7 +192,7 @@ buildMethodError(J9CfrError * errorStruct, UDATA code, UDATA action, I_32 method
  * @param[in] pc - the pc value
  * @param[in] method - pointer to J9CfrMethod
  * @param[in] constantPoolPointer - pointer to the constant pool
- * @param[in] errorDataIndex - the index value when verification error occurs (e.g. constant pool index, local varible index, etc)
+ * @param[in] errorDataIndex - the index value when verification error occurs (e.g. constant pool index, local variable index, etc)
  * @param[in] stackmapFrameIndex - index to stack frame when error occurs
  * @param[in] stackmapFrameBCI - the bci value of the stackmap frame when error occurs
  */

--- a/runtime/rasdump/heapdump.cpp
+++ b/runtime/rasdump/heapdump.cpp
@@ -415,7 +415,7 @@ protected :
 	Buffer*        _Buffer;
 	
 private :
-	/* Prevent use of the unimplemmented copy constructor and assignment operator */
+	/* Prevent use of the unimplemented copy constructor and assignment operator */
 	inline Strings& operator=(const Strings& source);
 	inline Strings(const Strings& source);
 };

--- a/runtime/rastrace/trcoptions.c
+++ b/runtime/rastrace/trcoptions.c
@@ -1137,7 +1137,7 @@ processEarlyOptions(const char **opts)
 
 
 	/*
-	 *  Options are in name / value pairs, and termainate with a NULL
+	 *  Options are in name / value pairs, and terminate with a NULL
 	 */
 
 	for(i = 0; opts[i] != NULL; i += 2) {

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -486,7 +486,7 @@ SH_CacheMap::startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* pico
 
 				/* Two reasons for moving the code to check for full cache from SH_CompositeCacheImpl::startup()
 				 * to SH_CacheMap::startup():
-				 * 	- While marking cache full, last unsused pages are also protected, which ideally should be done
+				 * 	- While marking cache full, last unused pages are also protected, which ideally should be done
 				 * 	  after protecting pages belonging to ROMClass area and metadata area.
 				 * 	- Secondly, when setting cache full flags, the code expects to be holding the write mutex, which is not done in
 				 * 	  SH_CompositeCacheImpl::startup().
@@ -1894,7 +1894,7 @@ SH_CacheMap::allocateClassDebugData(J9VMThread* currentThread, U_16 classnameLen
 }
 
 /**
- * Roll back uncommited changes made by the last call too 'allocateClassDebugData()'
+ * Roll back uncommitted changes made by the last call too 'allocateClassDebugData()'
  *
  * @param [in] currentThread the thread calling this function
  * @param [in] classnameLength ROMClass class name length

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -3046,7 +3046,7 @@ SH_CompositeCacheImpl::rollbackUpdate(J9VMThread* currentThread)
 }
 
 /**
- * Updatte value of _storedSegmentUsedBytes
+ * Update value of _storedSegmentUsedBytes
  *
  * Called before ::commitUpdate() if ROM Classes builder allocated more than it needed.
  *
@@ -5368,7 +5368,7 @@ SH_CompositeCacheImpl::allocateClassDebugData(J9VMThread* currentThread, U_16 cl
 }
 
 /**
- * Roll back uncommited changes made by the last call too 'allocateClassDebugData()'
+ * Roll back uncommitted changes made by the last call too 'allocateClassDebugData()'
  *
  * @param [in] currentThread the thread calling this function
  * @param [in] classnameLength ROMClass class name length
@@ -6376,7 +6376,7 @@ SH_CompositeCacheImpl::tryAdjustMinMaxSizes(J9VMThread *currentThread, bool isJC
 		goto done;
 	}
 
-	/* set the variables inside the wirte mutex */
+	/* set the variables inside the write mutex */
 	adjustMinAOT = (_sharedClassConfig->minAOT >= 0);
 	adjustMaxAOT = (_sharedClassConfig->maxAOT >= 0);
 	adjustMinJIT = (_sharedClassConfig->minJIT >= 0);
@@ -6611,7 +6611,7 @@ SH_CompositeCacheImpl::updateRuntimeFullFlags(J9VMThread *currentThread)
 		if (J9_ARE_ALL_BITS_SET(*_runtimeFlags, J9SHR_RUNTIMEFLAG_AVAILABLE_SPACE_FULL)) {
 			if (J9_ARE_NO_BITS_SET(*_runtimeFlags, J9SHR_RUNTIMEFLAG_BLOCK_SPACE_FULL)) {
 				/* J9SHR_BLOCK_SPACE_FULL is always unset together with J9SHR_AVAILABLE_SPACE_FULL, do not need to remove J9AVLTREE_DISABLE_SHARED_TREE_UPDATES
-				 * when unseting J9SHR_RUNTIMEFLAG_BLOCK_SPACE_FULL, do it here is enough.
+				 * when unsetting J9SHR_RUNTIMEFLAG_BLOCK_SPACE_FULL, do it here is enough.
 				 */
 				if (NULL != currentThread->javaVM->sharedInvariantInternTable) {
 					Trc_SHR_CC_updateRuntimeFullFlags_flagUnset(currentThread, J9AVLTREE_DISABLE_SHARED_TREE_UPDATES);
@@ -6684,7 +6684,7 @@ SH_CompositeCacheImpl::updateRuntimeFullFlags(J9VMThread *currentThread)
 
 	*_runtimeFlags &= ~flagUnset;
 	*_runtimeFlags |= flagSet;
-	/* JAZZ103 108287 Add wirte barrier to ensure the setting/unsetting of runtime flags happens before resetting 
+	/* JAZZ103 108287 Add write barrier to ensure the setting/unsetting of runtime flags happens before resetting 
 	 * _maxAOTUnstoredBytes/_maxJITUnstoredBytes/_softmxUnstoredBytes to 0.
 	 */
 	VM_AtomicSupport::writeBarrier();

--- a/runtime/stackmap/localmap.c
+++ b/runtime/stackmap/localmap.c
@@ -231,7 +231,7 @@ mapAllLocals(J9PortLibrary * portLibrary, J9ROMMethod * romMethod, PARALLEL_TYPE
 	@param romMethod Method containing the bytecodes to walk.
 	@param unknownsByPC Buffer used to store per-PC metadata (1 PARALLEL_TYPE per PC) + branch stack.
 	@param startPC Bytecode index to begin the walk.
-	@param localIndexBase Offset of the first local, usuually zero unless method has > PARALLEL_TYPE bits. 
+	@param localIndexBase Offset of the first local, usually zero unless method has > PARALLEL_TYPE bits. 
 	@param knownLocals Bitfield of locals whose types are known definitively.
 	@param knownObject Bitfield of locals which are definitively objects.
 	@param unknownsUpdated Pointer to a boolean value updated iff. any per-PC metadata was updated.

--- a/runtime/sunvmi/CMakeLists.txt
+++ b/runtime/sunvmi/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/sunvmi/CMakeLists.txt
+++ b/runtime/sunvmi/CMakeLists.txt
@@ -41,5 +41,5 @@ target_link_libraries(sunvmi
 		j9util
 )
 
-# Note we need to make sure the gc hookgen/tracgen headers exist before we start compiling
+# Note we need to make sure the gc hookgen/tracegen headers exist before we start compiling
 add_dependencies(sunvmi omrgc_hookgen omrgc_tracegen)

--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -27,7 +27,7 @@
 
 
 /**
- *  A list of all known tests. While adding new tesst, this is the only place that
+ *  A list of all known tests. While adding a new test, this is the only place that
  *  needs to be updated in order for the agent to recognize the test.
  */
 static jvmtiTest jvmtiTestList[] =

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getConstantPool/gcp001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getConstantPool/gcp001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getConstantPool/gcp001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getConstantPool/gcp001.c
@@ -156,7 +156,7 @@ testGetConstantPool (JavaVM * vm, jvmtiEnv * jvmti_env, char *args)
 
 
 /** 
- * \brief	classLoad handler used to intercept loading of the 'testGetConstantPool' testt class
+ * \brief	classLoad handler used to intercept loading of the 'testGetConstantPool' test class
  * \ingroup	GetConstantPool
  * 
  * @param jvmti_env 

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -612,7 +612,7 @@ printExpectedTypeFromStackMapFrame(MessageBuffer *msgBuf, J9BytecodeVerification
 		goto exit;
 	}
 
-	/* Walk thourgh the stackmap table for the specified stackmap frame */
+	/* Walk through the stackmap table for the specified stackmap frame */
 	while (stackmapFrameIndex != errorTargetFrameIndex) {
 		stackmapFrameIndex += 1;
 		nextStackmapFrame = decodeStackmapFrameData(targetFrame, nextStackmapFrame, stackmapFrameIndex, methodInfo, verifyData);
@@ -711,7 +711,7 @@ setStackMapFrameWithIndex(J9BytecodeVerificationData *verifyData, MethodContextI
 			goto exit;
 		}
 
-		/* Walk thourgh the stackmap table for the specified stackmap frame */
+		/* Walk through the stackmap table for the specified stackmap frame */
 		while (stackmapFrameIndex != errorTargetFrameIndex) {
 			stackmapFrameIndex += 1;
 			nextStackmapFrame = decodeStackmapFrameData(targetFrame, nextStackmapFrame, stackmapFrameIndex, methodInfo, verifyData);

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -1268,7 +1268,7 @@ verboseClassVerificationFallback(J9HookInterface** hook, UDATA eventNum, void* e
 }
 
 /*
- * This event callback is triggered before starting the verificaiton of each method.
+ * This event callback is triggered before starting the verification of each method.
  */
 static void
 verboseMethodVerificationStart(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -4157,7 +4157,7 @@ internalError:
 		} else {
 			updateVMStruct(REGISTER_ARGS);
 			J9ClassLoader* result = internalAllocateClassLoader(_vm, classLoaderObject);
-			VMStructHasBeenUpdated(REGISTER_ARGS); // likely unncessary - no code runs in internalAllocateClassLoader
+			VMStructHasBeenUpdated(REGISTER_ARGS); // likely unnecessary - no code runs in internalAllocateClassLoader
 			if (NULL == result) {
 				rc = GOTO_THROW_CURRENT_EXCEPTION;
 				goto done;

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -149,7 +149,7 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 				clazz = VM_VMHelpers::currentClass(clazz);
 				bcvd->vmStruct = NULL;
 				if (0 != verifyResult) {
-					/* INL had a check for Object here which is unncessary in SE */
+					/* INL had a check for Object here which is unnecessary in SE */
 					if (-2 == verifyResult) {
 						omrthread_monitor_exit(bcvd->verifierMutex);
 						/* vmStruct is already up to date */

--- a/runtime/vm/MHInterpreter.hpp
+++ b/runtime/vm/MHInterpreter.hpp
@@ -661,7 +661,7 @@ public:
 	 * FilterReturn:
 	 * 		[ ... MH bytecodeframe returnSlot0 returnslot1] --> [ ... MH returnSlot0 returnslot1]
 	 * ConstructorHandle:
-	 * 		[ ... newUnitializedObject bytecodeframe] --> [ ... newInitializedObject]
+	 * 		[ ... newUninitializedObject bytecodeframe] --> [ ... newInitializedObject]
 	 * FoldHandle:
 	 * 		Refer to the implementation in MHInterpreter.cpp
 	 * GuardWithTestHandle:

--- a/runtime/vm/ObjectFieldInfo.hpp
+++ b/runtime/vm/ObjectFieldInfo.hpp
@@ -325,7 +325,7 @@ public:
 
 	/**
 	 * Compute the total size of the object including padding to end on 8-byte boundary.
-	 * Update the backfill values to use for this class's fields and thoise of subclasses
+	 * Update the backfill values to use for this class's fields and those of subclasses
 	 * @return size of the object in bytes, not including the header
 	 */
 	U_32

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5793,7 +5793,7 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 
 #ifdef J9VM_OPT_SIDECAR
-	/* Whinge about -Djava.compiler after extra VM options are added, but before mappings are set */
+	/* Whine about -Djava.compiler after extra VM options are added, but before mappings are set */
 	if (RC_FAILED == checkDjavacompiler(portLibrary, vm->vmArgsArray)) {
 		goto error;
 	}

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -577,7 +577,7 @@ doneItableSearch:
  *		J9_LOOK_ALLOW_FWD						Allow lookup to follow the forwarding chain
  *		J9_LOOK_NO_VISIBILITY_CHECK				Do not perform any visilbity checking
  *		J9_LOOK_NO_JLOBJECT						When doing an interface lookup, do not consider method in java.lang.Object
- *		J9_LOOK_REFLECT_CALL					Use reflection behaviour when dealing with module visilibity
+ *		J9_LOOK_REFLECT_CALL					Use reflection behaviour when dealing with module visibility
  *		J9_LOOK_HANDLE_DEFAULT_METHOD_CONFLICTS	Handle default method conflicts
  *		J9_LOOK_IGNORE_INCOMPATIBLE_METHODS		If a static/virtual conflict occurs, ignore and move on to the next class
  *

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -81,7 +81,7 @@ hashMonitorCompare(void *tableEntryKey, void *userKey, void *userData)
 	/* In a Concurrent GC where monitor object can *move* in a middle of GC cycle,
 	 * we need a proper barrier to get an up-to-date location of the monitor object
 	 * Only access to the table entry needs the barrier. The user provided key should already have an updated location of the objects,
-	 * since a read barrier had to be executed some time prior to the construction of the key, whereever the value is read from */
+	 * since a read barrier had to be executed some time prior to the construction of the key, wherever the value is read from */
 	j9object_t tableEntryObject = J9MONITORTABLE_OBJECT_LOAD_VM((J9JavaVM *)userData, &(tableEntryMonitor->userData));
 
 	return tableEntryObject == (j9object_t)userMonitor->userData;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1263,7 +1263,7 @@ incompat:
 		}
 	}
 
-	/* Select the correct method for invocation - ignore visilbility in the super send case */
+	/* Select the correct method for invocation - ignore visibility in the super send case */
 	method = getMethodForSpecialSend(vmStruct, currentClass, resolvedClass, method, lookupOptions | J9_LOOK_NO_VISIBILITY_CHECK | J9_LOOK_IGNORE_INCOMPATIBLE_METHODS);
 	if (NULL == method) {
 		goto done;

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -165,7 +165,7 @@ dnl
 dnl 1. TX was a non-constrained transaction:
 dnl    If this was the case do not execute the read barrier and simply return to
 dnl    the fallback transaction abort JIT code to handle it by forcing condition
-dnl    code to be 2 with the below CL(G)FI instruction indicating a transitent 
+dnl    code to be 2 with the below CL(G)FI instruction indicating a transient 
 dnl    transaction abort.
 dnl
 dnl 2. TX was a constrained transaction:

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Builder.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Builder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2017 IBM Corp. and others
+ * Copyright (c) 1999, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Builder.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/Builder.java
@@ -168,7 +168,7 @@ public class Builder {
 	}
 
 	/**
-	 * Returns wheter or not this builder will only do an incremental build.
+	 * Returns whether or not this builder will only do an incremental build.
 	 *
 	 * @return		<code>true</code> if the build is incremental, <code>false</code> otherwise
 	 */

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ClassPathEntry.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ClassPathEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2017 IBM Corp. and others
+ * Copyright (c) 1999, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ClassPathEntry.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ClassPathEntry.java
@@ -160,7 +160,7 @@ public class ClassPathEntry {
 	}
 
 	/**
-	 * Returns wheter or not this classpath points to a local library
+	 * Returns whether or not this classpath points to a local library
 	 *
 	 * @return      <code>true</code> if this points to a local library, <code>false</code> otherwise
 	 */

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ConfigObject.java
@@ -393,7 +393,7 @@ public class ConfigObject {
 	}
 
 	/**
-	 * Returns thsi ConfigObject's immediate configuration dependencies.
+	 * Returns this ConfigObject's immediate configuration dependencies.
 	 *
 	 * @return      the configuration dependencies
 	 */

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/CmakeFlagInfo.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/CmakeFlagInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/CmakeFlagInfo.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/CmakeFlagInfo.java
@@ -34,7 +34,7 @@ class CmakeFlagInfo implements IFlagInfo {
 	private HashSet<String> seenFlags = new HashSet<String>();
 	private HashSet<String> setFlags = new HashSet<String>();
 
-	// Convert string  to  bool unsing same rules as cmake
+	// Convert string  to  bool using same rules as cmake
 	private static boolean strToBool(String str) {
 		str = str.trim().toUpperCase();
 		if (str.isEmpty() || str.equals("NO") || str.equals("FALSE") || str.equals("OFF") || str.endsWith("-NOTFOUND")) {

--- a/sourcetools/objectmodel/com/ibm/j9tools/om/FlagDefinitions.java
+++ b/sourcetools/objectmodel/com/ibm/j9tools/om/FlagDefinitions.java
@@ -57,7 +57,7 @@ public class FlagDefinitions extends OMObject {
 	}
 
 	/**
-	 * Returns the runtime to wich this flag definition belongs to, or <code>null</code> if none.
+	 * Returns the runtime to which this flag definition belongs to, or <code>null</code> if none.
 	 * 
 	 * @return the runtime
 	 */

--- a/test/TestConfig/openj9Settings.mk
+++ b/test/TestConfig/openj9Settings.mk
@@ -69,7 +69,7 @@ ifndef NATIVE_TEST_LIBS
 	NATIVE_TEST_LIBS=$(TEST_JDK_HOME)$(D)..$(D)native-test-libs$(D)
 endif
 
-# if JCL_VESION is current check for default locations for native test libs
+# if JCL_VERSION is current check for default locations for native test libs
 # otherwise, native test libs are under NATIVE_TEST_LIBS
 ifneq (, $(findstring current, $(JCL_VERSION)))
 	ifneq (,$(findstring win,$(SPEC)))

--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -162,7 +162,7 @@ sub generateOnDir {
 	while ( my $entry = readdir $dir ) {
 		next if $entry eq '.' or $entry eq '..';
 		my $tempExclude = 0;
-		# tmporary exclusion, remove this block when JCL_VERSION separation is removed
+		# temporary exclusion, remove this block when JCL_VERSION separation is removed
 		if (($jdkVersion ne "Panama") && ($jdkVersion ne "Valhalla")) {
 			my $JCL_VERSION = '';
 			if ( exists $ENV{'JCL_VERSION'} ) {

--- a/test/functional/JIT_Test/src/jit/test/jitt/codecache/TestManager.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/codecache/TestManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/jitt/codecache/TestManager.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/codecache/TestManager.java
@@ -322,7 +322,7 @@ public class TestManager {
 		jarTesterMTDriver = new JarTesterMTDriver( multipleClassLoaderRequired, multiThreadedCompilationRequired, jarDir );
 		jarTesterMTDriver.start();
 
-		//TODO: Do we need to give the compilation thiread this time to index the jar?
+		//TODO: Do we need to give the compilation thread this time to index the jar?
 		try {
 			Thread.sleep(2000);
 		} catch (InterruptedException e) {

--- a/test/functional/JIT_Test/src/jit/test/jitt/codecache/TrampolineTest_Basic.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/codecache/TrampolineTest_Basic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JIT_Test/src/jit/test/jitt/codecache/TrampolineTest_Basic.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/codecache/TrampolineTest_Basic.java
@@ -45,7 +45,7 @@ public class TrampolineTest_Basic extends TestCase {
 	}
 
 	/**
-	 * Basic trampline tests where code caches are sufficiently distant from each other,
+	 * Basic trampoline tests where code caches are sufficiently distant from each other,
 	 * and inter-code cache dispatches are made.
 	 */
 	public void testTrampolineBasic(){

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ThreadGroup.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ThreadGroup.java
@@ -483,7 +483,7 @@ public class Test_ThreadGroup {
 		final int TOTAL_DEPTH = 5;
 		ThreadGroup current = testRoot;
 		Vector groups = new Vector();
-		// To maintain teh invariant that a thread in the Vector is parent
+		// To maintain the invariant that a thread in the Vector is parent
 		// of the next one in the collection (and child of the previous one)
 		groups.addElement(testRoot);
 

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleTest.java
@@ -901,7 +901,7 @@ public class MethodHandleTest{
 	 * ****************************/
 	
 	/**
-	 * asFixedArity test to ensure MethodHandles.lookup().find* methods returned varargs handles for methods with the ACC_VARAGS bit
+	 * asFixedArity test to ensure MethodHandles.lookup().find* methods returned varargs handles for methods with the ACC_VARARGS bit
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.extended" })
@@ -1179,7 +1179,7 @@ public class MethodHandleTest{
 	 * **************************************/
 	
 	/**
-	 * Test isVarargsCollector using a call to asVaragrsCollector
+	 * Test isVarargsCollector using a call to asVarargsCollector
 	 * @throws Throwable
 	 */
 	@Test(groups = { "level.extended" })

--- a/test/functional/VM_Test/src/com/ibm/j9/recreateclass/tests/RecreateClassCompareTest.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/recreateclass/tests/RecreateClassCompareTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/VM_Test/src/com/ibm/j9/recreateclass/tests/RecreateClassCompareTest.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/recreateclass/tests/RecreateClassCompareTest.java
@@ -130,7 +130,7 @@ public class RecreateClassCompareTest extends TestCase {
 	public void testStackMapTableTestWithBooleanArray() throws Exception {
 		System.out.println("Start testStackMapTableTestWithBooleanArray");
 		/* To follow the Java 9 Spec in which boolean arrays are different from byte arrays
-		 * in terms of verfication type, Recreated StackMapTableWithByteBooleanArrayTest is 
+		 * in terms of verification type, recreated StackMapTableWithByteBooleanArrayTest is 
 		 * expected to keep boolean array in verification_type array of StackMapTable.
 		 */
 		runTest(StackMapTableWithByteBooleanArrayTest.class, 0);

--- a/test/functional/VM_Test/src/j9vm/test/invalidclasspath/SetClasspathTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/invalidclasspath/SetClasspathTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/VM_Test/src/j9vm/test/invalidclasspath/SetClasspathTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/invalidclasspath/SetClasspathTest.java
@@ -124,7 +124,7 @@ public class SetClasspathTest {
 		loader.setClasspath(urls5);
 		/* TestB3 should be stored as ROMCLASS in cache, as there is no invalid URL in the classpath.
 		 * Do not load any class from InvalidClasspathResource3.jar otherwise it will get marked as 'confirmed' by the VM
-		 * and further tranformations to remove InvalidClasspathResource3.jar won't be allowed.
+		 * and further transformations to remove InvalidClasspathResource3.jar won't be allowed.
 		 */
 		Class.forName("TestB3", true, loader);
 		


### PR DESCRIPTION
This PR should be purely comment changes for words (or families of words) that start w/ `t`..`w`

To make my life easier, these initial comment focused PRs will have 2 commits:
* one which is the fixes
* and one which is the copyright bumping

For more information, see #5722 

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `f` / `fchurn`.