### PR TITLE
report FreeMemoryStats via tgc on both gc-end and compact start

### DIFF
--- a/runtime/gc_trace_standard/TgcLargeAllocation.cpp
+++ b/runtime/gc_trace_standard/TgcLargeAllocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -627,6 +627,7 @@ tgcLargeAllocationInitialize(J9JavaVM *javaVM)
 
 			J9HookInterface** privateHooks = J9_HOOK_INTERFACE(extensions->privateHookInterface);
 			(*privateHooks)->J9HookRegisterWithCallSite(privateHooks, J9HOOK_MM_PRIVATE_CONCURRENT_HALTED, tgcHookVerifyHaltedInConcurrentGC, OMR_GET_CALLSITE(), NULL);
+			(*privateHooks)->J9HookRegisterWithCallSite(privateHooks, J9HOOK_MM_PRIVATE_COMPACT_START, tgcHookFreeMemoryGlobalPrintStats, OMR_GET_CALLSITE(), NULL);
 		}
 	}
 	return result;


### PR DESCRIPTION
	- due to FreeMemoryStats would be changed after compaction,
	add one tgc report more after sweep if there would be a compaction
	after sweep.

depends: omr#3936

Signed-off-by: Lin Hu <linhu@ca.ibm.com>