### PR TITLE
WIP: Reduce Number of VM_classHasBeenExtended Messages

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -479,9 +479,16 @@ TR_J9ServerVM::classHasBeenReplaced(TR_OpaqueClassBlock *clazz)
 bool
 TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
    {
+   uintptrj_t classDepthAndFlags = 0;
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_classHasBeenExtended, clazz);
-   return std::get<0>(stream->read<bool>());
+   JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
+   if((classDepthAndFlags & J9AccClassHasBeenOverridden) != 0)
+      return true;
+   else
+      {
+      stream->write(JITaaS::J9ServerMessageType::VM_classHasBeenExtended, clazz);
+      return std::get<0>(stream->read<bool>());
+      }
    }
 
 bool


### PR DESCRIPTION
[skip ci]
Reduce the number of msgs to client in VMJ9Server.cpp

-Call getAndCacheRAMClassInfo to get message from the
 persistent cache instead of asking client
-However, cache may not be accurate because cache are
 not invalidated in this case
-Therefore, we should check again with the client if
 value from cache is not true

Issue: #6084

Signed-off-by: caohaley <haleycao88@hotmail.com>