### PR TITLE
Remove cleanBeforeCheckout() from pipeline clones

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -50,9 +50,6 @@ pipelineJob("$JOB_NAME") {
                         refspec('$SCM_REFSPEC')
                     }
                     branch('$SCM_BRANCH')
-                    extensions {
-                        cleanBeforeCheckout()
-                    }
                 }
             }
             scriptPath(pipelineScript)


### PR DESCRIPTION
- This is an unnecessary step in the pipeline clone.
- Recently there was an intermittent issue in a few
  builds where the cleanWs would throw an error.
  Removing this step will avoid that problem.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>