### PR TITLE
Store default value in J9Class

### DIFF
--- a/runtime/gc_structs/ClassIterator.cpp
+++ b/runtime/gc_structs/ClassIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,6 +96,13 @@ GC_ClassIterator::nextSlot()
 
 	case classiterator_state_varhandlemethodtypes:
 		slotPtr = _varHandlesMethodTypesIterator.nextSlot();
+		if (NULL != slotPtr) {
+			return slotPtr;
+		}
+		_state += 1;
+
+	case classiterator_state_valuetypes:
+		slotPtr = _valueTypesIterator.nextSlot();
 		if (NULL != slotPtr) {
 			return slotPtr;
 		}

--- a/runtime/gc_structs/ClassIterator.hpp
+++ b/runtime/gc_structs/ClassIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,7 @@
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "MethodTypesIterator.hpp"
+#include "ValueTypesIterator.hpp"
 
 /**
  * State constants representing the current stage of the iteration process
@@ -51,6 +52,7 @@ enum {
 	classiterator_state_callsites,
 	classiterator_state_methodtypes,
 	classiterator_state_varhandlemethodtypes,
+	classiterator_state_valuetypes,
 	classiterator_state_end
 };
 
@@ -72,6 +74,7 @@ protected:
 	GC_CallSitesIterator _callSitesIterator;
 	GC_MethodTypesIterator _methodTypesIterator;
 	GC_MethodTypesIterator _varHandlesMethodTypesIterator;
+	GC_ValueTypesIterator _valueTypesIterator;
 	const bool _shouldScanClassObject; /**< Boolean needed for balanced GC to prevent ClassObject from being scanned twice  */
 
 public:
@@ -84,6 +87,7 @@ public:
 		, _callSitesIterator(clazz)
 		, _methodTypesIterator(clazz->romClass->methodTypeCount, clazz->methodTypes)
 		, _varHandlesMethodTypesIterator(clazz->romClass->varHandleMethodTypeCount, clazz->varHandleMethodTypes)
+		, _valueTypesIterator(clazz)
 		, _shouldScanClassObject(shouldScanClassObject)
 	{}
 
@@ -96,6 +100,7 @@ public:
 		, _callSitesIterator(clazz)
 		, _methodTypesIterator(clazz->romClass->methodTypeCount, clazz->methodTypes)
 		, _varHandlesMethodTypesIterator(clazz->romClass->varHandleMethodTypeCount, clazz->varHandleMethodTypes)
+		, _valueTypesIterator(clazz)
 		, _shouldScanClassObject(true)
 	{}
 

--- a/runtime/gc_structs/ValueTypesIterator.hpp
+++ b/runtime/gc_structs/ValueTypesIterator.hpp
@@ -1,0 +1,88 @@
+
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Structs
+ */
+
+#if !defined(VALUETYPESITERATOR_HPP_)
+#define VALUETYPESITERATOR_HPP_
+
+#include "j9.h"
+#include "j9cfg.h"
+#include "modron.h"
+
+/**
+ * Iterate over all ValueType slots in a class which contain an object reference.
+ * @ingroup GC_Structs
+ */
+class GC_ValueTypesIterator
+{
+private:
+	/**
+	 * State constants representing the current stage of the iteration process
+	 * @anchor ValueTypeIteratorState
+	 */
+	typedef enum {
+		valuetypesiterator_state_default_value = 0,
+		valuetypesiterator_state_end
+	} ValueTypesState;
+	
+	ValueTypesState _state;             /** current Iterator state  */	
+	J9Class *_clazzPtr;                 /** Class being scanned for default value  */
+	
+public:
+	GC_ValueTypesIterator(J9Class *clazz)
+		: _state(valuetypesiterator_state_default_value)
+		, _clazzPtr(clazz)
+	{};
+
+	/**
+	 * Fetch the next slot in the class.
+	 * Note that the pointer is volatile. In concurrent applications the mutator may 
+	 * change the value in the slot while iteration is in progress.
+	 * @return the address of the default value if the class is valuetype and is not array
+	 * @return NULL if not valuetype or is an array
+	 * or if the class has already been scanned
+	 */
+	j9object_t * nextSlot()
+	{	
+		switch(_state) {
+		case valuetypesiterator_state_default_value:
+			_state = valuetypesiterator_state_end;
+			if (J9_IS_J9CLASS_VALUETYPE(_clazzPtr) && (!J9CLASS_IS_ARRAY(_clazzPtr))) {
+				return &(_clazzPtr->flattenedClassCache->defaultValue);
+			}
+			break;
+
+		default:
+			break;
+		}
+
+		return NULL;
+	}
+};
+
+#endif /* VALUETYPESITERATOR_HPP_ */
+

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1711,11 +1711,36 @@ typedef struct J9ModuleExtraInfo {
 	UDATA patchPathCount;
 } J9ModuleExtraInfo;
 
-typedef struct J9FlattenedClassCache {
+/*             Structure of Flattened Class Cache              */
+/*                                                             *
+ *    Default Value   |   Number of Entries   |                *
+ *____________________|_______________________|________________* 
+ *                    |                       |                *
+ *      clazz 0       |   Name & Signature 0  |     offset 0   *
+ *____________________|_______________________|________________* 
+ *                    |                       |                *
+ *      clazz 1       |   Name & Signature 1  |     offset 1   *
+ *____________________|_______________________|________________* 
+ *         .          |           .           |        .       *
+ *         .          |           .           |        .       *
+ *         .          |           .           |        .       *
+ *____________________|_______________________|________________* 
+ *                    |                       |                *
+ *      clazz N       |   Name & Signature N  |     offset N   * 
+ ***************************************************************/
+typedef struct J9FlattenedClassCacheEntry {
 	struct J9Class* clazz;
 	struct J9ROMNameAndSignature* nameAndSignature;
 	UDATA offset;
+} J9FlattenedClassCacheEntry;
+
+typedef struct J9FlattenedClassCache {
+	j9object_t defaultValue;
+	UDATA numberOfEntries;
 } J9FlattenedClassCache;
+
+#define J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, index) (((J9FlattenedClassCacheEntry *)((flattenedClassCache) + 1)) + (index))
+#define J9_VM_FCC_ENTRY_FROM_CLASS(clazz, index) J9_VM_FCC_ENTRY_FROM_FCC((clazz)->flattenedClassCache, index)
 
 struct J9TranslationBufferSet;
 typedef struct J9VerboseStruct {

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6430,7 +6430,7 @@ retry:
 						_sp += (slotsToPop - 1);
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 						if (flags & J9FieldFlagFlattened) {
-							J9FlattenedClassCache *cache = J9OBJECT_CLAZZ(_currentThread, objectref)->flattenedClassCache + valueOffset;
+							J9FlattenedClassCacheEntry *cache = J9_VM_FCC_ENTRY_FROM_CLASS(J9OBJECT_CLAZZ(_currentThread, objectref), valueOffset);
 							J9Class *flattenedFieldClass = cache->clazz;
 							j9object_t newObjectRef = _objectAllocate.inlineAllocateObject(_currentThread, flattenedFieldClass, false, false);
 
@@ -6575,7 +6575,7 @@ resolve:
 				}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (flags & J9FieldFlagFlattened) {
-					J9FlattenedClassCache *cache = J9OBJECT_CLAZZ(_currentThread, objectref)->flattenedClassCache + valueOffset;
+					J9FlattenedClassCacheEntry *cache = J9_VM_FCC_ENTRY_FROM_CLASS(J9OBJECT_CLAZZ(_currentThread, objectref), valueOffset);
 
 					_objectAccessBarrier.copyObjectFields(_currentThread,
 										cache->clazz,
@@ -8388,7 +8388,7 @@ retry:
 				_sp += 2;
 			} else if (J9_ARE_ALL_BITS_SET(flags, J9FieldFlagObject)) {
 				if (J9_ARE_ALL_BITS_SET(flags, J9FieldFlagFlattened)) {
-					J9FlattenedClassCache *cache = objectRefClass->flattenedClassCache + valueOffset;
+					J9FlattenedClassCacheEntry *cache = J9_VM_FCC_ENTRY_FROM_CLASS(objectRefClass, valueOffset);
 					_objectAccessBarrier.copyObjectFields(_currentThread,
 										cache->clazz,
 										*(j9object_t*)_sp,

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -386,6 +386,24 @@ doVerify:
 				if (NULL == initializationLock) {
 					goto done;
 				}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+					PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, initializationLock);
+					/* Preparation is the earliest point where the defaultValue would needed. 
+					* I.e pre-filling static fields. Therefore, the defaultValue must be allocated at 
+					* the end of verification 
+					*/
+					j9object_t defaultValue = vm->memoryManagerFunctions->J9AllocateObject(currentThread, clazz, J9_GC_ALLOCATE_OBJECT_TENURED | J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+					initializationLock = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+					clazz = VM_VMHelpers::currentClass(clazz);
+					if (NULL == defaultValue) {
+						setHeapOutOfMemoryError(currentThread);
+						goto done;
+					}
+					j9object_t *defaultValueAddress = &(clazz->flattenedClassCache->defaultValue);
+					J9STATIC_OBJECT_STORE(currentThread, clazz, defaultValueAddress, defaultValue);
+				}
+#endif
 				if (((UDATA)currentThread | J9ClassInitUnverified) == clazz->initializeStatus) {
 					initializationLock = setInitStatus(currentThread, clazz, J9ClassInitUnprepared, initializationLock);
 					clazz = VM_VMHelpers::currentClass(clazz);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -52,7 +52,7 @@ extern "C" {
 
 #define LOCAL_INTERFACE_ARRAY_SIZE 10
 
-#define DEFAULT_SIZE_OF_CLASS_CACHE 8
+#define DEFAULLT_NUMBER_OF_ENTRIES_IN_FLATTENED_CLASS_CACHE 8
 
 enum J9ClassFragments {
 	RAM_CLASS_HEADER_FRAGMENT,
@@ -1750,7 +1750,7 @@ loadFlattenableFieldValueClasses(J9VMThread *currentThread, J9ClassLoader *class
 						goto done;
 					}
 
-					J9FlattenedClassCache *entry = flattenedClassCache + (flattenableInstanceFieldCount + 1);
+					J9FlattenedClassCacheEntry *entry = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, flattenableInstanceFieldCount);
 					entry->clazz = valueClass;
 					entry->nameAndSignature = &(field->nameAndSignature);
 					entry->offset = 0;
@@ -1775,7 +1775,7 @@ loadFlattenableFieldValueClasses(J9VMThread *currentThread, J9ClassLoader *class
 		}
 		field = romFieldsNextDo(&fieldWalkState);
 	}
-	flattenedClassCache[0].offset = flattenableInstanceFieldCount;
+	flattenedClassCache->numberOfEntries = flattenableInstanceFieldCount;
 
 done:
 	return result;
@@ -2061,7 +2061,6 @@ internalCreateRAMClassFromROMClassImpl(J9VMThread *vmThread, J9ClassLoader *clas
 	UDATA inheritedInterfaceCount = 0;
 	UDATA defaultConflictCount = 0;
 	J9OverrideErrorData errorData = {0};
-
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
 	state->retry = FALSE;
@@ -2403,9 +2402,13 @@ fail:
 
 			/* flattened classes cache */
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			UDATA flattenedClassCacheAllocSize = 0;
+			if (J9_ARE_ALL_BITS_SET(romClass->modifiers, J9AccValueType) || (flattenedClassCache->numberOfEntries > 0)) {
+				flattenedClassCacheAllocSize = sizeof(J9FlattenedClassCache) + (sizeof(J9FlattenedClassCacheEntry) * flattenedClassCache->numberOfEntries);
+			}
 			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].prefixSize = 0;
 			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].alignment = OMR_MAX(sizeof(J9Class *), sizeof(UDATA));
-			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].alignedSize = sizeof(J9FlattenedClassCache) * (flattenedClassCache[0].offset > 0 ? flattenedClassCache[0].offset + 1 : 0);
+			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].alignedSize = flattenedClassCacheAllocSize;
 			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].address = NULL;
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
@@ -2465,8 +2468,8 @@ fail:
 				}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				ramClass->flattenedClassCache = (J9FlattenedClassCache *) allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].address;
-				if (flattenedClassCache[0].offset > 0) {
-					memcpy(ramClass->flattenedClassCache, flattenedClassCache, sizeof(J9FlattenedClassCache) * (flattenedClassCache[0].offset + 1));
+				if (0 != flattenedClassCacheAllocSize) {
+					memcpy(ramClass->flattenedClassCache, flattenedClassCache, flattenedClassCacheAllocSize);
 				}
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 			}
@@ -2920,12 +2923,11 @@ internalCreateRAMClassFromROMClass(J9VMThread *vmThread, J9ClassLoader *classLoa
 	J9ClassLoader* hostClassLoader = classLoader;
 	J9Module* module = NULL;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	UDATA romFieldCount = romClass->romFieldCount;
-	UDATA flattenedClassCacheAllocSize = sizeof(J9FlattenedClassCache) * (romFieldCount + 1);
+	UDATA romFieldCount = romClass->romFieldCount;		
 	UDATA largestFieldType = 0;
-	/* The +1 is for the size field */
-	J9FlattenedClassCache flattenedClassCacheBuffer[DEFAULT_SIZE_OF_CLASS_CACHE + 1] = {0};
-	J9FlattenedClassCache *flattenedClassCache = flattenedClassCacheBuffer;
+	UDATA flattenedClassCacheAllocSize = sizeof(J9FlattenedClassCache) + (sizeof(J9FlattenedClassCacheEntry) * romFieldCount);
+	U_8 flattenedClassCacheBuffer[sizeof(J9FlattenedClassCache) + (sizeof(J9FlattenedClassCacheEntry) * DEFAULLT_NUMBER_OF_ENTRIES_IN_FLATTENED_CLASS_CACHE)] = {0};
+	J9FlattenedClassCache *flattenedClassCache = (J9FlattenedClassCache *) flattenedClassCacheBuffer;
 	PORT_ACCESS_FROM_VMC(vmThread);
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
@@ -3044,7 +3046,7 @@ retry:
 		}
 	}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	if (romFieldCount > DEFAULT_SIZE_OF_CLASS_CACHE) {
+	if (romFieldCount > DEFAULLT_NUMBER_OF_ENTRIES_IN_FLATTENED_CLASS_CACHE) {
 		flattenedClassCache = (J9FlattenedClassCache *) j9mem_allocate_memory(flattenedClassCacheAllocSize, J9MEM_CATEGORY_CLASSES);
 		if (NULL == flattenedClassCache) {
 			setNativeOutOfMemoryError(vmThread, 0, 0);
@@ -3061,7 +3063,7 @@ retry:
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (flattenedClassCache != flattenedClassCacheBuffer) {
+		if (flattenedClassCache != (J9FlattenedClassCache *) flattenedClassCacheBuffer) {
 			j9mem_free_memory(flattenedClassCache);
 		}
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
@@ -3073,7 +3075,7 @@ retry:
 	result = internalCreateRAMClassFromROMClassImpl(vmThread, classLoader, romClass, options, elementClass,
 		methodRemapArray, entryIndex, locationType, classBeingRedefined, packageID, superclass, &state, hostClassLoader, hostClass, module, flattenedClassCache);
 
-		if (flattenedClassCache != flattenedClassCacheBuffer) {
+		if (flattenedClassCache != (J9FlattenedClassCache *) flattenedClassCacheBuffer) {
 			j9mem_free_memory(flattenedClassCache);
 		}
 #else

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -615,13 +615,13 @@ J9Class *
 findJ9ClassInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, U_8 *className, UDATA classNameLength)
 {
 	/* first field indicates the number of classes in the cache */
-	UDATA length = flattenedClassCache->offset;
+	UDATA length = flattenedClassCache->numberOfEntries;
 	J9Class *clazz = NULL;
 
-	for (UDATA i = 1; i <= length; i++) {
-		J9UTF8* currentClassName = J9ROMCLASS_CLASSNAME(flattenedClassCache[i].clazz->romClass);
+	for (UDATA i = 0; i < length; i++) {
+		J9UTF8* currentClassName = J9ROMCLASS_CLASSNAME(J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->clazz->romClass);
 		if (J9UTF8_DATA_EQUALS(J9UTF8_DATA(currentClassName), J9UTF8_LENGTH(currentClassName), className, classNameLength)) {
-			clazz = flattenedClassCache[i].clazz;
+			clazz = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->clazz;
 			break;
 		}
 	}
@@ -634,19 +634,17 @@ UDATA
 findIndexInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, J9ROMNameAndSignature *nameAndSignature)
 {
 	/* first field indicates the number of classes in the cache */
-	UDATA length = flattenedClassCache->offset;
+	UDATA length = flattenedClassCache->numberOfEntries;
 	UDATA index = 0;
 
-	for (UDATA i = 1; i <= length; i++) {
-		if (J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature), J9ROMNAMEANDSIGNATURE_NAME(flattenedClassCache[i].nameAndSignature))
-			&& J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature), J9ROMNAMEANDSIGNATURE_SIGNATURE(flattenedClassCache[i].nameAndSignature))
+	for (UDATA i = 0; i < length; i++) {
+		if (J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature), J9ROMNAMEANDSIGNATURE_NAME(J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->nameAndSignature))
+			&& J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature), J9ROMNAMEANDSIGNATURE_SIGNATURE(J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->nameAndSignature))
 		) {
 			index = i;
 			break;
 		}
 	}
-
-	Assert_VM_true(index != 0);
 	return index;
 }
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -957,12 +957,12 @@ illegalAccess:
 					J9FlattenedClassCache *flattenedClassCache = classFromCP->flattenedClassCache;
 					J9Class *flattenableClass = NULL;
 					UDATA index = findIndexInFlattenedClassCache(flattenedClassCache, nameAndSig);
-					flattenableClass = flattenedClassCache[index].clazz;
+					flattenableClass = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, index)->clazz;
 
 					if (J9_ARE_ALL_BITS_SET(flattenableClass->classFlags, J9ClassIsFlattened)) {
 						modifiers |= J9FieldFlagFlattened;
 
-						flattenedClassCache[index].offset = valueOffset;
+						J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, index)->offset = valueOffset;
 						valueOffset = index;
 
 						/* offset must be written to flattenedClassCache before fieldref is marked as resolved */

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1245,6 +1245,26 @@ public class ValueTypeTests {
 		Object megaObjectRef = createAssorted(makeMegaObjectRef, megaFields);
 		checkFieldAccessMHOfAssortedType(megaGetterAndSetter, megaObjectRef, megaFields, false);
 	}
+	
+	/*
+	 * Create large number of value types and instantiate them 
+	 * 
+	 * value Point2D {
+	 * 	int x;
+	 * 	int y;
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testCreateLargeNumberOfPoint2D() throws Throwable {
+		String fields[] = {"x:I", "y:I"};
+		String className = "Point2D";
+		for(int valueIndex = 0; valueIndex < 200000; valueIndex++){
+			className =  "Point2D" + valueIndex;		
+			point2DClass = ValueTypeGenerator.generateValueClass(className, fields);
+			/* findStatic will trigger class resolution */
+			makePoint2D = lookup.findStatic(point2DClass, "makeValue", MethodType.methodType(point2DClass, int.class, int.class));
+		}
+	}
 
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {
 		try {


### PR DESCRIPTION
    1. Flattenable types can never be NULL.
       If a flattenable type is not flattened,
       it must be pre-filled with the defaultValue.
    2. For all non-array value types, allocate memory for its default value.
    3. Store the default value in the flattened class cache.
    4. Create ValuetypesIterator and update GC scanners to scan for default values
    5. Modifying the structure of flattened Class Cache
    6. Update Allocation Size for flattened Class Cache

Signed-off-by: thomasli <Xinhai.Li@ibm.com>