### PR TITLE
Move function getInternalPtrMapBit from Z to generic codegen class

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -349,6 +349,9 @@ public:
    // Java, likely Z
    bool supportsTrapsInTMRegion() { return true; }
 
+   // J9	
+   int32_t getInternalPtrMapBit() { return 31;}
+
    // --------------------------------------------------------------------------
    // GPU
    //

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -128,9 +128,6 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    TR_OpaquePseudoRegister * evaluateOPRNode(TR::Node* node);
    TR_PseudoRegister * evaluateBCDNode(TR::Node * node);
 
-   // J9
-   int32_t getInternalPtrMapBit() { return 31;}
-
    // --------------------------------------------------------------------------
    // Storage references
    //


### PR DESCRIPTION
Move `getInternalPtrMapBit` from `J9::Z::CodeGenerator` to `J9::CodeGenerator`.

Fix the problem:
When trying to relocate `getInternalPtrMapBit` from `OMR` to `OpenJ9` in eclipse/omr#1877, I mistakenly  moved a function definition of `int32_t getInternalPtrMapBit()` from `OMR::CodeGenerator` to `J9::Z::CodeGenerator`.  It should be relocated to the generic `J9::CodeGenerator` class.

Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>