### PR TITLE
Fix unguarded JIT trace message from BoolArrayStoreTransformer

### DIFF
--- a/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
+++ b/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
@@ -163,7 +163,10 @@ void TR_BoolArrayStoreTransformer::perform()
             _bstoreiBoolArrayTypeNodes->insert(_bstoreiUnknownArrayTypeNodes->begin(), _bstoreiUnknownArrayTypeNodes->end());
             }
          else
-            traceMsg(comp(), "only byte array exist as auto or checkcast type\n");
+            {
+            if (comp()->getOption(TR_TraceILGen))
+               traceMsg(comp(), "only byte array exist as auto or checkcast type\n");
+            }
          _bstoreiUnknownArrayTypeNodes->clear();
          }
       }


### PR DESCRIPTION
Unguarded trace message produces unwanted output in the JIT trace log.
Make sure it is guarded appropriately.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>