### PR TITLE
Fix typo in z/codegen/J9TreeEvaluator.cpp

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2453,9 +2453,9 @@ genInstanceOfOrCheckCastNullTest(TR::Node* node, TR::CodeGenerator* cg, TR::Regi
       {
       if (cg->getHasResumableTrapHandler())
          {
-         TR::Instruction* compareAndTrapInsturction = generateRIEInstruction(cg, TR::InstOpCode::getCmpImmTrapOpCode(), node, objectReg, 0, TR::InstOpCode::COND_BE);
-         compareAndTrapInsturction->setExceptBranchOp();
-         compareAndTrapInsturction->setNeedsGCMap(0x0000FFFF);
+         TR::Instruction* compareAndTrapInstruction = generateRIEInstruction(cg, TR::InstOpCode::getCmpImmTrapOpCode(), node, objectReg, 0, TR::InstOpCode::COND_BE);
+         compareAndTrapInstruction->setExceptBranchOp();
+         compareAndTrapInstruction->setNeedsGCMap(0x0000FFFF);
          }
       else
          {


### PR DESCRIPTION
Fixes: #6198

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>