### PR TITLE
Fetch VM-specific object model information

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -558,6 +558,9 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
             {
             vmInfo._arrayTypeClasses[i] = fe->getClassFromNewArrayTypeNonNull(i + 4);
             }
+         vmInfo._readBarrierType = TR::Compiler->om.readBarrierType();
+         vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
+         vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
          client->write(vmInfo);
          }
          break;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -152,6 +152,9 @@ class ClientSessionData
       bool _elgibleForPersistIprofileInfo;
       TR_OpaqueClassBlock *_arrayTypeClasses[8];
       bool _reportByteCodeInfoAtCatchBlock;
+      MM_GCReadBarrierType _readBarrierType;
+      MM_GCWriteBarrierType _writeBarrierType;
+      bool _compressObjectReferences;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -612,3 +612,36 @@ J9::ObjectModel::arrayletLeafLogSize()
       }
    return _arrayLetLeafLogSize;
    }
+
+MM_GCReadBarrierType
+J9::ObjectModel::readBarrierType()
+   {
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_readBarrierType;
+      }
+   return _readBarrierType;
+   }
+
+MM_GCWriteBarrierType
+J9::ObjectModel::writeBarrierType()
+   {
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_writeBarrierType;
+      }
+   return _writeBarrierType;
+   }
+
+bool
+J9::ObjectModel::compressObjectReferences()
+   {
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_compressObjectReferences;
+      }
+   return _compressObjectReferences;
+   }

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -115,17 +115,17 @@ public:
    /**
    * @brief Returns the read barrier type of VM's GC
    */
-   MM_GCReadBarrierType  readBarrierType()  { return _readBarrierType;  }
+   MM_GCReadBarrierType  readBarrierType();
 
    /**
    * @brief Returns the write barrier type of VM's GC
    */
-   MM_GCWriteBarrierType writeBarrierType() { return _writeBarrierType; }
+   MM_GCWriteBarrierType writeBarrierType();
 
    /**
    * @brief Returns whether or not object references are compressed
    */
-   bool compressObjectReferences() { return _compressObjectReferences; }
+   bool compressObjectReferences();
 
 private:
 


### PR DESCRIPTION
New queries were recently added to `J9::ObjectModel`:
`readBarrierType`, `writeBarrierType`, and
`compressObjectReferences`.
All of them access runtime-specific information, which
should be fetched from the client. Cache this information
to VM info.