### PR TITLE
Allow only one JVMTI sampling object allocation agent

### DIFF
--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -211,6 +211,7 @@ typedef struct J9JVMTIData {
  */ 
 #define J9JVMTI_FLAG_REDEFINE_CLASS_EXTENSIONS_ENABLED 1   /** Class Redefinition Extensions are enabled */
 #define J9JVMTI_FLAG_REDEFINE_CLASS_EXTENSIONS_USED    2   /** Class Redefinition Extensions have been actually used. Set (and remains set) the first time a redefined class with extensions has been used */
+#define J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED      4   /** Sampling Object Allocation is enabled */
 
 #define J9JVMTI_COMPILE_EVENT_THREAD_STATE_NEW 0
 #define J9JVMTI_COMPILE_EVENT_THREAD_STATE_ALIVE 1


### PR DESCRIPTION
### Allow only one JVMTI sampling object allocation agent ###

Added `J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED` to indicate that a `JVMTI` agent is enabled to sample object allocation;
Set this flag when adding new capability `can_generate_sampled_object_alloc_events`;
Clear the flag when relinquishing this capability.

This is to address a `JTreg failure - serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorTwoAgentsTest.java`
```
Exception in thread "main" java.lang.RuntimeException: Enabling sampling in second agent succeeded...
	at MyPackage.HeapMonitorTwoAgentsTest.main(HeapMonitorTwoAgentsTest.java:44)
```
With this PR, the output is:
```
## Set the capability for second agent error: 98
```
which matches `RI` behaviour.

Reviewer: @gacholio 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>