### PR TITLE
AArch64: Add ARM64ArrayCopy.spp

### DIFF
--- a/runtime/compiler/aarch64/runtime/ARM64ArrayCopy.spp
+++ b/runtime/compiler/aarch64/runtime/ARM64ArrayCopy.spp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+	.file	"ARM64ArrayCopy.s"
+
+	.global	__arrayCopy
+
+	.text
+	.align	2
+
+// Copy array elements
+//
+// in:    x0 - length in bytes
+//        x1 - src addr
+//        x2 - dst addr
+// trash: x3
+
+__arrayCopy:
+	cbz	x0, finished		// return if no bytes to copy
+	subs	x3, x2, x1
+	beq	finished		// return if srcAddr == dstAddr
+	cmp	x0, x3
+	bhi	reverseArrayCopy	// byteLength > dstAddr - srcAddr, must do reverse array copy
+
+// ToDo: Optimize the code with wider memory access
+
+// forward copy
+byteCopyLoop:
+	ldrb	w3, [x1], #1
+	subs	x0, x0, #1
+	strb	w3, [x2], #1
+	bne	byteCopyLoop
+finished:
+	ret
+
+// backward copy
+reverseArrayCopy:
+	add	x1, x1, x0
+	add	x2, x2, x0
+reverseByteCopyLoop:
+	ldrb	w3, [x1, #-1]!
+	subs	x0, x0, #1
+	strb	w3, [x2, #-1]!
+	bne	reverseByteCopyLoop
+	ret

--- a/runtime/compiler/aarch64/runtime/CMakeLists.txt
+++ b/runtime/compiler/aarch64/runtime/CMakeLists.txt
@@ -23,6 +23,7 @@
 j9jit_files(
 	${omr_SOURCE_DIR}/compiler/aarch64/runtime/CodeSync.cpp
 	${omr_SOURCE_DIR}/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+	aarch64/runtime/ARM64ArrayCopy.spp
 	aarch64/runtime/FlushICache.spp
 	aarch64/runtime/PicBuilder.spp
 	aarch64/runtime/Recomp.cpp

--- a/runtime/compiler/build/files/host/aarch64.mk
+++ b/runtime/compiler/build/files/host/aarch64.mk
@@ -23,6 +23,7 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
 
 JIT_PRODUCT_SOURCE_FILES+= \
+    compiler/aarch64/runtime/ARM64ArrayCopy.spp \
     compiler/aarch64/runtime/FlushICache.spp \
     compiler/aarch64/runtime/PicBuilder.spp \
     compiler/aarch64/runtime/Recomp.cpp \


### PR DESCRIPTION
This commit adds a new file ARM64ArrayCopy.spp for AArch64 with
minimal implementation of the routine.

Signed-off-by: knn-k <konno@jp.ibm.com>