### PR TITLE
Git GC repo cache on slaves

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos
+++ b/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos
@@ -95,7 +95,6 @@ def refresh(node, cacheDir, repos, isKnownOs) {
         sh "rm -fr ${cacheDir}"
     }
 
-    sh "mkdir -p ${cacheDir}"
     dir("${cacheDir}") {
         stage("${node} - Config") {
             sh "git init --bare"
@@ -111,6 +110,9 @@ def refresh(node, cacheDir, repos, isKnownOs) {
             } else {
                 sh "git fetch --all"
             }
+        }
+        stage("${node} - GC Repo") {
+            sh "git gc --aggressive --prune=all"
         }
     }
 }


### PR DESCRIPTION
- Significantly reduces size of repo cache.
- Also remove mkdir as it is unnecessary. The dir
  step will create it if it does not exist.

Related #5970

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>