### PR TITLE
Eliminate Warnings for Compilation in JITaaS Code

### DIFF
--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -482,7 +482,7 @@ TR::DefaultCompilationStrategy::processInterpreterSample(TR_MethodEvent *event)
                else
                   {
                   if (logSampling)
-                     curMsg += sprintf(curMsg, " cannot be compiled, extra field is %08X", TR::CompilationInfo::getJ9MethodExtra(j9method));
+                     curMsg += sprintf(curMsg, " cannot be compiled, extra field is %08lX", TR::CompilationInfo::getJ9MethodExtra(j9method));
                   }
                }
             TR::Recompilation::globalSampleCount++;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3109,7 +3109,7 @@ void TR::CompilationInfo::stopCompilationThreads()
           (uint32_t)_jitConfig->dataCacheTotalKB);
 
       if (getJProfilerThread())
-         fprintf(stderr, "Allocated memory for profile info = %d KB\n", getJProfilerThread()->getProfileInfoFootprint()/1024);
+         fprintf(stderr, "Allocated memory for profile info = %lu KB\n", getJProfilerThread()->getProfileInfoFootprint()/1024);
       }
 
    static char * printPersistentMem = feGetEnv("TR_PrintPersistentMem");
@@ -8938,7 +8938,7 @@ TR::CompilationInfoPerThreadBase::compile(
 
       if (compiler->getOption(TR_BreakAfterCompile))
          {
-         fprintf(stderr, "\n=== Finished compiling %s at %p ===\n", compiler->signature(), metaData->startPC);
+         fprintf(stderr, "\n=== Finished compiling %s at %p ===\n", compiler->signature(), (void *)metaData->startPC);
          TR::Compiler->debug.breakPoint();
          }
 

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -599,7 +599,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       J9UTF8 * name      = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
       J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
       int32_t sigLen = sprintf(buf, "%.*s.%.*s%.*s", className->length, utf8Data(className), name->length, utf8Data(name), signature->length, utf8Data(signature));
-      printf("Initial: Signature %s Count %d isLoopy %d isAOT %d is in SCC %d SCCContainsProfilingInfo %d \n",buf,TR::CompilationInfo::getInvocationCount(method),J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod),
+      printf("Initial: Signature %s Count %d isLoopy %d isAOT %lu is in SCC %d SCCContainsProfilingInfo %d \n",buf,TR::CompilationInfo::getInvocationCount(method),J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod),
             TR::Options::sharedClassCache() ? jitConfig->javaVM->sharedClassConfig->existsCachedCodeForROMMethod(vmThread, romMethod) : 0,
             TR::Options::sharedClassCache() ? compInfo->isRomClassForMethodInSharedCache(method, jitConfig->javaVM) : 0,containsInfo) ; fflush(stdout);
       }
@@ -1504,7 +1504,7 @@ static void jitHookLocalGCStart(J9HookInterface * * hookInterface, UDATA eventNu
 
    if (jitConfig->gcTraceThreshold && jitConfig->gcCount == jitConfig->gcTraceThreshold)
       {
-      printf("\n<jit: enabling stack tracing at gc %d>", jitConfig->gcCount);
+      printf("\n<jit: enabling stack tracing at gc %lu>", jitConfig->gcCount);
       TR::Options::getCmdLineOptions()->setVerboseOption(TR_VerboseGc);
       }
    jitReclaimMarkedAssumptions(false);
@@ -2391,7 +2391,7 @@ static void jitHookThreadEnd(J9HookInterface * * hookInterface, UDATA eventNum, 
 
    if (TR::Options::getCmdLineOptions()->getOption(TR_CountWriteBarriersRT))
       {
-      fprintf(stderr,"Thread %p: Executed %d barriers, %d went to slow path\n", vmThread, vmThread->debugEventData6, vmThread->debugEventData7);
+      fprintf(stderr,"Thread %p: Executed %lu barriers, %lu went to slow path\n", vmThread, vmThread->debugEventData6, vmThread->debugEventData7);
       }
    return;
    }
@@ -3436,7 +3436,7 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
                      {
                      if (traceIt)
                         {
-                        printf("For submethod %p,signature compare fails after bc walk bc !=genericReturn at i(%d)+2\n",i);
+                        printf("For submethod %p,signature compare fails after bc walk bc !=genericReturn at i(%d)+2\n", subMethod, i);
                         fflush(stdout);
                         }
                      matches=false;
@@ -3495,7 +3495,7 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
 
             if (traceIt)
                {
-               printf("For submethod %p, j9methods don't match.  Setting overridden bit. endbc - startbc = %d methodmodifiersaresafe = %d\n",subMethod,(J9_BYTECODE_END_FROM_ROM_METHOD(subROM) - J9_BYTECODE_START_FROM_ROM_METHOD(subROM)),methodModifiersAreSafe);
+               printf("For submethod %p, j9methods don't match.  Setting overridden bit. endbc - startbc = %ld methodmodifiersaresafe = %d\n",subMethod,(J9_BYTECODE_END_FROM_ROM_METHOD(subROM) - J9_BYTECODE_START_FROM_ROM_METHOD(subROM)),methodModifiersAreSafe);
                fflush(stdout);
                }
 

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -552,7 +552,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._cacheStartAddress = fe->sharedCache() ? fe->sharedCache()->getCacheStartAddress() : 0;
          vmInfo._stringCompressionEnabled = fe->isStringCompressionEnabledVM();
          vmInfo._hasSharedClassCache = TR::Options::sharedClassCache();
-         vmInfo._elgibleForPersistIprofileInfo = vmInfo._isIProfilerEnabled ? fe->getIProfiler()->elgibleForPersistIprofileInfo(comp) : NULL;
+         vmInfo._elgibleForPersistIprofileInfo = vmInfo._isIProfilerEnabled ? fe->getIProfiler()->elgibleForPersistIprofileInfo(comp) : false;
          vmInfo._reportByteCodeInfoAtCatchBlock = comp->getOptions()->getReportByteCodeInfoAtCatchBlock();
          for (int32_t i = 0; i <= 7; i++)
             {
@@ -2710,7 +2710,7 @@ remoteCompile(
                "Client successfully loaded method %s @ %s following compilation request. [metaData=%p, startPC=%p]",
                compiler->signature(),
                compiler->getHotnessName(),
-               metaData, (metaData) ? metaData->startPC : NULL
+               metaData, (metaData) ? (void *)metaData->startPC : NULL
                );
             }
          }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1399,7 +1399,7 @@ onLoadInternal(
       }
    if (!TR_DataCacheManager::initialize(jitConfig))
       {
-      printf("{JIT: fatal error, failed to allocate %d Kb data cache}\n", jitConfig->dataCacheKB);
+      printf("{JIT: fatal error, failed to allocate %lu Kb data cache}\n", jitConfig->dataCacheKB);
       return -1;
       }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2266,7 +2266,7 @@ TR_MarkHotField::markHotField(J9Class * clazz, bool rootClass)
       if (rootClass)
          {
          int32_t len; char * s = _symRef->getOwningMethod(_comp)->fieldName(_symRef->getCPIndex(), len, _comp->trMemory());
-         printf("hot field %*s with bitValue=%x and slotIndex=%d found while compiling \n   %s\n", len, s, _bitValue, _slotIndex, _comp->signature());
+         printf("hot field %*s with bitValue=%lx and slotIndex=%lu found while compiling \n   %s\n", len, s, _bitValue, _slotIndex, _comp->signature());
          }
 
       J9ROMClass* romClass = TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock*)clazz);
@@ -4477,7 +4477,7 @@ TR_J9VMBase::printAdditionalInfoOnAssertionFailure(TR::Compilation *comp)
    {
    char *c = (char *)comp->trMemory()->allocateHeapMemory(20);
 
-   sprintf(c, "VMState: %#010x", vmThread()->omrVMThread->vmState);
+   sprintf(c, "VMState: %#010lx", vmThread()->omrVMThread->vmState);
 
    return c;
    }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -8763,7 +8763,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             haveFilter = (bool *) comp()->trMemory()->allocateMemory(sizeof(bool) * numFilters, stackAlloc);
             for (int i = 0; i <numFilters; i++)
                {
-               haveFilter[i] = filters[i] != NULL;
+               haveFilter[i] = (filters[i] != 0) ? true: false;
                }
             }
          else


### PR DESCRIPTION
[skip ci]
Made small changes to eliminate warnings during compilation

-Eliminated warnings where possible in CompilationThread.cpp,
 JITaaSCompilationThread.cpp, VMJ9.cpp, j9method.cpp,
 CompilationControl.cpp, HookedBytheJIT.cpp, and rossa.cpp
-Left a few warnings relating to casting from int to pointer
-Corrected simple misuse of printf %d and %x, changed
 to %lx, %lu, %u, based on the variable type and the
 format it was intended to be printed as
-Misuse of comparison between int and NULL

Issue: #6144

Signed-off-by: caohaley <haleycao88@hotmail.com>