### PR TITLE
Minor JSR292 clean up and recognize two immutable arrays

### DIFF
--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,11 +126,7 @@ J9::KnownObjectTable::dumpObjectTo(TR::FILE *file, Index i, const char *fieldNam
 
       if (len == 29 && !strncmp("java/lang/invoke/DirectHandle", className, 29))
          {
-#if defined(J9VMJAVALANGINVOKEPRIMITIVEHANDLE_VMSLOT) // JTC 83328: Delete once VM changes promote
          J9Method *j9method  = (J9Method*)J9VMJAVALANGINVOKEPRIMITIVEHANDLE_VMSLOT(j9fe->vmThread(), (J9Object*)(*ref));
-#else
-         J9Method *j9method  = (J9Method*)J9VMJAVALANGINVOKEMETHODHANDLE_VMSLOT(j9fe->vmThread(), (J9Object*)(*ref));
-#endif
          J9UTF8   *className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(j9method)->romClass);
          J9UTF8   *methName  = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(j9method));
          int32_t offs = simpleNameOffset(utf8Data(className), J9UTF8_LENGTH(className));

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4329,8 +4329,6 @@ TR_J9VMBase::canDereferenceAtCompileTime(TR::SymbolReference *fieldRef, TR::Comp
          }
       else switch (fieldRef->getSymbol()->getRecognizedField())
          {
-         case TR::Symbol::Java_lang_invoke_MethodHandle_rawModifiers: // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
-         case TR::Symbol::Java_lang_invoke_MethodHandle_defc:         // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
          case TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers:
          case TR::Symbol::Java_lang_invoke_PrimitiveHandle_defc:
          case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:

--- a/runtime/compiler/il/symbol/J9Symbol.cpp
+++ b/runtime/compiler/il/symbol/J9Symbol.cpp
@@ -138,12 +138,12 @@
        {r(TR::Symbol::Java_lang_StringBuilder_value,                  "java/lang/StringBuilder", "value", "[B")},
        {r(TR::Symbol::Java_lang_StringBuilder_value,                  "java/lang/StringBuilder", "value", "[C")},
        {r(TR::Symbol::Java_lang_Throwable_stackTrace,                 "java/lang/Throwable", "stackTrace", "[Ljava/lang/StackTraceElement;")},
+       {r(TR::Symbol::Java_lang_invoke_BruteArgumentMoverHandle_extra,"java/lang/invoke/BruteArgumentMoverHandle", "extra", "[Ljava/lang/Object;")},
        {r(TR::Symbol::Java_lang_invoke_DynamicInvokerHandle_site,     "java/lang/invoke/DynamicInvokerHandle", "site", "Ljava/lang/invoke/CallSite;")},
        {r(TR::Symbol::Java_lang_invoke_MutableCallSite_target,        "java/lang/invoke/MutableCallSite", "target", "Ljava/lang/invoke/MethodHandle;")},
        {r(TR::Symbol::Java_lang_invoke_MutableCallSiteDynamicInvokerHandle_mutableSite,"java/lang/invoke/MutableCallSiteDynamicInvokerHandle", "mutableSite", "Ljava/lang/invoke/MutableCallSite;")},
        {r(TR::Symbol::Java_lang_invoke_MethodHandle_thunks,           "java/lang/invoke/MethodHandle", "thunks", "Ljava/lang/invoke/ThunkTuple;")},
-       {r(TR::Symbol::Java_lang_invoke_MethodHandle_rawModifiers,     "java/lang/invoke/MethodHandle", "rawModifiers", "I")},         // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
-       {r(TR::Symbol::Java_lang_invoke_MethodHandle_defc,             "java/lang/invoke/MethodHandle", "defc", "Ljava/lang/Class;")}, // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
+       {r(TR::Symbol::Java_lang_invoke_MethodType_arguments,          "java/lang/invoke/MethodType", "arguments", "[Ljava/lang/Class;")},
        {r(TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers,  "java/lang/invoke/PrimitiveHandle", "rawModifiers", "I")},
        {r(TR::Symbol::Java_lang_invoke_PrimitiveHandle_defc,          "java/lang/invoke/PrimitiveHandle", "defc", "Ljava/lang/Class;")},
        {r(TR::Symbol::Java_util_Hashtable_elementCount,               "java/util/Hashtable", "count", "I")},

--- a/runtime/compiler/il/symbol/J9Symbol.hpp
+++ b/runtime/compiler/il/symbol/J9Symbol.hpp
@@ -146,12 +146,12 @@ public:
       Java_lang_StringBuilder_count,
       Java_lang_StringBuilder_value,
       Java_lang_Throwable_stackTrace,
+      Java_lang_invoke_BruteArgumentMoverHandle_extra,
       Java_lang_invoke_DynamicInvokerHandle_site,
       Java_lang_invoke_MutableCallSite_target,
       Java_lang_invoke_MutableCallSiteDynamicInvokerHandle_mutableSite,
       Java_lang_invoke_MethodHandle_thunks,
-      Java_lang_invoke_MethodHandle_rawModifiers, // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
-      Java_lang_invoke_MethodHandle_defc,         // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
+      Java_lang_invoke_MethodType_arguments,
       Java_lang_invoke_PrimitiveHandle_rawModifiers,
       Java_lang_invoke_PrimitiveHandle_defc,
       Java_util_Hashtable_elementCount,

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -190,6 +190,8 @@ static bool isArrayWithConstantElements(TR::SymbolReference *symRef, TR::Compila
       {
       switch (symbol->getRecognizedField())
          {
+         case TR::Symbol::Java_lang_invoke_BruteArgumentMoverHandle_extra:
+         case TR::Symbol::Java_lang_invoke_MethodType_arguments:
          case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
          case TR::Symbol::Java_lang_String_value:
             return true;


### PR DESCRIPTION
`BruteArgumentMoverHandle.extra` and `MethodType.arguments` are arrays
with immutable content. Add them to the immutable array list such that
we can fold their array shadows.

Also remove code related to `MethodHandle.rawModifiers` and
`MethodHandle.defc` which are deprecated.

#4837 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>