### PR TITLE
Control building JITaaS with OpenSSL through an env flag

### DIFF
--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -24,7 +24,6 @@
 #define J9_CLIENT_H
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <openssl/ssl.h>
 #include "compile/CompilationTypes.hpp"
 #include "rpc/StreamTypes.hpp"
 #include "rpc/ProtobufTypeConvert.hpp"
@@ -32,8 +31,11 @@
 #include "ilgen/J9IlGeneratorMethodDetails.hpp"
 #include "rpc/J9Stream.hpp"
 
+#if defined(JITAAS_ENABLE_SSL)
+#include <openssl/ssl.h>
 class SSLOutputStream;
 class SSLInputStream;
+#endif
 
 namespace JITaaS
 {
@@ -86,7 +88,9 @@ public:
 private:
    uint32_t _timeout;
 
+#if defined(JITAAS_ENABLE_SSL)
    static SSL_CTX *_sslCtx;
+#endif
    };
 
 }

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -24,13 +24,15 @@
 #define J9_SERVER_H
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <openssl/ssl.h>
 #include "rpc/ProtobufTypeConvert.hpp"
 #include "rpc/J9Stream.hpp"
 #include "env/CHTable.hpp"
 
+#if defined(JITAAS_ENABLE_SSL)
+#include <openssl/ssl.h>
 class SSLOutputStream;
 class SSLInputStream;
+#endif
 class TR_ResolvedJ9Method;
 
 namespace JITaaS
@@ -38,7 +40,11 @@ namespace JITaaS
 class J9ServerStream : J9Stream
    {
 public:
+#if defined(JITAAS_ENABLE_SSL)
    J9ServerStream(int connfd, BIO *ssl, uint32_t timeout);
+#else
+   J9ServerStream(int connfd, uint32_t timeout);
+#endif
    virtual ~J9ServerStream() 
       {
       _numConnectionsClosed++;

--- a/runtime/compiler/rpc/SSLProtobufStream.hpp
+++ b/runtime/compiler/rpc/SSLProtobufStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #ifndef SSL_PROTOBUF_STREAM_HPP
 #define SSL_PROTOBUF_STREAM_HPP
 
+#if defined(JITAAS_ENABLE_SSL)
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -85,4 +86,5 @@ private:
    BIO *_ssl;
    };
 
+#endif // JITAAS_ENABLE_SSL
 #endif // SSL_PROTOBUF_STREAM_HPP


### PR DESCRIPTION
Currently JITaaS is built with the system default installed OpenSSL.
Some build systems might not have the right version that defines
`SSL_CTX_set_ecdh_auto()`. To enable our code to use Jenkins to
build and test, adding a build environment variable `JITAAS_ENABLE_SSL`.
If `export JITAAS_ENABLE_SSL=1` is set, JITaaS will be built with OpenSSL.
Otherwise SSL is disabled and not built into JITaaS. This is a temporary
solution until JITaaS can be built with the JVM build flag`--with-openssl`
(https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/303).

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>