### PR TITLE
Correctly align J9VMThread fields on ZOS

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4873,7 +4873,7 @@ typedef struct J9VMThread {
 	U_32 ludclBPOffset;
 #if defined(J9VM_JIT_FREE_SYSTEM_STACK_POINTER)
 	UDATA systemStackPointer;
-#if !defined(J9VM_ENV_DATA64)
+#if 0 && !defined(J9VM_ENV_DATA64) /* Change to 0 or 1 based on number of fields above */
 	U_32 zosPadTo8;
 #endif /* !J9VM_ENV_DATA64 */
 #endif /* J9VM_JIT_FREE_SYSTEM_STACK_POINTER */


### PR DESCRIPTION
Fix alignment broken by recent field removal in
https://github.com/eclipse/openj9/pull/5956

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>