### PR TITLE
Remove j2prof

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -112,8 +112,6 @@ static void printCompFailureInfo(TR::Compilation * comp, const char * reason);
 
 #if defined(AIXPPC)
 #include <unistd.h>
-extern FILE *j2Profile;
-extern void  j2Prof_methodReport(TR_Method * vmMethod, TR::Compilation * comp);
 #endif
 
 #if defined(J9VM_INTERP_PROFILING_BYTECODES)
@@ -9607,11 +9605,6 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
 
       if (!vm.isAOT_DEPRECATED_DO_NOT_USE())
          {
-#if defined(AIXPPC)
-         if (j2Profile != NULL)
-            j2Prof_methodReport(compilee->convertToMethod(), compiler);
-#endif
-
          if (J9_EVENT_IS_HOOKED(javaVM->hookInterface, J9HOOK_VM_DYNAMIC_CODE_LOAD))
             {
             OMR::CodeCacheMethodHeader *ccMethodHeader;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -850,9 +850,6 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_iprofilerSamplesBeforeTurningOff, 0, "P%d", NOT_IN_SUBSET},
    {"itFileNamePrefix=",  "L<filename>\tprefix for itrace filename",
         TR::Options::setStringForPrivateBase, offsetof(TR_JitPrivateConfig,itraceFileNamePrefix), 0, "P%s"},
-#if defined(AIXPPC)
-   {"j2prof",             0, SET_JITCONFIG_RUNTIME_FLAG(J9JIT_J2PROF) },
-#endif
    {"jProfilingEnablementSampleThreshold=", "M<nnn>\tNumber of global samples to allow generation of JProfiling bodies",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_jProfilingEnablementSampleThreshold, 0, "F%d", NOT_IN_SUBSET },
    {"kcaoffsets",         "I\tGenerate a header file with offset data for use with KCA", TR::Options::kcaOffsets, 0, 0, "F" },

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -38,11 +38,6 @@
 #include "p/codegen/PPCTableOfConstants.hpp"
 #include "runtime/CodeCacheManager.hpp"
 
-#if defined(AIXPPC)
-extern FILE *j2Profile;
-extern void  j2Prof_thunkReport(uint8_t *startP, uint8_t *endP, uint8_t *sig);
-#endif
-
 uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg)
    {
    int32_t        intArgNum=0, floatArgNum=0, offset;
@@ -973,30 +968,6 @@ uint8_t *TR::PPCCallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSize
    // patch size of thunk
    *(int32_t *)thunk = sizeThunk;
 
-#if defined(AIXPPC)
-   if (j2Profile != NULL) {
-      char         sigbuffer[1024], *signature;
-      TR_Method *amethod;
-      int32_t      len;
-
-      amethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
-      if (amethod == NULL)
-         {
-         signature = NULL;
-         }
-      else
-         {
-         len = amethod->signatureLength();
-         if (len >= 1024)
-            len = 1023;
-         memcpy(sigbuffer, amethod->signatureChars(), len);
-         sigbuffer[len] = '\0';
-         signature = sigbuffer;
-         }
-      j2Prof_thunkReport(returnValue, buffer, (uint8_t *)signature);
-      }
-#endif
-
    ppcCodeSync(thunk, codeSize);
 
    return(returnValue);
@@ -1113,30 +1084,6 @@ TR_J2IThunk *TR::PPCCallSnippet::generateInvokeExactJ2IThunk(TR::Node *callNode,
    // bcctr
    *(int32_t *)buffer = 0x4e800420;
    buffer += 4;
-
-#if defined(AIXPPC)
-   if (j2Profile != NULL) {
-      char         sigbuffer[1024], *signature;
-      TR_Method *amethod;
-      int32_t      len;
-
-      amethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
-      if (amethod == NULL)
-         {
-         signature = NULL;
-         }
-      else
-         {
-         len = amethod->signatureLength();
-         if (len >= 1024)
-            len = 1023;
-         memcpy(sigbuffer, amethod->signatureChars(), len);
-         sigbuffer[len] = '\0';
-         signature = sigbuffer;
-         }
-      j2Prof_thunkReport(thunk->entryPoint(), buffer, (uint8_t *)signature);
-      }
-#endif
 
    ppcCodeSync(thunk->entryPoint(), codeSize);
 

--- a/runtime/compiler/p/codegen/Trampoline.cpp
+++ b/runtime/compiler/p/codegen/Trampoline.cpp
@@ -52,13 +52,6 @@ extern "C"
 extern void     ppcCodeSync(uint8_t *, uint32_t);
 #endif
 
-#if defined(AIXPPC)
-extern FILE    *j2Profile;
-extern void     j2Prof_trampolineReport(uint8_t *startP, uint8_t *endP, int32_t num);
-extern int32_t  j2Prof_initialize();
-#endif
-
-
 void * ppcPicTrampInit(TR_FrontEnd *vm, TR::PersistentInfo * persistentInfo)
    {
    void *retVal = 0;
@@ -68,11 +61,6 @@ void * ppcPicTrampInit(TR_FrontEnd *vm, TR::PersistentInfo * persistentInfo)
       __j9_smp_flag = -1;
    else
       __j9_smp_flag = 0;
-#endif
-
-#if defined(AIXPPC)
-   if (TR::Options::getCmdLineOptions()->getOption(TR_CreatePCMaps))
-      j2Prof_initialize();
 #endif
 
 #ifdef TR_TARGET_64BIT

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3707,7 +3707,6 @@ typedef struct J9JITConfig {
 #define J9JIT_CODE_CACHE_FULL  0x40000000
 #define J9JIT_COMPILE_CLINIT  0x400000
 #define J9JIT_JVMPI_INLINE_ALLOCATION_OFF  32
-#define J9JIT_J2PROF  0x100
 
 typedef struct J9AOTConfig {
 	IDATA  ( *entryPoint)(struct J9JITConfig *jitConfig, struct J9VMThread *vmStruct, J9Method *method, void *oldStartPC) ;

--- a/runtime/oti/jilconsts.h
+++ b/runtime/oti/jilconsts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,7 +66,6 @@ extern "C" {
 #define J9JIT_CODE_CACHE_FULL  0x40000000
 #define J9JIT_COMPILE_CLINIT  0x400000
 #define J9JIT_JVMPI_INLINE_ALLOCATION_OFF  32
-#define J9JIT_J2PROF  0x100
 
 #define J9JIT_JIT_VTABLE_OFFSET 0x0
 #define J9JIT_INTERP_VTABLE_OFFSET sizeof(J9Class)


### PR DESCRIPTION
All remnants of j2prof, an old instruction-level profiling implementation
that has since been replaced by JVMTI, have been removed.

Signed-off-by: Jackie Midroni <jackie.midroni@mail.utoronto.ca>