### PR TITLE
Explicitly load the jdk.management.agent module

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -422,14 +422,16 @@ public class IPC {
 	 * Print the information about a throwable, including the exact class,
 	 * message, and stack trace.
 	 * @param msg User supplied message
-	 * @param thrown throwable
+	 * @param thrown Throwable object or null
 	 * @note nothing is printed if logging is disabled
 	 */
 	public static void logMessage(String msg, Throwable thrown) {
 		synchronized (accessorMutex) {
 			if (isLoggingEnabled()) {
 				printMessageWithHeader(msg, logStream);
-				thrown.printStackTrace(logStream);
+				if (null != thrown) {
+					thrown.printStackTrace(logStream);
+				}
 				logStream.flush();
 			}
 		}

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IbmAttachOperationFailedException.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IbmAttachOperationFailedException.java
@@ -8,7 +8,7 @@ import java.io.IOException;
  */
 @SuppressWarnings("serial")
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,7 @@ public class IbmAttachOperationFailedException extends IOException {
 	public IbmAttachOperationFailedException() {
 		super("IbmAttachOperationFailedException"); //$NON-NLS-1$
 	}
+	
 	/**
 	 * Constructs a new instance of this class with its 
 	 * walkback and message filled in.
@@ -48,4 +49,26 @@ public class IbmAttachOperationFailedException extends IOException {
 	public IbmAttachOperationFailedException(String message) {
 		super(message);
 	}
+
+	/**
+	 * Constructs the exception with a message and a nested Throwable.
+	 * @param message text of the message
+	 * @param cause underlying Throwable
+	 */
+	public IbmAttachOperationFailedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	@Override
+	public String toString() {
+		String result;
+		Throwable myCause = getCause();
+		if (null != myCause) {
+			result = String.format("\"%s\"; Caused by: \"%s\"", super.toString(), myCause.toString()); //$NON-NLS-1$
+		} else {
+			result = super.toString();
+		}
+		return result;
+	}
+	
 }


### PR DESCRIPTION
Runtimes which are explicitly jlinked with a subset of modules may not load
this module by default.

Fixes https://github.com/eclipse/openj9/issues/5872

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>