### PR TITLE
Fix lazy RuntimeAssumptionTable clean up

### DIFF
--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -87,11 +87,7 @@ class TR_RuntimeAssumptionTable
       {return (key >> 2) * 2654435761u; } // 2654435761u is the golden ratio of 2^32
    TR_RatHT* findAssumptionHashTable(TR_RuntimeAssumptionKind kind) { return (kind >= 0 && kind < LastAssumptionKind) ? _tables + kind : NULL; }
 
-   OMR::RuntimeAssumption **getBucketPtr(TR_RuntimeAssumptionKind kind, uintptrj_t hashIndex)
-      {
-      TR_RatHT *hashTable = findAssumptionHashTable(kind);
-      return hashTable->_htSpineArray + (hashIndex % hashTable->_spineArraySize);
-      }
+   OMR::RuntimeAssumption **getBucketPtr(TR_RuntimeAssumptionKind kind, uintptrj_t hashIndex);
    OMR::RuntimeAssumption *getBucket(TR_RuntimeAssumptionKind kind, uintptrj_t key)
       {
       return *getBucketPtr(kind, hashCode(key));

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -279,6 +279,14 @@ bool OMR::RuntimeAssumption::enqueueInListOfAssumptionsForJittedBody(OMR::Runtim
    return true;
    }
 
+OMR::RuntimeAssumption **TR_RuntimeAssumptionTable::getBucketPtr(TR_RuntimeAssumptionKind kind, uintptrj_t hashIndex)
+   {
+   TR_RatHT *hashTable = findAssumptionHashTable(kind);
+   OMR::RuntimeAssumption **head = hashTable->_htSpineArray + (hashIndex % hashTable->_spineArraySize);
+   while (head && *head && (*head)->isMarkedForDetach())
+      head = &((*head)->_next);
+   return head;
+   }
 
 void TR_RuntimeAssumptionTable::purgeAssumptionListHead(OMR::RuntimeAssumption *&assumptionList, TR_FrontEnd *fe)
    {

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -416,11 +416,11 @@ void jitRemoveAllMetaDataForClassLoader(J9VMThread * vmThread, J9ClassLoader * c
 void jitReclaimMarkedAssumptions(bool isEager)
    {
    static char *forceAggressiveRATCleaning = feGetEnv("TR_forceAggressiveRATCleaning");
-   if (isEager || forceAggressiveRATCleaning)
+   if (isEager && forceAggressiveRATCleaning)
       {
       reclaimMarkedAssumptionsFromRAT(-1);
       }
-   else
+   else if (!isEager)
       {
       reclaimMarkedAssumptionsFromRAT(100);
       }


### PR DESCRIPTION
This commit makes RAT clean-up lazy by default and fixes an issue
where the RAT getBucketPointer function could return a pointer pointing
at an assumption marked for removal.

Special thanks to @kobinau for his help debugging the issue and verifying the fix.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>