### PR TITLE
Correct default name of jdmpview from dtfjview

### DIFF
--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
@@ -462,7 +462,7 @@ public class Session implements ISession {
 	
 	//print some help for the user
 	private void printHelp() {
-		String launcher = System.getProperty(SYSPROP_LAUNCHER, "dtfjview");
+		String launcher = System.getProperty(SYSPROP_LAUNCHER, "jdmpview");
 		
 		out.print(
 				"Usage: \"" + launcher + " -core <core_file> [-verbose]\" or \n" +


### PR DESCRIPTION
Fixes #6221
Fixes ibmruntimes/openj9-openjdk-jdk8#314