### PR TITLE
Implement version checking for JITaaS

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3427,6 +3427,7 @@ void TR::CompilationInfo::stopCompilationThreads()
          }
       catch (const JITaaS::StreamFailure &e)
          {
+         JITaaS::J9ClientStream::markServerUnreachable(_jitConfig);
          // catch the stream failure exception if the server dies before the dummy message is send for termination.
          if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS StreamFailure (server died before the termination message send): %s", e.what());
@@ -6972,7 +6973,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
          _vm = TR_J9VMBase::get(_jitConfig, vmThread, TR_J9VMBase::AOT_VM);
 
       if ((_compInfo.getPersistentInfo()->getJITaaSMode() == CLIENT_MODE) &&
-         !shouldPerformLocalComp(entry))
+         !shouldPerformLocalComp(entry) && JITaaS::J9ClientStream::isServerReachable(_jitConfig, _compInfo.getPersistentInfo()))
          {
          entry->setRemoteCompReq();
          }
@@ -7032,7 +7033,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
                }
             }
 
-         if (!doLocalCompilation)
+         if (!doLocalCompilation && JITaaS::J9ClientStream::isServerReachable(_jitConfig, _compInfo.getPersistentInfo()))
             entry->setRemoteCompReq();
          }
       }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2070,6 +2070,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationRecoverableTrampolineFailure:
             case compilationIllegalCodeCacheSwitch:
             case compilationRecoverableCodeCacheError:
+            case compilationVersionIncompatible:
                tryCompilingAgain = true;
                break;
             case compilationExcessiveComplexity:
@@ -10834,6 +10835,13 @@ TR::CompilationInfoPerThreadBase::processException(
       if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS StreamFailure: %s", e.what());
       _methodBeingCompiled->_compErrCode = compilationStreamFailure;
+      }
+   catch (const JITaaS::VersionIncompatible &e)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS VersionIncompatible: %s", e.what());
+      _methodBeingCompiled->_compErrCode = compilationVersionIncompatible;  
+      // Try again with local compilations if server and client are incompatible
       }
    catch (const JITaaS::ServerCompFailure &e)
       {

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2378,6 +2378,18 @@ remoteCompile(
       
          compiler->failCompilation<std::bad_alloc>(e.what());
          }
+      catch (const JITaaS::VersionIncompatible &e)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
+
+         client->~J9ClientStream();
+         TR_Memory::jitPersistentFree(client);
+
+         // need to somehow mark server as incompatible
+
+         compiler->failCompilation<JITaaS::VersionIncompatible>(e.what());
+         }
       }
    else
       {

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2367,6 +2367,8 @@ remoteCompile(
          if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
 
+         JITaaS::J9ClientStream::markServerUnreachable(jitConfig);
+
          compiler->failCompilation<JITaaS::StreamFailure>(e.what());
          }
       catch (const std::bad_alloc &e)
@@ -2391,6 +2393,8 @@ remoteCompile(
             {
             if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
                TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, e.what());
+
+            JITaaS::J9ClientStream::markServerUnreachable(jitConfig);
 
             compiler->failCompilation<JITaaS::StreamFailure>(e.what());
             }
@@ -2498,6 +2502,8 @@ remoteCompile(
       client->~J9ClientStream();
       TR_Memory::jitPersistentFree(client);
       compInfoPT->setClientStream(NULL);
+
+      JITaaS::J9ClientStream::markServerUnreachable(jitConfig);
 
       compiler->failCompilation<JITaaS::StreamFailure>(e.what());
       }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -204,6 +204,7 @@ char *compilationErrorNames[]={
    "compilationAOTNoSupportForAOTFailure", //51
    "compilationStreamFailure", //52
    "compilationStreamLostMessage", // 53
+   "compilationVersionIncompatible", // 54
    "compilationMaxError"
 };
 

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -80,8 +80,14 @@ public:
 
    void shutdown();
 
+   static void markServerUnreachable(J9JITConfig *jitConfig);
+   static bool isServerReachable(J9JITConfig *jitConfig, TR::PersistentInfo *info);
+
    static int _numConnectionsOpened;
    static int _numConnectionsClosed;
+   static uint64_t _localCompStartTime;
+   static uint64_t _pingServerInterval;
+   static bool _serverUnreachable;
 
 private:
    uint32_t _timeout;

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -82,6 +82,7 @@ public:
 
    static void markServerUnreachable(J9JITConfig *jitConfig);
    static bool isServerReachable(J9JITConfig *jitConfig, TR::PersistentInfo *info);
+   static bool isVersionCompatible();
 
    static int _numConnectionsOpened;
    static int _numConnectionsClosed;

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -73,6 +73,7 @@ public:
       {
       return _clientId;
       }
+   static bool checkClientVersion(uint32_t version) const;
 
    static int _numConnectionsOpened;
    static int _numConnectionsClosed;

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -26,6 +26,10 @@
 #include "rpc/SSLProtobufStream.hpp"
 #include "env/TRMemory.hpp"
 
+static const uint8_t MAJOR_NUMBER = 0;
+static const uint16_t MINOR_NUMBER = 1;
+static const uint8_t PATCH_NUMBER = 0;
+
 namespace JITaaS
 {
 using namespace google::protobuf::io;

--- a/runtime/compiler/rpc/StreamTypes.hpp
+++ b/runtime/compiler/rpc/StreamTypes.hpp
@@ -45,6 +45,12 @@ private:
    std::string _message;
    };
 
+class VersionIncompatible: public virtual std::exception
+   {
+public:
+   virtual const char* what() const throw() { return "Version incompatible"; }
+   }
+
 class StreamCancel: public virtual std::exception
    {
 public:

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -51,6 +51,7 @@ enum J9ServerMessageType
    mirrorResolvedJ9Method = 1;
    get_params_to_construct_TR_j9method = 2;
    getUnloadedClassRanges = 3;
+   versionIncompatible = 4;
 
    // For TR_ResolvedJ9JITaaSServerMethod methods
    ResolvedMethod_isJNINative = 100;


### PR DESCRIPTION
Client sends the version information after it establishes connection with the Server. There will be at the maximum 7 connections in total for any given client. Server sends back a message which will inform the client whether they are compatible or not. Client will switch to local compilations if incompatible.

[skip ci]
Issue: #4467
    
Signed-off-by: Harry Yu <harryyu1994@gmail.com>