### PR TITLE
Load GPUAssist.Provider during bootstrap

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/gpu/spi/GPUAssist.java
+++ b/jcl/src/java.base/share/classes/com/ibm/gpu/spi/GPUAssist.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ public interface GPUAssist {
 	interface Provider {
 
 		/**
-		 * Answer a GPUAssist implementation if one is available and enabled\
+		 * Answer a GPUAssist implementation if one is available and enabled
 		 * or null otherwise.
 		 * 
 		 * @return a GPUAssist implementation or null

--- a/jcl/src/java.base/share/classes/com/ibm/gpu/spi/GPUAssistHolder.java
+++ b/jcl/src/java.base/share/classes/com/ibm/gpu/spi/GPUAssistHolder.java
@@ -20,26 +20,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-package java.util;
+package com.ibm.gpu.spi;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import com.ibm.gpu.spi.GPUAssist;
+/**
+ * GPUAssistHolder is an internal class used by java.util.Arrays.
+ */
+public final class GPUAssistHolder {
 
-final class GPUAssistHolder {
-	static final GPUAssist instance = AccessController.doPrivileged((PrivilegedAction<GPUAssist>) GPUAssistHolder::gpuAssist);
+	/**
+	 * The value of this field is updated as necessary by System.completeInitialization().
+	 */
+	public static GPUAssist instance = GPUAssist.NONE;
 
-	private static GPUAssist gpuAssist() {
-		ServiceLoader<GPUAssist.Provider> loaded = ServiceLoader.load(GPUAssist.Provider.class);
-
-		for (GPUAssist.Provider provider : loaded) {
-			GPUAssist assist = provider.getGPUAssist();
-
-			if (assist != null) {
-				return assist;
-			}
-		}
-
-		return GPUAssist.NONE;
-	}
 }


### PR DESCRIPTION
Refactor GPUAssistHolder so the GPUAssist instance can be updated if any of the relevant system properties are set.

This is a replay of #5913 for the 0.14.3 release branch.