### PR TITLE
Add test for ignoring blank/whitespace VM options

### DIFF
--- a/runtime/tests/redirector/nativevmargs/CMakeLists.txt
+++ b/runtime/tests/redirector/nativevmargs/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_subdirectory(genericlauncher)
-add_subdirectory(jep178)
-add_subdirectory(nativevmargs)
+add_executable(nativevmargs testnativevmargs.c)
+
+target_link_libraries(nativevmargs
+    PRIVATE
+        j9vm_interface
+
+        ${CMAKE_DL_LIBS}
+)

--- a/runtime/tests/redirector/nativevmargs/module.xml
+++ b/runtime/tests/redirector/nativevmargs/module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<module xmlns:xi="http://www.w3.org/2001/XInclude">
+	<artifact type="executable" name="nativevmargs">
+		<options>
+			<option name="doesNotRequireCMAIN"/>
+		</options>
+		<phase>j2se util</phase>
+		<includes>
+			<include path="j9include"/>
+			<include path="j9oti"/>
+		</includes>
+		<objects>
+			<object name="testnativevmargs"/>
+			<object name="nativevmargs.res">
+				<include-if condition="spec.win.*"/>
+			</object>
+		</objects>
+	</artifact>
+</module>

--- a/runtime/tests/redirector/nativevmargs/testnativevmargs.c
+++ b/runtime/tests/redirector/nativevmargs/testnativevmargs.c
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file testnativevmargs.c
+ * Executable provides a native framework to create a VM with specified VM arguments.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "jni.h"
+
+#if defined(WIN32)
+#include <windows.h>
+#elif defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#include <dlfcn.h>
+#else
+#include <dll.h>
+#include "atoe.h"
+#endif
+
+#define J9PATH_LENGTH_MAXIMUM 1024
+#if defined(WIN32)
+#define J9PATH_DIRECTORY_SEPARATOR '\\'
+#define J9PATH_JVM_LIBRARY "jvm.dll"
+#else /* defined(WIN32) */
+#define J9PATH_DIRECTORY_SEPARATOR '/'
+#if defined(OSX)
+#define J9PATH_JVM_LIBRARY "libjvm.dylib"
+#else /* defined(OSX) */
+#define J9PATH_JVM_LIBRARY "libjvm.so"
+#endif /* defined(OSX) */
+#endif /* defined(WIN32) */
+
+/* The JVM launcher. */
+int main(int argc, char **argv)
+{
+	JavaVMInitArgs vm_args;
+	JavaVMOption * args = NULL;
+	JavaVM * vm = NULL;
+	JNIEnv * env = NULL;
+	jint result;
+	jboolean ignoreUnrecognized = JNI_FALSE;
+	int i;
+	int jvmOptionCount = 0;
+	int optionCount = 0;
+	char * jvmPath = NULL;
+	int rc = 0;
+	char buffer[J9PATH_LENGTH_MAXIMUM] = {0};
+	typedef jint (JNICALL * createJVMFP)(JavaVM ** pvm, void ** penv, void * vm_args);
+	createJVMFP createJavaVM = NULL;
+#if defined(WIN32)
+	HINSTANCE handle = NULL;
+#else
+	void * handle = NULL;
+#endif
+
+	fprintf(stdout, "[MSG] Starting up native VM options test.\n");
+	if (argc < 2) {
+		fprintf(stderr, "[ERR] Insufficient arguments passed to test.\n");
+		fprintf(stderr, "[MSG] Usage: nativevmargs <jvmlibpath> <options>\n");
+		rc = 1;
+		goto fail;
+	}
+	fflush(stdout);
+
+	jvmPath = argv[1];
+	optionCount = argc - 2;
+
+	args = malloc(sizeof(JavaVMOption) * optionCount);
+	if (!args) {
+		fprintf(stderr, "[ERR] Failed memory allocation for JVM arguments.\n");
+		rc = 2;
+		goto fail;
+	}
+
+	/* Create the JVM options */
+	for (i = 2; jvmOptionCount < optionCount; i++) {
+		if (0 == strncmp(argv[i], "-Custom:", 8)) {
+			/* convert custom options to JVM options */
+			if (0 == strcmp(argv[i], "-Custom:WhitespaceOption")) {
+				args[jvmOptionCount].optionString = " \t ";
+			} else if (0 == strcmp(argv[i], "-Custom:EmptyOption")) {
+				args[jvmOptionCount].optionString = "";
+			} else if (0 == strcmp(argv[i], "-Custom:IgnoreUnrecognizedOptions")) {
+				ignoreUnrecognized = JNI_TRUE;
+				optionCount--;
+				continue;
+			} else {
+				fprintf(stderr, "[ERR] Invalid option: %s\n", argv[i]);
+				rc = 3;
+				goto fail;
+			}
+		} else {
+			args[jvmOptionCount].optionString = argv[i];
+		}
+		jvmOptionCount++;
+	}
+
+	vm_args.version = JNI_VERSION_1_8;
+	vm_args.nOptions = jvmOptionCount;
+	vm_args.options = args;
+	vm_args.ignoreUnrecognized = ignoreUnrecognized;
+
+	if ((NULL != jvmPath) && (0 != strlen(jvmPath))) {
+		sprintf(buffer, "%s%c%s", jvmPath, J9PATH_DIRECTORY_SEPARATOR, J9PATH_JVM_LIBRARY);
+	} else {
+		fprintf(stderr, "[ERR] Invalid path for JVM specified.\n");
+		rc = 4;
+		goto fail;
+	}
+
+	fprintf(stdout, "[MSG] Opening JVM from %s\n", buffer);
+	fflush(stdout);
+
+	/* Open a handle to the JVM's shared library. */
+#if defined(WIN32)
+	handle = LoadLibrary(buffer);
+#elif defined(LINUX) || defined(AIXPPC) || defined(OSX)
+	handle = dlopen(buffer, RTLD_NOW);
+#else /* ZOS */
+	handle = dllload(buffer);
+#endif
+	if (NULL == handle) {
+		fprintf(stderr, "[ERR] Failed opening virtual machine.\n");
+		rc = 5;
+		goto fail;
+	}
+
+	/* Lookup for the virtual machine entry point routine. */
+#if defined(WIN32)
+	createJavaVM = (createJVMFP) GetProcAddress((HINSTANCE)handle, "JNI_CreateJavaVM");
+#elif defined(LINUX) || defined(AIXPPC) || defined(OSX)
+	createJavaVM = (createJVMFP) dlsym(handle, "JNI_CreateJavaVM");
+#else /* Z/OS */
+	createJavaVM = (createJVMFP) dllqueryfn(handle, "JNI_CreateJavaVM");
+#endif
+	if (NULL == createJavaVM) {
+		fprintf(stderr, "[ERR] Failed locating virtual machine entry.\n");
+		rc = 6;
+		goto fail;
+	}
+
+	/* Actually launch the virtual machine. */
+	result = createJavaVM(&vm, (void **)&env, &vm_args);
+	if (JNI_OK != result) {
+		fprintf(stderr, "[ERR] Failed launching JVM.\n");
+		rc = 7;
+		goto fail;
+	}
+
+fail:
+	if (NULL != args) {
+		free(args);
+	}
+
+	fprintf(stdout, "[MSG] Test nativevmargs concluded with code: %d\n", rc);
+	fflush(stdout);
+
+	return rc;
+}

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_native.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_native.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Command-Line Option Tests" timeout="600">
+    <variable name="EMPTY_OPTION" value="-Custom:EmptyOption"/>
+    <variable name="WHITESPACE_OPTION" value="-Custom:WhitespaceOption"/>
+    <variable name="IGNORE_UNRECOGNIZED_OPTIONS" value="-Custom:IgnoreUnrecognizedOptions"/>
+    <variable name="COMMANDLINE_OPTION_UNRECOGNIZED" value="Command-line option unrecognised"/>
+    <variable name="TEST_NATIVEVMARGS_CONCLUDED_WITH_CODE" value="[MSG] Test nativevmargs concluded with code:"/>
+
+    <test id="test nativevmargs ignore empty and whitespace VM options">
+        <command>$NATIVEVMARGS$ $JVMLIBPATH$ $IGNORE_UNRECOGNIZED_OPTIONS$ $EMPTY_OPTION$ $WHITESPACE_OPTION$</command>
+        <output type="success" caseSensitive="yes" regex="no">$TEST_NATIVEVMARGS_CONCLUDED_WITH_CODE$ 0</output>
+        <output type="failure" regex="no">[ERR]</output>
+    </test>
+
+    <test id="test nativevmargs reject empty VM option">
+        <command>$NATIVEVMARGS$ $JVMLIBPATH$ $EMPTY_OPTION$</command>
+        <output type="success" caseSensitive="yes" regex="no">$COMMANDLINE_OPTION_UNRECOGNIZED$</output>
+        <output type="required" caseSensitive="yes" regex="no">$TEST_NATIVEVMARGS_CONCLUDED_WITH_CODE$ 7</output>
+    </test>
+
+    <test id="test nativevmargs reject whitespace VM option">
+        <command>$NATIVEVMARGS$ $JVMLIBPATH$ $WHITESPACE_OPTION$</command>
+        <output type="success" caseSensitive="yes" regex="no">$COMMANDLINE_OPTION_UNRECOGNIZED$</output>
+        <output type="required" caseSensitive="yes" regex="no">$TEST_NATIVEVMARGS_CONCLUDED_WITH_CODE$ 7</output>
+    </test>
+
+</suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -84,4 +84,29 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTest_J9test_native</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
+	-DNATIVEVMARGS=$(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)nativevmargs$(Q) \
+	-DJVMLIBPATH=$(Q)$(J9VM_PATH)$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
+	-Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests_native.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on windows; similar failures as https://github.com/eclipse/openj9/issues/3212, https://github.com/eclipse/openj9/issues/3560 -->
+		<platformRequirements>^os.win</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+	</test>
 </playlist>


### PR DESCRIPTION
For PR #5353 (Ignore empty and whitespace VM options)

This test checks that creating VMs from C with blank or whitespace options produces the appropriate results for the following cases:
- Ignore whitespace VM option (disregard option and start VM)
- Ignore empty VM option (disregard option and start VM)
- Reject whitespace VM option (indicate unrecognized option and do not start VM)
- Reject empty VM option (indicate unrecognized option and do not start VM)

Extensions changes: 
- JDK: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/117
- JDK 8: https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/309
- JDK 11: https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/184
- JDK 12: https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/57

(This PR fixes the Windows failure for the original PR introducing the test https://github.com/eclipse/openj9/pull/5930)

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>