### PR TITLE
Handle DLT failures on the server correctly

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9694,6 +9694,16 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
             jitMarkMethodReadyForDLT(vmThread, dltDetails.getMethod());
             }
          }
+      else if (entry && entry->_stream)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+                  "compThreadID=%d has failed to compile a DLT method", entry->_compInfoPT->getCompThreadId());
+            }
+         int8_t compErrCode = entry->_compInfoPT->_methodBeingCompiled->_compErrCode;
+         entry->_stream->finishCompilation(compErrCode);
+         }
 #endif // ifdef J9VM_JIT_DYNAMIC_LOOP_TRANSFER
       if (((jitConfig->runtimeFlags & J9JIT_TOSS_CODE) ||
            (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)) &&


### PR DESCRIPTION
When a DLT compilation fails on the server,
we were not calling `J9ServerStream::finishCompilation`,
which results in the client never learning that compilation
has failed, so the client thread gets stuck, waiting for
a new message from the server.
Fix by calling `finishCompilation` in this case.

Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>