### PR TITLE
Git gc openjdk repo cache in dockerfiles

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -248,7 +248,8 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \
-  && git fetch --all
+  && git fetch --all \
+  && git gc --aggressive --prune=all
 
 # set up sshd config
 RUN mkdir /var/run/sshd \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -94,7 +94,7 @@ RUN cd /usr/local \
 # Create links for c++,g++,cc,gcc and for GCC to access the C library
 # There is a true at the end of the library link because it throws an error and it allows the container to be built
 RUN ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
-  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include | true \ 
+  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include | true \
   && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++-7 \
   && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc-7
 
@@ -177,7 +177,8 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \
-  && git fetch --all
+  && git fetch --all \
+  && git gc --aggressive --prune=all
 
 # Expose SSH port and run SSH
 EXPOSE 22

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -261,7 +261,8 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \
-  && git fetch --all
+  && git fetch --all \
+  && git gc --aggressive --prune=all
 
 # Install OpenSSL v1.1.1b
 # Required for JITaaS  & Crypto functional testing


### PR DESCRIPTION
- Drastically reduces the size of the repo cache and
  therefore the size of the containers
- Also remove erroneous whitspace from another line

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>