### PR TITLE
Refactor per-compilation caches

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9617,12 +9617,6 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
    PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
    TR_DataCache *dataCache = NULL;
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
-   if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
-      {
-      // end of compilation, clear per-compilation caches
-      ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearIProfilerMap();
-      ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearResolvedMethodInfoMap(comp->trMemory());
-      }
 
    if (details.isNewInstanceThunk())
       {


### PR DESCRIPTION
TR::CompilationInfoPerThreadRemote` contains
multiple heap-allocated per-compilation caches.
All of them have similar methods for storing and
retrieving data, which leads to multiple instances
of very similar code.
To make it more generic, implemented template methods
for storing, retrieving and initializing per-compilation
caches. This should make adding caches in
the future easier well.