### PR TITLE
Move constLoadNeedsLiteralFromPool to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -344,6 +344,8 @@ public:
    bool getSupportsBigDecimalLongLookasideVersioning() { return _flags3.testAny(SupportsBigDecimalLongLookasideVersioning);}
    void setSupportsBigDecimalLongLookasideVersioning() { _flags3.set(SupportsBigDecimalLongLookasideVersioning);}
 
+   bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
+
    // --------------------------------------------------------------------------
    // GPU
    //

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -238,6 +238,19 @@ J9::Z::CodeGenerator::doInlineAllocate(TR::Node *node)
    return true;
    }
 
+bool
+J9::Z::CodeGenerator::constLoadNeedsLiteralFromPool(TR::Node *node)
+   {
+   if (node->isClassUnloadingConst() || node->getType().isIntegral() || node->getType().isAddress())
+      {
+      return false;
+      }
+   else
+      {
+      return true;  // Floats/Doubles require literal pool
+      }
+   }
+
 TR::Recompilation *
 J9::Z::CodeGenerator::allocateRecompilationInfo()
    {

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -113,6 +113,7 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    bool supportsPackedShiftRight(int32_t resultPrecision, TR::Node *shiftSource, int32_t shiftAmount);
    bool canGeneratePDBinaryIntrinsic(TR::ILOpCodes opCode, TR::Node * op1PrecNode, TR::Node * op2PrecNode, TR::Node * resultPrecNode);
 
+   bool constLoadNeedsLiteralFromPool(TR::Node *node);
 
    using J9::CodeGenerator::addAllocatedRegister;
    void addAllocatedRegister(TR_PseudoRegister * temp);


### PR DESCRIPTION
`OMR::CodeGenerator` has field `constLoadNeedsLiteralFromPool` that has only
relevance in OpenJ9. This commit duplicates the function in OpenJ9.

Issue: eclipse/omr#1873
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>