### PR TITLE
Use a common query to decide what to generate for virtual guards

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -107,6 +107,20 @@ public:
 
    void fixUpProfiledInterfaceGuardTest();
 
+   /**
+    * \brief
+    *      This query is used by both fixUpProfiledInterfaceGuardTest (a codegen level optimization) and virtual guard evaluators
+    *      to decide whether a NOP guard should be generated. It's used on all platforms and compilation phases so that the decision
+    *      of generating VG NOPs is made in a consistent way.
+    *
+    * \param node
+    *      the virtual guard node
+    *
+    * \return
+    *      true if a NOP virtual guard should be generated. Otherwise, false.
+   */
+   bool willGenerateNOPForVirtualGuard(TR::Node* node);
+
    void zeroOutAutoOnEdge(TR::SymbolReference * liveAutoSym, TR::Block *block, TR::Block *succBlock, TR::list<TR::Block*> *newBlocks, TR_ScratchList<TR::Node> *fsdStores);
 
    TR::Linkage *createLinkageForCompilation();


### PR DESCRIPTION
The virtualGuardHelper() on x86, PPC, and z uses separate but similar
logic to decide whether a NOP virtual guard should be generated.

This change pulls the logic from the OMR project into the common layer
so all platforms can use the same query and make VG NOP decisions in a
consistent way.

This unified query is based on x86 implementation and has HCR guard
added to it.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>