### PR TITLE
Duplicate supportsTrapsInTMRegion to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -345,6 +345,9 @@ public:
    void setSupportsBigDecimalLongLookasideVersioning() { _flags3.set(SupportsBigDecimalLongLookasideVersioning);}
 
    bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
+   
+   // Java, likely Z
+   bool supportsTrapsInTMRegion() { return true; }
 
    // --------------------------------------------------------------------------
    // GPU

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -114,6 +114,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    bool canGeneratePDBinaryIntrinsic(TR::ILOpCodes opCode, TR::Node * op1PrecNode, TR::Node * op2PrecNode, TR::Node * resultPrecNode);
 
    bool constLoadNeedsLiteralFromPool(TR::Node *node);
+   
+   bool supportsTrapsInTMRegion(){ return TR::Compiler->target.isZOS();}
 
    using J9::CodeGenerator::addAllocatedRegister;
    void addAllocatedRegister(TR_PseudoRegister * temp);


### PR DESCRIPTION
Duplicates all the declarations and definitions of
`supportsTrapsInTMRegion` from `OMR` to `OpenJ9`. Going to remove the field from `OMR` next.

Issue: eclipse/omr#1868
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>