### PR TITLE
Added Python3 to x and p build Dockerfiles

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -239,6 +239,23 @@ RUN cd /usr/src \
   && cd .. \
   && rm -rf /usr/src/curl-7.29.0
 
+# Install Python3 v3.7.3
+RUN yum -y update \
+  && yum -y install \
+    zlib-devel \
+    libffi-devel \
+  && yum clean all \
+  && cd /tmp \
+  && wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz \
+  && tar -xJf Python-3.7.3.tar.xz \
+  && rm -f Python-3.7.3.tar.xz \
+  && cd /tmp/Python-3.7.3 \
+  && ./configure --prefix=/usr/local \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf Python-3.7.3
+
 # Setup a reference repository cache for faster clones in the container
 RUN mkdir /home/${USER}/openjdk_cache \
   && cd /home/${USER}/openjdk_cache \

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -295,6 +295,23 @@ RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
   && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usr-local.conf \
   && ldconfig
 
+# Install Python3 v3.7.3
+RUN yum -y update \
+  && yum -y install \
+    zlib-devel \
+    libffi-devel \
+  && yum clean all \
+  && cd /tmp \
+  && wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz \
+  && tar -xJf Python-3.7.3.tar.xz \
+  && rm -f Python-3.7.3.tar.xz \
+  && cd /tmp/Python-3.7.3 \
+  && ./configure --prefix=/usr/local \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf Python-3.7.3
+
 # Expose SSH port and run SSHD
 EXPOSE 22
 


### PR DESCRIPTION
Installed Python-3.7.3 on x86 centos6.9 and ppc64le centos7 Dockerfiles as it is
required to build OMR. The s390x ubuntu16 Dockerfile already has Python-3.5.2 installed.
[skip ci]

Signed-off-by: Colton Mills <millscolt3@gmail.com>