### PR TITLE
Check name & sig lengths match before memcmp anything

### DIFF
--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -1482,7 +1482,7 @@ fieldIndexTableNew(J9JavaVM* vm, J9PortLibrary *portLib)
 	J9HashTable *result = NULL;
 #if !defined (J9VM_OUT_OF_PROCESS)
 	const IDATA initialSize = 64;
-	J9HookInterface ** vmHooks = getVMHookInterface(vm);
+	J9HookInterface ** vmHooks = J9_VM_FUNCTION_VIA_JAVAVM(vm, getVMHookInterface)(vm);
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	(*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, hookFieldTablePurge, OMR_GET_CALLSITE(), vm);


### PR DESCRIPTION
Existing resolvefield code was matching the name (length and
memcmp) before checking the sig (length and memcmp).  This
results in unnecessary memcmps when the names are the same
but the lengths are different.

Update the code to do both length comparisons before doing
any memcmps.

Also remove some functiontable calls as this file is in the VM
and doesn't need to go through the table.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>