### PR TITLE
Enable IProfiler during startup if only bootstrap classes are cached

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2329,11 +2329,17 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
          {
          if (!self()->getOption(TR_DisablePersistIProfile))
             {
-            TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
-            static char * dnipdsp = feGetEnv("TR_DisableNoIProfilerDuringStartupPhase");
-            if (compInfo->isWarmSCC() == TR_yes && !dnipdsp) // turn off Iprofiler only for the warm runs
+            // Turn off Iprofiler for the warm runs, but not if we cache only bootstrap classes
+            // This is because we may be missing IProfiler information for non-bootstrap classes
+            // that could not be stored in SCC
+            if (J9_ARE_ALL_BITS_SET(javaVM->sharedClassConfig->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHE_NON_BOOT_CLASSES))
                {
-               self()->setOption(TR_NoIProfilerDuringStartupPhase);
+               TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
+               static char * dnipdsp = feGetEnv("TR_DisableNoIProfilerDuringStartupPhase");
+               if (compInfo->isWarmSCC() == TR_yes && !dnipdsp)
+                  {
+                  self()->setOption(TR_NoIProfilerDuringStartupPhase);
+                  }
                }
             }
          }


### PR DESCRIPTION
The `bootClassesOnly` suboption for the `Xshareclasses` option disallows
the caching of non-bootstrap classes and therefore the IProfiler cannot
store profiling information about such classes. If we turn off IProfiler
during start-up (to improve start-up time) then throughput may be affected
because methods belonging to non-bootstrap classes may have little or
no profiling information at all.
This commit allows IProfiler collection during start-up if non-bootstrap
classes are not present in the shared class cache.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>