### PR TITLE
Spelling `a`

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/CIE.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/unwind/CIE.java
@@ -116,24 +116,24 @@ class CIE {
 			cfiStream.read(new byte[remainder], 0, remainder); 
 		}
 
-		private void parseAugmentationData(ImageInputStream cfiStream, String augmenString) throws IOException {
+		private void parseAugmentationData(ImageInputStream cfiStream, String augmentString) throws IOException {
 
-			for( int i = 0; i < augmenString.length(); i++ ) {
-				if( 'z' == augmenString.charAt(i) ) {
-					// Skip this, it just means we have augmenation data. (We know that.)
+			for( int i = 0; i < augmentString.length(); i++ ) {
+				if( 'z' == augmentString.charAt(i) ) {
+					// Skip this, it just means we have augmentation data. (We know that.)
 					continue;
 				}
-				if( 'P' == augmenString.charAt(i) ) {
+				if( 'P' == augmentString.charAt(i) ) {
 					personalityRoutinePointerEncoding = cfiStream.readByte();
 					personalityRoutinePointer = this.unwind.readEncodedPC(cfiStream, personalityRoutinePointerEncoding);
 				}
-				if( 'L' == augmenString.charAt(i) ) {
+				if( 'L' == augmentString.charAt(i) ) {
 					lsdaPointerEncoding = cfiStream.readByte();
 				}
-				if( 'R' == augmenString.charAt(i) ) {
+				if( 'R' == augmentString.charAt(i) ) {
 					fdePointerEncoding = cfiStream.readByte();
 				}
-				if( 'S' == augmenString.charAt(i) ) {
+				if( 'S' == augmentString.charAt(i) ) {
 					signalHandlerFrame = true;
 				}
 			}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/xml/XMLDOMComparator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/xml/XMLDOMComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/xml/XMLDOMComparator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/xml/XMLDOMComparator.java
@@ -169,7 +169,7 @@ public class XMLDOMComparator {
 							return false;		//attribute names don't match
 						}
 						if(!attrJ9DDR.getNodeValue().equals(attrJExtract.getNodeValue())) {
-							messages.add("The atribute " + attrJ9DDR.getNodeName()+ " for node " + nodeName + " does not match : " + attrJ9DDR.getNodeValue() + " != " + attrJExtract.getNodeValue());
+							messages.add("The attribute " + attrJ9DDR.getNodeName()+ " for node " + nodeName + " does not match : " + attrJ9DDR.getNodeValue() + " != " + attrJExtract.getNodeValue());
 							return false;		//attribute values don't match
 						}
 					}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapRegionManager.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapRegionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapRegionManager.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCHeapRegionManager.java
@@ -145,12 +145,12 @@ public class GCHeapRegionManager
 		if(heapAddress.gte(_lowTableEdge) && heapAddress.lt(_highTableEdge)) {
 			result = tableDescriptorForAddress(heapAddress);
 		} else {
-			result = auxillaryDescriptorForAddress(heapAddress);
+			result = auxiliaryDescriptorForAddress(heapAddress);
 		}
 		return result;
 	}
 	
-	public GCHeapRegionDescriptor auxillaryDescriptorForAddress(AbstractPointer heapAddress)
+	public GCHeapRegionDescriptor auxiliaryDescriptorForAddress(AbstractPointer heapAddress)
 	{
 		for(int i = 0; i < _auxRegionCount; i++) {
 			GCHeapRegionDescriptor region = _auxRegionDescriptorList[i];

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AllClassesCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AllClassesCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AllClassesCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AllClassesCommand.java
@@ -144,7 +144,7 @@ public class AllClassesCommand extends Command
 			/* Maximum 3 arguments can be specified as in: 
 			 * 	!allclasses rom ram 0x1000..0x2000 
 			 */
-			out.append("Invalid number of argments" + nl);
+			out.append("Invalid number of arguments" + nl);
 			return false;
 		}
 		switch (args.length) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
@@ -94,7 +94,7 @@ public class ObjectSizeInfo extends Command
 		className = null;
 		includeArrays = true;
 		if (args.length > 2) {
-			out.append("Invalid number of argments" + nl);
+			out.append("Invalid number of arguments" + nl);
 			return false;
 		}
 		for (String a: args) {
@@ -106,7 +106,7 @@ public class ObjectSizeInfo extends Command
 			} else if (!a.startsWith("-")) {
 				className = a;
 			} else {
-				out.append("Invalid argment: " + a);
+				out.append("Invalid argument: " + a);
 			}
 		}
 		return true;

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaVMInitArgsTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaVMInitArgsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaVMInitArgsTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaVMInitArgsTest.java
@@ -51,7 +51,7 @@ public class JavaVMInitArgsTest extends DTFJUnitTest {
 		// TODO: Can probably implement this better or re-use something like DTFJunitTest.invokeMethod()
 		boolean ddrDataUnavailable = false;
 		boolean ddrCorruptData = false;
-		boolean jextractDataUnavailabe = false;
+		boolean jextractDataUnavailable = false;
 		boolean jextractCorruptData = false;
 		
 		try {
@@ -65,12 +65,12 @@ public class JavaVMInitArgsTest extends DTFJUnitTest {
 		try {
 			jextractObjects.add(jextractJavaRuntime.getJavaVMInitArgs());
 		} catch (DataUnavailable e) {
-			jextractDataUnavailabe = true;
+			jextractDataUnavailable = true;
 		} catch (CorruptDataException e) {
 			jextractCorruptData = true;
 		}
 		
-		assertEquals(jextractDataUnavailabe, ddrDataUnavailable);
+		assertEquals(jextractDataUnavailable, ddrDataUnavailable);
 		assertEquals(jextractCorruptData, ddrCorruptData);
 	}
 	

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -130,10 +130,10 @@ public class OpenJ9AttachProvider extends AttachProvider {
 				}
 
 				boolean staleDirectory = true;
-				File advertisment = new File(f, Advertisement.getFilename());
+				File advertisement = new File(f, Advertisement.getFilename());
 				long uid = 0;
-				if (advertisment.exists()) {
-					OpenJ9VirtualMachineDescriptor descriptor = OpenJ9VirtualMachineDescriptor.fromAdvertisement(this, advertisment);
+				if (advertisement.exists()) {
+					OpenJ9VirtualMachineDescriptor descriptor = OpenJ9VirtualMachineDescriptor.fromAdvertisement(this, advertisement);
 					if (null != descriptor) {
 						long pid = descriptor.getProcessId();
 						uid = descriptor.getUid();
@@ -149,7 +149,7 @@ public class OpenJ9AttachProvider extends AttachProvider {
 						 * If getFileOwner fails, the uid will appear to be -1, and non-root users will ignore it.
 						 * CommonDirectory.deleteStaleDirectories() will handle the case of a target directory which does not have an advertisement directory.
 						 */
-						uid = CommonDirectory.getFileOwner(advertisment.getAbsolutePath());
+						uid = CommonDirectory.getFileOwner(advertisement.getAbsolutePath());
 					}
 				}
 

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/FindCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/FindCommand.java
@@ -244,14 +244,14 @@ public class FindCommand extends BaseJdmpviewCommand{
 		if (findAtt.pattern.startsWith("0x")) {
 			findAtt.pattern = findAtt.pattern.substring(2);
 			findAtt.mode = binary;
-			allignBits();
+			alignBits();
 		}
 		else{
 			findAtt.mode = text;
 		}
 	}
 	
-	private void allignBits(){
+	private void alignBits(){
 		int patternLength = findAtt.pattern.length();
 		if (0 != patternLength%2){
 			findAtt.pattern = "0" + findAtt.pattern;

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/FindCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/FindCommand.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/ScrollCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/ScrollCommand.java
@@ -48,15 +48,15 @@ public class ScrollCommand extends BaseJdmpviewCommand{
 			return;
 		}
 		
-		long newMemAddrss = 0;
+		long newMemAddress = 0;
 		if(command.equals("+")) {
-			newMemAddrss = currentMemAddress.longValue() + currentNumBytesToPrint.intValue();
+			newMemAddress = currentMemAddress.longValue() + currentNumBytesToPrint.intValue();
 		}
 		if(command.equals("-")) {
-			newMemAddrss = currentMemAddress.longValue() - currentNumBytesToPrint.intValue();
+			newMemAddress = currentMemAddress.longValue() - currentNumBytesToPrint.intValue();
 		}
-		ctx.getProperties().put(Utils.CURRENT_MEM_ADDRESS, Long.valueOf(newMemAddrss));
-		ctx.execute("hexdump", new String[]{Long.toHexString(newMemAddrss),currentNumBytesToPrint.toString()}, out);
+		ctx.getProperties().put(Utils.CURRENT_MEM_ADDRESS, Long.valueOf(newMemAddress));
+		ctx.execute("hexdump", new String[]{Long.toHexString(newMemAddress),currentNumBytesToPrint.toString()}, out);
 	}
 
 	@Override

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/ScrollCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/ScrollCommand.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceFormat.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceFormat.java
@@ -539,7 +539,7 @@ final public class TraceFormat
 			}
 			if (((fileLength - dataStart) % bufferSize) != 0) {
 				outStream
-						.println("*** TraceFile is truncated, or corrupted, will ignore some incomplete data at the end, but process everything that is avaiable");
+						.println("*** TraceFile is truncated, or corrupted, will ignore some incomplete data at the end, but process everything that is available");
 				traceFileIsTruncatedOrCorrupt = true;
 			}
 			if (numberOfBuffers == 0) {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -736,7 +736,7 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setJitConfigNumericValue, offsetof(J9JITConfig, dataCacheTotalKB), 0, " %d (KB)"},
    {"disableIProfilerClassUnloadThreshold=",      "R<nnn>\tNumber of classes that can be unloaded before we disable the IProfiler",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_disableIProfilerClassUnloadThreshold, 0, "F%d", NOT_IN_SUBSET},
-   {"dltPostponeThreshold=",      "M<nnn>\tNumber of dlt attepts inv. count for a method is seen not advancing",
+   {"dltPostponeThreshold=",      "M<nnn>\tNumber of dlt attempts inv. count for a method is seen not advancing",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_dltPostponeThreshold, 0, "F%d", NOT_IN_SUBSET },
    {"exclude=",           "D<xxx>\tdo not compile methods beginning with xxx", TR::Options::limitOption, 1, 0, "P%s"},
    {"expensiveCompWeight=", "M<nnn>\tweight of a comp request to be considered expensive",

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -795,7 +795,7 @@ public:
    virtual bool               hasTwoWordObjectHeader();
    virtual int32_t *          getReferenceSlotsInClass( TR::Compilation *, TR_OpaqueClassBlock *classPointer);
    virtual void               initializeLocalObjectHeader( TR::Compilation *, TR::Node * allocationNode,  TR::TreeTop * allocationTreeTop);
-   virtual void               initializeLocalArrayHeader ( TR::Compilation *, TR::Node * allocationNode,  TR::TreeTop * allocaitonTreeTop);
+   virtual void               initializeLocalArrayHeader ( TR::Compilation *, TR::Node * allocationNode,  TR::TreeTop * allocationTreeTop);
    virtual TR::TreeTop*        initializeClazzFlagsMonitorFields(TR::Compilation*, TR::TreeTop* prevTree, TR::Node* allocationNode, TR::Node* classNode, J9Class* ramClass);
 
    bool shouldPerformEDO(TR::Block *catchBlock,  TR::Compilation * comp);

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -2366,7 +2366,7 @@ J9::Node::chkOpsSkipCopyOnStore()
 bool
 J9::Node::skipCopyOnStore()
    {
-   TR_ASSERT(self()->chkOpsSkipCopyOnStore(), "flag only valid for BCD or aggregrate store ops\n");
+   TR_ASSERT(self()->chkOpsSkipCopyOnStore(), "flag only valid for BCD or aggregate store ops\n");
    if (self()->chkOpsSkipCopyOnStore())
       return _flags.testAny(SkipCopyOnStore);
    else
@@ -2377,7 +2377,7 @@ void
 J9::Node::setSkipCopyOnStore(bool v)
    {
    TR::Compilation *c = TR::comp();
-   TR_ASSERT(self()->chkOpsSkipCopyOnStore(), "flag only valid for BCD or aggregrate store ops\n");
+   TR_ASSERT(self()->chkOpsSkipCopyOnStore(), "flag only valid for BCD or aggregate store ops\n");
    if (self()->chkOpsSkipCopyOnStore() &&
        performNodeTransformation2(c, "O^O NODE FLAGS: Setting skipCopyOnStore flag on node %p to %d\n", self(), v))
       {
@@ -2448,7 +2448,7 @@ J9::Node::chkOpsUseStoreAsAnAccumulator()
 bool
 J9::Node::useStoreAsAnAccumulator()
    {
-   TR_ASSERT(self()->chkOpsUseStoreAsAnAccumulator(), "flag only valid for BCD or aggregrate store ops\n");
+   TR_ASSERT(self()->chkOpsUseStoreAsAnAccumulator(), "flag only valid for BCD or aggregate store ops\n");
    if (self()->chkOpsUseStoreAsAnAccumulator())
       return _flags.testAny(UseStoreAsAnAccumulator);
    else
@@ -2459,7 +2459,7 @@ void
 J9::Node::setUseStoreAsAnAccumulator(bool v)
    {
    TR::Compilation *c = TR::comp();
-   TR_ASSERT(self()->chkOpsUseStoreAsAnAccumulator(), "flag only valid for BCD or aggregrate store ops\n");
+   TR_ASSERT(self()->chkOpsUseStoreAsAnAccumulator(), "flag only valid for BCD or aggregate store ops\n");
    if (self()->chkOpsUseStoreAsAnAccumulator() &&
        performNodeTransformation2(c, "O^O NODE FLAGS: Setting UseStoreAsAnAccumulator flag on node %p to %d\n", self(), v))
       {

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -747,17 +747,17 @@ void TR::PPCJNILinkage::releaseVMAccessAtomicFree(TR::Node* callNode, TR::Regist
    generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::Op_cmpli, callNode, cr0Reg, tempReg1, J9_PUBLIC_FLAGS_VM_ACCESS);
 
    TR::SymbolReference *jitReleaseVMAccessSymRef = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getJittedMethodSymbol());
-   TR::LabelSymbol *releaseVMAcessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitReleaseVMAccessSymRef);
-   if (!releaseVMAcessSnippetLabel)
+   TR::LabelSymbol *releaseVMAccessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitReleaseVMAccessSymRef);
+   if (!releaseVMAccessSnippetLabel)
       {
-      releaseVMAcessSnippetLabel = generateLabelSymbol(cg());
-      cg()->addSnippet(new (trHeapMemory()) TR::PPCHelperCallSnippet(cg(), callNode, releaseVMAcessSnippetLabel, jitReleaseVMAccessSymRef));
+      releaseVMAccessSnippetLabel = generateLabelSymbol(cg());
+      cg()->addSnippet(new (trHeapMemory()) TR::PPCHelperCallSnippet(cg(), callNode, releaseVMAccessSnippetLabel, jitReleaseVMAccessSymRef));
       }
 
    if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
-      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, PPCOpProp_BranchUnlikely, callNode, releaseVMAcessSnippetLabel, cr0Reg);
+      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, PPCOpProp_BranchUnlikely, callNode, releaseVMAccessSnippetLabel, cr0Reg);
    else
-      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, callNode, releaseVMAcessSnippetLabel, cr0Reg);
+      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, callNode, releaseVMAccessSnippetLabel, cr0Reg);
    }
 
 void TR::PPCJNILinkage::acquireVMAccessAtomicFree(TR::Node* callNode, TR::RegisterDependencyConditions* deps, TR::RealRegister* metaReg, TR::Register* cr0Reg, TR::Register* tempReg1, TR::Register* tempReg2)
@@ -774,17 +774,17 @@ void TR::PPCJNILinkage::acquireVMAccessAtomicFree(TR::Node* callNode, TR::Regist
    generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::Op_cmpli, callNode, cr0Reg, tempReg1, J9_PUBLIC_FLAGS_VM_ACCESS);
 
    TR::SymbolReference *jitAcquireVMAccessSymRef = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getJittedMethodSymbol());
-   TR::LabelSymbol *acquireVMAcessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitAcquireVMAccessSymRef);
-   if (!acquireVMAcessSnippetLabel)
+   TR::LabelSymbol *acquireVMAccessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitAcquireVMAccessSymRef);
+   if (!acquireVMAccessSnippetLabel)
       {
-      acquireVMAcessSnippetLabel = generateLabelSymbol(cg());
-      cg()->addSnippet(new (trHeapMemory()) TR::PPCHelperCallSnippet(cg(), callNode, acquireVMAcessSnippetLabel, jitAcquireVMAccessSymRef));
+      acquireVMAccessSnippetLabel = generateLabelSymbol(cg());
+      cg()->addSnippet(new (trHeapMemory()) TR::PPCHelperCallSnippet(cg(), callNode, acquireVMAccessSnippetLabel, jitAcquireVMAccessSymRef));
       }
 
    if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
-      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, PPCOpProp_BranchUnlikely, callNode, acquireVMAcessSnippetLabel, cr0Reg);
+      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, PPCOpProp_BranchUnlikely, callNode, acquireVMAccessSnippetLabel, cr0Reg);
    else
-      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, callNode, acquireVMAcessSnippetLabel, cr0Reg);
+      generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, callNode, acquireVMAccessSnippetLabel, cr0Reg);
    }
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1246,7 +1246,7 @@ TR_RelocationRecordConstantPoolWithIndex::getAbstractMethodFromCP(TR_RelocationR
    J9Method *method = NULL;
 
       {
-      TR::VMAccessCriticalSection getAbstractlMethodFromCP(reloRuntime->fej9());
+      TR::VMAccessCriticalSection getAbstractMethodFromCP(reloRuntime->fej9());
       abstractClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(reloRuntime->currentThread(),
                                                                                             cp,
                                                                                             romMethodRef->classRefCPIndex,

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12200,8 +12200,8 @@ J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node, TR::CodeGener
    auto minus1 = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, MINUS1), cg);
    cursor = generateRegMemInstruction(MOVDQURegMem, node, xmmRegMinus1, minus1, cg); iComment("-1");
 
-   auto ascciUpperBnd = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
-   cursor = generateRegMemInstruction(MOVDQURegMem, node, xmmRegAsciiUpperBnd, ascciUpperBnd, cg); iComment("maximum ascii value ");
+   auto asciiUpperBnd = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
+   cursor = generateRegMemInstruction(MOVDQURegMem, node, xmmRegAsciiUpperBnd, asciiUpperBnd, cg); iComment("maximum ascii value ");
 
    generateRegImmInstruction(MOV4RegImm4, node, result, 1, cg);
 

--- a/runtime/compiler/z/codegen/S390Register.cpp
+++ b/runtime/compiler/z/codegen/S390Register.cpp
@@ -908,7 +908,7 @@ void TR_PseudoRegister::addRangeOfZeroDigits(int32_t startDigit, int32_t endDigi
    if (rangeStart <= leftAlignedZeroDigits && rangeEnd > leftAlignedZeroDigits)
       {
       if (comp()->cg()->traceBCDCodeGen())
-         traceMsg(comp(),"\t\tsetting leftAlignedZeroDigits to %d (leftAlignedZeroDigits %d + (rangeEnd %d - leftAlignedZeroDigits %d) because new range overlaps or is adjancent to current zero range\n",
+         traceMsg(comp(),"\t\tsetting leftAlignedZeroDigits to %d (leftAlignedZeroDigits %d + (rangeEnd %d - leftAlignedZeroDigits %d) because new range overlaps or is adjacent to current zero range\n",
             leftAlignedZeroDigits+(rangeEnd-leftAlignedZeroDigits),leftAlignedZeroDigits,rangeEnd,leftAlignedZeroDigits);
       setLeftAlignedZeroDigits(leftAlignedZeroDigits+(rangeEnd-leftAlignedZeroDigits));
       }

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -388,7 +388,7 @@ MM_MetronomeDelegate::incrementalCollect(MM_EnvironmentRealtime *env)
 }
 
 void
-MM_MetronomeDelegate::doAuxilaryGCWork(MM_EnvironmentBase *env)
+MM_MetronomeDelegate::doAuxiliaryGCWork(MM_EnvironmentBase *env)
 {
 #if defined(J9VM_GC_FINALIZATION)
 	if(isFinalizationRequired()) {

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -90,7 +90,7 @@ public:
 	void masterCleanupAfterGC(MM_EnvironmentBase *env);
 	void incrementalCollectStart(MM_EnvironmentRealtime *env);
 	void incrementalCollect(MM_EnvironmentRealtime *env);
-	void doAuxilaryGCWork(MM_EnvironmentBase *env);
+	void doAuxiliaryGCWork(MM_EnvironmentBase *env);
 	void clearGCStats();
 	void clearGCStatsEnvironment(MM_EnvironmentRealtime *env);
 	void mergeGCStats(MM_EnvironmentRealtime *env);

--- a/runtime/gc_realtime/RealtimeGC.cpp
+++ b/runtime/gc_realtime/RealtimeGC.cpp
@@ -287,9 +287,9 @@ MM_RealtimeGC::verbose(MM_EnvironmentBase *env) {
  * @note only called by master thread.
  */
 void
-MM_RealtimeGC::doAuxilaryGCWork(MM_EnvironmentBase *env)
+MM_RealtimeGC::doAuxiliaryGCWork(MM_EnvironmentBase *env)
 {
-	_realtimeDelegate.doAuxilaryGCWork(env);
+	_realtimeDelegate.doAuxiliaryGCWork(env);
 	
 	/* Restart the caches for all threads. */
 	GC_OMRVMThreadListIterator vmThreadListIterator(_vm);
@@ -347,7 +347,7 @@ MM_RealtimeGC::incrementalCollect(MM_EnvironmentRealtime *env)
 	_sched->run(env, &sweepTask);
 	reportSweepEnd(env);
 
-	doAuxilaryGCWork(env);
+	doAuxiliaryGCWork(env);
 
 	/* Get all components to clean up after themselves at the end of a collect */
 	masterCleanupAfterGC(env);

--- a/runtime/gc_realtime/RealtimeGC.hpp
+++ b/runtime/gc_realtime/RealtimeGC.hpp
@@ -109,7 +109,7 @@ protected:
 public:
 	void masterSetupForGC(MM_EnvironmentBase *env);
 	void masterCleanupAfterGC(MM_EnvironmentBase *env);
-	void doAuxilaryGCWork(MM_EnvironmentBase *env); /* Wake up finalizer thread. Discard segments freed by class unloading. */
+	void doAuxiliaryGCWork(MM_EnvironmentBase *env); /* Wake up finalizer thread. Discard segments freed by class unloading. */
 	void incrementalCollect(MM_EnvironmentRealtime *env);
 
 	virtual void *createSweepPoolState(MM_EnvironmentBase *env, MM_MemoryPool *memoryPool)

--- a/runtime/gc_trace/TgcExclusiveaccess.cpp
+++ b/runtime/gc_trace/TgcExclusiveaccess.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/gc_trace/TgcExclusiveaccess.cpp
+++ b/runtime/gc_trace/TgcExclusiveaccess.cpp
@@ -44,13 +44,13 @@ printExclusiveAccessTimes(J9VMThread *vmThread)
 
 	U_64 exlusiveAccessTime = j9time_hires_delta(0, env->getExclusiveAccessTime(), J9PORT_TIME_DELTA_IN_MICROSECONDS);
 	/* Note that these values were not being calculated in the GC and have been returning 0 for some time. */
-	U_64 preAquireExclusiveTime = (U_64)0;
-	U_64 postAquireExclusiveTime = (U_64)0;
+	U_64 preAcquireExclusiveTime = (U_64)0;
+	U_64 postAcquireExclusiveTime = (U_64)0;
 
 	tgcExtensions->printf("ExclusiveAccess Time(ms): total=\"%llu.%03.3llu\", preAcquire=\"%llu.%03.3llu\", postAcquire=\"%llu.%03.3llu\"\n",
 		exlusiveAccessTime /1000, exlusiveAccessTime % 1000,
-		preAquireExclusiveTime /1000, preAquireExclusiveTime % 1000,
-		postAquireExclusiveTime /1000, postAquireExclusiveTime % 1000);
+		preAcquireExclusiveTime /1000, preAcquireExclusiveTime % 1000,
+		postAcquireExclusiveTime /1000, postAcquireExclusiveTime % 1000);
 }
 
 /**

--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -2540,12 +2540,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock() call to j9shsem_wait has failed with error %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock() call to j9shsem_wait has failed with error %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC reported the following error '%s'
@@ -2873,13 +2873,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock() call to j9shsem_wait on semid %d has failed with error %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock() call to j9shsem_wait on semid %d has failed with error %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Enables the storage of class debug information in the shared class.
@@ -5462,7 +5462,7 @@ J9NLS_SHRC_OSCACHE_HANDLE_ERROR_ACTION_DESTROYSM_ERROR_V1.user_response=Contact 
 
 J9NLS_SHRC_OSCACHE_STARTUP_NONFATAL_TRY_READONLY=Error recovery: attempting to use shared cache in readonly mode if the shared memory region exists, in response to "-Xshareclasses:nonfatal" option.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_OSCACHE_STARTUP_NONFATAL_TRY_READONLY.explanation=An error occurred in shared class processing. Presence of "-Xshareclasses:nonfatal" option causes JVM to attemp to use shared cache in readonly mode.
+J9NLS_SHRC_OSCACHE_STARTUP_NONFATAL_TRY_READONLY.explanation=An error occurred in shared class processing. Presence of "-Xshareclasses:nonfatal" option causes JVM to attempt to use shared cache in readonly mode.
 J9NLS_SHRC_OSCACHE_STARTUP_NONFATAL_TRY_READONLY.system_action=The JVM attempts to attach to the shared memory segment of the shared class cache in the readonly mode if it exists.
 J9NLS_SHRC_OSCACHE_STARTUP_NONFATAL_TRY_READONLY.user_response=No action required.
 # END NON-TRANSLATABLE
@@ -5742,7 +5742,7 @@ J9NLS_SHRC_ERROR_SNAPSHOT_FILE_LOCK.user_response=Previous error messages may in
 J9NLS_SHRC_SHRINIT_ERROR_ENTER_MUTEX=Failed to acquire the mutex of cache \"%s\"
 # START NON-TRANSLATABLE
 J9NLS_SHRC_SHRINIT_ERROR_ENTER_MUTEX.sample_input_1=myCaches
-J9NLS_SHRC_SHRINIT_ERROR_ENTER_MUTEX.explanation=An error occurred while aqcuiring a cache mutex.
+J9NLS_SHRC_SHRINIT_ERROR_ENTER_MUTEX.explanation=An error occurred while acquiring a cache mutex.
 J9NLS_SHRC_SHRINIT_ERROR_ENTER_MUTEX.system_action=The JVM fails to complete the operation of creating the snapshot of a non-persistent shared cache.
 J9NLS_SHRC_SHRINIT_ERROR_ENTER_MUTEX.user_response=Verify that the system has enough native resources for the JVM to work properly. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
@@ -6101,7 +6101,7 @@ J9NLS_SHRC_CM_PARSE_METHOD_SPECS_ERROR.user_response=Correct the format of the m
 
 J9NLS_SHRC_CM_FAILED_ENTER_WRITE_MUTEX=Failed to get the cache write mutex
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CM_FAILED_ENTER_WRITE_MUTEX.explanation=An error has occurred in acquring the write mutex of the cache.
+J9NLS_SHRC_CM_FAILED_ENTER_WRITE_MUTEX.explanation=An error has occurred in acquiring the write mutex of the cache.
 J9NLS_SHRC_CM_FAILED_ENTER_WRITE_MUTEX.system_action=The JVM failed to perform the required operation on the AOT methods.
 J9NLS_SHRC_CM_FAILED_ENTER_WRITE_MUTEX.user_response=Verify that the system has enough native resources for the JVM to work properly. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE

--- a/runtime/nls/shrc/j9shr_ca.nls
+++ b/runtime/nls/shrc/j9shr_ca.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_ca.nls
+++ b/runtime/nls/shrc/j9shr_ca.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=La crida de SH_OSCachesysv::acquireWriteLock() a j9shsem_wait ha fallat amb l'error %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=La crida de SH_OSCachesysv::acquireWriteLock() a j9shsem_wait ha fallat amb l'error %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC ha notificat l'error seg\u00fcent '%s'.
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=La crida de SH_OSCachesysv::acquireWriteLock() a j9shsem_wait al semid %d ha fallat amb l'error %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=La crida de SH_OSCachesysv::acquireWriteLock() a j9shsem_wait al semid %d ha fallat amb l'error %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Habilita l'emmagatzematge d'informaci\u00f3 de depuraci\u00f3 de classes a la classe compartida.

--- a/runtime/nls/shrc/j9shr_cs.nls
+++ b/runtime/nls/shrc/j9shr_cs.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_cs.nls
+++ b/runtime/nls/shrc/j9shr_cs.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Vol\u00e1n\u00ed funkce SH_OSCachesysv::acquireWriteLock() pro semafor j9shsem_wait se nezda\u0159ilo, do\u0161lo k chyb\u011b %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Vol\u00e1n\u00ed funkce SH_OSCachesysv::acquireWriteLock() pro semafor j9shsem_wait se nezda\u0159ilo, do\u0161lo k chyb\u011b %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=Komunikace IPC syst\u00e9mu System V ohl\u00e1sila n\u00e1sleduj\u00edc\u00ed chybu: '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Vol\u00e1n\u00ed funkce SH_OSCachesysv::acquireWriteLock() pro semafor j9shsem_wait a ID semid %d se nezda\u0159ilo, do\u0161lo k chyb\u011b %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Vol\u00e1n\u00ed funkce SH_OSCachesysv::acquireWriteLock() pro semafor j9shsem_wait a ID semid %d se nezda\u0159ilo, do\u0161lo k chyb\u011b %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Povol\u00ed ukl\u00e1d\u00e1n\u00ed informac\u00ed o lad\u011bn\u00ed t\u0159\u00edd ve sd\u00edlen\u00e9 t\u0159\u00edd\u011b.

--- a/runtime/nls/shrc/j9shr_de.nls
+++ b/runtime/nls/shrc/j9shr_de.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_de.nls
+++ b/runtime/nls/shrc/j9shr_de.nls
@@ -2547,12 +2547,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock()-Aufruf an "j9shsem_wait" ist mit Fehler %d fehlgeschlagen.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock()-Aufruf an "j9shsem_wait" ist mit Fehler %d fehlgeschlagen.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC hat den folgenden Fehler "%s" zur\u00fcckgemeldet.
@@ -2880,13 +2880,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock()-Aufruf an "j9shsem_wait" auf Semaphor-ID %d ist mit Fehler %d fehlgeschlagen.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=SH_OSCachesysv::acquireWriteLock()-Aufruf an "j9shsem_wait" auf Semaphor-ID %d ist mit Fehler %d fehlgeschlagen.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Aktiviert die Speicherung von Klassendebuginformationen in der gemeinsam genutzten Klasse.

--- a/runtime/nls/shrc/j9shr_es.nls
+++ b/runtime/nls/shrc/j9shr_es.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_es.nls
+++ b/runtime/nls/shrc/j9shr_es.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=La llamada SH_OSCachesysv::acquireWriteLock() a j9shsem_wait ha fallado con el error %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=La llamada SH_OSCachesysv::acquireWriteLock() a j9shsem_wait ha fallado con el error %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=IPC de System V ha informado del siguiente error '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=La llamada SH_OSCachesysv::acquireWriteLock() a j9shsem_wait en semid %d ha fallado con el error %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=La llamada SH_OSCachesysv::acquireWriteLock() a j9shsem_wait en semid %d ha fallado con el error %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Permite el almacenamiento de informaci\u00f3n de depuraci\u00f3n de clases en la clase compartida.

--- a/runtime/nls/shrc/j9shr_fr.nls
+++ b/runtime/nls/shrc/j9shr_fr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_fr.nls
+++ b/runtime/nls/shrc/j9shr_fr.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Echec de l'appel de SH_OSCachesysv::acquireWriteLock() \u00e0 j9shsem_wait avec l'erreur %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Echec de l'appel de SH_OSCachesysv::acquireWriteLock() \u00e0 j9shsem_wait avec l'erreur %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC a signal\u00e9 l'erreur '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Echec de l'appel de SH_OSCachesysv::acquireWriteLock() \u00e0 j9shsem_wait sur semid %d avec l'erreur %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Echec de l'appel de SH_OSCachesysv::acquireWriteLock() \u00e0 j9shsem_wait sur semid %d avec l'erreur %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Active le stockage des informations de d\u00e9bogage de classe dans la classe partag\u00e9e.

--- a/runtime/nls/shrc/j9shr_hu.nls
+++ b/runtime/nls/shrc/j9shr_hu.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_hu.nls
+++ b/runtime/nls/shrc/j9shr_hu.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Az SH_OSCachesysv::acquireWriteLock() h\u00edv\u00e1s a j9shsem_wait fel\u00e9 %d hib\u00e1val meghi\u00fasult.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Az SH_OSCachesysv::acquireWriteLock() h\u00edv\u00e1s a j9shsem_wait fel\u00e9 %d hib\u00e1val meghi\u00fasult.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=A System V IPC a k\u00f6vetkez\u0151 hib\u00e1t jelentette: '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Az SH_OSCachesysv::acquireWriteLock() h\u00edv\u00e1s a j9shsem_wait fel\u00e9 a(z) %d szemaforazonos\u00edt\u00f3n %d hib\u00e1val meghi\u00fasult.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Az SH_OSCachesysv::acquireWriteLock() h\u00edv\u00e1s a j9shsem_wait fel\u00e9 a(z) %d szemaforazonos\u00edt\u00f3n %d hib\u00e1val meghi\u00fasult.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Lehet\u0151v\u00e9 teszi oszt\u00e1ly hibakeres\u00e9si inform\u00e1ci\u00f3k t\u00e1rol\u00e1s\u00e1t a megosztott oszt\u00e1lyban.

--- a/runtime/nls/shrc/j9shr_it.nls
+++ b/runtime/nls/shrc/j9shr_it.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_it.nls
+++ b/runtime/nls/shrc/j9shr_it.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Chiamata SH_OSCachesysv::acquireWriteLock() a j9shsem_wait non riuscita con l'errore 8%d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Chiamata SH_OSCachesysv::acquireWriteLock() a j9shsem_wait non riuscita con l'errore 8%d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=l'IPC System V ha segnalato il seguente errore '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Chiamata SH_OSCachesysv::acquireWriteLock() a j9shsem_wait su semid %d non riuscita con l'errore 8%d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Chiamata SH_OSCachesysv::acquireWriteLock() a j9shsem_wait su semid %d non riuscita con l'errore 8%d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Abilita la memorizzazione delle informazioni di debug classe nella classe condivisa.

--- a/runtime/nls/shrc/j9shr_ja.nls
+++ b/runtime/nls/shrc/j9shr_ja.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_ja.nls
+++ b/runtime/nls/shrc/j9shr_ja.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait \u3078\u306e SH_OSCachesysv::acquireWriteLock() \u547c\u3073\u51fa\u3057\u304c\u30a8\u30e9\u30fc %d \u3067\u5931\u6557\u3057\u307e\u3057\u305f\u3002
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait \u3078\u306e SH_OSCachesysv::acquireWriteLock() \u547c\u3073\u51fa\u3057\u304c\u30a8\u30e9\u30fc %d \u3067\u5931\u6557\u3057\u307e\u3057\u305f\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC \u304c\u6b21\u306e\u30a8\u30e9\u30fc\u3092\u5831\u544a\u3057\u307e\u3057\u305f: '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=semid %d \u3067 j9shsem_wait \u3078\u306e SH_OSCachesysv::acquireWriteLock() \u547c\u3073\u51fa\u3057\u304c\u30a8\u30e9\u30fc %d \u3067\u5931\u6557\u3057\u307e\u3057\u305f\u3002
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=semid %d \u3067 j9shsem_wait \u3078\u306e SH_OSCachesysv::acquireWriteLock() \u547c\u3073\u51fa\u3057\u304c\u30a8\u30e9\u30fc %d \u3067\u5931\u6557\u3057\u307e\u3057\u305f\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=\u5171\u7528\u30af\u30e9\u30b9\u3067\u30af\u30e9\u30b9\u30fb\u30c7\u30d0\u30c3\u30b0\u60c5\u5831\u306e\u4fdd\u7ba1\u3092\u6709\u52b9\u306b\u3057\u307e\u3059\u3002

--- a/runtime/nls/shrc/j9shr_ko.nls
+++ b/runtime/nls/shrc/j9shr_ko.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_ko.nls
+++ b/runtime/nls/shrc/j9shr_ko.nls
@@ -2545,12 +2545,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait\uc5d0 \ub300\ud55c SH_OSCachesysv::acquireWriteLock() \ud638\ucd9c\uc774 %d \uc624\ub958\ub85c \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait\uc5d0 \ub300\ud55c SH_OSCachesysv::acquireWriteLock() \ud638\ucd9c\uc774 %d \uc624\ub958\ub85c \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC\uac00 '%s' \uc624\ub958\ub97c \ubcf4\uace0\ud588\uc2b5\ub2c8\ub2e4.
@@ -2878,13 +2878,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=semid %d\uc758 j9shsem_wait\uc5d0 \ub300\ud55c SH_OSCachesysv::acquireWriteLock() \ud638\ucd9c\uc774 %d \uc624\ub958\ub85c \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=semid %d\uc758 j9shsem_wait\uc5d0 \ub300\ud55c SH_OSCachesysv::acquireWriteLock() \ud638\ucd9c\uc774 %d \uc624\ub958\ub85c \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=\uacf5\uc720 \ud074\ub798\uc2a4\uc5d0 \ud074\ub798\uc2a4 \ub514\ubc84\uadf8 \uc815\ubcf4 \uc800\uc7a5\uc774 \uac00\ub2a5\ud569\ub2c8\ub2e4.

--- a/runtime/nls/shrc/j9shr_pl.nls
+++ b/runtime/nls/shrc/j9shr_pl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_pl.nls
+++ b/runtime/nls/shrc/j9shr_pl.nls
@@ -2548,12 +2548,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Niepowodzenie wywo\u0142ania SH_OSCachesysv::acquireWriteLock() do j9shsem_wait. Zosta\u0142 zwr\u00f3cony b\u0142\u0105d %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Niepowodzenie wywo\u0142ania SH_OSCachesysv::acquireWriteLock() do j9shsem_wait. Zosta\u0142 zwr\u00f3cony b\u0142\u0105d %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=Komunikacja IPC System V zg\u0142osi\u0142a nast\u0119puj\u0105cy b\u0142\u0105d '%s'
@@ -2881,13 +2881,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Niepowodzenie wywo\u0142ania SH_OSCachesysv::acquireWriteLock() do j9shsem_wait z ID semafora %d. Zosta\u0142 zwr\u00f3cony b\u0142\u0105d %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Niepowodzenie wywo\u0142ania SH_OSCachesysv::acquireWriteLock() do j9shsem_wait z ID semafora %d. Zosta\u0142 zwr\u00f3cony b\u0142\u0105d %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=W\u0142\u0105cza zapisanie informacji debugowania klasy w klasie wsp\u00f3\u0142u\u017cytkowanej.

--- a/runtime/nls/shrc/j9shr_pt_BR.nls
+++ b/runtime/nls/shrc/j9shr_pt_BR.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_pt_BR.nls
+++ b/runtime/nls/shrc/j9shr_pt_BR.nls
@@ -2549,12 +2549,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=A chamada de SH_OSCachesysv::acquireWriteLock() para j9shsem_wait falhou com o erro %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=A chamada de SH_OSCachesysv::acquireWriteLock() para j9shsem_wait falhou com o erro %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=O IPC do System V relatou o seguinte erro '%s'
@@ -2882,13 +2882,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=A chamada de SH_OSCachesysv::acquireWriteLock() para j9shsem_wait em semid %d falhou com o erro %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=A chamada de SH_OSCachesysv::acquireWriteLock() para j9shsem_wait em semid %d falhou com o erro %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Ativa o armazenamento de informa\u00e7\u00f5es sobre depura\u00e7\u00e3o de classe na classe compartilhada.

--- a/runtime/nls/shrc/j9shr_ru.nls
+++ b/runtime/nls/shrc/j9shr_ru.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_ru.nls
+++ b/runtime/nls/shrc/j9shr_ru.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u0412\u044b\u0437\u043e\u0432 j9shsem_wait \u0432 SH_OSCachesysv::acquireWriteLock() \u043d\u0435 \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d; \u043e\u0448\u0438\u0431\u043a\u0430: %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u0412\u044b\u0437\u043e\u0432 j9shsem_wait \u0432 SH_OSCachesysv::acquireWriteLock() \u043d\u0435 \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d; \u043e\u0448\u0438\u0431\u043a\u0430: %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=\u041e\u0442 System V IPC \u043f\u043e\u043b\u0443\u0447\u0435\u043d\u043e \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435 \u043e \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0435\u0439 \u043e\u0448\u0438\u0431\u043a\u0435: '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u0412 SH_OSCachesysv::acquireWriteLock() \u043d\u0435 \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d \u0432\u044b\u0437\u043e\u0432 j9shsem_wait \u0434\u043b\u044f semid %d; \u043e\u0448\u0438\u0431\u043a\u0430: %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u0412 SH_OSCachesysv::acquireWriteLock() \u043d\u0435 \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d \u0432\u044b\u0437\u043e\u0432 j9shsem_wait \u0434\u043b\u044f semid %d; \u043e\u0448\u0438\u0431\u043a\u0430: %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=\u0420\u0430\u0437\u0440\u0435\u0448\u0430\u0435\u0442 \u0445\u0440\u0430\u043d\u0435\u043d\u0438\u0435 \u043e\u0442\u043b\u0430\u0434\u043e\u0447\u043d\u043e\u0439 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438 \u043a\u043b\u0430\u0441\u0441\u0430 \u0432 \u043e\u0431\u0449\u0435\u043c \u043a\u043b\u0430\u0441\u0441\u0435.

--- a/runtime/nls/shrc/j9shr_sk.nls
+++ b/runtime/nls/shrc/j9shr_sk.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_sk.nls
+++ b/runtime/nls/shrc/j9shr_sk.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Volanie SH_OSCachesysv::acquireWriteLock() pre j9shsem_wait zlyhalo s chybou %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Volanie SH_OSCachesysv::acquireWriteLock() pre j9shsem_wait zlyhalo s chybou %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC nahl\u00e1silo t\u00fato chybu: '%s'
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Volanie SH_OSCachesysv::acquireWriteLock() pre j9shsem_wait v semafore s ID %d zlyhalo s chybou %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Volanie SH_OSCachesysv::acquireWriteLock() pre j9shsem_wait v semafore s ID %d zlyhalo s chybou %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Povol\u00ed ulo\u017eenie inform\u00e1ci\u00ed o laden\u00ed triedy do zdie\u013eanej triedy.

--- a/runtime/nls/shrc/j9shr_sl.nls
+++ b/runtime/nls/shrc/j9shr_sl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_sl.nls
+++ b/runtime/nls/shrc/j9shr_sl.nls
@@ -2544,12 +2544,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Klic SH_OSCachesysv::acquireWriteLock() v j9shsem_wait ni uspel z napako %d.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Klic SH_OSCachesysv::acquireWriteLock() v j9shsem_wait ni uspel z napako %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=IPC sistema System V je javil naslednjo napako '%s'
@@ -2877,13 +2877,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=Klic SH_OSCachesysv::acquireWriteLock() v j9shsem_wait na semid %d ni uspel z napako %d.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=Klic SH_OSCachesysv::acquireWriteLock() v j9shsem_wait na semid %d ni uspel z napako %d.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=Omogo\u010di shrambo informacij o razhro\u0161\u010devanju razreda v razredu v skupni rabi.

--- a/runtime/nls/shrc/j9shr_tr.nls
+++ b/runtime/nls/shrc/j9shr_tr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_tr.nls
+++ b/runtime/nls/shrc/j9shr_tr.nls
@@ -2546,12 +2546,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait'e SH_OSCachesysv::acquireWriteLock() \u00e7a\u011fr\u0131s\u0131 %d hatas\u0131yla ba\u015far\u0131s\u0131z oldu.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait'e SH_OSCachesysv::acquireWriteLock() \u00e7a\u011fr\u0131s\u0131 %d hatas\u0131yla ba\u015far\u0131s\u0131z oldu.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC '%s' hatas\u0131n\u0131 bildirdi
@@ -2879,13 +2879,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait'e (semid %d \u00fczerinde) SH_OSCachesysv::acquireWriteLock() \u00e7a\u011fr\u0131s\u0131 %d hatas\u0131yla ba\u015far\u0131s\u0131z oldu.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=j9shsem_wait'e (semid %d \u00fczerinde) SH_OSCachesysv::acquireWriteLock() \u00e7a\u011fr\u0131s\u0131 %d hatas\u0131yla ba\u015far\u0131s\u0131z oldu.
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=S\u0131n\u0131f hata ay\u0131klama bilgilerinin payla\u015f\u0131lan s\u0131n\u0131fta depolanmas\u0131n\u0131 etkinle\u015ftirir.

--- a/runtime/nls/shrc/j9shr_zh.nls
+++ b/runtime/nls/shrc/j9shr_zh.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_zh.nls
+++ b/runtime/nls/shrc/j9shr_zh.nls
@@ -2554,12 +2554,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5bf9 j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5bf9 j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC \u62a5\u544a\u4ee5\u4e0b\u9519\u8bef\uff1a\u201c%s\u201d
@@ -2887,13 +2887,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5728 semid %d \u4e0a\u5bf9 j9shsem_wait \u8fdb\u884c SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5728 semid %d \u4e0a\u5bf9 j9shsem_wait \u8fdb\u884c SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=\u5df2\u542f\u7528\u5728\u5171\u4eab\u7c7b\u4e2d\u5b58\u50a8\u7c7b\u8c03\u8bd5\u4fe1\u606f\u3002

--- a/runtime/nls/shrc/j9shr_zh_CN.nls
+++ b/runtime/nls/shrc/j9shr_zh_CN.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_zh_CN.nls
+++ b/runtime/nls/shrc/j9shr_zh_CN.nls
@@ -2554,12 +2554,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5bf9 j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5bf9 j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=System V IPC \u62a5\u544a\u4ee5\u4e0b\u9519\u8bef\uff1a\u201c%s\u201d
@@ -2887,13 +2887,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5728 semid %d \u4e0a\u5bf9 j9shsem_wait \u8fdb\u884c SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5728 semid %d \u4e0a\u5bf9 j9shsem_wait \u8fdb\u884c SH_OSCachesysv::acquireWriteLock() \u8c03\u7528\u5931\u8d25\uff0c\u8fd4\u56de\u9519\u8bef %d\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=\u5df2\u542f\u7528\u5728\u5171\u4eab\u7c7b\u4e2d\u5b58\u50a8\u7c7b\u8c03\u8bd5\u4fe1\u606f\u3002

--- a/runtime/nls/shrc/j9shr_zh_TW.nls
+++ b/runtime/nls/shrc/j9shr_zh_TW.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/nls/shrc/j9shr_zh_TW.nls
+++ b/runtime/nls/shrc/j9shr_zh_TW.nls
@@ -2552,12 +2552,12 @@ J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.system_action=Th
 J9NLS_SHRC_OSCACHE_ERROR_INIT_SEMAPHORE_POST_SEM_USERLOCK_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5c0d j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u547c\u53eb\u5931\u6557\uff0c\u932f\u8aa4\u70ba %d\u3002
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5c0d j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u547c\u53eb\u5931\u6557\uff0c\u932f\u8aa4\u70ba %d\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SYSVIPC_ERROR=\u7cfb\u7d71 V IPC \u5831\u544a\u4e0b\u5217\u932f\u8aa4 '%s'
@@ -2885,13 +2885,13 @@ J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.system_action=The JVM terminates, unless y
 J9NLS_SHRC_SHRINIT_API_CREATE_FAILURE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5c0d semid %d \u4e0a j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u547c\u53eb\u5931\u6557\uff0c\u932f\u8aa4\u70ba %d\u3002
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX=\u5c0d semid %d \u4e0a j9shsem_wait \u7684 SH_OSCachesysv::acquireWriteLock() \u547c\u53eb\u5931\u6557\uff0c\u932f\u8aa4\u70ba %d\u3002
 # START NON-TRANSLATABLE
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
-J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_1=-1
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.sample_input_2=1234
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.explanation=An error occurred waiting on a semaphore.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.system_action=If this error happens during shared class cache startup, the JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes. Otherwise the JVM fails to store data in shared class cache.
+J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX.user_response=Contact your service representative.
 # END NON-TRANSLATABLE
 
 J9NLS_SHRC_SHRINIT_HELPTEXT_STORE_CLASS_DEBUG_DATA=\u555f\u7528\u5171\u7528\u985e\u5225\u4e2d\u7684\u985e\u5225\u9664\u932f\u8cc7\u8a0a\u5132\u5b58\u9ad4\u3002

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5670,7 +5670,7 @@ typedef struct J9CInterpreterStackFrame {
 	 */
 #endif /* J9VM_ENV_DATA64 */
 #else /* J9VM_ARCH_X86 */
-#error Unknown architechture
+#error Unknown architecture
 #endif /* J9VM_ARCH_X86 */
 } J9CInterpreterStackFrame;
 

--- a/runtime/port/common/j9prt.tdf
+++ b/runtime/port/common/j9prt.tdf
@@ -711,7 +711,7 @@ TraceEvent=Trc_PRT_sig_can_protect_J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION_suppor
 
 TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_ex_requested_large_page_outside_available_range Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory_ex requested large pages outside of available range, startAddress=%p, endAddress=%p"
 TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_ex_reverting_to_default_page_size Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory_ex reverting to default page size"
-TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_ex_large_page_request_failed_reverting_to_default_page_size Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory_ex_large_page_request_failed_reverting_to_default_page_size, byteAmout: %u, numPages: %u"
+TraceException=Trc_PRT_vmem_j9vmem_reserve_memory_ex_large_page_request_failed_reverting_to_default_page_size Obsolete Group=j9mem Overhead=1 Level=1 NoEnv Template="j9vmem_reserve_memory_ex_large_page_request_failed_reverting_to_default_page_size, byteAmount: %u, numPages: %u"
 
 TraceException=Trc_PRT_file_open_Exception1 Obsolete Group=j9file Overhead=1 Level=1 NoEnv Template="j9file_open returns failure, filename = %s, flags (%d) are incorrect"
 TraceException=Trc_PRT_file_open_Exception2 Obsolete Group=j9file Overhead=1 Level=1 NoEnv Template="j9file_open returns failure, filename = %s, os errno = %d, portable errno = %d"

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -1204,9 +1204,9 @@ SH_OSCachesysv::acquireWriteLock(UDATA lockID)
 		I_32 myerror = j9error_last_error_number();
 		if ( ((I_32)(myerror | 0xFFFF0000)) != J9PORT_ERROR_SYSV_IPC_ERRNO_EINTR) {
 #if !defined(WIN32)
-			OSC_ERR_TRACE2(J9NLS_SHRC_CC_SYSV_AQUIRE_LOCK_FAILED_ENTER_MUTEX, j9shsem_deprecated_getid(_semhandle), myerror);
+			OSC_ERR_TRACE2(J9NLS_SHRC_CC_SYSV_ACQUIRE_LOCK_FAILED_ENTER_MUTEX, j9shsem_deprecated_getid(_semhandle), myerror);
 #else
-			OSC_ERR_TRACE1(J9NLS_SHRC_CC_AQUIRE_LOCK_FAILED_ENTER_MUTEX, myerror);
+			OSC_ERR_TRACE1(J9NLS_SHRC_CC_ACQUIRE_LOCK_FAILED_ENTER_MUTEX, myerror);
 #endif
 			Trc_SHR_OSC_enterMutex_Exit3(myerror);
 			Trc_SHR_Assert_ShouldNeverHappen();

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1926,7 +1926,7 @@ TraceException=Trc_SHR_API_j9shr_createSharedClass_NoCacheMap_EventObsolete Obso
 TraceEvent=Trc_SHR_API_j9shr_createSharedClass_CalledTwice1_EventObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass : Info: tobj->newItemInCache != NULL"
 TraceEvent=Trc_SHR_API_j9shr_createSharedClass_CalledTwice2_EventObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass : Info: tobj->cacheAreaForAllocate != NULL"
 TraceEvent=Trc_SHR_API_j9shr_createSharedClass_NoAlloc_EventObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass : allocateROMClass : did not allocated required size %d bytes of shared memory for class %.*s"
-TraceEvent=Trc_SHR_API_j9shr_createSharedClass_OK_EventObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass :Successfully allcoated %d bytes for class %.*s at 0x%x"
+TraceEvent=Trc_SHR_API_j9shr_createSharedClass_OK_EventObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass :Successfully allocated %d bytes for class %.*s at 0x%x"
 TraceEvent=Trc_SHR_API_j9shr_createSharedClass_STLock_EventObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass : Info: enterStringTableMutex() failed. localRuntimeFlags=%llx stringTableBytes=%u readOnly=%d localRebuild=%d cacheRebuild=%d classname=%.*s"
 TraceExit=Trc_SHR_API_j9shr_createSharedClass_ExitObsolete Obsolete Overhead=1 Level=1 Template="API j9shr_classStoreTransaction_createSharedClass : exit"
 
@@ -2393,7 +2393,7 @@ TraceExit=Trc_SHR_OSC_Virt_startup_failed_dataLocks_init Obsolete NoEnv Overhead
 TraceEvent=Trc_SHR_OSC_Virt_startup_initialized_dataLocks Obsolete NoEnv Overhead=1 Level=5 Template="Trc_SHR_OSC_Virt_startup_initialized_dataLocks: Initialized the data locks"
 TraceExit=Trc_SHR_OSC_Virt_startup_badAcquireHeaderWriteLock Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Bad header write lock acquire"
 TraceEvent=Trc_SHR_OSC_Virt_startup_goodAcquireHeaderWriteLock Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Successfully acquired header lock"
-TraceEvent=Trc_SHR_OSC_Virt_startup_cacheAlreadyExists Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Cache alread exists"
+TraceEvent=Trc_SHR_OSC_Virt_startup_cacheAlreadyExists Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Cache already exists"
 TraceExit=Trc_SHR_OSC_Virt_startup_badAttach Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Bad attach"
 TraceExit=Trc_SHR_OSC_Virt_startup_cacheNotInitialized Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Uninitialized cache"
 TraceExit=Trc_SHR_OSC_Virt_startup_runningReadOnlyAndWrongLength Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Running read-only, cannot create cache"

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2018 IBM Corp. and others
+// Copyright (c) 2006, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/shared/SCStoreTransactionTests.cpp
+++ b/runtime/tests/shared/SCStoreTransactionTests.cpp
@@ -1842,7 +1842,7 @@ test23(J9JavaVM* vm)
 	}
 	
 	if (FALSE == j9shr_isAddressInCache(vm, romclassmem, sizes.romClassMinimalSize)) {
-		ERRPRINTF("Allcoated memory doesn't appear to be in the cache\n");
+		ERRPRINTF("Allocated memory doesn't appear to be in the cache\n");
 		retval = TEST_ERROR;
 		goto done;
 	}
@@ -1920,7 +1920,7 @@ test24(J9JavaVM* vm)
 	}
 
 	if (FALSE == j9shr_isAddressInCache(vm, romclassmem, sizes.romClassMinimalSize)) {
-		ERRPRINTF("Allcoated memory doesn't appear to be in the cache\n");
+		ERRPRINTF("Allocated memory doesn't appear to be in the cache\n");
 		retval = TEST_ERROR;
 		goto done;
 	}
@@ -2209,7 +2209,7 @@ test29(J9JavaVM* vm)
 		}
 
 		if (FALSE == j9shr_isAddressInCache(vm, romclassmem, sizes.romClassMinimalSize)) {
-			ERRPRINTF("Allcoated memory doesn't appear to be in the cache\n");
+			ERRPRINTF("Allocated memory doesn't appear to be in the cache\n");
 			retval = TEST_ERROR;
 			goto done;
 		}
@@ -2274,7 +2274,7 @@ test29(J9JavaVM* vm)
 		}
 
 		if (FALSE == j9shr_isAddressInCache(vm, romclassmem, sizes.romClassMinimalSize)) {
-			ERRPRINTF("Allcoated memory doesn't appear to be in the cache\n");
+			ERRPRINTF("Allocated memory doesn't appear to be in the cache\n");
 			retval = TEST_ERROR;
 			goto done;
 		}

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/RemoteTestServer.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/RemoteTestServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/RemoteTestServer.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/RemoteTestServer.java
@@ -83,7 +83,7 @@ public class RemoteTestServer {
 
 		memoryExhauster.usePercentageOfHeap(0.8);
 
-		log("Now we have used approximal 80% of current max heap size:  " + aBean.getHeapMemoryUsage().getUsed());
+		log("Now we have used approximately 80% of current max heap size:  " + aBean.getHeapMemoryUsage().getUsed());
 		log("Current committed max heap size is " + aBean.getHeapMemoryUsage().getCommitted());
 
 		//decrease max heap size 1024 bytes to notify SoftRemoteTest that allocation is done

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest.java
@@ -177,7 +177,7 @@ public class SoftmxAdvanceTest {
 
 		/* add a waiting time between performing GC and checking for free physical memory in the OS*/
 		try {
-			logger.debug("Going to sleep for 5 seconds after Agressive GC..");
+			logger.debug("Going to sleep for 5 seconds after Aggressive GC..");
 			Thread.currentThread().sleep(5000);
 		} catch (InterruptedException e) {
 			e.printStackTrace();
@@ -187,7 +187,7 @@ public class SoftmxAdvanceTest {
 		long postMemSize = ibmOSMBean.getFreePhysicalMemorySize();
 
 		logger.debug(
-				"	After resetting softmx and performing an aggresive GC to force heap to shrink, the OS free physical memory size is: "
+				"	After resetting softmx and performing an aggressive GC to force heap to shrink, the OS free physical memory size is: "
 						+ postMemSize + " bytes");
 
 		/*if -Xsoftmx is not present on the command line, -XX option will be ignored, use default setting, which are different on different OS's.

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxLocalTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxLocalTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxLocalTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxLocalTest.java
@@ -195,7 +195,7 @@ public class SoftmxLocalTest{
 			Assert.fail("Catch OutOfMemoryError before reaching 80% of current max heap size.");
 		}
 
-		logger.debug( "	Now we have used approximal 80% of current max heap size: " +  ibmBean.getHeapMemoryUsage().getUsed() + " bytes");
+		logger.debug( "	Now we have used approximately 80% of current max heap size: " +  ibmBean.getHeapMemoryUsage().getUsed() + " bytes");
 
 		long new_max_size = (long) (current_max_size * 0.5);
 		logger.debug("	Reset maximum heap size to 50% of original size: " + new_max_size);

--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxRemoteTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxRemoteTest.java
@@ -205,7 +205,7 @@ public class SoftmxRemoteTest{
 				new OutputStreamWriter(remoteServer.getOutputStream())), true);*/
 
 		logger.debug( "	Current max heap size:  " + ibmBean.getMaxHeapSize() + " bytes");
-		logger.debug(" 	Start Allocating New Object to approximal 80% of current max heap size.");
+		logger.debug(" 	Start Allocating New Object to approximately 80% of current max heap size.");
 
 
 		//RemoteTestServer will decrease max heap size to indicate allocation done, waiting for maximum 2 mins

--- a/test/functional/Java11andUp/src/org/openj9/test/nestmates/ClassGenerator.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/nestmates/ClassGenerator.java
@@ -178,7 +178,7 @@ public class ClassGenerator implements Opcodes {
 		return cw.toByteArray();
 	}
 
-	public static byte[] methodAcccess$InnerDump () throws Exception {
+	public static byte[] methodAccess$InnerDump () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 		

--- a/test/functional/Java11andUp/src/org/openj9/test/nestmates/ClassGenerator.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/nestmates/ClassGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java11andUp/src/org/openj9/test/nestmates/NestAttributeTest.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/nestmates/NestAttributeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java11andUp/src/org/openj9/test/nestmates/NestAttributeTest.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/nestmates/NestAttributeTest.java
@@ -241,7 +241,7 @@ public class NestAttributeTest {
 	static public void testMethodAccessAllowed() throws Exception {
 		CustomClassLoader classloader = new CustomClassLoader();
 		byte[] bytes = ClassGenerator.methodAccessDump();
-		byte[] bytesInner = ClassGenerator.methodAcccess$InnerDump();
+		byte[] bytesInner = ClassGenerator.methodAccess$InnerDump();
 		Class<?> clazz = classloader.getClass("MethodAccess", bytes);
 		Class<?> clazzInner = classloader.getClass("MethodAccess$Inner", bytesInner);
 		Object instance = clazz.getDeclaredConstructor().newInstance();

--- a/test/functional/Java8andUp/src/org/openj9/test/annotation/Test_Annotation.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/annotation/Test_Annotation.java
@@ -1378,14 +1378,14 @@ public class Test_Annotation {
 
 	@Test
 	@TestAnnotation()
-	public void test_method_Enum_arra_getDefaultValue() throws Exception {
+	public void test_method_Enum_array_getDefaultValue() throws Exception {
 		Method method = ValueAnnotation.class.getMethod("enumArrayValue", (Class[])null);
 		myAssert(enumArrayValueDefault, (Enum[])method.getDefaultValue());
 	}
 
 	@Test
 	@TestAnnotation()
-	public void test_method_Class_arra_getDefaultValue() throws Exception {
+	public void test_method_Class_array_getDefaultValue() throws Exception {
 		Method method = ValueAnnotation.class.getMethod("classArrayValue", (Class[])null);
 		myAssert(classArrayValueDefault, (Class[])method.getDefaultValue());
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/annotation/Test_Annotation.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/annotation/Test_Annotation.java
@@ -1,6 +1,6 @@
 package org.openj9.test.annotation;
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corp. and others
+ * Copyright (c) 2010, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
@@ -75,7 +75,7 @@ public class ContendedFieldsTests {
 			}
 		}
 		paddingIncrement = jep142Restricted ? 0 : CACHE_LINE_SIZE;
-		logger.debug("architecture = " + osArch + " reference size = "+REFERENCE_SIZE+" cache line size = " + CACHE_LINE_SIZE+" object aligment="+FieldUtilities.OBJECT_ALIGNMENT+" contended fields "+(jep142Restricted? "": "un")+"restricted");
+		logger.debug("architecture = " + osArch + " reference size = "+REFERENCE_SIZE+" cache line size = " + CACHE_LINE_SIZE+" object alignment="+FieldUtilities.OBJECT_ALIGNMENT+" contended fields "+(jep142Restricted? "": "un")+"restricted");
 		logger.debug("=============================================================================");
 		vmConfigInitialized = true;
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -1102,7 +1102,7 @@ public class Test_String {
 		// assertTrue("Returned array is of different size", buf.length !=
 		// schars.length);
 		for (int i = 0; i < s.length(); i++)
-			AssertJUnit.assertTrue("Returned incorrect char aray", buf[i] == schars[i]);
+			AssertJUnit.assertTrue("Returned incorrect char array", buf[i] == schars[i]);
 	}
 
 	/**

--- a/test/functional/Java8andUp/src/org/openj9/test/regression/Cmvc191564.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/regression/Cmvc191564.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src/org/openj9/test/regression/Cmvc191564.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/regression/Cmvc191564.java
@@ -43,7 +43,7 @@ public class Cmvc191564 {
 		Annotation[] annotations= OtherClass.class.getAnnotations();
 		for (int i =0 ; i < annotations.length; i++){
 			logger.info("Get Annotations:" + annotations[i].toString());
-			AssertJUnit.assertTrue("Wrong Anotation.",annotations[i].toString().contains("ReferencedClass"));
+			AssertJUnit.assertTrue("Wrong Annotation.",annotations[i].toString().contains("ReferencedClass"));
 		}
 				
 	}

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/regression/Cmvc194781.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/regression/Cmvc194781.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/regression/Cmvc194781.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/regression/Cmvc194781.java
@@ -43,7 +43,7 @@ import jdk.internal.misc.Unsafe;
 public class Cmvc194781 {
 
 	@Test
-	public void testFrameIteratorSkipAnnontationForNonBootstrapClass() throws Throwable {
+	public void testFrameIteratorSkipAnnotationForNonBootstrapClass() throws Throwable {
 		final byte[] classBytes = FrameIteratorTestGenerator.dump();
 		
 		Unsafe unsafe = Unsafe.getUnsafe();

--- a/test/functional/Java8andUp/src_80/org/openj9/test/regression/Cmvc194781.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/regression/Cmvc194781.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src_80/org/openj9/test/regression/Cmvc194781.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/regression/Cmvc194781.java
@@ -43,7 +43,7 @@ import sun.misc.Unsafe;
 public class Cmvc194781 {
 
 	@Test
-	public void testFrameIteratorSkipAnnontationForNonBootstrapClass() throws Throwable {
+	public void testFrameIteratorSkipAnnotationForNonBootstrapClass() throws Throwable {
 		final byte[] classBytes = FrameIteratorTestGenerator.dump();
 		
 		/* Use reflect to get Unsafe so we can avoid the 'must be bootstrap' check */

--- a/test/functional/Java8andUp/src_90/org/openj9/test/regression/Cmvc194781.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/regression/Cmvc194781.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Java8andUp/src_90/org/openj9/test/regression/Cmvc194781.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/regression/Cmvc194781.java
@@ -43,7 +43,7 @@ import sun.misc.Unsafe;
 public class Cmvc194781 {
 
 	@Test
-	public void testFrameIteratorSkipAnnontationForNonBootstrapClass() throws Throwable {
+	public void testFrameIteratorSkipAnnotationForNonBootstrapClass() throws Throwable {
 		final byte[] classBytes = FrameIteratorTestGenerator.dump();
 		
 		/* Use reflect to get Unsafe so we can avoid the 'must be bootstrap' check */

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Unreflect.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Unreflect.java
@@ -1228,7 +1228,7 @@ public class LookupAPITests_Unreflect {
 		
 		try {
 			level1InnerClassLookup_crossPackage.unreflect( innerclassMethod_Level2 );
-			System.out.println("IllegalAccessException NOT thrown while attempting to acccess " +
+			System.out.println("IllegalAccessException NOT thrown while attempting to access " +
 					"a protected method inside a level 2 protected inner class in a different package");
 		} catch ( IllegalAccessException e ) {
 			illegalAccessExceptionThrown = true;

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/RestrictReceiverTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/RestrictReceiverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/RestrictReceiverTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/RestrictReceiverTest.java
@@ -105,7 +105,7 @@ public class RestrictReceiverTest {
 				e.printStackTrace();
 			}
 		}
-		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly acces member of class A via findVirtual", pass);
+		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly access member of class A via findVirtual", pass);
 	}
 	
 	/**
@@ -130,7 +130,7 @@ public class RestrictReceiverTest {
 				e.printStackTrace();
 			}
 		}
-		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly acces member of class A via findSpecial", pass);
+		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly access member of class A via findSpecial", pass);
 	}
 	
 	/**
@@ -150,7 +150,7 @@ public class RestrictReceiverTest {
 		} catch (Exception e) {
 			pass = true;// none of the classes have private access for invokespecial in class apackage.A
 		}
-		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly acces member of class A via findSpecial", pass);
+		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly access member of class A via findSpecial", pass);
 	}
 	
 	/**
@@ -173,7 +173,7 @@ public class RestrictReceiverTest {
 				e.printStackTrace();
 			}
 		}
-		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly acces member of class A via bind", pass);
+		AssertJUnit.assertTrue(testInstance.getClass().toString() + "did not properly access member of class A via bind", pass);
 	}
 	
 	/**

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.java
@@ -43,11 +43,11 @@ public class rc019a {
 			}
 			Util.redefineClass(getClass(), rc019_Super.class, rc019_Super.class);
 			System.out.println("After redefine:");
-			String aftetDirect = o.getValue();
+			String afterDirect = o.getValue();
 			String afterJNI = getValue(o);
-			System.out.println("	Direct getValue() = " + aftetDirect);
+			System.out.println("	Direct getValue() = " + afterDirect);
 			System.out.println("	JNI    getValue() = " + afterJNI);
-			if (aftetDirect != afterJNI) {
+			if (afterDirect != afterJNI) {
 				System.out.println("FAIL: values do not match");
 				return false;
 			}

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.java
@@ -37,11 +37,11 @@ public class rc019b {
 			System.out.println("	Direct getValue() = " + direct);
 			Util.redefineClass(getClass(), rc019_Super.class, rc019_Super.class);
 			System.out.println("After redefine:");
-			String aftetDirect = o.getValue();
+			String afterDirect = o.getValue();
 			String afterJNI = getValue(o);
-			System.out.println("	Direct getValue() = " + aftetDirect);
+			System.out.println("	Direct getValue() = " + afterDirect);
 			System.out.println("	JNI    getValue() = " + afterJNI);
-			if (aftetDirect != afterJNI) {
+			if (afterDirect != afterJNI) {
 				System.out.println("FAIL: values do not match");
 				return false;
 			}

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/Animals/Alligator.java
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/Animals/Alligator.java
@@ -23,9 +23,9 @@
 /**
  * @author Matthew Kilner
  */
-public class Aligator implements Utilities.TestClass {
+public class Alligator implements Utilities.TestClass {
 
 	public String getLocation() {
-		return "AnimalsJar";
+		return "Animals";
 	}
 }

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/Animals/Alligator.java
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/Animals/Alligator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/AnimalsJar/Alligator.java
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/AnimalsJar/Alligator.java
@@ -23,9 +23,9 @@
 /**
  * @author Matthew Kilner
  */
-public class Aligator implements Utilities.TestClass {
+public class Alligator implements Utilities.TestClass {
 
 	public String getLocation() {
-		return "Animals";
+		return "AnimalsJar";
 	}
 }

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/AnimalsJar/Alligator.java
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/AnimalsJar/Alligator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
This PR should be changes for word families `a`:

To make my life easier, there are 2 types of commits:
* one which is the fixes
* and one which is the copyright bumping

I've split this family into a bunch of commits, I'm happy to drop any which seem problematic (we can revisit at a later round). I'd encourage reviewing on a commit-by-commit basis as opposed to looking at the flattened PR. (The easiest thing for me to drop is a whole commit.)

For more information, see #5722 

For reference, these [commits](https://github.com/jsoref/openj9/commits/spelling-full) are generated using https://github.com/jsoref/spelling `f` / `fchurn`. That branch will eventually shrink as I update it to reflect that I've merged a significant portion of its content.

