### PR TITLE
Fix creation of ResolvedMethods and mirrors for certain special methods

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1114,31 +1114,23 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          break;
       case J9ServerMessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror:
          {
-         auto recv = client->getRecvData<TR_ResolvedJ9Method *, I_32, bool>();
+         auto recv = client->getRecvData<TR_ResolvedJ9Method *, I_32>();
          TR_ResolvedJ9Method *method = std::get<0>(recv);
          int32_t cpIndex = std::get<1>(recv);
-         bool canBeUnresolved = std::get<2>(recv);
          J9Method *ramMethod = NULL;
-         bool unresolved = false, tookBranch = false;
          TR_ResolvedJ9JITaaSServerMethodInfo methodInfo;
-         if (canBeUnresolved)
-            {
-            ramMethod = jitGetJ9MethodUsingIndex(fe->vmThread(), method->cp(), cpIndex);
-            unresolved = true;
-            }
          if (!((fe->_jitConfig->runtimeFlags & J9JIT_RUNTIME_RESOLVE) &&
                !comp->ilGenRequest().details().isMethodHandleThunk() &&
                performTransformation(comp, "Setting as unresolved special call cpIndex=%d\n",cpIndex)))
             {
             TR::VMAccessCriticalSection resolveSpecialMethodRef(fe);
             ramMethod = jitResolveSpecialMethodRef(fe->vmThread(), method->cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
-            tookBranch = true;
 
             if (ramMethod)
                TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) ramMethod, 0, method, fe, trMemory);
             }
          
-         client->write(ramMethod, unresolved, tookBranch, methodInfo);
+         client->write(ramMethod, methodInfo);
          }
          break;
       case J9ServerMessageType::ResolvedMethod_classCPIndexOfMethod:

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -607,17 +607,12 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedSpecialMethod(TR::Compilation * comp
    if (unresolvedInCP)
       *unresolvedInCP = true;
 
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror, _remoteMirror, cpIndex, unresolvedInCP != NULL);
-   auto recv = _stream->read<J9Method *, bool, bool, TR_ResolvedJ9JITaaSServerMethodInfo>();
+   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror, _remoteMirror, cpIndex);
+   auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo>();
    J9Method * ramMethod = std::get<0>(recv);
-   bool unresolved = std::get<1>(recv);
-   bool tookBranch = std::get<2>(recv);
-   auto methodInfo = std::get<3>(recv);
+   auto methodInfo = std::get<1>(recv);
 
-   if (unresolved && unresolvedInCP)
-      *unresolvedInCP = true;
-
-   if (tookBranch && ramMethod)
+   if (ramMethod)
       {
       bool createResolvedMethod = true;
       if (comp->getOption(TR_UseSymbolValidationManager))


### PR DESCRIPTION
This PR contains one fix and one associated cleanup.

Fix remote mirror creation for special methods:
Client side resolved methods should only be created in this case when compile-time resolves are done and succeed.

Clean up JITaaS implementation of `getResolvedSpecialMethod`:
Don't need to pass `tookBranch` and `unresolved` back and forth and clean up some of the associated code paths.

[skip ci]