### PR TITLE
Adding the NullTest for checkcastAndNULLCHK

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -713,6 +713,8 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
    //
    if (objectNode->isNull())
       {
+      if (instanceOfOrCheckCastNode->getOpCodeValue() == TR::checkcastAndNULLCHK)
+            sequences[i++] = NullTest;
       sequences[i++] = isInstanceOf ? GoToFalse : GoToTrue;
       }
    // Cast class is unresolved, not a lot of room to be fancy here.


### PR DESCRIPTION
Adding the NullTest when the first child of `checkcastAndNULLCHK` is `aconst NULL` to ensure that it throws NullPointerException when it is expected to be.

closed #5876 
Signed-off-by: simonameng <simonameng97@gmail.com>