### PR TITLE
Add missing J9CFGSimplifier.cpp entry to CMakeFiles.txt

### DIFF
--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -34,6 +34,7 @@ j9jit_files(
 	optimizer/IdiomTransformations.cpp
 	optimizer/InlinerTempForJ9.cpp
 	optimizer/InterProceduralAnalyzer.cpp
+	optimizer/J9CFGSimplifier.cpp
 	optimizer/J9EstimateCodeSize.cpp
 	optimizer/J9Inliner.cpp
 	optimizer/J9LocalCSE.cpp


### PR DESCRIPTION
The new file added in #6040 was not added to the CMakeFiles.txt.
This commit corrects this oversight.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>