### PR TITLE
Add includes or forward declarations for TR_InlineBlock(s)

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "codegen/CodeGenerator.hpp"
+#include "compile/InlineBlock.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"

--- a/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,8 @@
 #include "env/IO.hpp"
 #include "env/jittypes.h"
 #include "infra/Annotations.hpp"
+
+class TR_InlineBlocks;
 
 namespace TR
 {

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -37,6 +37,7 @@
 #include "infra/Stack.hpp"
 #include "env/VMJ9.h"
 
+class TR_InlineBlocks;
 class TR_PersistentClassInfo;
 class TR_BitVector;
 namespace TR { class IlGeneratorMethodDetails; }

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #include "codegen/FrontEnd.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/InlineBlock.hpp"
 #include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/CompilerEnv.hpp"

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
+#include "compile/InlineBlock.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -26,6 +26,7 @@
 #include "optimizer/J9EstimateCodeSize.hpp"
 
 #include "env/KnownObjectTable.hpp"
+#include "compile/InlineBlock.hpp"
 #include "compile/OSRData.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/CompilerEnv.hpp"

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
+#include "compile/InlineBlock.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -105,7 +106,7 @@ class NeedsPeekingHeuristic
             //as soon as one of those becomes a receiver this very same assertion
             //should fire
             TR_ASSERT(comp->fej9()->isInstanceOf(argClass, clazz, true, true, true) == TR_yes || i != 0 || !calltarget->_myCallSite->_isIndirectCall, "Incompatible receiver should have been handled by findCallSiteTarget");
-            
+
             // even the arg type propagated from the caller might be not more specific
             // than the type got from callee signature, we should still try to
             // do peeking. if we don't do peeking here, we will lose the chance to propagate
@@ -422,10 +423,10 @@ static bool cameFromArchetypeSpecimen(TR_ResolvedMethod *method)
    else
       return cameFromArchetypeSpecimen(method->owningMethod());
    }
-   
-bool 
+
+bool
 TR_J9EstimateCodeSize::adjustEstimateForStringCompression(TR_ResolvedMethod* method, int32_t& value, float factor)
-   {   
+   {
    const uint16_t classNameLength = method->classNameLength();
 
    if ((classNameLength == 16 && !strncmp(method->classNameChars(), "java/lang/String", classNameLength)) ||
@@ -435,17 +436,17 @@ TR_J9EstimateCodeSize::adjustEstimateForStringCompression(TR_ResolvedMethod* met
       // A statistical analysis of the number of places certain methods got inlined yielded results which suggest that the
       // following recognized methods incurr several percent worth of increase in compile-time at no benefit to throughput.
       // As such we can save additional compile-time by not making adjustments to these methods.
-      
+
       if (method->getRecognizedMethod() != TR::java_lang_String_regionMatches &&
           method->getRecognizedMethod() != TR::java_lang_String_regionMatches_bool &&
           method->getRecognizedMethod() != TR::java_lang_String_equals)
          {
          value *= factor;
-      
+
          return true;
          }
       }
-      
+
    return false;
    }
 
@@ -1019,9 +1020,9 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
       bcSizes[i] = size;
       }
-      
+
    auto sizeBeforeAdjustment = size;
-      
+
    if (adjustEstimateForStringCompression(calltarget->_calleeMethod, size, STRING_COMPRESSION_ADJUSTMENT_FACTOR))
       {
       heuristicTrace(tracer(), "*** Depth %d: Adjusting size for %s because of string compression from %d to %d", _recursionDepth, callerName, sizeBeforeAdjustment, size);
@@ -2102,26 +2103,26 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          }
 
 	auto partialSizeBeforeAdjustment = calltarget->_partialSize;
-	
+
    if (adjustEstimateForStringCompression(calltarget->_calleeMethod, calltarget->_partialSize, STRING_COMPRESSION_ADJUSTMENT_FACTOR))
       {
       heuristicTrace(tracer(), "*** Depth %d: Adjusting partial size for %s because of string compression from %d to %d", _recursionDepth, callerName, partialSizeBeforeAdjustment, calltarget->_partialSize);
       }
-   
+
    auto fullSizeBeforeAdjustment = calltarget->_fullSize;
-   
+
    if (adjustEstimateForStringCompression(calltarget->_calleeMethod, calltarget->_fullSize, STRING_COMPRESSION_ADJUSTMENT_FACTOR))
       {
       heuristicTrace(tracer(), "*** Depth %d: Adjusting full size for %s because of string compression from %d to %d", _recursionDepth, callerName, fullSizeBeforeAdjustment, calltarget->_fullSize);
       }
-      
+
    auto realSizeBeforeAdjustment = _realSize;
-   
+
    if (adjustEstimateForStringCompression(calltarget->_calleeMethod, _realSize, STRING_COMPRESSION_ADJUSTMENT_FACTOR))
       {
       heuristicTrace(tracer(), "*** Depth %d: Adjusting real size for %s because of string compression from %d to %d", _recursionDepth, callerName, realSizeBeforeAdjustment, _realSize);
       }
-   
+
       reduceDAAWrapperCodeSize(calltarget);
 
       /****************** PHASE 5: Figure out if We're really going to do a partial Inline and add whatever we do to the realSize. *******************/


### PR DESCRIPTION
Refactoring in OMR means that OpenJ9 will have to explicitly forward declare
or include the definition.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>