### PR TITLE
Fix casting error in TR_J9MethodFieldAttributes

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1161,7 +1161,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          TR::DataType type;
          bool volatileP, isFinal, isPrivate, unresolvedInCP;
          bool result = method->staticAttributes(comp, cpIndex, &address, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
-         TR_J9MethodFieldAttributes attrs(address, type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
+         TR_J9MethodFieldAttributes attrs(reinterpret_cast<uintptr_t>(address), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
          client->write(attrs);
          }
          break;
@@ -1202,7 +1202,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          TR::DataType type;
          bool volatileP, isFinal, isPrivate, unresolvedInCP;
          bool result = method->fieldAttributes(comp, cpIndex, &fieldOffset, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
-         TR_J9MethodFieldAttributes attrs((void *) fieldOffset, type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
+         TR_J9MethodFieldAttributes attrs(static_cast<uintptr_t>(fieldOffset), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
          client->write(attrs);
          }
          break;
@@ -1822,7 +1822,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          bool volatileP, isFinal, isPrivate, unresolvedInCP;
          bool result = method->fieldAttributes(comp, cpIndex, &fieldOffset, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
 
-         TR_J9MethodFieldAttributes attrs((void *) fieldOffset, type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
+         TR_J9MethodFieldAttributes attrs(static_cast<uintptr_t>(fieldOffset), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
          TR_OpaqueClassBlock *definingClass = compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), fe->_jitConfig->javaVM, constantPool, cpIndex, false);
@@ -1841,7 +1841,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          TR::DataType type;
          bool volatileP, isFinal, isPrivate, unresolvedInCP;
          bool result = method->staticAttributes(comp, cpIndex, &address, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
-         TR_J9MethodFieldAttributes attrs(address, type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
+         TR_J9MethodFieldAttributes attrs(reinterpret_cast<uintptr_t>(address), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
          TR_OpaqueClassBlock *definingClass = compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), fe->_jitConfig->javaVM, constantPool, cpIndex, true);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -31,10 +31,10 @@ class TR_J9MethodFieldAttributes
    {
 public:
    TR_J9MethodFieldAttributes() :
-      TR_J9MethodFieldAttributes(NULL, TR::NoType, false, false, false, false, false)
+      TR_J9MethodFieldAttributes(0, TR::NoType, false, false, false, false, false)
       {}
 
-   TR_J9MethodFieldAttributes(void *fieldOffsetOrAddress,
+   TR_J9MethodFieldAttributes(uintptr_t fieldOffsetOrAddress,
                               TR::DataType type,
                               bool volatileP,
                               bool isFinal,
@@ -66,13 +66,13 @@ public:
    void setMethodFieldAttributesResult(uint32_t *fieldOffset, TR::DataType *type, bool *volatileP, bool *isFinal, bool *isPrivate, bool *unresolvedInCP, bool *result)
       {
       setMethodFieldAttributesResult(type, volatileP, isFinal, isPrivate, unresolvedInCP, result);
-      if (fieldOffset) *fieldOffset = (uint32_t) *( (uint32_t *) &_fieldOffsetOrAddress);
+      if (fieldOffset) *fieldOffset = static_cast<uint32_t>(_fieldOffsetOrAddress);
       }
 
    void setMethodFieldAttributesResult(void **address, TR::DataType *type, bool *volatileP, bool *isFinal, bool *isPrivate, bool *unresolvedInCP, bool *result)
       {
       setMethodFieldAttributesResult(type, volatileP, isFinal, isPrivate, unresolvedInCP, result);
-      if (address) *address = _fieldOffsetOrAddress;
+      if (address) *address = reinterpret_cast<void *>(_fieldOffsetOrAddress);
       }
 
    bool isUnresolvedInCP() const { return _unresolvedInCP; }
@@ -88,7 +88,7 @@ private:
       if (result) *result = _result;
       }
 
-   void *_fieldOffsetOrAddress; // stores uint32_t for non-static attributes
+   uintptr_t _fieldOffsetOrAddress; // Stores a uint32_t representing an offset for non-static fields, or an address for static fields.
    TR::DataType _type; 
    bool _volatileP;
    bool _isFinal;


### PR DESCRIPTION
`_fieldOffsetOrAddress` is a `void *` pointer,
but it can also store a `uint32_t` integer.
However, directly casting `uint32_t` to `void *`
and then casting back from `void *` to `uint32_t`
does not work correctly on Big Endian systems.
Fix by making `_fieldOffsetOrAddress` have type
`uintptr_t` and using C++ style casts.
