### PR TITLE
Add package access method java.lang.String.isLatin1()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -8355,4 +8355,15 @@ written authorization of the copyright holder.
 		return builder.toString();
 	}	
 /*[ENDIF] Java12 */
+	
+/*[IF Java13]*/
+	/*
+	 * Determine if current String object is LATIN1.
+	 * 
+	 * @return true if it is LATIN1, otherwise false.
+	 */
+	boolean isLatin1() {
+		return LATIN1 == coder();
+	}
+/*[ENDIF] Java13 */
 }


### PR DESCRIPTION
Add package access method `java.lang.String.isLatin1()`

Added this package access method to determine if current `String` object is `LATIN1`.
Verified that `Java 13 pConfig` still compiles.

Note: this was a `private` method in RI, and is not public as per [1].

\[1\]: http://cr.openjdk.java.net/~iris/se/13/build/latest/api/java.base/java/lang/String.html

closes: #5979 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>