### PR TITLE
Acquiring exclusive in native VM hook

### DIFF
--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -276,6 +276,18 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<struct>J9VMReleaseVMAccessEvent</struct>
 		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
 	</event>
+	
+	<event>
+		<name>J9HOOK_VM_ACQUIRING_EXCLUSIVE_IN_NATIVE</name>
+		<description>
+				Triggered during acquire exclusive thread loop, when encountered a thread in native (which we did not count for exclusive).
+				This hook serves similar purpose as J9HOOK_VM_RELEASEVMACCESS, to ensure that required work for thread in native
+				is performed before exclusive access is obtained. 
+		</description>
+		<struct>J9VMAcquringExclusiveInNativeEvent</struct>
+		<data type="struct J9VMThread*" name="currentThread" description="calling thread" />
+		<data type="struct J9VMThread*" name="targetThread" description="thread in native" />
+	</event>
 
 	<event>
 		<name>J9HOOK_VM_THREAD_CRASH</name>

--- a/runtime/vm/VMAccess.cpp
+++ b/runtime/vm/VMAccess.cpp
@@ -271,6 +271,7 @@ acquireExclusiveVMAccess(J9VMThread * vmThread)
 #endif /* !J9VM_INTERP_TWO_PASS_EXCLUSIVE */
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 				if (currentThread->inNative) {
+					TRIGGER_J9HOOK_VM_ACQUIRING_EXCLUSIVE_IN_NATIVE(vm->hookInterface, vmThread, currentThread);
 #if !defined(J9VM_INTERP_TWO_PASS_EXCLUSIVE)
 					VM_VMAccess::setPublicFlags(currentThread, J9_PUBLIC_FLAGS_NOT_COUNTED_BY_EXCLUSIVE);
 #endif /* !J9VM_INTERP_TWO_PASS_EXCLUSIVE */
@@ -1135,6 +1136,7 @@ acquireSafePointVMAccess(J9VMThread * vmThread)
 #endif /* !J9VM_INTERP_TWO_PASS_EXCLUSIVE */
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 			if (currentThread->inNative) {
+				TRIGGER_J9HOOK_VM_ACQUIRING_EXCLUSIVE_IN_NATIVE(vm->hookInterface, vmThread, currentThread);
 				Assert_VM_false(J9_ARE_ANY_BITS_SET(currentThread->publicFlags, J9_PUBLIC_FLAGS_NOT_AT_SAFE_POINT));
 #if !defined(J9VM_INTERP_TWO_PASS_EXCLUSIVE)
 				VM_VMAccess::setPublicFlags(currentThread, J9_PUBLIC_FLAGS_NOT_COUNTED_BY_SAFE_POINT);


### PR DESCRIPTION
While in acquire exclusive thread loop, and encountered a thread in
native (which we did not count for exclusive), trigger a hook.
This hook serves similar purpose as J9HOOK_VM_RELEASEVMACCESS, to ensure
that required work for the thread in native	is performed before
exclusive access is obtained.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>