### PR TITLE
Implement version checking for JITaaS

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -381,6 +381,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/j9methodServer.cpp \
     compiler/rpc/J9Server.cpp \
     compiler/rpc/J9Client.cpp \
+    compiler/rpc/J9Stream.cpp \
     compiler/rpc/ProtobufTypeConvert.cpp \
     compiler/control/JITaaSCompilationThread.cpp \
     compiler/env/JITaaSPersistentCHTable.cpp \

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -326,6 +326,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
       bool getCachedNullClassOfStatic(TR_OpaqueClassBlock *ramClass, int32_t cpIndex);
 
       void clearPerCompilationCaches();
+      void deleteClientSessionData(uint64_t clientId, TR::CompilationInfo* compInfo, J9VMThread* compThread);
 
    private:
       /* Template method for allocating a cache of type T on the heap.

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -205,11 +205,12 @@ char *compilationErrorNames[]={
    "compilationAOTValidateTMFailure", //52
    "compilationStreamFailure", //53
    "compilationStreamLostMessage", // 54
+   "compilationStreamMessageTypeMismatch", // 55
+   "compilationStreamVersionIncompatible", // 56
    "compilationMaxError"
 };
 
 int32_t aggressiveOption = 0;
-
 
 // Tells the sampler thread whether it is being interrupted to resume it or to
 // shut it down.
@@ -1603,6 +1604,8 @@ onLoadInternal(
    
    if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
       {
+      JITaaS::J9Stream::initVersion();
+
       // Allocate the hashtable that holds information about clients
       compInfo->setClientSessionHT(ClientSessionHT::allocate());
 
@@ -1631,6 +1634,7 @@ onLoadInternal(
 
       // Try to initialize SSL
       JITaaS::J9ClientStream::static_init(compInfo->getPersistentInfo());
+      JITaaS::J9Stream::initVersion();
       }
 
 #if defined(TR_HOST_S390)

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -78,6 +78,8 @@ typedef enum {
    compilationAOTValidateTMFailure                 = 52,
    compilationStreamFailure                        = 53,
    compilationStreamLostMessage                    = 54,
+   compilationStreamMessageTypeMismatch            = 55,
+   compilationStreamVersionIncompatible            = 56,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -44,6 +44,10 @@ namespace JITaaS
 
 int J9ClientStream::_numConnectionsOpened = 0;
 int J9ClientStream::_numConnectionsClosed = 0;
+int J9ClientStream::_incompatibilityCount = 0;
+uint64_t J9ClientStream::_incompatibleStartTime = 0;
+const uint64_t J9ClientStream::RETRY_COMPATIBILITY_INTERVAL = 10000; //ms
+const int J9ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
 
 // Create SSL context, load certs and keys. Only needs to be done once.
 // This is called during startup from rossa.cpp
@@ -250,8 +254,7 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    }
 
 J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
-   : J9Stream(),
-   _timeout(info->getJITaaSTimeout())
+   : J9Stream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    BIO *ssl = openSSLConnection(_sslCtx, connfd);
@@ -260,8 +263,7 @@ J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
    }
 #else // JITAAS_ENABLE_SSL
 J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
-   : J9Stream(),
-   _timeout(info->getJITaaSTimeout())
+   : J9Stream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    initStream(connfd);
@@ -274,14 +276,6 @@ J9ClientStream::waitForFinish()
    {
    // any error would have thrown earlier
    return Status::OK;
-   }
-
-void
-J9ClientStream::writeError()
-   {
-   _cMsg.set_status(false);
-   _cMsg.mutable_data()->clear_data();
-   writeBlocking(_cMsg);
    }
 
 void

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -66,13 +66,8 @@ J9ServerStream::J9ServerStream(int connfd, uint32_t timeout)
 #endif
 
 // J9Stream destructor is used instead
-// cancel is unnecessary as errors will either throw or be indicated by the statusCode
 void
 J9ServerStream::finish()
-   {
-   }
-void
-J9ServerStream::cancel()
    {
    }
 

--- a/runtime/compiler/rpc/J9Stream.cpp
+++ b/runtime/compiler/rpc/J9Stream.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <google/protobuf/io/zero_copy_stream_impl.h>	
+#include "rpc/ProtobufTypeConvert.hpp"
+#include "rpc/J9Stream.hpp"
+
+uint32_t JITaaS::J9Stream::CONFIGURATION_FLAGS = 0;

--- a/runtime/compiler/rpc/StreamTypes.hpp
+++ b/runtime/compiler/rpc/StreamTypes.hpp
@@ -48,7 +48,25 @@ private:
 class StreamCancel: public virtual std::exception
    {
 public:
-   virtual const char* what() const throw() { return "compilation canceled by client"; }
+   StreamCancel(J9ServerMessageType type, uint64_t clientId=0) : _type(type), _clientId(clientId) { }
+   virtual const char* what() const throw()
+      {
+      if (_type == J9ServerMessageType::clientTerminate)
+         return "Client session terminated at client's request";
+      else
+         return "Compilation cancelled by client";
+      }
+   J9ServerMessageType getType() const
+      {
+      return _type;
+      }
+   uint64_t getClientId() const
+      {
+      return _clientId;
+      }
+private:
+   J9ServerMessageType _type;
+   uint64_t _clientId;
    };
 
 class StreamOOO : public virtual std::exception
@@ -61,6 +79,37 @@ class StreamTypeMismatch: public virtual StreamFailure
    {
 public:
    StreamTypeMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "Type mismatch: %s", message.c_str()); }
+   };
+
+class StreamMessageTypeMismatch: public virtual std::exception
+   {
+public:
+   StreamMessageTypeMismatch(J9ServerMessageType serverType, J9ServerMessageType clientType)
+      {
+      _message = "server expected mesasge type " + std::to_string(serverType) + " received " + std::to_string(clientType);
+      }
+   virtual const char* what() const throw() 
+      {
+      return _message.c_str();
+      }
+private:
+   std::string _message;
+   };
+
+class StreamVersionIncompatible: public virtual std::exception
+   {
+public:
+   StreamVersionIncompatible() : _message("server incompatible") { }
+   StreamVersionIncompatible(uint64_t serverVersion, uint64_t clientVersion)
+      {
+      _message = "server expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
+      }
+   virtual const char* what() const throw()
+      {
+      return _message.c_str();
+      }
+private:
+   std::string _message;
    };
 
 class StreamArityMismatch: public virtual StreamFailure

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -51,6 +51,9 @@ enum J9ServerMessageType
    mirrorResolvedJ9Method = 1;
    get_params_to_construct_TR_j9method = 2;
    getUnloadedClassRanges = 3;
+   compilationRequest = 4; // type used when client sends remote compilation requests
+   compilationAbort = 5; // type used when client informs the server to abort the remote compilation
+   clientTerminate = 6; // type used when client process is about to terminate
 
    // For TR_ResolvedJ9JITaaSServerMethod methods
    ResolvedMethod_isJNINative = 100;
@@ -300,8 +303,9 @@ message J9ServerMessage
 
 message J9ClientMessage
    {
-   bool status = 1;
+   J9ServerMessageType type = 1;
    AnyData data = 2;
+   uint64 version = 3;
    }
 
 service J9CompileService

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -569,11 +569,11 @@ TR_JITaaSClientIProfiler::serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodB
          intptrj_t writtenBytes = serializeIProfilerMethodEntries(pcEntries, numEntries, (uintptr_t)&buffer[0], methodStart);
          TR_ASSERT(writtenBytes == bytesFootprint, "BST doesn't match expected footprint");
          // send the information to the server
-         client->write(buffer, true, usePersistentCache);
+         client->write(JITaaS::J9ServerMessageType::IProfiler_profilingSample, buffer, true, usePersistentCache);
          }
       else if (!numEntries && !abort)// Empty IProfiler data for this method
          {
-         client->write(std::string(), true, usePersistentCache);
+         client->write(JITaaS::J9ServerMessageType::IProfiler_profilingSample, std::string(), true, usePersistentCache);
          }
 
       // release any entry that has been locked by us


### PR DESCRIPTION
Newly added exceptions:
1. **StreamMessageTypeMismatch**: a server side exception, the throw happens in `read()` and `readCompileRequest()` when the received message from client is not of the expected type.
When we catch this exception, we terminate the compilation without closing the connection by writing to client `stream->finishCompilation(compilationStreamMessageTypeMismatch)` with the error code `compilationStreamMessageTypeMismatch`.
2. **StreamVersionIncompatible**: the throw happens in `readCompileRequest()` when client version is not compatible with server version. Used for both client and server, but mainly for server. When we catch this exception, we terminate the compilation by writing to client `stream->finishCompilation(compilationStreamVersionIncompatible)` with the error code `compilationStreamVersionIncompatible`

Newly added compilation error codes: The error codes are handled in routine `shouldRetryCompilation` on the client upon receiving the `stream->finishCompilation()` message from server.
1. **compilationStreamMessageTypeMismatch**: tryCompilingAgain = true
2. **compilationStreamVersionIncompatible**: we mark the server as incompatible and proceed with recompilation locally.

Version Checking:
3 status: INCOMPATIBLE, COMPATIBLE, NOT_DONE
Client message now has 3 fields: type, data and version
Server message now has 2 fields: type and data
The version field is an uint64_t flag: CONFIGURATION_FLAG (32bit) + MAJOR_NUMBER(8bit) + MINOR_NUMBER(16bit) + PATCH_NUMBER(8bit)

Incorporated the version checking mechanism in `buildCompileRequest` and `readCompileRequest`:
1. **buildCompileRequest**: a client side routine, if status is NOT_DONE, we set the version before sending for the server to check for compatibility. If status is COMPATIBLE, that means we have already confirmed that server is compatible, so we want to send data without the version field to bypass the check. If status is INCOMPATIBLE, it means server has already rejected the client request, so we should always do local compilations instead.

2. **readCompileRequest**: a server side routine, if version is not 0 (default is 0), then it means client wants to check for compatibility. If version is 0, it means that the client has already been checked and it's compatible.




[skip ci]
Issue: #4467

Signed-off-by: Harry Yu <harryyu1994@gmail.com>