### PR TITLE
Fix Indy/Condy exception handling for static args

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1039,11 +1039,17 @@ public abstract class MethodHandle
 				break;
 			case 3: {
 				int cpValue = cp.getIntAt(index);
-				Class<?> argClass;
+				Class<?> argClass = null;
 				if (treatLastArgAsVarargs && (staticArgIndex >= (bsmTypeArgCount - 1))) {
 					argClass = varargsComponentType;
 				} else {
-					argClass = bsm.type.parameterType(staticArgIndex);
+					/* Verify that a call to MethodType.parameterType will not cause an ArrayIndexOutOfBoundsException. 
+					* If the number of static arguments is greater than the number of argument slots in the bsm
+					* leave argClass unset. A more meaningful user error WrongMethodTypeException will be thrown later on.
+					*/
+					if (staticArgIndex < bsmTypeArgCount) {
+						argClass = bsm.type.parameterType(staticArgIndex);
+					}
 				}
 				if (argClass == Short.TYPE) {
 					cpEntry = (short) cpValue;
@@ -1201,11 +1207,17 @@ public abstract class MethodHandle
 					break;
 				case 3: {
 					int cpValue = cp.getIntAt(index);
-					Class<?> argClass;
+					Class<?> argClass = null;
 					if (treatLastArgAsVarargs && (staticArgIndex >= (bsmTypeArgCount - 1))) {
 						argClass = varargsComponentType;
 					} else {
-						argClass = bsm.type.parameterType(staticArgIndex);
+						/* Verify that a call to MethodType.parameterType will not cause an ArrayIndexOutOfBoundsException. 
+						* If the number of static arguments is greater than the number of argument slots in the bsm
+						* leave argClass unset. A more meaningful user error WrongMethodTypeException will be thrown later on.
+						*/
+						if (staticArgIndex < bsmTypeArgCount) {
+							argClass = bsm.type.parameterType(staticArgIndex);
+						}
 					}
 					if (argClass == Short.TYPE) {
 						cpEntry = (short) cpValue;


### PR DESCRIPTION
In the case of too many BSM arguments that are of type int an ArrayIndexOutOfBoundsException is thrown from a call to MethodType.parameterType. The correct error message should be BootstrapMethodError caused by WrongMethodTypeException to match the other cpType cases.

This pr is dependent on https://github.com/eclipse/openj9/pull/5442 which refactors these methods.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>