### PR TITLE
 Change the format of shared cache file to include layer number.

### DIFF
--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -6737,3 +6737,10 @@ J9NLS_SHRC_GET_DIR_NO_SPACE.explanation=Cannot allocate native memory.
 J9NLS_SHRC_GET_DIR_NO_SPACE.system_action=The JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes.
 J9NLS_SHRC_GET_DIR_NO_SPACE.user_response=Ensure the process has enough native memory to run.
 # END NON-TRANSLATABLE
+
+J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROYALLLAYERS=Destroy all shared cache layers of the same name (use name parm or default)
+# START NON-TRANSLATABLE
+J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROYALLLAYERS.explanation=NOTAG
+J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROYALLLAYERS.system_action=
+J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROYALLLAYERS.user_response=
+# END NON-TRANSLATABLE

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -71,8 +71,13 @@ extern "C" {
 #define J9SH_SNAPSHOT_PREFIX_CHAR 'S'
 #define J9SH_PREFIX_SEPARATOR_CHAR '_'
 
+#define J9SH_GENERATION_37		37
 #define J9SH_GENERATION_29		29
 #define J9SH_GENERATION_07		7
+
+#define J9SH_LAYER_NUM_MAX_VALUE 99
+#define J9SH_LAYER_NUM_UNSET (-1)
+#define J9SH_LAYER_NUM_CHAR 'L'
 
 #define J9SH_VERSION_STRING_G07ANDLOWER_SPEC "C%dD%dA%d"
 #define J9SH_VERSION_STRING_G07TO29_SPEC "C%dM%dA%d"
@@ -120,6 +125,8 @@ uintptr_t
 isCacheFileName(J9PortLibrary* portlib, const char* nameToTest, uintptr_t expectPersistent, const char* optionalExtraID);
 
 intptr_t getModLevelFromName(const char* cacheNameWithVGen);
+
+I_8 getLayerFromName(const char* cacheNameWithVGen);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/runtime/shared_common/CacheLifecycleManager.hpp
+++ b/runtime/shared_common/CacheLifecycleManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,8 @@
 #define J9SH_DESTROY_FAILED_CURRENT_GEN_SNAPSHOT 	J9SH_DESTROY_FAILED_CURRENT_GEN_CACHE
 #define J9SH_DESTROY_FAILED_OLDER_GEN_SNAPSHOT		J9SH_DESTROY_FAILED_OLDER_GEN_CACHE
 
+#define J9SH_DESTROY_TOP_LAYER_ONLY (J9SH_LAYER_NUM_MAX_VALUE + 1)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,9 +51,9 @@ extern "C" {
 IDATA j9shr_iterateSharedCaches(J9JavaVM *vm, const char *ctrlDirName, UDATA groupPerm, BOOLEAN useCommandLineValue, IDATA (*callback)(J9JavaVM *vm, J9SharedCacheInfo *event_data, void *user_data), void *user_data);
 IDATA j9shr_destroySharedCache(J9JavaVM *vm, const char *ctrlDirName, const char *name, U_32 cacheType, BOOLEAN useCommandLineValue);
 
-IDATA j9shr_destroy_cache(struct J9JavaVM* vm, const char* ctrlDirName, UDATA verboseFlags, const char* cacheName, UDATA generationStart, UDATA generationEnd, J9PortShcVersion* versionData, BOOLEAN isReset);
+IDATA j9shr_destroy_cache(struct J9JavaVM* vm, const char* ctrlDirName, UDATA verboseFlags, const char* cacheName, UDATA generationStart, UDATA generationEnd, J9PortShcVersion* versionData, BOOLEAN isReset, I_8 layerStart, I_8 layerEnd);
 
-IDATA j9shr_destroy_snapshot(struct J9JavaVM* vm, const char* ctrlDirName, UDATA verboseFlags, const char* cacheName, UDATA generationStart, UDATA generationEnd, J9PortShcVersion* versionData);
+IDATA j9shr_destroy_snapshot(struct J9JavaVM* vm, const char* ctrlDirName, UDATA verboseFlags, const char* cacheName, UDATA generationStart, UDATA generationEnd, J9PortShcVersion* versionData, I_8 layerStart, I_8 layerEnd);
 
 IDATA j9shr_destroy_all_snapshot(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA verboseFlags);
 
@@ -61,7 +63,7 @@ IDATA j9shr_destroy_all_cache(struct J9JavaVM* vm, const char* ctrlDirName, UDAT
 
 IDATA j9shr_destroy_expire_cache(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA verboseFlags, UDATA minutes);
 
-IDATA j9shr_stat_cache(struct J9JavaVM* vm, const char* cacheDirName, UDATA verboseFlags, const char* name, J9PortShcVersion* versionData, UDATA generation);
+IDATA j9shr_stat_cache(struct J9JavaVM* vm, const char* cacheDirName, UDATA verboseFlags, const char* name, J9PortShcVersion* versionData, UDATA generation, I_8 layer);
 
 IDATA j9shr_report_utility_incompatible(struct J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA verboseFlags, const char* name, const char* utility);
 

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -288,7 +288,7 @@ SH_CacheMap::initialize(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, Bl
 
 	_managers = SH_Managers::newInstance(vm, (SH_Managers *)allocPtr);
 
-	_ccHead = _cc = SH_CompositeCacheImpl::newInstance(vm, sharedClassConfig, (SH_CompositeCacheImpl*)(allocPtr += SH_Managers::getRequiredConstrBytes()), cacheName, cacheTypeRequired, startupForStats);
+	_ccHead = _cc = SH_CompositeCacheImpl::newInstance(vm, sharedClassConfig, (SH_CompositeCacheImpl*)(allocPtr += SH_Managers::getRequiredConstrBytes()), cacheName, cacheTypeRequired, startupForStats, OSCACHE_CURRENT_LAYER_LAYER);
 
 	_tsm = SH_TimestampManagerImpl::newInstance(vm, (SH_TimestampManagerImpl*)(allocPtr += SH_CompositeCacheImpl::getRequiredConstrBytesWithCommonInfo(false, startupForStats)), sharedClassConfig);
 

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -176,12 +176,12 @@ SH_CompositeCacheImpl::SH_SharedCacheHeaderInit::init(BlockPtr data, U_32 len, I
  * @return A pointer to the new instance
  */
 SH_CompositeCacheImpl*
-SH_CompositeCacheImpl::newInstance(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, SH_CompositeCacheImpl* memForConstructor, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats)
+SH_CompositeCacheImpl::newInstance(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, SH_CompositeCacheImpl* memForConstructor, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats, I_8 layer)
 {
 	SH_CompositeCacheImpl* newCC = (SH_CompositeCacheImpl*)memForConstructor;
 
 	new(newCC) SH_CompositeCacheImpl();
-	newCC->initializeWithCommonInfo(vm, sharedClassConfig, ((BlockPtr)memForConstructor + sizeof(SH_CompositeCacheImpl)), cacheName, cacheTypeRequired, startupForStats);
+	newCC->initializeWithCommonInfo(vm, sharedClassConfig, ((BlockPtr)memForConstructor + sizeof(SH_CompositeCacheImpl)), cacheName, cacheTypeRequired, startupForStats, layer);
 
 	return newCC;
 }
@@ -348,7 +348,7 @@ SH_CompositeCacheImpl::getFreeBlockBytes(void)
 }
 
 void
-SH_CompositeCacheImpl::initializeWithCommonInfo(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, BlockPtr memForConstructor, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats)
+SH_CompositeCacheImpl::initializeWithCommonInfo(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, BlockPtr memForConstructor, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats, I_8 layer)
 {
 	const char * ctrlDirName = NULL;
 	BlockPtr memToUse = (BlockPtr)memForConstructor;
@@ -358,23 +358,23 @@ SH_CompositeCacheImpl::initializeWithCommonInfo(J9JavaVM* vm, J9SharedClassConfi
 		ctrlDirName = sharedClassConfig->ctrlDirName;
 	}
 
-	Trc_SHR_CC_initializeWithCommonInfo_Entry1(memForConstructor, ctrlDirName, cacheName, cacheTypeRequired);
+	Trc_SHR_CC_initializeWithCommonInfo_Entry2(memForConstructor, ctrlDirName, cacheName, cacheTypeRequired, layer);
 
 	_commonCCInfo = (J9ShrCompositeCacheCommonInfo *)memToUse;
 	initCommonCCInfoHelper();
 
 	memToUse += sizeof(J9ShrCompositeCacheCommonInfo);
-	initialize(vm, memToUse, sharedClassConfig, cacheName, cacheTypeRequired, startupForStats);
+	initialize(vm, memToUse, sharedClassConfig, cacheName, cacheTypeRequired, startupForStats, layer);
 
 	Trc_SHR_CC_initializeWithCommonInfo_Exit();
 }
 
 void
-SH_CompositeCacheImpl::initialize(J9JavaVM* vm, BlockPtr memForConstructor, J9SharedClassConfig* sharedClassConfig, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats)
+SH_CompositeCacheImpl::initialize(J9JavaVM* vm, BlockPtr memForConstructor, J9SharedClassConfig* sharedClassConfig, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats, I_8 layer)
 {
 	J9PortShcVersion versionData;
 
-	Trc_SHR_CC_initialize_Entry1(memForConstructor, sharedClassConfig, cacheName, cacheTypeRequired, UnitTest::unitTest);
+	Trc_SHR_CC_initialize_Entry2(memForConstructor, sharedClassConfig, cacheName, cacheTypeRequired, layer, UnitTest::unitTest);
 
 	commonInit(vm);
 	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
@@ -401,9 +401,9 @@ SH_CompositeCacheImpl::initialize(J9JavaVM* vm, BlockPtr memForConstructor, J9Sh
 		_osPageSize = 0;
 	} else {
 		if ((sharedClassConfig->runtimeFlags & J9SHR_RUNTIMEFLAG_CREATE_OLD_GEN) != 0) {
-			_oscache = SH_OSCache::newInstance(_portlib, (SH_OSCache*)memForConstructor, cacheName, SH_OSCache::getCurrentCacheGen()-1, &versionData);
+			_oscache = SH_OSCache::newInstance(_portlib, (SH_OSCache*)memForConstructor, cacheName, SH_OSCache::getCurrentCacheGen()-1, &versionData, layer);
 		} else {
-			_oscache = SH_OSCache::newInstance(_portlib, (SH_OSCache*)memForConstructor, cacheName, SH_OSCache::getCurrentCacheGen(), &versionData);
+			_oscache = SH_OSCache::newInstance(_portlib, (SH_OSCache*)memForConstructor, cacheName, SH_OSCache::getCurrentCacheGen(), &versionData, layer);
 		}
 		_newHdrPtr = (SH_SharedCacheHeaderInit*)((BlockPtr)memForConstructor + SH_OSCache::getRequiredConstrBytes());
 		_debugData = (ClassDebugDataProvider *)((BlockPtr)memForConstructor + SH_OSCache::getRequiredConstrBytes() + sizeof(SH_CompositeCacheImpl::SH_SharedCacheHeaderInit));

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -93,7 +93,7 @@ public:
 			J9SharedClassPreinitConfig* piconfig, U_32* actualSize, UDATA* localCrashCntr);
 #endif /* J9SHR_CACHELET_SUPPORT */
 	
-	static SH_CompositeCacheImpl* newInstance(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, SH_CompositeCacheImpl* memForConstructor, const char* cacheName, I_32 newPersistentCacheReqd, bool startupForStats);
+	static SH_CompositeCacheImpl* newInstance(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, SH_CompositeCacheImpl* memForConstructor, const char* cacheName, I_32 newPersistentCacheReqd, bool startupForStats, I_8 layer);
 	
 	IDATA startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* piconfig, BlockPtr cacheMemoryUT, U_64* runtimeFlags, UDATA verboseFlags,
 			const char* rootName, const char* ctrlDirName, UDATA cacheDirPerm, U_32* actualSize, UDATA* localCrashCntr, bool isFirstStart, bool* cacheHasIntegrity);
@@ -555,8 +555,8 @@ private:
 	void incReaderCount(J9VMThread* currentThread);
 	void decReaderCount(J9VMThread* currentThread);
 
-	void initialize(J9JavaVM* vm, BlockPtr memForConstructor, J9SharedClassConfig* sharedClassConfig, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats);
-	void initializeWithCommonInfo(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, BlockPtr memForConstructor, const char* cacheName, I_32 newPersistentCacheReqd, bool startupForStats);
+	void initialize(J9JavaVM* vm, BlockPtr memForConstructor, J9SharedClassConfig* sharedClassConfig, const char* cacheName, I_32 cacheTypeRequired, bool startupForStats, I_8 layer);
+	void initializeWithCommonInfo(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, BlockPtr memForConstructor, const char* cacheName, I_32 newPersistentCacheReqd, bool startupForStats, I_8 layer);
 	void initCommonCCInfoHelper();
 
 #if defined(J9SHR_CACHELET_SUPPORT)

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -54,19 +54,20 @@
  * @param [in] cacheName  The name of the cache
  * @param [in] versionData  The version information for the cache
  * @param [in] generation  The generation
- * @param [in] isMemoryType  True if the file is a shared memory control file, false if for a semaphore  
+ * @param [in] isMemoryType  True if the file is a shared memory control file, false if for a semaphore
+ * @param [in] layer  The shared cache layer number.
  */
 void
 SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* buffer, UDATA bufferSize, const char* cacheName,
-		J9PortShcVersion* versionData, UDATA generation, bool isMemoryType)
+		J9PortShcVersion* versionData, UDATA generation, bool isMemoryType, I_8 layer)
 {
-	char genString[4];
+	char genString[7];
 	char versionStr[J9SH_VERSION_STRING_LEN+3];
 	UDATA versionStrLen = 0;
 	
 	PORT_ACCESS_FROM_PORT(portlib);
 	
-	Trc_SHR_OSC_getCacheVersionAndGen_Entry(cacheName, generation);
+	Trc_SHR_OSC_getCacheVersionAndGen_Entry_V1(cacheName, generation, layer);
 
 	memset(versionStr, 0, J9SH_VERSION_STRING_LEN+1);
 	if (generation <= J9SH_GENERATION_07) {
@@ -107,8 +108,16 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 	} else if (J9PORT_SHR_CACHE_TYPE_SNAPSHOT == versionData->cacheType) {
 		versionStr[versionStrLen] = J9SH_SNAPSHOT_PREFIX_CHAR;
 	}
+	if (generation <= J9SH_GENERATION_37) {
+		j9str_printf(PORTLIB, genString, 4, "G%02d", generation);
+	} else {
+		Trc_SHR_Assert_True(
+							((0 <= layer) && (layer <= J9SH_LAYER_NUM_MAX_VALUE))
+							|| (J9SH_LAYER_NUM_UNSET == layer)
+							);
+		j9str_printf(PORTLIB, genString, 7, "G%02dL%02d", generation, layer);
+	}
 
-	j9str_printf(PORTLIB, genString, 4, "G%02d", generation);
 #if defined(WIN32)
 	j9str_printf(PORTLIB, buffer, bufferSize, "%s%c%s%c%s", versionStr, J9SH_PREFIX_SEPARATOR_CHAR, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
 #else
@@ -141,7 +150,7 @@ IDATA
 SH_OSCache::removeCacheVersionAndGen(char* buffer, UDATA bufferSize, UDATA versionLen, const char* cacheNameWithVGen)
 {
 	char* nameStart;
-	UDATA lengthMinusGen;
+	UDATA lengthMinusGenAndLayer = 0;
 	UDATA generation = getGenerationFromName(cacheNameWithVGen);
 	
 	Trc_SHR_OSC_removeCacheVersionAndGen_Entry(versionLen, cacheNameWithVGen);
@@ -159,13 +168,17 @@ SH_OSCache::removeCacheVersionAndGen(char* buffer, UDATA bufferSize, UDATA versi
 	}
 
 	nameStart = (char*)(cacheNameWithVGen + versionLen);
-	lengthMinusGen = strlen(nameStart) - strlen("_GXX");
-	if (lengthMinusGen >= bufferSize) {
+	if (generation <= J9SH_GENERATION_37) {
+		lengthMinusGenAndLayer = strlen(nameStart) - strlen("_GXX");
+	} else {
+		lengthMinusGenAndLayer = strlen(nameStart) - strlen("_GXXLXX");
+	}
+	if (lengthMinusGenAndLayer >= bufferSize) {
 		Trc_SHR_OSC_removeCacheVersionAndGen_overflow();
 		return -1;
 	}
-	strncpy(buffer, nameStart, lengthMinusGen);
-	buffer[lengthMinusGen] = '\0';
+	strncpy(buffer, nameStart, lengthMinusGenAndLayer);
+	buffer[lengthMinusGenAndLayer] = '\0';
 	Trc_SHR_OSC_removeCacheVersionAndGen_Exit();
 	return 0;
 }
@@ -394,14 +407,14 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 	}
 
 	/* Allocate enough memory for _cacheName and _cacheNameWithVGen. J9SH_MEMORY_ID only used on sysv UNIX */
-	cacheNameLen = (strlen(cacheName) * 2) + versionStrLen + strlen("_GXX") + 2 + strlen(J9SH_MEMORY_ID);
+	cacheNameLen = (strlen(cacheName) * 2) + versionStrLen + strlen("_GXXLXX") + 2 + strlen(J9SH_MEMORY_ID);
 	if (!(_cacheNameWithVGen = (char*)j9mem_allocate_memory(cacheNameLen, J9MEM_CATEGORY_CLASSES))) {
 		Trc_SHR_OSC_commonStartup_nomem_cacheName();
 		OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_ALLOC_FAILED);
 		return -1;
 	}
 	memset(_cacheNameWithVGen, 0, cacheNameLen);
-	getCacheVersionAndGen(PORTLIB, vm, _cacheNameWithVGen, cacheNameLen, cacheName, versionData, _activeGeneration, true);
+	getCacheVersionAndGen(PORTLIB, vm, _cacheNameWithVGen, cacheNameLen, cacheName, versionData, _activeGeneration, true, _layer);
 
 	/* The assert below is just a precaution.
 	 * Check if cacheName with version and generation string is less than maximum length.
@@ -445,11 +458,12 @@ SH_OSCache::dontNeedMetadata(J9VMThread* currentThread, const void* startAddress
 
 /* Function that initializes class variables common to OSCache subclasses */
 void
-SH_OSCache::commonInit(J9PortLibrary* portLibrary, UDATA generation)
+SH_OSCache::commonInit(J9PortLibrary* portLibrary, UDATA generation, I_8 layer)
 {
 	_startupCompleted = false;
 	_portLibrary = portLibrary;
 	_activeGeneration = generation;
+	_layer = layer;
 	_cacheNameWithVGen = NULL;
 	_cacheName = NULL;
 	_cachePathName = NULL;
@@ -487,7 +501,7 @@ SH_OSCache::commonCleanup()
 	}
 
 	/* If the cache is destroyed and then restarted, we still need portLibrary, versionData and generation */
-	commonInit(_portLibrary, _activeGeneration);
+	commonInit(_portLibrary, _activeGeneration, _layer);
 	
 	Trc_SHR_OSC_commonCleanup_Exit();
 }
@@ -500,18 +514,19 @@ SH_OSCache::commonCleanup()
  * @param [in] cacheName  Name of the cache
  * @param [in] generation  Generation of the cache
  * @param [in] versionData  Version data of the cache
+ * @param [in] layer  The layer number of the cache
  *
  * @return A pointer to the new OSCache object (which will be the same as the memForConstructor parameter)
  * 			It never returns NULL.
  */
 SH_OSCache*
-SH_OSCache::newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, const char* cacheName, UDATA generation, J9PortShcVersion* versionData)
+SH_OSCache::newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, const char* cacheName, UDATA generation, J9PortShcVersion* versionData, I_8 layer)
 {
 	SH_OSCache* newOSC = (SH_OSCache*)memForConstructor;
 
 	PORT_ACCESS_FROM_PORT(portlib);
 	
-	Trc_SHR_OSC_newInstance_Entry(memForConstructor, cacheName, versionData->cacheType);
+	Trc_SHR_OSC_newInstance_Entry_V1(memForConstructor, cacheName, versionData->cacheType, layer);
 	
 	switch(versionData->cacheType) {
 	case J9PORT_SHR_CACHE_TYPE_PERSISTENT :
@@ -530,7 +545,7 @@ SH_OSCache::newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, c
 #endif
 	}
 	Trc_SHR_OSC_newInstance_initializingNewObject();
-	newOSC->initialize(PORTLIB, ((char*)memForConstructor + SH_OSCache::getRequiredConstrBytes()), generation);
+	newOSC->initialize(PORTLIB, ((char*)memForConstructor + SH_OSCache::getRequiredConstrBytes()), generation, layer);
 	
 	Trc_SHR_OSC_newInstance_Exit(newOSC);
 	return newOSC;
@@ -824,6 +839,12 @@ SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char
 		Trc_SHR_OSC_getCacheStatistics_FutureGen();
 		return -1;
 	}
+
+	result->layer = getLayerFromName(cacheNameWithVGen);
+	Trc_SHR_Assert_True(
+						((0 <= result->layer) && (result->layer <= J9SH_LAYER_NUM_MAX_VALUE))
+						|| (J9SH_LAYER_NUM_UNSET == result->layer)
+						);
 
 	if (0 == getValuesFromShcFilePrefix(PORTLIB, cacheNameWithVGen, &(result->versionData))) {
 		Trc_SHR_OSC_getCacheStatistics_getValuesFromShcFilePrefix_Failed_Exit();

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -61,7 +61,8 @@
 #define OSCACHE_LOWEST_ACTIVE_GEN 1
 
 /* Always increment this value by 2. For testing we use the (current generation - 1) and expect the cache contents to be compatible. */
-#define OSCACHE_CURRENT_CACHE_GEN 37
+#define OSCACHE_CURRENT_CACHE_GEN 39
+#define OSCACHE_CURRENT_LAYER_LAYER 0
 
 #define J9SH_VERSION(versionMajor, versionMinor) (versionMajor*100 + versionMinor)
 
@@ -109,6 +110,7 @@ typedef struct SH_OSCache_Info {
         UDATA isCompatible; /** Is the cache compatible with this VM */
         UDATA isCorrupt; /** Is set when the cache is found to be corrupt */
         UDATA isJavaCorePopulated; /** Is set when the javacoreData contains valid data */
+        I_8 layer; /** cache layer number */
         J9SharedClassJavacoreDataDescriptor javacoreData; /** If isCompatible is true, then extra information about the cache is available in here*/
 } SH_OSCache_Info;
 
@@ -183,7 +185,7 @@ public:
 	 */
 	void *operator new(size_t size, void *memoryPtr) { return memoryPtr; };
 
-	static SH_OSCache* newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, const char* cacheName, UDATA generation, J9PortShcVersion* versionData);
+	static SH_OSCache* newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, const char* cacheName, UDATA generation, J9PortShcVersion* versionData, I_8 layer);
 
 	static UDATA getRequiredConstrBytes(void);
 	
@@ -192,7 +194,7 @@ public:
 	static IDATA createCacheDir(J9PortLibrary* portLibrary, char* cacheDirName, UDATA cacheDirPerm, bool cleanMemorySegments);
 
 	static void getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* buffer, UDATA bufferSize, const char* cacheName,
-			J9PortShcVersion* versionData, UDATA generation, bool isMemoryType);
+			J9PortShcVersion* versionData, UDATA generation, bool isMemoryType, I_8 layer);
 
 	static UDATA getCurrentCacheGen(void);
 
@@ -255,7 +257,7 @@ protected:
 	/*This constructor should only be used by this class*/
 	SH_OSCache() {};
 
-	virtual void initialize(J9PortLibrary* portLib_, char* memForConstructor, UDATA generation) = 0;
+	virtual void initialize(J9PortLibrary* portLib_, char* memForConstructor, UDATA generation, I_8 layer) = 0;
 
 	virtual void errorHandler(U_32 moduleName, U_32 id, LastErrorInfo *lastErrorInfo) = 0;
 
@@ -263,7 +265,7 @@ protected:
 	
 	IDATA commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData);
 	
-	void commonInit(J9PortLibrary* portLibrary, UDATA generation);
+	void commonInit(J9PortLibrary* portLibrary, UDATA generation, I_8 layer = 0);
 
 	void commonCleanup();
 	
@@ -294,6 +296,7 @@ protected:
 	char* _cacheNameWithVGen;
 	char* _cachePathName;
 	UDATA _activeGeneration;
+	I_8 _layer;
 	UDATA _createFlags;
 	UDATA _verboseFlags;
 	IDATA _errorCode;

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -74,7 +74,7 @@ SH_OSCachemmap::SH_OSCachemmap(J9PortLibrary* portLibrary, J9JavaVM* vm, const c
 		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer)
 {
 	Trc_SHR_OSC_Mmap_Constructor_Entry(cacheName, piconfig->sharedClassCacheSize, numLocks, createFlag, verboseFlags);
-	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN);
+	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN, OSCACHE_CURRENT_LAYER_LAYER);
 	startup(vm, cacheDirName, J9SH_DIRPERM_ABSENT, cacheName, piconfig, numLocks, createFlag, verboseFlags, runtimeFlags, openMode, 0, versionData, initializer, SHR_STARTUP_REASON_NORMAL);
 	Trc_SHR_OSC_Mmap_Constructor_Exit();
 }
@@ -87,12 +87,13 @@ SH_OSCachemmap::SH_OSCachemmap(J9PortLibrary* portLibrary, J9JavaVM* vm, const c
  * @param [in]  portLibraryArg The Port library
  * @param [in]  memForConstructorArg Pointer to the memory to build the OSCachemmap into
  * @param [in]  generation The generation of this cache
+ * @param [in]  layer The layer number of this cache
  */
 void
-SH_OSCachemmap::initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation)
+SH_OSCachemmap::initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation, I_8 layer)
 {
 	Trc_SHR_OSC_Mmap_initialize_Entry(portLibrary, memForConstructor);
-	commonInit(portLibrary, generation);
+	commonInit(portLibrary, generation, layer);
 	_fileHandle = -1;
 	_actualFileLength = 0;
 	_finalised = 0;
@@ -1427,7 +1428,7 @@ SH_OSCachemmap::getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char
 		reasonForStartup = SHR_STARTUP_REASON_EXPIRE;
 	}
 
-	cache = (SH_OSCachemmap *) SH_OSCache::newInstance(PORTLIB, &cacheStruct, cacheInfo->name, cacheInfo->generation, &versionData);
+	cache = (SH_OSCachemmap *) SH_OSCache::newInstance(PORTLIB, &cacheStruct, cacheInfo->name, cacheInfo->generation, &versionData, getLayerFromName(cacheNameWithVGen));
 	
 	/* We try to open the cache read/write */
 	if (!cache->startup(vm, cacheDirName, vm->sharedCacheAPI->cacheDirPerm, cacheInfo->name, &piconfig, SH_CompositeCacheImpl::getNumRequiredOSLocks(), J9SH_OSCACHE_OPEXIST_STATS, 0, 0/*runtime flags*/, 0, 0, &versionData, NULL, reasonForStartup)) {

--- a/runtime/shared_common/OSCachemmap.hpp
+++ b/runtime/shared_common/OSCachemmap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,7 +77,7 @@ public:
 	
 	virtual IDATA getLockCapabilities();
 	
-	virtual void initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation);
+	virtual void initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation, I_8 layer);
 	
 	virtual IDATA setRegionPermissions(J9PortLibrary* portLibrary, void *address, UDATA length, UDATA flags);
 	

--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -173,7 +173,7 @@ public:
 /* protected: */
 	/*This constructor should only be used by this class and parent*/
 	SH_OSCachesysv() {};
-	virtual void initialize(J9PortLibrary* portLib_, char* memForConstructor, UDATA generation);
+	virtual void initialize(J9PortLibrary* portLib_, char* memForConstructor, UDATA generation, I_8 layer);
 
 protected :
 	

--- a/runtime/shared_common/OSCachevmem.cpp
+++ b/runtime/shared_common/OSCachevmem.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,14 +43,14 @@
 SH_OSCachevmem::SH_OSCachevmem(J9PortLibrary* portLibrary, const char* cachedirname, const char* cacheName, J9SharedClassPreinitConfig* piconfig,
 		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer)
 {
-	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN);
+	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN, OSCACHE_CURRENT_LAYER_LAYER);
 	startup(cachedirname, J9SH_DIRPERM_ABSENT, cacheName, piconfig, numLocks, createFlag, verboseFlags, runtimeFlags, openMode, 0, versionData, initializer, SHR_STARTUP_REASON_NORMAL);
 }
 
 void
-SH_OSCachevmem::initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation)
+SH_OSCachevmem::initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation, I_8 layer)
 {	
-	commonInit(portLibrary, generation);
+	commonInit(portLibrary, generation, layer);
 	_fileHandle = -1;
 	_writeLockCounter = 0;
 	_headerStart = NULL;

--- a/runtime/shared_common/OSCachevmem.hpp
+++ b/runtime/shared_common/OSCachevmem.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,7 +85,7 @@ public:
 	
 	virtual IDATA getLockCapabilities();
 	
-	virtual void initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation);
+	virtual void initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation, I_8 layer);
 	
 	virtual U_32 getTotalSize();
 

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1157,7 +1157,7 @@ TraceEvent=Trc_SHR_OSC_Mmap_cleanup_goodUpdateLastDetachedTime NoEnv Overhead=1 
 TraceEvent=Trc_SHR_OSC_Mmap_cleanup_badUpdateLastDetachedTime NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::cleanup: Failed to update last detached time"
 TraceExit=Trc_SHR_OSC_Mmap_cleanup_Exit NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::cleanup: Exiting"
 
-TraceEntry=Trc_SHR_OSC_newInstance_Entry NoEnv Overhead=1 Level=1 Template="SH_OSCache::newInstance: Entered, memForConstructor=%p, cacheName=%s, newPersistentCacheReqd=%d"
+TraceEntry=Trc_SHR_OSC_newInstance_Entry Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCache::newInstance: Entered, memForConstructor=%p, cacheName=%s, newPersistentCacheReqd=%d"
 TraceEvent=Trc_SHR_OSC_newInstance_mmapFilepath NoEnv Overhead=1 Level=1 Template="SH_OSCache::newInstance: mmap file path=%s"
 TraceEvent=Trc_SHR_OSC_newInstance_sysvFilepath NoEnv Overhead=1 Level=1 Template="SH_OSCache::newInstance: sysv file path=%s"
 TraceEvent=Trc_SHR_OSC_newInstance_mmapFileExists NoEnv Overhead=1 Level=1 Template="SH_OSCache::newInstance: mmap file exists"
@@ -1473,7 +1473,7 @@ TraceExit=Trc_SHR_CLM_j9shr_destroy_expire_cache_Exit NoEnv Overhead=1 Level=1 T
 TraceEntry=Trc_SHR_CLM_j9shr_destroy_all_cache_Entry NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_all_cache: Entry - verboseFlags=%zu"
 TraceExit=Trc_SHR_CLM_j9shr_destroy_all_cache_noCaches NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_all_cache: Exit - no caches, returning -1"
 TraceExit=Trc_SHR_CLM_j9shr_destroy_all_cache_Exit NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_all_cache: Exit - returning 0"
-TraceEntry=Trc_SHR_CLM_j9shr_destroy_cache_Entry NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_cache: Entry - verboseFlags=%zu cacheName=%s genStart=%zu genEnd=%zu"
+TraceEntry=Trc_SHR_CLM_j9shr_destroy_cache_Entry Obsolete NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_cache: Entry - verboseFlags=%zu cacheName=%s genStart=%zu genEnd=%zu"
 TraceExit=Trc_SHR_CLM_j9shr_destroy_cache_allocFailed NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_cache: Exit - allocate failed, returning -1"
 TraceExit=Trc_SHR_CLM_j9shr_destroy_cache_Exit NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_cache: Exit - returning %zi"
 TraceEntry=Trc_SHR_CLM_j9shr_stat_cache_Entry NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_stat_cache: Entry - verboseFlags=%zu cacheName=%s generation=%zu"
@@ -1481,7 +1481,7 @@ TraceExit=Trc_SHR_CLM_j9shr_stat_cache_Exit NoEnv Overhead=1 Level=1 Template="C
 TraceEntry=Trc_SHR_CLM_j9shr_report_utility_incompatible_Entry NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_report_utility_incompatible: Entry - verboseFlags=%zu cacheName=%s utility=%s"
 TraceExit=Trc_SHR_CLM_j9shr_report_utility_incompatible_Exit NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_report_utility_incompatible: Exit - returning %zi"
 
-TraceEntry=Trc_SHR_OSC_getCacheVersionAndGen_Entry NoEnv Overhead=1 Level=1 Template="OSCache::getCacheVersionAndGen: Entry - cacheName=%s generation=%zu"
+TraceEntry=Trc_SHR_OSC_getCacheVersionAndGen_Entry Obsolete NoEnv Overhead=1 Level=1 Template="OSCache::getCacheVersionAndGen: Entry - cacheName=%s generation=%zu"
 TraceExit=Trc_SHR_OSC_getCacheVersionAndGen_Exit NoEnv Overhead=1 Level=1 Template="OSCache::getCacheVersionAndGen: Exit - buffer=%s"
 TraceEntry=Trc_SHR_OSC_removeCacheVersionAndGen_Entry NoEnv Overhead=1 Level=1 Template="OSCache::removeCacheVersionAndGen: Entry - versionLen=%zu cacheNameWithVGen=%s"
 TraceExit=Trc_SHR_OSC_removeCacheVersionAndGen_overflow NoEnv Overhead=1 Level=1 Template="OSCache::removeCacheVersionAndGen: OVERFLOW"
@@ -2167,7 +2167,7 @@ TraceExit=Trc_SHR_OSC_getCacheDir_j9shmem_createDir_failed NoEnv Overhead=1 Leve
 TraceEvent=Trc_SHR_INIT_NoCoreMmapDisablePersistence NoEnv Overhead=1 Level=1 Template="Disable persistence when CORE_MMAP is not set to yes"
 TraceExit=Trc_SHR_OSC_checkOSCacheHeader_testBadBuildID NoEnv Overhead=1 Level=1 Template="OSCache::checkOSCacheHeader: Exit - In testing mode: returning different build ID"
 
-TraceEntry=Trc_SHR_CC_initialize_Entry1 NoEnv Overhead=1 Level=1 Template="CC initialize: memForConstructor=%p, sharedClassConfig=%p, cacheName=%s, newPersistentCacheReqd=%d, unitTest=%zd"
+TraceEntry=Trc_SHR_CC_initialize_Entry1 Obsolete NoEnv Overhead=1 Level=1 Template="CC initialize: memForConstructor=%p, sharedClassConfig=%p, cacheName=%s, newPersistentCacheReqd=%d, unitTest=%zd"
 
 TraceEntry=Trc_SHR_OSC_createCacheDir_Entry NoEnv Overhead=1 Level=1 Template="OSCache::createCacheDir: Entry - cacheDirName=%s, cleanMemorySegments=%d"
 TraceExit=Trc_SHR_OSC_createCacheDir_Exit NoEnv Overhead=1 Level=1 Template="OSCache::createCacheDir: Exit"
@@ -2725,7 +2725,7 @@ TraceException=Trc_SHR_CLM_deleteSnapshot_fileLockFailed NoEnv Overhead=1 Level=
 TraceException=Trc_SHR_CLM_deleteSnapshot_fileUnlinkFailed NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::deleteSnapshot: failed to delete the snapshot file %s"
 TraceExit=Trc_SHR_CLM_deleteSnapshot_Exit NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::deleteSnapshot: Exit - returning %zd"
 
-TraceEntry=Trc_SHR_CLM_j9shr_destroy_snapshot_Entry NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_snapshot: Entry - verboseFlags=%zu snapshotName=%s genStart= %zu genEnd=%zu"
+TraceEntry=Trc_SHR_CLM_j9shr_destroy_snapshot_Entry Obsolete NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_snapshot: Entry - verboseFlags=%zu snapshotName=%s genStart= %zu genEnd=%zu"
 TraceException=Trc_SHR_CLM_j9shr_destroy_snapshot_getCacheDirFailed NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_snapshot: getCacheDir() failed"
 TraceExit=Trc_SHR_CLM_j9shr_destroy_snapshot_Exit NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_snapshot: Exit - returning %zd"
 
@@ -2935,3 +2935,9 @@ TraceEvent=Trc_SHR_INIT_j9shr_findGCHints_Event_Found Overhead=1 Level=4 Templat
 TraceEvent=Trc_SHR_CM_storeSharedData_OverwriteExisting Overhead=1 Level=4 Template="CM storeSharedData: Existing data in the shared cache has been overwritten (result %p, data->address %p, foundDatalen %zu)."
 TraceEvent=Trc_SHR_CM_updateLocalHintsData_OverwriteHeapSizes Overhead=1 Level=4 Template="CM updateLocalHintsData: Existing hints (heapSize1=%zu, heapSize2=%zu) in the shared cache will be overwritten to (heapSize1=%zu, heapSize2=%zu)."
 TraceEvent=Trc_SHR_CM_updateLocalHintsData_WriteHeapSizes Overhead=1 Level=4 Template="CM updateLocalHintsData: Will write hints (heapSize1=%zu, heapSize2=%zu) to shared cache."
+TraceEntry=Trc_SHR_CLM_j9shr_destroy_cache_Entry_V1 NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_cache: Entry - verboseFlags=%zu cacheName=%s genStart=%zu genEnd=%zu layerStart=%d layerEnd=%d"
+TraceEntry=Trc_SHR_CLM_j9shr_destroy_snapshot_Entry_V1 NoEnv Overhead=1 Level=1 Template="CacheLifecycleManager::j9shr_destroy_snapshot: Entry - verboseFlags=%zu snapshotName=%s genStart= %zu genEnd=%zu layerStart=%d layerEnd=%d"
+TraceEntry=Trc_SHR_OSC_getCacheVersionAndGen_Entry_V1 NoEnv Overhead=1 Level=1 Template="OSCache::getCacheVersionAndGen: Entry - cacheName=%s generation=%zu layer=%d"
+TraceEntry=Trc_SHR_CC_initializeWithCommonInfo_Entry2 NoEnv Overhead=1 Level=3 Template="CC initializeWithCommonInfo: memForConstructor=%p, ctrlDirName=%s, cacheName=%s, newPersistentCacheReqd=%d, layer=%d"
+TraceEntry=Trc_SHR_CC_initialize_Entry2 NoEnv Overhead=1 Level=1 Template="CC initialize: memForConstructor=%p, sharedClassConfig=%p, cacheName=%s, newPersistentCacheReqd=%d, layer=%d, unitTest=%zd"
+TraceEntry=Trc_SHR_OSC_newInstance_Entry_V1 NoEnv Overhead=1 Level=1 Template="SH_OSCache::newInstance: Entered, memForConstructor=%p, cacheName=%s, newPersistentCacheReqd=%d layer=%d"

--- a/runtime/shared_common/sharedconsts.h
+++ b/runtime/shared_common/sharedconsts.h
@@ -48,13 +48,14 @@
  * maximum length of user specified or default cacheName  => 64 chars
  * prefix separator char is _     => 1 char
  * generation string is of form Gnn where nn stands for 2 digit number => 3 chars
+ * layer number string is of form Lnn where nn stands for 2 digit number => 3 chars
  *
- * Total chars needed  = 11 + 8 + 64 + 1 + 3 = 87 chars.
+ * Total chars needed  = 11 + 8 + 64 + 1 + 3 + 3 = 90 chars.
  *
  * Add 1 to above length to accommodate NULL char.
  * Reference:  getCacheVersionAndGen function
  */
-#define CACHE_ROOT_MAXLEN 88
+#define CACHE_ROOT_MAXLEN 91
 
 #define SHR_SUBOPT_BUFLEN (2 * J9SH_MAXPATH)
 

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -183,6 +183,7 @@ J9SharedClassesHelpText J9SHAREDCLASSESHELPTEXT[] = {
 	HELPTEXT_NEWLINE,
 	{OPTION_DESTROY, J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROY, 0, 0},
 	{OPTION_DESTROYALL, J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROYALL, 0, 0},
+	{OPTION_DESTROYALLLAYERS, J9NLS_SHRC_SHRINIT_HELPTEXT_DESTROYALLLAYERS, 0, 0},
 	HELPTEXT_NEWLINE,
 #if !defined(J9SHR_CACHELET_SUPPORT)
 	{OPTION_RESET, J9NLS_SHRC_SHRINIT_HELPTEXT_RESET, 0, 0},
@@ -281,6 +282,7 @@ J9SharedClassesOptions J9SHAREDCLASSESOPTIONS[] = {
 	{ OPTION_NAME_EQUALS, PARSE_TYPE_STARTSWITH, RESULT_DO_NAME_EQUALS, 0},
 	{ OPTION_DESTROY, PARSE_TYPE_EXACT, RESULT_DO_DESTROY, 0},
 	{ OPTION_DESTROYALL, PARSE_TYPE_EXACT, RESULT_DO_DESTROYALL, 0},
+	{ OPTION_DESTROYALLLAYERS, PARSE_TYPE_EXACT, RESULT_DO_DESTROYALLLAYERS, 0},
 	{ OPTION_EXPIRE_EQUALS, PARSE_TYPE_STARTSWITH, RESULT_DO_EXPIRE, 0},
 	{ OPTION_LISTALLCACHES, PARSE_TYPE_EXACT, RESULT_DO_LISTALLCACHES, 0},
 	{ OPTION_PRINTSTATS, PARSE_TYPE_EXACT, RESULT_DO_PRINTSTATS, 0},
@@ -378,11 +380,11 @@ bool modifyCacheName(J9JavaVM *vm, const char* origName, UDATA verboseFlags, cha
 static BOOLEAN j9shr_parseMemSize(char * str, UDATA & value);
 static void addTestJitHint(J9HookInterface** hookInterface, UDATA eventNum, void* voidData, void* userData);
 static IDATA j9shr_restoreFromSnapshot(J9JavaVM* vm, const char* ctrlDirName, const char* cacheName, bool* cacheExist);
-static void j9shr_print_snapshot_filename(J9JavaVM* vm, const char* cacheDirName, const char* snapshotName);
+static void j9shr_print_snapshot_filename(J9JavaVM* vm, const char* cacheDirName, const char* snapshotName, I_8 layer);
 static IDATA j9shr_aotMethodOperation(J9JavaVM* vm, char* methodSpecs, UDATA action);
 static bool recoverMethodSpecSeparator(char* string, char* end);
 static void adjustCacheSizes(J9PortLibrary* portlib, UDATA verboseFlags, J9SharedClassPreinitConfig* piconfig, U_64 newSize);
-static IDATA checkIfCacheExists(J9JavaVM* vm, const char* ctrlDirName, char* cacheDirName, const char* cacheName, J9PortShcVersion* versionData, U_32 cacheType);
+static IDATA checkIfCacheExists(J9JavaVM* vm, const char* ctrlDirName, char* cacheDirName, const char* cacheName, J9PortShcVersion* versionData, U_32 cacheType, I_8 layer);
 static bool isClassFromPatchedModule(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDATA classNameLength, J9ClassLoader* classLoader);
 static J9Module* getModule(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9ClassLoader* classLoader);
 static bool isFreeDiskSpaceLow(J9JavaVM *vm, U_64* maxsize);
@@ -424,7 +426,7 @@ IDATA
 j9shr_print_stats(J9JavaVM *vm, UDATA parseResult, U_64 runtimeFlags, UDATA printStatsOptions);
 
 static void 
-j9shr_print_cache_filename(J9JavaVM* vm, const char* cacheDirName, U_64 runtimeFlags, const char* cacheName);
+j9shr_print_cache_filename(J9JavaVM* vm, const char* cacheDirName, U_64 runtimeFlags, const char* cacheName, I_8 layer);
 
 static void
 reportUtilityNotApplicable(J9JavaVM* vm, const char* ctrlDirName, const char* cacheName, UDATA verboseFlags, U_64 runtimeFlags, UDATA command);
@@ -949,6 +951,7 @@ parseArgs(J9JavaVM* vm, char* options, U_64* runtimeFlags, UDATA* verboseFlags, 
 
 		case RESULT_DO_DESTROY:
 		case RESULT_DO_DESTROYALL:
+		case RESULT_DO_DESTROYALLLAYERS:
 		case RESULT_DO_PRINT_CACHENAME:
 		case RESULT_DO_PRINT_SNAPSHOTNAME:
 		case RESULT_DO_LISTALLCACHES:
@@ -2278,6 +2281,7 @@ reportUtilityNotApplicable(J9JavaVM* vm, const char* ctrlDirName, const char* ca
 	char cacheDirName[J9SH_MAXPATH];
 	const char *optionName;
 	UDATA groupPerm = 0;
+	I_8 layer = 0;
 
 	if ((runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_GROUP_ACCESS) != 0) {
 		groupPerm = 1;
@@ -2301,7 +2305,7 @@ reportUtilityNotApplicable(J9JavaVM* vm, const char* ctrlDirName, const char* ca
 	if (SH_OSCache::getCacheDir(vm, ctrlDirName, cacheDirName, J9SH_MAXPATH, versionData.cacheType) == -1) {
 		return;
 	}
-	if ((reportedIncompatibleNum == 0) && (j9shr_stat_cache(vm, cacheDirName, 0, cacheName, &versionData, OSCACHE_CURRENT_CACHE_GEN))) {
+	if ((reportedIncompatibleNum == 0) && (j9shr_stat_cache(vm, cacheDirName, 0, cacheName, &versionData, OSCACHE_CURRENT_CACHE_GEN, layer))) {
 		if (versionData.cacheType == J9PORT_SHR_CACHE_TYPE_PERSISTENT) {
 			SHRINIT_ERR_TRACE2(verboseFlags, J9NLS_SHRC_SHRINIT_OTHER_PERS_TYPE_CACHE_EXISTS, optionName, cacheName);
 		} else if (versionData.cacheType == J9PORT_SHR_CACHE_TYPE_NONPERSISTENT) {
@@ -2362,6 +2366,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 	J9PortShcVersion versionData;
 	U_32 cacheType = getCacheTypeFromRuntimeFlags(runtimeFlags);
 	UDATA groupPerm = 0;
+	I_8 layer = 0;
 
 	if ((runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_GROUP_ACCESS) != 0) {
 		groupPerm = 1;
@@ -2375,15 +2380,22 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 		j9shr_dump_help(vm, (command==RESULT_DO_MORE_HELP));
 		break;
 	case RESULT_DO_DESTROY: 
+	case RESULT_DO_DESTROYALLLAYERS:
 	case RESULT_DO_RESET:
-		setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
-		versionData.cacheType = cacheType;
-		j9shr_destroy_cache(vm, sharedClassConfig->ctrlDirName, verboseFlags, cacheName, OSCACHE_LOWEST_ACTIVE_GEN, OSCACHE_CURRENT_CACHE_GEN, &versionData, (RESULT_DO_RESET == command));
-		if (command == RESULT_DO_RESET) {
-			/* Return with a return code intended for non-utility options */
-			return J9VMDLLMAIN_NON_UTILITY_OK;
+		{
+			I_8 layerEnd = J9SH_DESTROY_TOP_LAYER_ONLY;
+			if (RESULT_DO_DESTROYALLLAYERS == command) {
+				layerEnd = J9SH_LAYER_NUM_MAX_VALUE;
+			}
+			setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+			versionData.cacheType = cacheType;
+			j9shr_destroy_cache(vm, sharedClassConfig->ctrlDirName, verboseFlags, cacheName, OSCACHE_LOWEST_ACTIVE_GEN, OSCACHE_CURRENT_CACHE_GEN, &versionData, (RESULT_DO_RESET == command), -1, layerEnd);
+			if (command == RESULT_DO_RESET) {
+				/* Return with a return code intended for non-utility options */
+				return J9VMDLLMAIN_NON_UTILITY_OK;
+			}
+			break;
 		}
-		break;
 	case RESULT_DO_DESTROYALL:
 		j9shr_destroy_all_cache(vm, sharedClassConfig->ctrlDirName, groupPerm, verboseFlags);
 		break;
@@ -2391,7 +2403,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 	case RESULT_DO_DESTROYSNAPSHOT:
 		setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
 		versionData.cacheType = J9PORT_SHR_CACHE_TYPE_SNAPSHOT;
-		j9shr_destroy_snapshot(vm, sharedClassConfig->ctrlDirName, verboseFlags, cacheName, OSCACHE_LOWEST_ACTIVE_GEN, OSCACHE_CURRENT_CACHE_GEN, &versionData);
+		j9shr_destroy_snapshot(vm, sharedClassConfig->ctrlDirName, verboseFlags, cacheName, OSCACHE_LOWEST_ACTIVE_GEN, OSCACHE_CURRENT_CACHE_GEN, &versionData, -1, J9SH_DESTROY_TOP_LAYER_ONLY);
 		break;
 	case RESULT_DO_DESTROYALLSNAPSHOTS:
 		j9shr_destroy_all_snapshot(vm, sharedClassConfig->ctrlDirName, groupPerm, verboseFlags);
@@ -2405,7 +2417,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 			break;
 		}
 		if (RESULT_DO_SNAPSHOTCACHE == command) {
-			if (1 != checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType)) {
+			if (1 != checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType, layer)) {
 				SHRINIT_ERR_TRACE1(verboseFlags, J9NLS_SHRC_SHRINIT_FAILURE_CREATE_SNAPSHOT, cacheName);
 			} else {
 				return J9VMDLLMAIN_OK;
@@ -2443,7 +2455,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 	case RESULT_DO_PRINTORPHANSTATS:
 		{
 			/* Test for existence of cache first. If it exists, proceed with cache init */
-			IDATA cacheExists = checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType);
+			IDATA cacheExists = checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType, layer);
 
 			if (0 == cacheExists) {
 				if (verboseFlags != 0) {
@@ -2467,7 +2479,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 				break;
 			}
 			/* Test for existence of cache first. If it exists, proceed with cache init */
-			cacheExists = checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType);
+			cacheExists = checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType, layer);
 			if (0 == cacheExists) {
 				if (verboseFlags != 0) {
 					reportUtilityNotApplicable(vm, sharedClassConfig->ctrlDirName, cacheName, verboseFlags, runtimeFlags, command);
@@ -2482,14 +2494,14 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 		if (SH_OSCache::getCacheDir(vm, sharedClassConfig->ctrlDirName, cacheDirName, J9SH_MAXPATH, cacheType) == -1) {
 			return J9VMDLLMAIN_SILENT_EXIT_VM;
 		}
-		j9shr_print_cache_filename(vm, cacheDirName, runtimeFlags, cacheName);
+		j9shr_print_cache_filename(vm, cacheDirName, runtimeFlags, cacheName, layer);
 		break;
 
 	case RESULT_DO_PRINT_SNAPSHOTNAME:
 		if (-1 == SH_OSCache::getCacheDir(vm, sharedClassConfig->ctrlDirName, cacheDirName, J9SH_MAXPATH, J9PORT_SHR_CACHE_TYPE_SNAPSHOT)) {
 			return J9VMDLLMAIN_SILENT_EXIT_VM;
 		}
-		j9shr_print_snapshot_filename(vm, cacheDirName, cacheName);
+		j9shr_print_snapshot_filename(vm, cacheDirName, cacheName, layer);
 		break;
 
 	case RESULT_DO_INVALIDATE_AOT_METHODS_EQUALS:
@@ -2514,7 +2526,7 @@ performSharedClassesCommandLineAction(J9JavaVM* vm, J9SharedClassConfig* sharedC
 	case RESULT_DO_ADJUST_MAXAOT_EQUALS:
 	case RESULT_DO_ADJUST_MINJITDATA_EQUALS:
 	case RESULT_DO_ADJUST_MAXJITDATA_EQUALS:
-		if (1 == checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType)) {
+		if (1 == checkIfCacheExists(vm, sharedClassConfig->ctrlDirName, cacheDirName, cacheName, &versionData, cacheType, layer)) {
 			return J9VMDLLMAIN_OK;
 		}
 		break;
@@ -3721,7 +3733,7 @@ j9shr_print_stats(J9JavaVM *vm, UDATA parseResult, U_64 runtimeFlags, UDATA prin
  *
  */
 static void
-j9shr_print_cache_filename(J9JavaVM* vm, const char* cacheDirName, U_64 runtimeFlags, const char* cacheName)
+j9shr_print_cache_filename(J9JavaVM* vm, const char* cacheDirName, U_64 runtimeFlags, const char* cacheName, I_8 layer)
 {	
 	char cacheNameWithVGen[J9SH_MAXPATH];
 	PORT_ACCESS_FROM_JAVAVM(vm);	
@@ -3741,7 +3753,7 @@ j9shr_print_cache_filename(J9JavaVM* vm, const char* cacheDirName, U_64 runtimeF
 			cacheName, 
 			&versionData, 
 			SH_OSCache::getCurrentCacheGen(), 
-			true);
+			true, layer);
 
 	j9tty_printf(PORTLIB, "%s%s\n", cacheDirName, cacheNameWithVGen);
 	return;
@@ -4353,6 +4365,7 @@ j9shr_createCacheSnapshot(J9JavaVM* vm, const char* cacheName)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	char cacheDirName[J9SH_MAXPATH];
 	UDATA verboseFlags = vm->sharedCacheAPI->verboseFlags;
+	I_8 layer = 0;
 
 	Trc_SHR_INIT_j9shr_createCacheSnapshot_Entry(cacheName);
 
@@ -4369,7 +4382,7 @@ j9shr_createCacheSnapshot(J9JavaVM* vm, const char* cacheName)
 
 		setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
 		versionData.cacheType = J9PORT_SHR_CACHE_TYPE_SNAPSHOT;
-		SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, nameWithVGen, CACHE_ROOT_MAXLEN, cacheName, &versionData, OSCACHE_CURRENT_CACHE_GEN, false);
+		SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, nameWithVGen, CACHE_ROOT_MAXLEN, cacheName, &versionData, OSCACHE_CURRENT_CACHE_GEN, false, layer);
 		/* No check for the return value of getCachePathName() as it always returns 0 */
 		SH_OSCache::getCachePathName(PORTLIB, cacheDirName, pathFileName, J9SH_MAXPATH, nameWithVGen);
 
@@ -4627,7 +4640,7 @@ j9shr_restoreFromSnapshot(J9JavaVM* vm, const char* ctrlDirName, const char* cac
  * @param [in] snapshotName User specified snapshot name (possibly null)
  */
 static void
-j9shr_print_snapshot_filename(J9JavaVM* vm, const char* cacheDirName, const char* snapshotName)
+j9shr_print_snapshot_filename(J9JavaVM* vm, const char* cacheDirName, const char* snapshotName, I_8 layer)
 {
 	char snapshotNameWithVGen[J9SH_MAXPATH];
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -4645,7 +4658,7 @@ j9shr_print_snapshot_filename(J9JavaVM* vm, const char* cacheDirName, const char
 			snapshotName,
 			&versionData,
 			SH_OSCache::getCurrentCacheGen(),
-			true);
+			true, layer);
 
 	j9tty_printf(PORTLIB, "%s%s\n", cacheDirName, snapshotNameWithVGen);
 	return;
@@ -4803,7 +4816,7 @@ j9shr_jvmPhaseChange(J9VMThread *currentThread, UDATA phase)
  * @return 1 if the cache exist, 0 if the cache does not exist, and -1 if failed to get cache directory.
  */
 static IDATA
-checkIfCacheExists(J9JavaVM* vm, const char* ctrlDirName, char* cacheDirName, const char* cacheName, J9PortShcVersion* versionData, U_32 cacheType)
+checkIfCacheExists(J9JavaVM* vm, const char* ctrlDirName, char* cacheDirName, const char* cacheName, J9PortShcVersion* versionData, U_32 cacheType, I_8 layer)
 {
 	IDATA ret = -1;
 	if (-1 == SH_OSCache::getCacheDir(vm, ctrlDirName, cacheDirName, J9SH_MAXPATH, cacheType)) {
@@ -4811,7 +4824,7 @@ checkIfCacheExists(J9JavaVM* vm, const char* ctrlDirName, char* cacheDirName, co
 	} else {
 		setCurrentCacheVersion(vm, J2SE_VERSION(vm), versionData);
 		versionData->cacheType = cacheType;
-		ret = j9shr_stat_cache(vm, cacheDirName, vm->sharedCacheAPI->verboseFlags, cacheName, versionData, OSCACHE_CURRENT_CACHE_GEN);
+		ret = j9shr_stat_cache(vm, cacheDirName, vm->sharedCacheAPI->verboseFlags, cacheName, versionData, OSCACHE_CURRENT_CACHE_GEN, layer);
 	}
 	return ret;
 }

--- a/runtime/shared_common/shrinit.h
+++ b/runtime/shared_common/shrinit.h
@@ -98,6 +98,7 @@ typedef struct J9SharedClassesOptions {
 #define OPTION_NAME_EQUALS "name="
 #define OPTION_DESTROY "destroy"
 #define OPTION_DESTROYALL "destroyAll"
+#define OPTION_DESTROYALLLAYERS "destroyAllLayers"
 #define OPTION_EXPIRE_EQUALS "expire="
 #define OPTION_LISTALLCACHES "listAllCaches"
 #define OPTION_HELP "help"
@@ -258,6 +259,7 @@ typedef struct J9SharedClassesOptions {
 #define RESULT_DO_ADJUST_MINJITDATA_EQUALS 47
 #define RESULT_DO_ADJUST_MAXJITDATA_EQUALS 48
 #define RESULT_DO_BOOTCLASSESONLY 49
+#define RESULT_DO_DESTROYALLLAYERS 50
 
 
 #define PARSE_TYPE_EXACT 1

--- a/runtime/tests/shared/CompositeCacheSizesTests.cpp
+++ b/runtime/tests/shared/CompositeCacheSizesTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,7 +78,7 @@ createTestCompositeCache (J9JavaVM* vm, SH_CompositeCacheImpl** cc, J9SharedClas
 	memset((void*)memForCC, 0, totalSize);
 
 	/*Request non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, &runtimeFlags, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		ERRPRINTF(("Failed to start the composite cache.\n"));
@@ -349,7 +349,7 @@ test4(J9JavaVM* vm)
 	memset((void*)memForCC, 0, totalSize);
 
 	/*Request non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
 
 	runtimeFlags = J9SHR_RUNTIMEFLAG_ENABLE_REDUCE_STORE_CONTENTION;
@@ -404,7 +404,7 @@ test4(J9JavaVM* vm)
  */
 #if 0
 	memset(actualCC, 0, requiredBytes);
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 
 	runtimeFlags = J9SHR_RUNTIMEFLAG_ENABLE_REDUCE_STORE_CONTENTION;
 	if (actualCC->startup(vm->mainThread, &piconfig, cache, &runtimeFlags, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {

--- a/runtime/tests/shared/CompositeCacheTest.cpp
+++ b/runtime/tests/shared/CompositeCacheTest.cpp
@@ -90,7 +90,7 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	/* Test normal scenario */
 	memset((void*)memForCC, 0, totalSize);
 	/* Currently requests non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		return 2;
@@ -107,7 +107,7 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	piconfig->sharedClassCacheSize = 10;
 	memset((void*)memForCC, 0, totalSize);
 	/* Currently requests non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myRoot", false, false, 0);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myRoot", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		return 5;
 	}
@@ -127,7 +127,7 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	/* Test normal scenario */
 	memset((void*)memForCC, 0, totalSize);
 	/* Currently requests non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache1", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache1", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myCache1", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		return 8;
@@ -139,7 +139,7 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 		return 9;
 	}
 	/* Currently requests non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache1a", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache1a", false, false, 0);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags0, 1, "myCache1a", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		return 10;
 	}
@@ -150,7 +150,7 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 	}
 	memset((void*)memForCC, 0, totalSize);
 	/* Currently requests non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache2", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache2", false, false, 0);
 	cache = (char*)((char*)actualCC + requiredBytes);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags1, 1, "myCache2", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		return 12;
@@ -162,7 +162,7 @@ CompositeCacheTest::createTest(J9JavaVM* vm, IDATA testCacheSize, SH_CompositeCa
 		return 13;
 	}
 	/* Currently requests non-persistent cache */
-	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache2a", false, false);
+	actualCC = SH_CompositeCacheImpl::newInstance(vm, NULL, memForCC, "myCache2a", false, false, 0);
 	if (actualCC->startup(vm->mainThread, piconfig, cache, runtimeFlags0, 1, "myCache2a", NULL, J9SH_DIRPERM_ABSENT, &cacheSize, &localCrashCntr, true, &cacheHasIntegrity) != 0) {
 		return 14;
 	}

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -825,7 +825,7 @@ zeroOutCache(J9JavaVM *vm, I_32 cacheType)
 	}
 	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
 	versionData.cacheType = cacheType;
-	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true);
+	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true, 0);
 	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
 
 	fd = j9file_open(fullPath, EsOpenRead | EsOpenWrite, 0644);
@@ -891,7 +891,7 @@ truncateCache(J9JavaVM *vm, I_32 cacheType)
 	}
 	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
 	versionData.cacheType = cacheType;
-	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true);
+	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true, 0);
 	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
 
 	fd = j9file_open(fullPath, EsOpenRead | EsOpenWrite, 0644);

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -90,7 +90,7 @@ SH_OSCacheTestSysv::testBasic(J9PortLibrary* portLibrary, J9JavaVM *vm)
 		goto cleanup;
 	}
 	/* Currently explicitly requests non-persistent cache */
-	SH_OSCache::newInstance(PORTLIB, (SH_OSCache*)osc, CACHE_NAME, SH_OSCache::getCurrentCacheGen(), &versionData);
+	SH_OSCache::newInstance(PORTLIB, (SH_OSCache*)osc, CACHE_NAME, SH_OSCache::getCurrentCacheGen(), &versionData, 0);
 	if (!osc->startup(vm, cacheDir, J9SH_DIRPERM_ABSENT, CACHE_NAME, piconfig, 1, J9SH_OSCACHE_CREATE, 0, 0, 0, 0, &versionData, initObj, SHR_STARTUP_REASON_NORMAL)) {
 		j9tty_printf(PORTLIB, "testBasic: cannot create new region");
 		rc = FAIL;

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -130,6 +130,36 @@ getGenerationFromName(const char* cacheNameWithVGen)
 }
 
 /**
+ * Return the value of the layer number from the cache filename
+ *
+ * @param [in] cacheNameWithVGen  the cache name with layer number
+ *
+ * @return J9SH_LAYER_NUM_UNSET(-1) if an error occurred or there is no layer number in file name.
+ * 		   Otherwise return the layer number
+ */
+I_8
+getLayerFromName(const char* cacheNameWithVGen)
+{
+	char* cursor = (char*)cacheNameWithVGen;
+	IDATA nameLen = strlen(cacheNameWithVGen);
+	I_8 layerNumber = J9SH_LAYER_NUM_UNSET;
+	UDATA temp0 = 0;
+
+	cursor += (nameLen - 3);
+	if (J9SH_LAYER_NUM_CHAR != *cursor ) {
+		goto done;
+	}
+	cursor++;
+	if (scan_udata(&cursor, &temp0) == 0) {
+		if (temp0 <= J9SH_LAYER_NUM_MAX_VALUE) {
+			layerNumber = (I_8)temp0;
+		}
+	}
+done:
+	return layerNumber;
+}
+
+/**
  * Return the value of the modLevel from the cache filename
  *
  * @param [in] cacheNameWithVGen  the cache file name
@@ -357,9 +387,24 @@ isCacheFileName(J9PortLibrary* portlib, const char* nameToTest, uintptr_t expect
 		}
 	}
 	nameToTestLen = strlen(nameToTest);
-	if ((nameToTest[nameToTestLen-3] != 'G') && (nameToTest[nameToTestLen-4] != '_')) {
-		return 0;
+	/**
+	 * For old cache file with no layer number like C290M4F1A64P_CC1_G37, 'G' is at nameToTestLen-3.
+	 * For cache file with layer number like C290M4F1A64P_CC1_G39L01, 'G' is at nameToTestLen-6.
+	 */
+	if (getLayerFromName(nameToTest) == J9SH_LAYER_NUM_UNSET) {
+		if ((nameToTest[nameToTestLen-3] != 'G')
+			|| (nameToTest[nameToTestLen-4] != '_')
+		) {
+			return 0;
+		}
+	} else {
+		if ((nameToTest[nameToTestLen-6] != 'G')
+			|| (nameToTest[nameToTestLen-7] != '_')
+		) {
+			return 0;
+		}
 	}
+
 	if (getValuesFromShcFilePrefix(portlib, nameToTest, &versionData) != 0) {
 		if (versionData.feature > J9SH_FEATURE_MAX_VALUE) {
 			return 0;


### PR DESCRIPTION
1. Increase the cache generation number to 39.  

2. Add layer number to the cache file name. It is appended after the
generation number. e.g. C290M4F1A64P_CC1_G39L00, C290M4F1A64P_CC1_G39L01

3. Add a new option -Xshareclasses:name=<cacheName>,destroyAllLayers
that destroys cache of all layers under the specified name. The older
generation cache file will also be deleted by this CML.

4. -Xshareclasses:name=<cacheName>,destroy deletes the top-most layer
under the specified cache name. The older generation cache file will
also be deleted by this CML.

5. -Xshareclasses:destroyAll deletes all the cache files found in the
cache directory. 

issue #5480

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>