### PR TITLE
Spelling build

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -75,7 +75,7 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - `<platform>` is one of the platform shorthands above
     - `<version>` is the number of the supported release, e.g. 8 | 11 | next
 - Note: You can use keyword `all` for platform but not for test level/type or JDK versions.
-- Note: For backward compatability `<level>.<test type>` equal to `sanity` or `extended` is acceptable and will map to `sanity.functional` and `extended.functional` respectively.
+- Note: For backward compatibility `<level>.<test type>` equal to `sanity` or `extended` is acceptable and will map to `sanity.functional` and `extended.functional` respectively.
 
 ###### Examples
 - Request a Compile-only build on all platforms and multiple versions by commenting in a PR

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -553,7 +553,7 @@ def cleanup_artifactory(artifactory_manual_cleanup, job_name, artifactory_server
 
             build job: 'Cleanup_Artifactory', parameters: cleanup_job_params, wait: false
         } catch (any){
-            echo 'The Cleanup_Artifactory job is not availible'
+            echo 'The Cleanup_Artifactory job is not available'
         }
     }
 }

--- a/buildenv/jenkins/jobs/infrastructure/wrapper_job.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/wrapper_job.groovy
@@ -80,7 +80,7 @@ def getAdminList(admin_list_spec){
     def all_admin_lists = readYaml file: 'buildenv/jenkins/variables/admin_list.yml'
 
     switch(admin_list_spec) {
-        case 'Extentions':
+        case 'Extensions':
             admin_list.addAll(all_admin_lists.extensions)
             admin_list.addAll(all_admin_lists.openj9)
             admin_list.addAll(all_admin_lists.infra)

--- a/buildenv/jenkins/jobs/infrastructure/wrapper_template
+++ b/buildenv/jenkins/jobs/infrastructure/wrapper_template
@@ -39,9 +39,9 @@ pipelineJob(job_name){
             scm{
                 git{
                     remote{
-                        url(reprository_url)
+                        url(repository_url)
                     }
-                    branch(reprository_branch)
+                    branch(repository_branch)
                     if (extra_git_options){
                         extensions{
                             cloneOption{

--- a/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
+++ b/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
@@ -149,7 +149,7 @@ PullRequest-OpenJDK:
         pull_request_builder:
             trigger_phrase: .*\bjenkins\s+(compile|test)\b.*
             cron: "H/5 * * * *"
-            admin_list: "Extentions"
+            admin_list: "Extensions"
             blacklist: "kenrai123"
             context: "Pull Request - OpenJDK"
             triggered_status: "Job Triggered"
@@ -163,6 +163,6 @@ general:
         PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,x86-64_windows,x86-32_windows,x86-64_mac"
         RESTART_TIMEOUT: "Time allowed to restart a job"
         TIMEOUT_TIME: "Overall build timeout"
-    reprository_url: "https://github.com/eclipse/openj9.git"
-    reprository_branch: "refs/heads/master"
+    repository_url: "https://github.com/eclipse/openj9.git"
+    repository_branch: "refs/heads/master"
     pipeline_script_path: "buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All"

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -52,7 +52,7 @@
  *   VARIABLE_FILE: String - the custom variables file. Uses defaults.yml when no value is provided.
  *   VENDOR_REPO: String - the repository URL of a Git repository that stores a custom variables file
  *   VENDOR_BRANCH: String - the vendor branch to clone from
- *   VENDOR_CREDENTIALS_ID: String - the Jenkis credentials to connect to the vendor Git repository if VENDOR_REPO is a private repository
+ *   VENDOR_CREDENTIALS_ID: String - the Jenkins credentials to connect to the vendor Git repository if VENDOR_REPO is a private repository
  *   SETUP_LABEL: String - the node label(s) to run this job on; could be any node that has Git installed on it
  *   BUILD_NODE_LABELS: String - the labels of a node to compile and build the Eclipse OpenJ9 extensions for OpenJDK
  *   TEST_NODE_LABELS: String - the labels of a node to run tests on

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -397,7 +397,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 	</flag>
 	<flag id="gc_generational">
 		<description>Does the VM use a multi-generational collector</description>
-		<ifRemoved>The VM does NOT use a multi-generatonal collector</ifRemoved>
+		<ifRemoved>The VM does NOT use a multi-generational collector</ifRemoved>
 	</flag>
 	<flag id="gc_heapCardTable">
 		<description>Means that the Java heap has a card table which is used to track modifications during the GC cycle (be it concurrent or incremental).</description>
@@ -408,7 +408,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 	</flag>
 	<flag id="gc_hybridArraylets">
 		<description>Arraylet header has bimodal shape in runtime, separate for contiguous and discontiguous arraylets </description>
-		<ifRemoved>Arraylet header has only one shape (same for contiguous and discontigous arraylets)</ifRemoved>
+		<ifRemoved>Arraylet header has only one shape (same for contiguous and discontiguous arraylets)</ifRemoved>
 		<requires>
 			<require flag="gc_arraylets"/>
 		</requires>
@@ -512,7 +512,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 		<ifRemoved></ifRemoved>
 	</flag>
 	<flag id="gc_nonZeroTLH">
-		<description>Allocator might use special non-zerowed thread local heap for objects</description>
+		<description>Allocator might use special non-zeroed thread local heap for objects</description>
 		<ifRemoved>Allocator uses a general thread local heap for objects</ifRemoved>
 		<requires>
 			<require flag="gc_threadLocalHeap"/>
@@ -619,7 +619,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 		<ifRemoved>The VM build will not be compiled</ifRemoved>
 	</flag>
 	<flag id="graph_copyJ2SEToToronto">
-		<description>Mirror J2SE rebuilds to Toronoto</description>
+		<description>Mirror J2SE rebuilds to Toronto</description>
 		<ifRemoved>Mirroring of J2SE rebuilds to toronto will not be done causing test failures</ifRemoved>
 		<requires>
 			<require flag="build_j2se"/>
@@ -689,7 +689,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 	</flag>
 	<flag id="graph_excludeFloatsanity">
 		<description>Indicates that this spec wishes to not run the floatsanity(g) test in the nightly build.</description>
-		<ifRemoved>The floatsasnity(g) test will be run in the nightly build, if otherwise included.</ifRemoved>
+		<ifRemoved>The floatsanity(g) test will be run in the nightly build, if otherwise included.</ifRemoved>
 	</flag>
 	<flag id="graph_excludeInvtest">
 		<description>Indicates that this spec wishes to not run the invtest in the nightly build.</description>
@@ -870,7 +870,7 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 		</requires>
 	</flag>
 	<flag id="interp_customSpinOptions">
-		<description>Enables support for the "-Xthr:customSpinOptions=" option, which is used to specifiy class-specific spin parameters.</description>
+		<description>Enables support for the "-Xthr:customSpinOptions=" option, which is used to specify class-specific spin parameters.</description>
 		<ifRemoved>Disables support for the "-Xthr:customSpinOptions=" option.</ifRemoved>
 	</flag>
 	<flag id="interp_debugSupport">

--- a/debugtools/DDR_VM/binary_operation_investigation/process_test_suite_output.pl
+++ b/debugtools/DDR_VM/binary_operation_investigation/process_test_suite_output.pl
@@ -68,7 +68,7 @@ END
 		
 		my ($type1,$value1,$operation,$type2,$value2,$result_type,$result1,$result2) = $csv->fields();
 		
-		die "Could't parse $line" unless defined $result2;
+		die "Couldn't parse $line" unless defined $result2;
 		
 		$type1 =~ s/_//g;
 		$type2 =~ s/_//g;

--- a/debugtools/DDR_VM/binary_operation_investigation/process_test_suite_output.pl
+++ b/debugtools/DDR_VM/binary_operation_investigation/process_test_suite_output.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1573,7 +1573,7 @@ ZZ  If resolved offset is greater than 4k
     JH     LDataOOL
 
     L_GPR   r3,eq_codeRef_inDataSnippet(,r14) #DataRef instr location
-ZZ  needsToBeSignExtenedTo8Bytes
+ZZ  needsToBeSignExtendedTo8Bytes
 ifdef([TR_HOST_64BIT],[dnl
     CLI     0(r3),HEX(59)  #check if this is OC_C
     JNZ     LclearD2
@@ -2048,9 +2048,9 @@ ZZ                        # jit-to-jit offset, so we need to
 
     LR_GPR  r14,r0
 ifdef([TR_HOST_64BIT],[dnl
-    STPQ    r2,eq_implementorClass_inInterfaceSnippet(,r14)
+    STPQ    r2,eq_implementerClass_inInterfaceSnippet(,r14)
 ],[dnl
-    STM     r2,r3,eq_implementorClass_inInterfaceSnippet(r14)
+    STM     r2,r3,eq_implementerClass_inInterfaceSnippet(r14)
 ])dnl
 
 ZZ check if this picSite has already been registered,
@@ -2098,7 +2098,7 @@ ifdef([J9ZOS390],[dnl
 
     ST_GPR  J9SP,J9TR_VMThread_sp(r13)
 
-    LA      CARG2,eq_implementorClass_inInterfaceSnippet(r14)
+    LA      CARG2,eq_implementerClass_inInterfaceSnippet(r14)
 
 ZZ make the call
 
@@ -2532,7 +2532,7 @@ ZZ  restore all regs
     CHI_GPR CRINT,1
     JNE     ifCHMLcontinueLookup
 
-LABEL(ifCHMLInovkeIFCPrivate)
+LABEL(ifCHMLInvokeIFCPrivate)
 ZZ  remove low tag and call
     L_GPR   r0,eq_intfMethodIndex_inInterfaceSnippet(r14)
     LR_GPR  r3,r14         # free r14 for RA

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -112,8 +112,8 @@ SETVAL(eq_lastSlotField_inInterfaceSnippet,72)
 SETVAL(eq_firstSlot_inInterfaceSnippet,80)
 
 ZZ For single dynamic slot case
-SETVAL(eq_implementorClass_inInterfaceSnippet,48)
-SETVAL(eq_implementorMethod_inInterfaceSnippet,56)
+SETVAL(eq_implementerClass_inInterfaceSnippet,48)
+SETVAL(eq_implementerMethod_inInterfaceSnippet,56)
 SETVAL(eq_flag_inInterfaceSnippetSingleDynamicSlot,64)
 SETVAL(eq_picreg_inInterfaceSnippetSingleDynamicSlot,65)
 
@@ -139,8 +139,8 @@ SETVAL(eq_lastSlotField_inInterfaceSnippet,36)
 SETVAL(eq_firstSlot_inInterfaceSnippet,40)
 
 ZZ For Single dynamic slot case
-SETVAL(eq_implementorClass_inInterfaceSnippet,24)
-SETVAL(eq_implementorMethod_inInterfaceSnippet,28)
+SETVAL(eq_implementerClass_inInterfaceSnippet,24)
+SETVAL(eq_implementerMethod_inInterfaceSnippet,28)
 SETVAL(eq_flag_inInterfaceSnippetSingleDynamicSlot,32)
 SETVAL(eq_picreg_inInterfaceSnippetSingleDynamicSlot,33)
 

--- a/runtime/jcl/uma/readme.txt
+++ b/runtime/jcl/uma/readme.txt
@@ -18,4 +18,4 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
-This directory contains UMA metedata files that are shared between multiple configurations.
+This directory contains UMA metadata files that are shared between multiple configurations.

--- a/runtime/jcl/uma/readme.txt
+++ b/runtime/jcl/uma/readme.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2009, 2017 IBM Corp. and others
+Copyright (c) 2009, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/vm_lifecycle/CMakeLists.txt
+++ b/runtime/tests/vm_lifecycle/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/vm_lifecycle/CMakeLists.txt
+++ b/runtime/tests/vm_lifecycle/CMakeLists.txt
@@ -20,11 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(vmLifecyleTests
+add_executable(vmLifecycleTests
 	main.c
 )
 
-target_link_libraries(vmLifecyleTests
+target_link_libraries(vmLifecycleTests
 	PRIVATE
 		j9vm_interface
 		j9vm_gc_includes
@@ -43,6 +43,6 @@ target_link_libraries(vmLifecyleTests
 )
 
 install(
-	TARGETS vmLifecyleTests
+	TARGETS vmLifecycleTests
 	RUNTIME DESTINATION ${j9vm_SOURCE_DIR}
 )

--- a/test/TestConfig/openj9Settings.mk
+++ b/test/TestConfig/openj9Settings.mk
@@ -157,7 +157,7 @@ endif
 # convert ascii to ebcdic on zos
 #######################################
 TOEBCDIC_CMD= \
-$(ECHO) $(Q)coverting asciii files to ebcdic$(Q); \
+$(ECHO) $(Q)converting ascii files to ebcdic$(Q); \
 find | grep \\.java$ | while read f; do echo $$f; iconv -f iso8859-1 -t ibm-1047 < $$f > $$f.ebcdic; rm $$f; mv $$f.ebcdic $$f; done; \
 find | grep \\.txt$ | while read f; do echo $$f; iconv -f iso8859-1 -t ibm-1047 < $$f > $$f.ebcdic; rm $$f; mv $$f.ebcdic $$f; done; \
 find | grep \\.mf$ | while read f; do echo $$f; iconv -f iso8859-1 -t ibm-1047 < $$f > $$f.ebcdic; rm $$f; mv $$f.ebcdic $$f; done; \

--- a/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
+++ b/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
@@ -45,7 +45,7 @@ for (my $i = 0; $i < scalar(@ARGV); $i++) {
 }
 
 if (!$failuremkarg) {
-	die "Please specify a vaild file path using --failuremk= option!";
+	die "Please specify a valid file path using --failuremk= option!";
 }
 
 my $failures = resultReporter();

--- a/test/TestConfig/scripts/tools/sysvcleanup.pl
+++ b/test/TestConfig/scripts/tools/sysvcleanup.pl
@@ -108,7 +108,7 @@ foreach $iter (@stdoutvar) {
 		#we expect 3 entries in this row ... the 1st three are kei,id,owner ...
 		#the rest are don't cares ...
 		if (@vals<3) {
-			die("ipcs did not return expected ouput");
+			die("ipcs did not return expected output");
 		}
 
 		my $key = $vals[$keyindex];
@@ -152,7 +152,7 @@ foreach $iter (@stdoutvar) {
 		#we expect 3 entries in this row ... the 1st three are kei,id,owner ...
 		#the rest are don't cares ...
 		if (@vals<3) {
-			die("ipcs did not return expected ouput");
+			die("ipcs did not return expected output");
 		}
 		my $key = $vals[$keyindex];
 		my $id  = $vals[$idindex];

--- a/test/TestConfig/scripts/tools/sysvcleanup.pl
+++ b/test/TestConfig/scripts/tools/sysvcleanup.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 ##############################################################################
-#  Copyright (c) 2016, 2017 IBM Corp. and others
+#  Copyright (c) 2016, 2019 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/VM_Test/SharedClassesSysVTesting/testSC_SysV_Java7_Tests.pl
+++ b/test/functional/VM_Test/SharedClassesSysVTesting/testSC_SysV_Java7_Tests.pl
@@ -356,7 +356,7 @@ sub Test1
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	@semaphoreList = &listSysVSemaphores($osname);
 	$endCount = scalar(@semaphoreList);
@@ -393,7 +393,7 @@ sub Test2
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	@memoryList = &listSysVMemory($osname);
 	$endCount = scalar(@memoryList);
@@ -428,7 +428,7 @@ sub Test3
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 
 	my $semCount = scalar(&listSysVSemaphores($osname));
@@ -443,7 +443,7 @@ sub Test3
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	if  ($semCount != scalar(&listSysVSemaphores($osname))) {
 		print "\tTEST FAIL\n";
@@ -1507,7 +1507,7 @@ sub Test16
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	#$chmodcmd = "chmod ug+w ".$semfile;
 	#`$chmodcmd`;
@@ -1556,7 +1556,7 @@ sub Test17
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	my @memList = &listSysVMemory($osname);
 	my @semList = &listSysVSemaphores($osname);
@@ -1581,7 +1581,7 @@ sub Test17
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	my $cleanupCmd = "rm -f /tmp/javasharedresources/*".$cachename."*";
 	`$cleanupCmd`;
@@ -1626,7 +1626,7 @@ sub Test18
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	#my @stdout = `ipcs`;
 	#print @stdout,"\n";
@@ -1650,7 +1650,7 @@ sub Test18
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	#my @stdout = `ipcs`;
 	#print @stdout,"\n";
@@ -1737,7 +1737,7 @@ sub Test20
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	my @memList = &listSysVMemory($osname);
 	my @semList = &listSysVSemaphores($osname);
@@ -1754,7 +1754,7 @@ sub Test20
 	while (wait() != -1) {
 		$waitedfor = $waitedfor + 1;
 	}
-	printf("\tWe succesfully ran " . $waitedfor . " JVMs with shared classes.\n");
+	printf("\tWe successfully ran " . $waitedfor . " JVMs with shared classes.\n");
 
 	my $cleanupCmd = "rm -f /tmp/javasharedresources/*".$cachename."*";
 	`$cleanupCmd`;
@@ -2015,7 +2015,7 @@ sub listSysVSemaphores
 			#we expect 3 entries in this row ... the 1st three are kei,id,owner ...
 			#the rest are don't cares ...
 			if (@vals<3) {
-				die("ipcs did not return expected ouput");
+				die("ipcs did not return expected output");
 			}
 			my $key = $vals[$keyindex];
 			my $id  = $vals[$idindex];
@@ -2088,7 +2088,7 @@ sub listSysVMemory
 			#we expect 3 entries in this row ... the 1st three are kei,id,owner ...
 			#the rest are don't cares ...
 			if (@vals<3) {
-				die("ipcs did not return expected ouput");
+				die("ipcs did not return expected output");
 			}
 			my $key = $vals[$keyindex];
 			my $id  = $vals[$idindex];

--- a/test/functional/VM_Test/SharedClassesSysVTesting/testSC_SysV_Java7_Tests.pl
+++ b/test/functional/VM_Test/SharedClassesSysVTesting/testSC_SysV_Java7_Tests.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 ##############################################################################
-#  Copyright (c) 2016, 2018 IBM Corp. and others
+#  Copyright (c) 2016, 2019 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/readme.txt
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/readme.txt
@@ -34,7 +34,7 @@ FindStore.BuildInitial
 
 FindStore.StoreExplicit
 	Runs A_Main which will cause classes to be loaded from A.jar B.jar C.Jar and D.jar.
-	The classpath used specifies explcit paths.
+	The classpath used specifies explicit paths.
 	Nothing.jar is added as the 0th element of the classpath. This is used for testing classpath matching later.
 
 FindStore.StoreRelative

--- a/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/readme.txt
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/readme.txt
@@ -1,6 +1,6 @@
 
 #
-# Copyright (c) 2001, 2018 IBM Corp. and others
+# Copyright (c) 2001, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/jvmtitests/README
+++ b/test/functional/cmdLineTests/jvmtitests/README
@@ -80,7 +80,7 @@ Testcase Packages
 			The testSomething() method should return true on success and false on failure.
 
 
-		public String helpSomething() { return "testSomthing does something"; }
+		public String helpSomething() { return "testSomething does something"; }
 
 			The helpSomething() method should return a description of what the test does. The
 			"Something" part of the help method name must match the "Something" part of the
@@ -129,7 +129,7 @@ Adding new testcases
 	   method, the help method MUST start with a 'help' prefix.
 
 	   For ex:
-	      public String helpSomething() { return "testSomthing does something"; }
+	      public String helpSomething() { return "testSomething does something"; }
 
 	  NOTE that a help method is mandatory.
 

--- a/test/functional/cmdLineTests/jvmtitests/README
+++ b/test/functional/cmdLineTests/jvmtitests/README
@@ -1,5 +1,5 @@
 *******************************************************************************
-*  Copyright (c) 2001, 2018 IBM Corp. and others
+*  Copyright (c) 2001, 2019 IBM Corp. and others
 *
 *  This program and the accompanying materials are made available under
 *  the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption10.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption10.bat
@@ -37,7 +37,7 @@ set NAME=*%u
 if exist %TESTSCRIPT%.out (
     %1/java SimpleGrep "JVMSHRC147E Character * not valid for cache name" %TESTSCRIPT%.out 1
 )else (
-    echso %TESTSCRIPT%: TEST FAILED: No file created
+    echo %TESTSCRIPT%: TEST FAILED: No file created
 )    
 
 endlocal

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption10.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption10.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem
-rem Copyright (c) 2004, 2018 IBM Corp. and others
+rem Copyright (c) 2004, 2019 IBM Corp. and others
 rem
 rem This program and the accompanying materials are made available under
 rem the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption12.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption12.bat
@@ -39,7 +39,7 @@ set NAME="=%%u"
 if exist %TESTSCRIPT%.out (
     %1\java SimpleGrep "JVMSHRC147E Character = not valid for cache name" %TESTSCRIPT%.out 1
 )else (
-    echso %TESTSCRIPT%: TEST FAILED: No file created
+    echo %TESTSCRIPT%: TEST FAILED: No file created
 )    
 
 endlocal

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption12.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption12.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem
-rem Copyright (c) 2004, 2018 IBM Corp. and others
+rem Copyright (c) 2004, 2019 IBM Corp. and others
 rem
 rem This program and the accompanying materials are made available under
 rem the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption13.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption13.bat
@@ -36,7 +36,7 @@ set NAME="?%%u"
 if exist %TESTSCRIPT%.out (
     %1\java SimpleGrep "JVMSHRC147E Character ? not valid for cache name" %TESTSCRIPT%.out 1
 )else (
-    echso %TESTSCRIPT%: TEST FAILED: No file created
+    echo %TESTSCRIPT%: TEST FAILED: No file created
 )    
 
 endlocal

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption13.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption13.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem
-rem Copyright (c) 2004, 2018 IBM Corp. and others
+rem Copyright (c) 2004, 2019 IBM Corp. and others
 rem
 rem This program and the accompanying materials are made available under
 rem the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption7.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption7.bat
@@ -38,7 +38,7 @@ set NAME=\\%u
 if exist %TESTSCRIPT%.out (
     %1\java SimpleGrep "JVMSHRC147E Character \ not valid for cache name" %TESTSCRIPT%.out 1
 )else (
-    echso %TESTSCRIPT%: TEST FAILED: No file created
+    echo %TESTSCRIPT%: TEST FAILED: No file created
 )    
 
 endlocal

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption7.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption7.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem
-rem Copyright (c) 2004, 2018 IBM Corp. and others
+rem Copyright (c) 2004, 2019 IBM Corp. and others
 rem
 rem This program and the accompanying materials are made available under
 rem the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
@@ -31,7 +31,7 @@ use strict;
 # greps the word in the dump file and returns true if the number of occurrence
 # of the word matches with the number passed in as arg
 sub words_grep_from_file {
-	my ($dump_file, $grep_word, $num_of_expected_occurences) = @_;
+	my ($dump_file, $grep_word, $num_of_expected_occurrences) = @_;
 	my $counter = 0;
 
 	open(my $in,  "<",  $dump_file)  or die "TEST FAILED. unable to  read $dump_file";
@@ -43,7 +43,7 @@ sub words_grep_from_file {
 	}
 
 	close($in)  or die "TEST FAILED. unable to  close $dump_file";
-	return ( $counter == $num_of_expected_occurences );
+	return ( $counter == $num_of_expected_occurrences );
 }
 
 # removes a file if it exists and if it is not writable


### PR DESCRIPTION
This PR should be changes to:

* build scripts
* documentation (mostly build)
* assembly files (because one is lumped in a build category)

To make my life easier, there are 2 commits:
* one which is the fixes
* and one which is the copyright bumping

For more information, see #5722 

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `f` / `fchurn`. That branch will eventually shrink as I update it to reflect that I've merged a significant portion of its content.

