### PR TITLE
Object sampling hook object ptr is now a returned value

### DIFF
--- a/runtime/gc_include/j9mm.hdf
+++ b/runtime/gc_include/j9mm.hdf
@@ -64,13 +64,15 @@ struct J9VMThread;
 	<event>
 		<name>J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING</name>
 		<description>
-			Triggered when the object allocations sampling threshold is reached
+			Triggered when the object allocations sampling threshold is reached. The current thread has VM access,
+			but a handler may safely release and reacquire access.  If VM access is released, the listener is
+			responsible for keeping the object up-to-date.
 		</description>
 		<struct>MM_ObjectAllocationSamplingEvent</struct>
 		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
 		<data type="U_64" name="timestamp" description="time of event" />
 		<data type="UDATA" name="eventid" description="unique identifier for event" />
-		<data type="j9object_t" name="object" description="the object which has been allocated." />
+		<data type="j9object_t" name="object" return="true" description="the object which has been allocated." />
 		<data type="struct J9Class*" name="clazz" description="the class of the object just allocated" />
 		<data type="uintptr_t" name="objectSize" description="the size of the object just allocated" />
 	</event>

--- a/runtime/gc_modron_startup/mgcalloc.cpp
+++ b/runtime/gc_modron_startup/mgcalloc.cpp
@@ -61,7 +61,7 @@ extern "C" {
 static uintptr_t stackIterator(J9VMThread *currentThread, J9StackWalkState *walkState);
 static void dumpStackFrames(J9VMThread *currentThread);
 static void traceAllocateIndexableObject(J9VMThread *vmThread, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields);
-static void traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields=0);
+static J9Object * traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields=0);
 static bool traceObjectCheck(J9VMThread *vmThread);
 
 #define STACK_FRAMES_TO_DUMP	8
@@ -215,7 +215,7 @@ traceAllocateIndexableObject(J9VMThread *vmThread, J9Class* clazz, uintptr_t obj
 	return;
 }
 
-static void
+static J9Object *
 traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields)
 {
 	if(traceObjectCheck(vmThread)){
@@ -246,6 +246,7 @@ traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uin
 		 */
 		env->_oolTraceAllocationBytes = (env->_oolTraceAllocationBytes) % byteGranularity;
 	}
+	return object;
 }
 
 /* Required to check if we're going to trace or not since a java stack trace needs
@@ -436,7 +437,7 @@ J9AllocateObject(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFlags)
 		dumpStackFrames(vmThread);
 		TRIGGER_J9HOOK_MM_PRIVATE_OUT_OF_MEMORY(extensions->privateHookInterface, vmThread->omrVMThread, j9time_hires_clock(), J9HOOK_MM_PRIVATE_OUT_OF_MEMORY, memorySpace, memorySpace->getName());
 	} else {
-		traceAllocateObject(vmThread, objectPtr, clazz, sizeInBytesRequired);
+		objectPtr = traceAllocateObject(vmThread, objectPtr, clazz, sizeInBytesRequired);
 		if (extensions->isStandardGC()) {
 			if (OMR_GC_ALLOCATE_OBJECT_TENURED == (allocateFlags & OMR_GC_ALLOCATE_OBJECT_TENURED)) {
 				/* Object must be allocated in Tenure if it is requested */
@@ -559,7 +560,7 @@ J9AllocateIndexableObject(J9VMThread *vmThread, J9Class *clazz, uint32_t numberO
 				highThreshold);
 		}
 		
-		traceAllocateObject(vmThread, objectPtr, clazz, sizeInBytesRequired, (uintptr_t)numberOfIndexedFields);
+		objectPtr = traceAllocateObject(vmThread, objectPtr, clazz, sizeInBytesRequired, (uintptr_t)numberOfIndexedFields);
 		if (extensions->isStandardGC()) {
 			if (OMR_GC_ALLOCATE_OBJECT_TENURED == (allocateFlags & OMR_GC_ALLOCATE_OBJECT_TENURED)) {
 				/* Object must be allocated in Tenure if it is requested */


### PR DESCRIPTION
When the hook is triggered the current thread will have VMAccess but
it may release VMAccess as long as it properly handles that the object
may move while VMAccess has been released. The users of the hook now
have to ensure that the object pointer is properly returned if a GC
may happen.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>