### PR TITLE
Decrease number of VM_getClassFromSignature messages in JITaaS mode

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2270,6 +2270,7 @@ J9::Options::setupJITaaSOptions()
       self()->setOption(TR_DisableEDO); // JITaaS limitation, EDO counters are not relocatable yet
       self()->setOption(TR_DisableKnownObjectTable);
       self()->setOption(TR_DisableMethodIsCold); // shady heuristic; better to disable to reduce client/server traffic
+      self()->setOption(TR_DisableDecimalFormatPeephole);// JITaas decimalFormatPeephole, 
 
       if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
          {

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -453,13 +453,15 @@ void TR_StringPeepholes::processBlock(TR::Block *block)
             }
 
          // check that the helper class is available before invoking the matcher
-         TR_OpaqueClassBlock *DFHClass = fe()->getClassFromSignature("com/ibm/jit/DecimalFormatHelper", 31, comp()->getCurrentMethod());
-         if (comp()->isOutermostMethod() && !optimizer()->isIlGenOpt() && !comp()->getOption(TR_DisableDecimalFormatPeephole) &&
-            DFHClass != NULL)
+         if (comp()->isOutermostMethod() && !optimizer()->isIlGenOpt() && !comp()->getOption(TR_DisableDecimalFormatPeephole))
             {
-            TR::TreeTop *newTree = detectFormatPattern(tt, exit, callNode);
-            if (newTree)
-               tt = newTree;
+            TR_OpaqueClassBlock *DFHClass = fe()->getClassFromSignature("com/ibm/jit/DecimalFormatHelper", 31, comp()->getCurrentMethod());
+            if (DFHClass != NULL)
+               {
+               TR::TreeTop *newTree = detectFormatPattern(tt, exit, callNode);
+               if (newTree)
+                  tt = newTree;
+               }
             }
 
          if (comp()->isOptServer() &&


### PR DESCRIPTION
The recent merge from master branch caused more than 10x of `VM_getClassFromSignature`
messages between client and server. This is cause by a change in optimizer `TR_StringPeepholes`
that requires a lot of information about `decimalFormatHelper` and keep calling function
`getClassFromSignature`. 

This commit disables this information exchange between client and
server in JITaaS mode, thus decreases the number of messages btween client and server to
the original level before merge.