### PR TITLE
Move thread management information to java.base

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -328,6 +328,12 @@ K0611="not null"
 K0612="CompositeData contains an unexpected threadState value."
 
 K0613="{0} (loaded from {1} by {2}) called from {3} (loaded from {4} by {5})."
+K0614="class cannot be null"
+K0615="name '{0}' does not match pattern '{1}'"
+K0616="name '{0}' must not be a pattern"
+
+K0617="Unexpected exception accessing ThreadInfo constructor"
+K0618="Unexpected exception invoking ThreadInfo constructor"
 
 K0619="Malformated VarHandleDesc, {0} could not be retrieved."
 K0620="This VarHandle operation is not supported by type {0}."

--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -30,6 +30,7 @@ exports com.ibm.sharedclasses.spi to openj9.sharedclasses, java.management, java
 exports com.ibm.oti.vm to java.management, jdk.attach, jdk.management, openj9.jvm, openj9.sharedclasses;
 exports com.ibm.oti.util to java.management, jdk.attach, jdk.jcmd, jdk.management, openj9.sharedclasses;
 exports com.ibm.tools.attach.target to jdk.attach, jdk.jcmd, jdk.management;
+exports openj9.management.internal to java.management;
 exports openj9.tools.attach.diagnostics.spi to jdk.attach, jdk.jcmd;
 exports openj9.tools.attach.diagnostics.base to jdk.attach, jdk.jcmd;
 exports jdk.internal.org.objectweb.asm to openj9.dtfj, openj9.dtfjview;

--- a/jcl/src/java.base/share/classes/openj9/management/internal/LockInfoBase.java
+++ b/jcl/src/java.base/share/classes/openj9/management/internal/LockInfoBase.java
@@ -1,0 +1,80 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package openj9.management.internal;
+
+/**
+ * Container for lock information for use by classes which have access only to the
+ * java.base module.
+ * This is typically wrapped in a LockInfo object.
+ */
+public class LockInfoBase {
+	private final String className;
+	private final int identityHashCode;
+
+	@SuppressWarnings("unused") /* Used only by native code. */
+	private LockInfoBase(Object object) {
+		this(object.getClass().getName(), System.identityHashCode(object));
+	}
+
+	/**
+	 * @param classNameVal        the name (including the package prefix) of the
+	 *                         associated lock object's class
+	 * @param identityHashCodeVal the value of the associated lock object's identity hash code.
+	 * @throws NullPointerException if <code>className</code> is <code>null</code>
+	 */
+	public LockInfoBase(String classNameVal, int identityHashCodeVal) {
+		if (classNameVal == null) {
+			/*[MSG "K0600", "className cannot be null"]*/
+			throw new NullPointerException(com.ibm.oti.util.Msg.getString("K0600")); //$NON-NLS-1$
+		}
+		className = classNameVal;
+		identityHashCode = identityHashCodeVal;
+	}
+
+	/**
+	 * Provides callers with a string value representing the associated lock. The
+	 * string will hold both the name of the lock object's class and its identity
+	 * hash code expressed as an unsigned hexadecimal.
+	 *
+	 * @return a string containing the key details of the lock
+	 */
+	@Override
+	public String toString() {
+		return className + '@' + Integer.toHexString(identityHashCode);
+	}
+
+	/**
+	 * @return class name
+	 */
+	public String getClassName() {
+		return className;
+	}
+
+	/**
+	 * @return lock's identity hash code
+	 */
+	public int getIdentityHashCode() {
+		return identityHashCode;
+	}
+
+}

--- a/jcl/src/java.base/share/classes/openj9/management/internal/MonitorInfoBase.java
+++ b/jcl/src/java.base/share/classes/openj9/management/internal/MonitorInfoBase.java
@@ -1,0 +1,74 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package openj9.management.internal;
+
+/**
+ * Container for monitor information for use by classes which have access only to the
+ * java.base module.
+ * This is typically wrapped in a MonitorInfo object.
+ */
+public class MonitorInfoBase extends LockInfoBase {
+	private final int stackDepth;
+	private final StackTraceElement stackFrame;
+
+	/**
+	 * @param classNameVal name, including the package prefix, of the object's class
+	 * @param identityHashCodeVal object's identity hash code
+	 * @param stackDepthVal the number of frames deep in the stack where the thread locked the monitor
+	 * @param stackFrameVal complete stack frame at which the thread locked the monitor
+	 */
+	public MonitorInfoBase(String classNameVal, int identityHashCodeVal, int stackDepthVal, StackTraceElement stackFrameVal) {
+		super(classNameVal, identityHashCodeVal);
+		if (((stackFrameVal == null) && (stackDepthVal >= 0))
+				|| ((stackFrameVal != null) && (stackDepthVal < 0))) {
+			String arg;
+			if (stackFrameVal == null) {
+				/*[MSG "K0610", "null"]*/
+				arg = com.ibm.oti.util.Msg.getString("K0610"); //$NON-NLS-1$
+			} else {
+				/*[MSG "K0611", "not null"]*/
+				arg = com.ibm.oti.util.Msg.getString("K0611"); //$NON-NLS-1$
+			}
+			/*[MSG "K060F", "Parameter stackDepth is {0} but stackFrame is {1}"]*/
+			throw new IllegalArgumentException(
+					com.ibm.oti.util.Msg.getString("K060F", Integer.valueOf(stackDepthVal), arg)); //$NON-NLS-1$
+		}
+		stackDepth = stackDepthVal;
+		stackFrame = stackFrameVal;
+	}
+
+	/**
+	 * @return depth of the stack frame in which the object was locked
+	 */
+	public int getStackDepth() {
+		return stackDepth;
+	}
+
+	/**
+	 * @return StackTraceElement for the locking frame
+	 */
+	public StackTraceElement getStackFrame() {
+		return stackFrame;
+	}
+
+}

--- a/jcl/src/java.base/share/classes/openj9/management/internal/ThreadInfoBase.java
+++ b/jcl/src/java.base/share/classes/openj9/management/internal/ThreadInfoBase.java
@@ -1,0 +1,390 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package openj9.management.internal;
+
+import java.lang.Thread.State;
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.ibm.oti.util.Util;
+
+/**
+ * Container for thread information for use by classes which have access only to the
+ * java.base module.
+ * This is typically wrapped in a ThreadInfo object.
+ */
+public class ThreadInfoBase {
+
+	private final long threadId;
+	private final long nativeTId;
+	private final String threadName;
+	private final Thread.State threadState;
+	private final boolean suspended;
+	private final boolean inNative;
+	private final long blockedCount;
+	private final long blockedTime;
+	private final long waitedCount;
+	private final long waitedTime;
+	private final String lockName;
+	private final long lockOwnerId;
+	private final String lockOwnerName;
+	private StackTraceElement[] stackTrace = new StackTraceElement[0];
+	private final LockInfoBase blockingLockInfo;
+	private LockInfoBase[] lockedSynchronizers = new LockInfoBase[0];
+	private MonitorInfoBase[] lockedMonitors = new MonitorInfoBase[0];
+	private String cachedToStringResult;
+/*[IF Sidecar19-SE]*/
+	private final boolean daemon;
+	private final int priority;
+/*[ENDIF]*/
+
+	/**
+	 * used by ThreadInfo's constructor only
+	 * @param threadIdVal
+	 * @param threadNameVal
+	 * @param threadStateVal
+	 * @param suspendedVal
+	 * @param inNativeVal
+	 * @param blockedCountVal
+	 * @param blockedTimeVal
+	 * @param waitedCountVal
+	 * @param waitedTimeVal
+	 * @param lockNameVal
+	 * @param lockOwnerIdVal
+	 * @param lockOwnerNameVal
+	 * @param stackTraceVal
+	 * @param lockInfoVal
+	 * @param lockedMonitorsVal
+	 * @param lockedSynchronizersVal
+/*[IF Sidecar19-SE]
+	 * @param daemon
+	 * @param priority
+/*[ENDIF]
+	 */
+	public ThreadInfoBase(long threadIdVal, String threadNameVal, Thread.State threadStateVal, boolean suspendedVal,
+			boolean inNativeVal, long blockedCountVal, long blockedTimeVal, long waitedCountVal, long waitedTimeVal,
+			String lockNameVal, long lockOwnerIdVal, String lockOwnerNameVal, StackTraceElement[] stackTraceVal,
+			LockInfoBase lockInfoVal, MonitorInfoBase[] lockedMonitorsVal, LockInfoBase[] lockedSynchronizersVal
+/*[IF Sidecar19-SE]*/
+			, boolean daemonVal, int priorityVal
+/*[ENDIF]*/
+	) {
+		threadId = threadIdVal;
+		nativeTId = -1;
+		threadName = threadNameVal;
+		threadState = threadStateVal;
+		suspended = suspendedVal;
+		inNative = inNativeVal;
+		blockedCount = blockedCountVal;
+		blockedTime = blockedTimeVal;
+		waitedCount = waitedCountVal;
+		waitedTime = waitedTimeVal;
+		lockName = lockNameVal;
+		lockOwnerId = lockOwnerIdVal;
+		lockOwnerName = lockOwnerNameVal;
+		stackTrace = stackTraceVal;
+		blockingLockInfo = lockInfoVal;
+		lockedMonitors = lockedMonitorsVal;
+		lockedSynchronizers = lockedSynchronizersVal;
+/*[IF Sidecar19-SE]*/
+		daemon = daemonVal;
+		priority = priorityVal;
+/*[ENDIF]*/
+	}
+
+	@SuppressWarnings("unused")
+	/* used by native code */
+	private ThreadInfoBase(Thread thread, long nativeId, int state, boolean isSuspended, boolean isInNative,
+			long blockedCountVal, long blockedTimeVal, long waitedCountVal, long waitedTimeVal, StackTraceElement[] stackTraceVal,
+			Object blockingObject, Thread blockingObjectOwner, MonitorInfoBase[] lockedMonitorsVal,
+			LockInfoBase[] lockedSynchronizersVal) {
+		threadId = thread.getId();
+		nativeTId = nativeId;
+		threadName = thread.getName();
+		/*[IF Sidecar19-SE]*/
+		daemon = thread.isDaemon();
+		priority = thread.getPriority();
+		/*[ENDIF]*/
+
+		// Use the supplied state int to index into the array returned
+		// by values() which should be all thread states in the order
+		// they have been declared. Doing this rather than just issuing a
+		// call to thread.getState() because the Thread state may have
+		// changed after the VM issued the call to this method.
+		threadState = Thread.State.values()[state];
+		suspended = isSuspended;
+		inNative = isInNative;
+		blockedCount = blockedCountVal;
+		blockedTime = blockedTimeVal;
+		waitedCount = waitedCountVal;
+		waitedTime = waitedTimeVal;
+
+		if (blockingObjectOwner != null) {
+			lockOwnerId = blockingObjectOwner.getId();
+			lockOwnerName = blockingObjectOwner.getName();
+		} else {
+			lockOwnerId = -1;
+			lockOwnerName = null;
+		}
+
+		stackTrace = stackTraceVal;
+		lockedMonitors = lockedMonitorsVal;
+		lockedSynchronizers = lockedSynchronizersVal;
+
+		if (blockingObject != null) {
+			blockingLockInfo = new LockInfoBase(blockingObject.getClass().getName(),
+					System.identityHashCode(blockingObject));
+			lockName = blockingLockInfo.toString();
+		} else {
+			blockingLockInfo = null;
+			lockName = null;
+		}
+	}
+
+	/**
+	 * @return a text description of this thread info.
+	 */
+	@Override
+	public String toString() {
+		/* Since ThreadInfoBases are immutable the string value need be calculated only once. */
+		String ls = System.lineSeparator();
+		if (cachedToStringResult == null) {
+			StringBuilder result = new StringBuilder();
+/*[IF Java11]*/
+			result.append(String.format("\"%s\" prio=%d Id=%d %s", //$NON-NLS-1$
+					threadName, Integer.valueOf(priority), Long.valueOf(threadId), threadState));
+/*[ELSE]*/
+			result.append(String.format("\"%s\" Id=%d %s", //$NON-NLS-1$
+					threadName, Long.valueOf(threadId), threadState));
+/*[ENDIF]*/
+			if (State.BLOCKED == threadState) {
+				result.append(String.format(" on %s owned by \"%s\" Id=%d", //$NON-NLS-1$
+						lockName, lockOwnerName, Long.valueOf(lockOwnerId)));
+			}
+			result.append(ls);
+			if ((stackTrace != null) && (stackTrace.length > 0)) {
+				MonitorInfoBase[] lockArray = new MonitorInfoBase[stackTrace.length];
+				for (MonitorInfoBase mi : lockedMonitors) {
+					lockArray[mi.getStackDepth()] = mi;
+				}
+				int stackDepth = 0;
+				for (StackTraceElement element : stackTrace) {
+					result.append("\tat "); //$NON-NLS-1$
+					Util.printStackTraceElement(element, null, result, true);
+					result.append(ls);
+					MonitorInfoBase mi = lockArray[stackDepth];
+					if (null != mi) {
+						result.append(String.format("\t- locked %s%n", //$NON-NLS-1$
+								mi.toString()));
+					}
+					stackDepth += 1;
+				}
+			}
+			cachedToStringResult = result.toString();
+		}
+		return cachedToStringResult;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		boolean result = false;
+		if (obj instanceof ThreadInfoBase) {
+			// Safe to cast if the instanceof test passed.
+			ThreadInfoBase ti = (ThreadInfoBase) obj;
+			result =
+					(ti.threadId == threadId)
+					&& (ti.blockedCount == blockedCount)
+					&& (ti.blockedTime == blockedTime)
+					&& (ti.lockOwnerId == lockOwnerId)
+					&& (ti.waitedCount == waitedCount)
+					&& (ti.waitedTime == waitedTime)
+					&& (ti.inNative == inNative)
+					&& (ti.suspended == suspended)
+					/*[IF Sidecar19-SE]*/
+					&& (ti.daemon == daemon)
+					&& (ti.priority == priority)
+					/*[ENDIF]*/
+					&& ti.threadName.equals(threadName)
+					&& ti.threadState.equals(threadState)
+					&& Objects.equals(ti.lockName, lockName)
+					&& Objects.equals(ti.lockOwnerName , lockOwnerName)
+					&& Objects.equals(ti.blockingLockInfo, blockingLockInfo)
+					&& Arrays.equals(ti.stackTrace, stackTrace);
+		}
+		return result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		return (Long.toString(blockedCount) + blockedTime + lockName + lockOwnerId
+				+ lockOwnerName + stackTrace.length + threadId + threadName
+				+ threadState + waitedCount + waitedTime + inNative
+				+ suspended
+/*[IF Sidecar19-SE]*/
+				+ daemon + priority
+/*[ENDIF]*/
+		).hashCode();
+	}
+
+	/**
+	 * @return thread ID
+	 */
+	public long getThreadId() {
+		return threadId;
+	}
+
+	/**
+	 * @return native thread ID
+	 */
+	public long getNativeTId() {
+		return nativeTId;
+	}
+
+	/**
+	 * @return thread name
+	 */
+	public String getThreadName() {
+		return threadName;
+	}
+
+	/**
+	 * @return thread state
+	 */
+	public Thread.State getThreadState() {
+		return threadState;
+	}
+
+	/**
+	 * @return true if thread is suspended
+	 */
+	public boolean isSuspended() {
+		return suspended;
+	}
+
+	/**
+	 * @return true if in native code 
+	 */
+	public boolean isInNative() {
+		return inNative;
+	}
+
+	/**
+	 * @return number of times the thread has tried to enter a locked monitor
+	 */
+	public long getBlockedCount() {
+		return blockedCount;
+	}
+
+	/**
+	 * @return time spent waiting to enter a monitor, in milliseconds
+	 */
+	public long getBlockedTime() {
+		return blockedTime;
+	}
+
+	/**
+	 * @return number of times the thread has stopped for notification
+	 */
+	public long getWaitedCount() {
+		return waitedCount;
+	}
+
+	/**
+	 * @return time spent waiting for notification
+	 */
+	public long getWaitedTime() {
+		return waitedTime;
+	}
+
+	/**
+	 * @return name of the object on which the thread is blocked
+	 */
+	public String getLockName() {
+		return lockName;
+	}
+
+	/**
+	 * @return ID of thread owning the object on which the thread is blocked
+	 */
+	public long getLockOwnerId() {
+		return lockOwnerId;
+	}
+
+	/**
+	 * @return name of thread owning the object on which the thread is blocked
+	 */
+	public String getLockOwnerName() {
+		return lockOwnerName;
+	}
+
+	/**
+	 * @return stack trace for this thread
+	 */
+	public StackTraceElement[] getStackTrace() {
+		return stackTrace;
+	}
+
+	/**
+	 * @return information on the object on which the thread is blocked
+	 */
+	public LockInfoBase getBlockingLockInfo() {
+		return blockingLockInfo;
+	}
+
+	/**
+	 * @return information on ownable synchronizers locked by this thread
+	 */
+	public LockInfoBase[] getLockedSynchronizers() {
+		return lockedSynchronizers;
+	}
+
+	/**
+	 * @return information on monitors locked by this thread
+	 */
+	public MonitorInfoBase[] getLockedMonitors() {
+		return lockedMonitors;
+	}
+	/*[IF Sidecar19-SE]*/
+
+	/**
+	 * @return true if this is a daemon thread
+	 */
+	public boolean isDaemon() {
+		return daemon;
+	}
+
+	/**
+	 * @return priority of this thread
+	 */
+	public int getPriority() {
+		return priority;
+	}
+	/*[ENDIF]*/
+}

--- a/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2018 IBM Corp. and others
+ * Copyright (c) 2008, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,8 @@ import javax.management.openmbean.CompositeData;
 
 import com.ibm.java.lang.management.internal.ManagementUtils;
 
+import openj9.management.internal.LockInfoBase;
+
 /**
  * This class represents information about locked objects.
  *
@@ -33,16 +35,10 @@ import com.ibm.java.lang.management.internal.ManagementUtils;
  */
 public class LockInfo {
 
-	private final String className;
-
-	private final int identityHashCode;
-
-	/*[IF]*/
-	@SuppressWarnings("unused") /* Used only by native code. */
-	/*[ENDIF]*/
-	private LockInfo(Object object) {
-		this(object.getClass().getName(), System.identityHashCode(object));
-	}
+	/**
+	 * Container for the actual data from the native method
+	 */
+	private final LockInfoBase baseInfo;
 
 	/**
 	 * Creates a new <code>LockInfo</code> instance.
@@ -59,13 +55,15 @@ public class LockInfo {
 	 *             if <code>className</code> is <code>null</code>
 	 */
 	public LockInfo(String className, int identityHashCode) {
-		super();
-		if (className == null) {
-			/*[MSG "K0600", "className cannot be null"]*/
-			throw new NullPointerException(com.ibm.oti.util.Msg.getString("K0600")); //$NON-NLS-1$
-		}
-		this.className = className;
-		this.identityHashCode = identityHashCode;
+		baseInfo = new LockInfoBase(className, identityHashCode);
+	}
+
+	/**
+	 * Constructor for use by subclasses
+	 * @param base base data
+	 */
+	LockInfo(LockInfoBase base) {
+		baseInfo = base;
 	}
 
 	/**
@@ -75,7 +73,7 @@ public class LockInfo {
 	 * @return the associated lock object's class name
 	 */
 	public String getClassName() {
-		return className;
+		return baseInfo.getClassName();
 	}
 
 	/**
@@ -84,7 +82,7 @@ public class LockInfo {
 	 * @return the identity hash code of the lock object
 	 */
 	public int getIdentityHashCode() {
-		return identityHashCode;
+		return baseInfo.getIdentityHashCode();
 	}
 
 	/**
@@ -153,11 +151,11 @@ public class LockInfo {
 	 */
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		sb.append(className);
-		sb.append('@');
-		sb.append(Integer.toHexString(identityHashCode));
-		return sb.toString();
+		return baseInfo.toString();
+	}
+
+	LockInfoBase getBaseInfo() {
+		return baseInfo;
 	}
 
 }

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -22,7 +22,6 @@
  *******************************************************************************/
 package java.lang.management;
 
-import java.lang.Thread.State;
 import java.util.Arrays;
 import java.util.StringTokenizer;
 
@@ -34,7 +33,10 @@ import com.ibm.java.lang.management.internal.ManagementAccessControl;
 import com.ibm.java.lang.management.internal.MonitorInfoUtil;
 import com.ibm.java.lang.management.internal.StackTraceElementUtil;
 import com.ibm.java.lang.management.internal.ThreadInfoUtil;
-import com.ibm.oti.util.Util;
+
+import openj9.management.internal.LockInfoBase;
+import openj9.management.internal.MonitorInfoBase;
+import openj9.management.internal.ThreadInfoBase;
 
 /**
  * Information about a snapshot of the state of a thread.
@@ -43,56 +45,22 @@ import com.ibm.oti.util.Util;
  */
 public class ThreadInfo {
 
+	private static final MonitorInfo[] EMPTY_MONITORINFO_ARRAY = new MonitorInfo[0];
+
 	/* Set up access to ThreadInfo shared secret.*/
 	static {
 		ManagementAccessControl.setThreadInfoAccess(new ThreadInfoAccessImpl());
 	}
-
-	private long threadId;
-
-	private long nativeTId;
-
-	private String threadName;
-
-	private Thread.State threadState;
-
-	private boolean suspended;
-
-	private boolean inNative;
-
-	private long blockedCount;
-
-	private long blockedTime;
-
-	private long waitedCount;
-
-	private long waitedTime;
-
-	private String lockName;
-
-	private long lockOwnerId = -1;
-
-	private String lockOwnerName;
-
-	private StackTraceElement[] stackTraces = new StackTraceElement[0];
-
-	private LockInfo lockInfo;
-
-	private LockInfo[] lockedSynchronizers = new LockInfo[0];
-
-	private MonitorInfo[] lockedMonitors = new MonitorInfo[0];
-
-	private String TOSTRING_VALUE;
-
-	/*[IF Sidecar19-SE]*/
-	private boolean daemon;
-
-	private int priority;
-	/*[ENDIF]*/
 	
 	/**
-	 * Creates a new <code>ThreadInfo</code> instance.
-	 * 
+	 * Container for the actual data.
+	 */
+	private final ThreadInfoBase baseInfo;
+	private static final LockInfo[] EMPTY_LOCKINFO_ARRAY = new LockInfo[0];
+
+	
+	/**
+	 * Used by from().
 	 * @param threadIdVal
 	 * @param threadNameVal
 	 * @param threadStateVal
@@ -121,117 +89,40 @@ public class ThreadInfo {
 			long lockOwnerIdVal, String lockOwnerNameVal,
 			StackTraceElement[] stackTraceVal, LockInfo lockInfo,
 			MonitorInfo[] lockedMonitors, LockInfo[] lockedSynchronizers
-			/*[IF Sidecar19-SE]*/
+/*[IF Sidecar19-SE]*/
 			, boolean daemon, int priority
-			/*[ENDIF]*/
+/*[ENDIF]*/
 	) {
-		this.threadId = threadIdVal;
-		this.threadName = threadNameVal;
-		this.threadState = threadStateVal;
-		this.suspended = suspendedVal;
-		this.inNative = inNativeVal;
-		this.blockedCount = blockedCountVal;
-		this.blockedTime = blockedTimeVal;
-		this.waitedCount = waitedCountVal;
-		this.waitedTime = waitedTimeVal;
-		this.lockName = lockNameVal;
-		this.lockOwnerId = lockOwnerIdVal;
-		this.lockOwnerName = lockOwnerNameVal;
-		this.stackTraces = stackTraceVal;
-		this.lockInfo = lockInfo;
-		this.lockedMonitors = lockedMonitors;
-		this.lockedSynchronizers = lockedSynchronizers;
-		/*[IF Sidecar19-SE]*/
-		this.daemon = daemon;
-		this.priority = priority;
-		/*[ENDIF]*/
+		MonitorInfoBase[] monInfoBases = null;
+		if (null != lockedMonitors) {
+			monInfoBases = Arrays.stream(lockedMonitors)
+					.map(MonitorInfo::getBaseInfo).toArray(MonitorInfoBase[]::new);
+		}
+		
+		LockInfoBase[] lockedSyncs = null;
+		if (null != lockedSynchronizers) {
+			lockedSyncs = Arrays.stream(lockedSynchronizers)
+					.map(LockInfo::getBaseInfo).toArray(LockInfoBase[]::new);
+		}
+		LockInfoBase lckInfo = null;
+		if (null != lockInfo) {
+			lckInfo = lockInfo.getBaseInfo();
+		}
+		baseInfo = new ThreadInfoBase(threadIdVal, threadNameVal, threadStateVal, suspendedVal, inNativeVal,
+				blockedCountVal, blockedTimeVal, waitedCountVal, waitedTimeVal, lockNameVal, lockOwnerIdVal,
+				lockOwnerNameVal, stackTraceVal, lckInfo, monInfoBases, lockedSyncs
+/*[IF Sidecar19-SE]*/
+				, daemon, priority
+/*[ENDIF]*/
+				);
 	}
 
 	/**
-	 * @param thread
-	 * @param state
-	 * @param isSuspended
-	 * @param isInNative
-	 * @param blockedCount
-	 * @param blockedTime
-	 * @param waitedCount
-	 * @param waitedTime
-	 * @param stackTrace
-	 * @param blockingMonitor
-	 * @param lockOwner
+	 * Constructor for use via reflection from ThreadMXBeanImpl.
+	 * @param base data for the object
 	 */
-	private ThreadInfo(Thread thread, long nativeId, int state, boolean isSuspended,
-			boolean isInNative, long blockedCount, long blockedTime,
-			long waitedCount, long waitedTime, StackTraceElement[] stackTrace,
-			Object blockingMonitor, Thread lockOwner) {
-		this.threadId = thread.getId();
-		this.nativeTId = nativeId;
-		this.threadName = thread.getName();
-		/*[IF Sidecar19-SE]*/
-		this.daemon = thread.isDaemon();
-		this.priority = thread.getPriority();
-		/*[ENDIF]*/
-
-		// Use the supplied state int to index into the array returned
-		// by values() which should be all thread states in the order
-		// they have been declared. Doing this rather than just issuing a
-		// call to thread.getState() because the Thread state may have
-		// changed after the VM issued the call to this method.
-		this.threadState = Thread.State.values()[state];
-		this.suspended = isSuspended;
-		this.inNative = isInNative;
-		this.blockedCount = blockedCount;
-		this.blockedTime = blockedTime;
-		this.waitedCount = waitedCount;
-		this.waitedTime = waitedTime;
-
-		if (lockOwner != null) {
-			this.lockOwnerId = lockOwner.getId();
-			this.lockOwnerName = lockOwner.getName();
-		}
-
-		this.stackTraces = stackTrace;
-		if (blockingMonitor != null) {
-			this.lockName = blockingMonitor.getClass().getName()
-					+ '@'
-					+ Integer.toHexString(System
-							.identityHashCode(blockingMonitor));
-		}
-	}
-
-	/**
-	 * @param thread
-	 * @param state
-	 * @param isSuspended
-	 * @param isInNative
-	 * @param blockedCount
-	 * @param blockedTime
-	 * @param waitedCount
-	 * @param waitedTime
-	 * @param stackTrace
-	 * @param blockingObject 
-	 * @param blockingObjectOwner 
-	 * @param lockedMonitors
-	 * @param lockedSynchronizers
-	 */
-	private ThreadInfo(Thread thread, long nativeId, int state, boolean isSuspended,
-			boolean isInNative, long blockedCount, long blockedTime,
-			long waitedCount, long waitedTime, StackTraceElement[] stackTrace,
-			Object blockingObject, Thread blockingObjectOwner,
-			MonitorInfo[] lockedMonitors, LockInfo[] lockedSynchronizers) {
-		this(thread,nativeId,state,isSuspended,isInNative,blockedCount,blockedTime,waitedCount,waitedTime,stackTrace,blockingObject,blockingObjectOwner);
-
-		this.lockedMonitors = lockedMonitors;
-		this.lockedSynchronizers = lockedSynchronizers;
-
-		if (blockingObject != null) {
-			this.lockInfo = new LockInfo(blockingObject.getClass().getName(),
-					System.identityHashCode(blockingObject));
-		}
-
-		if (this.lockInfo != null) {
-			this.lockName = this.lockInfo.toString();
-		}
+	private ThreadInfo(ThreadInfoBase base) {
+		baseInfo = base;
 	}
 
 	/**
@@ -243,7 +134,7 @@ public class ThreadInfo {
 	 *         a monitor.
 	 */
 	public long getBlockedCount() {
-		return this.blockedCount;
+		return baseInfo.getBlockedCount();
 	}
 
 	/**
@@ -265,7 +156,7 @@ public class ThreadInfo {
 	 * @see ThreadMXBean#isThreadContentionMonitoringEnabled()
 	 */
 	public long getBlockedTime() {
-		return this.blockedTime;
+		return baseInfo.getBlockedTime();
 	}
 
 	/**
@@ -286,7 +177,7 @@ public class ThreadInfo {
 	 * @see System#identityHashCode(java.lang.Object)
 	 */
 	public String getLockName() {
-		return this.lockName;
+		return baseInfo.getLockName();
 	}
 
 	/**
@@ -301,7 +192,7 @@ public class ThreadInfo {
 	 *         is no other thread holding the monitor, returns a <code>-1</code>.
 	 */
 	public long getLockOwnerId() {
-		return this.lockOwnerId;
+		return baseInfo.getLockOwnerId();
 	}
 
 	/**
@@ -317,7 +208,7 @@ public class ThreadInfo {
 	 *         reference.
 	 */
 	public String getLockOwnerName() {
-		return lockOwnerName;
+		return baseInfo.getLockOwnerName();
 	}
 
 	/**
@@ -329,7 +220,8 @@ public class ThreadInfo {
 	 *         thread is currently blocked, else <code>null</code>.
 	 */
 	public LockInfo getLockInfo() {
-		return this.lockInfo;
+		LockInfoBase li = baseInfo.getBlockingLockInfo();
+		return (null == li) ? null : new LockInfo(li);
 	}
 
 	/**
@@ -340,7 +232,7 @@ public class ThreadInfo {
 	 *         <code>ThreadInfo</code>.
 	 */
 	long getNativeThreadId() {
-		return this.nativeTId;
+		return baseInfo.getNativeTId();
 	}
 
 	/**
@@ -359,7 +251,7 @@ public class ThreadInfo {
 	 *         <code>ThreadInfo</code>.
 	 */
 	public StackTraceElement[] getStackTrace() {
-		return this.stackTraces.clone();
+		return baseInfo.getStackTrace().clone();
 	}
 
 	/**
@@ -370,7 +262,7 @@ public class ThreadInfo {
 	 *         <code>ThreadInfo</code>.
 	 */
 	public long getThreadId() {
-		return this.threadId;
+		return baseInfo.getThreadId();
 	}
 
 	/**
@@ -381,7 +273,7 @@ public class ThreadInfo {
 	 *         <code>ThreadInfo</code>.
 	 */
 	public String getThreadName() {
-		return this.threadName;
+		return baseInfo.getThreadName();
 	}
 
 	/**
@@ -393,7 +285,7 @@ public class ThreadInfo {
 	 * @see Thread#getState()
 	 */
 	public Thread.State getThreadState() {
-		return this.threadState;
+		return baseInfo.getThreadState();
 	}
 
 	/**
@@ -405,7 +297,7 @@ public class ThreadInfo {
 	 *         &quot;wait&quot; or &quot;timed wait&quot; state.
 	 */
 	public long getWaitedCount() {
-		return this.waitedCount;
+		return baseInfo.getWaitedCount();
 	}
 
 	/**
@@ -427,7 +319,7 @@ public class ThreadInfo {
 	 * @see ThreadMXBean#isThreadContentionMonitoringEnabled()
 	 */
 	public long getWaitedTime() {
-		return this.waitedTime;
+		return baseInfo.getWaitedTime();
 	}
 
 	/**
@@ -439,7 +331,7 @@ public class ThreadInfo {
 	 *         then <code>true</code>, otherwise <code>false</code>.
 	 */
 	public boolean isInNative() {
-		return this.inNative;
+		return baseInfo.isInNative();
 	}
 
 	/**
@@ -450,7 +342,7 @@ public class ThreadInfo {
 	 *         <code>true</code>, otherwise <code>false</code>.
 	 */
 	public boolean isSuspended() {
-		return this.suspended;
+		return baseInfo.isSuspended();
 	}
 
 	/**
@@ -465,7 +357,13 @@ public class ThreadInfo {
 	 *         length of zero.
 	 */
 	public MonitorInfo[] getLockedMonitors() {
-		return this.lockedMonitors;
+		MonitorInfo lockedMons[] = null;
+		MonitorInfoBase[] lockedMonBases = baseInfo.getLockedMonitors();
+		if (null != lockedMonBases) {
+			lockedMons = Arrays.stream(lockedMonBases)
+					.map(MonitorInfo::new).toArray(MonitorInfo[]::new);
+		}
+		return lockedMons;
 	}
 
 	/**
@@ -482,7 +380,11 @@ public class ThreadInfo {
 	 *         have a length of zero.
 	 */
 	public LockInfo[] getLockedSynchronizers() {
-		return this.lockedSynchronizers;
+		LockInfo lockedSyncs[] = null;
+		LockInfoBase[] lockedSyncBases = baseInfo.getLockedSynchronizers();
+		lockedSyncs = Arrays.stream(lockedSyncBases)
+				.map(LockInfo::new).toArray(LockInfo[]::new);
+		return lockedSyncs;
 	}
 
 	/**
@@ -653,9 +555,7 @@ public class ThreadInfo {
 			CompositeData[] lockedSynchronizersDataVal = (CompositeData[]) cd.get("lockedSynchronizers"); //$NON-NLS-1$
 			result = LockInfoUtil.fromArray(lockedSynchronizersDataVal);
 		} catch (InvalidKeyException e) {
-			// create the recommended default for lockedSynchronizers,
-			// an empty array of LockInfo
-			result = new LockInfo[0];
+			result = EMPTY_LOCKINFO_ARRAY;
 		}
 		return result;
 	}
@@ -675,9 +575,7 @@ public class ThreadInfo {
 			CompositeData[] lockedMonitorsDataVal = (CompositeData[]) cd.get("lockedMonitors"); //$NON-NLS-1$
 			result = MonitorInfoUtil.fromArray(lockedMonitorsDataVal);
 		} catch (InvalidKeyException e) {
-			// create the recommended default for lockedMonitors,
-			// an empty array of MonitorInfo
-			result = new MonitorInfo[0];
+			result = EMPTY_MONITORINFO_ARRAY;
 		}
 		return result;
 	}
@@ -734,7 +632,7 @@ public class ThreadInfo {
 	 * @return <code>true</code> if this thread is a daemon thread, otherwise <code>false</code> .
 	 */
 	public boolean isDaemon() {
-		return daemon;
+		return baseInfo.isDaemon();
 	}
 	
 	/**
@@ -743,59 +641,17 @@ public class ThreadInfo {
 	 * @return The priority of the thread represented by this <code>ThreadInfo</code>.
 	 */
 	public int getPriority() {
-		return priority;
+		return baseInfo.getPriority();
 	}
 	
 	/*[ENDIF]*/
 	
 	/**
-	 * Returns a text description of this thread info.
-	 * 
-	 * @return a text description of this thread info.
+	 * @return a text description of this thread.
 	 */
 	@Override
 	public String toString() {
-		// Since ThreadInfos are immutable the string value need only be
-		// calculated the one time
-		final String ls = System.lineSeparator();
-		if (TOSTRING_VALUE == null) {
-			StringBuilder result = new StringBuilder();
-/*[IF Java11]*/
-			result.append(String.format("\"%s\" prio=%d Id=%d %s",  //$NON-NLS-1$
-					threadName, Integer.valueOf(priority), Long.valueOf(threadId), threadState));
-/*[ELSE]*/
-			result.append(String.format("\"%s\" Id=%d %s",  //$NON-NLS-1$
-					threadName, Long.valueOf(threadId), threadState));
-/*[ENDIF]*/
-			if (State.BLOCKED == threadState) {
-				result.append(String.format(" on %s owned by \"%s\" Id=%d",  //$NON-NLS-1$
-						lockName, lockOwnerName, Long.valueOf(lockOwnerId)));
-			}
-			result.append(ls);
-			if (stackTraces != null && stackTraces.length > 0) {
-				MonitorInfo[] lockList = getLockedMonitors();
-				MonitorInfo[] lockArray = new MonitorInfo[stackTraces.length];
-				for (MonitorInfo mi: lockList) {
-					int lockDepth = mi.getLockedStackDepth();
-					lockArray[lockDepth] = mi;
-				}
-				int stackDepth = 0;
-				for (StackTraceElement element : stackTraces) {
-					result.append("\tat "); //$NON-NLS-1$
-					Util.printStackTraceElement(element,
-							null, result, true);
-					result.append(ls);
-					if (null != lockArray[stackDepth]) {
-						MonitorInfo mi = lockArray[stackDepth];
-						result.append(String.format("\t- locked %s%n",  //$NON-NLS-1$
-								mi.toString()));
-					}
-					++stackDepth;
-				}
-			}
-			TOSTRING_VALUE = result.toString();
-		}
-		return TOSTRING_VALUE;
+		return baseInfo.toString();
 	}
 
 	/**
@@ -803,116 +659,11 @@ public class ThreadInfo {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj == null) {
-			return false;
+		boolean result = (this == obj);
+		if (!result && (null != obj) && (obj instanceof ThreadInfo)) {
+			result = baseInfo.equals(((ThreadInfo) obj).baseInfo);
 		}
-
-		if (!(obj instanceof ThreadInfo)) {
-			return false;
-		}
-
-		if (this == obj) {
-			return true;
-		}
-
-		// Safe to cast if the instanceof test above was passed.
-		ThreadInfo ti = (ThreadInfo) obj;
-		if (!(ti.getBlockedCount() == this.getBlockedCount())) {
-			return false;
-		}
-
-		if (!(ti.getBlockedTime() == this.getBlockedTime())) {
-			return false;
-		}
-
-		// It is possible that the lock name is null
-		if ((ti.getLockName() != null) && (this.getLockName() != null)) {
-			// Both non-null values. Can string compare...
-			if (!(ti.getLockName().equals(this.getLockName()))) {
-				return false;
-			}
-		} else {
-			// One or both are null. Only succeed if both are null
-			if (ti.getLockName() != this.getLockName()) {
-				return false;
-			}
-		}
-
-		if (!(ti.getLockOwnerId() == this.getLockOwnerId())) {
-			return false;
-		}
-
-		// It is possible that the lock owner name is null
-		if ((ti.getLockOwnerName() != null)
-				&& (this.getLockOwnerName() != null)) {
-			// Both non-null values. Can string compare...
-			if (!(ti.getLockOwnerName().equals(this.getLockOwnerName()))) {
-				return false;
-			}
-		} else {
-			// One or both are null. Only succeed if both are null
-			if (ti.getLockOwnerName() != this.getLockOwnerName()) {
-				return false;
-			}
-		}
-
-		// It is possible that the lock info is null
-		if ((ti.getLockInfo() != null) && (this.getLockInfo() != null)) {
-			// Both non-null values. Can compare string representations...
-			if (!(ti.getLockInfo().toString().equals(this.getLockInfo()
-					.toString()))) {
-				return false;
-			}
-		} else {
-			// One or both are null. Only succeed if both are null
-			if (ti.getLockInfo() != this.getLockInfo()) {
-				return false;
-			}
-		}
-
-		if (!(Arrays.equals(ti.getStackTrace(), this.getStackTrace()))) {
-			return false;
-		}
-
-		if (!(ti.getThreadId() == this.getThreadId())) {
-			return false;
-		}
-
-		if (!(ti.getThreadName().equals(this.getThreadName()))) {
-			return false;
-		}
-
-		if (!(ti.getThreadState().equals(this.getThreadState()))) {
-			return false;
-		}
-
-		if (!(ti.getWaitedCount() == this.getWaitedCount())) {
-			return false;
-		}
-
-		if (!(ti.getWaitedTime() == this.getWaitedTime())) {
-			return false;
-		}
-
-		if (!(ti.isInNative() == this.isInNative())) {
-			return false;
-		}
-
-		if (!(ti.isSuspended() == this.isSuspended())) {
-			return false;
-		}
-
-		/*[IF Sidecar19-SE]*/
-		if (!(ti.isDaemon() == this.isDaemon())) {
-			return false;
-		}
-
-		if (!(ti.getPriority() == this.getPriority())) {
-			return false;
-		}
-		/*[ENDIF]*/
-		
-		return true;
+		return result;
 	}
 
 	/**
@@ -920,24 +671,7 @@ public class ThreadInfo {
 	 */
 	@Override
 	public int hashCode() {
-		return (Long.toString(this.getBlockedCount())
-				+ this.getBlockedTime()
-				+ getLockName()
-				+ this.getLockOwnerId()
-				+ getLockOwnerName()
-				+ this.getStackTrace().length
-				+ this.getThreadId()
-				+ getThreadName()
-				+ getThreadState()
-				+ this.getWaitedCount()
-				+ this.getWaitedTime()
-				+ this.isInNative()
-				+ this.isSuspended()
-				/*[IF Sidecar19-SE]*/
-				+ this.isDaemon()
-				+ this.getPriority()
-				/*[ENDIF]*/
-		).hashCode();
+		return baseInfo.hashCode();
 	}
 
 	/**
@@ -962,14 +696,12 @@ public class ThreadInfo {
 			StringTokenizer strTok = new StringTokenizer(lockString, "@"); //$NON-NLS-1$
 			if (strTok.countTokens() == 2) {
 				try {
-					// TODO : can the recovered values be sanity checked?
 					result = new LockInfo(strTok.nextToken(), Integer.parseInt(strTok.nextToken(), 16));
 				} catch (NumberFormatException e) {
 					// ignore and move on - the lockString is not in the correct format
 				}
 			}
 		}
-
 		return result;
 	}
 

--- a/runtime/jcl/common/jclglob.h
+++ b/runtime/jcl/common/jclglob.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,13 +55,13 @@ typedef struct JniIDCache {
 	
 	traceDotCGlobalMemory traceGlobals;
 
-	jclass CLS_java_lang_management_ThreadInfo;
-	jclass CLS_java_lang_management_MonitorInfo;
-	jclass CLS_java_lang_management_LockInfo;
-	jmethodID MID_java_lang_management_ThreadInfo_init_nolocks;
-	jmethodID MID_java_lang_management_ThreadInfo_init;
-	jmethodID MID_java_lang_management_MonitorInfo_init;
-	jmethodID MID_java_lang_management_LockInfo_init;
+	jclass CLS_openj9_management_internal_ThreadInfoBase;
+	jclass CLS_openj9_management_internal_MonitorInfoBase;
+	jclass CLS_openj9_management_internal_LockInfoBase;
+	jmethodID MID_openj9_management_internal_ThreadInfoBase_init_nolocks;
+	jmethodID MID_openj9_management_internal_ThreadInfoBase_init;
+	jmethodID MID_openj9_management_internal_MonitorInfoBase_init;
+	jmethodID MID_openj9_management_internal_LockInfoBase_init;
 	jclass CLS_java_lang_StackTraceElement;
 	jmethodID MID_java_lang_StackTraceElement_isNativeMethod;
 

--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -629,7 +629,7 @@ Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_getMultiThreadInfoIm
 	 * so skip doing anything extra and just return the new array
 	 */
 	if (0 == numThreads){
-		jclass cls = JCL_CACHE_GET(env, CLS_java_lang_management_ThreadInfo);
+		jclass cls = JCL_CACHE_GET(env, CLS_openj9_management_internal_ThreadInfoBase);
 		result = (*env)->NewObjectArray(env, 0, cls, NULL);
 	} else {
 		threadIDs = (*env)->GetLongArrayElements(env, ids, &isCopy);
@@ -1131,7 +1131,7 @@ initIDCache(JNIEnv *env)
 		goto initIDCache_fail;
 	}
 	
-	cls = (*env)->FindClass(env, "java/lang/management/ThreadInfo");
+	cls = (*env)->FindClass(env, "openj9/management/internal/ThreadInfoBase");
 	if (!cls) {
 		err = JNI_ERR;
 		goto initIDCache_fail;
@@ -1141,20 +1141,20 @@ initIDCache(JNIEnv *env)
 		goto initIDCache_fail;
 	}
 	(*env)->DeleteLocalRef(env, cls);
-	JCL_CACHE_SET(env, CLS_java_lang_management_ThreadInfo, gcls);
+	JCL_CACHE_SET(env, CLS_openj9_management_internal_ThreadInfoBase, gcls);
 
 	mid = (*env)->GetMethodID(env, gcls, "<init>", 
-		"(Ljava/lang/Thread;JIZZJJJJ[Ljava/lang/StackTraceElement;Ljava/lang/Object;Ljava/lang/Thread;[Ljava/lang/management/MonitorInfo;[Ljava/lang/management/LockInfo;)V");
+		"(Ljava/lang/Thread;JIZZJJJJ[Ljava/lang/StackTraceElement;Ljava/lang/Object;Ljava/lang/Thread;[Lopenj9/management/internal/MonitorInfoBase;[Lopenj9/management/internal/LockInfoBase;)V");
 	if (mid) {
-		JCL_CACHE_SET(env, MID_java_lang_management_ThreadInfo_init, mid);
-		JCL_CACHE_SET(env, MID_java_lang_management_ThreadInfo_init_nolocks, NULL);
+		JCL_CACHE_SET(env, MID_openj9_management_internal_ThreadInfoBase_init, mid);
+		JCL_CACHE_SET(env, MID_openj9_management_internal_ThreadInfoBase_init_nolocks, NULL);
 	}
 	if (!mid) {
 		err = JNI_ERR;
 		goto initIDCache_fail;
 	}
 
-	cls = (*env)->FindClass(env, "java/lang/management/MonitorInfo");
+	cls = (*env)->FindClass(env, "openj9/management/internal/MonitorInfoBase");
 	if (!cls) {
 		err = JNI_ERR;
 		goto initIDCache_fail;
@@ -1164,7 +1164,7 @@ initIDCache(JNIEnv *env)
 		goto initIDCache_fail;
 	}
 	(*env)->DeleteLocalRef(env, cls);
-	JCL_CACHE_SET(env, CLS_java_lang_management_MonitorInfo, gcls);
+	JCL_CACHE_SET(env, CLS_openj9_management_internal_MonitorInfoBase, gcls);
 
 	mid = (*env)->GetMethodID(env, gcls, "<init>",
 			"(Ljava/lang/String;IILjava/lang/StackTraceElement;)V");
@@ -1172,7 +1172,7 @@ initIDCache(JNIEnv *env)
 		err = JNI_ERR;
 		goto initIDCache_fail;
 	}
-	JCL_CACHE_SET(env, MID_java_lang_management_MonitorInfo_init, mid);
+	JCL_CACHE_SET(env, MID_openj9_management_internal_MonitorInfoBase_init, mid);
 
 	cls = (*env)->FindClass(env, "java/lang/Class");
 	if (!cls) {
@@ -1187,7 +1187,7 @@ initIDCache(JNIEnv *env)
 	(*env)->DeleteLocalRef(env, cls);
 	JCL_CACHE_SET(env, MID_java_lang_Class_getName, mid);
 
-	cls = (*env)->FindClass(env, "java/lang/management/LockInfo");
+	cls = (*env)->FindClass(env, "openj9/management/internal/LockInfoBase");
 	if (!cls) {
 		err = JNI_ERR;
 		goto initIDCache_fail;
@@ -1197,14 +1197,14 @@ initIDCache(JNIEnv *env)
 		goto initIDCache_fail;
 	}
 	(*env)->DeleteLocalRef(env, cls);
-	JCL_CACHE_SET(env, CLS_java_lang_management_LockInfo, gcls);
+	JCL_CACHE_SET(env, CLS_openj9_management_internal_LockInfoBase, gcls);
 
 	mid = (*env)->GetMethodID(env, gcls, "<init>", "(Ljava/lang/Object;)V");
 	if (!mid) {
 		err = JNI_ERR;
 		goto initIDCache_fail;
 	}
-	JCL_CACHE_SET(env, MID_java_lang_management_LockInfo_init, mid);
+	JCL_CACHE_SET(env, MID_openj9_management_internal_LockInfoBase_init, mid);
 
 	cls = (*env)->FindClass(env, "java/lang/StackTraceElement");
 	if (!cls) {
@@ -1233,15 +1233,15 @@ initIDCache_fail:
 	if (NULL != gcls) {
 		(*env)->DeleteGlobalRef(env, gcls);
 	}
-	gcls = JCL_CACHE_GET(env, CLS_java_lang_management_LockInfo);
+	gcls = JCL_CACHE_GET(env, CLS_openj9_management_internal_LockInfoBase);
 	if (NULL != gcls) {
 		(*env)->DeleteGlobalRef(env, gcls);
 	}
-	gcls = JCL_CACHE_GET(env, CLS_java_lang_management_MonitorInfo);
+	gcls = JCL_CACHE_GET(env, CLS_openj9_management_internal_MonitorInfoBase);
 	if (NULL != gcls) {
 		(*env)->DeleteGlobalRef(env, gcls);
 	}
-	gcls = JCL_CACHE_GET(env, CLS_java_lang_management_ThreadInfo);
+	gcls = JCL_CACHE_GET(env, CLS_openj9_management_internal_ThreadInfoBase);
 	if (NULL != gcls) {
 		(*env)->DeleteGlobalRef(env, gcls);
 	}
@@ -1603,13 +1603,13 @@ getMonitors(J9VMThread *currentThread, J9VMThread *targetThread, ThreadInfo *tin
 }
 
 /**
- * Allocate and populate an array of java/lang/management/ThreadInfo.
+ * Allocate and populate an array of openj9/management/internal/ThreadInfoBase.
  * @pre must not have VM access
  * @post temp memory in allinfo[] is freed
  * @param[in] env
  * @param[in] allinfo
  * @param[in] allinfolen
- * @return java/lang/management/ThreadInfo[]
+ * @return openj9/management/internal/ThreadInfoBase[]
  * @retval non-null success
  * @retval null error, an exception is set
  */
@@ -1620,7 +1620,7 @@ createThreadInfoArray(JNIEnv *env, ThreadInfo *allinfo, UDATA allinfolen, jsize 
 	jobjectArray result;
 	UDATA i;
 
-	cls = JCL_CACHE_GET(env, CLS_java_lang_management_ThreadInfo);
+	cls = JCL_CACHE_GET(env, CLS_openj9_management_internal_ThreadInfoBase);
 	Assert_JCL_notNull(cls);
 
 	result = (*env)->NewObjectArray(env, (jsize)allinfolen, cls, NULL);
@@ -1647,13 +1647,13 @@ createThreadInfoArray(JNIEnv *env, ThreadInfo *allinfo, UDATA allinfolen, jsize 
 }
 
 /**
- * Allocate and populate a single java/lang/management/ThreadInfo object.
+ * Allocate and populate a single openj9/management/internal/ThreadInfoBase object.
  * @pre must not have VM access
  * @post temp memory in tinfo is freed
  * @param[in] env
  * @param[in] tinfo
  * @param[in] maxStackDepth The stack trace is pruned to this depth.
- * @return java/lang/management/ThreadInfo object
+ * @return openj9/management/internal/ThreadInfoBase object
  * @retval non-null success
  * @retval null error, an exception is set
  */
@@ -1671,13 +1671,13 @@ createThreadInfo(JNIEnv *env, ThreadInfo *tinfo, jsize maxStackDepth)
 	jboolean isNative;
 	jboolean getOwnedLocks = JNI_TRUE;
 
-	cls = JCL_CACHE_GET(env, CLS_java_lang_management_ThreadInfo);
+	cls = JCL_CACHE_GET(env, CLS_openj9_management_internal_ThreadInfoBase);
 	Assert_JCL_notNull(cls);
 
 	/* look for Java 6 version of the constructor */
-	ctor = JCL_CACHE_GET(env, MID_java_lang_management_ThreadInfo_init);
+	ctor = JCL_CACHE_GET(env, MID_openj9_management_internal_ThreadInfoBase_init);
 	if (!ctor) {
-		ctor = JCL_CACHE_GET(env, MID_java_lang_management_ThreadInfo_init_nolocks);
+		ctor = JCL_CACHE_GET(env, MID_openj9_management_internal_ThreadInfoBase_init_nolocks);
 		getOwnedLocks = JNI_FALSE;
 	}
 	Assert_JCL_notNull(ctor);
@@ -1754,7 +1754,7 @@ createThreadInfo(JNIEnv *env, ThreadInfo *tinfo, jsize maxStackDepth)
  * @post frees tinfo->lockedMonitors.arr_safe.
  * @param[in] env
  * @param[in] tinfo
- * @return java/lang/management/MonitorInfo[]
+ * @return openj9/management/internal/MonitorInfoBase[]
  * @retval non-null success
  * @retval null error, an exception is set
  */ 
@@ -1769,10 +1769,10 @@ createLockedMonitors(JNIEnv *env, ThreadInfo *tinfo)
 	UDATA count;
 	UDATA i, j;
 
-	cls = JCL_CACHE_GET(env, CLS_java_lang_management_MonitorInfo);
+	cls = JCL_CACHE_GET(env, CLS_openj9_management_internal_MonitorInfoBase);
 	Assert_JCL_notNull(cls);
 
-	ctor = JCL_CACHE_GET(env, MID_java_lang_management_MonitorInfo_init);
+	ctor = JCL_CACHE_GET(env, MID_openj9_management_internal_MonitorInfoBase_init);
 	Assert_JCL_notNull(ctor);
 
 	getName = JCL_CACHE_GET(env, MID_java_lang_Class_getName);
@@ -1854,7 +1854,7 @@ createLockedMonitors(JNIEnv *env, ThreadInfo *tinfo)
  * 
  * @param[in] env
  * @param[in] tinfo
- * @return java/lang/management/LockInfo[]
+ * @return openj9/management/internal/LockInfoBase[]
  * @retval non-null success
  * @retval null error, an exception is set
  */ 
@@ -1868,10 +1868,10 @@ createLockedSynchronizers(JNIEnv *env, ThreadInfo *tinfo)
 	jmethodID ctor;
 	UDATA i;
 
-	cls = JCL_CACHE_GET(env, CLS_java_lang_management_LockInfo);
+	cls = JCL_CACHE_GET(env, CLS_openj9_management_internal_LockInfoBase);
 	Assert_JCL_notNull(cls);
 
-	ctor = JCL_CACHE_GET(env, MID_java_lang_management_LockInfo_init);
+	ctor = JCL_CACHE_GET(env, MID_openj9_management_internal_LockInfoBase_init);
 	Assert_JCL_notNull(ctor);
 
 	lockedSyncs = (*env)->NewObjectArray(env, (jsize)tinfo->lockedSynchronizers.len, cls, NULL);


### PR DESCRIPTION
Move the data and critical methods from java.lang.management classes to a
package in java.base to make the management data available to applications
running with only java.base. The public java.lang.management classes wrap these
classes.

This is the first part of changes for resolving https://github.com/eclipse/openj9/issues/5815.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>