### PR TITLE
Fix SSL connection initialization issue

### DIFF
--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -47,12 +47,10 @@ int J9ClientStream::_numConnectionsClosed = 0;
 // This is called during startup from rossa.cpp
 void J9ClientStream::static_init(TR::PersistentInfo *info)
    {
-   if (!(info->getJITaaSSslKeys().size() || info->getJITaaSSslCerts().size() || info->getJITaaSSslRootCerts().size()))
+   if (!J9Stream::useSSL(info))
       return;
 
-   SSL_load_error_strings();
-   SSL_library_init();
-   OpenSSL_add_ssl_algorithms();
+   J9Stream::initSSL();
 
    SSL_CTX *ctx = SSL_CTX_new(SSLv23_client_method());
    if (!ctx)
@@ -116,7 +114,7 @@ void J9ClientStream::static_init(TR::PersistentInfo *info)
    _sslCtx = ctx;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Sucessfully initialized SSL context");
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
    }
 
 SSL_CTX *J9ClientStream::_sslCtx;
@@ -191,6 +189,9 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
       ERR_print_errors_fp(stderr);
       throw JITaaS::StreamFailure("Failed to create new SSL connection");
       }
+
+   SSL_set_connect_state(ssl);
+
    if (SSL_set_fd(ssl, connfd) != 1)
       {
       ERR_print_errors_fp(stderr);
@@ -203,7 +204,6 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
       SSL_free(ssl);
       throw JITaaS::StreamFailure("Failed to SSL_connect");
       }
-   SSL_set_connect_state(ssl);
 
    X509* cert = SSL_get_peer_certificate(ssl);
    if (!cert)
@@ -231,11 +231,14 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    if (BIO_set_ssl(bio, ssl, true) != 1)
       {
       ERR_print_errors_fp(stderr);
-      SSL_free(ssl);
       BIO_free_all(bio);
+      SSL_free(ssl);
       throw JITaaS::StreamFailure("Failed to set BIO SSL");
       }
 
+   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
+                                                      connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
    return bio;
    }
 

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -46,11 +46,6 @@ namespace JITaaS
 int J9ServerStream::_numConnectionsOpened = 0;
 int J9ServerStream::_numConnectionsClosed = 0;
 
-bool useSSL(TR::PersistentInfo *info)
-   {
-   return info->getJITaaSSslKeys().size() || info->getJITaaSSslCerts().size() || info->getJITaaSSslRootCerts().size();
-   }
-
 J9ServerStream::J9ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    : J9Stream(),
    _msTimeout(timeout)
@@ -87,13 +82,6 @@ J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, st
       if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Could not finish compilation: %s", e.what());
       }
-   }
-
-void initSSL()
-   {
-   SSL_load_error_strings();
-   SSL_library_init();
-   OpenSSL_add_ssl_algorithms();
    }
 
 SSL_CTX *createSSLContext(TR::PersistentInfo *info)
@@ -177,20 +165,70 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
    // verify server identity using standard method
    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
 
+   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
+
    return ctx;
    }
+
+static bool
+handleOpenSSLConnectionError(int connfd, SSL *&ssl, BIO *&bio, const char *errMsg)
+{
+   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "%s: errno=%d", errMsg, errno);
+   ERR_print_errors_fp(stderr);
+
+   close(connfd);
+   if (bio)
+      {
+      BIO_free_all(bio);
+      bio = NULL;
+      }
+   if (ssl)
+      {
+      SSL_free(ssl);
+      ssl = NULL;
+      }
+   return false;
+}
+
+static bool
+acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
+   {
+   SSL *ssl = SSL_new(sslCtx);
+   if (!ssl)
+      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error creating SSL connection");
+
+   SSL_set_accept_state(ssl);
+
+   if (SSL_set_fd(ssl, connfd) != 1)
+      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error setting SSL file descriptor");
+
+   if (SSL_accept(ssl) <= 0)
+      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error accepting SSL connection");
+
+   bio = BIO_new_ssl(sslCtx, false);
+   if (!bio)
+      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error creating new BIO");
+
+   if (BIO_set_ssl(bio, ssl, true) != 1)
+      return handleOpenSSLConnectionError(connfd, ssl, bio, "Error setting BIO SSL");
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
+                                                     connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
+   return true;
+   }
+
 
 void
 J9CompileServer::buildAndServe(J9BaseCompileDispatcher *compiler, TR::PersistentInfo *info)
    {
    SSL_CTX *sslCtx = NULL;
-   if (useSSL(info))
+   if (J9Stream::useSSL(info))
       {
-      initSSL();
+      J9Stream::initSSL();
       sslCtx = createSSLContext(info);
-
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Sucessfully initialized SSL context");
       }
 
    uint32_t port = info->getJITaaSServerPort();
@@ -248,8 +286,6 @@ J9CompileServer::buildAndServe(J9BaseCompileDispatcher *compiler, TR::Persistent
       {
       struct sockaddr_in cli_addr;
       socklen_t clilen = sizeof(cli_addr);
-      SSL *ssl = NULL;
-      BIO *bio = NULL;
 
       int connfd = accept(sockfd, (struct sockaddr *)&cli_addr, &clilen);
       if (connfd < 0)
@@ -259,59 +295,9 @@ J9CompileServer::buildAndServe(J9BaseCompileDispatcher *compiler, TR::Persistent
          continue;
          }
 
-      if (sslCtx)
-         {
-         ssl = SSL_new(sslCtx);
-         if (!ssl)
-            {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error creating SSL connection: errno=%d", errno);
-            ERR_print_errors_fp(stderr);
-            close(connfd);
-            SSL_free(ssl);
-            continue;
-            }
-         if (SSL_set_fd(ssl, connfd) != 1)
-            {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error setting SSL file descriptor: errno=%d", errno);
-            ERR_print_errors_fp(stderr);
-            close(connfd);
-            SSL_free(ssl);
-            continue;
-            }
-         if (SSL_accept(ssl) <= 0)
-            {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error accepting SSL connection: errno=%d", errno);
-            ERR_print_errors_fp(stderr);
-            close(connfd);
-            SSL_free(ssl);
-            continue;
-            }
-         SSL_set_accept_state(ssl);
-
-         bio = BIO_new_ssl(sslCtx, false);
-         if (!bio)
-            {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error creating new BIO: errno=%d", errno);
-            ERR_print_errors_fp(stderr);
-            close(connfd);
-            SSL_free(ssl);
-            continue;
-            }
-         if (BIO_set_ssl(bio, ssl, true) != 1)
-            {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error setting BIO SSL: errno=%d", errno);
-            ERR_print_errors_fp(stderr);
-            close(connfd);
-            BIO_free_all(bio);
-            SSL_free(ssl);
-            continue;
-            }
-         }
+      BIO *bio = NULL;
+      if (sslCtx && !acceptOpenSSLConnection(sslCtx, connfd, bio))
+         continue;
 
       J9ServerStream *stream = new (PERSISTENT_NEW) J9ServerStream(connfd, bio, timeoutMs);
       compiler->compile(stream);

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -32,6 +32,19 @@ using namespace google::protobuf::io;
 
 class J9Stream
    {
+public:
+   static bool useSSL(TR::PersistentInfo *info)
+      {
+      return (info->getJITaaSSslKeys().size() || info->getJITaaSSslCerts().size() || info->getJITaaSSslRootCerts().size());
+      }
+
+   static void initSSL()
+      {
+      SSL_load_error_strings();
+      SSL_library_init();
+      OpenSSL_add_ssl_algorithms();
+      }
+
 protected:
    J9Stream()
       : _inputStream(NULL),


### PR DESCRIPTION
[skip ci]
When establishing OpenSSL connection, `SSL_set_connect_state()`
was called at the client after `SSL_connect()`; `SSL_set_accept_state()`
was called at the server after `SSL_accept()`. This is incorrect.

SSL_set_*_state() clears SSL state machine states, especially s->statem.state
to MSG_FLOW_UNINITED, s->statem.hand_state to TLS_ST_BEFORE,
and s->statem.in_init to 1. After the SSL handshake, s->statem.state
becomes MSG_FLOW_FINISHED, s->statem.hand_state becomes TLS_ST_OK,
and s->statem.in_init becomes 0.

When SSL_set_*_state() is called after the SSL handshake,
these states are overwritten which likely puts the state machine
back in wrong states. This causes ssl3_read_bytes() to throw errors
at both client and server.

SSL_set_*_state() should be called before the SSL handshake.
This fix enables our code to work with OpenSSL 1.1.1
and establish TLSv1.3 SSL connections.

Fixes ##6033

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>