### PR TITLE
AArch64: Add a missing symbol in PicBuilder.spp

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -103,6 +103,7 @@ L_refreshHelper:
 	cmp	x3, x4
 	bne	L_outOfRange			// distance is out of +/-128MB range
 
+L_rewriteBranch:
 	ldr	w2, [x0]			// fetch branch instruction
 	ubfx	x1, x3, #2, #26			// distance >> 2, masking out sign bits
 	and	w2, w2, #0xFC000000		// mask out branch distance


### PR DESCRIPTION
This commit adds a symbol missing in PicBuilder.spp for aarch64,
L_rewriteBranch.  #5246 added a reference to it but I forgot to
define the label.

Signed-off-by: knn-k <konno@jp.ibm.com>