### PR TITLE
Replace the call to Modifier.isVolatile with a boolean field

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldGetterHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldGetterHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ final class FieldGetterHandle extends FieldHandle {
 	// {{{ JIT support
 	@FrameIteratorSkip
 	private final int    invokeExact_thunkArchetype_I(Object receiver, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getIntVolatile(receiver, vmSlot + HEADER_SIZE);
 		else
 			return UNSAFE.getInt        (receiver, vmSlot + HEADER_SIZE);
@@ -63,7 +63,7 @@ final class FieldGetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final long   invokeExact_thunkArchetype_J(Object receiver, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getLongVolatile(receiver, vmSlot + HEADER_SIZE);
 		else
 			return UNSAFE.getLong        (receiver, vmSlot + HEADER_SIZE);
@@ -71,7 +71,7 @@ final class FieldGetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final float  invokeExact_thunkArchetype_F(Object receiver, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getFloatVolatile(receiver, vmSlot + HEADER_SIZE);
 		else
 			return UNSAFE.getFloat        (receiver, vmSlot + HEADER_SIZE);
@@ -79,7 +79,7 @@ final class FieldGetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final double invokeExact_thunkArchetype_D(Object receiver, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getDoubleVolatile(receiver, vmSlot + HEADER_SIZE);
 		else
 			return UNSAFE.getDouble        (receiver, vmSlot + HEADER_SIZE);
@@ -87,7 +87,7 @@ final class FieldGetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final Object invokeExact_thunkArchetype_L(Object receiver, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getObjectVolatile(receiver, vmSlot + HEADER_SIZE);
 		else
 			return UNSAFE.getObject        (receiver, vmSlot + HEADER_SIZE);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,14 +34,14 @@ import java.lang.reflect.Modifier;
 /*[ENDIF]*/
 abstract class FieldHandle extends PrimitiveHandle {
 	final Class<?> fieldClass;
-	final int final_modifiers;
+	final boolean isVolatile;
 	
 	FieldHandle(MethodType type, Class<?> referenceClass, String fieldName, Class<?> fieldClass, byte kind, Class<?> accessClass) throws IllegalAccessException, NoSuchFieldException { 	
 		super(type, referenceClass, fieldName, kind, null);
 		this.fieldClass = fieldClass;
 		/* modifiers is set inside the native */
 		this.defc = finishFieldInitialization(accessClass);
-		final_modifiers = rawModifiers;
+		isVolatile = Modifier.isVolatile(rawModifiers);
 		assert(isVMSlotCorrectlyTagged());
 	}
 	
@@ -54,14 +54,14 @@ abstract class FieldHandle extends PrimitiveHandle {
 		if (!succeed) {
 			throw new IllegalAccessException();
 		}
-		final_modifiers = rawModifiers;
+		isVolatile = Modifier.isVolatile(rawModifiers);
 		assert(isVMSlotCorrectlyTagged());
 	}
 	
 	FieldHandle(FieldHandle originalHandle, MethodType newType) {
 		super(originalHandle, newType);
 		this.fieldClass = originalHandle.fieldClass;
-		final_modifiers = rawModifiers;
+		this.isVolatile = originalHandle.isVolatile;
 		assert(isVMSlotCorrectlyTagged());
 	}
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldSetterHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldSetterHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,7 +57,7 @@ final class FieldSetterHandle extends FieldHandle {
 	// {{{ JIT support
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(Object receiver, int    newValue, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putIntVolatile(receiver, vmSlot + HEADER_SIZE, newValue);
 		else
 			UNSAFE.putInt        (receiver, vmSlot + HEADER_SIZE, newValue);
@@ -65,7 +65,7 @@ final class FieldSetterHandle extends FieldHandle {
 	
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(Object receiver, long   newValue, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putLongVolatile(receiver, vmSlot + HEADER_SIZE, newValue);
 		else
 			UNSAFE.putLong        (receiver, vmSlot + HEADER_SIZE, newValue);
@@ -73,7 +73,7 @@ final class FieldSetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(Object receiver, float  newValue, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putFloatVolatile(receiver, vmSlot + HEADER_SIZE, newValue);
 		else
 			UNSAFE.putFloat        (receiver, vmSlot + HEADER_SIZE, newValue);
@@ -81,7 +81,7 @@ final class FieldSetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(Object receiver, double newValue, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putDoubleVolatile(receiver, vmSlot + HEADER_SIZE, newValue);
 		else
 			UNSAFE.putDouble        (receiver, vmSlot + HEADER_SIZE, newValue);
@@ -89,7 +89,7 @@ final class FieldSetterHandle extends FieldHandle {
 
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(Object receiver, Object newValue, int argPlaceholder) {
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putObjectVolatile(receiver, vmSlot + HEADER_SIZE, newValue);
 		else
 			UNSAFE.putObject        (receiver, vmSlot + HEADER_SIZE, newValue);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldGetterHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldGetterHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ final class StaticFieldGetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final int    invokeExact_thunkArchetype_I(int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getIntVolatile(defc, vmSlot);
 		else
 			return UNSAFE.getInt        (defc, vmSlot);
@@ -64,7 +64,7 @@ final class StaticFieldGetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final long   invokeExact_thunkArchetype_J(int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getLongVolatile(defc, vmSlot);
 		else
 			return UNSAFE.getLong        (defc, vmSlot);
@@ -73,7 +73,7 @@ final class StaticFieldGetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final float  invokeExact_thunkArchetype_F(int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getFloatVolatile(defc, vmSlot);
 		else
 			return UNSAFE.getFloat        (defc, vmSlot);
@@ -82,7 +82,7 @@ final class StaticFieldGetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final double invokeExact_thunkArchetype_D(int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getDoubleVolatile(defc, vmSlot);
 		else
 			return UNSAFE.getDouble        (defc, vmSlot);
@@ -91,7 +91,7 @@ final class StaticFieldGetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final Object invokeExact_thunkArchetype_L(int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			return UNSAFE.getObjectVolatile(defc, vmSlot);
 		else
 			return UNSAFE.getObject        (defc, vmSlot);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldSetterHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldSetterHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ final class StaticFieldSetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(int    newValue, int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putIntVolatile(defc, vmSlot, newValue);
 		else
 			UNSAFE.putInt        (defc, vmSlot, newValue);
@@ -64,7 +64,7 @@ final class StaticFieldSetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(long   newValue, int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putLongVolatile(defc, vmSlot, newValue);
 		else
 			UNSAFE.putLong        (defc, vmSlot, newValue);
@@ -73,7 +73,7 @@ final class StaticFieldSetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(float  newValue, int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putFloatVolatile(defc, vmSlot, newValue);
 		else
 			UNSAFE.putFloat        (defc, vmSlot, newValue);
@@ -82,7 +82,7 @@ final class StaticFieldSetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(double newValue, int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putDoubleVolatile(defc, vmSlot, newValue);
 		else
 			UNSAFE.putDouble        (defc, vmSlot, newValue);
@@ -91,7 +91,7 @@ final class StaticFieldSetterHandle extends FieldHandle {
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(Object newValue, int argPlaceholder) {
 		initializeClassIfRequired();
-		if (Modifier.isVolatile(final_modifiers))
+		if (isVolatile)
 			UNSAFE.putObjectVolatile(defc, vmSlot, newValue);
 		else
 			UNSAFE.putObject        (defc, vmSlot, newValue);


### PR DESCRIPTION
In `FieldHandle`, we use `Modifier.isVolatile(final_modifiers)` to check
if the field is volatile. `Modifier.isVolatile` is a public method and
has the overhead of HCR guard when inlined. Get rid of the call by
storing the answer in a field. Also remove `final_modifiers` since it's
no longer used after this change.

#4837 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>