### PR TITLE
Determine if static in the constructor rather than at invoke

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectHandle.java
@@ -117,7 +117,7 @@ class DirectHandle extends PrimitiveHandle {
 	}
 
 	final void nullCheckIfRequired(Object receiver) throws NullPointerException {
-		if (!isStatic && (receiver == null)) {
+		if (!isStatic) {
 			receiver.getClass(); // Deliberate NPE
 		}
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2009 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectHandle.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Modifier;
  * The vmSlot will hold a J9Method address.
  */
 class DirectHandle extends PrimitiveHandle {
-	final int final_modifiers;
+	final boolean isStatic;
 	final boolean originIsFindVirtual;
 	
 	DirectHandle(Class<?> referenceClass, String methodName, MethodType type, byte kind, Class<?> specialCaller) throws NoSuchMethodException, IllegalAccessException {
@@ -52,7 +52,7 @@ class DirectHandle extends PrimitiveHandle {
 		this.defc = finishMethodInitialization(specialCaller, type);
 		/* Kind should have been changed from KIND_VIRTUAL in finishMethodInitialization */
 		assert (this.kind != KIND_VIRTUAL);
-		final_modifiers = rawModifiers;
+		isStatic = Modifier.isStatic(rawModifiers);
 		this.originIsFindVirtual = originIsFindVirtual;
 	}
 	
@@ -69,7 +69,7 @@ class DirectHandle extends PrimitiveHandle {
 		if (!succeed) {
 			throw new IllegalAccessException();
 		}
-		final_modifiers = rawModifiers;
+		isStatic = Modifier.isStatic(rawModifiers);
 		this.originIsFindVirtual = originIsFindVirtual;
 	}
 	
@@ -86,13 +86,13 @@ class DirectHandle extends PrimitiveHandle {
 		addHandleToClassCache();
 		this.vmSlot = other.vmSlot;
 		this.defc = other.defc;
-		final_modifiers = rawModifiers;
+		isStatic = Modifier.isStatic(other.rawModifiers);
 		this.originIsFindVirtual = other.directHandleOriginatedInFindVirtual();
 	}
 	
 	DirectHandle(DirectHandle originalHandle, MethodType newType) {
 		super(originalHandle, newType);
-		final_modifiers = rawModifiers;
+		isStatic = originalHandle.isStatic;
 		this.originIsFindVirtual = originalHandle.originIsFindVirtual;
 		addHandleToClassCache();
 		// Reassigning the vmSlot because an HCR may have occurred since it was assigned in super()
@@ -117,7 +117,7 @@ class DirectHandle extends PrimitiveHandle {
 	}
 
 	final void nullCheckIfRequired(Object receiver) throws NullPointerException {
-		if ((receiver == null) && !Modifier.isStatic(final_modifiers)) {
+		if (!isStatic && (receiver == null)) {
 			receiver.getClass(); // Deliberate NPE
 		}
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -110,25 +110,9 @@ final class ReceiverBoundHandle extends DirectHandle {
 	private static final ThunkTable _thunkTable = new ThunkTable();
 	protected final ThunkTable thunkTable(){ return _thunkTable; }
 	
-	/*[IF ]*/
-	/* Null check the receiver if the handle isn't for a static method.
-	 * This is the lowest risk change for this failure.
-	 * TODO: Investigate introducing a new handle subclass: 
-	 * NullReceiverBoundHandle as a subclass of RBH that only
-	 * throws NPE.  We should always know at creation time
-	 * which kind of handle it will be - NRBH or RBH.
-	 * 
-	 */
-	/*[ENDIF]*/
-	final void nullCheckReceiverIfNonStatic(){
-		if (!isStatic && (receiver == null)) {
-			receiver.getClass(); // Deliberate NPE
-		}
-	}
-	
 	@FrameIteratorSkip
 	private final void invokeExact_thunkArchetype_V(int argPlaceholder) {
-		nullCheckReceiverIfNonStatic();
+		nullCheckIfRequired(receiver);
 		if (ILGenMacros.isCustomThunk()) {
 			directCall_V(receiver, argPlaceholder); 
 		} else if (isAlreadyCompiled(vmSlot))
@@ -140,7 +124,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	
 	@FrameIteratorSkip
 	private final int invokeExact_thunkArchetype_I(int argPlaceholder) {
-		nullCheckReceiverIfNonStatic();
+		nullCheckIfRequired(receiver);
 		if (ILGenMacros.isCustomThunk()) {
 			return directCall_I(receiver, argPlaceholder);
 		} else if (isAlreadyCompiled(vmSlot))
@@ -152,7 +136,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	
 	@FrameIteratorSkip
 	private final long invokeExact_thunkArchetype_J(int argPlaceholder) {
-		nullCheckReceiverIfNonStatic();
+		nullCheckIfRequired(receiver);
 		if (ILGenMacros.isCustomThunk()) {
 			return directCall_J(receiver, argPlaceholder);
 		} else if (isAlreadyCompiled(vmSlot))
@@ -164,7 +148,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	
 	@FrameIteratorSkip
 	private final float invokeExact_thunkArchetype_F(int argPlaceholder) {
-		nullCheckReceiverIfNonStatic();
+		nullCheckIfRequired(receiver);
 		if (ILGenMacros.isCustomThunk()) {
 			return directCall_F(receiver, argPlaceholder);
 		} else if (isAlreadyCompiled(vmSlot))
@@ -176,7 +160,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	
 	@FrameIteratorSkip
 	private final double invokeExact_thunkArchetype_D(int argPlaceholder) {
-		nullCheckReceiverIfNonStatic();
+		nullCheckIfRequired(receiver);
 		if (ILGenMacros.isCustomThunk()) {
 			return directCall_D(receiver, argPlaceholder);
 		} else if (isAlreadyCompiled(vmSlot))
@@ -188,7 +172,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	
 	@FrameIteratorSkip
 	private final Object invokeExact_thunkArchetype_L(int argPlaceholder) { 
-		nullCheckReceiverIfNonStatic();
+		nullCheckIfRequired(receiver);
 		if (ILGenMacros.isCustomThunk()) {
 			return directCall_L(receiver, argPlaceholder); 
 		} else if (isAlreadyCompiled(vmSlot))

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -121,7 +121,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	 */
 	/*[ENDIF]*/
 	final void nullCheckReceiverIfNonStatic(){
-		if ((receiver == null) && !Modifier.isStatic(final_modifiers)) {
+		if (!isStatic && (receiver == null)) {
 			receiver.getClass(); // Deliberate NPE
 		}
 	}


### PR DESCRIPTION
`final_modifiers` was a hack to enable the modifiers field to be
final for JIT purposes.  It's better to just do the isStatic
check in the constructor once rather than making it part of the
invoke/invokeExact sequence.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>