### PR TITLE
Support compile time folding of fabricated java fields

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -153,8 +153,8 @@ static bool isJavaField(TR::SymbolReference *symRef, TR::Compilation *comp)
    TR::Symbol *symbol = symRef->getSymbol();
    if (symbol->isShadow() &&
        (symRef->getCPIndex() >= 0 ||
-        // java/lang/invoke/VarHandle.handleTable can be fabricated by VarHandleTransformer, thus does not have a valid cp index
-        symbol->getRecognizedField() == TR::Symbol::Java_lang_invoke_VarHandle_handleTable))
+        // recognized fields are java fields
+        symbol->getRecognizedField() != TR::Symbol::UnknownField))
       return true;
 
    return false;
@@ -200,22 +200,6 @@ static bool isArrayWithConstantElements(TR::SymbolReference *symRef, TR::Compila
    return false;
    }
 
-static bool isFabricatedVarHandleField(TR::SymbolReference *symRef, TR::Compilation *comp)
-   {
-   TR::Symbol *symbol = symRef->getSymbol();
-   if (symbol->isShadow() && symRef->getCPIndex() < 0)
-      {
-      switch (symbol->getRecognizedField())
-         {
-         case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
-            return true;
-         default:
-            break;
-         }
-      }
-   return false;
-   }
-
 static bool verifyFieldAccess(void *curStruct, TR::SymbolReference *field, TR::Compilation *comp)
    {
    // Return true only if loading the given field from the given struct will
@@ -235,8 +219,15 @@ static bool verifyFieldAccess(void *curStruct, TR::SymbolReference *field, TR::C
 
       TR_OpaqueClassBlock *objectClass = fej9->getObjectClass((uintptrj_t)curStruct);
       TR_OpaqueClassBlock *fieldClass = NULL;
-      if (isFabricatedVarHandleField(field, comp))
-         fieldClass = fej9->getSystemClassFromClassName("java/lang/invoke/VarHandle", strlen("java/lang/invoke/VarHandle"));
+      // Fabriated fields don't have valid cp index
+      if (field->getCPIndex() < 0 &&
+          field->getSymbol()->getRecognizedField() != TR::Symbol::UnknownField)
+         {
+         const char* className;
+         int32_t length;
+         className = field->getSymbol()->owningClassNameCharsForRecognizedField(length);
+         fieldClass = fej9->getClassFromSignature(className, length, field->getOwningMethod(comp));
+         }
       else
          fieldClass = field->getOwningMethod(comp)->getDeclaringClassFromFieldOrStatic(comp, field->getCPIndex());
 
@@ -416,7 +407,7 @@ static void *dereferenceStructPointerChain(void *baseStruct, TR::Node *baseNode,
    return NULL;
    }
 
-bool J9::TransformUtil::foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp)
+bool J9::TransformUtil::foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, const char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp)
    {
    TR::SimpleRegex *classRegex = comp->getOptions()->getClassesWithFoldableFinalFields();
    if (classRegex)

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -48,7 +48,7 @@ class OMR_EXTENSIBLE TransformUtil : public OMR::TransformUtilConnector
 public:
    static TR::TreeTop *generateRetranslateCallerWithPrepTrees(TR::Node *node, TR_PersistentMethodInfo::InfoBits reason, TR::Compilation *comp);
    static int32_t getLoopNestingDepth(TR::Compilation *comp, TR::Block *block);
-   static bool foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp);
+   static bool foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, const char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp);
 
    static TR::Node *generateArrayElementShiftAmountTrees(
          TR::Compilation *comp,


### PR DESCRIPTION
Fabricated fields have invalid cp index, therefore their class
information can't be obtained from the constant pool, preventing
eligible fabricated fields from being folded. Fix it by looking up the
class from its signature.

Part of #4837 improvement.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>