### PR TITLE
AArch64: Implementation of ArrayLengthEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -76,6 +76,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *anewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   
+   static TR::Register *arraylengthEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    };
 
 }


### PR DESCRIPTION
This commit implements the arraylengthevaluator for openj9.

Signed-off-by: marufunb <mrahma15@unb.ca>