### PR TITLE
Reduce number of classHasBeenReplaced messages

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -400,9 +400,10 @@ TR_J9ServerVM::getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass)
 bool
 TR_J9ServerVM::classHasBeenReplaced(TR_OpaqueClassBlock *clazz)
    {
+   uintptrj_t classDepthAndFlags = 0;
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_classHasBeenReplaced, clazz);
-   return std::get<0>(stream->read<bool>());
+   JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
+   return ((classDepthAndFlags & J9AccClassHotSwappedOut) != 0);
    }
 
 bool
@@ -440,6 +441,7 @@ TR_J9ServerVM::getClassNameChars(TR_OpaqueClassBlock * ramClass, int32_t & lengt
    return classNameChars;
    }
 */
+
 uintptrj_t
 TR_J9ServerVM::getOverflowSafeAllocSize()
    {


### PR DESCRIPTION
[skip ci]
Reduce use of classHasBeenReplaced messages by
searching the persistent cache first

-We search in the persistent cache for
 ClassInfo.classDepthAndFlags values and if it is
 not found we uses ask client for the flag value

Fixes: #5650

Signed-off-by: caohaley <haleycao88@hotmail.com>