### PR TITLE
Unlimited user processes in Docker build containers

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -277,8 +277,13 @@ RUN mkdir /var/run/sshd \
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
+# Expose SSH port and run SSHD
+EXPOSE 22
+
 # Generate ssh host keys
 RUN /usr/bin/ssh-keygen -A
 
-# Expose SSH port and run SSHD
-EXPOSE 22
+# Adding bash profile so ${USER} max user processes will be unlimited
+RUN echo >> /home/${USER}/.bashrc \
+  && echo "# Change max user processes in ${USER}" >> /home/${USER}/.bashrc \
+  && echo "ulimit -u unlimited" >> /home/${USER}/.bashrc

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -168,6 +168,9 @@ RUN mkdir /var/run/sshd \
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
+# Expose SSH port
+EXPOSE 22
+
 # Setup a reference repository cache for faster clones in the container
 RUN mkdir /home/${USER}/openjdk_cache \
   && cd /home/${USER}/openjdk_cache \
@@ -180,5 +183,7 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git fetch --all \
   && git gc --aggressive --prune=all
 
-# Expose SSH port and run SSH
-EXPOSE 22
+# Adding bash profile so ${USER} max user processes will be unlimited
+RUN echo >> /home/${USER}/.bashrc \
+  && echo "# Change max user processes in ${USER}" >> /home/${USER}/.bashrc \
+  && echo "ulimit -u unlimited" >> /home/${USER}/.bashrc

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -321,9 +321,7 @@ RUN mkdir -p /var/run/sshd \
   && service sshd start \
   && service sshd stop
 
-# Adding bash profile so jenkins max user processes will be unlimited
-RUN echo >> /home/jenkins/.bashrc \
-  && echo "# Change max user processes in jenkins" >> /home/jenkins/.bashrc \
-  && echo "ulimit -u unlimited" >> /home/jenkins/.bashrc
-
-CMD ["/usr/sbin/sshd","-D"]
+# Adding bash profile so ${USER} max user processes will be unlimited
+RUN echo >> /home/${USER}/.bashrc \
+  && echo "# Change max user processes in ${USER}" >> /home/${USER}/.bashrc \
+  && echo "ulimit -u unlimited" >> /home/${USER}/.bashrc


### PR DESCRIPTION
- Fixes an issue where the GC fails to start during the
  compile because the max user process limit is exceeded.
- Also remove the CMD from the x build container as Jenkins
  overwrites these by default.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>