### PR TITLE
Reduce number of messages for TR_J9ServerVM::getMethods

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3878,6 +3878,11 @@ JITaaSHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo, Cl
          *(uintptrj_t *)data = classInfo.classFlags;
          }
          break;
+      case CLASSINFO_METHODS_OF_CLASS :
+         {
+         *(J9Method **)data = classInfo.methodsOfClass;
+         }
+         break;
       default :
          {
          TR_ASSERT(0, "Class Info not supported %u \n", dataType);

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -416,6 +416,7 @@ class JITaaSHelpers
       CLASSINFO_CLASS_OF_STATIC_CACHE,
       CLASSINFO_REMOTE_ROM_CLASS,
       CLASSINFO_CLASS_FLAGS,
+      CLASSINFO_METHODS_OF_CLASS,
       };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -626,9 +626,10 @@ TR_J9ServerVM::isString(TR_OpaqueClassBlock * clazz)
 void *
 TR_J9ServerVM::getMethods(TR_OpaqueClassBlock * clazz)
    {
+   J9Method *methodsOfClass = NULL;
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getMethods, clazz);
-   return std::get<0>(stream->read<void *>());
+   JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *) clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_METHODS_OF_CLASS, (void *) &methodsOfClass); 
+   return methodsOfClass;
    }
 
 void


### PR DESCRIPTION
This method simply returns a pointer to `J9Method`s of the
class, which is already cached in `ClassInfo`.
Look it up there, instead of making a remote call to the client.
