### PR TITLE
Share VLHGC barrier details with the JIT

### DIFF
--- a/runtime/gc_include/j9modron.h
+++ b/runtime/gc_include/j9modron.h
@@ -95,6 +95,8 @@ typedef enum {
 	j9gc_modron_configuration_gcThreadCount,  /* a UDATA representing the MAX number of GC threads being used */
 	j9gc_modron_configuration_objectAlignment, /* a UDATA representing the alignment of the object in heap */
 	j9gc_modron_configuration_compressObjectReferences, /* a UDATA (TRUE or FALSE) representing whether or not object references are compressed */
+	j9gc_modron_configuration_heapRegionShift, /* a UDATA representing the shift amount to convert an object pointer to the address of the region */
+	j9gc_modron_configuration_heapRegionStateTable, /* a pointer to the base of the region state table */
 	/* Add new values before this comment */
 	j9gc_modron_configuration_count /* Total number of known configuration keys */
 } J9GCConfigurationKey;

--- a/runtime/gc_modron_startup/mmhelpers.cpp
+++ b/runtime/gc_modron_startup/mmhelpers.cpp
@@ -35,6 +35,7 @@
 #include "j9modron.h"
 #include "ModronAssertions.h"
 #include "omr.h"
+#include "omrcfg.h"
 #include "VerboseGCInterface.h"
 
 #if defined(J9VM_GC_FINALIZATION)
@@ -43,6 +44,10 @@
 #include "GCExtensions.hpp"
 #include "GlobalCollector.hpp"
 #include "Heap.hpp"
+#include "HeapRegionManager.hpp"
+#if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
+#include "HeapRegionStateTable.hpp"
+#endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 #include "MemorySpace.hpp"
 #include "MemorySubSpace.hpp"
 
@@ -322,7 +327,30 @@ j9gc_modron_getConfigurationValueForKey(J9JavaVM *javaVM, UDATA key, void *value
 		*((UDATA *)value) = extensions->compressObjectReferences();
 		keyFound = TRUE;
 		break;
-		
+	case j9gc_modron_configuration_heapRegionShift:
+		if (extensions->isVLHGC()) {
+			*((UDATA *)value) = extensions->heapRegionManager->getRegionShift();
+			keyFound = TRUE;
+		} else {
+			*((UDATA *)value) = 0;
+			keyFound = FALSE;
+		}
+		break;
+	case j9gc_modron_configuration_heapRegionStateTable:
+#if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
+		if (extensions->isConcurrentCopyForwardEnabled()) {
+			*((UDATA *)value) = (UDATA) extensions->heapRegionStateTable->getTable();
+			keyFound = TRUE;
+		} else {
+			*((UDATA *)value) = 0;
+			keyFound = FALSE;
+		}
+#else /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
+		*((UDATA *)value) = 0;
+		keyFound = FALSE;
+#endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
+
+		break;
 	default:
 		/* key is either invalid or unknown for this configuration - should not have been requested */
 		Assert_MM_unreachable();


### PR DESCRIPTION
VLHGC will be implementing a new read barrier to support concurrent copy
forward.  This commit creates helpers for the JIT to query details
important for the implementation of a read barrier for concurrent copy
forward in VLHGC.

The helpers return 2 new values:
 - heapRegionShift
 - base address of the heapRegionStateTable

The region state should should be accessed with:
`heapRegionStateTable[(address - heapBaseForBarrierRange0) >> heapRegionShift]`

Signed-off-by: Andrew Young <youngar17@gmail.com>

cc @amicic @charliegracie @rwy0717 