### PR TITLE
Disable CFGSimpliciation

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -33,6 +33,10 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
+   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
+   if (enableCFGSimplification == NULL)
+      return false;
+
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
           || simplifyResolvedRequireNonNull(needToDuplicateTree)
           || simplifyUnresolvedRequireNonNull(needToDuplicateTree)


### PR DESCRIPTION
The enhancements to CFGSimplication enhanced by #6040 seem to have a
bug not found during testing. This commit disables the optimization
with an environment variable to re-enable the optimization for testing.
The optimization will be re-enabled once we find and fix the problem.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>