### PR TITLE
Deep Structure Scan Optimization

### DIFF
--- a/runtime/gc_api/HeapIteratorAPI.cpp
+++ b/runtime/gc_api/HeapIteratorAPI.cpp
@@ -399,6 +399,7 @@ j9mm_iterate_object_slots(
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(javaVM->omrVM);
 	
 	switch(extensions->objectModel.getScanType(objectPtr)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_base/ReferenceChainWalker.cpp
+++ b/runtime/gc_base/ReferenceChainWalker.cpp
@@ -348,6 +348,7 @@ MM_ReferenceChainWalker::scanObject(J9Object *objectPtr)
 	doClassSlot(&clazz, J9GC_REFERENCE_TYPE_CLASS, -1, objectPtr);
 
 	switch(_extensions->objectModel.getScanType(objectPtr)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_glue_java/CompactDelegate.cpp
+++ b/runtime/gc_glue_java/CompactDelegate.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,7 @@ MM_CompactDelegate::verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap)
 		omrobjectptr_t objectPtr = NULL;
 		while (NULL != (objectPtr = markedObjectIterator.nextObject())) {
 			switch(extensions->objectModel.getScanType(objectPtr)) {
+			case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 			case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 			case GC_ObjectModel::SCAN_MIXED_OBJECT:
 			case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupObject.cpp
@@ -71,6 +71,7 @@ void
 MM_CompactSchemeFixupObject::fixupObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr)
 {
 	switch(env->getExtensions()->objectModel.getScanType(objectPtr)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_CLASS_OBJECT:

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,6 +118,7 @@ public:
 
 		GC_ObjectScanner *objectScanner = NULL;
 		switch(_extensions->objectModel.getScanType(objectPtr)) {
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -210,6 +210,7 @@ public:
 	{
 		UDATA pointersScanned = 0;
 		switch(_extensions->objectModel.getScanType(objectPtr)) {
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_glue_java/ObjectIterator.hpp
+++ b/runtime/gc_glue_java/ObjectIterator.hpp
@@ -65,6 +65,7 @@ public:
 		switch (_type) {
 		case GC_ObjectModel::SCAN_INVALID_OBJECT:
 			return;
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
@@ -91,6 +92,7 @@ public:
 		switch (_type) {
 		case GC_ObjectModel::SCAN_INVALID_OBJECT:
 			return NULL;
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
@@ -118,6 +120,7 @@ public:
 		switch (_type) {
 		case GC_ObjectModel::SCAN_INVALID_OBJECT:
 			return;
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
@@ -142,6 +145,7 @@ public:
 		switch (_type) {
 		case GC_ObjectModel::SCAN_INVALID_OBJECT:
 			return;
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:

--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -114,6 +114,7 @@ public:
 		SCAN_CLASSLOADER_OBJECT = 6,
 		SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT = 7,
 		SCAN_OWNABLESYNCHRONIZER_OBJECT = 8,
+		SCAN_MIXED_OBJECT_LINKED = 9
 	};
 
 	/**
@@ -179,7 +180,12 @@ public:
 		{
 			UDATA classFlags = J9CLASS_FLAGS(clazz) & (J9AccClassReferenceMask | J9AccClassGCSpecial | J9AccClassOwnableSynchronizer);
 			if (0 == classFlags) {
-				result = SCAN_MIXED_OBJECT;
+				/* TODO try an approach with a separate class flag */
+				if (0 != clazz->selfReferencingField1) {
+					result = SCAN_MIXED_OBJECT_LINKED;
+				} else {
+					result = SCAN_MIXED_OBJECT;
+				}
 			} else {
 				if (0 != (classFlags & J9AccClassReferenceMask)) {
 					result = SCAN_REFERENCE_MIXED_OBJECT;

--- a/runtime/gc_realtime/RealtimeAccessBarrier.cpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.cpp
@@ -190,6 +190,7 @@ MM_RealtimeAccessBarrier::validateWriteBarrier(J9VMThread *vmThread, J9Object *d
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
 	switch(_extensions->objectModel.getScanType(dstObject)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_trace_vlhgc/TgcInterRegionReferences.cpp
+++ b/runtime/gc_trace_vlhgc/TgcInterRegionReferences.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,6 +101,7 @@ tgcHookReportInterRegionReferenceCounting(J9HookInterface** hookInterface, UDATA
 				case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 					Assert_MM_true(GC_ObjectModel::REF_STATE_REMEMBERED != J9GC_J9VMJAVALANGREFERENCE_STATE(env, object));
 					/* fall through */
+				case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 				case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 				case GC_ObjectModel::SCAN_MIXED_OBJECT:
 				case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2822,6 +2822,7 @@ MM_CopyForwardScheme::scanObject(MM_EnvironmentVLHGC *env, MM_AllocationContextT
 	J9Class* clazz = J9GC_J9OBJECT_CLAZZ(objectPtr);
 	Assert_MM_mustBeClass(clazz);
 	switch(_extensions->objectModel.getScanType(clazz)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		scanMixedObjectSlots(env, reservingContext, objectPtr, reason);
@@ -3108,6 +3109,7 @@ MM_CopyForwardScheme::incrementalScanCacheBySlot(MM_EnvironmentVLHGC *env)
 			while ((objectPtr = heapChunkIterator.nextObject()) != NULL) {
 				/* retrieve scan state of the scan cache */
 				switch(_extensions->objectModel.getScanType(objectPtr)) {
+				case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 				case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 				case GC_ObjectModel::SCAN_MIXED_OBJECT:
 				case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
@@ -4474,6 +4476,7 @@ MM_CopyForwardScheme::verifyObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr
 	J9Class* clazz = J9GC_J9OBJECT_CLAZZ(objectPtr);
 	Assert_MM_mustBeClass(clazz);
 	switch(_extensions->objectModel.getScanType(clazz)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
@@ -129,6 +129,7 @@ MM_GlobalMarkCardScrubber::scrubObject(MM_EnvironmentVLHGC *env, J9Object *objec
 	Assert_MM_mustBeClass(clazz);
 	switch(MM_GCExtensions::getExtensions(env)->objectModel.getScanType(clazz)) {
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 		case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:
 		case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -867,6 +867,7 @@ MM_GlobalMarkingScheme::scanObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr
 		J9Class* clazz = J9GC_J9OBJECT_CLAZZ(objectPtr);
 		Assert_MM_mustBeClass(clazz);
 		switch(_extensions->objectModel.getScanType(clazz)) {
+			case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 			case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 			case GC_ObjectModel::SCAN_MIXED_OBJECT:
 			case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1785,6 +1785,7 @@ MM_IncrementalGenerationalGC::verifyMarkMapClosure(MM_EnvironmentVLHGC *env, MM_
 				case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 					Assert_MM_true(GC_ObjectModel::REF_STATE_REMEMBERED != J9GC_J9VMJAVALANGREFERENCE_STATE(env, object));
 					/* fall through */
+				case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 				case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 				case GC_ObjectModel::SCAN_MIXED_OBJECT:
 				case GC_ObjectModel::SCAN_CLASS_OBJECT:

--- a/runtime/gc_vlhgc/PartialMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.cpp
@@ -872,6 +872,7 @@ MM_PartialMarkingScheme::scanObject(MM_EnvironmentVLHGC *env, J9Object *objectPt
 	J9Class* clazz = J9GC_J9OBJECT_CLAZZ(objectPtr);
 	Assert_MM_mustBeClass(clazz);
 	switch(_extensions->objectModel.getScanType(clazz)) {
+		case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 		case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 		case GC_ObjectModel::SCAN_MIXED_OBJECT:
 			scanMixedObject(env, objectPtr, reason);

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1383,6 +1383,7 @@ MM_WriteOnceCompactor::fixupObject(MM_EnvironmentVLHGC* env, J9Object *objectPtr
 	J9Class* clazz = J9GC_J9OBJECT_CLAZZ(objectPtr);
 	Assert_MM_mustBeClass(clazz);
 	switch(_extensions->objectModel.getScanType(clazz)) {
+	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 	case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 	case GC_ObjectModel::SCAN_MIXED_OBJECT:
 	case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
@@ -1821,6 +1822,7 @@ MM_WriteOnceCompactor::verifyHeap(MM_EnvironmentVLHGC *env, bool beforeCompactio
 
 		while (J9Object* objectPtr = markedObjectIterator.nextObject()) {
 			switch(_extensions->objectModel.getScanType(objectPtr)) {
+			case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
 			case GC_ObjectModel::SCAN_ATOMIC_MARKABLE_REFERENCE_OBJECT:
 			case GC_ObjectModel::SCAN_MIXED_OBJECT:
 			case GC_ObjectModel::SCAN_OWNABLESYNCHRONIZER_OBJECT:

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
  *
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
@@ -2978,6 +2978,8 @@ typedef struct J9Class {
 	UDATA* instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 	UDATA instanceHotFieldDescription;
+	UDATA selfReferencingField1;
+	UDATA selfReferencingField2;
 	struct J9Method* initializerCache;
 	UDATA romableAotITable;
 	UDATA packageID;
@@ -3044,6 +3046,8 @@ typedef struct J9ArrayClass {
 	UDATA* instanceLeafDescription;
 #endif /* J9VM_GC_LEAF_BITS */
 	UDATA instanceHotFieldDescription;
+	UDATA selfReferencingField1;
+	UDATA selfReferencingField2;
 	struct J9Method* initializerCache;
 	UDATA romableAotITable;
 	UDATA packageID;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2691,6 +2691,10 @@ fail:
 					memcpy(ramClass->superclasses, superclass->superclasses, superclassCount * sizeof(UDATA));
 				}
 				ramClass->superclasses[superclassCount] = superclass;
+
+				/* Propagate self referencing field offsets from superclass (special treated during GC) - these take priority over self referencing fields of derived class*/
+				ramClass->selfReferencingField1 = superclass->selfReferencingField1;
+				ramClass->selfReferencingField2 = superclass->selfReferencingField2;
 			}
 			tempClassDepthAndFlags |= ((romClass->instanceShape & OBJECT_HEADER_SHAPE_MASK) << J9AccClassRAMShapeShift);
 			if (J9ROMCLASS_IS_ARRAY(romClass)) {


### PR DESCRIPTION
See https://github.com/eclipse/openj9/issues/6060 for background and results

* Introduced new scan type `SCAN_MIXED_OBJECT_LINKED` for objects with self referencing fields
   * Scan type is recognized when non-zero self referencing field offset is found
* Introduced new class fields to store offset of self referencing fields (at most 2) which are to be scanned with priority
   * If a self referencing field is found while building the class description, the offset to that field is stored to either `selfReferencingField1` or `selfReferencingField2`
   * Superclass self referencing field offsets are propagated and given priority over derived class fields
* Scavenger delegate handles `SCAN_MIXED_OBJECT_LINKED` obj types by calling deepScan (resides on OMR side) to "special treat" these objects with priority 

Depends on: https://github.com/eclipse/omr/pull/3967