### PR TITLE
 Java 13: deprecate -Xverify:none and -noverify

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1932,3 +1932,10 @@ J9NLS_VM_CLASS_LOADING_ERROR_NON_INTERFACE.explanation=The specified interface i
 J9NLS_VM_CLASS_LOADING_ERROR_NON_INTERFACE.system_action=The JVM will throw an IncompatibleClassChangeError.
 J9NLS_VM_CLASS_LOADING_ERROR_NON_INTERFACE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_XVERIFYNONE_DEPRECATED=Since Java 13 -Xverify:none and -noverify were deprecated for removal and may not be accepted options in the future.
+# START NON-TRANSLATABLE
+J9NLS_VM_XVERIFYNONE_DEPRECATED.explanation=Since Java 13 -Xverify:none and -noverify were deprecated for removal and may not be accepted options in the future.
+J9NLS_VM_XVERIFYNONE_DEPRECATED.system_action=The JVM will show a warning and continue to recognize the options.
+J9NLS_VM_XVERIFYNONE_DEPRECATED.user_response=Consider not using these options as they will likely be removed in a future release.
+# END NON-TRANSLATABLE

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -208,7 +208,6 @@ enum INIT_STAGE {
 #define VMOPT_XJCL_COLON "-Xjcl:"
 #define VMOPT_XFUTURE "-Xfuture"
 #define VMOPT_ALL "all"
-#define VMOPT_XVERIFY_ALL "-Xverify:" VMOPT_ALL
 #define VMOPT_XSIGQUITTOFILE "-XsigquitToFile"
 #define VMOPT_XDEBUG "-Xdebug"
 #define VMOPT_XNOAGENT "-Xnoagent"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2532,8 +2532,11 @@ static void consumeVMArgs(J9JavaVM* vm, J9VMInitArgs* j9vm_args) {
 	BOOLEAN assertOptionFound = FALSE;
 
 	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XINT, NULL, TRUE);
-	/* If -Xverify:none, other -Xverify args previous to that should be ignored */
+	/* If -Xverify:none, other -Xverify args previous to that should be ignored. As of Java 13 -Xverify:none and -noverify are deprecated. */
 	if (findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XVERIFY_COLON, OPT_NONE, TRUE) >= 0) {
+		if (J2SE_VERSION(vm) >= J2SE_V13) {
+			j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_XVERIFYNONE_DEPRECATED);
+		}
 		findArgInVMArgs( PORTLIB, j9vm_args, OPTIONAL_LIST_MATCH, VMOPT_XVERIFY, NULL, TRUE);
 	}
 #if defined(J9VM_INTERP_VERBOSE)


### PR DESCRIPTION
Fixes: #5822

Doc issue https://github.com/eclipse/openj9-docs/issues/300

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>