### PR TITLE
Remove unused variable mandatoryCodeCacheAddress

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -251,8 +251,6 @@ int32_t J9::Options::_jProfilingEnablementSampleThreshold = 10000;
 
 bool J9::Options::_aggressiveLockReservation = false;
 
-uintptr_t J9::Options::_mandatoryCodeCacheAddress = 0;
-
 uint32_t J9::Options::_compilationSequenceNumber = 0;
 
 //************************************************************************
@@ -884,8 +882,6 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_lowerBoundNumProcForScaling, 0, "F%d", NOT_IN_SUBSET},
    {"lowVirtualMemoryMBThreshold=","M<nnn>\tThreshold when we declare we are running low on virtual memory. Use 0 to disable the feature",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_lowVirtualMemoryMBThreshold, 0, "F%d", NOT_IN_SUBSET},
-   {"mandatoryCodeCacheAddress=", "M<nnn>\tforce the allocation of code cache repository at specified address. Use hexa without 0x",
-        TR::Options::setStaticHexadecimal, (uintptr_t)&TR::Options::_mandatoryCodeCacheAddress, 0, "F%x", NOT_IN_SUBSET },
    {"maxCheckcastProfiledClassTests=", "R<nnn>\tnumber inlined profiled classes for profiledclass test in checkcast/instanceof",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_maxCheckcastProfiledClassTests, 0, "%d", NOT_IN_SUBSET},
    {"maxOnsiteCacheSlotForInstanceOf=", "R<nnn>\tnumber of onsite cache slots for instanceOf",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -302,8 +302,6 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static bool _aggressiveLockReservation;
 
-   static uintptr_t _mandatoryCodeCacheAddress;
-
    static uint32_t _compilationSequenceNumber;
 
    static void  printPID();

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -386,14 +386,6 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
       }
    if (!codeCacheSegment && preferredStartAddress)
       {
-      // Fail the VM if we requested a specific address, but couldn't get it
-      if (TR::Options::_mandatoryCodeCacheAddress)
-         {
-         if (config.verboseCodeCache())
-            TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "Could not allocate code cache at mandatory address %p", (void*)TR::Options::_mandatoryCodeCacheAddress);
-         mcc_printf("TR::CodeCache::allocate : codeCacheSegment is NULL, %p\n", codeCacheSegment);
-         exit(1);
-         }
 #if !defined(J9ZOS390)
       // we could have failed because we wanted a start address
       // let's try without it
@@ -515,9 +507,6 @@ J9::CodeCacheManager::chooseCacheStartAddress(size_t repositorySize)
    {
    void *startAddress = NULL;
 #if defined(TR_HOST_64BIT) && defined(TR_TARGET_X86)
-   if (TR::Options::_mandatoryCodeCacheAddress)
-      return (void*)TR::Options::_mandatoryCodeCacheAddress;
-   
    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableSmartPlacementOfCodeCaches))
       {
       size_t alignment = 2 * 1024 * 1024; // 2MB alignment
@@ -717,7 +706,7 @@ J9::CodeCacheManager::printRemainingSpaceInCodeCaches()
    CacheListCriticalSection scanCacheList(self());
    for (TR::CodeCache *codeCache = self()->getFirstCodeCache(); codeCache; codeCache = codeCache->next())
       {
-      fprintf(stderr, "cache %p has %u bytes empty\n", codeCache, codeCache->getFreeContiguousSpace());
+      fprintf(stderr, "cache %p has %lu bytes empty\n", codeCache, codeCache->getFreeContiguousSpace());
       if (codeCache->isReserved())
          fprintf(stderr, "Above cache is reserved by compThread %d\n", codeCache->getReservingCompThreadID());
       }


### PR DESCRIPTION
[skip ci]
Remove code related to mandatoryCodeCacheAddress

-This variable is no longer used due to changes in
 code
-Removed code related to mandatoryCodeCacheAddress
 including initialization and calls and gets
-Related code in 3 files including J9Options.cpp and
 hpp, J8CodeCacheManager.cpp
-Discovered by a compilation warning related to it

Issue: #6144

Signed-off-by: caohaley <haleycao88@hotmail.com>