### PR TITLE
Modify TR_Method references to TR::Method

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -33,6 +33,7 @@
 #include "codegen/CodeGenPhase.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "il/Block.hpp"
 #include "optimizer/SequentialStoreSimplifier.hpp"
 #include "env/VMJ9.h"
@@ -58,7 +59,7 @@ J9::CodeGenPhase::getNumPhases()
    return static_cast<int>(TR::CodeGenPhase::LastJ9Phase);
    }
 
-void 
+void
 J9::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
    {
    cg->fixUpProfiledInterfaceGuardTest();
@@ -104,7 +105,7 @@ J9::CodeGenPhase::performInsertEpilogueYieldPointsPhase(TR::CodeGenerator * cg, 
    //
    if ((comp->getCurrentMethod()->maxBytecodeIndex() >= BYTECODESIZE_THRESHOLD_FOR_ASYNCCHECKS) &&
        !comp->mayHaveLoops() &&
-       comp->getCurrentMethod()->convertToMethod()->methodType() == TR_Method::J9 &&  // FIXME: enable for ruby and python
+       comp->getCurrentMethod()->convertToMethod()->methodType() == TR::Method::J9 &&  // FIXME: enable for ruby and python
        comp->getOSRMode() != TR::involuntaryOSR)
       {
       cg->insertEpilogueYieldPoints();

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -503,7 +503,7 @@ J9::SymbolReferenceTable::methodSymRefWithSignature(TR::SymbolReference *origina
 
    // Check _methodsBySignature to see if we've already created a symref for this one
    //
-   TR_Method *originalMethod = originalSymbol->getMethod();
+   TR::Method *originalMethod = originalSymbol->getMethod();
 
    TR::StackMemoryRegion stackMemoryRegion(*trMemory());
 
@@ -1338,7 +1338,7 @@ J9::SymbolReferenceTable::isStaticTypeBool(TR::SymbolReference *symRef)
 bool
 J9::SymbolReferenceTable::isReturnTypeBool(TR::SymbolReference *symRef)
    {
-   TR_Method *method = symRef->getSymbol()->castToResolvedMethodSymbol()->getMethod();
+   TR::Method *method = symRef->getSymbol()->castToResolvedMethodSymbol()->getMethod();
    char *methodSignature = method->signatureChars();
    const int32_t len = method->signatureLength();
    dumpOptDetails(comp(), "got method signature as %.*s\n", len, methodSignature);

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -36,6 +36,7 @@
 #include "vmaccess.h"
 #include "codegen/CodeGenerator.hpp"
 #include "compile/CompilationTypes.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/OptimizationPlan.hpp"
 #include "control/OptionsUtil.hpp"
@@ -189,7 +190,7 @@ TR::OptionSet *findOptionSet(J9Method *method, bool isAOT)
 
       TR_FilterBST * filter = 0;
       if (TR::Options::getDebug() && TR::Options::getDebug()->getCompilationFilters())
-         TR::Options::getDebug()->methodSigCanBeCompiled(methodSignature, filter, TR_Method::J9);
+         TR::Options::getDebug()->methodSigCanBeCompiled(methodSignature, filter, TR::Method::J9);
 
       int32_t index = filter ? filter->getOptionSet() : 0;
       int32_t lineNum = filter ? filter->getLineNumber() : 0;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -61,6 +61,7 @@
 #include "codegen/Snippet.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/VirtualGuard.hpp"
 #include "control/OptionsUtil.hpp"
@@ -2771,7 +2772,7 @@ TR_J9VMBase::isQueuedForVeryHotOrScorching(TR_ResolvedMethod *calleeMethod, TR::
    }
 
 bool
-TR_J9VMBase::maybeHighlyPolymorphic(TR::Compilation *comp, TR_ResolvedMethod *caller, int32_t cpIndex, TR_Method *callee, TR_OpaqueClassBlock * receiverClass)
+TR_J9VMBase::maybeHighlyPolymorphic(TR::Compilation *comp, TR_ResolvedMethod *caller, int32_t cpIndex, TR::Method *callee, TR_OpaqueClassBlock * receiverClass)
    {
    //if (method->isInterface())
      {
@@ -4665,13 +4666,13 @@ J9JITConfig * getJ9JitConfigFromFE(void * fe)
    }
 
 void *
-TR_J9VMBase::setJ2IThunk(TR_Method *method, void *thunkptr, TR::Compilation *comp)
+TR_J9VMBase::setJ2IThunk(TR::Method *method, void *thunkptr, TR::Compilation *comp)
    {
    return setJ2IThunk(method->signatureChars(), method->signatureLength(), thunkptr, comp);
    }
 
 void *
-TR_J9VMBase::getJ2IThunk(TR_Method *method, TR::Compilation *comp)
+TR_J9VMBase::getJ2IThunk(TR::Method *method, TR::Compilation *comp)
    {
    return getJ2IThunk(method->signatureChars(), method->signatureLength(), comp);
    }
@@ -4785,7 +4786,7 @@ TR_J9VMBase::needsInvokeExactJ2IThunk(TR::Node *callNode, TR::Compilation *comp)
    TR_ASSERT(callNode->getOpCode().isCall(), "needsInvokeExactJ2IThunk expects call node; found %s", callNode->getOpCode().getName());
 
    TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
-   TR_Method       *method       = methodSymbol->getMethod();
+   TR::Method       *method       = methodSymbol->getMethod();
    if (  methodSymbol->isComputed()
       && (  method->getMandatoryRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact
          || method->isArchetypeSpecimen()))
@@ -7418,7 +7419,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
          TR::MethodSymbol *sym = callNode->getSymbol()->castToMethodSymbol();
          sym->setVMInternalNative(false);
          sym->setInterpreted(false);
-         TR_Method *method = sym->getMethod();
+         TR::Method *method = sym->getMethod();
 
          TR::SymbolReference *helperSymRef = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
          sym->setMethodAddress(helperSymRef->getMethodAddress());
@@ -7998,7 +7999,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
                // first get the helpers object
                // acall getHelpers
                //
-               TR_Method *method = getHelpersSymRef->getSymbol()->castToMethodSymbol()->getMethod();
+               TR::Method *method = getHelpersSymRef->getSymbol()->castToMethodSymbol()->getMethod();
                TR::Node *helpersCallNode = TR::Node::createWithSymRef(callNode, method->directCallOpCode(), 0, getHelpersSymRef);
                TR::TreeTop *helpersCallTT = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, helpersCallNode));
                callNodeTreeTop->insertBefore(helpersCallTT);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -354,7 +354,7 @@ public:
       return getVolatileReferenceFieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, fieldSignature));
       }
 
-   virtual TR_Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
+   virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
    virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory *, TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *, char *signature, int32_t signatureLength, TR_ResolvedMethod *);
    void * getStaticFieldAddress(TR_OpaqueClassBlock *, unsigned char *, uint32_t, unsigned char *, uint32_t);
@@ -667,7 +667,7 @@ public:
 
    virtual bool               isInlineableNativeMethod( TR::Compilation *, TR::ResolvedMethodSymbol * methodSymbol);
    //receiverClass is for specifying a more specific receiver type. otherwise it is determined from the call.
-   virtual bool               maybeHighlyPolymorphic(TR::Compilation *, TR_ResolvedMethod *caller, int32_t cpIndex, TR_Method *callee, TR_OpaqueClassBlock *receiverClass = NULL);
+   virtual bool               maybeHighlyPolymorphic(TR::Compilation *, TR_ResolvedMethod *caller, int32_t cpIndex, TR::Method *callee, TR_OpaqueClassBlock *receiverClass = NULL);
    virtual bool isQueuedForVeryHotOrScorching(TR_ResolvedMethod *calleeMethod, TR::Compilation *comp);
 
    //getSymbolAndFindInlineTarget queries
@@ -709,13 +709,13 @@ public:
 
    virtual void *getJ2IThunk(char *signatureChars, uint32_t signatureLength,  TR::Compilation *comp);
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp);
-   virtual void *setJ2IThunk(TR_Method *method, void *thunkptr, TR::Compilation *comp);  // DMDM: J9 now
+   virtual void *setJ2IThunk(TR::Method *method, void *thunkptr, TR::Compilation *comp);  // DMDM: J9 now
 
    // JSR292 {{{
 
    // J2I thunk support
    //
-   virtual void * getJ2IThunk(TR_Method *method, TR::Compilation *comp);  // DMDM: J9 now
+   virtual void * getJ2IThunk(TR::Method *method, TR::Compilation *comp);  // DMDM: J9 now
 
    virtual char    *getJ2IThunkSignatureForDispatchVirtual(char *invokeHandleSignature, uint32_t signatureLength,  TR::Compilation *comp);
    virtual TR::Node *getEquivalentVirtualCallNodeForDispatchVirtual(TR::Node *node,  TR::Compilation *comp);

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -22,6 +22,7 @@
 
 #define J9_EXTERNAL_TO_VM
 #include "vmaccess.h"
+#include "compile/Method.hpp"
 #include "env/annotations/AnnotationBase.hpp"
 #include "il/Symbol.hpp"
 #include "il/symbol/LabelSymbol.hpp"
@@ -317,7 +318,7 @@ TR_AnnotationBase::getAnnotationInfoEntry(TR::SymbolReference *symRef,const char
       annotationj9Type = ANNOTATION_TYPE_METHOD;
 
       J9Class *clazz = (J9Class *)sym->castToResolvedMethodSymbol()->getResolvedMethod()->containingClass();
-      TR_Method * vmSym = sym->castToMethodSymbol()->getMethod();
+      TR::Method * vmSym = sym->castToMethodSymbol()->getMethod();
       memberName = vmSym->nameChars();
       memberSignature = vmSym->signatureChars();
       int32_t nameLen = vmSym->nameLength();
@@ -385,7 +386,7 @@ TR_AnnotationBase::getAnnotationInfoEntry(TR::SymbolReference *symRef,const char
       const char *s = symRef->getSymbol()->castToParmSymbol()->getTypeSignature(len);
 
       TR::Symbol *sym =  _comp->getOwningMethodSymbol(symRef->getOwningMethodIndex());
-      TR_Method * vmSym =sym->castToMethodSymbol()->getMethod();
+      TR::Method * vmSym =sym->castToMethodSymbol()->getMethod();
       if(NULL == vmSym) return NULL;
 
       TR::ResolvedMethodSymbol *resolvedSym = sym->castToResolvedMethodSymbol();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -34,6 +34,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "compile/AOTClassInfo.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
@@ -201,7 +202,7 @@ TR_J9VMBase::offsetOfMethodIsBreakpointedBit()
    return J9_STARTPC_METHOD_BREAKPOINTED;
    }
 
-TR_Method *
+TR::Method *
 TR_J9VMBase::createMethod(TR_Memory * trMemory, TR_OpaqueClassBlock * clazz, int32_t refOffset)
    {
    return new (trMemory->trHeapMemory()) TR_J9Method(this, trMemory, TR::Compiler->cls.convertClassOffsetToClassPtr(clazz), refOffset);
@@ -1435,7 +1436,7 @@ TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars(I_32 cpIndex, int32_t & l
    return ""; // TODO: Implement me
    }
 
-TR_Method *   TR_ResolvedRelocatableJ9Method::convertToMethod()              { return this; }
+TR::Method *   TR_ResolvedRelocatableJ9Method::convertToMethod()              { return this; }
 
 bool TR_ResolvedRelocatableJ9Method::isStatic()            { return methodModifiers() & J9AccStatic ? true : false; }
 bool TR_ResolvedRelocatableJ9Method::isNative()            { return methodModifiers() & J9AccNative ? true : false; }
@@ -4617,7 +4618,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
                   }
          }
 
-      if (TR_Method::getMandatoryRecognizedMethod() == TR::unknownMethod)
+      if (TR::Method::getMandatoryRecognizedMethod() == TR::unknownMethod)
          {
          // Cases where multiple method names all map to the same RecognizedMethod
          //
@@ -5049,7 +5050,7 @@ TR_ResolvedJ9Method::romClassPtr()
    return constantPoolHdr()->romClass;
    }
 
-TR_Method * TR_ResolvedJ9Method::convertToMethod()                { return this; }
+TR::Method * TR_ResolvedJ9Method::convertToMethod()                { return this; }
 uint32_t      TR_ResolvedJ9Method::numberOfParameters()           { return TR_J9Method::numberOfExplicitParameters() + (isStatic()? 0 : 1); }
 uint32_t      TR_ResolvedJ9Method::numberOfExplicitParameters()   { return TR_J9Method::numberOfExplicitParameters(); }
 TR::DataType     TR_ResolvedJ9Method::parmType(uint32_t n)           { return TR_J9Method::parmType(n); }

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -25,6 +25,7 @@
 
 #include "codegen/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
@@ -95,7 +96,7 @@ private:
    friend class TR_J9MethodBase;
    };
 
-class TR_J9MethodBase : public TR_Method
+class TR_J9MethodBase : public TR::Method
    {
 public:
    TR_ALLOC(TR_Memory::Method)
@@ -261,7 +262,7 @@ public:
    J9ClassLoader *         getClassLoader();
 
    virtual J9ConstantPool *      cp();
-   virtual TR_Method *           convertToMethod();
+   virtual TR::Method *           convertToMethod();
 
    virtual uint32_t              numberOfParameters();
    virtual uint32_t              numberOfExplicitParameters();
@@ -504,7 +505,7 @@ class TR_ResolvedRelocatableJ9Method : public TR_ResolvedJ9Method
 public:
    TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
 
-   virtual TR_Method *           convertToMethod();
+   virtual TR::Method *           convertToMethod();
 
    virtual void *                constantPool();
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "env/CompilerEnv.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -2602,7 +2603,7 @@ J9::Node::isArrayCopyCall()
       }
    else
       {
-      TR_Method *method = self()->getSymbol()->castToMethodSymbol()->getMethod();
+      TR::Method *method = self()->getSymbol()->castToMethodSymbol()->getMethod();
 
       // Method may be unresolved but we would still like to transform arraycopy calls so pattern match the signature as well
       if (method != NULL &&

--- a/runtime/compiler/il/J9SymbolReference.cpp
+++ b/runtime/compiler/il/J9SymbolReference.cpp
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "il/Symbol.hpp"
@@ -385,7 +386,7 @@ SymbolReference::getTypeSignature(int32_t & len, TR_AllocationKind allocKind, bo
       case TR::Symbol::IsMethod:
       case TR::Symbol::IsResolvedMethod:
          {
-         TR_Method * method = _symbol->castToMethodSymbol()->getMethod();
+         TR::Method * method = _symbol->castToMethodSymbol()->getMethod();
          if (method)
             {
             char * sig   = method->signatureChars();

--- a/runtime/compiler/il/symbol/J9MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.hpp
@@ -53,7 +53,7 @@ class OMR_EXTENSIBLE MethodSymbol : public OMR::MethodSymbolConnector
 
 protected:
 
-   MethodSymbol(TR_LinkageConventions lc = TR_Private, TR_Method * m = NULL) :
+   MethodSymbol(TR_LinkageConventions lc = TR_Private, TR::Method * m = NULL) :
       OMR::MethodSymbolConnector(lc, m) { }
 
 public:

--- a/runtime/compiler/il/symbol/MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/MethodSymbol.hpp
@@ -28,7 +28,7 @@
 #include <stddef.h>
 #include "codegen/LinkageConventionsEnum.hpp"
 
-class TR_Method;
+#include "compile/Method.hpp"
 
 namespace TR
 {
@@ -38,7 +38,7 @@ class OMR_EXTENSIBLE MethodSymbol : public J9::MethodSymbolConnector
 
 protected:
 
-   MethodSymbol(TR_LinkageConventions lc = TR_Private, TR_Method* m = NULL) :
+   MethodSymbol(TR_LinkageConventions lc = TR_Private, TR::Method * m = NULL) :
       J9::MethodSymbolConnector(lc, m) { }
 
 private:

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -22,6 +22,7 @@
 
 #include "ilgen/ClassLookahead.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compiler/il/OMRTreeTop_inlines.hpp"
 #include "env/ClassTableCriticalSection.hpp"
@@ -258,7 +259,7 @@ static bool isCalledByNonConstructorMethodsInClass(TR_ResolvedMethod *calleeMeth
                 node->getFirstChild()->getOpCode().isCall() &&
                 !node->getFirstChild()->getOpCode().isIndirect())
                {
-               TR_Method *calleeMethod1 = node->getFirstChild()->getSymbol()->getMethodSymbol()->getMethod();
+               TR::Method *calleeMethod1 = node->getFirstChild()->getSymbol()->getMethodSymbol()->getMethod();
                if (calleeMethod1 &&
                    calleeMethod1->nameLength() == calleeMethod->nameLength() &&
                    calleeMethod1->signatureLength() == calleeMethod->signatureLength() &&
@@ -828,7 +829,7 @@ TR_ClassLookahead::examineNode(TR::TreeTop *nextTree, TR::Node *grandParent, TR:
 
    if (node->getOpCode().isCall())
       {
-      TR_Method *calleeMethod = node->getSymbol()->castToMethodSymbol()->getMethod();
+      TR::Method *calleeMethod = node->getSymbol()->castToMethodSymbol()->getMethod();
       if (calleeMethod != NULL && !strncmp(calleeMethod->classNameChars(), "java/lang/reflect", 17))
          return false;
       }

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -22,6 +22,7 @@
 
 #include "codegen/CodeGenerator.hpp"
 #include "compile/InlineBlock.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
@@ -2204,7 +2205,7 @@ bool TR_J9ByteCodeIlGenerator::replaceMethods(TR::TreeTop *tt, TR::Node *node)
    {
    if (!node->getOpCode().isCall() || !node->getOpCode().hasSymbolReference()) return true;
    if (node->getSymbolReference()->getSymbol()->castToMethodSymbol()->isHelper()) return true;
-   TR_Method * method = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod();
+   TR::Method * method = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod();
    //I use heapAlloc because this function is called many times for a small set of methods.
    const char* nodeName = method->signature(trMemory(), heapAlloc);
    for (int i = 0; i < _numDecFormatRenames; i++)

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -22,6 +22,7 @@
 
 #include "ilgen/J9ByteCodeIterator.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "env/VMJ9.h"
 #include "ras/Debug.hpp"
 #include "env/IO.hpp"
@@ -148,7 +149,7 @@ TR_J9ByteCodeIterator::findFloatingPointInstruction()
                index = index | J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
 
             TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
-            TR_Method *thisMethod = fej9->createMethod(_trMemory, method()->containingClass(), index);
+            TR::Method *thisMethod = fej9->createMethod(_trMemory, method()->containingClass(), index);
 
             // check return type
             type = thisMethod->returnType();

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
 #include "compile/InlineBlock.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
@@ -3894,7 +3895,7 @@ TR_J9ByteCodeIlGenerator::genInvokeSpecial(int32_t cpIndex)
       return;
       }
 
-   TR_Method *callee = methodSymRef->getSymbol()->castToMethodSymbol()->getMethod();
+   TR::Method *callee = methodSymRef->getSymbol()->castToMethodSymbol()->getMethod();
    if (callee->isConstructor())
       {
       if (trace)
@@ -4170,7 +4171,7 @@ TR_J9ByteCodeIlGenerator::genInvokeHandle(TR::SymbolReference *invokeExactSymRef
          }
       if (comp()->getOptions()->getVerboseOption(TR_VerboseMethodHandleDetails))
          {
-         TR_Method *callee = callNode->getSymbol()->castToMethodSymbol()->getMethod();
+         TR::Method *callee = callNode->getSymbol()->castToMethodSymbol()->getMethod();
          TR_VerboseLog::writeLineLocked(TR_Vlog_MHD, "Call to invokeExact%.*s from %s", callee->signatureLength(), callee->signatureChars(), comp()->signature());
          }
       }
@@ -4216,7 +4217,7 @@ TR_J9ByteCodeIlGenerator::genInvokeHandleGeneric(int32_t cpIndex)
       comp()->failCompilation<J9::FSDHasInvokeHandle>("FSD_HAS_INVOKEHANDLE 2");
 
    TR::SymbolReference * invokeGenericSymRef = symRefTab()->findOrCreateHandleMethodSymbol(_methodSymbol, cpIndex);
-   TR_Method *invokeGeneric = invokeGenericSymRef->getSymbol()->castToMethodSymbol()->getMethod();
+   TR::Method *invokeGeneric = invokeGenericSymRef->getSymbol()->castToMethodSymbol()->getMethod();
    TR::SymbolReference *invokeExactOriginal = symRefTab()->methodSymRefFromName(_methodSymbol,
       JSR292_MethodHandle, JSR292_invokeExact, JSR292_invokeExactSig, TR::MethodSymbol::ComputedVirtual, invokeGenericSymRef->getCPIndex());
    TR::SymbolReference *invokeExactSymRef = symRefTab()->methodSymRefWithSignature(
@@ -4308,7 +4309,7 @@ static int32_t numOpsNonStandardLengths[] =
 TR::Node *
 TR_J9ByteCodeIlGenerator::getReceiverFor(TR::SymbolReference *symRef)
    {
-   TR_Method * method = symRef->getSymbol()->castToMethodSymbol()->getMethod();
+   TR::Method * method = symRef->getSymbol()->castToMethodSymbol()->getMethod();
    int32_t receiverDepth = method->numberOfExplicitParameters(); // look past all the explicit arguments
    return _stack->element(_stack->topIndex() - receiverDepth);
    }
@@ -4331,7 +4332,7 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
    bool isStatic     = symbol->isStatic();
    bool isDirectCall = indirectCallFirstChild == NULL;
 
-   TR_Method * calledMethod = symbol->getMethod();
+   TR::Method * calledMethod = symbol->getMethod();
    int32_t numArgs = calledMethod->numberOfExplicitParameters() + (isStatic ? 0 : 1);
 
    TR::ILOpCodes opcode = TR::BadILOp;
@@ -4560,7 +4561,7 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
 
       // Get the type of prefetch
       PrefetchType prefetchType = NoPrefetch;
-      TR_Method *method = symbol->castToMethodSymbol()->getMethod();
+      TR::Method *method = symbol->castToMethodSymbol()->getMethod();
       if (method->nameLength() == 15 && !strncmp(method->nameChars(), "_TR_Release_All", 15))
          {
          prefetchType = ReleaseAll;

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2551,7 +2551,7 @@ bool TR_EscapeAnalysis::checkAllNewsOnRHSInLoopWithAliasing(int32_t defIndex, TR
             // that has the value number of a candidate allocation, other than the
             // current candidate, is harmless.  The added restriction in the
             // second case avoids allowing the current candidate through from a
-            // a previous loop iteration. 
+            // a previous loop iteration.
             if (otherAllocNode->_node == firstChild
                    || (candidate->_node != otherAllocNode->_node
                        && _valueNumberInfo->getValueNumber(otherAllocNode->_node)
@@ -4694,7 +4694,7 @@ void TR_EscapeAnalysis::checkEscapeViaCall(TR::Node *node, TR::NodeChecklist& vi
                TR_ResolvedMethod *owningMethod = symRef->getOwningMethod(comp());
                TR_ResolvedMethod *resolvedMethod = NULL;
                TR::MethodSymbol *sym = symRef->getSymbol()->castToMethodSymbol();
-               TR_Method * originalMethod = sym->getMethod();
+               TR::Method * originalMethod = sym->getMethod();
                int32_t len = originalMethod->classNameLength();
                char *s = classNameToSignature(originalMethod->classNameChars(), len, comp());
                TR_OpaqueClassBlock *originalMethodClass = comp()->fej9()->getClassFromSignature(s, len, owningMethod);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -27,6 +27,7 @@
 
 #include "env/KnownObjectTable.hpp"
 #include "compile/InlineBlock.hpp"
+#include "compile/Method.hpp"
 #include "compile/OSRData.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/CompilerEnv.hpp"
@@ -5071,7 +5072,7 @@ static TR_PrexArgument *stronger(TR_PrexArgument *left, TR_PrexArgument *right, 
       return right;
    }
 
-static void populateClassNameSignature(TR_Method* m, TR_ResolvedMethod* caller, TR_OpaqueClassBlock* &c, char* &nc, int32_t &nl, char* &sc, int32_t &sl)
+static void populateClassNameSignature(TR::Method *m, TR_ResolvedMethod* caller, TR_OpaqueClassBlock* &c, char* &nc, int32_t &nl, char* &sc, int32_t &sl)
    {
    int32_t len = m->classNameLength();
    char* cs = classNameToSignature(m->classNameChars(), len, TR::comp());
@@ -5082,7 +5083,7 @@ static void populateClassNameSignature(TR_Method* m, TR_ResolvedMethod* caller, 
    sl = m->signatureLength();
    }
 
-static char* classSignature (TR_Method* m, TR::Compilation* comp) //tracer helper
+static char* classSignature (TR::Method * m, TR::Compilation* comp) //tracer helper
    {
    int32_t len = m->classNameLength();
    return classNameToSignature(m->classNameChars(), len /*don't care, cos this gives us a null terminated string*/, comp);
@@ -5116,7 +5117,7 @@ TR::Node* TR_PrexArgInfo::getCallNode (TR::ResolvedMethodSymbol* methodSymbol, T
 
 
          populateClassNameSignature (callsite->_initialCalleeMethod ?
-               callsite->_initialCalleeMethod->convertToMethod() : //TR_ResolvedMethod doesn't extend TR_Method
+               callsite->_initialCalleeMethod->convertToMethod() : //TR_ResolvedMethod doesn't extend TR::Method
                callsite->_interfaceMethod,
             methodSymbol->getResolvedMethod(),
             callSiteClass,

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
@@ -214,7 +214,7 @@ List<OMR::RuntimeAssumption> *TR::InterProceduralAnalyzer::analyzeCallGraph(TR::
    if (!resolvedMethodSymbol)  // as per current logic, it is an interface method
       {
       int32_t cpIndex = symRef->getCPIndex();
-      TR_Method * originalMethod = methodSymbol->getMethod();
+      TR::Method * originalMethod = methodSymbol->getMethod();
       int32_t len = originalMethod->classNameLength();
       char *s = classNameToSignature(originalMethod->classNameChars(), len, comp());
       clazz = fe()->getClassFromSignature(s, len, owningMethod);

--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "compile/Method.hpp"
 #include "optimizer/CFGSimplifier.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/TransformUtil.hpp"
@@ -40,7 +41,7 @@ bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
           || simplifyResolvedRequireNonNull(needToDuplicateTree)
           || simplifyUnresolvedRequireNonNull(needToDuplicateTree)
-          ; 
+          ;
    }
 
 // Look for pattern of the form:
@@ -90,7 +91,7 @@ bool J9::CFGSimplifier::simplifyUnresolvedRequireNonNull(bool needToDuplicateTre
 
    if (trace())
       traceMsg(comp(), "   Found an ifacmp[eq/ne] n%dn\n", compareNode->getGlobalIndex());
-  
+
    if (compareNode->getSecondChild()->getOpCodeValue() != TR::aconst
        || compareNode->getSecondChild()->getAddress() != 0)
       return false;
@@ -102,7 +103,7 @@ bool J9::CFGSimplifier::simplifyUnresolvedRequireNonNull(bool needToDuplicateTre
    if (trace())
       traceMsg(comp(), "  Matched nullBlock %d\n", nullBlock->getNumber());
 
-   TR::TreeTop *nullBlockCursor = nullBlock->getEntry()->getNextTreeTop(); 
+   TR::TreeTop *nullBlockCursor = nullBlock->getEntry()->getNextTreeTop();
 
    if (nullBlockCursor->getNode()->getOpCodeValue() != TR::ResolveCHK
        || nullBlockCursor->getNode()->getFirstChild()->getOpCodeValue() != TR::loadaddr)
@@ -137,7 +138,7 @@ bool J9::CFGSimplifier::simplifyUnresolvedRequireNonNull(bool needToDuplicateTre
        || nullBlockCursor->getNode()->getFirstChild()->getFirstChild() != exceptionNode)
       return false;
 
-   TR::Node *initCall = nullBlockCursor->getNode()->getFirstChild(); 
+   TR::Node *initCall = nullBlockCursor->getNode()->getFirstChild();
 
    if (trace())
       traceMsg(comp(), "   Matched call node %d\n", initCall->getGlobalIndex());
@@ -145,7 +146,7 @@ bool J9::CFGSimplifier::simplifyUnresolvedRequireNonNull(bool needToDuplicateTre
    if (!initCall->getSymbolReference()->isUnresolved())
       return false;
 
-   TR_Method *calleeMethod = initCall->getSymbol()->castToMethodSymbol()->getMethod();
+   TR::Method *calleeMethod = initCall->getSymbol()->castToMethodSymbol()->getMethod();
    if (trace())
       traceMsg(comp(), "   Matched calleeMethod %s %s %s\n", calleeMethod->classNameChars(), calleeMethod->nameChars(), calleeMethod->signatureChars());
    if (strncmp(calleeMethod->nameChars(), "<init>", 6) != 0
@@ -284,7 +285,7 @@ bool J9::CFGSimplifier::simplifyResolvedRequireNonNull(bool needToDuplicateTree)
    TR::Node *exceptionNode = nullBlockCursor->getNode()->getFirstChild();
    TR::Node *loadaddr = nullBlockCursor->getNode()->getFirstChild()->getFirstChild();
    // check for java/lang/NullPointerException as the loadaddr
-   TR_OpaqueClassBlock *NPEclazz = comp()->fej9()->getSystemClassFromClassName("java/lang/NullPointerException", strlen("java/lang/NullPointerException")); 
+   TR_OpaqueClassBlock *NPEclazz = comp()->fej9()->getSystemClassFromClassName("java/lang/NullPointerException", strlen("java/lang/NullPointerException"));
    if (loadaddr->getSymbolReference()->isUnresolved()
        || loadaddr->getSymbolReference()->getSymbol()->castToStaticSymbol()->getStaticAddress() != NPEclazz)
       return false;
@@ -323,7 +324,7 @@ bool J9::CFGSimplifier::simplifyResolvedRequireNonNull(bool needToDuplicateTree)
 
    if (trace())
       traceMsg(comp(), "   Matched exceptionNode call\n");
-   
+
    nullBlockCursor = nullBlockCursor->getNextTreeTop();
    if ((nullBlockCursor->getNode()->getOpCodeValue() != TR::treetop
         && nullBlockCursor->getNode()->getOpCodeValue() != TR::NULLCHK)

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
 #include "compile/InlineBlock.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -827,7 +828,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                      }
                   else
                      {
-                     TR_Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                     TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
                      heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                      }
                   }
@@ -849,7 +850,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
             resolvedMethod = calltarget->_calleeMethod->getResolvedSpecialMethod(comp(), (bc == J9BCinvokespecialsplit)?cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
             bool isIndirectCall = false;
             bool isInterface = false;
-            TR_Method *interfaceMethod = 0;
+            TR::Method *interfaceMethod = 0;
             TR::TreeTop *callNodeTreeTop = 0;
             TR::Node *parent = 0;
             TR::Node *callNode = 0;
@@ -866,7 +867,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                       {
                       if (bc == J9BCinvokespecialsplit)
                          cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
-                      TR_Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                      TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
                       heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                       }
                    }
@@ -885,7 +886,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
             resolvedMethod = calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (bc == J9BCinvokestaticsplit)?cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
             bool isIndirectCall = false;
             bool isInterface = false;
-            TR_Method *interfaceMethod = 0;
+            TR::Method *interfaceMethod = 0;
             TR::TreeTop *callNodeTreeTop = 0;
             TR::Node *parent = 0;
             TR::Node *callNode = 0;
@@ -902,7 +903,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                       {
                       if (bc == J9BCinvokestaticsplit)
                          cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
-                      TR_Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                      TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
                       heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                       }
                    }
@@ -1388,7 +1389,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   resolvedMethod == NULL
                   || (!resolvedMethod->isFinal() && !resolvedMethod->isPrivate());
                bool isInterface = false;
-               TR_Method *interfaceMethod = 0;
+               TR::Method *interfaceMethod = 0;
                TR::TreeTop *callNodeTreeTop = 0;
                TR::Node *parent = 0;
                TR::Node *callNode = 0;
@@ -1403,7 +1404,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                          heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
                       else
                          {
-                         TR_Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                         TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
                          heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                          }
                       }
@@ -1519,7 +1520,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                resolvedMethod = calltarget->_calleeMethod->getResolvedSpecialMethod(comp(), (bc == J9BCinvokespecialsplit)?cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
                bool isIndirectCall = false;
                bool isInterface = false;
-               TR_Method *interfaceMethod = 0;
+               TR::Method *interfaceMethod = 0;
                TR::TreeTop *callNodeTreeTop = 0;
                TR::Node *parent = 0;
                TR::Node *callNode = 0;
@@ -1534,7 +1535,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                          {
                          if (bc == J9BCinvokespecialsplit)
                             cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
-                         TR_Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                         TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
                          heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                          }
                       }
@@ -1585,7 +1586,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                resolvedMethod = calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (bc == J9BCinvokestaticsplit)?cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
                bool isIndirectCall = false;
                bool isInterface = false;
-               TR_Method *interfaceMethod = 0;
+               TR::Method *interfaceMethod = 0;
                TR::TreeTop *callNodeTreeTop = 0;
                TR::Node *parent = 0;
                TR::Node *callNode = 0;
@@ -1602,7 +1603,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                          {
                          if (bc == J9BCinvokestaticsplit)
                             cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
-                         TR_Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                         TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
                          heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                          }
                       }
@@ -1658,7 +1659,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                      && !resolvedMethod->convertToMethod()->isFinalInObject();
                   }
 
-               TR_Method * interfaceMethod = NULL;
+               TR::Method * interfaceMethod = NULL;
                if (isInterface)
                   interfaceMethod = comp()->fej9()->createMethod( comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
 

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -24,6 +24,7 @@
 #include "optimizer/VPBCDConstraint.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "il/symbol/ParameterSymbol.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -182,7 +183,7 @@ void
 J9::ValuePropagation::transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop* callTree, int32_t result, bool isGlobal, bool inPlace)
    {
     TR::Node * callNode = callTree->getNode()->getFirstChild();
-    TR_Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
+    TR::Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
     const char *signature = calledMethod->signature(comp()->trMemory(), stackAlloc);
     if (inPlace)
        {
@@ -928,7 +929,7 @@ J9::ValuePropagation::doDelayedTransformations()
       TR::TreeTop *callTree = it->_tree;
       int32_t result = it->_result;
       TR::Node * callNode = callTree->getNode()->getFirstChild();
-      TR_Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
+      TR::Method * calledMethod = callNode->getSymbol()->castToMethodSymbol()->getMethod();
       const char *signature = calledMethod->signature(comp()->trMemory(), stackAlloc);
 
       if (!performTransformation(comp(), "%sTransforming call %s on node %p on tree %p to iconst %d\n", OPT_DETAILS, signature, callNode, callTree, result))
@@ -1274,7 +1275,7 @@ static void transformToOptimizedCloneCall(OMR::ValuePropagation *vp, TR::Node *n
         {
         //FIXME: add me to the list of calls to be inlined
         //
-        TR_Method *method = optimizedCloneSymRef->getSymbol()->castToMethodSymbol()->getMethod();
+        TR::Method *method = optimizedCloneSymRef->getSymbol()->castToMethodSymbol()->getMethod();
         TR::Node *helpersCallNode = TR::Node::createWithSymRef(node, method->directCallOpCode(), 0, getHelpersSymRef);
         TR::TreeTop *helpersCallTT = TR::TreeTop::create(vp->comp(), TR::Node::create(TR::treetop, 1, helpersCallNode));
         vp->_curTree->insertBefore(helpersCallTT);

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -5307,7 +5307,7 @@ bool TR::CoarseningInterProceduralAnalyzer::analyzeNode(TR::Node *node, vcount_t
              else if (symRef->getSymbol()->getMethodSymbol())
                 {
                 TR::MethodSymbol *methodSymbol = symRef->getSymbol()->getMethodSymbol();
-                TR_Method * originalMethod = methodSymbol->getMethod();
+                TR::Method * originalMethod = methodSymbol->getMethod();
                 if (originalMethod)
                    {
                    classnameLength = originalMethod->classNameLength();

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -31,6 +31,7 @@
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
@@ -302,7 +303,7 @@ bool TR_SPMDKernelParallelizer::visitTreeTopToSIMDize(TR::TreeTop *tt, TR_SPMDKe
    TR::SymbolReference *piv = pSPMDInfo->getInductionVariableSymRef();
    bool trace = comp->trace(OMR::SPMDKernelParallelization);
 
-   // SIMD_TODO: check first child if node is TR::TreeTop 
+   // SIMD_TODO: check first child if node is TR::TreeTop
 
    if (trace)
       {
@@ -581,10 +582,10 @@ bool TR_SPMDKernelParallelizer::visitTreeTopToSIMDize(TR::TreeTop *tt, TR_SPMDKe
          }
       }
    else if (scalarOp.isBranch() || node->getOpCodeValue()==TR::BBEnd ||
-            node->getOpCodeValue()==TR::BBStart || node->getOpCodeValue()==TR::asynccheck || 
+            node->getOpCodeValue()==TR::BBStart || node->getOpCodeValue()==TR::asynccheck ||
             (node->getOpCodeValue()==TR::compressedRefs && node->getFirstChild()->getOpCode().isLoad()))
       {
-      //Compressed ref treetops with a load can be ignored due to the load 
+      //Compressed ref treetops with a load can be ignored due to the load
       // either being present under another tree top in the loop, which
       // will be processed, or not used at all. Stores under a compressed ref
       // tree top, will need to be handled differently
@@ -912,8 +913,8 @@ bool TR_SPMDKernelParallelizer::visitNodeToSIMDize(TR::Node *parent, int32_t chi
          return true;
          }
 
-      if (scalarOp.isNeg() || 
-          scalarOp.getOpCodeValue() == TR::l2d) 
+      if (scalarOp.isNeg() ||
+          scalarOp.getOpCodeValue() == TR::l2d)
          {
          if (isCheckMode)
             return true;
@@ -945,7 +946,7 @@ bool TR_SPMDKernelParallelizer::autoSIMDReductionSupported(TR::Compilation *comp
    //float and double not currently supported.
    static bool enableFPAutoSIMDReduction = feGetEnv("TR_enableFPAutoSIMDReduction") ? true : false;
 
-   if (!enableFPAutoSIMDReduction 
+   if (!enableFPAutoSIMDReduction
        && !_fpreductionAnnotation
        && (node->getDataType() == TR::Float || node->getDataType() == TR::Double))
       {
@@ -1002,7 +1003,7 @@ bool TR_SPMDKernelParallelizer::isReduction(TR::Compilation *comp, TR_RegionStru
    TR::ILOpCode opCode = node->getOpCode();
 
    if (opCode.isConversion() && node->getFirstChild()->getOpCode().isLoadVar()) {
-      node = node->getFirstChild(); 
+      node = node->getFirstChild();
       opCode = node->getOpCode();
    }
 
@@ -1090,7 +1091,7 @@ bool TR_SPMDKernelParallelizer::noReductionVar(TR::Compilation *comp, TR_RegionS
    TR::ILOpCode opCode = node->getOpCode();
 
    if (opCode.isConversion() && node->getFirstChild()->getOpCode().isLoadVar()) {
-      node = node->getFirstChild(); 
+      node = node->getFirstChild();
       opCode = node->getOpCode();
    }
 
@@ -2706,7 +2707,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionExits(List<TR::Block>* exitBlocks
    for (exitBlock = si.getCurrent(); exitBlock; exitBlock = si.getNext())
       {
       TR::TreeTop *insertionPoint = exitBlock->getEntry();
-      
+
       TR::Node* regionExitGPUNode = TR::Node::create(insertionPoint->getNode(), TR::icall, 4);
       helper = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_regionExitGPU, false, false, false);
       helper->getSymbol()->castToMethodSymbol()->setLinkage(_helperLinkage/*@*/);
@@ -2737,7 +2738,7 @@ void TR_SPMDKernelParallelizer::insertGPURegionExitInRegionExits(List<TR::Block>
    {
    List<TR::CFGEdge> exitEdges(comp()->trMemory());
 
-   TR::CFG *cfg = comp()->getFlowGraph(); 
+   TR::CFG *cfg = comp()->getFlowGraph();
    TR_BitVector *blocksInsideLoop = new (trStackMemory()) TR_BitVector(cfg->getNextNodeNumber(), trMemory(), stackAlloc);
 
    TR::Block *blockInLoop = 0;
@@ -3271,7 +3272,7 @@ bool TR_SPMDKernelParallelizer::processGPULoop(TR_RegionStructure *loop, TR_SPMD
          exitBlocks.add(kernelExitBlock);
 
          insertGPURegionEntry(hoistRegionInvariantBlock, gpuScope->_scopeSymRef, gpuPtxCount, gpuScope->getScopeType());
-         insertGPURegionExits(&exitBlocks, gpuScope->_scopeSymRef, gpuPtxCount, liveSymRef, gpuScope->getExitLocationsList()); 
+         insertGPURegionExits(&exitBlocks, gpuScope->_scopeSymRef, gpuPtxCount, liveSymRef, gpuScope->getExitLocationsList());
 
          insertGPUTemporariesLivenessCode(gpuScope->getExitLocationsList(), liveSymRef, true);
          break;
@@ -3303,7 +3304,7 @@ bool TR_SPMDKernelParallelizer::processGPULoop(TR_RegionStructure *loop, TR_SPMD
             }
          else
             {
-            scopeSymRef = gpuScope->_scopeSymRef;      
+            scopeSymRef = gpuScope->_scopeSymRef;
             liveSymRef  = gpuScope->_liveSymRef;
             insertGPUTemporariesLivenessCode(gpuScope->getExitLocationsList(), liveSymRef, false);
             }
@@ -3517,7 +3518,7 @@ bool TR_SPMDKernelParallelizer::visitCPUNode(TR::Node *node, int32_t visitCount,
             return false;
             }
 
-         TR_Method * method = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod();
+         TR::Method * method = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod();
          const char * signature = method->signature(comp()->trMemory(), stackAlloc);
 
          traceMsg(comp(), "signature: %s\n", signature ? signature : "NULL");
@@ -3969,7 +3970,7 @@ int TR_SPMDKernelParallelizer::symbolicEvaluateTree(TR::Node *node)
          if (node->getOpCodeValue() == TR::lconst || node->getOpCodeValue() == TR::iconst) return node->getInt();
          return 0; //else
       case 1:
-         // only ilop that will do this is TR::i2l 
+         // only ilop that will do this is TR::i2l
          return symbolicEvaluateTree(node->getFirstChild());
       case 2:
          c1 = symbolicEvaluateTree(node->getFirstChild());
@@ -3978,8 +3979,8 @@ int TR_SPMDKernelParallelizer::symbolicEvaluateTree(TR::Node *node)
 
    switch(node->getOpCodeValue()) // support either add, sub or mul
       {
-      case TR::imul: 
-      case TR::lmul: 
+      case TR::imul:
+      case TR::lmul:
          return (c1*c2);
       case TR::iadd:
       case TR::ladd:
@@ -3997,7 +3998,7 @@ TR::Node* TR_SPMDKernelParallelizer::findSingleLoopVariant(TR::Node *node, TR_Re
    TR::Node* node1 = NULL;
    TR::Node* node2 = NULL;
    if (node->getNumChildren() >= 1) node1 = findSingleLoopVariant(node->getFirstChild(), loop, sign, constantsOnly);
-   if (node->getNumChildren() == 2) 
+   if (node->getNumChildren() == 2)
       {
       *sign = (*sign)^(node->getOpCode().isSub());
       node2 = findSingleLoopVariant(node->getSecondChild(), loop, sign, constantsOnly);
@@ -4009,8 +4010,8 @@ TR::Node* TR_SPMDKernelParallelizer::findSingleLoopVariant(TR::Node *node, TR_Re
       *constantsOnly = 1;
       }
 
-   if (node->getNumChildren() == 0 && !loop->isExprInvariant(node)) return node; 
-   if (node->getNumChildren() == 0 && loop->isExprInvariant(node)) return NULL; 
+   if (node->getNumChildren() == 0 && !loop->isExprInvariant(node)) return node;
+   if (node->getNumChildren() == 0 && loop->isExprInvariant(node)) return NULL;
    if (node1 != NULL && node2 != NULL) return NULL;
    if (node1 == NULL && node2 == NULL) return NULL;
    if (node1 != NULL && node2 == NULL) return node1;
@@ -4031,9 +4032,9 @@ bool TR_SPMDKernelParallelizer::checkConstantDistanceDependence(TR_RegionStructu
       {
       return false;
       }
- 
-   TR::Node* invariantNodedefs; 
-   TR::Node* invariantNodeuses; 
+
+   TR::Node* invariantNodedefs;
+   TR::Node* invariantNodeuses;
    int sign1 = 0;
    int sign2 = 0;
    int constantsOnly1 = 0;
@@ -4044,8 +4045,8 @@ bool TR_SPMDKernelParallelizer::checkConstantDistanceDependence(TR_RegionStructu
    // and ensure the signs on the loop variant nodes is correct
    invariantNodedefs = findSingleLoopVariant(node1->getFirstChild()->getSecondChild(), loop, &sign1, &constantsOnly1);
    invariantNodeuses = findSingleLoopVariant(node2->getFirstChild()->getSecondChild(), loop, &sign2, &constantsOnly2);
-   if (!areNodesEquivalent(comp,invariantNodedefs,invariantNodeuses) && 
-       sign1 == sign2) 
+   if (!areNodesEquivalent(comp,invariantNodedefs,invariantNodeuses) &&
+       sign1 == sign2)
       {
       return false;
       }
@@ -4067,7 +4068,7 @@ bool TR_SPMDKernelParallelizer::checkConstantDistanceDependence(TR_RegionStructu
 
       if (type == 0 && (distance >= VECTOR_SIZE || distance <= 0))
          { // permissable flow dependence
-         return true; 
+         return true;
          }
       if (type == 1 && (distance >= 0 || distance <= -VECTOR_SIZE))
          { // permissable output dependence
@@ -4118,12 +4119,12 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
                }
 
             if (checkConstantDistanceDependence(loop,defs[dc],defs[dc2],comp,1))
-               { 
+               {
                continue;
                }
 
             traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: def %p and def %p are dependent\n", defs[dc], defs[dc2]);
-            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n"); 
+            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n");
             return false;
             }
          }
@@ -4141,14 +4142,14 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
                {
                continue;
                }
-            
+
             if (checkConstantDistanceDependence(loop,defs[dc],uses[uc],comp,0))
-               { 
+               {
                continue;
                }
 
             traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: def %p and use %p are dependent\n", defs[dc], uses[uc]);
-            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n"); 
+            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n");
             return false;
             }
          }

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -26,6 +26,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
@@ -180,7 +181,7 @@ int32_t TR_VarHandleTransformer::perform()
          TR::TreeTop *callTree = tt;
          TR::SymbolReference *symRef = node->getSymbolReference();
          OMR::MethodSymbol *symbol = node->getSymbol()->castToMethodSymbol();
-         TR_Method * method = symbol->getMethod();
+         TR::Method * method = symbol->getMethod();
          TR::RecognizedMethod varHandleAccessMethod = getVarHandleAccessMethod(node);
 
          if (varHandleAccessMethod != TR::unknownMethod)

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -33,6 +33,7 @@
 #include "codegen/Relocation.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/VirtualGuard.hpp"
 #include "control/MethodToBeCompiled.hpp"
@@ -3802,7 +3803,7 @@ TR_DebugExt::dxGetSignature(J9UTF8 *className, J9UTF8 *name, J9UTF8 *signature)
 const char *
 TR_DebugExt::getMethodName(TR::SymbolReference * symRef)
    {
-   TR_Method * method = symRef->getSymbol()->castToMethodSymbol()->getMethod();
+   TR::Method * method = symRef->getSymbol()->castToMethodSymbol()->getMethod();
    TR_J9MethodBase *localMethod = (TR_J9MethodBase *) dxMallocAndRead(sizeof(TR_J9MethodBase), (void*)method);
    //TR_J9MethodBase *localMethod = (TR_J9MethodBase *)symRef->getSymbol()->castToMethodSymbol()->getMethod();
 

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -443,7 +443,7 @@ void TR_ValueProfiler::modifyTrees()
 
             if (methodSymbol->isInterface())
                {
-               TR_Method *interfaceMethod = methodSymbol->getMethod();
+               TR::Method *interfaceMethod = methodSymbol->getMethod();
                int32_t         cpIndex      = methodSymRef->getCPIndex();
                int32_t len = interfaceMethod->classNameLength();
                char * s = classNameToSignature(interfaceMethod->classNameChars(), len, comp());
@@ -1351,7 +1351,7 @@ TR_ExternalValueProfileInfo::getInfo(TR_OpaqueMethodBlock *method, TR::Compilati
          return *info;
       }
 
-   return NULL; 
+   return NULL;
    }
 
 /**
@@ -1786,7 +1786,7 @@ TR_BlockFrequencyInfo::getFrequencyInfo(
          callStack.push_back(std::make_pair(comp->fe()->getInlinedCallSiteMethod(callSite), bciToCheck));
          bciToCheck = callSite->_byteCodeInfo;
          }
-      
+
       // step 2 - find the level at which the inlining has begun to differ for the previous compile
       // eg find the point where the current profiling info has no profiling data for the given bci
       TR_ByteCodeInfo lastProfiledBCI = bciToCheck;
@@ -1953,7 +1953,7 @@ TR_BlockFrequencyInfo::getOriginalBlockNumberToGetRawCount(TR_ByteCodeInfo &bci,
    int32_t byteCodeToSearch = resolvedMethod->getProfilingByteCodeIndex(bci.getByteCodeIndex());
    TR_ByteCodeInfo searchBCI = bci;
    searchBCI.setByteCodeIndex(byteCodeToSearch);
-   bool currentCallSiteInfo = TR_CallSiteInfo::getCurrent(comp) == _callSiteInfo; 
+   bool currentCallSiteInfo = TR_CallSiteInfo::getCurrent(comp) == _callSiteInfo;
    for (auto i=0; i < _numBlocks; ++i)
       {
       if (currentCallSiteInfo && _callSiteInfo->hasSameBytecodeInfo(_blocks[i], searchBCI, comp) ||
@@ -2717,7 +2717,7 @@ TR_PersistentProfileInfo *TR_AccessedProfileInfo::get(TR::Compilation *comp)
       // it may mislead and confuse
       if (_current && _current == TR_PersistentProfileInfo::getCurrent(comp))
          {
-         TR_PersistentProfileInfo::decRefCount(_current); 
+         TR_PersistentProfileInfo::decRefCount(_current);
          _current = NULL;
          }
       }

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
+#include "compile/Method.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CHTable.hpp"
@@ -1315,7 +1316,7 @@ void TR::AMD64PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *
    lastPicSlot.setHelperMethodSymbolRef(callHelperSymRef);
    TR::Instruction *slotPatchInstruction = NULL;
 
-   TR_Method *method = site.getMethodSymbol()->getMethod();
+   TR::Method *method = site.getMethodSymbol()->getMethod();
    TR_OpaqueClassBlock *declaringClass = NULL;
    uintptrj_t itableIndex;
    if (  useLastITableCache

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -31,6 +31,7 @@
 #include "codegen/RegisterPair.hpp"
 #include "codegen/Snippet.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/VirtualGuard.hpp"
 #include "env/CHTable.hpp"
@@ -1173,7 +1174,7 @@ TR::X86CallSite::X86CallSite(TR::Node *callNode, TR::Linkage *calleeLinkage)
       // Find the class pointer to the interface class if it is already loaded.
       // This is needed by both static PICs
       //
-      TR_Method *interfaceMethod = getMethodSymbol()->getMethod();
+      TR::Method *interfaceMethod = getMethodSymbol()->getMethod();
       int32_t len = interfaceMethod->classNameLength();
       char * s = classNameToSignature(interfaceMethod->classNameChars(), len, comp());
       _interfaceClassOfMethod = fej9->getClassFromSignature(s, len, getSymbolReference()->getOwningMethod(comp()));
@@ -1730,7 +1731,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    if (getProperties().getNeedsThunksForIndirectCalls())
       {
       TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
-      TR_Method       *method       = methodSymbol->getMethod();
+      TR::Method       *method       = methodSymbol->getMethod();
       if (methodSymbol->isComputed())
          {
          switch (method->getMandatoryRecognizedMethod())

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -30,6 +30,7 @@
 #include "codegen/Register.hpp"
 #include "codegen/RegisterPair.hpp"
 #include "codegen/Snippet.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
@@ -640,7 +641,7 @@ void TR::IA32PrivateLinkage::buildIPIC(
 
    TR::Instruction *slotPatchInstruction = NULL;
 
-   TR_Method *method = site.getMethodSymbol()->getMethod();
+   TR::Method *method = site.getMethodSymbol()->getMethod();
    TR_OpaqueClassBlock *declaringClass = NULL;
    uintptrj_t itableIndex;
    if (  useLastITableCache


### PR DESCRIPTION
Prepare to make the `TR_Method` base class an extensible class.  OMR has introduced
a typedef of `TR_Method` to `TR::Method`.  Modify references throughout the OpenJ9
compiler.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>