### PR TITLE
Add JDK13 ref repo to slave repo caches

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -262,6 +262,8 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git init --bare \
   && git remote add jdk8 https://github.com/ibmruntimes/openj9-openjdk-jdk8.git \
   && git remote add jdk11 https://github.com/ibmruntimes/openj9-openjdk-jdk11.git \
+  && git remote add jdk12 https://github.com/ibmruntimes/openj9-openjdk-jdk12.git \
+  && git remote add jdk13 https://github.com/ibmruntimes/openj9-openjdk-jdk13.git \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -177,6 +177,8 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git init --bare \
   && git remote add jdk8 https://github.com/ibmruntimes/openj9-openjdk-jdk8.git \
   && git remote add jdk11 https://github.com/ibmruntimes/openj9-openjdk-jdk11.git \
+  && git remote add jdk12 https://github.com/ibmruntimes/openj9-openjdk-jdk12.git \
+  && git remote add jdk13 https://github.com/ibmruntimes/openj9-openjdk-jdk13.git \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -258,6 +258,8 @@ RUN mkdir /home/${USER}/openjdk_cache \
   && git init --bare \
   && git remote add jdk8 https://github.com/ibmruntimes/openj9-openjdk-jdk8.git \
   && git remote add jdk11 https://github.com/ibmruntimes/openj9-openjdk-jdk11.git \
+  && git remote add jdk12 https://github.com/ibmruntimes/openj9-openjdk-jdk12.git \
+  && git remote add jdk13 https://github.com/ibmruntimes/openj9-openjdk-jdk13.git \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
   && git remote add omr https://github.com/eclipse/openj9-omr.git \

--- a/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos
+++ b/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos
@@ -131,7 +131,7 @@ def config(remoteName, remoteUrl) {
 */
 def get_openjdk_repos(openJdkMap, useDefault) {
     def repos = []
-    def releases = ['8', '11', '12']
+    def releases = ['8', '11', '12', '13']
 
     // iterate over VARIABLES.openjdk map and fetch the repository URL
     openJdkMap.entrySet().each { mapEntry ->


### PR DESCRIPTION
- Add JDK12,13 repos to Dockerfile repo caches
- Add JDK13 repo to Ref Repo Updater job

[Skip ci]
Fixes #6202

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>