### PR TITLE
Transform and inline dsqrt evaluator

### DIFF
--- a/runtime/compiler/il/symbol/J9ResolvedMethodSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9ResolvedMethodSymbol.cpp
@@ -34,9 +34,6 @@ J9::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod *method, TR::Co
          (method->getRecognizedMethod() == TR::java_lang_StrictMath_floor) ||
          (method->getRecognizedMethod() == TR::java_lang_Math_ceil) ||
          (method->getRecognizedMethod() == TR::java_lang_StrictMath_ceil))) ||
-       (TR::Compiler->target.cpu.getSupportsHardwareSQRT() &&
-        ((method->getRecognizedMethod() == TR::java_lang_Math_sqrt) ||
-         (method->getRecognizedMethod() == TR::java_lang_StrictMath_sqrt))) ||
        (TR::Compiler->target.cpu.getSupportsHardwareCopySign() &&
         ((method->getRecognizedMethod() == TR::java_lang_Math_copySign_F) ||
          (method->getRecognizedMethod() == TR::java_lang_Math_copySign_D))))

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -388,9 +388,8 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_StringUTF16_toBytes:
          return !comp()->compileRelocatableCode();
       case TR::java_lang_StrictMath_sqrt:
-         return true;
       case TR::java_lang_Math_sqrt:
-         return true;
+         return TR::Compiler->target.cpu.isZ();
       default:
          return false;
       }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -106,8 +106,6 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
 
 void J9::RecognizedCallTransformer::process_java_lang_StrictMath_sqrt(TR::TreeTop* treetop, TR::Node* node)
    {
-   if (!node->getSymbol()->castToResolvedMethodSymbol()->canReplaceWithHWInstr())
-      {
       TR::Node* dumpNode = node->getChild(0);
       TR::Node* valueNode = node->getChild(1);
 
@@ -116,13 +114,6 @@ void J9::RecognizedCallTransformer::process_java_lang_StrictMath_sqrt(TR::TreeTo
 
       TR::Node::recreateWithoutProperties(node, TR::dsqrt, 1, valueNode, getSymRefTab()->findOrCreateNewArraySymbolRef(node->getSymbolReference()->getOwningMethodSymbol(comp())));
       TR::TransformUtil::removeTree(comp(), treetop);
-      }
-
-   else
-      {
-      TR::Node::recreate(node, TR::dsqrt);
-      TR::TransformUtil::removeTree(comp(), treetop);
-      }
    }
 /*
 Transform an Unsafe atomic call to diamonds with equivalent semantics
@@ -389,7 +380,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          return !comp()->compileRelocatableCode();
       case TR::java_lang_StrictMath_sqrt:
       case TR::java_lang_Math_sqrt:
-         return true;
+         return TR::Compiler->target.cpu.getSupportsHardwareSQRT();;
       default:
          return false;
       }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -103,7 +103,13 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
 
    treetop->insertAfter(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, newCallNode)));
    }
-
+   
+void J9::RecognizedCallTransformer::process_java_lang_StrictMath_sqrt(TR::TreeTop* treetop, TR::Node* node)
+   {
+      anchorNode(node->getFirstChild(), treetop);
+      TR::Node::recreate(node, TR::dsqrt);
+      TR::TransformUtil::removeTree(comp(), treetop);
+   }
 /*
 Transform an Unsafe atomic call to diamonds with equivalent semantics
 
@@ -420,6 +426,12 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
          break;
       case TR::java_lang_StringUTF16_toBytes:
          process_java_lang_StringUTF16_toBytes(treetop, node);
+         break;
+      case TR::java_lang_StrictMath_sqrt:
+         process_java_lang_StrictMath_sqrt(treetop, node);
+         break;
+      case TR::java_lang_Math_sqrt:
+         processIntrinsicFunction(treetop, node, TR::dsqrt);
          break;
       default:
          break;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -389,7 +389,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          return !comp()->compileRelocatableCode();
       case TR::java_lang_StrictMath_sqrt:
       case TR::java_lang_Math_sqrt:
-         return TR::Compiler->target.cpu.isZ();
+         return true;
       default:
          return false;
       }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -104,12 +104,11 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
    treetop->insertAfter(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, newCallNode)));
    }
 
-void J9::RecognizedCallTransformer::process_java_lang_StrictMath_sqrt(TR::TreeTop* treetop, TR::Node* node)
+void J9::RecognizedCallTransformer::process_java_lang_StrictMath_and_Math_sqrt(TR::TreeTop* treetop, TR::Node* node)
    {
-      TR::Node* dumpNode = node->getChild(0);
-      TR::Node* valueNode = node->getChild(1);
+      TR::Node* valueNode = node->getLastChild();
 
-      anchorNode(dumpNode, treetop);
+      anchorAllChildren(node, treetop);
       prepareToReplaceNode(node);
 
       TR::Node::recreateWithoutProperties(node, TR::dsqrt, 1, valueNode, getSymRefTab()->findOrCreateNewArraySymbolRef(node->getSymbolReference()->getOwningMethodSymbol(comp())));
@@ -436,10 +435,8 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
          process_java_lang_StringUTF16_toBytes(treetop, node);
          break;
       case TR::java_lang_StrictMath_sqrt:
-         process_java_lang_StrictMath_sqrt(treetop, node);
-         break;
       case TR::java_lang_Math_sqrt:
-         processIntrinsicFunction(treetop, node, TR::dsqrt);
+         process_java_lang_StrictMath_and_Math_sqrt(treetop, node);
          break;
       default:
          break;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -78,6 +78,22 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     */
    void process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node);
    /** \brief
+    *     Transforms java/lang/StrictMath.sqrt(D)D into a CodeGen inlined function with equivalent semantics.
+    *
+    *  \param treetop
+    *     The treetop which anchors the call node.
+    *
+    *  \param node
+    *     The call node representing a call to java/lang/StrictMath.sqrt(D)D which has the following shape:
+    *
+    *     \code
+    *     dcall  java/lang/StrictMath.sqrt(D)D
+    *       <jclass>
+    *       <value>
+    *     \endcode
+    */
+   void process_java_lang_StrictMath_sqrt(TR::TreeTop* treetop, TR::Node* node);
+   /** \brief
     *     Transforms certain Unsafe atomic helpers into a CodeGen inlined helper with equivalent semantics.
     *
     *  \param treetop

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under
 * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -78,7 +78,7 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     */
    void process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node);
    /** \brief
-    *     Transforms java/lang/StrictMath.sqrt(D)D into a CodeGen inlined function with equivalent semantics.
+    *     Transforms java/lang/StrictMath.sqrt(D)D and java/lang/Math.sqrt(D)D into a CodeGen inlined function with equivalent semantics.
     *
     *  \param treetop
     *     The treetop which anchors the call node.
@@ -87,12 +87,12 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     *     The call node representing a call to java/lang/StrictMath.sqrt(D)D which has the following shape:
     *
     *     \code
-    *     dcall  java/lang/StrictMath.sqrt(D)D
+    *     dcall  java/lang/StrictMath.sqrt(D)D or java/lang/Math.sqrt(D)D
     *       <jclass>
     *       <value>
     *     \endcode
     */
-   void process_java_lang_StrictMath_sqrt(TR::TreeTop* treetop, TR::Node* node);
+   void process_java_lang_StrictMath_and_Math_sqrt(TR::TreeTop* treetop, TR::Node* node);
    /** \brief
     *     Transforms certain Unsafe atomic helpers into a CodeGen inlined helper with equivalent semantics.
     *

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -13423,15 +13423,6 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          break;
          }
 
-      case TR::java_lang_Math_sqrt:
-      case TR::java_lang_StrictMath_sqrt:
-         if (methodSymbol->getResolvedMethodSymbol()->canReplaceWithHWInstr())
-            {
-            resultReg = inlineDoublePrecisionFP(node, TR::InstOpCode::fsqrt, cg);
-            return true;
-            }
-         break;
-
       case TR::java_lang_Math_ceil:
       case TR::java_lang_StrictMath_ceil:
          if (methodSymbol->getResolvedMethodSymbol()->canReplaceWithHWInstr())

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -8978,115 +8978,6 @@ inlineNanoTime(
 #endif
 #endif // LINUX
 
-static bool
-inlineMathSQRT(
-      TR::Node *node,
-      TR::CodeGenerator *cg)
-   {
-   // Sometimes the call can have 2 children, where the first one is loadaddr
-   TR::Node *operand = NULL;
-   TR::Node *firstChild = NULL;
-   TR::Register *targetRegister = NULL;
-
-   if (node->getNumChildren() == 1)
-      {
-      operand = node->getFirstChild();
-      }
-   else
-      {
-      firstChild = node->getFirstChild();
-      operand    = node->getSecondChild();
-      }
-
-   if (node->getReferenceCount()==1)
-      {
-      if (firstChild)
-         cg->recursivelyDecReferenceCount(firstChild);
-
-      cg->recursivelyDecReferenceCount(operand);
-      return true;
-      }
-
-
-   // The current Neutrino sqrt() runtime function does not always return
-   // a result in the expected precision.  Hence, do not fold constants
-   // at compile time.
-   //
-   // TODO: Instead of avoiding it altogether the preferred fix is to call
-   // the fdlibm version of sqrt (involves linking in the fdlibm library).
-   //
-   if (operand->getOpCode().isLoadConst())
-      {
-      union
-         {
-         struct
-            {
-            uint32_t lower;
-            uint32_t upper;
-            } s;
-         double   doubleVal;
-         int64_t  rawBits;
-         } d;
-
-      d.doubleVal = operand->getDouble();
-
-      // Do not assume that the C runtime will return the correct values that Java requires
-      // for a j/l/Math.sqrt() call.  Provide the correct values for the special cases.
-      //
-      if (d.s.upper & 0x80000000)
-         {
-         if (d.s.upper != 0x80000000 || d.s.lower != 0x00000000)
-            {
-            // -ve number other than -0.0 returns NaN.
-            // -0.0 returns -0.0.
-            //
-            d.s.lower = 0;
-            d.s.upper = 0x7ff80000;
-            }
-         }
-      else if (! ((d.s.lower == 0) && (d.s.upper == 0 || d.s.upper == 0x7ff00000 || d.s.upper == 0x7ff80000)))
-         {
-         // +0.0 or +INF or NaN returns the argument.
-         // Anything else can be computed from the sqrt() function.
-         //
-         d.doubleVal = sqrt(d.doubleVal);
-         }
-
-      auto cds = cg->findOrCreate8ByteConstant(operand, d.rawBits);
-
-      targetRegister = cg->allocateRegister(TR_FPR);
-      generateRegMemInstruction(MOVSDRegMem, node, targetRegister, generateX86MemoryReference(cds, cg), cg);
-      }
-   else
-      {
-      TR::Register *opRegister = NULL;
-      opRegister = cg->evaluate(operand);
-
-      if (opRegister->getKind() == TR_FPR)
-         {
-         if (operand->getReferenceCount()==1)
-            targetRegister = opRegister;
-         else
-            targetRegister = cg->allocateRegister(TR_FPR);
-
-         generateRegRegInstruction(SQRTSDRegReg, node, targetRegister, opRegister, cg);
-         }
-      else
-         {
-         targetRegister = cg->doubleClobberEvaluate(operand);
-         generateFPRegInstruction(DSQRTReg, node, targetRegister, cg);
-         }
-      }
-
-   node->setRegister(targetRegister);
-   if (firstChild)
-      cg->recursivelyDecReferenceCount(firstChild);
-
-   cg->decReferenceCount(operand);
-   return true;
-
-   }
-
 // Convert serial String.hashCode computation into vectorization copy and implement with SSE instruction
 //
 // Conversion process example:
@@ -10038,11 +9929,6 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             }
             break;
 
-         case TR::java_lang_Math_sqrt:
-         case TR::java_lang_StrictMath_sqrt:
-            {
-            return inlineMathSQRT(node, cg);
-            }
 
          case TR::java_lang_Long_reverseBytes:
          case TR::java_lang_Integer_reverseBytes:


### PR DESCRIPTION
Transform to `dsqrt` and inline it when calling `java_lang_StrictMath_sqrt` and `java_lang_Math_sqrt`. Also, anchor and delete the `jclass` child when there are two children in the `dcall java_lang_StrictMath_sqrt`/`dcall java_lang_Math_sqrt` tree.

The changes are for all platforms.

Closes: #5702