### PR TITLE
Create codeCache allocation pointers callbacks

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -608,6 +608,23 @@ jitExclusiveVMShutdownPending(J9VMThread * vmThread)
    #endif
    }
 
+// Code cache callbacks to be used by the VM
+//
+extern "C" U_8*
+getCodeCacheWarmAlloc(void *codeCache)
+   {
+   TR::CodeCache * cc = static_cast<TR::CodeCache*>(codeCache);
+   return cc->getWarmCodeAlloc();
+   }
+
+extern "C" U_8*
+getCodeCacheColdAlloc(void *codeCache)
+   {
+   TR::CodeCache * cc = static_cast<TR::CodeCache*>(codeCache);
+   return cc->getColdCodeAlloc();
+   }
+
+
 // -----------------------------------------------------------------------------
 // JIT control
 // -----------------------------------------------------------------------------
@@ -771,7 +788,6 @@ command(J9VMThread * vmThread, const char * cmdString)
 
    return 0;
    }
-
 
 static IDATA
 internalCompileClass(J9VMThread * vmThread, J9Class * clazz)
@@ -1020,6 +1036,10 @@ onLoadInternal(
       if ((jitConfig->dataCacheList = javaVM->internalVMFunctions->allocateMemorySegmentList(javaVM, 3, J9MEM_CATEGORY_JIT)) == NULL)
          return -1;
       }
+
+   // Callbacks for code cache allocation pointers
+   jitConfig->codeCacheWarmAlloc = getCodeCacheWarmAlloc;
+   jitConfig->codeCacheColdAlloc = getCodeCacheColdAlloc;
 
    /* Allocate the privateConfig structure.  Note that the AOTRT DLL does not allocate this structure */
    jitConfig->privateConfig = j9mem_allocate_memory(sizeof(TR_JitPrivateConfig), J9MEM_CATEGORY_JIT);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3671,6 +3671,8 @@ typedef struct J9JITConfig {
 	void ( *jitMethodBreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitMethodUnbreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitIllegalFinalFieldModification)(struct J9VMThread *currentThread, struct J9Class *fieldClass);
+	U_8* (*codeCacheWarmAlloc)(void *codeCache);
+	U_8* (*codeCacheColdAlloc)(void *codeCache);
 } J9JITConfig;
 
 #define J9JIT_GROW_CACHES  0x100000


### PR DESCRIPTION
The contract between VM and JIT is that the TR::CodeCache
will have warmCodeAlloc and coldCodeAlloc pointers as the
first two fields. This commit removes that restriction by
creating a pair of callbacks that the VM can use to find
the code cache allocation pointers.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>