### PR TITLE
Fix OPENJDK_* variables initialization

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -169,11 +169,17 @@ def get_openjdk_info(SDK_VERSION, SPECS, MULTI_RELEASE) {
         def branch = default_openjdk_info.get('default').get('branch')
         def sha = ''
 
-        // check build params
+        if (default_openjdk_info[build_spec]) {
+            repo = default_openjdk_info.get(build_spec).get('repoUrl')
+            branch = default_openjdk_info.get(build_spec).get('branch')
+        }
+
+        // check build parameters
         if (params."${param_name}_REPO") {
             // got OPENJDK*_REPO build parameter, overwrite repo
             repo = params."${param_name}_REPO"
-        } 
+        }
+
         if (params."${param_name}_BRANCH") {
             // got OPENJDK*_BRANCH build parameter, overwrite branch
             branch = params."${param_name}_BRANCH"
@@ -184,14 +190,12 @@ def get_openjdk_info(SDK_VERSION, SPECS, MULTI_RELEASE) {
             sha = params."${param_name}_SHA"
         }
 
-        if (default_openjdk_info.get(build_spec)) {
-            repo = default_openjdk_info.get(build_spec).get('repoUrl')
+        if (MULTI_RELEASE) {
             if (params."${param_name}_REPO_${build_spec}") {
                 // got OPENJDK*_REPO_<spec> build parameter, overwrite repo
                 repo = params."${param_name}_REPO_${build_spec}"
             }
 
-            branch = default_openjdk_info.get(build_spec).get('branch')
             if (params."${param_name}_BRANCH_${build_spec}") {
                 // got OPENJDK*_BRANCH_<spec> build parameter, overwrite branch
                 branch = params."${param_name}_BRANCH_${build_spec}"


### PR DESCRIPTION
Override default values for platforms specific variables with user's
provided values in wrappers pipelines.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>