### PR TITLE
Add compressedrefs modes to jsr335 tests

### DIFF
--- a/test/functional/Jsr335/playlist.xml
+++ b/test/functional/Jsr335/playlist.xml
@@ -56,8 +56,11 @@
 		<testCaseName>jsr335tests</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
+			<variation>Mode600</variation>
 			<variation>Mode101</variation>
+			<variation>Mode601</variation>
 			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 			<variation>Mode301</variation>
 			<variation>Mode501</variation>
 		</variations>

--- a/test/functional/Jsr335/playlist.xml
+++ b/test/functional/Jsr335/playlist.xml
@@ -27,8 +27,11 @@
 		<testCaseName>jsr335tests_SE80</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
+			<variation>Mode600</variation>
 			<variation>Mode101</variation>
+			<variation>Mode601</variation>
 			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 			<variation>Mode301</variation>
 			<variation>Mode501</variation>
 		</variations>


### PR DESCRIPTION
This test is only run in -Xnocompressedrefs modes which are the less common PR test modes.  Enabling this test for -Xcompressedrefs as well.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>