### PR TITLE
Correct non-null terminated string format in nls default method

### DIFF
--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -939,7 +939,7 @@ defaultMethodConflictExceptionMessage(J9VMThread *currentThread, J9Class *target
 	Assert_VM_true(methodsLength > 1);
 
 	errorMsg = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,
-			J9NLS_VM_DEFAULT_METHOD_CONFLICT_LIST, "conflicting default methods for '%*.s%*.s' in %*.s from classes [%s]");
+			J9NLS_VM_DEFAULT_METHOD_CONFLICT_LIST, "conflicting default methods for '%.*s%.*s' in %.*s from classes [%s]");
 	
 	/* Construct class list string */
 	for (i = 0; i < methodsLength; i++) {


### PR DESCRIPTION
@charliegracie found my bug - ‘*.s’ versus ‘.*s’

This should allow the eclipse/omr#3912 to be re-applied.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>