### PR TITLE
Remove space in DDR GC directory list

### DIFF
--- a/runtime/gc_ddr/gcddrstructs.properties
+++ b/runtime/gc_ddr/gcddrstructs.properties
@@ -31,7 +31,7 @@ ddrblob.headers.directories=gc_api,\
 omr/gc/base,\
 omr/gc/base/standard,\
 omr/gc/base/segregated,\
-omr/gc/base/vlhgc, \
+omr/gc/base/vlhgc,\
 omr/gc/structs,\
 omr/gc/stats,\
 omr/gc/include,\


### PR DESCRIPTION
The list is split into separate strings for the java DDR tool to
process. The space creates an empty string, which later results in a
NULL ptr exception.