### PR TITLE
Enable Contiguous TR_DataAddress Relocations on Power

### DIFF
--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -202,6 +202,10 @@ TR_PPC32RelocationTarget::storeRelativeAddressSequence(uint8_t *address, uint8_t
 void
 TR_PPC64RelocationTarget::storeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber)
    {
+   //Contingious Word
+   if(seqNumber == 7)
+      return storePointer(address, reloLocation);
+
    uint16_t value1, value2, value3, value4;
    uint16_t *patchAddr1, *patchAddr2, *patchAddr3, *patchAddr4;
    uintptr_t highValue;


### PR DESCRIPTION
Currently Power only supports Dis-contiguous Relocations during the TR_DataAddress relocation kind.
Contiguous relocations will be represented by the fixedSequence7 fixed sequence kind.

Signed-off-by: Alen Badel <Alen.Badel@ibm.com>