### PR TITLE
OpenJ9 Signal Support Changes

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -366,81 +366,33 @@ static const J9SignalMapping signalMap[] = {
 #if defined(SIGCONT)
 	J9_SIGNAL_MAP_ENTRY("CONT", SIGCONT),
 #endif /* defined(SIGCONT) */
-#if defined(SIGCPUFAIL)
-	J9_SIGNAL_MAP_ENTRY("CPUFAIL", SIGCPUFAIL),
-#endif /* defined(SIGCPUFAIL) */
-#if defined(SIGDANGER)
-	J9_SIGNAL_MAP_ENTRY("DANGER", SIGDANGER),
-#endif /* defined(SIGDANGER) */
-#if defined(SIGEMT)
-	J9_SIGNAL_MAP_ENTRY("EMT", SIGEMT),
-#endif /* defined(SIGEMT) */
 #if defined(SIGFPE)
 	J9_SIGNAL_MAP_ENTRY("FPE", SIGFPE),
 #endif /* defined(SIGFPE) */
-#if defined(SIGGRANT)
-	J9_SIGNAL_MAP_ENTRY("GRANT", SIGGRANT),
-#endif /* defined(SIGGRANT) */
 #if defined(SIGHUP)
 	J9_SIGNAL_MAP_ENTRY("HUP", SIGHUP),
 #endif /* defined(SIGHUP) */
 #if defined(SIGILL)
 	J9_SIGNAL_MAP_ENTRY("ILL", SIGILL),
 #endif /* defined(SIGILL) */
-#if defined(SIGINFO)
-	J9_SIGNAL_MAP_ENTRY("INFO", SIGINFO),
-#endif /* defined(SIGINFO) */
 #if defined(SIGINT)
 	J9_SIGNAL_MAP_ENTRY("INT", SIGINT),
 #endif /* defined(SIGINT) */
 #if defined(SIGIO)
 	J9_SIGNAL_MAP_ENTRY("IO", SIGIO),
 #endif /* defined(SIGIO) */
-#if defined(SIGKILL)
-	J9_SIGNAL_MAP_ENTRY("KILL", SIGKILL),
-#endif /* defined(SIGKILL) */
-#if defined(SIGMIGRATE)
-	J9_SIGNAL_MAP_ENTRY("MIGRATE", SIGMIGRATE),
-#endif /* defined(SIGMIGRATE) */
-#if defined(SIGMSG)
-	J9_SIGNAL_MAP_ENTRY("MSG", SIGMSG),
-#endif /* defined(SIGMSG) */
 #if defined(SIGPIPE)
 	J9_SIGNAL_MAP_ENTRY("PIPE", SIGPIPE),
 #endif /* defined(SIGPIPE) */
-#if defined(SIGPOLL)
-	J9_SIGNAL_MAP_ENTRY("POLL", SIGPOLL),
-#endif /* defined(SIGPOLL) */
-#if defined(SIGPRE)
-	J9_SIGNAL_MAP_ENTRY("PRE", SIGPRE),
-#endif /* defined(SIGPRE) */
 #if defined(SIGPROF)
 	J9_SIGNAL_MAP_ENTRY("PROF", SIGPROF),
 #endif /* defined(SIGPROF) */
-#if defined(SIGPWR)
-	J9_SIGNAL_MAP_ENTRY("PWR", SIGPWR),
-#endif /* defined(SIGPWR) */
 #if defined(SIGQUIT)
 	J9_SIGNAL_MAP_ENTRY("QUIT", SIGQUIT),
 #endif /* defined(SIGQUIT) */
-#if defined(SIGRETRACT)
-	J9_SIGNAL_MAP_ENTRY("RETRACT", SIGRETRACT),
-#endif /* defined(SIGRETRACT) */
-#if defined(SIGSAK)
-	J9_SIGNAL_MAP_ENTRY("SAK", SIGSAK),
-#endif /* defined(SIGSAK) */
 #if defined(SIGSEGV)
 	J9_SIGNAL_MAP_ENTRY("SEGV", SIGSEGV),
 #endif /* defined(SIGSEGV) */
-#if defined(SIGSOUND)
-	J9_SIGNAL_MAP_ENTRY("SOUND", SIGSOUND),
-#endif /* defined(SIGSOUND) */
-#if defined(SIGSTKFLT)
-	J9_SIGNAL_MAP_ENTRY("STKFLT", SIGSTKFLT),
-#endif /* defined(SIGSTKFLT) */
-#if defined(SIGSTOP)
-	J9_SIGNAL_MAP_ENTRY("STOP", SIGSTOP),
-#endif /* defined(SIGSTOP) */
 #if defined(SIGSYS)
 	J9_SIGNAL_MAP_ENTRY("SYS", SIGSYS),
 #endif /* defined(SIGSYS) */
@@ -459,9 +411,6 @@ static const J9SignalMapping signalMap[] = {
 #if defined(SIGTTOU)
 	J9_SIGNAL_MAP_ENTRY("TTOU", SIGTTOU),
 #endif /* defined(SIGTTOU) */
-#if defined(SIGUNUSED)
-	J9_SIGNAL_MAP_ENTRY("UNUSED", SIGUNUSED),
-#endif /* defined(SIGUNUSED) */
 #if defined(SIGURG)
 	J9_SIGNAL_MAP_ENTRY("URG", SIGURG),
 #endif /* defined(SIGURG) */

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -4188,18 +4188,6 @@ isSignalReservedByJVM(jint sigNum)
 #if defined(SIGBREAK)
 		(SIGBREAK == sigNum) ||
 #endif /* defined(SIGBREAK) */
-#if defined(SIGABRT)
-		(SIGABRT == sigNum) ||
-#endif /* defined(SIGABRT) */
-#if defined(SIGCHLD)
-		(SIGCHLD == sigNum) ||
-#endif /* defined(SIGCHLD) */
-#if defined(SIGRECONFIG)
-		(SIGRECONFIG == sigNum) ||
-#endif /* defined(SIGRECONFIG) */
-#if defined(J9ZOS390) && defined(SIGUSR1)
-		(SIGUSR1 == sigNum) ||
-#endif /* defined(J9ZOS390) && defined(SIGUSR1) */
 		FALSE;
 }
 


### PR DESCRIPTION
- Remove unneeded signals from `J9SignalMapping`
- Update `isSignalReservedByJVM` to correct the `JVM_*Signal` functions

Refer to the individual commits for more details.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>