### PR TITLE
Declare FieldInfo a friend of TR_EscapeAnalysis

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -708,6 +708,7 @@ class TR_EscapeAnalysis : public TR::Optimization
 
    friend class TR_FlowSensitiveEscapeAnalysis;
    friend class TR_LocalFlushElimination;
+   friend struct FieldInfo;
    };
 
 //class Candidate;


### PR DESCRIPTION
A `TR_ASSERT` in `FieldInfo::rememberFieldSymRef` checks that the `_parms` field of `TR_EscapeAnalysis` is non-NULL.  However, pull request #5699 made most fields of `TR_EscapeAnalysis` protected, which causes debug builds to fail to compile because of that reference to `_parms`.

Fixed this by declaring `FieldInfo` to be a friend of `EscapeAnalysis`.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>