### PR TITLE
(0.14.3) Explicitly load the jdk.management.agent module

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
@@ -70,31 +70,51 @@ final class Attachment extends Thread implements Response {
 	private static final class MethodRefsHolder {
 		static Method startLocalManagementAgentMethod = null;
 		static Method startRemoteManagementAgentMethod = null;
+		static final Throwable managementAgentMethodThrowable;
 		static {
-			AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-				Class<?> agentClass;
-				Class<?> startRemoteArgumentType;
+			managementAgentMethodThrowable = AccessController.doPrivileged((PrivilegedAction<Throwable>) () -> {
+				String agentClassName = 
+						/*[IF Sidecar19-SE]*/
+						"jdk.internal.agent.Agent"; //$NON-NLS-1$
+						/*[ELSE] Sidecar19-SE
+						"sun.management.Agent"; //$NON-NLS-1$
+						/*[ENDIF] Sidecar19-SE */
+				IPC.logMessage("Loading " + agentClassName); //$NON-NLS-1$
+				Throwable mamtTemp = null;
 				try {
-					/*[IF Sidecar19-SE-OpenJ9]*/
-					agentClass = Class.forName("jdk.internal.agent.Agent"); //$NON-NLS-1$
-					/*[ELSE] Sidecar19-SE-OpenJ9 */
-					agentClass = Class.forName("sun.management.Agent"); //$NON-NLS-1$
-					/*[ENDIF] Sidecar19-SE-OpenJ9 */
-					
-					/*[IF Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9]*/
+					Class<?> agentClass = null;
+					Class<?> startRemoteArgumentType = null;
+					/*[IF Sidecar19-SE]*/
+					String jmaName = "jdk.management.agent"; //$NON-NLS-1$
+					java.lang.Module jmaModule = jdk.internal.module.Modules.loadModule(jmaName);
+					/* this should not happen because loadModule() should throw java.lang.module.FindException */
+					if (null == jmaModule) {
+						throw new ClassNotFoundException("Cannot load " + jmaName); //$NON-NLS-1$
+					}
+					/* This does not throw ClassNotFoundException. */
+					agentClass = Class.forName(jmaModule, agentClassName);
+					if (null == agentClass) {
+						throw new ClassNotFoundException("Cannot load " + agentClassName); //$NON-NLS-1$
+					}
+					/*[ELSE] Sidecar19-SE */
+					agentClass = Class.forName(agentClassName);
+					/*[ENDIF] Sidecar19-SE */
+
+					/*[IF Sidecar19-SE | Sidecar18-SE-OpenJ9]*/
 					startRemoteArgumentType = String.class;
-					/*[ELSE] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+					/*[ELSE] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 					startRemoteArgumentType = Properties.class;
-					/*[ENDIF] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+					/*[ENDIF] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 					startLocalManagementAgentMethod = agentClass.getDeclaredMethod(START_LOCAL_MANAGEMENT_AGENT);
 					startRemoteManagementAgentMethod = agentClass.getDeclaredMethod(START_REMOTE_MANAGEMENT_AGENT, startRemoteArgumentType);
 					startLocalManagementAgentMethod.setAccessible(true);
 					startRemoteManagementAgentMethod.setAccessible(true);
-				} catch (ClassNotFoundException | NoSuchMethodException | SecurityException e) {
-					startLocalManagementAgentMethod = null;
-					startRemoteManagementAgentMethod = null;
+					IPC.logMessage("Loaded " + agentClassName); //$NON-NLS-1$
+				} catch (Throwable e) {
+					IPC.logMessage("Error loading " + agentClassName, e); //$NON-NLS-1$
+					mamtTemp = e;
 				}
-				return null;
+				return mamtTemp;
 			});
 		}
 	}
@@ -222,8 +242,8 @@ final class Attachment extends Thread implements Response {
 					String serviceAddress = startLocalAgent();
 					AttachmentConnection.streamSend(respStream, Response.ATTACH_RESULT + serviceAddress);
 				} catch (IbmAttachOperationFailedException e) {
-					AttachmentConnection.streamSend(respStream, Response.ERROR + " " //$NON-NLS-1$
-							+ EXCEPTION_ATTACH_OPERATION_FAILED_EXCEPTION + " in startLocalManagementAgent:  " + e.getMessage()); //$NON-NLS-1$
+					AttachmentConnection.streamSend(respStream, String.format("%s: %s in startLocalManagementAgent: %s", //$NON-NLS-1$
+							Response.ERROR, EXCEPTION_ATTACH_OPERATION_FAILED_EXCEPTION, e.toString()));
 					return false;
 				}
 			} else if (cmd.startsWith(Command.START_MANAGEMENT_AGENT)) {
@@ -416,13 +436,13 @@ final class Attachment extends Thread implements Response {
 			IPC.logMessage("startAgent"); //$NON-NLS-1$
 			if (null != MethodRefsHolder.startRemoteManagementAgentMethod) {
 				Object startArgument;
-				/*[IF Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9]*/
+				/*[IF Sidecar19-SE | Sidecar18-SE-OpenJ9]*/
 				startArgument = agentProperties.entrySet().stream()
 						.map(entry -> entry.getKey() + "=" + entry.getValue()) //$NON-NLS-1$
 						.collect(java.util.stream.Collectors.joining(",")); //$NON-NLS-1$
-				/*[ELSE] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+				/*[ELSE] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 				startArgument = agentProperties;
-				/*[ENDIF] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
+				/*[ENDIF] Sidecar19-SE | Sidecar18-SE-OpenJ9 */
 				MethodRefsHolder.startRemoteManagementAgentMethod.invoke(null, startArgument);
 				return true;
 			}
@@ -439,19 +459,24 @@ final class Attachment extends Thread implements Response {
 
 	private static String startLocalAgent() throws IbmAttachOperationFailedException {
 		IPC.logMessage("startLocalAgent"); //$NON-NLS-1$
-		try {
-			if (null != MethodRefsHolder.startLocalManagementAgentMethod) {	/* forces initialization */			
+		if (null != MethodRefsHolder.startLocalManagementAgentMethod) { /* forces initialization */
+			try {
 				MethodRefsHolder.startLocalManagementAgentMethod.invoke(null);
-			} else {
-				throw new IbmAttachOperationFailedException("startLocalManagementAgent cannot access " + START_LOCAL_MANAGEMENT_AGENT);		 //$NON-NLS-1$
+			} catch (Throwable exc) {
+				IPC.logMessage("Exception starting management agent:", exc); //$NON-NLS-1$
+				throw new IbmAttachOperationFailedException("startLocalManagementAgent error starting agent", exc); //$NON-NLS-1$
 			}
-		} catch (Throwable e) {
-			throw new IbmAttachOperationFailedException("startLocalManagementAgent error starting agent:" + e.getClass() + " " + e.getMessage());		 //$NON-NLS-1$ //$NON-NLS-2$
+		} else {
+			Throwable exc = MethodRefsHolder.managementAgentMethodThrowable;
+			String msg = "Target VM cannot access " + START_LOCAL_MANAGEMENT_AGENT; //$NON-NLS-1$
+			IPC.logMessage(msg, exc);
+			throw new IbmAttachOperationFailedException(msg, exc);
 		}
 
 		String addr = saveLocalConnectorAddress();
 		if (Objects.isNull(addr)) {
-			throw new IbmAttachOperationFailedException("startLocalManagementAgent: " + LOCAL_CONNECTOR_ADDRESS + " not defined"); //$NON-NLS-1$ //$NON-NLS-2$
+			throw new IbmAttachOperationFailedException(
+					"startLocalManagementAgent: " + LOCAL_CONNECTOR_ADDRESS + " not defined"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return addr;
 	}

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -418,14 +418,16 @@ public class IPC {
 	 * Print the information about a throwable, including the exact class,
 	 * message, and stack trace.
 	 * @param msg User supplied message
-	 * @param thrown throwable
+	 * @param thrown Throwable object or null
 	 * @note nothing is printed if logging is disabled
 	 */
 	public static void logMessage(String msg, Throwable thrown) {
 		synchronized (accessorMutex) {
 			if (isLoggingEnabled()) {
 				printMessageWithHeader(msg, logStream);
-				thrown.printStackTrace(logStream);
+				if (null != thrown) {
+					thrown.printStackTrace(logStream);
+				}
 				logStream.flush();
 			}
 		}

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IbmAttachOperationFailedException.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IbmAttachOperationFailedException.java
@@ -8,7 +8,7 @@ import java.io.IOException;
  */
 @SuppressWarnings("serial")
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,7 @@ public class IbmAttachOperationFailedException extends IOException {
 	public IbmAttachOperationFailedException() {
 		super("IbmAttachOperationFailedException"); //$NON-NLS-1$
 	}
+	
 	/**
 	 * Constructs a new instance of this class with its 
 	 * walkback and message filled in.
@@ -48,4 +49,26 @@ public class IbmAttachOperationFailedException extends IOException {
 	public IbmAttachOperationFailedException(String message) {
 		super(message);
 	}
+
+	/**
+	 * Constructs the exception with a message and a nested Throwable.
+	 * @param message text of the message
+	 * @param cause underlying Throwable
+	 */
+	public IbmAttachOperationFailedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	@Override
+	public String toString() {
+		String result;
+		Throwable myCause = getCause();
+		if (null != myCause) {
+			result = String.format("\"%s\"; Caused by: \"%s\"", super.toString(), myCause.toString()); //$NON-NLS-1$
+		} else {
+			result = super.toString();
+		}
+		return result;
+	}
+	
 }


### PR DESCRIPTION
Runtimes which are `jlink`ed with a subset of modules may not load this module by default.
Clean up some of the error reporting.

This is a replay of #5916 and #5337 for the 0.14.3 release branch.