### PR TITLE
Correctly re-add validation records

### DIFF
--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1601,7 +1601,7 @@ TR_ResolvedJ9JITaaSServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key)
+TR_ResolvedJ9JITaaSServerMethod::addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method)
    {
    // This method should be called whenever this resolved method is fetched from
    // cache during AOT compilation, because
@@ -1611,9 +1611,7 @@ TR_ResolvedJ9JITaaSServerMethod::addValidationRecordForCachedResolvedMethod(cons
    int32_t cpIndex = key.cpIndex;
    TR_OpaqueClassBlock *classObject = key.classObject;
    bool added = false;
-   TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *) _ramMethod;
-   TR_ResolvedJ9Method *owner = static_cast<TR_ResolvedJ9Method *>(owningMethod());
-   J9ConstantPool *cp = (J9ConstantPool *) owner->cp();
+   J9ConstantPool *cp = (J9ConstantPool *) static_cast<TR_ResolvedJ9Method *>(this)->cp();
    switch (key.type)
       {
       case VirtualFromCP:
@@ -1625,7 +1623,7 @@ TR_ResolvedJ9JITaaSServerMethod::addValidationRecordForCachedResolvedMethod(cons
       case Interface:
          added = svm->addInterfaceMethodFromCPRecord(
             method,
-            (TR_OpaqueClassBlock *) ((TR_J9VM *) _fe)->getClassFromMethodBlock(owner->getPersistentIdentifier()),
+            (TR_OpaqueClassBlock *) ((TR_J9VM *) _fe)->getClassFromMethodBlock(getPersistentIdentifier()),
             classObject,
             cpIndex);
          break;

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -273,7 +273,7 @@ public:
    bool inROMClass(void *address);
    static void createResolvedMethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
-   bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key);
+   bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method);
    void cacheResolvedMethodsCallees();
 
 protected:


### PR DESCRIPTION
When resolved method was retrieved from the cache,
symbol validation record would be added after the method
was recreated from its method info. However, constructor
of `TR_ResolvedRelocatableJ9JITaaSServerMethod` requires
the record to already exist. Thus, many compilations
were failing due to SVM failure.
Fix by moving `addValidationRecordForCachedResolvedMethod`
up before creation of resolved method