### PR TITLE
Add jvmtiSetHeapSamplingInterval implementation and enable JEP331

### DIFF
--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -175,8 +175,7 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 
 #if JAVA_SPEC_VERSION >= 11
 	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)) {
-		/* hardcode to 0 (not enabled) for empty JEP331 implementation */
-		rv_capabilities.can_generate_sampled_object_alloc_events = 0;
+		rv_capabilities.can_generate_sampled_object_alloc_events = 1;
 	}
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
@@ -315,7 +314,7 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 	J9JVMTIData * jvmtiData = J9JVMTI_DATA_FROM_VM(vm);
 	jvmtiCapabilities potentialCapabilities;
 	jvmtiCapabilities newCapabilities;
-	UDATA i;
+	UDATA i = 0;
 	jvmtiError rc = JVMTI_ERROR_NOT_AVAILABLE;
 	J9VMThread *currentThread = NULL;
 
@@ -358,7 +357,7 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 
 		/* can't request original method order after onLoad phase */
 
-		if (1 == newCapabilities.can_maintain_original_method_order) {
+		if (newCapabilities.can_maintain_original_method_order) {
 			if (J9_ARE_NO_BITS_SET(vm->requiredDebugAttributes, J9VM_DEBUG_ATTRIBUTE_MAINTAIN_ORIGINAL_METHOD_ORDER)) {
 				if (JVMTI_PHASE_ONLOAD == jvmtiData->phase) {
 					/* turn off ROMClassMethodSorting */
@@ -371,6 +370,16 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 				}
 			}
 		}
+
+#if JAVA_SPEC_VERSION >= 11
+		if (newCapabilities.can_generate_sampled_object_alloc_events) {
+			/* Initial sampling interval is MM_GCExtensions::oolObjectSamplingBytesGranularity which is 16M by default
+			 * or set by command line option -Xgc:allocationSamplingGranularity.
+			 * Set it to 512KB which is default sampling interval as per JEP 331 specification.
+			 */
+			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(currentThread, 512 * 1024);
+		}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 		/* Always consider can_generate_compiled_method_load_events to be a newly-requested capability
 		 * so that hookNonEventCapabilities will fork the event thread if need be.

--- a/runtime/jvmti/jvmtiMemory.c
+++ b/runtime/jvmti/jvmtiMemory.c
@@ -86,6 +86,7 @@ jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
 	jint samplingInterval)
 {
 	jvmtiError rc = JVMTI_ERROR_NONE;
+	J9VMThread *currentThread = NULL;
 	
 	Trc_JVMTI_jvmtiSetHeapSamplingInterval_Entry(env, samplingInterval);
 	
@@ -93,8 +94,11 @@ jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
 	ENSURE_CAPABILITY(env, can_generate_sampled_object_alloc_events);
 	ENSURE_NON_NEGATIVE(samplingInterval);
 
-	/* this method is to be implemented via https://github.com/eclipse/openj9/pull/3754 */
-	JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_VERSION);
+	rc = getCurrentVMThread(((J9JVMTIEnv *)env)->vm, &currentThread);
+	if ((JVMTI_ERROR_NONE == rc) && (NULL != currentThread)) {
+		/* No negative samplingInterval, and there is no data lost when jint is casted to UDATA. */
+		currentThread->javaVM->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(currentThread, samplingInterval);
+	}
 
 done:
 	TRACE_JVMTI_RETURN(jvmtiSetHeapSamplingInterval);

--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -1299,15 +1299,4 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<data type="struct J9VMThread*" name="vmThread" description="current thread" />
 		<data type="U_32" name="state" description="the VM runtime state" />
 	</event>
-	
-	<event>
-		<name>J9HOOK_SAMPLED_OBJECT_ALLOCATE</name>
-		<description>
-			Triggered when the size of objects specified via SetHeapSamplingInterval have been allocated. See JVMTI spec for details.
-		</description>
-		<struct>J9SampledObjectAllocateEvent</struct>
-		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
-		<data type="j9object_t" name="object" return="true" description="the object which was just allocated" />
-		<data type="UDATA" name="size" description="the number of bytes allocated" />
-	</event>
 </interface>

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -413,11 +413,6 @@
 		<return type="success" value="1"/>
 	</test>
 
-	<test id="soae001">
-		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:soae001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
-		<return type="success" value="1"/>
-	</test>
-
 	<test id="gsp001">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:gsp001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_soae.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_soae.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<!-- Format
+	For OnLoad JVMTI tests
+		$EXE$ $JVM_OPTS$ $AGENTLIB$=test:fer003 -cp $Q$$JAR$$Q$ $TESTRUNNER$
+	For OnAttach JVMTI tests
+		$EXE$ $JVM_OPTS$ -cp $Q$$JAR$$Q$ $TESTRUNNER$ testid=[TESTID]
+-->
+
+<suite id="JVMTI Tests" timeout="240">
+	<variable name="JVM_OPTS" value=" " />
+	<variable name="AGENTLIB" value="-agentlib:jvmtitest" />
+	<variable name="TESTRUNNER" value="com.ibm.jvmti.tests.util.TestRunner" />
+
+	<test id="soae001">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:soae001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -460,4 +460,36 @@
 			<group>functional</group>
 		</groups>
 	</test>
+	<test>
+		<testCaseName>cmdLineTester_jvmtitests_soae</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode148</variation>
+			<variation>Mode149</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+	-DTEST_ROOT=$(Q)$(TEST_RESROOT)$(Q) \
+	-DJAR=$(Q)$(TEST_RESROOT)$(D)jvmtitest.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump $(SQ) \
+	-DMODE_HINTS=$(Q)$(MODE_HINTS)$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)jvmtitests_soae.xml$(Q) \
+	-explainExcludes \
+	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
@@ -37,9 +37,6 @@ public class soae001 {
 		jvmtiResult = enable();
 		if (0 != jvmtiResult) {
 			System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.enable() failed with: " + jvmtiResult);
-			// following to be deleted when actual JEP331 implementation is in place
-			System.out.println("This is expected with an empty JEP331 implementation!");
-			result = true;
 		} else {
 			byte[] bytes;
 			bytes = new byte[DEFAULT_SAMPLING_RATE];


### PR DESCRIPTION
#### Add `jvmtiSetHeapSamplingInterval` implementation and enable `JEP331`

Replaced `JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_VERSION)` with `j9gc_set_allocation_sampling_interval()` within `jvmtiSetHeapSamplingInterval()`;
Enabled `can_generate_sampled_object_alloc_events`;
Updated the test for actual `JEP331` implementation and exclude it for Java 8 and modes with `-Xgcpolicy:[balanced|metronome]`.

Related PRs: https://github.com/eclipse/openj9/pull/4461, https://github.com/eclipse/openj9/pull/4618, https://github.com/eclipse/openj9/pull/5869

Note: `J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING` is triggered based on https://github.com/eclipse/openj9/blob/79bb39a30f3e175d4b5794a1d7a20a56ee6ccdf0/runtime/gc_modron_startup/mgcalloc.cpp#L257-L270 which is not supported in `-Xgcpolicy:[balanced|metronome]`. That was the reason to exclude these two modes from the test. 

Additional note: there are two intermittent failures when running `JTReg Test Failure - serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorArrayAllSampledTest.java`, it is not immediately clear that they were caused by this PR hence submitting this for review while investigating the failure in a separate issue https://github.com/eclipse/openj9/issues/5969. 

Reviewer: @gacholio 
FYI: @DanHeidinga @charliegracie 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>