### PR TITLE
Add known obj info to method handle thunk receiver

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -253,10 +253,13 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     * \param type
     *    TR::DataType of the parameter.
     *
+    * \param knownObjectIndex
+    *    known object index is needed if the parameter is a known object, like the receiver of a customer thunk
+    *
     * \return
     *    The created TR::ParameterSymbol
     */
-   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type);
+   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);
 
    void initShadowSymbol(TR_ResolvedMethod *, TR::SymbolReference *, bool, TR::DataType, uint32_t, bool);
 
@@ -265,6 +268,13 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    bool isFieldTypeBool(TR::SymbolReference *symRef);
    bool isStaticTypeBool(TR::SymbolReference *symRef);
    bool isReturnTypeBool(TR::SymbolReference *symRef);
+
+   /*
+    * Creates symbol references for parameters in @param owningMethodSymbol
+    * and add them to the current symbol reference table which is usually different
+    * from the global symbol reference table. This API is used for peeking and
+    * optimizations where a local symbol reference table is needed.
+    */
    void addParameters(TR::ResolvedMethodSymbol * owningMethodSymbol);
 
    // NO LONGER NEEDED?  Disabled since inception (2009)

--- a/runtime/compiler/il/symbol/J9ResolvedMethodSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9ResolvedMethodSymbol.cpp
@@ -22,6 +22,7 @@
 #include "compile/ResolvedMethod.hpp"
 #include "env/CompilerEnv.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "compile/Compilation.hpp"
 
 
 J9::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod *method, TR::Compilation *comp) :
@@ -129,3 +130,18 @@ J9::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod *method, TR::Co
 
    }
 
+TR::KnownObjectTable::Index
+J9::ResolvedMethodSymbol::getKnownObjectIndexForParm(int32_t ordinal)
+   {
+   TR::KnownObjectTable::Index index = TR::KnownObjectTable::UNKNOWN;
+   if (ordinal == 0)
+      {
+      if (self()->getResolvedMethod()->convertToMethod()->isArchetypeSpecimen())
+         {
+         TR::KnownObjectTable *knot = self()->comp()->getOrCreateKnownObjectTable();
+         if (knot)
+            index = knot->getExistingIndexAt(self()->getResolvedMethod()->getMethodHandleLocation());
+         }
+      }
+   return index;
+   }

--- a/runtime/compiler/il/symbol/J9ResolvedMethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9ResolvedMethodSymbol.hpp
@@ -43,6 +43,15 @@ namespace J9
 
 class OMR_EXTENSIBLE ResolvedMethodSymbol : public OMR::ResolvedMethodSymbolConnector
    {
+public:
+   /*
+    * \brief Get known object index of a parameter if there is any known object information available
+    *
+    * \parm ordinal
+    *     the ordinal of a parameter starting from 0 for the first parameter of a method
+    */
+   TR::KnownObjectTable::Index getKnownObjectIndexForParm(int32_t ordinal);
+
 protected:
 
    ResolvedMethodSymbol(TR_ResolvedMethod *method, TR::Compilation *comp);


### PR DESCRIPTION
This change creates symbol reference with known object index
for a parameter if it is a known object such as the receiver of
a method handle thunk. Optimizations can make use of the info
without running global VP which is very expensive and doesn't
kick in at warm.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>