### PR TITLE
WIP: Move/Repurpose JDBCNative Bit Class Flag For New Self Referencing Flag

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1143,7 +1143,7 @@ done:
 				currentThread->javaOffloadState = 0;
 				/* check if the class requires lazy switching (for JDBC) or normal switching */
 				J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
-				if (J9_ARE_ANY_BITS_SET(J9CLASS_FLAGS(methodClass), J9AccClassHasJDBCNatives)) {
+				if (J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(methodClass), J9AccClassHasJDBCNatives)) {
 					vm->javaOffloadSwitchJDBCWithMethodFunc(currentThread, method);
 				} else {
 					vm->javaOffloadSwitchOffWithMethodFunc(currentThread, method);

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -49,7 +49,7 @@
 #define J9AccClassHasEmptyFinalize 0x200000
 #define J9AccClassIsUnmodifiable 0x400000
 #define J9AccClassHasFinalFields 0x2000000
-#define J9AccClassHasJDBCNatives 0x400000
+#define J9AccClassSelfReferencing 0x400000
 #define J9AccClassHasNonStaticNonAbstractMethods 0x8000000
 #define J9AccClassHasVerifyData 0x800000
 #define J9AccClassHotSwappedOut 0x4000000

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -77,6 +77,7 @@
 #define J9ClassLargestAlignmentConstraintReference 0x800
 #define J9ClassLargestAlignmentConstraintDouble 0x1000
 #define J9ClassIsExemptFromValidation 0x2000
+#define J9AccClassHasJDBCNatives 0x4000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 

--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -1017,7 +1017,7 @@ lookupJNINative(J9VMThread *currentThread, J9NativeLibrary *nativeLibrary, J9Met
 				J9Class* ramClass;
 				
 				ramClass = J9_CLASS_FROM_METHOD(nativeMethod);
-				ramClass->classDepthAndFlags |= J9AccClassHasJDBCNatives;
+				ramClass->classFlags |= J9AccClassHasJDBCNatives;
 			}
 		}
 #endif

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2579,7 +2579,7 @@ fail:
 			 *
 			 *              + AccClassHasBeenOverridden (set during internal class load hook, not inherited)
 			 *             + AccClassOwnableSynchronizer (set during internal class load hook and inherited)
-			 *            + AccClassHasJDBCNatives (set during native method binding, not inherited)
+			 *            + AccClassSelfReferencing (set while calculating class description, inherited)
 			 *           + AccClassGCSpecial (set during internal class load hook and inherited)
 			 *
 			 *         + AccClassIsContended (from romClass->extraModifiers and inherited)
@@ -2612,7 +2612,7 @@ fail:
 			 *
 			 *                        + J9ClassLargestAlignmentConstraintDouble
 			 *                       + J9ClassIsExemptFromValidation (inherited)
-			 *                      + Unused
+			 *                      + J9AccClassHasJDBCNatives (set during native method binding, not inherited)
 			 *                     + Unused
 			 *
 			 *                   + Unused
@@ -2673,7 +2673,7 @@ fail:
 				}
 				/* fill in class depth */
 				tempClassDepthAndFlags |= superclass->classDepthAndFlags;
-				tempClassDepthAndFlags &= ~(J9AccClassHotSwappedOut | J9AccClassHasBeenOverridden | J9AccClassHasJDBCNatives | J9AccClassRAMArray | (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift));
+				tempClassDepthAndFlags &= ~(J9AccClassHotSwappedOut | J9AccClassHasBeenOverridden | J9AccClassRAMArray | (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift));
 				tempClassDepthAndFlags++;
 				
 #if defined(J9VM_GC_FINALIZATION)


### PR DESCRIPTION
- New class flag, J9AccClassSelfReferencing, introduced to mark classes
with self referencing fields (i.e., 0x400000 bit in classDepthAndFlags)
- Replace JDBCNative bit in classDepthAndFlags for new J9AccClassSelfReferencing
	- J9AccClassSelfReferencing flag must be part of classDepthAndFlags to optimize
check for GC
	- All bits in classDepthAndFlags are used, hence JDBCNative has been
moved to an unused bit (0x4000) in extended flags

Signed-off-by: Salman Rana <salman.rana@ibm.com>