### PR TITLE
Adopt JDK13 new StringLatin1/StringUTF16 method lines()

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -185,7 +185,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava12.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava13.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -2584,13 +2584,13 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public Stream<String> lines() {
 		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
-			/*[IF Java12]*/
+			/*[IF Java12 & !Java13]*/
 			return StringLatin1.lines(value, 0, 0);
 			/*[ELSE]*/
 			return StringLatin1.lines(value);
 			/*[ENDIF] Java12*/
 		} else {
-			/*[IF Java12]*/
+			/*[IF Java12 & !Java13]*/
 			return StringUTF16.lines(value, 0, 0);
 			/*[ELSE]*/
 			return StringUTF16.lines(value);


### PR DESCRIPTION
#### Adopt JDK13 new StringLatin1/StringUTF16 method lines() ####

Changed API usages for `JDK13` StringLatin1.lines(byte[]) and StringUTF16.lines(byte[]).

Verified that `Java 13 pConfig` still compiles.

closes: #6050 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>