### PR TITLE
Extend DDR rules to handle *.mc files

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -363,6 +363,7 @@ DDR_NOLIST := <#if uma.spec.type.zos>-Wc,noconvlit -Wc,nolist,nooffset</#if>
 # just create empty output files
 %.i : %.asm ; touch $@
 %.i : %.m4  ; touch $@
+%.i : %.mc  ; touch $@
 %.i : %.s   ; touch $@
 
 <#if uma.spec.type.windows>


### PR DESCRIPTION
Fixes error on z/OS:
```
No rule to make target 'j9guardedstorage.i', needed by 'ddrgen'.
```