### PR TITLE
Duplicate getInternalPtrMapBit to OpenJ9

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,6 +90,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    bool enableAESInHardwareTransformations();
 
    void insertPrefetchIfNecessary(TR::Node *node, TR::Register *targetRegister);
+
+   int32_t getInternalPtrMapBit() { return 18;}
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    bool suppressInliningOfCryptoMethod(TR::RecognizedMethod method);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -125,6 +125,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    TR_OpaquePseudoRegister * evaluateOPRNode(TR::Node* node);
    TR_PseudoRegister * evaluateBCDNode(TR::Node * node);
 
+   // J9
+   int32_t getInternalPtrMapBit() { return 31;}
 
    // --------------------------------------------------------------------------
    // Storage references


### PR DESCRIPTION
This commit duplicates all the declarations of the function
`getInternalPtrMapBit` from OMR to OpenJ9.

Issue: eclipse/omr#1877
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>