### PR TITLE
Specialize MethodHandle.invokeExact in ILGen

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -3291,6 +3291,16 @@ void TR_J9ByteCodeIlGenerator::expandMethodHandleInvokeCall(TR::TreeTop *tree)
       TR_ASSERT(comp(), "Unexpected MethodHandle invoke call at n%dn %p", callNode->getGlobalIndex(), callNode);
       }
 
+   // Specialize MethodHandle.invokeExact if the receiver handle is a known object
+   TR::Node* methodHandle = callNode->getFirstArgument();
+   if (methodHandle->getOpCode().hasSymbolReference()
+       && methodHandle->getSymbolReference()->hasKnownObjectIndex())
+      {
+      TR::KnownObjectTable::Index index = methodHandle->getSymbolReference()->getKnownObjectIndex();
+      uintptrj_t* objectLocation = comp()->getKnownObjectTable()->getPointerLocation(index);
+      TR::TransformUtil::specializeInvokeExactSymbol(comp(), callNode,  objectLocation);
+      }
+
    _bcIndex = oldBCIndex;
 
    if (comp()->getOption(TR_TraceILGen))

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -190,6 +190,19 @@ public:
     *
     */
    static void truncateBooleanForUnsafeGetPut(TR::Compilation *comp, TR::TreeTop* tree);
+
+   /*
+    * \brief
+    *    Speclize `MethodHandle.invokeExact` with a known receiver handle to a thunk archetype specimen.
+    *    This will allow inliner inline the call.
+    *
+    *   \param comp  The compilation Object
+    *   \param callNode The node with `MethodHandle.invokeExact` call
+    *   \param methodHandleLocation A pointer to the MethodHandle object reference
+    *
+    *   \return True if specialization succeeds, false otherwise
+    */
+   static bool specializeInvokeExactSymbol(TR::Compilation *comp, TR::Node *callNode, uintptrj_t *methodHandleLocation);
 protected:
    /**
     * \brief


### PR DESCRIPTION
If the receiver for `MethodHandle.invokeExact` is a known object, the
method symbol can be replaced with a specialized thunk archetype
specimen to trigger MethodHandle inlining. Currently, this specializatin
is done in invariantArgumentPreexistence which is conditional on the VM
phase.

#4837 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>