### PR TITLE
AArch64: Move encodeHelperBranchAndLink() to J9CodeGenerator.cpp

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -66,6 +66,15 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     * @return created linkage object
     */
    TR::Linkage *createLinkage(TR_LinkageConventions lc);
+
+   /**
+    * @brief Encode a BL instruction to the specified symbol
+    * @param[in] symRef : target symbol
+    * @param[in] cursor : instruction cursor
+    * @param[in] node : node
+    * @return Endoded BL instruction
+    */
+   uint32_t encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node);
    };
 
 }


### PR DESCRIPTION
This commit moves the aarch64 function encodeHelperBranchAndLink()
from CallSnippet.cpp to J9CodeGenerator.cpp, because the function
needs to be called from outside of CallSnippet.cpp.

Signed-off-by: knn-k <konno@jp.ibm.com>