### PR TITLE
Remove the assert on checking isUnresolvedString being called after stringConstant

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1665,7 +1665,6 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          break;
       case J9ServerMessageType::ResolvedMethod_isUnresolvedString:
          {
-         TR_ASSERT(false, "ResolvedMethod_isUnresolvedString is combined into ResolvedMethod_stringConstant");
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t, bool>();
          auto mirror = std::get<0>(recv);
          auto cpIndex = std::get<1>(recv);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1122,7 +1122,6 @@ TR_ResolvedJ9JITaaSServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeF
       }
    else
       {
-      TR_ASSERT(false, "isUnresolvedString should have already been fetched through querying stringConstant");
       _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex, optimizeForAOT);
       return std::get<0>(_stream->read<bool>());
       }


### PR DESCRIPTION

[skip ci]
The assumption that `isUnresolvedString()` is always called after `stringConstant()`
is not true. It is also called in `hasNotYetRun()` by OMR without stringConstant().
These asserts need to be removed.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>