### PR TITLE
Support OpenSSL 1.1.1 up to TLS1_2_VERSION

### DIFF
--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -32,6 +32,19 @@ using namespace google::protobuf::io;
 
 class J9Stream
    {
+public:
+   static bool useSSL(TR::PersistentInfo *info)
+      {
+      return (info->getJITaaSSslKeys().size() || info->getJITaaSSslCerts().size() || info->getJITaaSSslRootCerts().size());
+      }
+
+   static void initSSL()
+      {
+      SSL_load_error_strings();
+      SSL_library_init();
+      OpenSSL_add_ssl_algorithms();
+      }
+
 protected:
    J9Stream()
       : _inputStream(NULL),


### PR DESCRIPTION
With OpenSSL 1.1.1,`TLSv1.3` is automatically selected. With prev 1.1.1,
`TLVs1.2` is selected. The current setup for client and server supports
`TLVs1.2` but not `TLSv1.3`. To work with OpenSSL 1.1.1, add
`SSL_CTX_set_max_proto_version()` to limit the max supported version to
`TLS1_2_VERSION`.
Also refactored the server side code on accepting OpenSSL
connections into its own function to make the code cleaner.

Fixes #5856

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>