### PR TITLE
Allow sampling result more than one

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
@@ -43,8 +43,8 @@ public class soae001 {
 			System.out.println("Allocated a byte array with size " + bytes.length);
 			
 			int samplingResult = check();
-			if (1 != samplingResult) {
-				System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.check() failed, expected 1 but got: " + samplingResult);
+			if (samplingResult < 1) {
+				System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.check() failed, expected 1+ but got: " + samplingResult);
 			} else {
 				jvmtiResult = disable();
 				if (0 != jvmtiResult) {


### PR DESCRIPTION
Allow sampling result more than one

Allocating `byte[DEFAULT_SAMPLING_RATE]` should trigger at least one sampling event, more than one is acceptable since there might be other allocations and sampling is not deterministic.

fixes: #5981 

Reviewer: @gacholio 
FYI: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>