### PR TITLE
Verify LocalVariable(Type)Table index

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1921,6 +1921,8 @@ checkAttributes(J9CfrClassFile* classfile, J9CfrAttribute** attributes, U_32 att
 					errorCode = J9NLS_CFR_ERR_LOCAL_VARIABLE_SIGNATURE_INVALID__ID;
 					goto _errorFound;
 				}
+
+				/* index range verification happens in ClassFileOracle.cpp with Xfuture */
 			}
 			break;
 
@@ -1956,6 +1958,8 @@ checkAttributes(J9CfrClassFile* classfile, J9CfrAttribute** attributes, U_32 att
 					errorCode = J9NLS_CFR_ERR_LOCAL_VARIABLE_SIGNATURE_NOT_UTF8__ID;
 					goto _errorFound;
 				}
+
+				/* index range verification happens in ClassFileOracle.cpp with Xfuture */
 			}
 			break;
 

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -486,6 +486,8 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 	if ((J9VM_DEBUG_ATTRIBUTE_RECORD_ALL == (vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_RECORD_ALL))
 			&& classCouldPossiblyBeShared(vmThread, loadData)) {
 		/* Shared Classes has requested that all debug information be kept and the class will be shared. */
+	} else if (0 != (vm->runtimeFlags & J9_RUNTIME_XFUTURE)) {
+		/* Don't strip debug information with Xfuture */
 	} else {
 		/* either the class is not going to be shared  -or- shared classes does not require the debug information to be maintained */
 		UDATA stripFlags = 0;


### PR DESCRIPTION
JVM spec for Java 9+ states in section 4.7.13 and 4.7.14 for LocalVariableTable and LocalVariableTypeTable:

"The value of the index item must be a valid index into the local variable
array of the current frame. The given local variable is at index in the local
variable array of the current frame."

Java 8:
"The given local variable must be at index in the local variable array of the
current frame."

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>