### PR TITLE
Remove the old version of incRefCountForOpaquePseudoRegister function

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3525,24 +3525,6 @@ J9::Z::CodeGenerator::canGeneratePDBinaryIntrinsic(TR::ILOpCodes opCode, TR::Nod
    }
 
 void
-J9::Z::CodeGenerator::incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp)
-   {
-   if (node->getOpaquePseudoRegister())
-      {
-      TR_OpaquePseudoRegister *reg = node->getOpaquePseudoRegister();
-      TR_StorageReference *ref = reg->getStorageReference();
-      if (ref && ref->isNodeBased() && ref->getNodeReferenceCount() > 0)
-         {
-         if (cg->traceBCDCodeGen())
-            comp->getDebug()->trace("\tnode %s (%p) with storageRef #%d (%s): increment nodeRefCount %d->%d when artificially incrementing ref count\n",
-               node->getOpCode().getName(),node,ref->getReferenceNumber(),comp->getDebug()->getName(ref->getSymbol()),ref->getNodeReferenceCount(),ref->getNodeReferenceCount()+1);
-         ref->incrementNodeReferenceCount();
-         }
-      }
-   }
-
-//AN OVERLOAD OF ABOVE FUNCTION; DOES EXACTLY THE SAME JOB
-void
 J9::Z::CodeGenerator::incRefCountForOpaquePseudoRegister(TR::Node * node)
    {
    if (node->getOpaquePseudoRegister())

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -260,8 +260,6 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    bool inlineCryptoMethod(TR::Node *node, TR::Register *&resultReg);
 #endif
 
-   void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp);
-   //OVERLOAD THE ABOVE FUNCTION
    void incRefCountForOpaquePseudoRegister(TR::Node * node);
 
    /** \brief


### PR DESCRIPTION
As the newer version of function `incRefCountForOpaquePseudoRegister` has
been implemented, this patch removes the old version of the function from OMR.

Issue: eclipse/omr#1855
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>