### PR TITLE
Minor java code improvement for JSR292

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/BruteArgumentMoverHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BruteArgumentMoverHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -278,6 +278,10 @@ final class BruteArgumentMoverHandle extends ArgumentMoverHandle {
 	}
 
 	final MethodHandle permuteArguments(MethodType permuteType, int... outerPermute) throws NullPointerException, IllegalArgumentException {
+		if (isUnnecessaryPermute(permuteType, outerPermute)) {
+			return this;
+		}
+
 		return new BruteArgumentMoverHandle(
 			permuteType,
 			next,

--- a/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/GuardWithTestHandle.java
@@ -42,7 +42,18 @@ final class GuardWithTestHandle extends MethodHandle {
 		this.falseTarget = originalHandle.falseTarget;
 	}
 
-	public static GuardWithTestHandle get(MethodHandle guard, MethodHandle trueTarget, MethodHandle falseTarget) {
+	public static MethodHandle get(MethodHandle guard, MethodHandle trueTarget, MethodHandle falseTarget) {
+		/* Constant boolean is implemented with ConstantIntHandle, if `guard` handle is a ConstantIntHandle,
+		we can evaluate the if statement now and return the target handle*/
+		if (guard instanceof ConstantIntHandle) {
+			ConstantIntHandle constantHandle = (ConstantIntHandle)guard;
+			if (constantHandle.value != 0) {
+				return trueTarget;
+			} else {
+				return falseTarget;
+			}
+		}
+
 		return new GuardWithTestHandle(guard, trueTarget, falseTarget);
 	}
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -872,6 +872,31 @@ public abstract class MethodHandle
 		return MethodHandles.insertArguments(this, 0, value);
 	}
 
+
+	/**
+	 * Check if a permutation is unnecessary
+	 * <p>
+	 * Comparing {@code permuteType} and {@code this.type} is not sufficent to determine if permutation
+	 * is needed. If two arguments have the same type, swapping them won't change the method type. we
+	 * have to check if the permute is identity permute.
+	 *
+	 * @param permuteType Type of the MethodHandle after the permutation
+	 * @param permute The permutation array
+	 * @return a boolean indicating if the permutation is unnecessary
+	 */
+	boolean isUnnecessaryPermute(MethodType permuteType, int... permute) {
+		if (!this.type.equals(permuteType)) {
+			return false;
+		}
+
+		for (int i = 0; i < permute.length; i++) {
+			if (permute[i] != i) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 	/**
 	 * Create an interception point to allow PermuteHandle to merge 
 	 * permute(permute(originalHandle, ...), ...).
@@ -882,6 +907,10 @@ public abstract class MethodHandle
 	 * </ul> 
 	 */
 	MethodHandle permuteArguments(MethodType permuteType, int... permute) {
+		if (isUnnecessaryPermute(permuteType, permute)) {
+			return this;
+		}
+
 		MethodHandle result = new PermuteHandle(permuteType, this, permute);
 		if (true) {
 			result = new BruteArgumentMoverHandle(permuteType, this, permute, EMPTY_CLASS_ARRAY, result);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -737,10 +737,13 @@ public class MethodHandles {
 					 */
 					/*[ENDIF]*/
 					handle = new DirectHandle(clazz, methodName, type, MethodHandle.KIND_VIRTUAL, clazz, true);
-					int handleModifiers = handle.getModifiers();
-					/* Static check is performed by native code */
-					if (!Modifier.isPrivate(handleModifiers) && !Modifier.isFinal(handleModifiers)) {
-						handle = new VirtualHandle((DirectHandle) handle);
+					/* If the class is final, then there are no subclasses and the DirectHandle is sufficient */
+					if (!Modifier.isFinal(clazz.getModifiers())) {
+						int handleModifiers = handle.getModifiers();
+						/* Static check is performed by native code */
+						if (!Modifier.isPrivate(handleModifiers) && !Modifier.isFinal(handleModifiers)) {
+							handle = new VirtualHandle((DirectHandle) handle);
+						}
 					}
 				}
 				handle = convertToVarargsIfRequired(handle);
@@ -3186,6 +3189,7 @@ public class MethodHandles {
 			/*[MSG "K039c", "Invalid parameters"]*/
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K039c")); //$NON-NLS-1$
 		}
+
 		
 		MethodType permuteType = originalType.insertParameterTypes(location, valueTypes);
 		/* Build equivalent permute array */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/PermuteHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/PermuteHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2011 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,10 +47,19 @@ final class PermuteHandle extends MethodHandle {
 	 */
 	@Override
 	MethodHandle permuteArguments(MethodType permuteType, int... permute2) {
+		if (isUnnecessaryPermute(permuteType, permute2)) {
+			return this;
+		}
+
 		int[] combinedPermute = new int[permute.length];
 		for (int i = 0; i < permute.length; i++) {
 			combinedPermute[i] = permute2[permute[i]];
 		}
+
+		if (next.isUnnecessaryPermute(permuteType, combinedPermute)) {
+			return next;
+		}
+
 		return new PermuteHandle(permuteType, next, combinedPermute);
 	}
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -90,11 +90,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	 */
 	/*[ENDIF]*/
 	MethodHandle permuteArguments(MethodType permuteType, int... permute) throws NullPointerException, IllegalArgumentException {
-		MethodHandle result = new PermuteHandle(permuteType, this, permute);
-		if (true) {
-			result = combinableVersion.permuteArguments(permuteType, permute);
-		}
-		return result;
+		return combinableVersion.permuteArguments(permuteType, permute);
 	}
 
 	MethodHandle insertArguments(MethodHandle equivalent, MethodHandle unboxingHandle, int location, Object... values) {


### PR DESCRIPTION
- Return original handle if types of arguments to drop is empty
- Don't create VirtualHandle if class is final
- Return target handle according to the value of `guard` when it's a
  ConstantIntHandle

#4837 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>