### PR TITLE
 Enable direct calls in defineClass.c 

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -42,7 +42,7 @@ static J9ROMClass * createROMClassFromClassFile (J9VMThread *currentThread, J9Lo
 static void throwNoClassDefFoundError (J9VMThread* vmThread, J9LoadROMClassData * loadData);
 static void reportROMClassLoadEvents (J9VMThread* vmThread, J9ROMClass* romClass, J9ClassLoader* classLoader);
 static J9Class* checkForExistingClass (J9VMThread* vmThread, J9LoadROMClassData * loadData);
-static UDATA callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediateClassData, UDATA intermediateClassDataLength, UDATA translationFlags, UDATA classFileBytesReplacedByRIA, UDATA classFileBytesReplacedByRCA, J9TranslationLocalBuffer *localBuffer);
+static UDATA callDynamicLoader(J9VMThread* vmThread, J9LoadROMClassData *loadData, U_8 * intermediateClassData, UDATA intermediateClassDataLength, UDATA translationFlags, UDATA classFileBytesReplacedByRIA, UDATA classFileBytesReplacedByRCA, J9TranslationLocalBuffer *localBuffer);
 
 static BOOLEAN hasSamePackageName(J9ROMClass *anonROMClass, J9ROMClass *hostROMClass);
 static char* createErrorMessage(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *hostROMClass, const char* errorMsg);
@@ -163,7 +163,7 @@ internalDefineClass(
 		/* localBuffer should not be NULL */
 		Trc_BCU_Assert_True(NULL != localBuffer);
 
-		result = vm->internalVMFunctions->internalCreateRAMClassFromROMClass(vmThread, classLoader, romClass, options,
+		result = J9_VM_FUNCTION(vmThread, internalCreateRAMClassFromROMClass)(vmThread, classLoader, romClass, options,
 				NULL, loadData.protectionDomain, NULL, (IDATA)localBuffer->entryIndex, (IDATA)localBuffer->loadLocationType, NULL, hostClass);
 		if (NULL == result) {
 			/* ramClass creation failed - remember the orphan romClass for next time */
@@ -234,11 +234,11 @@ throwNoClassDefFoundError(J9VMThread* vmThread, J9LoadROMClassData * loadData)
 
 		Trc_BCU_throwNoClassDefFoundError_ErrorBuf(vmThread, errorBuf);
 
-		vm->internalVMFunctions->setCurrentExceptionUTF(vmThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (char *) errorBuf);
+		J9_VM_FUNCTION(vmThread, setCurrentExceptionUTF)(vmThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (char *) errorBuf);
 
 		j9mem_free_memory(errorBuf);
 	} else {
-		vm->internalVMFunctions->setCurrentException(vmThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, NULL);
+		J9_VM_FUNCTION(vmThread, setCurrentException)(vmThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, NULL);
 	}
 
 	Trc_BCU_throwNoClassDefFoundError_Exit(vmThread);
@@ -257,7 +257,7 @@ checkForExistingClass(J9VMThread* vmThread, J9LoadROMClassData * loadData)
 
 	Trc_BCU_checkForExistingClass_Entry(vmThread, loadData->className, loadData->classLoader);
 
-	existingClass = J9_VM_FUNCTION(vmThread, hashClassTableAt)(
+	existingClass = hashClassTableAt(
 		loadData->classLoader,
 		loadData->className,
 		loadData->classNameLength);
@@ -552,7 +552,7 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 
 	/* TODO toss tracepoint?? Trc_BCU_internalLoadROMClass_AttemptExisting(vmThread, segment, romAvailable, bytesRequired); */
 	/* Attempt dynamic load */
-	result = callDynamicLoader(vm, loadData, intermediateClassData, intermediateClassDataLength, translationFlags, classFileBytesReplacedByRIA, classFileBytesReplacedByRCA, localBuffer);
+	result = callDynamicLoader(vmThread, loadData, intermediateClassData, intermediateClassDataLength, translationFlags, classFileBytesReplacedByRIA, classFileBytesReplacedByRCA, localBuffer);
 
 	/* Free the class file bytes if necessary */
 doneFreeMem:
@@ -657,8 +657,9 @@ done:
 }
 
 static UDATA
-callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediateClassData, UDATA intermediateClassDataLength, UDATA translationFlags, UDATA classFileBytesReplacedByRIA, UDATA classFileBytesReplacedByRCA, J9TranslationLocalBuffer *localBuffer)
+callDynamicLoader(J9VMThread *vmThread, J9LoadROMClassData *loadData, U_8 * intermediateClassData, UDATA intermediateClassDataLength, UDATA translationFlags, UDATA classFileBytesReplacedByRIA, UDATA classFileBytesReplacedByRCA, J9TranslationLocalBuffer *localBuffer)
 {
+	J9JavaVM * vm = vmThread->javaVM;
 	BOOLEAN createIntermediateROMClass = FALSE;
 	UDATA result = BCT_ERR_NO_ERROR;
 	U_8 *intermediateData = NULL;
@@ -758,8 +759,7 @@ callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediat
 		&& (classFileBytesReplacedByRIA || classFileBytesReplacedByRCA)
 		&& (NULL != loadData->romClass)
 	) {
-		J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
-		J9Module *module = vm->internalVMFunctions->findModuleForPackage(currentThread, loadData->classLoader,
+		J9Module *module = findModuleForPackage(vmThread, loadData->classLoader,
 				loadData->className, (U_32) packageNameLength(loadData->romClass));
 		if (NULL != module) {
 			module->isLoose = TRUE;
@@ -903,10 +903,10 @@ createROMClassFromClassFile(J9VMThread *currentThread, J9LoadROMClassData *loadD
 		/*Trc_BCU_internalLoadROMClass_NoMemory(vmThread);*/
 	} else {
 		if (errorUTF == NULL) {
-			vm->internalVMFunctions->setCurrentException(currentThread, exceptionNumber, NULL);
+			J9_VM_FUNCTION(currentThread, setCurrentException)(currentThread, exceptionNumber, NULL);
 		} else {
 			PORT_ACCESS_FROM_JAVAVM(vm);
-			vm->internalVMFunctions->setCurrentExceptionUTF(currentThread, exceptionNumber, (const char*)errorUTF);
+			J9_VM_FUNCTION(currentThread, setCurrentExceptionUTF)(currentThread, exceptionNumber, (const char*)errorUTF);
 			j9mem_free_memory(errorUTF);
 		}
 	}
@@ -991,12 +991,11 @@ static void
 setIllegalArgumentExceptionHostClassAnonClassHaveDifferentPackages(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *hostROMClass) {
 	PORT_ACCESS_FROM_VMC(vmStruct);
 	const J9JavaVM *vm = vmStruct->javaVM;
-	const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
 	/* Construct error string */
 	const char *errorMsg = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES, NULL);
 	char *buf = createErrorMessage(vmStruct, anonROMClass, hostROMClass, errorMsg);
-	vmFuncs->setCurrentExceptionUTF(vmStruct, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, buf);
+	J9_VM_FUNCTION(vmStruct, setCurrentExceptionUTF)(vmStruct, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, buf);
 	j9mem_free_memory(buf);
 }
 
@@ -1025,7 +1024,7 @@ freeAnonROMClass(J9JavaVM *vm, J9ROMClass *romClass) {
 					 */
 					*previousSegmentPointerROM = nextSegmentROM;
 					/* Free memory segment corresponding to the ROM class. */
-					vm->internalVMFunctions->freeMemorySegment(vm, segmentROM, 1);
+					J9_VM_FUNCTION_VIA_JAVAVM(vm, freeMemorySegment)(vm, segmentROM, 1);
 					break;
 				}
 				previousSegmentPointerROM = &segmentROM->nextSegmentInClassLoader;

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -257,7 +257,7 @@ checkForExistingClass(J9VMThread* vmThread, J9LoadROMClassData * loadData)
 
 	Trc_BCU_checkForExistingClass_Entry(vmThread, loadData->className, loadData->classLoader);
 
-	existingClass = hashClassTableAt(
+	existingClass = J9_VM_FUNCTION(vmThread, hashClassTableAt)(
 		loadData->classLoader,
 		loadData->className,
 		loadData->classNameLength);
@@ -759,7 +759,7 @@ callDynamicLoader(J9VMThread *vmThread, J9LoadROMClassData *loadData, U_8 * inte
 		&& (classFileBytesReplacedByRIA || classFileBytesReplacedByRCA)
 		&& (NULL != loadData->romClass)
 	) {
-		J9Module *module = findModuleForPackage(vmThread, loadData->classLoader,
+		J9Module *module = J9_VM_FUNCTION(vmThread, findModuleForPackage)(vmThread, loadData->classLoader,
 				loadData->className, (U_32) packageNameLength(loadData->romClass));
 		if (NULL != module) {
 			module->isLoose = TRUE;

--- a/runtime/bcutil/test/recompiled/CMakeLists.txt
+++ b/runtime/bcutil/test/recompiled/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-set_source_files_properties(${j9vm_BINARY_DIR}/bcutil/ut_j9bcu.c PROPERTIES GENERATED TRUE)
+set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
 add_library(j9dyn_generic_test STATIC
 
 	${j9vm_BINARY_DIR}/vm/ut_j9vm.c

--- a/runtime/bcutil/test/recompiled/CMakeLists.txt
+++ b/runtime/bcutil/test/recompiled/CMakeLists.txt
@@ -21,6 +21,7 @@
 ################################################################################
 
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
+set_source_files_properties(${j9vm_BINARY_DIR}/bcutil/ut_j9bcu.c PROPERTIES GENERATED TRUE)
 add_library(j9dyn_generic_test STATIC
 
 	${j9vm_BINARY_DIR}/vm/ut_j9vm.c

--- a/runtime/bcutil/test/recompiled/CMakeLists.txt
+++ b/runtime/bcutil/test/recompiled/CMakeLists.txt
@@ -29,6 +29,13 @@ add_library(j9dyn_generic_test STATIC
 	${j9vm_SOURCE_DIR}/vm/ModularityHashTables.c
 	${j9vm_SOURCE_DIR}/vm/dllsup.c
 )
+
+# We need to add an explicit dependency since CMake doesn't track dependencies for generated files across directories
+add_dependencies(j9dyn_generic_test trc_j9vm)
+
+# And add the vm binary dir to our include path
+target_include_directories(j9dyn_generic_test PRIVATE ${j9vm_BINARY_DIR}/vm)
+
 target_link_libraries(j9dyn_generic_test
 	PRIVATE
 		j9vm_interface

--- a/runtime/bcutil/test/recompiled/CMakeLists.txt
+++ b/runtime/bcutil/test/recompiled/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,14 @@
 ################################################################################
 
 set_source_files_properties(${j9vm_BINARY_DIR}/bcutil/ut_j9bcu.c PROPERTIES GENERATED TRUE)
-add_library(j9dyn_generic_test STATIC)
+add_library(j9dyn_generic_test STATIC
+
+	${j9vm_BINARY_DIR}/vm/ut_j9vm.c
+	${j9vm_SOURCE_DIR}/vm/stringhelpers.cpp
+	${j9vm_SOURCE_DIR}/vm/KeyHashTable.c
+	${j9vm_SOURCE_DIR}/vm/ModularityHashTables.c
+	${j9vm_SOURCE_DIR}/vm/dllsup.c
+)
 target_link_libraries(j9dyn_generic_test
 	PRIVATE
 		j9vm_interface

--- a/runtime/cfdumper/CMakeLists.txt
+++ b/runtime/cfdumper/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(cfdump
 	main.c
 	pvdump.c
 	romdump.c
+	stubs.c
 
 	${j9vm_BINARY_DIR}/vm/ut_j9vm.c
 	${j9vm_SOURCE_DIR}/vm/stringhelpers.cpp

--- a/runtime/cfdumper/module.xml
+++ b/runtime/cfdumper/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/cfdumper/module.xml
+++ b/runtime/cfdumper/module.xml
@@ -48,6 +48,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<object name="main"/>
 			<object name="pvdump"/>
 			<object name="romdump"/>
+			<object name="stubs"/>
 		</objects>
 		<libraries>
 			<library name="j9verutil"/>

--- a/runtime/cfdumper/stubs.c
+++ b/runtime/cfdumper/stubs.c
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+
+/* Stub methods called from files in the runtime/bcutil directory.
+ *
+ * These functions are called using the following macros which
+ * 	* J9_VM_FUNCTION(currentThread, function)
+ *	* J9_VM_FUNCTION_VIA_JAVAVM(javaVM, function)
+ * allow them to be direct calls or indirect through the 
+ * internalVMFunctions table.
+ *
+ * The bcutil directory is compiled as a static library with
+ * `J9_INTERNAL_TO_VM` defined so the calls appear to be direct.
+ *
+ * cfdump needs to stub some of these functions to allow the
+ * bcutil static library to be linked.  This avoids the following
+ * link errors:
+ *
+ *
+ * "_freeMemorySegment", referenced from:
+ *    _internalDefineClass in libj9dyn.a(defineclass.o)
+ * "_internalCreateRAMClassFromROMClass", referenced from:
+ *    _internalDefineClass in libj9dyn.a(defineclass.o)
+ * "_setCurrentException", referenced from:
+ *    _internalDefineClass in libj9dyn.a(defineclass.o)
+ * "_setCurrentExceptionUTF", referenced from:
+ *    _internalDefineClass in libj9dyn.a(defineclass.o)
+ */
+
+void freeMemorySegment (J9JavaVM *javaVM, J9MemorySegment *segment, BOOLEAN freeDescriptor)
+{
+	printf("freeMemorySegment stub called!\n");
+	return;
+}
+
+J9Class *   
+internalCreateRAMClassFromROMClass(J9VMThread *vmThread, J9ClassLoader *classLoader, J9ROMClass *romClass,
+	UDATA options, J9Class* elementClass, j9object_t protectionDomain, J9ROMMethod ** methodRemapArray,
+	IDATA entryIndex, I_32 locationType, J9Class *classBeingRedefined, J9Class *hostClass)
+{
+	printf("internalCreateRAMClassFromROMClass stub called!\n");
+	return NULL;
+
+}
+
+void  
+setCurrentExceptionUTF(J9VMThread * vmThread, UDATA exceptionNumber, const char * detailUTF)
+{
+	printf("setCurrentExceptionUTF stub called!\n");
+	return;
+}
+
+void  
+setCurrentException(J9VMThread *currentThread, UDATA exceptionNumber, UDATA *detailMessage)
+{
+	printf("setCurrentException stub called!\n");
+	return;
+}


### PR DESCRIPTION
Enable direct calls rather than calling through the internalVMFunction table.  Also pass the vmthread
into the callDynamicLoader() function to avoid a call to currentVMThread().

Stub methods called from files in the runtime/bcutil directory.

These functions are called using the following macros which
	* J9_VM_FUNCTION(currentThread, function)
	* J9_VM_FUNCTION_VIA_JAVAVM(javaVM, function)
allow them to be direct calls or indirect through the
internalVMFunctions table.

The bcutil directory is compiled as a static library with
`J9_INTERNAL_TO_VM` defined so the calls appear to be direct.

cfdump needs to stub some of these functions to allow the
bcutil static library to be linked.  This avoids the following
link errors:

"_freeMemorySegment", referenced from:
   _internalDefineClass in libj9dyn.a(defineclass.o)
"_internalCreateRAMClassFromROMClass", referenced from:
   _internalDefineClass in libj9dyn.a(defineclass.o)
"_setCurrentException", referenced from:
   _internalDefineClass in libj9dyn.a(defineclass.o)
"_setCurrentExceptionUTF", referenced from:
   _internalDefineClass in libj9dyn.a(defineclass.o)

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>