### PR TITLE
Use new unstable step for downstream jobs that are UNSTABLE

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -305,7 +305,11 @@ def build_with_slack(DOWNSTREAM_JOB_NAME, ghprbGhRepository, ghprbActualCommit, 
             // want to offer the restart option as it is not desired for PR builds.
             // If the job was UNSTABLE this indicates test(s) failed and we don't want to offer the restart option.
             echo "WARNING: Downstream job ${DOWNSTREAM_JOB_NAME} is ${JOB.result} after ${DOWNSTREAM_JOB_TIME}. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
-            currentBuild.result = JOB.result
+            if (JOB.result == "UNSTABLE") {
+                unstable "Setting overall pipeline status to UNSTABLE"
+            } else {
+                currentBuild.result = JOB.result
+            }
             if (SLACK_CHANNEL) {
                 slackSend channel: SLACK_CHANNEL, color: 'warning', message: "${JOB.result}: ${DOWNSTREAM_JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)\n${build_causes_string}"
             }


### PR DESCRIPTION
- A change in BlueOcean to address JENKINS-39203 now
  requires updated plugins as well as a code change in
  order to visualize unstable stages.
- For more info see:
  - https://issues.jenkins-ci.org/browse/JENKINS-39203?focusedCommentId=367029&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-367029
  - https://wiki.jenkins.io/display/JENKINS/Pipeline+Basic+Steps+Plugin
    - Changelog 2.16 May 14, 2019

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>