### PR TITLE
Modify CFG in realEstimateCodeSize to use internal memory regions.

### DIFF
--- a/runtime/compiler/infra/Cfg.hpp
+++ b/runtime/compiler/infra/Cfg.hpp
@@ -35,8 +35,8 @@ class CFG : public J9::CFGConnector
    {
    public:
 
-   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method) :
-      J9::CFGConnector(comp, method) {}
+   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method, TR::Region *region = NULL) :
+      J9::CFGConnector(comp, method, region) {}
    };
 
 }

--- a/runtime/compiler/infra/J9Cfg.hpp
+++ b/runtime/compiler/infra/J9Cfg.hpp
@@ -64,8 +64,8 @@ class CFG : public OMR::CFGConnector
    {
 public:
 
-   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m) :
-         OMR::CFGConnector(c, m),
+   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region *r= NULL) :
+         OMR::CFGConnector(c, m, r),
       _externalProfiler(NULL)
       {
       }

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1085,7 +1085,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                (uint16_t) handler, (uint32_t) type);
          }
 
-      TR::CFG cfg(comp(), calltarget->_calleeSymbol);
+      TR::CFG cfg(comp(), calltarget->_calleeSymbol, &comp()->trMemory()->currentStackRegion());
       cfg.setStartAndEnd(new (comp()->trStackMemory()) TR::Block(
             TR::TreeTop::create(comp(), TR::Node::createOnStack(NULL,
                   TR::BBStart, 0)), TR::TreeTop::create(comp(),
@@ -1163,7 +1163,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                debugTrace(tracer(),"joining nodes between blocks %p %d and %p %d", currentBlock, currentBlock->getNumber(), newBlock, newBlock->getNumber());
                currentBlock->getExit()->join(newBlock->getEntry());
 
-               cfg.addEdge(currentBlock, newBlock, stackAlloc);
+               cfg.addEdge(currentBlock, newBlock);
                addFallThruEdge = true;
                }
             else
@@ -1236,20 +1236,20 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   setupLastTreeTop(currentBlock, bc, i, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), calltarget->_calleeMethod, comp());
                   cfg.addEdge(currentBlock, getBlock(comp(), blocks,
                         calltarget->_calleeMethod, i + bci.relativeBranch(),
-                        cfg), stackAlloc);
+                        cfg));
                   addFallThruEdge = true;
                   break;
                   }
                case J9BCgoto:
                case J9BCgotow:
                   setupLastTreeTop(currentBlock, bc, i, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), stackAlloc);
+                  cfg.addEdge(currentBlock, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg));
                   addFallThruEdge = false;
                   break;
                case J9BCgenericReturn:
                case J9BCathrow:
                   setupLastTreeTop(currentBlock, bc, i, cfg.getEnd()->asBlock(), calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, cfg.getEnd(), stackAlloc);
+                  cfg.addEdge(currentBlock, cfg.getEnd());
                   addFallThruEdge = false;
                   break;
                case J9BCtableswitch:
@@ -1260,13 +1260,13 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                               index), cfg);
                   setupLastTreeTop(currentBlock, bc, i, defaultBlock,
                         calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, defaultBlock, stackAlloc);
+                  cfg.addEdge(currentBlock, defaultBlock);
                   int32_t low = bci.nextSwitchValue(index);
                   int32_t high = bci.nextSwitchValue(index) - low + 1;
                   for (int32_t j = 0; j < high; ++j)
                      cfg.addEdge(currentBlock, getBlock(comp(), blocks,
                            calltarget->_calleeMethod, i + bci.nextSwitchValue(
-                                 index), cfg), stackAlloc);
+                                 index), cfg));
                   addFallThruEdge = false;
                   break;
                   }
@@ -1278,14 +1278,14 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                               index), cfg);
                   setupLastTreeTop(currentBlock, bc, i, defaultBlock,
                         calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, defaultBlock, stackAlloc);
+                  cfg.addEdge(currentBlock, defaultBlock);
                   int32_t tableSize = bci.nextSwitchValue(index);
                   for (int32_t j = 0; j < tableSize; ++j)
                      {
                      index += 4; // match value
                      cfg.addEdge(currentBlock, getBlock(comp(), blocks,
                            calltarget->_calleeMethod, i + bci.nextSwitchValue(
-                                 index), cfg), stackAlloc);
+                                 index), cfg));
                      }
                   addFallThruEdge = false;
                   break;
@@ -1307,7 +1307,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
          for (int32_t j = handlerInfo->_startIndex; j <= handlerInfo->_endIndex; ++j)
             if (blocks[j])
-               cfg.addExceptionEdge(blocks[j], blocks[handlerInfo->_handlerIndex], stackAlloc);
+               cfg.addExceptionEdge(blocks[j], blocks[handlerInfo->_handlerIndex]);
          }
 
       // Adjust call frequency for unknown or direct calls, for which we don't get profiling information


### PR DESCRIPTION
The CFG in realEstimateCodeSize is being allocated on the stack.
This means that CFG edges are also stack allocated and this
memory layout must be specify each time a CFG edge is built.
Instead of specifying stackAlloc every single time a CFG edge is
built, we specify the memory region during the initialization of
the CFG. This commit contributes to the following issue:

Issue: #6099

Signed-off-by: Erick Ochoa <eochoa@ualberta.ca>