### PR TITLE
AArch64: Add J9MemoryReference class

### DIFF
--- a/runtime/compiler/aarch64/codegen/CMakeLists.txt
+++ b/runtime/compiler/aarch64/codegen/CMakeLists.txt
@@ -28,6 +28,7 @@ j9jit_files(
 	aarch64/codegen/J9ARM64Snippet.cpp
 	aarch64/codegen/J9AheadOfTimeCompile.cpp
 	aarch64/codegen/J9CodeGenerator.cpp
+	aarch64/codegen/J9MemoryReference.cpp
 	aarch64/codegen/J9TreeEvaluator.cpp
 	aarch64/codegen/J9UnresolvedDataSnippet.cpp
 	aarch64/codegen/StackCheckFailureSnippet.cpp

--- a/runtime/compiler/aarch64/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/aarch64/codegen/J9MemoryReference.cpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/ARM64Instruction.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/Relocation.hpp"
+#include "codegen/UnresolvedDataSnippet.hpp"
+
+uint8_t *
+J9::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *currentInstruction, uint8_t *cursor, TR::CodeGenerator *cg)
+   {
+   TR::UnresolvedDataSnippet *snippet = self()->getUnresolvedSnippet();
+
+   if (snippet)
+      {
+      if (self()->getIndexRegister())
+         {
+         TR_ASSERT(false, "Unresolved indexed snippet is not supported");
+         return NULL;
+         }
+      else
+         {
+         TR::RealRegister *x9reg = cg->machine()->getRealRegister(TR::RealRegister::x9);
+         uint32_t *wcursor = (uint32_t *)cursor;
+         uint32_t preserve = *wcursor; // original instruction
+         snippet->setAddressOfDataReference(cursor);
+         snippet->setMemoryReference(self());
+         cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, snippet->getSnippetLabel()));
+         *wcursor = 0x14000000; // b snippetLabel
+         wcursor++;
+         cursor += ARM64_INSTRUCTION_LENGTH;
+
+         // insert instructions for computing the address of the resolved field;
+         // the actual immediate operands are patched in by L_mergedDataResolve
+         // in PicBuilder.spp
+
+         // movk x9, #0, LSL #16
+         *wcursor = 0xF2800000;
+         x9reg->setRegisterFieldRD(wcursor);
+         wcursor++;
+         cursor += ARM64_INSTRUCTION_LENGTH;
+
+         // movk x9, #0, LSL #32
+         *wcursor = 0xF2C00000;
+         x9reg->setRegisterFieldRD(wcursor);
+         wcursor++;
+         cursor += ARM64_INSTRUCTION_LENGTH;
+
+         // movk x9, #0, LSL #48
+         *wcursor = 0xF2E00000;
+         x9reg->setRegisterFieldRD(wcursor);
+         wcursor++;
+         cursor += ARM64_INSTRUCTION_LENGTH;
+
+         // finally, encode the original instruction
+         *wcursor = preserve;
+         TR::RealRegister *base = self()->getBaseRegister() ? toRealRegister(self()->getBaseRegister()) : NULL;
+         if (base)
+            {
+            // if the load or store had a base, add it in as an index.
+            base->setRegisterFieldRN(wcursor);
+            x9reg->setRegisterFieldRM(wcursor);
+            }
+         else
+            {
+            x9reg->setRegisterFieldRN(wcursor);
+            }
+         cursor += ARM64_INSTRUCTION_LENGTH;
+
+         return cursor;
+         }
+      }
+   else
+      {
+      return OMR::MemoryReferenceConnector::generateBinaryEncoding(currentInstruction, cursor, cg);
+      }
+   }
+
+uint32_t
+J9::ARM64::MemoryReference::estimateBinaryLength(TR::InstOpCode op)
+   {
+   if (self()->getUnresolvedSnippet())
+      {
+      if (self()->getIndexRegister())
+         {
+         TR_ASSERT(false, "Unresolved indexed snippet is not supported");
+         return 0;
+         }
+      else
+         {
+         return 5 * ARM64_INSTRUCTION_LENGTH;
+         }
+      }
+   else
+      {
+      return OMR::MemoryReferenceConnector::estimateBinaryLength(op);
+      }
+   }

--- a/runtime/compiler/aarch64/codegen/J9MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/J9MemoryReference.hpp
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_ARM64_MEMORY_REFERENCE_INCL
+#define J9_ARM64_MEMORY_REFERENCE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_MEMORY_REFERENCE_CONNECTOR
+#define J9_MEMORY_REFERENCE_CONNECTOR
+
+namespace J9 { namespace ARM64 { class MemoryReference; } }
+namespace J9 { typedef J9::ARM64::MemoryReference MemoryReferenceConnector; }
+#else
+#error J9::ARM64::MemoryReference expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "codegen/OMRMemoryReference.hpp"
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+   {
+public:
+   /**
+    * @brief Constructor
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::CodeGenerator *cg)
+      : OMR::MemoryReferenceConnector(cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] br : base register
+    * @param[in] ir : index register
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(
+         TR::Register *br,
+         TR::Register *ir,
+         TR::CodeGenerator *cg)
+      : OMR::MemoryReferenceConnector(br, ir, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] br : base register
+    * @param[in] ir : index register
+    * @param[in] scale : scale of index
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(
+         TR::Register *br,
+         TR::Register *ir,
+         uint8_t scale,
+         TR::CodeGenerator *cg)
+      : OMR::MemoryReferenceConnector(br, ir, scale, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] br : base register
+    * @param[in] disp : displacement
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(
+         TR::Register *br,
+         int32_t disp,
+         TR::CodeGenerator *cg)
+      : OMR::MemoryReferenceConnector(br, disp, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] node : load or store node
+    * @param[in] len : length
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg)
+      : OMR::MemoryReferenceConnector(node, len, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] node : node
+    * @param[in] symRef : symbol reference
+    * @param[in] len : length
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg)
+      : OMR::MemoryReferenceConnector(node, symRef, len, cg) {}
+
+   /**
+    * @brief Estimates the length of generated binary
+    * @param[in] op : opcode of the instruction to attach this memory reference to
+    * @return estimated binary length
+    */
+   uint32_t estimateBinaryLength(TR::InstOpCode op);
+
+   /**
+    * @brief Generates binary encoding
+    * @param[in] ci : current instruction
+    * @param[in] cursor : instruction cursor
+    * @param[in] cg : CodeGenerator
+    * @return instruction cursor after encoding
+    */
+   uint8_t *generateBinaryEncoding(TR::Instruction *ci, uint8_t *cursor, TR::CodeGenerator *cg);
+   };
+
+} // ARM64
+
+} // J9
+
+#endif

--- a/runtime/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_MEMORYREFERENCE_INCL
+#define TR_MEMORYREFERENCE_INCL
+
+#include "codegen/J9MemoryReference.hpp"
+
+namespace TR { class Snippet; }
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE MemoryReference : public J9::MemoryReferenceConnector
+   {
+   public:
+
+   MemoryReference(TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(cg) {}
+
+   MemoryReference(
+         TR::Register *br,
+         TR::Register *ir,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(br, ir, cg) {}
+
+   MemoryReference(
+         TR::Register *br,
+         TR::Register *ir,
+         uint8_t scale,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(br, ir, scale, cg) {}
+
+   MemoryReference(
+         TR::Register *br,
+         int32_t disp,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(br, disp, cg) {}
+
+   MemoryReference(
+         TR::Node *node,
+         uint32_t len,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(node, len, cg) {}
+
+   MemoryReference(
+         TR::Node *node,
+         TR::SymbolReference *symRef,
+         uint32_t len,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(node, symRef, len, cg) {}
+   };
+
+} // TR
+
+#endif

--- a/runtime/compiler/build/files/target/aarch64.mk
+++ b/runtime/compiler/build/files/target/aarch64.mk
@@ -51,6 +51,7 @@ JIT_PRODUCT_SOURCE_FILES+= \
     compiler/aarch64/codegen/J9ARM64Snippet.cpp \
     compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp \
     compiler/aarch64/codegen/J9CodeGenerator.cpp \
+    compiler/aarch64/codegen/J9MemoryReference.cpp \
     compiler/aarch64/codegen/J9TreeEvaluator.cpp \
     compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp \
     compiler/aarch64/codegen/StackCheckFailureSnippet.cpp \


### PR DESCRIPTION
This commit adds J9MemoryReference class for AArch64, for generating code
for UnresolvedSnippet.

Signed-off-by: knn-k <konno@jp.ibm.com>