### PR TITLE
Fix Windows compile failure

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -698,8 +698,9 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_LOAD_AGENT_MODULE)
 		&& (NULL != vm->modulesPathEntry->extraInfo))
 	{
+		const char *module = NULL;
 		Trc_JCL_initializeRequiredClasses_addAgentModuleEntry(vmThread);
-		const char *module = vm->jimageIntf->jimagePackageToModule(
+		module = vm->jimageIntf->jimagePackageToModule(
 				vm->jimageIntf, (UDATA) vm->modulesPathEntry->extraInfo,
 				"jdk/internal/agent");
 		if (NULL != module) {


### PR DESCRIPTION
Put the tracepoint after the variable declaration.
Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>