### PR TITLE
Update to use renamed compiler headers

### DIFF
--- a/runtime/compiler/p/codegen/GenerateInstructions.hpp
+++ b/runtime/compiler/p/codegen/GenerateInstructions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "omr/compiler/p/codegen/GenerateInstructions.hpp"
+#include "codegen/GenerateOMRInstructions.hpp"
 
 TR::Instruction *generateVirtualGuardNOPInstruction(
                    TR::CodeGenerator      *cg,


### PR DESCRIPTION
See eclipse/omr#4062

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>