### PR TITLE
CMake: Fix typo in j9ddr_misc

### DIFF
--- a/runtime/ddr/CMakeLists.txt
+++ b/runtime/ddr/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(j9ddr_misc
 	${omr_SOURCE_DIR}/compiler
 )
 
-if(OMR_TOOLCONFIG STREQUAL "GNU")
+if(OMR_TOOLCONFIG STREQUAL "gnu")
 	target_compile_options(j9ddr_misc PRIVATE  -femit-class-debug-always)
 endif()
 


### PR DESCRIPTION
OMR_TOOLCONFIG variable is set in lowercase

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>