### PR TITLE
Add value type support to DDR struct commands V2

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -29,17 +29,21 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 
 import com.ibm.j9ddr.CorruptDataException;
-import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMFieldShapePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ROMFieldShapeHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
+import com.ibm.j9ddr.vm29.pointer.helper.ValueTypeHelper;
 import com.ibm.j9ddr.vm29.structure.J9Object;
+import com.ibm.j9ddr.vm29.types.Scalar;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.U64;
 import com.ibm.j9ddr.vm29.types.UDATA;
-import com.ibm.j9ddr.vm29.j9.ObjectModel;
 
 public class ObjectFieldInfo {
+	ValueTypeHelper valueTypeHelper = ValueTypeHelper.getValueTypeHelper();
 	J9ROMClassPointer romClass;
 	int superclassFieldsSize;
 	boolean objectCanUseBackfill; /* true if an object reference is the same size as a backfill slot */
@@ -60,6 +64,11 @@ public class ObjectFieldInfo {
 	int superclassBackfillOffset; /* inherited backfill */
 	int myBackfillOffset; /* backfill available for this class's fields */
 	int subclassBackfillOffset; /* backfill available to subclasses */
+	boolean isValue = false;
+	J9ClassPointer containerClazz = J9ClassPointer.NULL;
+	int totalFlatFieldDoubleBytes = 0;
+	int totalFlatFieldRefBytes = 0;
+	int totalFlatFieldSingleBytes = 0;
 
 	public static final int	NO_BACKFILL_AVAILABLE = -1;
 	public static final int		BACKFILL_SIZE = U32.SIZEOF;
@@ -81,6 +90,15 @@ public class ObjectFieldInfo {
 		subclassBackfillOffset = NO_BACKFILL_AVAILABLE;
 		objectCanUseBackfill = (fj9object_t_SizeOf == BACKFILL_SIZE);
 		instanceFieldBackfillEligible = false;
+	}
+
+	ObjectFieldInfo(J9ROMClassPointer romClass, J9ClassPointer clazz) throws CorruptDataException {
+		this(romClass);
+		containerClazz = clazz;
+		isValue = valueTypeHelper.isRomClassAValueType(romClass);
+		totalFlatFieldDoubleBytes = 0;
+		totalFlatFieldRefBytes = 0;
+		totalFlatFieldSingleBytes = 0;
 	}
 
 	int getTotalDoubleCount() {
@@ -213,10 +231,12 @@ public class ObjectFieldInfo {
 	 */
 	int calculateFieldDataStart() {
 		int fieldDataStart = getSuperclassFieldsSize();
+		boolean doubleAlignment = (totalDoubleCount > 0) || (totalFlatFieldDoubleBytes > 0);
+
 		if (
-				((getSuperclassObjectSize() % ObjectModel.getObjectAlignmentInBytes()) != 0) && /* superclass is not end-aligned */
-				((totalDoubleCount > 0) || (!objectCanUseBackfill && (totalObjectCount > 0)))
-				){ /* our fields start on a 8-byte boundary */
+			((getSuperclassObjectSize() % ObjectModel.getObjectAlignmentInBytes()) != 0) && /* superclass is not end-aligned */
+			(doubleAlignment || (!objectCanUseBackfill && (totalObjectCount > 0)))
+		) { /* our fields start on a 8-byte boundary */
 			fieldDataStart += BACKFILL_SIZE;
 		}
 		return fieldDataStart;
@@ -282,10 +302,23 @@ public class ObjectFieldInfo {
 		for  (J9ROMFieldShapePointer f: fields) {
 			UDATA modifiers = f.modifiers();
 			if (!modifiers.anyBitsIn(J9AccStatic) ) {
-
 				if (modifiers.anyBitsIn(J9FieldFlagObject)) {
-					instanceObjectCount += 1;
-					totalObjectCount += 1;
+					if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(f))) {
+						J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(containerClazz,J9ROMFieldShapeHelper.getName(f));
+						if (null == fieldClass) {
+							instanceObjectCount += 1;
+							totalObjectCount += 1;
+						} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintDouble(fieldClass)) {
+							totalFlatFieldDoubleBytes += Scalar.roundToSizeofU64(fieldClass.totalInstanceSize().sub(fieldClass.backfillOffset())).intValue();
+						} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintReference(fieldClass)) {
+							totalFlatFieldRefBytes += Scalar.roundToSizeToFJ9object(fieldClass.totalInstanceSize().sub(fieldClass.backfillOffset())).intValue();
+						} else {
+							totalFlatFieldSingleBytes += fieldClass.totalInstanceSize().sub(fieldClass.backfillOffset()).intValue();
+						}
+					} else {
+						instanceObjectCount += 1;
+						totalObjectCount += 1;
+					}
 				} else if (modifiers.anyBitsIn(J9FieldSizeDouble)) {
 					instanceDoubleCount += 1;
 					totalDoubleCount += 1;
@@ -321,29 +354,67 @@ public class ObjectFieldInfo {
 	}
 
 	int calculateTotalFieldsSizeAndBackfill() { /* TODO update to handle contended fields */
-		long accumulator = superclassFieldsSize + 
-				(totalObjectCount * J9Object.SIZEOF) + (totalSingleCount * U32.SIZEOF) + (totalDoubleCount * U64.SIZEOF);
-		/* if the superclass is not end aligned but we have doubleword fields, use the space before the first field as the backfill */
-		if (
-				((getSuperclassObjectSize() % ObjectModel.getObjectAlignmentInBytes()) != 0) && /* superclass is not end-aligned */
-				((totalDoubleCount > 0) || (!objectCanUseBackfill && (totalObjectCount > 0)))
-				){ /* our fields start on a 8-byte boundary */
-			superclassBackfillOffset = getSuperclassFieldsSize();
-			accumulator += BACKFILL_SIZE;
-		}
-		if (isSuperclassBackfillSlotAvailable() && isBackfillSuitableFieldAvailable()) {
-			accumulator -= BACKFILL_SIZE;
-			myBackfillOffset = superclassBackfillOffset;
-			superclassBackfillOffset = NO_BACKFILL_AVAILABLE;
-		}
-		if (((accumulator + J9Object.SIZEOF) % ObjectModel.getObjectAlignmentInBytes()) != 0) {
-			/* we have consumed the superclass's backfill (if any), so let our subclass use the residue at the end of this class. */
-			subclassBackfillOffset = (int) accumulator;
-			accumulator += BACKFILL_SIZE;
+		long accumulator = superclassFieldsSize + (totalObjectCount * J9Object.SIZEOF) + (totalSingleCount * U32.SIZEOF)
+				+ (totalDoubleCount * U64.SIZEOF);
+
+		accumulator += totalFlatFieldDoubleBytes + totalFlatFieldRefBytes + totalFlatFieldSingleBytes;
+
+		/* ValueTypes cannot be subtyped and their superClass contains no fields */
+		if (isValue) {
+			int firstFieldOffset = calculateFieldDataStart();
+			accumulator += firstFieldOffset;
+			subclassBackfillOffset = firstFieldOffset;
 		} else {
-			subclassBackfillOffset = superclassBackfillOffset;
+			if (((getSuperclassObjectSize() % ObjectModel.getObjectAlignmentInBytes()) != 0)
+					&& /* superclass is not end-aligned */
+					((totalDoubleCount > 0) || (!objectCanUseBackfill
+							&& (totalObjectCount > 0)))) { /* our fields start on a 8-byte boundary */
+				superclassBackfillOffset = getSuperclassFieldsSize();
+				accumulator += BACKFILL_SIZE;
+			}
+			if (isSuperclassBackfillSlotAvailable() && isBackfillSuitableFieldAvailable()) {
+				accumulator -= BACKFILL_SIZE;
+				myBackfillOffset = superclassBackfillOffset;
+				superclassBackfillOffset = NO_BACKFILL_AVAILABLE;
+			}
+			if (((accumulator + J9Object.SIZEOF) % ObjectModel.getObjectAlignmentInBytes()) != 0) {
+				/* we have consumed the superclass's backfill (if any), so let our subclass use the residue at the end of this class. */
+				subclassBackfillOffset = (int)accumulator;
+				accumulator += BACKFILL_SIZE;
+			} else {
+				subclassBackfillOffset = superclassBackfillOffset;
+			}
 		}
 		return (int) accumulator;
 	}
 
+	/**
+	 * @param start end of previous field area, which should be the first field area
+	 * @return offset to end of the flat doubles area
+	 */
+	int
+	addFlatDoublesArea(int start)
+	{
+		return start + totalFlatFieldDoubleBytes;
+	}
+
+	/**
+	 * @param start end of previous field area, which should be after doubles
+	 * @return offset to end of the flat doubles area
+	 */
+	int
+	addFlatObjectsArea(int start)
+	{
+		return start + totalFlatFieldRefBytes;
+	}
+
+	/**
+	 * @param start end of previous field area, which should be after objects
+	 * @return offset to end of the flat doubles area
+	 */
+	int
+	addFlatSinglesArea(int start)
+	{
+		return start + totalFlatFieldSingleBytes;
+	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
@@ -1,0 +1,321 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.pointer.helper;
+
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
+import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN;
+import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffset;
+import com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator;
+import com.ibm.j9ddr.vm29.j9.ObjectModel;
+import com.ibm.j9ddr.vm29.pointer.AbstractPointer;
+import com.ibm.j9ddr.vm29.pointer.I32Pointer;
+import com.ibm.j9ddr.vm29.pointer.U32Pointer;
+import com.ibm.j9ddr.vm29.pointer.U64Pointer;
+import com.ibm.j9ddr.vm29.pointer.U8Pointer;
+import com.ibm.j9ddr.vm29.pointer.UDATAPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ROMFieldShapePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
+import com.ibm.j9ddr.vm29.structure.J9Object;
+import com.ibm.j9ddr.vm29.types.U32;
+import com.ibm.j9ddr.vm29.types.UDATA;
+
+
+/**
+ * Helper class to print j9object fields. Also contains helper functions
+ * for formatting output.
+ */
+public class PrintObjectFieldsHelper {
+	private static ValueTypeHelper valueTypeHelper = ValueTypeHelper.getValueTypeHelper();
+	private static final String PADDING = "\t";
+
+	/**
+	 * Prints all the j9object fields
+	 *
+	 * @param out output stream
+	 * @param tabLevel indicates the starting tab level
+	 * @param localClazz the class of the j9object
+	 * @param dataStart start location of the j9object
+	 * @param localObject pointer to the j9object
+	 * @param address address of the object being printed
+	 * @throws CorruptDataException
+	 */
+	public static void printJ9ObjectFields(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject, long address) throws CorruptDataException
+	{
+		printJ9ObjectFields(out, tabLevel, localClazz, dataStart, localObject, address, null, false);
+	}
+
+	/**
+	 * Prints all the j9object fields
+	 *
+	 * @param out The output stream
+	 * @param tabLevel Indicates the starting tab level
+	 * @param localClazz The class of the j9object
+	 * @param dataStart The start location of the object. If printing a nested
+	 * type this is the effect address of the nested type
+	 * @param localObject The pointer to the j9object
+	 * @param address The address of the object being printed. If printing a
+	 * nested type this is the address of the top level container
+	 * @param nestingHierarchy This is an array of field names that specifies
+	 * which nested type contained in the top level container to be printed
+	 * The first array element is the name of a nested field in the top level
+	 * container. The second array element is the name of a nested field that
+	 * is a member of the of the nested field specified  in the first array
+	 * element. And so on...
+	 * @param showNestedFields Specifies if the entire structure of nested
+	 * fields should be outputted
+	 * @throws CorruptDataException
+	 */
+	public static void printJ9ObjectFields(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject, long address, String[] nestingHierarchy, boolean showNestedFields) throws CorruptDataException
+	{
+		long superclassIndex;
+		long depth;
+		J9ClassPointer previousSuperclass = J9ClassPointer.NULL;
+		boolean lockwordPrinted = false;
+		UDATA nestedFieldOffset = new UDATA(0);
+		boolean flatObject = false;
+
+		J9ClassPointer nestedClassHierarchy[] = null;
+
+		if ((null != nestingHierarchy) && (nestingHierarchy.length > 0)) {
+			flatObject = true;
+		}
+
+		/* This is true when !flatobject is specified are currently printing a nested structure */
+		boolean showObjectHeader = tabLevel <= 1;
+
+		if (flatObject) {
+			/* If it is a flatObject skip ahead to the nested field */
+			nestedClassHierarchy = valueTypeHelper.findNestedClassHierarchy(localClazz, nestingHierarchy);
+			J9ClassPointer clazz = null;
+
+			U32 flags = new U32(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN);
+			for (int i = 0; i < nestedClassHierarchy.length - 1; i++) {
+				clazz = nestedClassHierarchy[i];
+				depth = J9ClassHelper.classDepth(clazz).longValue();
+				boolean found = false;
+				for (superclassIndex = 0; (superclassIndex <= depth) && !found; superclassIndex++) {
+					J9ClassPointer superclass;
+					if (superclassIndex == depth) {
+						superclass = clazz;
+					} else {
+						superclass = J9ClassPointer.cast(clazz.superclasses().at(superclassIndex));
+					}
+					Iterator<J9ObjectFieldOffset> iterator = J9ObjectFieldOffsetIterator.J9ObjectFieldOffsetIteratorFor(superclass.romClass(), clazz, previousSuperclass, flags);
+
+					while (iterator.hasNext()) {
+						J9ObjectFieldOffset result = iterator.next();
+						if (result.getName().equals(nestingHierarchy[i])) {
+							nestedFieldOffset = nestedFieldOffset.add(result.getOffsetOrAddress());
+							found = true;
+							break;
+						}
+					}
+					previousSuperclass = superclass;
+				}
+			}
+
+			localClazz = nestedClassHierarchy[nestedClassHierarchy.length - 1];
+			dataStart = dataStart.add(nestedFieldOffset);
+			previousSuperclass = J9ClassPointer.NULL;
+		}
+		if (showObjectHeader) {
+			if (flatObject) {
+				padding(out, tabLevel);
+				out.format("// EA = %s, offset in top level container = %d;%n", dataStart.getHexAddress(), nestedFieldOffset.add(ObjectModel.getHeaderSize(localObject)).intValue());
+			}
+
+			/* print individual fields */
+			J9UTF8Pointer classNameUTF = localClazz.romClass().className();
+			padding(out, tabLevel);
+			out.format("struct J9Class* clazz = !j9class 0x%X // %s%n", localClazz.getAddress(), J9UTF8Helper.stringValue(classNameUTF));
+			padding(out, tabLevel);
+			out.format("Object flags = %s;%n", J9ObjectHelper.flags(localObject).getHexValue());
+		}
+
+		depth = J9ClassHelper.classDepth(localClazz).longValue();
+		for (superclassIndex = 0; superclassIndex <= depth; superclassIndex++) {
+			J9ClassPointer superclass;
+			if (superclassIndex == depth) {
+				superclass = localClazz;
+			} else {
+				superclass = J9ClassPointer.cast(localClazz.superclasses().at(superclassIndex));
+			}
+
+			U32 flags = new U32(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN);
+			Iterator<J9ObjectFieldOffset> iterator = J9ObjectFieldOffsetIterator.J9ObjectFieldOffsetIteratorFor(superclass.romClass(), localClazz, previousSuperclass, flags);
+
+			while (iterator.hasNext()) {
+				J9ObjectFieldOffset result = iterator.next();
+				boolean printField = true;
+				boolean isHiddenField = result.isHidden();
+				boolean isLockword = isHiddenField && result.getOffsetOrAddress().add(J9Object.SIZEOF).eq(superclass.lockOffset());
+
+				if (isLockword) {
+					/* Print the lockword field if it is indeed the lockword for this instanceClass and we haven't printed it yet. */
+					printField = !lockwordPrinted && localClazz.lockOffset().eq(superclass.lockOffset());
+					if (printField) {
+						lockwordPrinted = true;
+					}
+				}
+
+
+				if (printField) {
+					if (showNestedFields) {
+						J9ClassPointer containerClazz = null;
+						if (null == nestedClassHierarchy) {
+							/* if nestedClassHierarchy is null then this class is the container class */
+							containerClazz = localClazz;
+						} else {
+							containerClazz = nestedClassHierarchy[0];
+						}
+						printNestedObjectField(out, tabLevel, localClazz, dataStart, superclass, result, address, nestingHierarchy, containerClazz);
+					} else {
+						printObjectField(out, tabLevel, localClazz, dataStart, superclass, result, address, nestingHierarchy);
+					}
+
+					out.println();
+				}
+			}
+			previousSuperclass = superclass;
+		}
+	}
+
+	private static void printObjectField(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ClassPointer fromClass, J9ObjectFieldOffset objectFieldOffset, long address, String[] nestingHierarchy) throws CorruptDataException
+	{
+		J9ROMFieldShapePointer fieldShape = objectFieldOffset.getField();
+		UDATA fieldOffset = objectFieldOffset.getOffsetOrAddress();
+		boolean isHiddenField = objectFieldOffset.isHidden();
+		boolean containerIsFlatObject = (nestingHierarchy != null) && (nestingHierarchy.length > 0);
+		String className = J9ClassHelper.getName(fromClass);
+		String fieldName = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().name());
+		String fieldSignature = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().signature());
+		boolean fieldIsFlattened = valueTypeHelper.isFieldInClassFlattened(localClazz, fieldName);
+		U8Pointer valuePtr = dataStart.add(fieldOffset);
+
+		padding(out, tabLevel);
+		out.format("%s %s = ", fieldSignature, fieldName);
+
+		if (fieldShape.modifiers().anyBitsIn(J9FieldSizeDouble)) {
+			out.print(U64Pointer.cast(valuePtr).at(0).getHexValue());
+		} else if (fieldShape.modifiers().anyBitsIn(J9FieldFlagObject)) {
+			if (fieldIsFlattened) {
+				J9ObjectPointer object = J9ObjectPointer.cast(address);
+				StringBuilder hierarchy = new StringBuilder("");
+
+				if (containerIsFlatObject) {
+					for (int i = 0; i < nestingHierarchy.length; i++) {
+						hierarchy.append(nestingHierarchy[i]);
+						hierarchy.append(".");
+					}
+				}
+
+				hierarchy.append(fieldName);
+				out.format("!j9object 0x%x %s", object.getAddress(), hierarchy);
+			} else {
+				AbstractPointer ptr = J9BuildFlags.gc_compressedPointers ? U32Pointer.cast(valuePtr) : UDATAPointer.cast(valuePtr);
+				out.format("!fj9object 0x%x", ptr.at(0).longValue());
+			}
+		} else {
+			out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+		}
+		if (fieldIsFlattened) {
+			out.format(" (offset = %d) (%s)", fieldOffset.longValue(), fieldSignature.substring(1, fieldSignature.length() - 1));
+		} else {
+			out.format(" (offset = %d) (%s)", fieldOffset.longValue(), className);
+		}
+
+		if (isHiddenField) {
+			out.print(" <hidden>");
+		}
+	}
+
+	private static void printNestedObjectField(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ClassPointer fromClass, J9ObjectFieldOffset objectFieldOffset, long address, String[] nestingHierarchy, J9ClassPointer containerClazz) throws CorruptDataException
+	{
+		J9ROMFieldShapePointer fieldShape = objectFieldOffset.getField();
+		UDATA fieldOffset = objectFieldOffset.getOffsetOrAddress();
+		boolean isHiddenField = objectFieldOffset.isHidden();
+		String fieldName = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().name());
+		String fieldSignature = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().signature());
+		boolean fieldIsFlattened = valueTypeHelper.isFieldInClassFlattened(localClazz, fieldName);
+		U8Pointer valuePtr = dataStart.add(fieldOffset);
+
+		padding(out, tabLevel);
+		if (fieldIsFlattened) {
+			out.format("%s %s { // EA = %s (offset = %d)%n", fieldSignature.substring(1, fieldSignature.length() - 1), fieldName, valuePtr.getHexAddress(), fieldOffset.longValue());
+		} else {
+			out.format("%s %s = ", fieldSignature, fieldName);
+		}
+
+		if (fieldShape.modifiers().anyBitsIn(J9FieldSizeDouble)) {
+			out.print(U64Pointer.cast(valuePtr).at(0).getHexValue());
+		} else if (fieldShape.modifiers().anyBitsIn(J9FieldFlagObject)) {
+			if (fieldIsFlattened) {
+				String newNestingHierarchy[] = null;
+
+				if (nestingHierarchy == null) {
+					/* we are currently at the container level */
+					newNestingHierarchy = new String[] {fieldName};
+				} else {
+					newNestingHierarchy = Arrays.copyOf(nestingHierarchy, nestingHierarchy.length + 1);
+					newNestingHierarchy[nestingHierarchy.length] = fieldName;
+				}
+
+				J9ObjectPointer obj = J9ObjectPointer.cast(address);
+				dataStart = U8Pointer.cast(obj).add(ObjectModel.getHeaderSize(obj));
+				printJ9ObjectFields(out, tabLevel + 1, containerClazz, dataStart, null, address, newNestingHierarchy, true);
+
+			} else {
+				AbstractPointer ptr = J9BuildFlags.gc_compressedPointers ? U32Pointer.cast(valuePtr) : UDATAPointer.cast(valuePtr);
+				out.format("!fj9object 0x%x%n", ptr.at(0).longValue());
+			}
+		} else {
+			out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+		}
+
+		if (fieldIsFlattened) {
+			padding(out, tabLevel);
+			out.print("}");
+		}
+
+		if (isHiddenField) {
+			out.print(" <hidden>");
+		}
+	}
+
+	public static void padding(PrintStream out, int level)
+	{
+		for (int i = 0; i < level; i++) {
+			out.print(PADDING);
+		}
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
@@ -1,0 +1,421 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.pointer.helper;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.logging.LoggerNames;
+import com.ibm.j9ddr.vm29.j9.J9ConstantHelper;
+import com.ibm.j9ddr.vm29.pointer.AbstractPointer;
+import com.ibm.j9ddr.vm29.pointer.StructurePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ROMClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ROMNameAndSignaturePointer;
+import com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags;
+import com.ibm.j9ddr.vm29.structure.J9JavaClassFlags;
+import com.ibm.j9ddr.vm29.types.UDATA;
+
+/**
+ * Value type helper class
+ *
+ * areValueTypesSupported() must return true before using any other methods in this class
+ */
+public class ValueTypeHelper {
+	protected static final Logger logger = Logger.getLogger(LoggerNames.LOGGER_INTERACTIVE_CONTEXT);
+
+	private static ValueTypeHelper helper = null;
+
+	private static class ValueTypeSupportEnabledHelper extends ValueTypeHelper {
+		private static final long J9AccValueType = J9ConstantHelper.getLong(J9JavaAccessFlags.class, "J9AccValueType", 0);
+		private static final long J9ClassIsValueType = J9ConstantHelper.getLong(J9JavaClassFlags.class, "J9ClassIsValueType", 0);
+		private static final long J9ClassLargestAlignmentConstraintDouble = J9ConstantHelper.getLong(J9JavaClassFlags.class, "J9ClassLargestAlignmentConstraintDouble", 0);
+		private static final long J9ClassLargestAlignmentConstraintReference = J9ConstantHelper.getLong(J9JavaClassFlags.class, "J9ClassLargestAlignmentConstraintReference", 0);
+		private static final long J9ClassIsFlattened = J9ConstantHelper.getLong(J9JavaClassFlags.class, "J9ClassIsFlattened", 0);
+		private MethodHandle getFlattenedClassCachePointer = null;
+		private Class<?> flattenedClassCachePointer = null;
+		private MethodHandle flattenedClassCache_numberOfEntries = null;
+		private MethodHandle flattenedClassCacheEntry_NaS = null;
+		private MethodHandle flattenedClassCacheEntry_clazz = null;
+		private MethodHandle flattenedClassCacheEntry_cast = null;
+		private Class<?> flattenedClassCacheEntryPointer = null;
+
+		ValueTypeSupportEnabledHelper() {
+			super();
+			try {
+				Lookup lookup = MethodHandles.lookup();
+				flattenedClassCachePointer = Class.forName("com.ibm.j9ddr.vm29.pointer.generated.J9FlattenedClassCachePointer");
+				getFlattenedClassCachePointer = lookup.findVirtual(J9ClassPointer.class, "flattenedClassCache", MethodType.methodType(flattenedClassCachePointer));
+				flattenedClassCache_numberOfEntries = lookup.findVirtual(flattenedClassCachePointer, "numberOfEntries", MethodType.methodType(UDATA.class));
+				flattenedClassCacheEntryPointer = Class.forName("com.ibm.j9ddr.vm29.pointer.generated.J9FlattenedClassCacheEntryPointer");
+				flattenedClassCacheEntry_NaS = lookup.findVirtual(flattenedClassCacheEntryPointer, "nameAndSignature", MethodType.methodType(J9ROMNameAndSignaturePointer.class));
+				flattenedClassCacheEntry_clazz = lookup.findVirtual(flattenedClassCacheEntryPointer, "clazz", MethodType.methodType(J9ClassPointer.class));
+				flattenedClassCacheEntry_cast = lookup.findStatic(flattenedClassCacheEntryPointer, "cast", MethodType.methodType(flattenedClassCacheEntryPointer, AbstractPointer.class));
+			} catch (Throwable t) {
+				/* should not happen */
+				throwUncheckedExceptions(t);
+				logger.log(Level.SEVERE, "ValueTypeHelper: failed to get ValueTypeHelper method handles", t);
+			}
+		}
+
+		private static void throwUncheckedExceptions(Throwable t) {
+			if (t instanceof Error) {
+				throw (Error)t;
+			} else if (t instanceof RuntimeException) {
+				throw (RuntimeException)t;
+			}
+		}
+
+		private static CorruptDataException handleThrowable(Throwable t) throws CorruptDataException {
+			throwUncheckedExceptions(t);
+			throw new CorruptDataException(t);
+		}
+
+		@Override
+		public boolean areValueTypesSupported() {
+			return true;
+		}
+
+		private J9ClassPointer findJ9ClassInFlattenedClassCacheWithFieldNameImpl(StructurePointer flattenedClassCache, String fieldName) throws CorruptDataException {
+			J9ClassPointer resultClazz = J9ClassPointer.NULL;
+			try {
+				UDATA length = (UDATA) flattenedClassCache_numberOfEntries.invoke(flattenedClassCache);
+
+				/* bump the pointer past the header */
+				StructurePointer entry = (StructurePointer) flattenedClassCacheEntry_cast.invoke(flattenedClassCache.add(1));
+
+				int cacheLength = length.intValue();
+				for (int i = 0; i < cacheLength; i++) {
+					String field = J9UTF8Helper.stringValue(((J9ROMNameAndSignaturePointer)flattenedClassCacheEntry_NaS.invoke(entry)).name());
+					if (field.equals(fieldName)) {
+						resultClazz = (J9ClassPointer) flattenedClassCacheEntry_clazz.invoke(entry);
+						break;
+					}
+					entry = (StructurePointer) entry.add(1);
+				}
+			} catch (WrongMethodTypeException | ClassCastException e) {
+				/* should not happen */
+				logger.log(Level.SEVERE, "ValueTypeHelper: failed to find field in flattened class cache with field name.", e);
+			} catch (Throwable t) {
+				throw handleThrowable(t);
+			}
+			return resultClazz;
+		}
+
+		@Override
+		public J9ClassPointer findJ9ClassInFlattenedClassCacheWithFieldName(J9ClassPointer clazz, String fieldName) throws CorruptDataException {
+			J9ClassPointer resultClazz = J9ClassPointer.NULL;
+
+			try {
+				StructurePointer flattenedClassCache = (StructurePointer) getFlattenedClassCachePointer.invoke(clazz);
+				if (!flattenedClassCache.isNull()) {
+					resultClazz = findJ9ClassInFlattenedClassCacheWithFieldNameImpl(flattenedClassCache, fieldName);
+				}
+			} catch (WrongMethodTypeException | ClassCastException e) {
+				/* should not happen */
+				logger.log(Level.SEVERE, "ValueTypeHelper: failed to find field in flattened class cache with field name", e);
+			} catch (Throwable t) {
+				throw handleThrowable(t);
+			}
+			return resultClazz;
+		}
+
+		private J9ClassPointer findJ9ClassInFlattenedClassCacheWithFieldSigImpl(StructurePointer flattenedClassCache, String fieldSig) throws CorruptDataException {
+			J9ClassPointer resultClazz = J9ClassPointer.NULL;
+			try {
+				UDATA length = (UDATA) flattenedClassCache_numberOfEntries.invoke(flattenedClassCache);
+
+				/* bump the pointer past the header */
+				StructurePointer entry = (StructurePointer) flattenedClassCacheEntry_cast.invoke(flattenedClassCache.add(1));
+
+				int cacheLength = length.intValue();
+				for (int i = 0; i < cacheLength; i++) {
+					String field = J9UTF8Helper.stringValue(((J9ROMNameAndSignaturePointer)flattenedClassCacheEntry_NaS.invoke(entry)).signature());
+					field = field.substring(1,  field.length() - 1);
+					if (field.equals(fieldSig)) {
+						resultClazz = (J9ClassPointer) flattenedClassCacheEntry_clazz.invoke(entry);
+						break;
+					}
+					entry = (StructurePointer) entry.add(1);
+				}
+			} catch (WrongMethodTypeException | ClassCastException e) {
+				/* should not happen */
+				logger.log(Level.SEVERE, "ValueTypeHelper: failed to find field in flattened class cache with field signature", e);
+			} catch (Throwable t) {
+				throw handleThrowable(t);
+			}
+			return resultClazz;
+		}
+
+		@Override
+		public J9ClassPointer[] findNestedClassHierarchy(J9ClassPointer containerClazz, String[] nestingHierarchy) throws CorruptDataException {
+			J9ClassPointer[] resultClasses = new J9ClassPointer[nestingHierarchy.length + 1];
+			J9ClassPointer clazz = containerClazz;
+			resultClasses[0] = containerClazz;
+
+			for (int i = 0; i < nestingHierarchy.length; i++) {
+				clazz = findJ9ClassInFlattenedClassCacheWithFieldName(clazz, nestingHierarchy[i]);
+				resultClasses[i + 1] = clazz;
+			}
+
+			return resultClasses;
+		}
+
+		@Override
+		public J9ClassPointer findJ9ClassInFlattenedClassCacheWithSigName(J9ClassPointer clazz, String fieldSig) throws CorruptDataException {
+			J9ClassPointer resultClazz = J9ClassPointer.NULL;
+			try {
+				StructurePointer flattenedClassCache = (StructurePointer) getFlattenedClassCachePointer.invoke(clazz);
+				if (!flattenedClassCache.isNull()) {
+					resultClazz = findJ9ClassInFlattenedClassCacheWithFieldSigImpl(flattenedClassCache, fieldSig);
+				}
+			} catch (WrongMethodTypeException | ClassCastException e) {
+				/* should not happen */
+				logger.log(Level.SEVERE, "ValueTypeHelper: failed to find field in flattened class cache with field signature", e);
+			} catch (Throwable t) {
+				throw handleThrowable(t);
+			}
+			return resultClazz;
+		}
+
+		@Override
+		public boolean isRomClassAValueType(J9ROMClassPointer romClass) throws CorruptDataException {
+			if (J9AccValueType != 0) {
+				return romClass.modifiers().allBitsIn(J9AccValueType);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean isJ9ClassAValueType(J9ClassPointer clazz) throws CorruptDataException {
+			if (J9ClassIsValueType != 0) {
+				return clazz.classFlags().allBitsIn(J9ClassIsValueType);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean isFieldInClassFlattened(J9ClassPointer clazz, String fieldName) throws CorruptDataException {
+			boolean result = false;
+
+			try {
+				StructurePointer flattenedClassCache = (StructurePointer) getFlattenedClassCachePointer.invoke(clazz);
+				if (!flattenedClassCache.isNull()) {
+					J9ClassPointer flattenableClazz = findJ9ClassInFlattenedClassCacheWithFieldNameImpl(flattenedClassCache, fieldName);
+					if (!flattenableClazz.isNull()) {
+						result = isJ9ClassIsFlattened(flattenableClazz);
+					}
+				}
+			} catch (WrongMethodTypeException | ClassCastException e) {
+				/* should not happen */
+				logger.log(Level.SEVERE, "ValueTypeHelper: failed to determine if field is flattened", e);
+				throw new RuntimeException(e);
+			} catch (Throwable t) {
+				throw handleThrowable(t);
+			}
+
+			return result;
+		}
+
+		@Override
+		public boolean isJ9ClassLargestAlignmentConstraintDouble(J9ClassPointer clazz) throws CorruptDataException {
+			if (J9ClassLargestAlignmentConstraintDouble != 0) {
+				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9ClassLargestAlignmentConstraintDouble);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean isJ9ClassLargestAlignmentConstraintReference(J9ClassPointer clazz) throws CorruptDataException {
+			if (J9ClassLargestAlignmentConstraintReference != 0) {
+				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9ClassLargestAlignmentConstraintReference);
+			}
+			return false;
+		}
+
+		private boolean isJ9ClassIsFlattened(J9ClassPointer clazz) throws CorruptDataException {
+			if (J9ClassIsFlattened != 0) {
+				return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9ClassIsFlattened);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean isFlattenableFieldSignature(String signature) {
+			return signature.startsWith("Q");
+		}
+	}
+
+	private ValueTypeHelper() {
+		/* empty constructor */
+	}
+
+	private static boolean checkIfValueTypesAreSupported() {
+		/* Older builds have builds flags in camel case, newer builds have flags capitalized */
+		return J9ConstantHelper.getBoolean(J9BuildFlags.class, "J9VM_OPT_VALHALLA_VALUE_TYPES", false)
+				|| J9ConstantHelper.getBoolean(J9BuildFlags.class, "opt_valhallaValueTypes", false);
+	}
+
+	/**
+	 * Factory method that returns a valueTypeHelper instance.
+	 *
+	 * @return valueTypeHelper
+	 */
+	public static ValueTypeHelper getValueTypeHelper() {
+		if (helper == null) {
+			if (checkIfValueTypesAreSupported()) {
+				helper = new ValueTypeSupportEnabledHelper();
+			} else {
+				helper = new ValueTypeHelper();
+			}
+		}
+		return helper;
+	}
+
+	/**
+	 * Queries if the JVM that produced the core file supports value types. This
+	 * must be called before any other ValueTypeHelper functions are called.
+	 *
+	 * @return true if value types are supported, false otherwise
+	 */
+	public boolean areValueTypesSupported() {
+		return false;
+	}
+
+	/**
+	 * Searches the flattenedClassCache (FCC) for a J9Class given a field name.
+	 * areValueTypesSupported() must return true before using this method.
+	 *
+	 * @param clazz J9Class pointer that owns the FCC to be searched
+	 * @param fieldName name of the field to lookup in the FCC
+	 *
+	 * @return J9Class of the fieldName if found, J9ClassPointer.NULL otherwise
+	 * @throws CorruptDataException
+	 */
+	public J9ClassPointer findJ9ClassInFlattenedClassCacheWithFieldName(J9ClassPointer clazz, String fieldName) throws CorruptDataException {
+		logger.log(Level.SEVERE, "Value types were not enabled in the JVM that produced this core file.");
+		throw new RuntimeException("Invalid operation");
+	}
+
+	/**
+	 * Returns an array of J9ClassPointers that contains the containerClazz passed in addition to the J9ClassPointers
+	 * that correspond to the types of the field names passed in the nestingHierarchy array. Each subsequent
+	 * field name in the nestingHierarchy array is a nested field of the previous element. For example
+	 * nestingHierarchy[1] is a member of nestingHierarchy[0], and nestingHierarchy[2] is a member of
+	 * nestingHierarchy[1]. nestingHierarchy[0] is the first nested member in the containerClazz. The resulting array contains
+	 * at least one element (containerClazz).
+	 *
+	 * areValueTypesSupported() must return true before using this method.
+	 *
+	 * @param containerClazz type that contains all the nested members
+	 * @param nestingHierarchy array that contains field names for nested members. Must be non-NULL
+	 * @return an array containing at least the containerClazz, and J9ClassPointer's corresponding to the names passed in the nestingHierarchy
+	 * @throws CorruptDataException
+	 */
+	public J9ClassPointer[] findNestedClassHierarchy(J9ClassPointer containerClazz, String[] nestingHierarchy) throws CorruptDataException {
+		logger.log(Level.SEVERE, "Value types were not enabled in the JVM that produced this core file.");
+		throw new RuntimeException("Invalid operation");
+	}
+
+	/**
+	 * Searches the flattenedClassCache (FCC) for a J9Class given a field signature.
+	 * areValueTypesSupported() must return true before using this method.
+	 *
+	 * @param clazz J9Class pointer that owns the FCC to be searched
+	 * @param fieldSig signature to lookup in the FCC
+	 *
+	 * @return J9ClassPointer corresponding to the signature if found, J9ClassPointer.NULL otherwise
+	 * @throws CorruptDataException
+	 */
+	public J9ClassPointer findJ9ClassInFlattenedClassCacheWithSigName(J9ClassPointer clazz, String fieldSig) throws CorruptDataException {
+		logger.log(Level.SEVERE, "Value types were not enabled in the JVM that produced this core file.");
+		throw new RuntimeException("Invalid operation");
+	}
+
+	/**
+	 * Queries if J9ROMClass is a value type
+	 *
+	 * @param romClass clazz to query
+	 * @return true if romClass is a value type, false otherwise
+	 * @throws CorruptDataException
+	 */
+	public boolean isRomClassAValueType(J9ROMClassPointer romClass) throws CorruptDataException {
+		return false;
+	}
+
+	/**
+	 * Queries if J9Class is a value type
+	 *
+	 * @param clazz clazz to query
+	 * @return true if class is a value type, false otherwise
+	 * @throws CorruptDataException
+	 */
+	public boolean isJ9ClassAValueType(J9ClassPointer clazz) throws CorruptDataException {
+		return false;
+	}
+
+	/**
+	 * Queries whether field is flattened of not.
+	 *
+	 * @param clazz clazz containing the field
+	 * @param fieldName name of the field
+	 * @return true if field is flattened, false otherwise
+	 * @throws CorruptDataException
+	 */
+	public boolean isFieldInClassFlattened(J9ClassPointer clazz, String fieldName) throws CorruptDataException {
+		return false;
+	}
+
+	/**
+	 * Queries if field signature is flattenable
+	 * @param signature field signature
+	 * @return true if field signature is flattenable, false otherwise
+	 */
+	public boolean isFlattenableFieldSignature(String signature) {
+		return false;
+	}
+
+	/**
+	 * Queries if class contains a field with a double (64 bit) alignment constraint
+	 * @param clazz J9Class
+	 * @return true if clazz has double alignment constraint, false otherwise
+	 */
+	public boolean isJ9ClassLargestAlignmentConstraintDouble(J9ClassPointer clazz) throws CorruptDataException {
+		return false;
+	}
+
+	/**
+	 * Queries if class contains a field with a reference alignment constraint
+	 * @param clazz J9Class
+	 * @return true if clazz has reference alignment constraint, false otherwise
+	 */
+	public boolean isJ9ClassLargestAlignmentConstraintReference(J9ClassPointer clazz) throws CorruptDataException {
+		return false;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corp. and others
+ * Copyright (c) 2010, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,18 +27,18 @@ import com.ibm.j9ddr.IBootstrapRunnable;
 import com.ibm.j9ddr.IVMData;
 import com.ibm.j9ddr.tools.ddrinteractive.BaseJVMCommands;
 import com.ibm.j9ddr.tools.ddrinteractive.ICommand;
+import com.ibm.j9ddr.vm29.pointer.helper.ValueTypeHelper;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.ACCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.AllClassesCommand;
-import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.ITableSizeCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.AnalyseRomClassUTF8Command;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.BuildFlagsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.BytecodesCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.CPDescriptionCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.ClassForNameCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.ClassloadersSummaryCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.CompressedRefMappingCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.CoreInfoCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllClassesInModuleCommand;
-import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.CPDescriptionCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllClassloadersCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRamClassLinearCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRegionsCommand;
@@ -46,9 +46,9 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRomClassLinearCom
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllSegmentsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpContendedLoadTable;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleCommand;
-import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleReadsCommand;
-import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleExportsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleDirectedExportsCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleExportsCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleReadsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpPackageCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpRamClassLinearCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpRomClassCommand;
@@ -67,8 +67,10 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindOverlappingSegmentsC
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindPatternCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindStackValueCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindVMCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FlatObjectCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.GCCheckCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.HashCodeCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.ITableSizeCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.J9ClassShapeCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.J9MemTagCommands;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.J9RegCommand;
@@ -102,21 +104,22 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.WalkJ9PoolCommand;
 
 /**
  * @author andhall
- * 
+ *
  */
-public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnable 
+public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnable
 {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see com.ibm.j9ddr.IBootstrapRunnable#run(com.ibm.j9ddr.IVMData,
 	 * java.lang.Object[])
 	 */
-	public void run(IVMData vmData, Object[] userData) 
+	@Override
+	public void run(IVMData vmData, Object[] userData)
 	{
 		Object[] passbackArray = (Object[]) userData[0];
-		Object loader = (Object) passbackArray[1];
+		Object loader = passbackArray[1];
 
 		List<ICommand> toPassBack = getBaseJVMCommands();
 
@@ -195,6 +198,10 @@ public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnab
 		toPassBack.add(new FindModulesCommand());
 		toPassBack.add(new DumpModuleCommand());
 		toPassBack.add(new DumpPackageCommand());
+
+		if (ValueTypeHelper.getValueTypeHelper().areValueTypesSupported()) {
+			toPassBack.add(new FlatObjectCommand());
+		}
 
 		loadPlugins(toPassBack, loader);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FlatObjectCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FlatObjectCommand.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.corereaders.memory.MemoryFault;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.ObjectModel;
+import com.ibm.j9ddr.vm29.pointer.U8Pointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.PrintObjectFieldsHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.ValueTypeHelper;
+
+/**
+ *
+ * FlatObjectCommand
+ *
+ * Displays all the fields of a j9object. If a field is nested, all of its fields are
+ * displayed as well. Nested fields are indented by one tab space.
+ *
+ */
+public class FlatObjectCommand extends Command {
+
+	public FlatObjectCommand() {
+		addCommand("flatobject", "<addressOfContainer> [<fieldName1>[.<fieldName2>]...]", "Display a flattened representation of a j9object given an address.");
+	}
+
+	private void printHelp(PrintStream out) {
+		out.println("Usage:");
+		out.println("  !flatobject <addressOfContainer> [<fieldName1>[.<fieldName2>]...]");
+	}
+
+	/**
+	 * The method runs the flatobject command. If the first element of args is not empty
+	 * this command will start printing fields at a nested member and not the container.
+	 *
+	 * @param command command name
+	 * @param args string array of args.
+	 * @param context ddrinteractive context
+	 * @param out output stream
+	 *
+	 */
+	@Override
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException {
+		if (args.length == 0) {
+			printHelp(out);
+			return;
+		}
+		printFlatObject(command, args, context, out);
+	}
+
+	private void printFlatObject(String command, String[] args, Context context, PrintStream out) {
+		J9ClassPointer clazz = null;
+		J9ObjectPointer object = null;
+		String[] argElements = args[0].split("\\.");
+
+		if (!ValueTypeHelper.getValueTypeHelper().areValueTypesSupported()) {
+			out.println("<this core file does not support flattened types>");
+			return;
+		}
+
+		try {
+			long address = CommandUtils.parsePointer(argElements[0], J9BuildFlags.env_data64);
+			String nestingHeirarchy = null;
+
+			if (1 < args.length) {
+				nestingHeirarchy = args[1];
+			}
+
+			object = J9ObjectPointer.cast(address);
+			clazz = J9ObjectHelper.clazz(object);
+
+			if (clazz.isNull()) {
+				out.println("<can not read RAM class address>");
+				return;
+			}
+
+			if (J9ClassHelper.isArrayClass(clazz)) {
+				out.println("<instance an array and not a flatobject>");
+				return;
+			}
+
+			U8Pointer dataStart =  U8Pointer.cast(object).add(ObjectModel.getHeaderSize(object));
+
+			if (null != nestingHeirarchy) {
+				out.format("!flatobject %s %s {%n", object.getHexAddress(), nestingHeirarchy);
+			} else {
+				out.format("!flatobject %s {%n", object.getHexAddress());
+			}
+
+			PrintObjectFieldsHelper.printJ9ObjectFields(out, 1, clazz, dataStart, object, address, nestingHeirarchy == null ? null : nestingHeirarchy.split("\\."), true);
+			out.println("}");
+
+		} catch (MemoryFault ex2) {
+			if ((object == null) || (clazz == null)) {
+				out.format("Unable to read object with command !flatobject %s%n", argElements[0]);
+			} else {
+				out.format("Unable to read object clazz at %s (clazz = %s) with command !flatoject %s%n", object.getHexAddress(), clazz.getHexAddress(), argElements[0]);
+			}
+		} catch (CorruptDataException | DDRInteractiveCommandException ex) {
+			out.println("Error for");
+			ex.printStackTrace(out);
+		}
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/J9ObjectStructureFormatter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/J9ObjectStructureFormatter.java
@@ -21,13 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions;
 
-import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
-import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
-import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN;
-import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE;
-
 import java.io.PrintStream;
-import java.util.Iterator;
 import java.util.List;
 
 import com.ibm.j9ddr.CorruptDataException;
@@ -37,10 +31,7 @@ import com.ibm.j9ddr.tools.ddrinteractive.Context;
 import com.ibm.j9ddr.tools.ddrinteractive.FormatWalkResult;
 import com.ibm.j9ddr.tools.ddrinteractive.IFieldFormatter;
 import com.ibm.j9ddr.vm29.j9.DataType;
-import com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffset;
-import com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator;
 import com.ibm.j9ddr.vm29.j9.ObjectModel;
-import com.ibm.j9ddr.vm29.pointer.AbstractPointer;
 import com.ibm.j9ddr.vm29.pointer.DoublePointer;
 import com.ibm.j9ddr.vm29.pointer.FloatPointer;
 import com.ibm.j9ddr.vm29.pointer.I16Pointer;
@@ -49,73 +40,68 @@ import com.ibm.j9ddr.vm29.pointer.I64Pointer;
 import com.ibm.j9ddr.vm29.pointer.ObjectReferencePointer;
 import com.ibm.j9ddr.vm29.pointer.U16Pointer;
 import com.ibm.j9ddr.vm29.pointer.U32Pointer;
-import com.ibm.j9ddr.vm29.pointer.U64Pointer;
 import com.ibm.j9ddr.vm29.pointer.U8Pointer;
-import com.ibm.j9ddr.vm29.pointer.UDATAPointer;
 import com.ibm.j9ddr.vm29.pointer.VoidPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9IndexableObjectPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
-import com.ibm.j9ddr.vm29.pointer.generated.J9ROMFieldShapePointer;
-import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9IndexableObjectHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
-import com.ibm.j9ddr.vm29.structure.J9Object;
+import com.ibm.j9ddr.vm29.pointer.helper.PrintObjectFieldsHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.ValueTypeHelper;
 import com.ibm.j9ddr.vm29.types.U32;
-import com.ibm.j9ddr.vm29.types.UDATA;
 
 /**
  * Custom structure formatter for J9Object and J9Indexable object
  */
-public class J9ObjectStructureFormatter extends BaseStructureFormatter 
+public class J9ObjectStructureFormatter extends BaseStructureFormatter
 {
 	public static final int DEFAULT_ARRAY_FORMAT_BEGIN = 0;
 	public static final int DEFAULT_ARRAY_FORMAT_END = 16;
-	public static final String PADDING = "      ";
-	
+
 	@Override
 	public FormatWalkResult format(String type, long address, PrintStream out,
-			Context context, List<IFieldFormatter> fieldFormatters, String[] extraArgs) 
+			Context context, List<IFieldFormatter> fieldFormatters, String[] extraArgs)
 	{
 		if (type.equalsIgnoreCase("j9object") || type.equalsIgnoreCase("j9indexableobject")) {
 			J9ClassPointer clazz = null;
 			J9ObjectPointer object = null;
-			
+
 			try {
 				boolean isArray;
 				String className;
 				object = J9ObjectPointer.cast(address);
 				clazz = J9ObjectHelper.clazz(object);
-				
+
 				if (clazz.isNull()) {
 					out.println("<can not read RAM class address>");
 					return FormatWalkResult.STOP_WALKING;
 				}
-	
+
 				isArray = J9ClassHelper.isArrayClass(clazz);
 				className = J9UTF8Helper.stringValue(clazz.romClass().className());
-				
+
 				U8Pointer dataStart =  U8Pointer.cast(object).add(ObjectModel.getHeaderSize(object));
-				
+
 				if (className.equals("java/lang/String")) {
-					formatStringObject(out, 0, clazz, dataStart, object);
+					formatStringObject(out, 0, clazz, dataStart, object, address);
 				} else if (isArray) {
 					int begin = DEFAULT_ARRAY_FORMAT_BEGIN;
 					int end = DEFAULT_ARRAY_FORMAT_END;
 					if (extraArgs.length > 0) {
 						begin = Integer.parseInt(extraArgs[0]);
 					}
-					
+
 					if (extraArgs.length > 1) {
 						end = Integer.parseInt(extraArgs[1]);
 					}
 
 					formatArrayObject(out, clazz, dataStart, J9IndexableObjectPointer.cast(object), begin, end);
 				} else {
-					formatObject(out, clazz, dataStart, object);
+					formatObject(out, clazz, dataStart, object, address, extraArgs);
 				}
 			} catch (MemoryFault ex2) {
 				out.println("Unable to read object clazz at " + object.getHexAddress() + " (clazz = "  + clazz.getHexAddress() + ")");
@@ -128,48 +114,56 @@ public class J9ObjectStructureFormatter extends BaseStructureFormatter
 			return FormatWalkResult.KEEP_WALKING;
 		}
 	}
-	
-	private void formatObject(PrintStream out, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject) throws CorruptDataException
-	{
-		out.print(String.format("!J9Object %s {", localObject.getHexAddress()));
-		out.println();
 
-		printJ9ObjectFields(out, 1, localClazz, dataStart, localObject);
+	private void formatObject(PrintStream out, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject, long address, String[] extraArgs) throws CorruptDataException
+	{
+		String[] nestHierarchy = null;
+
+		if (ValueTypeHelper.getValueTypeHelper().areValueTypesSupported()) {
+			nestHierarchy = extraArgs.length == 0 ? null : extraArgs[0].split("\\.");
+		}
+
+		if (null != nestHierarchy) {
+			out.format("!J9Object %s %s {%n", localObject.getHexAddress(), extraArgs[0]);
+		} else {
+			out.format("!J9Object %s {%n", localObject.getHexAddress());
+		}
+
+		PrintObjectFieldsHelper.printJ9ObjectFields(out, 1, localClazz, dataStart, localObject, address, nestHierarchy, false);
 		out.println("}");
 	}
-	
-	private void formatArrayObject(PrintStream out, J9ClassPointer localClazz, U8Pointer dataStart, J9IndexableObjectPointer localObject, int begin, int end) throws CorruptDataException 
+
+	private void formatArrayObject(PrintStream out, J9ClassPointer localClazz, U8Pointer dataStart, J9IndexableObjectPointer localObject, int begin, int end) throws CorruptDataException
 	{
 		String className = J9IndexableObjectHelper.getClassName(localObject);
-		
-		out.print(String.format("!J9IndexableObject %s {", localObject.getHexAddress()));
-		out.println();
-		
+
+		out.format("!J9IndexableObject %s {%n", localObject.getHexAddress());
+
 		/* print individual fields */
-		out.println(String.format("    struct J9Class* clazz = !j9arrayclass 0x%X   // %s", localClazz.getAddress(), className));
-		out.println(String.format("    Object flags = %s;", J9IndexableObjectHelper.flags(localObject).getHexValue()));
-		
+		out.format("    struct J9Class* clazz = !j9arrayclass 0x%X   // %s%n", localClazz.getAddress(), className);
+		out.format("    Object flags = %s;%n", J9IndexableObjectHelper.flags(localObject).getHexValue());
+
 		U32 size = J9IndexableObjectHelper.size(localObject);
-		
+
 		if (size.anyBitsIn(0x80000000)) {
-			out.println(String.format("    U_32 size = %s; // Size exceeds Integer.MAX_VALUE!", size.getHexValue()));
+			out.format("    U_32 size = %s; // Size exceeds Integer.MAX_VALUE!%n", size.getHexValue());
 		} else {
-			out.println(String.format("    U_32 size = %s;", size.getHexValue()));
+			out.format("    U_32 size = %s;%n", size.getHexValue());
 		}
-		
+
 		printSubArrayType(out, 1, localClazz, dataStart, begin, end, localObject);
 		out.println("}");
 	}
-	
-	void 
+
+	void
 	printSubArrayType(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, int begin, int end, J9IndexableObjectPointer array) throws CorruptDataException
 	{
 		U32 arraySize = J9IndexableObjectHelper.size(array);
-		if (arraySize.anyBitsIn(0x80000000)) {			
+		if (arraySize.anyBitsIn(0x80000000)) {
 			arraySize = new U32(Integer.MAX_VALUE);
 		}
 		int finish = Math.min(arraySize.intValue(), end);
-		
+
 		if (begin < finish) {
 			String className = J9IndexableObjectHelper.getClassName(array);
 			char signature = className.charAt(1);
@@ -178,41 +172,41 @@ public class J9ObjectStructureFormatter extends BaseStructureFormatter
 			case 'B':
 			case 'Z':
 				for (int index = begin; index < finish; index++) {
-					padding(out, tabLevel);
+					PrintObjectFieldsHelper.padding(out, tabLevel);
 					VoidPointer slot = J9IndexableObjectHelper.getElementEA(array, index, 1);
-					out.println(String.format("[%d] = %3d, 0x%02x", index, U8Pointer.cast(slot).at(0).longValue(), U8Pointer.cast(slot).at(0).longValue()));
+					out.format("[%d] = %3d, 0x%02x%n", index, U8Pointer.cast(slot).at(0).longValue(), U8Pointer.cast(slot).at(0).longValue());
 				}
 				break;
 			case 'C':
 				for (int index = begin; index < finish; index++) {
-					padding(out, tabLevel);
+					PrintObjectFieldsHelper.padding(out, tabLevel);
 					VoidPointer slot = J9IndexableObjectHelper.getElementEA(array, index, 2);
 					long value = U16Pointer.cast(slot).at(0).longValue();
-					out.println(String.format("[%d] = %5d, 0x%2$04x, '%c'", index, value, (char)value));
+					out.format("[%d] = %5d, 0x%2$04x, '%c'%n", index, value, (char)value);
 				}
 				break;
 			case 'S':
 				for (int index = begin; index < finish; index++) {
-					padding(out, tabLevel);
+					PrintObjectFieldsHelper.padding(out, tabLevel);
 					VoidPointer slot = J9IndexableObjectHelper.getElementEA(array, index, 2);
-					out.println(String.format("[%d] = %6d, 0x%04x", index, I16Pointer.cast(slot).at(0).longValue(), U16Pointer.cast(slot).at(0).longValue()));
+					out.format("[%d] = %6d, 0x%04x%n", index, I16Pointer.cast(slot).at(0).longValue(), U16Pointer.cast(slot).at(0).longValue());
 				}
 				break;
 			case 'I':
 			case 'F':
 				for (int index = begin; index < finish; index++) {
-					padding(out, tabLevel);
+					PrintObjectFieldsHelper.padding(out, tabLevel);
 					VoidPointer slot = J9IndexableObjectHelper.getElementEA(array, index, 4);
-					out.println(String.format("[%d] = %10d, 0x%08x, %8.8fF", index, I32Pointer.cast(slot).at(0).longValue(), U32Pointer.cast(slot).at(0).longValue(), FloatPointer.cast(slot).floatAt(0)));
+					out.format("[%d] = %10d, 0x%08x, %8.8fF%n", index, I32Pointer.cast(slot).at(0).longValue(), U32Pointer.cast(slot).at(0).longValue(), FloatPointer.cast(slot).floatAt(0));
 				}
 				break;
 
 			case 'J':
 			case 'D':
 				for (int index = begin; index < finish; index++) {
-					padding(out, tabLevel);
+					PrintObjectFieldsHelper.padding(out, tabLevel);
 					VoidPointer slot = J9IndexableObjectHelper.getElementEA(array, index, 8);
-					out.println(String.format("[%d] = %2d, 0x%016x, %8.8fF", index, I64Pointer.cast(slot).at(0).longValue(), I64Pointer.cast(slot).at(0).longValue(), DoublePointer.cast(slot).doubleAt(0)));
+					out.format("[%d] = %2d, 0x%016x, %8.8fF%n", index, I64Pointer.cast(slot).at(0).longValue(), I64Pointer.cast(slot).at(0).longValue(), DoublePointer.cast(slot).doubleAt(0));
 				}
 				break;
 			case 'L':
@@ -226,120 +220,30 @@ public class J9ObjectStructureFormatter extends BaseStructureFormatter
 						} else {
 							compressedPtrValue = DataType.getProcess().getPointerAt(slot.getAddress());
 						}
-						padding(out, tabLevel);
-						out.println(String.format("[%d] = !fj9object 0x%x = !j9object 0x%x", index, compressedPtrValue, ObjectReferencePointer.cast(slot).at(0).longValue()));
+						PrintObjectFieldsHelper.padding(out, tabLevel);
+						out.format("[%d] = !fj9object 0x%x = !j9object 0x%x%n", index, compressedPtrValue, ObjectReferencePointer.cast(slot).at(0).longValue());
 					} else {
-						padding(out, tabLevel);
-						out.println(String.format("[%d] = null", slot));
+						PrintObjectFieldsHelper.padding(out, tabLevel);
+						out.format("[%d] = null%n", slot);
 					}
 				}
 				break;
 			}
 		}
-		
+
 		/* check if it just printed a range; if so, give cmd to see all data */
 		arraySize = J9IndexableObjectHelper.size(array);
 		if (begin > 0 || arraySize.longValue() > finish ) {
-			out.println(String.format("To print entire range: !j9indexableobject %s %d %d\n", array.getHexAddress(), 0, arraySize.longValue()));
+			out.format("To print entire range: !j9indexableobject %s %d %d%n", array.getHexAddress(), 0, arraySize.longValue());
 		}
 	}
-	
-	private void formatStringObject(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject) throws CorruptDataException 
-	{
-		out.println(String.format("J9VMJavaLangString at %s {\n", localObject.getHexAddress()));
-		printJ9ObjectFields(out, tabLevel, localClazz, dataStart, localObject);
-		padding(out, tabLevel);
-		out.println(String.format("\"%s\"\n", J9ObjectHelper.stringValue(localObject)));
-		out.println("}");		
-	}
-	
-	private void printJ9ObjectFields(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject) throws CorruptDataException 
-	{
-		J9ClassPointer instanceClass = localClazz;
-		long superclassIndex;
-		long depth;
-		J9ClassPointer previousSuperclass = J9ClassPointer.NULL;
-		boolean lockwordPrinted = false;
-		
-		/* print individual fields */
-		J9UTF8Pointer classNameUTF = instanceClass.romClass().className();
-		padding(out, tabLevel);		
-		out.println(String.format("struct J9Class* clazz = !j9class 0x%X   // %s", localClazz.getAddress(), J9UTF8Helper.stringValue(classNameUTF)));
-		padding(out, tabLevel);
-		out.println(String.format("Object flags = %s;", J9ObjectHelper.flags(localObject).getHexValue()));
-		
-		depth = J9ClassHelper.classDepth(instanceClass).longValue();
-		for (superclassIndex = 0; superclassIndex <= depth; superclassIndex++) {
-			J9ClassPointer superclass;
-			if (superclassIndex == depth) {
-				superclass = instanceClass;
-			} else {
-				superclass = J9ClassPointer.cast(instanceClass.superclasses().at(superclassIndex));
-			}
 
-			U32 flags = new U32(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN);
-			Iterator<J9ObjectFieldOffset> iterator = J9ObjectFieldOffsetIterator.J9ObjectFieldOffsetIteratorFor(superclass.romClass(), instanceClass, previousSuperclass, flags);
-
-			while (iterator.hasNext()) 
-			{
-				J9ObjectFieldOffset result = iterator.next();
-				boolean printField = true;
-				boolean isHiddenField = result.isHidden();
-				boolean isLockword = (isHiddenField && ((result.getOffsetOrAddress().add(J9Object.SIZEOF).eq(superclass.lockOffset()))));
-				
-				if (isLockword) {
-					/* Print the lockword field if it is indeed the lockword for this instanceClass and we haven't printed it yet. */
-					printField = (!lockwordPrinted && (instanceClass.lockOffset().eq(superclass.lockOffset())));
-					if (printField) {
-						lockwordPrinted = true;
-					}
-				}
-				
-				if (printField) {
-					printObjectField(out, tabLevel, localClazz, dataStart, superclass, result);
-					out.println();
-				}
-			}
-			previousSuperclass = superclass;
-		}
-	}
-	
-	public void printObjectField(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ClassPointer fromClass, J9ObjectFieldOffset objectFieldOffset) throws CorruptDataException 
+	private void formatStringObject(PrintStream out, int tabLevel, J9ClassPointer localClazz, U8Pointer dataStart, J9ObjectPointer localObject, long address) throws CorruptDataException
 	{
-		J9ROMFieldShapePointer fieldShape = objectFieldOffset.getField();
-		UDATA fieldOffset = objectFieldOffset.getOffsetOrAddress();
-		boolean isHiddenField = objectFieldOffset.isHidden();
-		
-		String className = J9UTF8Helper.stringValue(fromClass.romClass().className());
-		String fieldName = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().name());
-		String fieldSignature = J9UTF8Helper.stringValue(fieldShape.nameAndSignature().signature());
-		
-		U8Pointer valuePtr = dataStart;
-		valuePtr = valuePtr.add(fieldOffset);
-
-		padding(out, tabLevel);
-		out.print(String.format("%s %s = ", fieldSignature, fieldName));
-		
-		if (fieldShape.modifiers().anyBitsIn(J9FieldSizeDouble)) {
-			out.print(U64Pointer.cast(valuePtr).at(0).getHexValue());
-		} else if (fieldShape.modifiers().anyBitsIn(J9FieldFlagObject)) {
-			AbstractPointer ptr = J9BuildFlags.gc_compressedPointers ? U32Pointer.cast(valuePtr) : UDATAPointer.cast(valuePtr);
-			out.print(String.format("!fj9object 0x%x", ptr.at(0).longValue()));
-		} else {
-			out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
-		}
-		
-		out.print(String.format(" (offset=%d) (%s)", fieldOffset.longValue(), className));
-				
-		if (isHiddenField) {
-			out.print(" <hidden>");
-		}
-	}
-	
-	private void padding(PrintStream out, int level) 
-	{
-		for (int i = 0; i < level; i++) {
-			out.print(PADDING);
-		}
+		out.format("J9VMJavaLangString at %s {%n", localObject.getHexAddress());
+		PrintObjectFieldsHelper.printJ9ObjectFields(out, tabLevel, localClazz, dataStart, localObject, address);
+		PrintObjectFieldsHelper.padding(out, tabLevel);
+		out.format("\"%s\"%n", J9ObjectHelper.stringValue(localObject));
+		out.println("}");
 	}
 }


### PR DESCRIPTION
Add value type support to DDR struct commands

Add support for printing nested types in DDR. Add new command 
(!flatobject) to print nested structure. Extend existing 
!j9object command to handle nested structures.

This is based on Mark Guo's changes in #5348

Signed-off-by: tajila <atobia@ca.ibm.com>

This is a continuation from https://github.com/eclipse/openj9/pull/5878#pullrequestreview-249517520