### PR TITLE
AArch64: Implement StackCheckFailureSnippet

### DIFF
--- a/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
@@ -22,20 +22,99 @@
 
 #include "codegen/StackCheckFailureSnippet.hpp"
 
+#include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/GCStackAtlas.hpp"
+#include "codegen/Linkage.hpp"
+#include "codegen/Machine.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
 
 uint8_t *
 TR::ARM64StackCheckFailureSnippet::emitSnippetBody()
    {
-   TR_UNIMPLEMENTED();
+   TR::ResolvedMethodSymbol *bodySymbol = cg()->comp()->getJittedMethodSymbol();
+   TR::Machine *machine = cg()->machine();
+   TR::SymbolReference *sofRef = cg()->comp()->getSymRefTab()->findOrCreateStackOverflowSymbolRef(bodySymbol);
 
-   uint8_t *buffer = cg()->getBinaryBufferCursor();
-   return buffer;
+   uint8_t *cursor = cg()->getBinaryBufferCursor();
+   uint8_t *returnLocation;
+
+   getSnippetLabel()->setCodeLocation(cursor);
+
+   // Pass cg()->getFrameSizeInBytes() to jitStackOverflow in register x9.
+   //
+   const TR::ARM64LinkageProperties &linkage = cg()->getLinkage()->getProperties();
+   uint32_t frameSize = cg()->getFrameSizeInBytes();
+
+   if (frameSize <= 0xffff)
+      {
+      // mov x9, #frameSize
+      *(int32_t *)cursor = 0xd2800009 | (frameSize << 5);
+      cursor += ARM64_INSTRUCTION_LENGTH;
+      }
+   else
+      {
+      TR_ASSERT(false, "Frame size too big.  Not supported yet");
+      }
+
+   // add J9SP, J9SP, x9
+   *(int32_t *)cursor = 0x8b090294;
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   // str LR, [J9SP]
+   // ToDo: Skip saving/restoring LR when not required
+   *(int32_t *)cursor = 0xf900029e;
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   // bl helper
+   *(int32_t *)cursor = cg()->encodeHelperBranchAndLink(sofRef, cursor, getNode());
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   returnLocation = cursor;
+
+   // ldr LR, [J9SP]
+   *(int32_t *)cursor = 0xf940029e;
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   // sub J9SP, J9SP, x9 ; assume that jitStackOverflow does not clobber x9
+   *(int32_t *)cursor = 0xcb090294;
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   // b restartLabel
+   intptr_t distance = (intptr_t)(getReStartLabel()->getCodeLocation()) - (intptr_t)cursor;
+   if (constantIsSignedImm28(distance))
+      {
+      *(int32_t *)cursor = 0x14000000 | ((distance >> 2) & 0x3ffffff); // imm26
+      }
+   else
+      {
+      TR_ASSERT(false, "Target too far away.  Not supported yet");
+      }
+
+   TR::GCStackAtlas *atlas = cg()->getStackAtlas();
+   if (atlas)
+      {
+      // only the arg references are live at this point
+      TR_GCStackMap *map = atlas->getParameterMap();
+
+      // set the GC map
+      gcMap().setStackMap(map);
+      }
+   gcMap().registerStackMap(returnLocation, cg());
+
+   return cursor+ARM64_INSTRUCTION_LENGTH;
    }
 
 uint32_t
 TR::ARM64StackCheckFailureSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   TR_UNIMPLEMENTED();
-   return 0;
+   uint32_t frameSize = cg()->getFrameSizeInBytes();
+
+   if (frameSize <= 0xffff)
+      {
+      return 7*ARM64_INSTRUCTION_LENGTH;
+      }
+   else
+      {
+      TR_ASSERT(false, "Frame size too big.  Not supported yet");
+      }
    }


### PR DESCRIPTION
This commit implements StackCheckFailureSnippet for AArch64.

Signed-off-by: knn-k <konno@jp.ibm.com>