### PR TITLE
Check class contain unflattened flattenables and set default value to them

### DIFF
--- a/runtime/gc_modron_startup/mgcalloc.cpp
+++ b/runtime/gc_modron_startup/mgcalloc.cpp
@@ -126,6 +126,10 @@ J9AllocateObjectNoGC(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFla
 		}
 	}
 
+	if ((NULL != objectPtr) && J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassContainsUnflattenedFlattenables)) {
+		vmThread->javaVM->internalVMFunctions->defaultValueWithUnflattenedFlattenables(vmThread, clazz, objectPtr);
+	}
+
 	return objectPtr;
 }
 
@@ -461,6 +465,10 @@ J9AllocateObject(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFlags)
 			}
 #endif /* defined(J9VM_GC_REALTIME) */
 		}
+	}
+
+	if ((NULL != objectPtr) && J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassContainsUnflattenedFlattenables)) {
+		vmThread->javaVM->internalVMFunctions->defaultValueWithUnflattenedFlattenables(vmThread, clazz, objectPtr);
 	}
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -733,34 +733,6 @@ done:
 	}
 
 	/**
-	 * Perform a non-instrumentable allocation of a non-indexable class.
-	 * If inline allocation fails, the out of line allocator will be called.
-	 * This function assumes that the stack and live values are in a valid state for GC.
-	 *
-	 * If allocation fails, a heap OutOfMemory error is set pending on the thread.
-	 *
-	 * @param currentThread[in] the current J9VMThread
-	 * @param objectAllocate[in] instance of MM_ObjectAllocationAPI created on the current thread
-	 * @param j9clazz[in] the non-indexable J9Class to instantiate
-	 * @param initializeSlots[in] whether or not to initialize the slots (default true)
-	 * @param memoryBarrier[in] whether or not to issue a write barrier (default true)
-	 *
-	 * @returns the new object, or NULL if allocation failed
-	 */
-	static VMINLINE j9object_t
-	allocateObject(J9VMThread *currentThread, MM_ObjectAllocationAPI *objectAllocate, J9Class *clazz, bool initializeSlots = true, bool memoryBarrier = true)
-	{
-		j9object_t instance = objectAllocate->inlineAllocateObject(currentThread, clazz, initializeSlots, memoryBarrier);
-		if (NULL == instance) {
-			instance = currentThread->javaVM->memoryManagerFunctions->J9AllocateObject(currentThread, clazz, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
-			if (J9_UNEXPECTED(NULL == instance)) {
-				setHeapOutOfMemoryError(currentThread);
-			}
-		}
-		return instance;
-	}
-
-	/**
 	 * Perform a non-instrumentable allocation of an indexable class.
 	 * If inline allocation fails, the out of line allocator will be called.
 	 * This function assumes that the stack and live values are in a valid state for GC.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -77,6 +77,7 @@
 #define J9ClassLargestAlignmentConstraintReference 0x800
 #define J9ClassLargestAlignmentConstraintDouble 0x1000
 #define J9ClassIsExemptFromValidation 0x2000
+#define J9ClassContainsUnflattenedFlattenables 0x4000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 
@@ -1730,7 +1731,7 @@ typedef struct J9ModuleExtraInfo {
  ***************************************************************/
 typedef struct J9FlattenedClassCacheEntry {
 	struct J9Class* clazz;
-	struct J9ROMNameAndSignature* nameAndSignature;
+	struct J9ROMFieldShape * field;
 	UDATA offset;
 } J9FlattenedClassCacheEntry;
 
@@ -4641,6 +4642,7 @@ typedef struct J9InternalVMFunctions {
 #else
 	struct J9ROMFieldOffsetWalkResult*  ( *fieldOffsetsStartDo)(struct J9JavaVM *vm, struct J9ROMClass *romClass, struct J9Class *superClazz, struct J9ROMFieldOffsetWalkState *state, U_32 flags) ;
 #endif
+	void ( *defaultValueWithUnflattenedFlattenables)(struct J9VMThread *currentThread, struct J9Class *clazz, j9object_t instance) ;
 	struct J9ROMFieldOffsetWalkResult*  ( *fieldOffsetsNextDo)(struct J9ROMFieldOffsetWalkState *state) ;
 	struct J9ROMFieldShape*  ( *fullTraversalFieldOffsetsStartDo)(struct J9JavaVM *vm, struct J9Class *clazz, struct J9ROMFullTraversalFieldOffsetWalkState *state, U_32 flags) ;
 	struct J9ROMFieldShape*  ( *fullTraversalFieldOffsetsNextDo)(struct J9ROMFullTraversalFieldOffsetWalkState *state) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2204,6 +2204,19 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 #endif
 
 /**
+ * Initialize fields to default values when the class
+ * contains unflattened flattenables.
+ *
+ * @param[in] *currentThread the current thread
+ * @param[in] *clazz the resolved class
+ * @param[in] instance J9Object with unflattened flattenable fields
+ * 
+ * @returns void
+ */
+void
+defaultValueWithUnflattenedFlattenables(J9VMThread *currentThread, J9Class *clazz, j9object_t instance);
+
+/**
 * @brief Iterate over fields of the specified class in JVMTI order.
 * @param state[in/out]  the walk state that was initialized via fieldOffsetsStartDo()
 * @return J9ROMFieldOffsetWalkResult *

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1028,9 +1028,15 @@ obj:;
 	 * @returns the new object, or NULL if allocation failed
 	 */
 	VMINLINE j9object_t
-	allocateObject(REGISTER_ARGS_LIST, J9Class *clazz, bool initializeSlots = true, bool memoryBarrier = true)
+	allocateObject(REGISTER_ARGS_LIST, J9Class *clazz, bool initializeSlots = true, bool memoryBarrier = true, bool skipUnflattenedFlattenableCheck = false)
 	{
-		j9object_t instance = _objectAllocate.inlineAllocateObject(_currentThread, clazz, initializeSlots, memoryBarrier);
+		j9object_t instance = NULL;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (skipUnflattenedFlattenableCheck || J9_ARE_NO_BITS_SET(clazz->classFlags, J9ClassContainsUnflattenedFlattenables))
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+		{
+			instance = _objectAllocate.inlineAllocateObject(_currentThread, clazz, initializeSlots, memoryBarrier);
+		}
 		if (NULL == instance) {
 			updateVMStruct(REGISTER_ARGS);
 			instance = _vm->memoryManagerFunctions->J9AllocateObject(_currentThread, clazz, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
@@ -7406,7 +7412,13 @@ retry:
 		J9Class* volatile resolvedClass = ramCPEntry->value;
 		if ((NULL != resolvedClass) && J9ROMCLASS_ALLOCATES_VIA_NEW(resolvedClass->romClass)) {
 			if (!VM_VMHelpers::classRequiresInitialization(_currentThread, resolvedClass)) {
-				j9object_t instance = _objectAllocate.inlineAllocateObject(_currentThread, resolvedClass);
+				j9object_t instance = NULL;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				if (J9_ARE_NO_BITS_SET(resolvedClass->classFlags, J9ClassContainsUnflattenedFlattenables))
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+				{
+					instance = _objectAllocate.inlineAllocateObject(_currentThread, resolvedClass);
+				}
 				if (NULL == instance) {
 					updateVMStruct(REGISTER_ARGS);
 					instance = _vm->memoryManagerFunctions->J9AllocateObject(_currentThread, resolvedClass, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);
@@ -8326,7 +8338,10 @@ retry:
 		J9Class * volatile resolvedClass = ramCPEntry->value;
 
 		if ((NULL != resolvedClass) && J9_IS_J9CLASS_VALUETYPE(resolvedClass) && !VM_VMHelpers::classRequiresInitialization(_currentThread, resolvedClass)) {
-			j9object_t instance = _objectAllocate.inlineAllocateObject(_currentThread, resolvedClass);
+			j9object_t instance = NULL;
+			if (J9_ARE_NO_BITS_SET(resolvedClass->classFlags, J9ClassContainsUnflattenedFlattenables)) {
+				instance = _objectAllocate.inlineAllocateObject(_currentThread, resolvedClass);
+			}
 			if (NULL == instance) {
 				updateVMStruct(REGISTER_ARGS);
 				instance = _vm->memoryManagerFunctions->J9AllocateObject(_currentThread, resolvedClass, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(j9vm SHARED
 	threadhelp.cpp
 	threadpark.c
 	throwexception.c
+	valueTypeHelpers.cpp
 	visible.c
 	VMAccess.cpp
 	vmbootlib.c

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -228,6 +228,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	structuredSignalHandlerVM,
 	addHiddenInstanceField,
 	fieldOffsetsStartDo,
+	defaultValueWithUnflattenedFlattenables,
 	fieldOffsetsNextDo,
 	fullTraversalFieldOffsetsStartDo,
 	fullTraversalFieldOffsetsNextDo,

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -606,12 +606,14 @@ UDATA
 findIndexInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, J9ROMNameAndSignature *nameAndSignature)
 {
 	/* first field indicates the number of classes in the cache */
+	UDATA index = UDATA_MAX;
 	UDATA length = flattenedClassCache->numberOfEntries;
-	UDATA index = 0;
+	J9ROMFieldShape *fccEntryField = NULL;
 
 	for (UDATA i = 0; i < length; i++) {
-		if (J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature), J9ROMNAMEANDSIGNATURE_NAME(J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->nameAndSignature))
-			&& J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature), J9ROMNAMEANDSIGNATURE_SIGNATURE(J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->nameAndSignature))
+		fccEntryField = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->field;
+		if (J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature), J9ROMFIELDSHAPE_NAME(fccEntryField))
+			&& J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature), J9ROMFIELDSHAPE_SIGNATURE(fccEntryField))
 		) {
 			index = i;
 			break;

--- a/runtime/vm/valueTypeHelpers.cpp
+++ b/runtime/vm/valueTypeHelpers.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+#include "ut_j9vm.h"
+#include "ObjectAccessBarrierAPI.hpp"
+
+extern "C" {
+void
+defaultValueWithUnflattenedFlattenables(J9VMThread *currentThread, J9Class *clazz, j9object_t instance)
+{
+        J9FlattenedClassCacheEntry * entry = NULL;
+        J9Class * entryClazz = NULL;
+        UDATA length = clazz->flattenedClassCache->numberOfEntries;
+        UDATA const objectHeaderSize = J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread);
+        for (UDATA index = 0; index < length; index++) {
+                entry = J9_VM_FCC_ENTRY_FROM_CLASS(clazz, index);
+                entryClazz = entry->clazz;
+                if (J9_ARE_NO_BITS_SET(J9ClassIsFlattened, entryClazz->classFlags)) {
+                        if (entry->offset == UDATA_MAX) {
+                                J9Class *definingClass = NULL;
+                                J9ROMFieldShape *field = NULL;
+                                J9ROMFieldShape *entryField = entry->field;
+                                J9UTF8 *name = J9ROMFIELDSHAPE_NAME(entryField);
+                                J9UTF8 *signature = J9ROMFIELDSHAPE_SIGNATURE(entryField);
+                                entry->offset = instanceFieldOffset(currentThread, clazz, J9UTF8_DATA(name), J9UTF8_LENGTH(name), J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), &definingClass, (UDATA *)&field, 0);
+                                Assert_VM_notNull(field);
+                        }
+                        MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
+                        objectAccessBarrier.inlineMixedObjectStoreObject(currentThread, 
+                                                                                instance, 
+                                                                                entry->offset + objectHeaderSize, 
+                                                                                entryClazz->flattenedClassCache->defaultValue, 
+                                                                                false);
+                }
+        }
+}
+} /* extern "C" */

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -24,6 +24,10 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>ValueTypeTests</testCaseName>
+		<variations>
+                  <variation>-XX:ValueTypeFlatteningThreshold=1</variation>
+		  <variation>NoOptions</variation>
+          	</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xverify:none \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -84,6 +84,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		
 		if (isRef) {
 			makeRef(cw, className, makeValueSig, makeValueGenericSig, fields, makeMaxLocal);
+			makeRefDefaultValue(cw, className, makeValueSig, fields, makeMaxLocal);
 			if (!isVerifiable) {
 				makeGeneric(cw, className, "makeRefGeneric", "makeRef", makeValueSig, makeValueGenericSig, fields, makeMaxLocal);
 				/* makeValue is invalid on ref: Included to test if runtime error is (correctly) thrown */
@@ -98,6 +99,7 @@ public class ValueTypeGenerator extends ClassLoader {
 			testMonitorEnterAndExitWithRefType(cw, className, fields);
 		} else {
 			makeValue(cw, className, makeValueSig, fields, makeMaxLocal);
+			makeValueTypeDefaultValue(cw, className, makeValueSig, fields, makeMaxLocal);
 			if (!isVerifiable) {
 				makeGeneric(cw, className, "makeValueGeneric", "makeValue", makeValueSig, makeValueGenericSig, fields, makeMaxLocal);
 			}
@@ -267,6 +269,24 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitEnd();
 	}
 	
+	private static void makeValueTypeDefaultValue(ClassWriter cw, String valueName, String makeValueSig, String[] fields, int makeMaxLocal) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "makeValueTypeDefaultValue", "()L" + valueName + ";", null, null);
+		mv.visitCode();
+		mv.visitTypeInsn(DEFAULTVALUE, valueName);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 0);
+		mv.visitEnd();
+	}
+
+	private static void makeRefDefaultValue(ClassWriter cw, String className, String makeValueSig, String[] fields, int makeMaxLocal) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "makeRefDefaultValue", "()L" + className + ";", null, null);
+		mv.visitCode();
+		mv.visitTypeInsn(NEW, className);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 0);
+		mv.visitEnd();
+	}
+
 	private static void makeGeneric(ClassWriter cw, String className, String methodName, String specificMethodName, String makeValueSig, String makeValueGenericSig, String[] fields, int makeMaxLocal) {
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, methodName, "(" + makeValueGenericSig + ")L" + className + ";", null, new String[] {"java/lang/Exception"});
 		mv.visitCode();

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -104,6 +104,14 @@ public class ValueTypeTests {
 	static Class largeObjectValueClass = null;
 	static MethodHandle makeLargeObjectValue = null;
 	static MethodHandle[] getObjects = null;
+	/* assortedRefWithLongAlignment */
+	static Class assortedRefWithLongAlignmentClass = null;
+	static MethodHandle makeAssortedRefWithLongAlignment = null;
+	static MethodHandle[][] assortedRefWithLongAlignmentGetterAndSetter = null;
+	/* assortedValueWithLongAlignment */
+	static Class assortedValueWithLongAlignmentClass = null;
+	static MethodHandle makeAssortedValueWithLongAlignment = null;
+	static MethodHandle[][] assortedValueWithLongAlignmentGetterAndWither = null;
 	
 	/* default values */
 	static int[] defaultPointPositions1 = {0xFFEEFFEE, 0xAABBAABB};
@@ -891,18 +899,18 @@ public class ValueTypeTests {
 				"d:QValueDouble;:value",
 				"i:QValueInt;:value",
 				"tri:QTriangle2D;:value"};
-		Class assortedValueWithLongAlignmentClass = ValueTypeGenerator.generateValueClass("AssortedValueWithLongAlignment", fields);
+		assortedValueWithLongAlignmentClass = ValueTypeGenerator.generateValueClass("AssortedValueWithLongAlignment", fields);
 
-		MethodHandle makeAssortedValueWithLongAlignment = lookup.findStatic(assortedValueWithLongAlignmentClass,
+		makeAssortedValueWithLongAlignment = lookup.findStatic(assortedValueWithLongAlignmentClass,
 				"makeValueGeneric", MethodType.methodType(assortedValueWithLongAlignmentClass, Object.class,
 						Object.class, Object.class, Object.class, Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterAndWither[i][0] according to the order of fields i
 		 * Withers are created in array getterAndWither[i][1] according to the order of fields i
 		 */
-		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(assortedValueWithLongAlignmentClass, fields);
+		assortedValueWithLongAlignmentGetterAndWither = generateGenericGetterAndWither(assortedValueWithLongAlignmentClass, fields);
 		Object assortedValueWithLongAlignment = createAssorted(makeAssortedValueWithLongAlignment, fields);
-		checkFieldAccessMHOfAssortedType(getterAndWither, assortedValueWithLongAlignment, fields, true);
+		checkFieldAccessMHOfAssortedType(assortedValueWithLongAlignmentGetterAndWither, assortedValueWithLongAlignment, fields, true);
 	}
 
 	/*
@@ -928,9 +936,9 @@ public class ValueTypeTests {
 				"d:QValueDouble;:value",
 				"i:QValueInt;:value",
 				"tri:QTriangle2D;:value"};
-		Class assortedRefWithLongAlignmentClass = ValueTypeGenerator.generateRefClass("AssortedRefWithLongAlignment", fields);
+		assortedRefWithLongAlignmentClass = ValueTypeGenerator.generateRefClass("AssortedRefWithLongAlignment", fields);
 
-		MethodHandle makeAssortedRefWithLongAlignment = lookup.findStatic(assortedRefWithLongAlignmentClass,
+		makeAssortedRefWithLongAlignment = lookup.findStatic(assortedRefWithLongAlignmentClass,
 				"makeRefGeneric", MethodType.methodType(assortedRefWithLongAlignmentClass, Object.class, Object.class,
 						Object.class, Object.class, Object.class, Object.class, Object.class));
 
@@ -938,9 +946,9 @@ public class ValueTypeTests {
 		 * Getters are created in array getterAndSetter[i][0] according to the order of fields i
 		 * Setters are created in array getterAndSetter[i][1] according to the order of fields i
 		 */
-		MethodHandle[][] getterAndSetter = generateGenericGetterAndSetter(assortedRefWithLongAlignmentClass, fields);
+		assortedRefWithLongAlignmentGetterAndSetter = generateGenericGetterAndSetter(assortedRefWithLongAlignmentClass, fields);
 		Object assortedRefWithLongAlignment = createAssorted(makeAssortedRefWithLongAlignment, fields);
-		checkFieldAccessMHOfAssortedType(getterAndSetter, assortedRefWithLongAlignment, fields, false);
+		checkFieldAccessMHOfAssortedType(assortedRefWithLongAlignmentGetterAndSetter, assortedRefWithLongAlignment, fields, false);
 	}
 
 	/*
@@ -1278,6 +1286,65 @@ public class ValueTypeTests {
 
 		Object megaObjectRef = createAssorted(makeMegaObjectRef, megaFields);
 		checkFieldAccessMHOfAssortedType(megaGetterAndSetter, megaObjectRef, megaFields, false);
+	}
+
+	/*
+	 * Create a value type and read the fields before
+	 * they are set. The test should Verify that the
+	 * flattenable fields are set to the default values.
+	 * NULL should never be observed for Qtypes.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValues() throws Throwable {
+
+		/* Test with assorted value object with long alignment */
+		String assortedValueWithLongAlignmentFields[] = {
+				"point:QPoint2D;:value",
+				"line:QFlattenedLine2D;:value",
+				"o:QValueObject;:value",
+				"l:QValueLong;:value",
+				"d:QValueDouble;:value",
+				"i:QValueInt;:value",
+				"tri:QTriangle2D;:value"};
+
+		MethodHandle makeValueTypeDefaultValueWithLong = lookup.findStatic(assortedValueWithLongAlignmentClass,
+				"makeValueTypeDefaultValue", MethodType.methodType(assortedValueWithLongAlignmentClass));
+
+		Object assortedValueWithLongAlignment = makeValueTypeDefaultValueWithLong.invoke();
+		for (int i = 0; i < 7; i++) {
+			assertNotNull(assortedValueWithLongAlignmentGetterAndWither[i][0].invoke(assortedValueWithLongAlignment));
+		}
+
+		/* Test with assorted Ref object with long alignment */
+		String assortedRefWithLongAlignmentfields[] = {
+				"point:QPoint2D;:value",
+				"line:QFlattenedLine2D;:value",
+				"o:QValueObject;:value",
+				"l:QValueLong;:value",
+				"d:QValueDouble;:value",
+				"i:QValueInt;:value",
+				"tri:QTriangle2D;:value"};
+		MethodHandle makeRefDefaultValueWithLong = lookup.findStatic(assortedRefWithLongAlignmentClass,
+				"makeRefDefaultValue", MethodType.methodType(assortedRefWithLongAlignmentClass));
+		Object assortedRefWithLongAlignment = makeRefDefaultValueWithLong.invoke();
+		for (int i = 0; i < 7; i++) {
+			assertNotNull(assortedRefWithLongAlignmentGetterAndSetter[i][0].invoke(assortedRefWithLongAlignment));
+		}
+
+		/* Test with flattened line 2D */
+		String lineFields[] = {"st:QPoint2D;:value", "en:QPoint2D;:value"};
+		MethodHandle makeDefaultValueFlattenedLine2D = lookup.findStatic(flattenedLine2DClass, "makeValueTypeDefaultValue", MethodType.methodType(flattenedLine2DClass));
+		Object lineObject = makeDefaultValueFlattenedLine2D.invoke();
+		assertNotNull(getFlatSt.invoke(lineObject));
+		assertNotNull(getFlatEn.invoke(lineObject));
+
+		/* Test with triangle 2D */
+		String triangleFields[] = {"v1:QFlattenedLine2D;:value", "v2:QFlattenedLine2D;:value", "v3:QFlattenedLine2D;:value"};
+		MethodHandle makeDefaultValueTriangle2D = lookup.findStatic(triangle2DClass, "makeValueTypeDefaultValue", MethodType.methodType(triangle2DClass));
+		Object triangleObject = makeDefaultValueTriangle2D.invoke();
+		assertNotNull(getV1.invoke(triangleObject));
+		assertNotNull(getV2.invoke(triangleObject));
+		assertNotNull(getV3.invoke(triangleObject));
 	}
 	
 	/*


### PR DESCRIPTION
1. Define a new class flag J9ClassContainsUnflattenedFlattenables
   and set when a class contains unflattened flattenables.
2. When creating an object, check if the resolved class contains 
   unflattened flattenables. If it does, default value of the unflattened
   field's class from FCC are stored into the unflattened field of the  
   object being created.
3. Tests are created to check if all flattenable fields are initialized
   when created.

Signed-off-by: thomasli <Xinhai.Li@ibm.com>