### PR TITLE
CMake: Default to release build with debug info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
 project(openj9)
 
+# if no build type has been set, default to release with debug info
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "")
+endif()
+
 if(NOT $ENV{BOOT_JDK} STREQUAL "")
     set(JAVA_HOME $ENV{BOOT_JDK})
 


### PR DESCRIPTION
Debug info is required for ddrgen to operate


Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>