### PR TITLE
Change -XX:-TransparentHugePage to be the default

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1820,9 +1820,9 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			argIndex2 = FIND_ARG_IN_VMARGS(EXACT_MATCH, VMOPT_XXTRANSPARENT_HUGEPAGE, NULL);
 			{
 				/* Last instance of +/- TransparentHugepage found on the command line wins
-				 * Default to -XX:+TransparentHugepage for performance reasons
+				 * Default to -XX:-TransparentHugepage for performance reasons
 				 */
-				if (argIndex2 >= argIndex) {
+				if (argIndex2 > argIndex) {
 					j9port_control(J9PORT_CTLDATA_VMEM_ADVISE_HUGEPAGE, 1);
 				} else {
 					j9port_control(J9PORT_CTLDATA_VMEM_ADVISE_HUGEPAGE, 0);


### PR DESCRIPTION
Performance testing indicates that -XX:+TransparentHugePage can
negatively impact footprint measurements. In particular, a footprint
regression of 8% was found on pLinux with the OS setting of
/sys/kernel/mm/transparent_hugepage set to madvise, compared to a build
without madvise(..., MADV_HUGEPAGE) support. Modify the default from
-XX:+TransparentHugePage to -XX:-TransparentHugePage while investigating
if changes to the OMR code that call madvise can avoid any footprint
regression.

Issue #6156

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>