### PR TITLE
Rename global register allocated indexes on ParameterSymbol

### DIFF
--- a/runtime/compiler/codegen/CodeGenGC.cpp
+++ b/runtime/compiler/codegen/CodeGenGC.cpp
@@ -185,7 +185,7 @@ J9::CodeGenerator::createStackAtlas()
          parmCursor->setGCMapIndex(slotIndex);
 
          if (parmCursor->getLinkageRegisterIndex()<0 ||
-             parmCursor->getAllocatedIndex()<0 ||
+             parmCursor->getAssignedGlobalRegisterIndex()<0 ||
              _bodyLinkage->hasToBeOnStack(parmCursor))
             {
             parameterMap->setBit(slotIndex);

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -672,7 +672,7 @@ bool TR::PPCPrivateLinkage::hasToBeOnStack(TR::ParameterSymbol *parm)
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-   bool result = (parm->getAllocatedIndex()>=0       &&
+   bool result = (parm->getAssignedGlobalRegisterIndex()>=0       &&
           ( (  parm->getLinkageRegisterIndex()==0 &&
                parm->isCollectedReference()       &&
                !bodySymbol->isStatic()            &&

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -154,7 +154,7 @@ void TR::X86PrivateLinkage::copyGlRegDepsToParameterSymbols(TR::Node *bbStart, T
          {
          TR::Node *child = glRegDeps->getChild(childNum);
          TR::ParameterSymbol *sym = child->getSymbol()->getParmSymbol();
-         sym->setAllocatedIndex(cg->getGlobalRegister(child->getGlobalRegisterNumber()));
+         sym->setAssignedGlobalRegisterIndex(cg->getGlobalRegister(child->getGlobalRegisterNumber()));
          }
       }
    }
@@ -248,7 +248,7 @@ TR::Instruction *TR::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruc
       {
       int8_t lri = paramCursor->getLinkageRegisterIndex();     // How the parameter enters the method
       TR::RealRegister::RegNum ai                               // Where method body expects to find it
-         = (TR::RealRegister::RegNum)paramCursor->getAllocatedIndex();
+         = (TR::RealRegister::RegNum)paramCursor->getAssignedGlobalRegisterIndex();
       int32_t offset = paramCursor->getParameterOffset();      // Location of the parameter's stack slot
       TR_MovDataTypes movDataType = paramMovType(paramCursor); // What sort of MOV instruction does it need?
 
@@ -675,7 +675,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
       paramCursor != NULL;
       paramCursor = paramIterator.getNext()
       ){
-      TR::RealRegister::RegNum ai = (TR::RealRegister::RegNum)paramCursor->getAllocatedIndex();
+      TR::RealRegister::RegNum ai = (TR::RealRegister::RegNum)paramCursor->getAssignedGlobalRegisterIndex();
       debugFrameSlotInfo = new (trHeapMemory()) TR_DebugFrameSegmentInfo(comp(),
          paramCursor->getOffset(), paramCursor->getSize(), "Parameter",
          debugFrameSlotInfo,

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -851,7 +851,7 @@ TR::S390PrivateLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
    //      2. the address of the parameter is taken (JNI calls)
    //             (You can't get an address of the parameter if it is stored in a register -
    //              hence, parameter needs to be saved it onto the stack).
-   bool result = (  parm->getAllocatedIndex() >= 0 &&                        // is using global RA
+   bool result = (  parm->getAssignedGlobalRegisterIndex() >= 0 &&   // is using global RA
             (  (  parm->getLinkageRegisterIndex() == 0 &&            // is first parameter (this pointer)
                   parm->isCollectedReference() &&                    // is object reference
                   !bodySymbol->isStatic() &&                         // is virtual


### PR DESCRIPTION
Use renamed API from OMR #4025.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>