### PR TITLE
Use getter/setter for warmCodeAlloc/coldCodeAlloc

### DIFF
--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -2757,8 +2757,8 @@ TR_DebugExt::dxPrintCodeCacheInfo(TR::CodeCache *cacheInfo)
       }
    TR::CodeCache *localCacheInfo = (TR::CodeCache*) dxMallocAndRead(sizeof(TR::CodeCache), cacheInfo);
    _dbgPrintf("TR::CodeCache = 0x%p\n", cacheInfo);
-   _dbgPrintf("  ->warmCodeAlloc = (U_8*)0x%p\n", localCacheInfo->_warmCodeAlloc);
-   _dbgPrintf("  ->coldCodeAlloc = (U_8*)0x%p\n", localCacheInfo->_coldCodeAlloc);
+   _dbgPrintf("  ->warmCodeAlloc = (U_8*)0x%p\n", localCacheInfo->getWarmCodeAlloc());
+   _dbgPrintf("  ->coldCodeAlloc = (U_8*)0x%p\n", localCacheInfo->getColdCodeAlloc());
    _dbgPrintf("  ->segment = (TR::CodeCacheMemorySegment*)0x%p\n", localCacheInfo->_segment);
    _dbgPrintf("  ->helperBase = (U_8*)0x%p\n", localCacheInfo->_helperBase);
    _dbgPrintf("  ->helperTop = (U_8*)0x%p\n", localCacheInfo->_helperTop);

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -667,20 +667,20 @@ J9::CodeCache::reserveUnresolvedTrampoline(void *cp, int32_t cpIndex)
 void
 J9::CodeCache::setInitialAllocationPointers()
    {
-   _warmCodeAllocBase = _warmCodeAlloc;
-   _coldCodeAllocBase = _coldCodeAlloc;
+   _warmCodeAllocBase = self()->getWarmCodeAlloc();
+   _coldCodeAllocBase = self()->getColdCodeAlloc();
    }
 
 void
 J9::CodeCache::resetAllocationPointers()
    {
    // Compute how much memory we give back to update the free space in the repository
-   size_t warmSize = _warmCodeAlloc - _warmCodeAllocBase;
-   size_t coldSize = _coldCodeAllocBase - _coldCodeAlloc;
+   size_t warmSize = self()->getWarmCodeAlloc() - _warmCodeAllocBase;
+   size_t coldSize = _coldCodeAllocBase - self()->getColdCodeAlloc();
    size_t freedSpace = warmSize + coldSize;
    _manager->increaseFreeSpaceInCodeCacheRepository(freedSpace);
-   _warmCodeAlloc = _warmCodeAllocBase;
-   _coldCodeAlloc = _coldCodeAllocBase;
+   self()->setWarmCodeAlloc(_warmCodeAllocBase);
+   self()->setColdCodeAlloc(_coldCodeAllocBase);
    }
 
 void


### PR DESCRIPTION
This commit will allow us to change the definition of OMR::CodeCacheBase
without breaking the openj9 code.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>