### PR TITLE
Add JITSERVER_SUPPORT  flag for JITaaS conditional build

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -374,7 +374,10 @@ JIT_PRODUCT_SOURCE_FILES+=\
     omr/compiler/runtime/OMRCodeCacheConfig.cpp \
     omr/compiler/runtime/OMRCodeCacheManager.cpp \
     omr/compiler/runtime/OMRCodeCacheMemorySegment.cpp \
-    omr/compiler/runtime/OMRRuntimeAssumptions.cpp \
+    omr/compiler/runtime/OMRRuntimeAssumptions.cpp
+
+ifneq ($(JITSERVER_SUPPORT),)
+JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/Listener.cpp \
     compiler/runtime/StatisticsThread.cpp \
     compiler/env/VMJ9Server.cpp \
@@ -388,10 +391,13 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/JITaaSCHTable.cpp \
     compiler/runtime/JITaaSIProfiler.cpp \
     compiler/runtime/CompileService.cpp
+endif
 
 -include $(JIT_MAKE_DIR)/files/extra.mk
 include $(JIT_MAKE_DIR)/files/host/$(HOST_ARCH).mk
 include $(JIT_MAKE_DIR)/files/target/$(TARGET_ARCH).mk
 -include $(JIT_MAKE_DIR)/files/host/$(HOST_ARCH)-extra.mk
 -include $(JIT_MAKE_DIR)/files/target/$(TARGET_ARCH)-extra.mk
+ifneq ($(JITSERVER_SUPPORT),)
 include $(JIT_MAKE_DIR)/files/net.mk
+endif

--- a/runtime/compiler/build/rules/common.mk
+++ b/runtime/compiler/build/rules/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,8 +24,9 @@ clean: jit_cleanobjs jit_cleandeps jit_cleandll
 cleanobjs: jit_cleanobjs
 cleandeps: jit_cleandeps
 cleandll: jit_cleandll
-proto: proto_clean protoc
-
+ifneq ($(JITSERVER_SUPPORT),)
+    proto: proto_clean protoc
+endif
 #
 # Define our targets. "jit_cleanobjs" "jit_cleandeps" and "jit_cleandll" are double-colon so they can be appended to
 # throughout the makefile.
@@ -36,7 +37,9 @@ jit_createdirs::
 jit_cleanobjs::
 jit_cleandeps::
 jit_cleandll::
-protoc:
-proto_clean:
+ifneq ($(JITSERVER_SUPPORT),)
+    protoc:
+    proto_clean:
+endif
 
 include $(JIT_MAKE_DIR)/rules/$(TOOLCHAIN)/common.mk

--- a/runtime/compiler/build/rules/gnu/common.mk
+++ b/runtime/compiler/build/rules/gnu/common.mk
@@ -65,9 +65,10 @@ JIT_DIR_LIST+=$(dir $(JIT_PRODUCT_BUILDNAME_SRC))
 jit_cleanobjs::
 	rm -f $(JIT_PRODUCT_BUILDNAME_SRC)
 
-protoc: $(PROTO_GEN_DIR)/compile.pb.h
-
-$(call RULE.proto,$(PROTO_GEN_DIR)/compile,$(PROTO_DIR)/compile.proto)
+ifneq ($(JITSERVER_SUPPORT),)
+   protoc: $(PROTO_GEN_DIR)/compile.pb.h
+   $(call RULE.proto,$(PROTO_GEN_DIR)/compile,$(PROTO_DIR)/compile.proto)
+endif
 
 #
 # This part calls the "RULE.x" macros for each source file

--- a/runtime/compiler/build/rules/gnu/filetypes.mk
+++ b/runtime/compiler/build/rules/gnu/filetypes.mk
@@ -22,29 +22,31 @@
 # These are the rules to compile files of type ".x" into object files
 # as well as to generate clean and cleandeps rules
 #
-#
-# Compile .proto files to .cpp files
-#
-PROTO_GEN_DIR=$(FIXED_SRCBASE)/compiler/net/gen
-PROTO_DIR=$(FIXED_SRCBASE)/compiler/net/protos
+ifneq ($(JITSERVER_SUPPORT),)
+   #
+   # Compile .proto files to .cpp files
+   #
+   PROTO_GEN_DIR=$(FIXED_SRCBASE)/compiler/net/gen
+   PROTO_DIR=$(FIXED_SRCBASE)/compiler/net/protos
 
-#
-# Compile .proto file into .cpp and .h files
-#
-define DEF_RULE.proto
+   #
+   # Compile .proto file into .cpp and .h files
+   #
+   define DEF_RULE.proto
 
-$(1).pb.cpp $(1).pb.h: $(2) | jit_createdirs
-	$$(PROTO_CMD) --cpp_out=$$(PROTO_GEN_DIR) -I $$(PROTO_DIR) $$<
-	cp $(1).pb.cc $(1).pb.cpp
+   $(1).pb.cpp $(1).pb.h: $(2) | jit_createdirs
+	   $$(PROTO_CMD) --cpp_out=$$(PROTO_GEN_DIR) -I $$(PROTO_DIR) $$<
+	   cp $(1).pb.cc $(1).pb.cpp
 
-JIT_DIR_LIST+=$(dir $(1))
+   JIT_DIR_LIST+=$(dir $(1))
 
-jit_cleanobjs::
-	rm -f $(1).pb.cpp $(1).pb.h
+   jit_cleanobjs::
+	   rm -f $(1).pb.cpp $(1).pb.h
 
-endef # DEF_RULE.proto
+   endef # DEF_RULE.proto
 
-RULE.proto=$(eval $(DEF_RULE.proto))
+   RULE.proto=$(eval $(DEF_RULE.proto))
+endif
 
 #
 # Compile .c file into .o file

--- a/runtime/compiler/build/toolcfg/common.mk
+++ b/runtime/compiler/build/toolcfg/common.mk
@@ -79,13 +79,14 @@ PRODUCT_SLINK=$(J9LIBS) $(J9LIBS)
 # Optional project-specific settings
 -include $(JIT_MAKE_DIR)/toolcfg/common-extra.mk
 
+ifneq ($(JITSERVER_SUPPORT),)
 #
-# RPC
+# Networking
 #
 PRODUCT_INCLUDES+=\
     $(FIXED_SRCBASE)/compiler/net/gen \
-	$(FIXED_SRCBASE)/compiler/net
-
+    $(FIXED_SRCBASE)/compiler/net
+endif
 #
 # Now we include the host and target tool config
 # These don't really do much generally... They set a few defines but there really


### PR DESCRIPTION
Guarded makefiles with `JITSERVER_SUPPORT`.
By default it is enabled for now before the full change completes.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>