### PR TITLE
Fix Trampoline.cpp AArch64 build error

### DIFF
--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -930,7 +930,7 @@ bool arm64CodePatching(void *callee, void *callSite, void *currentPC, void *curr
             }
          else
             {
-            *((uint32_t*)currentTramp+1) = (uint32_t)entryAddress;
+            *((uint64_t*)currentTramp+1) = (uint64_t)entryAddress;
             }
          }
 


### PR DESCRIPTION
Change to openj9\runtime\compiler\runtime\Trampoline.cpp to fix
AArch64 build error.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>