### PR TITLE
Truncate boolean for Unsafe.getBoolean and Unsafe.putBoolean

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5705,6 +5705,23 @@ TR_J9MethodBase::isVolatileUnsafe(TR::RecognizedMethod rm)
    return false;
    }
 
+bool
+TR_J9MethodBase::isUnsafeGetPutBoolean(TR::RecognizedMethod rm)
+   {
+   switch (rm)
+      {
+      case TR::sun_misc_Unsafe_getBoolean_jlObjectJ_Z:
+      case TR::sun_misc_Unsafe_getBooleanVolatile_jlObjectJ_Z:
+      case TR::sun_misc_Unsafe_putBoolean_jlObjectJZ_V:
+      case TR::sun_misc_Unsafe_putBooleanVolatile_jlObjectJZ_V:
+         return true;
+      default:
+         break;
+      }
+
+   return false;
+   }
+
 // Might need to add more unsafe put methods to this list
 bool
 TR_J9MethodBase::isUnsafePut(TR::RecognizedMethod rm)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -112,6 +112,7 @@ public:
    bool                          isBigDecimalConvertersMethod( TR::Compilation * comp = NULL);
 
    static bool                   isUnsafeGetPutWithObjectArg(TR::RecognizedMethod rm);
+   static bool                   isUnsafeGetPutBoolean(TR::RecognizedMethod rm);
    static bool                   isUnsafePut(TR::RecognizedMethod rm);
    static bool                   isVolatileUnsafe(TR::RecognizedMethod rm);
    static TR::DataType           unsafeDataTypeForArray(TR::RecognizedMethod rm);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1055,6 +1055,12 @@ TR_J9InlinerPolicy::createUnsafePutWithOffset(TR::ResolvedMethodSymbol *calleeSy
    if(comp()->getOption(TR_TraceUnsafeInlining))
        traceMsg(comp(),"\tcreateUnsafePutWithOffset.  call tree %p offset(datatype) %d isvolatile %d needNullCheck %d isOrdered %d\n", callNodeTreeTop, type.getDataType(),isVolatile,needNullCheck,isOrdered);
 
+   // Truncate the value before inlining the call
+   if (TR_J9MethodBase::isUnsafeGetPutBoolean(calleeSymbol->getRecognizedMethod()))
+      {
+      TR::TransformUtil::truncateBooleanForUnsafeGetPut(comp(), callNodeTreeTop);
+      }
+
    // Preserve null check on the unsafe object
    TR::TransformUtil::separateNullCheck(comp(), callNodeTreeTop, comp()->getOption(TR_TraceUnsafeInlining));
 
@@ -1391,6 +1397,12 @@ TR_J9InlinerPolicy::createUnsafeGetWithOffset(TR::ResolvedMethodSymbol *calleeSy
 
    if (debug("traceUnsafe"))
       printf("createUnsafeGetWithOffset %s in %s\n", type.toString(), comp()->signature());
+
+   // Truncate the return before inlining the call
+   if (TR_J9MethodBase::isUnsafeGetPutBoolean(calleeSymbol->getRecognizedMethod()))
+      {
+      TR::TransformUtil::truncateBooleanForUnsafeGetPut(comp(), callNodeTreeTop);
+      }
 
    // Preserve null check on the unsafe object
    TR::TransformUtil::separateNullCheck(comp(), callNodeTreeTop, comp()->getOption(TR_TraceUnsafeInlining));

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -179,6 +179,17 @@ public:
     */
    static TR::TreeTop* generateReportFinalFieldModificationCallTree(TR::Compilation *comp, TR::Node *node);
 
+   /*
+    * \brief
+    *    Truncate boolean for Unsafe get/put APIs.
+    *    The boolean loaded or written by Unsafe APIs can only have value zero or one. The spec rules on
+    *    Unsafe behavior regarding boolean is to check `(0 != value)`.
+    *
+    *   \param comp  The compilation Object
+    *   \param tree  The tree containing Unsafe call that reads/writes a boolean
+    *
+    */
+   static void truncateBooleanForUnsafeGetPut(TR::Compilation *comp, TR::TreeTop* tree);
 protected:
    /**
     * \brief

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -717,6 +717,12 @@ int32_t TR_UnsafeFastPath::perform()
 
          if (type != TR::NoType && performTransformation(comp(), "%s Found unsafe/JITHelpers calls, turning node [" POINTER_PRINTF_FORMAT "] into a load/store\n", optDetailString(), node))
             {
+
+            if (TR_J9MethodBase::isUnsafeGetPutBoolean(calleeMethod))
+               {
+               TR::TransformUtil::truncateBooleanForUnsafeGetPut(comp(), tt);
+               }
+
             TR::SymbolReference * unsafeSymRef = comp()->getSymRefTab()->findOrCreateUnsafeSymbolRef(type, true, isStatic, isVolatile);
 
             // some helpers are special - we know they are accessing an array and we know the kind of that array


### PR DESCRIPTION
Ensure boolean value passed `Unsafe.putBoolean` or returned from
`Unsafe.getBoolean` is zero or one. The correct value is produced by
checking `!= 0`. This is to match the RI's behavior.

issue: #2049

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>