### PR TITLE
Parsing command line option for GC-on-idle compact trigger options

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -965,6 +965,36 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue ;
 		}
 
+		if (try_scan(&scan_start, "darkMatterCompactThreshold=")) {
+			UDATA percentage = 0;
+			if(!scan_udata_helper(vm, &scan_start, &percentage, "darkMatterCompactThreshold=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			if(percentage > 100) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->darkMatterCompactThreshold = ((float)percentage) / 100.0f;
+			continue;
+		}
+		
+#if defined(OMR_GC_IDLE_HEAP_MANAGER)
+		if (try_scan(&scan_start, "gcOnIdleCompactThreshold=")) {
+			UDATA percentage = 0;
+			if(!scan_udata_helper(vm, &scan_start, &percentage, "gcOnIdleCompactThreshold=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			if(percentage > 100) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->gcOnIdleCompactThreshold = ((float)percentage) / 100.0f;
+			continue;
+		}
+#endif /* defined(OMR_GC_IDLE_HEAP_MANAGER) */
+
 #if defined (J9VM_GC_VLHGC)
 		if (try_scan(&scan_start, "fvtest_tarokSimulateNUMA=")) {
 			UDATA simulatedNodeCount = 0;


### PR DESCRIPTION
- This change is dependant on change on the OMR side. Refer to eclipse/omr#3939 for more information on proposed change
- Command line option `-XXgc:darkMatterCompactThreshold=` is used to set `darkMatterCompactThreshold`. Values should be percentages between 0-100.
- Command line option `-XXgc:gcOnIdleCompactThreshold=`  is used to set `gcOnIdleCompactThreshold`. Values should be percentages between 0-100.

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>