### PR TITLE
Disallow thread enable/disable JVMTI_EVENT_SAMPLED_OBJECT_ALLOC

### DIFF
--- a/runtime/jvmti/jvmtiEventManagement.c
+++ b/runtime/jvmti/jvmtiEventManagement.c
@@ -88,8 +88,8 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 {
 	J9JVMTIEnv * j9env = (J9JVMTIEnv *) env;
 	J9JavaVM * vm = j9env->vm;
-	J9VMThread * currentThread;
-	jvmtiError rc;
+	J9VMThread * currentThread = NULL;
+	jvmtiError rc = JVMTI_ERROR_NONE;
 
 	Trc_JVMTI_jvmtiSetEventNotificationMode_Entry(env);
 
@@ -185,6 +185,9 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 			case JVMTI_EVENT_COMPILED_METHOD_UNLOAD:
 			case JVMTI_EVENT_DYNAMIC_CODE_GENERATED:
 			case JVMTI_EVENT_DATA_DUMP_REQUEST:
+#if JAVA_SPEC_VERSION >= 11
+			case  JVMTI_EVENT_SAMPLED_OBJECT_ALLOC:
+#endif /* JAVA_SPEC_VERSION >= 11 */
 				if (event_thread != NULL) {
 					JVMTI_ERROR(JVMTI_ERROR_ILLEGAL_ARGUMENT);
 				}

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
@@ -84,16 +84,16 @@ Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_reset(JNIEnv *jni_env,
 }
 
 jint JNICALL
-Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_enable(JNIEnv *jni_env, jclass cls)
+Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_enable(JNIEnv *jni_env, jclass cls, jthread thread)
 {
 	jint result = JNI_OK;
 	jvmtiError err = JVMTI_ERROR_NONE;
 	JVMTI_ACCESS_FROM_AGENT(env);
 	
 	/* Enable the JVMTI_EVENT_SAMPLED_OBJECT_ALLOC callback */
-	err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
+	err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, thread);
 	if (JVMTI_ERROR_NONE != err) {
-		error(env, err, "Failed to enable JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
+		softError(env, err, "Failed to enable JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
 		result = JNI_ERR;
 	}
 	

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
@@ -25,7 +25,7 @@ public class soae001 {
 	private final static int DEFAULT_SAMPLING_RATE = 512 * 1024; /* 512 KB */
 	
 	private native static void reset();	/* reset native internal counters */
-	private native static int enable();	/* enable event JVMTI_EVENT_SAMPLED_OBJECT_ALLOC */
+	private native static int enable(Thread thread);	/* enable event JVMTI_EVENT_SAMPLED_OBJECT_ALLOC */
 	private native static int disable();	/* disable event JVMTI_EVENT_SAMPLED_OBJECT_ALLOC */
 	private native static int check();	/* check how many times the event callback was invoked */
 	
@@ -34,7 +34,7 @@ public class soae001 {
 		int jvmtiResult = 0;
 
 		reset();
-		jvmtiResult = enable();
+		jvmtiResult = enable(null);
 		if (0 != jvmtiResult) {
 			System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.enable() failed with: " + jvmtiResult);
 		} else {
@@ -46,16 +46,12 @@ public class soae001 {
 			if (samplingResult < 1) {
 				System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.check() failed, expected 1+ but got: " + samplingResult);
 			} else {
-				jvmtiResult = disable();
+				jvmtiResult = enable(Thread.currentThread());
 				if (0 != jvmtiResult) {
-					System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.disable() failed with: " + jvmtiResult);
-				} else {
-					reset();
-					bytes = new byte[DEFAULT_SAMPLING_RATE];
-					System.out.println("Allocated another byte array with size " + bytes.length);
-					samplingResult = check();
-					if (0 != samplingResult) {
-						System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.check() failed, expected 0 but got: " + samplingResult);
+					System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.enable(thread) failed as expected with: " + jvmtiResult);
+					jvmtiResult = disable();
+					if (0 != jvmtiResult) {
+						System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.disable() failed with: " + jvmtiResult);
 					} else {
 						result = true;
 					}


### PR DESCRIPTION
### Disallow thread enable/disable JVMTI_EVENT_SAMPLED_OBJECT_ALLOC ###

`JVMTI_EVENT_SAMPLED_OBJECT_ALLOC` is enabled or disabled globally to match RI behaviour.
Throws `JVMTI_ERROR_ILLEGAL_ARGUMENT` if there is an attempt to thread enable/disable.

**Note**: this is to address a `JTReg Test Failure - serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorEventsForTwoThreadsTest.java`:
```
Exception in thread "main" java.lang.RuntimeException: Sampling event is thread enabled, that is unexpected.
	at MyPackage.HeapMonitorEventsForTwoThreadsTest.main(HeapMonitorEventsForTwoThreadsTest.java:46)
```
With this PR, the test has following output:
```
## Set event notifications error: 103
```
which is same as `RI`.

**Additional note**: this test (and the name HeapMonitorEventsFor**TwoThreads**Test.java) is misleading, the failure messages are identical for first and second thread [1]. It might give an impression that the `SetEventNotificationMode()` failed at second thread but indeed failed at first thread and the second thread serves no purpose from my perspective.

`RI` only allows `JVMTI_EVENT_SAMPLED_OBJECT_ALLOC` to be enabled or disabled globally though `JVMTI` specification doesn't include `Sampled Object Allocation` in the list of events that cannot be controlled at the thread level.

`OpenJ9` matches `RI` behaviours.

[1] https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/2a60f1f273a2c29b411ec9c4d9263d8ff5434529/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.c#L762-L773
[2] https://docs.oracle.com/en/java/javase/12/docs/specs/jvmti.html#SetEventNotificationMode

Reviewer: @DanHeidinga 
FYI: @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>