### PR TITLE
Change J9ServerMessageType into MessageType

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1088,7 +1088,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
             // to avoid having to call scanForNativeMethodsUntilMonitorNode again.
             if (auto stream = TR::CompilationInfo::getStream())
                {
-               stream->write(JITaaS::J9ServerMessageType::CHTable_clearReservable, classPointer);
+               stream->write(JITaaS::MessageType::CHTable_clearReservable, classPointer);
                // No response necessary - we can continue concurrently
                }
             }

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -454,7 +454,7 @@ public:
       {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_isCompiled, method);
+         stream->write(JITaaS::MessageType::CompInfo_isCompiled, method);
          return std::get<0>(stream->read<bool>());
          }
       return (((uintptrj_t)method->extra) & J9_STARTPC_NOT_TRANSLATED) == 0;
@@ -463,7 +463,7 @@ public:
       {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_isJNINative, method);
+         stream->write(JITaaS::MessageType::CompInfo_isJNINative, method);
          return std::get<0>(stream->read<bool>());
          }
       // Note: This query is only concerned with the method to be compiled
@@ -475,7 +475,7 @@ public:
       {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_getInvocationCount, method);
+         stream->write(JITaaS::MessageType::CompInfo_getInvocationCount, method);
          return std::get<0>(stream->read<int32_t>());
          }
       if (((intptrj_t)method->extra & J9_STARTPC_NOT_TRANSLATED) == 0)
@@ -489,7 +489,7 @@ public:
       {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_getJ9MethodExtra, method);
+         stream->write(JITaaS::MessageType::CompInfo_getJ9MethodExtra, method);
          return (intptrj_t) std::get<0>(stream->read<uint64_t>());
          }
       return (intptrj_t)method->extra;
@@ -506,7 +506,7 @@ public:
    static void * getJ9MethodStartPC(J9Method *method) {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_getJ9MethodStartPC, method);
+         stream->write(JITaaS::MessageType::CompInfo_getJ9MethodStartPC, method);
          return std::get<0>(stream->read<void*>());
          }
       else
@@ -518,7 +518,7 @@ public:
    static void setJ9MethodExtra(J9Method *method, intptrj_t newValue) {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_setJ9MethodExtra, method, (uint64_t) newValue);
+         stream->write(JITaaS::MessageType::CompInfo_setJ9MethodExtra, method, (uint64_t) newValue);
          std::get<0>(stream->read<JITaaS::Void>());
          }
       else
@@ -547,7 +547,7 @@ public:
       {
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_setInvocationCount, method, newCount);
+         stream->write(JITaaS::MessageType::CompInfo_setInvocationCount, method, newCount);
          return std::get<0>(stream->read<bool>());
          }
       newCount = (newCount << 1) | 1;
@@ -558,7 +558,7 @@ public:
    static bool setInvocationCount(J9Method *method, int32_t oldCount, int32_t newCount){
       if (auto stream = getStream())
          {
-         stream->write(JITaaS::J9ServerMessageType::CompInfo_setInvocationCountAtomic, method, oldCount, newCount);
+         stream->write(JITaaS::MessageType::CompInfo_setInvocationCountAtomic, method, oldCount, newCount);
          return std::get<0>(stream->read<bool>());
          }
       newCount = (newCount << 1) | 1;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1389,7 +1389,7 @@ TR::CompilationInfo::getMethodBytecodeSize(J9Method* method)
             return getMethodBytecodeSize(it->second._romMethod);
             }
          }
-      stream->write(JITaaS::J9ServerMessageType::CompInfo_getMethodBytecodeSize, method);
+      stream->write(JITaaS::MessageType::CompInfo_getMethodBytecodeSize, method);
       return std::get<0>(stream->read<uint32_t>());
       }
    return getMethodBytecodeSize(J9_ROM_METHOD_FROM_RAM_METHOD(method));
@@ -1415,7 +1415,7 @@ TR::CompilationInfo::isJSR292(J9Method *j9method) // Check to see if the J9AccMe
             return isJSR292(it->second._romMethod);
             }
          }
-      stream->write(JITaaS::J9ServerMessageType::CompInfo_isJSR292, j9method);
+      stream->write(JITaaS::MessageType::CompInfo_isJSR292, j9method);
       return std::get<0>(stream->read<bool>());
       }
    return isJSR292(J9_ROM_METHOD_FROM_RAM_METHOD(j9method));
@@ -3414,7 +3414,7 @@ void TR::CompilationInfo::stopCompilationThreads()
       try
          {
          JITaaS::J9ClientStream client(getPersistentInfo());
-         client.writeError(JITaaS::J9ServerMessageType::clientTerminate, getPersistentInfo()->getJITaaSId());
+         client.writeError(JITaaS::MessageType::clientTerminate, getPersistentInfo()->getJITaaSId());
          }
       catch (const JITaaS::StreamFailure &e)
          {

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -88,7 +88,7 @@ J9::ClassEnv::classFlagsValue(TR_OpaqueClassBlock * classPointer)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_classFlagsValue, classPointer);
+      stream->write(JITaaS::MessageType::ClassEnv_classFlagsValue, classPointer);
       return std::get<0>(stream->read<uintptrj_t>());
       }
    return (TR::Compiler->cls.convertClassOffsetToClassPtr(classPointer)->classFlags);
@@ -103,7 +103,7 @@ J9::ClassEnv::classFlagReservableWorldInitValue(TR_OpaqueClassBlock * classPoint
       uintptrj_t classFlags = 0;
       JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)classPointer, TR::compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_FLAGS, (void *)&classFlags);
 #ifdef DEBUG
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_classFlagsValue, classPointer);
+      stream->write(JITaaS::MessageType::ClassEnv_classFlagsValue, classPointer);
       uintptrj_t classFlagsRemote = std::get<0>(stream->read<uintptrj_t>());
       // check that class flags from remote call is equal to the cached ones
       classFlags = classFlags & J9ClassReservableLockWordInit;
@@ -158,7 +158,7 @@ J9::ClassEnv::superClassesOf(TR_OpaqueClassBlock * clazz)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_superClassesOf, clazz);
+      stream->write(JITaaS::MessageType::ClassEnv_superClassesOf, clazz);
       return std::get<0>(stream->read<J9Class **>());
       }
    return TR::Compiler->cls.convertClassOffsetToClassPtr(clazz)->superclasses;
@@ -169,7 +169,7 @@ J9::ClassEnv::romClassOfSuperClass(TR_OpaqueClassBlock * clazz, size_t index)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_indexedSuperClassOf, clazz, index);
+      stream->write(JITaaS::MessageType::ClassEnv_indexedSuperClassOf, clazz, index);
       J9Class *j9clazz = std::get<0>(stream->read<J9Class *>());
       return TR::compInfoPT->getAndCacheRemoteROMClass(j9clazz);
       }
@@ -181,7 +181,7 @@ J9::ClassEnv::iTableOf(TR_OpaqueClassBlock * clazz)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_iTableOf, clazz);
+      stream->write(JITaaS::MessageType::ClassEnv_iTableOf, clazz);
       return std::get<0>(stream->read<J9ITable*>());
       }
    return (J9ITable*) convertClassOffsetToClassPtr(clazz)->iTable;
@@ -192,7 +192,7 @@ J9::ClassEnv::iTableNext(J9ITable *current)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_iTableNext, current);
+      stream->write(JITaaS::MessageType::ClassEnv_iTableNext, current);
       return std::get<0>(stream->read<J9ITable*>());
       }
    return current->next;
@@ -203,7 +203,7 @@ J9::ClassEnv::iTableRomClass(J9ITable *current)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_iTableRomClass, current);
+      stream->write(JITaaS::MessageType::ClassEnv_iTableRomClass, current);
       return std::get<0>(stream->read<J9ROMClass*>());
       }
    return current->interfaceClass->romClass;
@@ -216,7 +216,7 @@ J9::ClassEnv::getITable(TR_OpaqueClassBlock *clazz)
       {
       // this normally shouldn't be called from the server,
       // because it will have a cached table
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_getITable, clazz);
+      stream->write(JITaaS::MessageType::ClassEnv_getITable, clazz);
       return std::get<0>(stream->read<std::vector<TR_OpaqueClassBlock *>>());
       }
    std::vector<TR_OpaqueClassBlock *> iTableSerialization;
@@ -309,7 +309,7 @@ J9::ClassEnv::classHasIllegalStaticFinalFieldModification(TR_OpaqueClassBlock * 
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_classHasIllegalStaticFinalFieldModification, clazzPointer);
+      stream->write(JITaaS::MessageType::ClassEnv_classHasIllegalStaticFinalFieldModification, clazzPointer);
       return std::get<0>(stream->read<bool>());
       }
    J9Class* j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazzPointer);
@@ -478,7 +478,7 @@ J9::ClassEnv::getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *cla
    auto stream = TR::CompilationInfo::getStream();
    if (stream && comp->isOutOfProcessCompilation())
       {
-      stream->write(JITaaS::J9ServerMessageType::ClassEnv_getROMClassRefName, clazz, cpIndex);
+      stream->write(JITaaS::MessageType::ClassEnv_getROMClassRefName, clazz, cpIndex);
       auto classRefNameStr = std::get<0>(stream->read<std::string>());
       classRefLen = classRefNameStr.length();
       uint8_t *classRefName = (uint8_t *) comp->trMemory()->allocateHeapMemory(classRefLen);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -822,7 +822,7 @@ TR_J9JITaaSServerSharedCache::rememberClass(J9Class *clazz, bool create)
          return it->second;
          }
       }
-   _stream->write(JITaaS::J9ServerMessageType::SharedCache_rememberClass, clazz, create);
+   _stream->write(JITaaS::MessageType::SharedCache_rememberClass, clazz, create);
    UDATA * chainData = std::get<0>(_stream->read<UDATA *>());
    if (chainData)
       {
@@ -852,7 +852,7 @@ uintptrj_t
 TR_J9JITaaSServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
-   _stream->write(JITaaS::J9ServerMessageType::SharedCache_getClassChainOffsetInSharedCache, clazz);
+   _stream->write(JITaaS::MessageType::SharedCache_getClassChainOffsetInSharedCache, clazz);
    return std::get<0>(_stream->read<uintptrj_t>());
    }
 
@@ -863,7 +863,7 @@ TR_J9JITaaSServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theH
    auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
    if (vmInfo->_hasSharedClassCache)
       {
-      _stream->write(JITaaS::J9ServerMessageType::SharedCache_addHint, method, theHint);
+      _stream->write(JITaaS::MessageType::SharedCache_addHint, method, theHint);
       _stream->read<JITaaS::Void>();
       }
    }
@@ -874,6 +874,6 @@ TR_J9JITaaSServerSharedCache::storeSharedData(J9VMThread *vmThread, char *key, J
    TR_ASSERT(_stream, "stream must be initialized by now");
    std::string dataStr((char *) descriptor->address, descriptor->length);
 
-   _stream->write(JITaaS::J9ServerMessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);
+   _stream->write(JITaaS::MessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);
    return std::get<0>(_stream->read<const void *>());
    }

--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -54,7 +54,7 @@ J9ROMMethod *romMethodOfRamMethod(J9Method* method)
    if (!romMethod)
       {
       auto stream = TR::CompilationInfo::getStream();
-      stream->write(JITaaS::J9ServerMessageType::VM_getClassOfMethod, (TR_OpaqueMethodBlock*) method);
+      stream->write(JITaaS::MessageType::VM_getClassOfMethod, (TR_OpaqueMethodBlock*) method);
       J9Class *clazz = (J9Class*) std::get<0>(stream->read<TR_OpaqueClassBlock *>());
       TR::compInfoPT->getAndCacheRemoteROMClass(clazz);
          {

--- a/runtime/compiler/env/JITaaSPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.cpp
@@ -58,7 +58,7 @@ TR_JITaaSServerPersistentCHTable::initializeIfNeeded(TR_J9VMBase *fej9)
       }
 
    auto stream = TR::CompilationInfo::getStream();
-   stream->write(JITaaS::J9ServerMessageType::CHTable_getAllClassInfo, JITaaS::Void());
+   stream->write(JITaaS::MessageType::CHTable_getAllClassInfo, JITaaS::Void());
    std::string rawData = std::get<0>(stream->read<std::string>());
    auto infos = FlatPersistentClassInfo::deserializeHierarchy(rawData);
       {

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -37,7 +37,7 @@ void
 TR_J9ServerVM::getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getResolvedMethodsAndMirror, classPointer);
+   stream->write(JITaaS::MessageType::VM_getResolvedMethodsAndMirror, classPointer);
    auto recv = stream->read<J9Method *, std::vector<TR_ResolvedJ9JITaaSServerMethodInfo>>();
    auto methodsInClass = std::get<0>(recv);
    auto &methodsInfo = std::get<1>(recv);
@@ -57,7 +57,7 @@ bool
 TR_J9ServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isClassLibraryMethod, method, vettedForAOT);
+   stream->write(JITaaS::MessageType::VM_isClassLibraryMethod, method, vettedForAOT);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -65,7 +65,7 @@ bool
 TR_J9ServerVM::isClassLibraryClass(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isClassLibraryClass, clazz);
+   stream->write(JITaaS::MessageType::VM_isClassLibraryClass, clazz);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -148,7 +148,7 @@ bool
 TR_J9ServerVM::isInterfaceClass(TR_OpaqueClassBlock *clazzPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isInterfaceClass, clazzPointer);
+   stream->write(JITaaS::MessageType::VM_isInterfaceClass, clazzPointer);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -156,7 +156,7 @@ bool
 TR_J9ServerVM::isClassFinal(TR_OpaqueClassBlock *clazzPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isClassFinal, clazzPointer);
+   stream->write(JITaaS::MessageType::VM_isClassFinal, clazzPointer);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -164,7 +164,7 @@ bool
 TR_J9ServerVM::isAbstractClass(TR_OpaqueClassBlock *clazzPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isAbstractClass, clazzPointer);
+   stream->write(JITaaS::MessageType::VM_isAbstractClass, clazzPointer);
    return std::get<0>(stream->read<bool>());
    }
 */
@@ -184,7 +184,7 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
    }
    // classname not found; ask the client and cache the answer
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getSystemClassFromClassName, className, isVettedForAOT);
+   stream->write(JITaaS::MessageType::VM_getSystemClassFromClassName, className, isVettedForAOT);
    TR_OpaqueClassBlock * clazz = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    if (clazz)
       {
@@ -213,7 +213,7 @@ TR_J9ServerVM::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
       }
 
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isMethodTracingEnabled, method);
+   stream->write(JITaaS::MessageType::VM_isMethodTracingEnabled, method);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -241,7 +241,7 @@ TR_J9ServerVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
       {
       // If value is not cached, fetch it from client and cache it
       JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-      stream->write(JITaaS::J9ServerMessageType::VM_getClassClassPointer, objectClassPointer);
+      stream->write(JITaaS::MessageType::VM_getClassClassPointer, objectClassPointer);
       javaLangClass = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
       _compInfoPT->getClientData()->setJavaLangClassPtr(javaLangClass); // cache value for later
       }
@@ -320,7 +320,7 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_OpaqueM
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    std::string str(sig, length);
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassFromSignature, str, method, isVettedForAOT);
+   stream->write(JITaaS::MessageType::VM_getClassFromSignature, str, method, isVettedForAOT);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
@@ -374,7 +374,7 @@ TR_J9ServerVM::jitFieldsAreSame(TR_ResolvedMethod * method1, I_32 cpIndex1, TR_R
             }
          if (needRemoteCall)
             {
-            stream->write(JITaaS::J9ServerMessageType::VM_jitFieldsAreSame, clientMethod1, cpIndex1, clientMethod2, cpIndex2, isStatic);
+            stream->write(JITaaS::MessageType::VM_jitFieldsAreSame, clientMethod1, cpIndex1, clientMethod2, cpIndex2, isStatic);
             auto recv = stream->read<J9Class *, J9Class *, UDATA, UDATA>();
             declaringClass1 = std::get<0>(recv);
             declaringClass2 = std::get<1>(recv);
@@ -451,7 +451,7 @@ TR_J9ServerVM::jitStaticsAreSame(TR_ResolvedMethod *method1, I_32 cpIndex1, TR_R
       if (sigSame)
          {
          // if name and signature comparison is inconclusive, make a remote call 
-         stream->write(JITaaS::J9ServerMessageType::VM_jitStaticsAreSame, clientMethod1, cpIndex1, clientMethod2, cpIndex2);
+         stream->write(JITaaS::MessageType::VM_jitStaticsAreSame, clientMethod1, cpIndex1, clientMethod2, cpIndex2);
          result = std::get<0>(stream->read<bool>());
          }
       }
@@ -495,7 +495,7 @@ TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
       else
          {
          //Flag not set, check with client as cache data may be outdated
-         stream->write(JITaaS::J9ServerMessageType::VM_classHasBeenExtended, clazz);
+         stream->write(JITaaS::MessageType::VM_classHasBeenExtended, clazz);
          return std::get<0>(stream->read<bool>());
          }
       }
@@ -511,7 +511,7 @@ TR_J9ServerVM::compiledAsDLTBefore(TR_ResolvedMethod *method)
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto mirror = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method)->getRemoteMirror();
-   stream->write(JITaaS::J9ServerMessageType::VM_compiledAsDLTBefore, static_cast<TR_ResolvedMethod *>(mirror));
+   stream->write(JITaaS::MessageType::VM_compiledAsDLTBefore, static_cast<TR_ResolvedMethod *>(mirror));
    return std::get<0>(stream->read<bool>());
 #else
    return 0;
@@ -524,7 +524,7 @@ char *
 TR_J9ServerVM::getClassNameChars(TR_OpaqueClassBlock * ramClass, int32_t & length)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassNameChars, ramClass);
+   stream->write(JITaaS::MessageType::VM_getClassNameChars, ramClass);
    const std::string className = std::get<0>(stream->read<std::string>());
    char * classNameChars = (char*) _compInfoPT->getCompilation()->trMemory()->allocateMemory(className.length(), heapAlloc);
    memcpy(classNameChars, &className[0], className.length());
@@ -545,7 +545,7 @@ bool
 TR_J9ServerVM::isThunkArchetype(J9Method * method)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isThunkArchetype, method);
+   stream->write(JITaaS::MessageType::VM_isThunkArchetype, method);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -561,7 +561,7 @@ int32_t
 TR_J9ServerVM::printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_printTruncatedSignature, method);
+   stream->write(JITaaS::MessageType::VM_printTruncatedSignature, method);
    auto recv = stream->read<std::string, std::string, std::string>();
    const std::string classNameStr = std::get<0>(recv);
    const std::string nameStr = std::get<1>(recv);
@@ -577,7 +577,7 @@ bool
 TR_J9ServerVM::isPrimitiveClass(TR_OpaqueClassBlock * clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isPrimitiveClass, clazz);
+   stream->write(JITaaS::MessageType::VM_isPrimitiveClass, clazz);
    return std::get<0>(stream->read<bool>());
    }
 */
@@ -591,7 +591,7 @@ TR_J9ServerVM::isClassInitialized(TR_OpaqueClassBlock * clazz)
    if (!isClassInitialized)
       {
       JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-      stream->write(JITaaS::J9ServerMessageType::VM_isClassInitialized, clazz);
+      stream->write(JITaaS::MessageType::VM_isClassInitialized, clazz);
       isClassInitialized = std::get<0>(stream->read<bool>());
       if (isClassInitialized)
          {
@@ -619,7 +619,7 @@ TR_J9ServerVM::getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method)
          }
       }
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getOSRFrameSizeInBytes, method);
+   stream->write(JITaaS::MessageType::VM_getOSRFrameSizeInBytes, method);
    return std::get<0>(stream->read<UDATA>());
    }
 
@@ -640,7 +640,7 @@ bool
 TR_J9ServerVM::isString(TR_OpaqueClassBlock * clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isString1, clazz);
+   stream->write(JITaaS::MessageType::VM_isString1, clazz);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -664,7 +664,7 @@ TR_J9ServerVM::getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * cl
 TR_J9ServerVM::getNumMethods(TR_OpaqueClassBlock * clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getNumMethods, clazz);
+   stream->write(JITaaS::MessageType::VM_getNumMethods, clazz);
    return std::get<0>(stream->read<uint32_t>());
    }
 
@@ -672,7 +672,7 @@ uint32_t
 TR_J9ServerVM::getNumInnerClasses(TR_OpaqueClassBlock * clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getNumInnerClasses, clazz);
+   stream->write(JITaaS::MessageType::VM_getNumInnerClasses, clazz);
    return std::get<0>(stream->read<uint32_t>());
    }*/
 bool
@@ -706,7 +706,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getObjectClass(uintptrj_t objectPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getObjectClass, objectPointer);
+   stream->write(JITaaS::MessageType::VM_getObjectClass, objectPointer);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
@@ -714,7 +714,7 @@ uintptrj_t
 TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptrj_t fieldAddress)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getStaticReferenceFieldAtAddress, fieldAddress);
+   stream->write(JITaaS::MessageType::VM_getStaticReferenceFieldAtAddress, fieldAddress);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -722,7 +722,7 @@ bool
 TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_stackWalkerMaySkipFrames, method, clazz);
+   stream->write(JITaaS::MessageType::VM_stackWalkerMaySkipFrames, method, clazz);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -744,7 +744,7 @@ TR_J9ServerVM::sampleSignature(TR_OpaqueMethodBlock * aMethod, char *buf, int32_
    // so we just get it out of the compilation.
    TR_Memory *trMemory = _compInfoPT->getCompilation()->trMemory();
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassNameSignatureFromMethod, (J9Method*) aMethod);
+   stream->write(JITaaS::MessageType::VM_getClassNameSignatureFromMethod, (J9Method*) aMethod);
    auto recv = stream->read<std::string, std::string, std::string>();
    const std::string str_className = std::get<0>(recv);
    const std::string str_name = std::get<1>(recv);
@@ -774,7 +774,7 @@ intptrj_t
 TR_J9ServerVM::getStringUTF8Length(uintptrj_t objectPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getStringUTF8Length, objectPointer);
+   stream->write(JITaaS::MessageType::VM_getStringUTF8Length, objectPointer);
    return std::get<0>(stream->read<intptrj_t>());
    }
 /*
@@ -789,7 +789,7 @@ bool
 TR_J9ServerVM::classInitIsFinished(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_classInitIsFinished, clazz);
+   stream->write(JITaaS::MessageType::VM_classInitIsFinished, clazz);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -797,7 +797,7 @@ int32_t
 TR_J9ServerVM::getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getNewArrayTypeFromClass, clazz);
+   stream->write(JITaaS::MessageType::VM_getNewArrayTypeFromClass, clazz);
    return std::get<0>(stream->read<int32_t>());
    }
 
@@ -805,7 +805,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromNewArrayType(int32_t arrayType)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassFromNewArrayType, arrayType);
+   stream->write(JITaaS::MessageType::VM_getClassFromNewArrayType, arrayType);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
@@ -829,7 +829,7 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
   if (!isClassInitialized)
      {
      JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-     stream->write(JITaaS::J9ServerMessageType::VM_isClassInitialized, clazz);
+     stream->write(JITaaS::MessageType::VM_isClassInitialized, clazz);
      isClassInitialized = std::get<0>(stream->read<bool>());
      if (isClassInitialized)
         {
@@ -856,7 +856,7 @@ TR_J9ServerVM::getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentCla
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)componentClass, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_ARRAY_CLASS, (void *)&arrayClass);
    if (!arrayClass)
       {
-      stream->write(JITaaS::J9ServerMessageType::VM_getArrayClassFromComponentClass, componentClass);
+      stream->write(JITaaS::MessageType::VM_getArrayClassFromComponentClass, componentClass);
       arrayClass = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
       if (arrayClass)
          {
@@ -876,7 +876,7 @@ J9Class *
 TR_J9ServerVM::matchRAMclassFromROMclass(J9ROMClass *clazz, TR::Compilation *comp)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_matchRAMclassFromROMclass, clazz);
+   stream->write(JITaaS::MessageType::VM_matchRAMclassFromROMclass, clazz);
    return std::get<0>(stream->read<J9Class *>());
    }
 
@@ -898,7 +898,7 @@ uintptrj_t
 TR_J9ServerVM::getReferenceFieldAtAddress(uintptrj_t fieldAddress)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getReferenceFieldAtAddress, fieldAddress);
+   stream->write(JITaaS::MessageType::VM_getReferenceFieldAtAddress, fieldAddress);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -906,7 +906,7 @@ uintptrj_t
 TR_J9ServerVM::getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getVolatileReferenceFieldAt, objectPointer, fieldOffset);
+   stream->write(JITaaS::MessageType::VM_getVolatileReferenceFieldAt, objectPointer, fieldOffset);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -914,7 +914,7 @@ int32_t
 TR_J9ServerVM::getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getInt32FieldAt, objectPointer, fieldOffset);
+   stream->write(JITaaS::MessageType::VM_getInt32FieldAt, objectPointer, fieldOffset);
    return std::get<0>(stream->read<int32_t>());
    }
 
@@ -922,7 +922,7 @@ int64_t
 TR_J9ServerVM::getInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getInt64FieldAt, objectPointer, fieldOffset);
+   stream->write(JITaaS::MessageType::VM_getInt64FieldAt, objectPointer, fieldOffset);
    return std::get<0>(stream->read<int64_t>());
    }
 
@@ -930,7 +930,7 @@ void
 TR_J9ServerVM::setInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t newValue)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_setInt64FieldAt, objectPointer, fieldOffset, newValue);
+   stream->write(JITaaS::MessageType::VM_setInt64FieldAt, objectPointer, fieldOffset, newValue);
    stream->read<JITaaS::Void>();
    }
 
@@ -938,7 +938,7 @@ bool
 TR_J9ServerVM::compareAndSwapInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t oldValue, int64_t newValue)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_compareAndSwapInt64FieldAt, objectPointer, fieldOffset, oldValue, newValue);
+   stream->write(JITaaS::MessageType::VM_compareAndSwapInt64FieldAt, objectPointer, fieldOffset, oldValue, newValue);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -946,7 +946,7 @@ intptrj_t
 TR_J9ServerVM::getArrayLengthInElements(uintptrj_t objectPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getArrayLengthInElements, objectPointer);
+   stream->write(JITaaS::MessageType::VM_getArrayLengthInElements, objectPointer);
    return std::get<0>(stream->read<intptrj_t>());
    }
 
@@ -954,7 +954,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromJavaLangClass(uintptrj_t objectPointer)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassFromJavaLangClass, objectPointer);
+   stream->write(JITaaS::MessageType::VM_getClassFromJavaLangClass, objectPointer);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
@@ -962,7 +962,7 @@ UDATA
 TR_J9ServerVM::getOffsetOfClassFromJavaLangClassField()
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getOffsetOfClassFromJavaLangClassField, JITaaS::Void());
+   stream->write(JITaaS::MessageType::VM_getOffsetOfClassFromJavaLangClassField, JITaaS::Void());
    return std::get<0>(stream->read<UDATA>());
    }
 
@@ -970,7 +970,7 @@ uintptrj_t
 TR_J9ServerVM::getConstantPoolFromMethod(TR_OpaqueMethodBlock *method)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getConstantPoolFromMethod, method);
+   stream->write(JITaaS::MessageType::VM_getConstantPoolFromMethod, method);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -978,7 +978,7 @@ uintptrj_t
 TR_J9ServerVM::getConstantPoolFromClass(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getConstantPoolFromClass, clazz);
+   stream->write(JITaaS::MessageType::VM_getConstantPoolFromClass, clazz);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -994,7 +994,7 @@ UDATA
 TR_J9ServerVM::getIdentityHashSaltPolicy()
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getIdentityHashSaltPolicy, JITaaS::Void());
+   stream->write(JITaaS::MessageType::VM_getIdentityHashSaltPolicy, JITaaS::Void());
    return std::get<0>(stream->read<UDATA>());
    }
 
@@ -1002,7 +1002,7 @@ UDATA
 TR_J9ServerVM::getOffsetOfJLThreadJ9Thread()
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getOffsetOfJLThreadJ9Thread, JITaaS::Void());
+   stream->write(JITaaS::MessageType::VM_getOffsetOfJLThreadJ9Thread, JITaaS::Void());
    return std::get<0>(stream->read<UDATA>());
    }
 
@@ -1010,7 +1010,7 @@ bool
 TR_J9ServerVM::scanReferenceSlotsInClassForOffset(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, int32_t offset)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_scanReferenceSlotsInClassForOffset, clazz, offset);
+   stream->write(JITaaS::MessageType::VM_scanReferenceSlotsInClassForOffset, clazz, offset);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -1018,7 +1018,7 @@ int32_t
 TR_J9ServerVM::findFirstHotFieldTenuredClassOffset(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_findFirstHotFieldTenuredClassOffset, clazz);
+   stream->write(JITaaS::MessageType::VM_findFirstHotFieldTenuredClassOffset, clazz);
    return std::get<0>(stream->read<int32_t>());
    }
 
@@ -1026,7 +1026,7 @@ TR_OpaqueMethodBlock *
 TR_J9ServerVM::getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, I_32 virtualCallOffset, bool ignoreRtResolve)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve);
+   stream->write(JITaaS::MessageType::VM_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve);
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
    }
 
@@ -1101,7 +1101,7 @@ uint32_t
 TR_J9ServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, char *fieldName, uint32_t fieldLen, char *sig, uint32_t sigLen, UDATA options)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getInstanceFieldOffset, clazz, std::string(fieldName, fieldLen), std::string(sig, sigLen), options);
+   stream->write(JITaaS::MessageType::VM_getInstanceFieldOffset, clazz, std::string(fieldName, fieldLen), std::string(sig, sigLen), options);
    return std::get<0>(stream->read<uint32_t>());
    }
 
@@ -1109,7 +1109,7 @@ int32_t
 TR_J9ServerVM::getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, bool &hashCodeComputed)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getJavaLangClassHashCode, clazz);
+   stream->write(JITaaS::MessageType::VM_getJavaLangClassHashCode, clazz);
    auto recv = stream->read<int32_t, bool>();
    hashCodeComputed = std::get<1>(recv);
    return std::get<0>(recv);
@@ -1129,7 +1129,7 @@ uintptrj_t
 TR_J9ServerVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassDepthAndFlagsValue, clazz);
+   stream->write(JITaaS::MessageType::VM_getClassDepthAndFlagsValue, clazz);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -1137,7 +1137,7 @@ uintptrj_t
 TR_J9ServerVM::getClassFlagsValue(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::ClassEnv_classFlagsValue, clazz);
+   stream->write(JITaaS::MessageType::ClassEnv_classFlagsValue, clazz);
    return std::get<0>(stream->read<uintptrj_t>());
    }
 
@@ -1145,7 +1145,7 @@ TR_OpaqueMethodBlock *
 TR_J9ServerVM::getMethodFromName(char *className, char *methodName, char *signature)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getMethodFromName, std::string(className, strlen(className)),
+   stream->write(JITaaS::MessageType::VM_getMethodFromName, std::string(className, strlen(className)),
          std::string(methodName, strlen(methodName)), std::string(signature, strlen(signature)));
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
    }
@@ -1154,7 +1154,7 @@ TR_OpaqueMethodBlock *
 TR_J9ServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getMethodFromClass, methodClass, std::string(methodName, strlen(methodName)),
+   stream->write(JITaaS::MessageType::VM_getMethodFromClass, methodClass, std::string(methodName, strlen(methodName)),
          std::string(signature, strlen(signature)), callingClass);
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
    }
@@ -1163,7 +1163,7 @@ bool
 TR_J9ServerVM::isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isClassVisible, sourceClass, destClass);
+   stream->write(JITaaS::MessageType::VM_isClassVisible, sourceClass, destClass);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -1173,7 +1173,7 @@ TR_J9ServerVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, void 
    TR_J9VMBase::setJ2IThunk(signatureChars, signatureLength, thunkptr, comp);
    std::string signature(signatureChars, signatureLength);
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_setJ2IThunk, thunkptr, signature);
+   stream->write(JITaaS::MessageType::VM_setJ2IThunk, thunkptr, signature);
    stream->read<JITaaS::Void>();
    return thunkptr;
    }
@@ -1182,7 +1182,7 @@ void
 TR_J9ServerVM::markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_markClassForTenuredAlignment, clazz, alignFromStart);
+   stream->write(JITaaS::MessageType::VM_markClassForTenuredAlignment, clazz, alignFromStart);
    stream->read<JITaaS::Void>();
    }
 
@@ -1190,7 +1190,7 @@ int32_t *
 TR_J9ServerVM::getReferenceSlotsInClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getReferenceSlotsInClass, clazz);
+   stream->write(JITaaS::MessageType::VM_getReferenceSlotsInClass, clazz);
    std::string slotsStr = std::get<0>(stream->read<std::string>());
    if (slotsStr == "")
       return NULL;
@@ -1205,7 +1205,7 @@ uint32_t
 TR_J9ServerVM::getMethodSize(TR_OpaqueMethodBlock *method)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getMethodSize, method);
+   stream->write(JITaaS::MessageType::VM_getMethodSize, method);
    return std::get<0>(stream->read<uint32_t>());
    }
 
@@ -1213,7 +1213,7 @@ void *
 TR_J9ServerVM::addressOfFirstClassStatic(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_addressOfFirstClassStatic, clazz);
+   stream->write(JITaaS::MessageType::VM_addressOfFirstClassStatic, clazz);
    return std::get<0>(stream->read<void *>());
    }
 
@@ -1221,7 +1221,7 @@ void *
 TR_J9ServerVM::getStaticFieldAddress(TR_OpaqueClassBlock *clazz, unsigned char *fieldName, uint32_t fieldLen, unsigned char *sig, uint32_t sigLen)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getStaticFieldAddress, clazz, std::string(reinterpret_cast<char*>(fieldName), fieldLen), std::string(reinterpret_cast<char*>(sig), sigLen));
+   stream->write(JITaaS::MessageType::VM_getStaticFieldAddress, clazz, std::string(reinterpret_cast<char*>(fieldName), fieldLen), std::string(reinterpret_cast<char*>(sig), sigLen));
    return std::get<0>(stream->read<void *>());
    }
 
@@ -1229,7 +1229,7 @@ int32_t
 TR_J9ServerVM::getInterpreterVTableSlot(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getInterpreterVTableSlot, method, clazz);
+   stream->write(JITaaS::MessageType::VM_getInterpreterVTableSlot, method, clazz);
    return std::get<0>(stream->read<int32_t>());
    }
 
@@ -1237,7 +1237,7 @@ void
 TR_J9ServerVM::revertToInterpreted(TR_OpaqueMethodBlock *method)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_revertToInterpreted, method);
+   stream->write(JITaaS::MessageType::VM_revertToInterpreted, method);
    stream->read<JITaaS::Void>();
    }
 
@@ -1245,7 +1245,7 @@ void *
 TR_J9ServerVM::getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *clazz)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getLocationOfClassLoaderObjectPointer, clazz);
+   stream->write(JITaaS::MessageType::VM_getLocationOfClassLoaderObjectPointer, clazz);
    return std::get<0>(stream->read<void *>());
    }
 
@@ -1272,7 +1272,7 @@ TR_J9ServerVM::getClassFromMethodBlock(TR_OpaqueMethodBlock *method)
       }
 
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassFromMethodBlock, method);
+   stream->write(JITaaS::MessageType::VM_getClassFromMethodBlock, method);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
@@ -1280,7 +1280,7 @@ U_8 *
 TR_J9ServerVM::fetchMethodExtendedFlagsPointer(J9Method *method)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_fetchMethodExtendedFlagsPointer, method);
+   stream->write(JITaaS::MessageType::VM_fetchMethodExtendedFlagsPointer, method);
    return std::get<0>(stream->read<U_8 *>());
    }
 
@@ -1288,7 +1288,7 @@ void *
 TR_J9ServerVM::getStaticHookAddress(int32_t event)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getStaticHookAddress, event);
+   stream->write(JITaaS::MessageType::VM_getStaticHookAddress, event);
    return std::get<0>(stream->read<void *>());
    }
 
@@ -1296,7 +1296,7 @@ bool
 TR_J9ServerVM::stringEquals(TR::Compilation *comp, uintptrj_t* stringLocation1, uintptrj_t*stringLocation2, int32_t& result)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_stringEquals, stringLocation1, stringLocation2);
+   stream->write(JITaaS::MessageType::VM_stringEquals, stringLocation1, stringLocation2);
    auto recv = stream->read<int32_t, bool>();
    result = std::get<0>(recv);
    return std::get<1>(recv);
@@ -1306,7 +1306,7 @@ bool
 TR_J9ServerVM::getStringHashCode(TR::Compilation *comp, uintptrj_t* stringLocation, int32_t& result)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getStringHashCode, stringLocation);
+   stream->write(JITaaS::MessageType::VM_getStringHashCode, stringLocation);
    auto recv = stream->read<int32_t, bool>();
    result = std::get<0>(recv);
    return std::get<1>(recv);
@@ -1316,7 +1316,7 @@ int32_t
 TR_J9ServerVM::getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getLineNumberForMethodAndByteCodeIndex, method, bcIndex);
+   stream->write(JITaaS::MessageType::VM_getLineNumberForMethodAndByteCodeIndex, method, bcIndex);
    return std::get<0>(stream->read<int32_t>());
    }
 
@@ -1324,7 +1324,7 @@ TR_OpaqueMethodBlock *
 TR_J9ServerVM::getObjectNewInstanceImplMethod()
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getObjectNewInstanceImplMethod, JITaaS::Void());
+   stream->write(JITaaS::MessageType::VM_getObjectNewInstanceImplMethod, JITaaS::Void());
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
    }
 
@@ -1332,7 +1332,7 @@ uintptrj_t
 TR_J9ServerVM::getBytecodePC(TR_OpaqueMethodBlock *method, TR_ByteCodeInfo &bcInfo)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getBytecodePC, method);
+   stream->write(JITaaS::MessageType::VM_getBytecodePC, method);
    uintptrj_t methodStart = std::get<0>(stream->read<uintptrj_t>());
    return methodStart + (uintptrj_t)(bcInfo.getByteCodeIndex());
    }
@@ -1352,7 +1352,7 @@ TR_J9ServerVM::setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp)
    {
    TR_J9VMBase::setInvokeExactJ2IThunk(thunkptr, comp);
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_setInvokeExactJ2IThunk, thunkptr);
+   stream->write(JITaaS::MessageType::VM_setInvokeExactJ2IThunk, thunkptr);
    stream->read<JITaaS::Void>();
    }
 
@@ -1378,7 +1378,7 @@ TR_ResolvedMethod *
 TR_J9ServerVM::createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptrj_t *methodHandleLocation, TR_ResolvedMethod *owningMethod)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_createMethodHandleArchetypeSpecimen, methodHandleLocation);
+   stream->write(JITaaS::MessageType::VM_createMethodHandleArchetypeSpecimen, methodHandleLocation);
    auto recv = stream->read<TR_OpaqueMethodBlock*, std::string>();
    TR_OpaqueMethodBlock *archetype = std::get<0>(recv);
    std::string thunkableSignature = std::get<1>(recv);
@@ -1395,7 +1395,7 @@ bool
 TR_J9ServerVM::getArrayLengthOfStaticAddress(void *ptr, int32_t &length)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getArrayLengthOfStaticAddress, ptr);
+   stream->write(JITaaS::MessageType::VM_getArrayLengthOfStaticAddress, ptr);
    auto recv = stream->read<bool, int32_t>();
    length = std::get<1>(recv);
    return std::get<0>(recv);
@@ -1405,7 +1405,7 @@ intptrj_t
 TR_J9ServerVM::getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getVFTEntry, clazz, offset);
+   stream->write(JITaaS::MessageType::VM_getVFTEntry, clazz, offset);
    return std::get<0>(stream->read<intptrj_t>());
    }
 
@@ -1422,7 +1422,7 @@ TR_J9ServerVM::isClassArray(TR_OpaqueClassBlock *klass)
       // otherwise, do it remote
       TR_ASSERT(_compInfoPT, "must have either compInfoPT or Compiler");
       JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-      stream->write(JITaaS::J9ServerMessageType::VM_isClassArray, klass);
+      stream->write(JITaaS::MessageType::VM_isClassArray, klass);
       return std::get<0>(stream->read<bool>());
       }
    }
@@ -1474,7 +1474,7 @@ TR_J9ServerVM::instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass)
             // getComponentFromArrayClass multiple times, or getLeafComponentTypeFromArrayClass.
             // each call requires a remote message, faster and easier to call instanceOfOrCheckCast on the client
             JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-            stream->write(JITaaS::J9ServerMessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
+            stream->write(JITaaS::MessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
             return std::get<0>(stream->read<bool>());
             }
          // instance class is cached, and all of the checks failed, cast is invalid
@@ -1484,7 +1484,7 @@ TR_J9ServerVM::instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass)
 
    // instance class is not cached, make a remote call
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
+   stream->write(JITaaS::MessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -1492,7 +1492,7 @@ bool
 TR_J9ServerVM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_transformJlrMethodInvoke, callerMethod, callerClass);
+   stream->write(JITaaS::MessageType::VM_transformJlrMethodInvoke, callerMethod, callerClass);
    return std::get<0>(stream->read<bool>());
    }
 
@@ -1539,7 +1539,7 @@ TR_J9ServerVM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType a
 
    // value at the static address is not cached, ask the client
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_dereferenceStaticAddress, staticAddress, addressType);
+   stream->write(JITaaS::MessageType::VM_dereferenceStaticAddress, staticAddress, addressType);
    auto data =  std::get<0>(stream->read<TR_StaticFinalData>());
    // cache the result
    OMR::CriticalSection dereferenceStaticFinalAddress(_compInfoPT->getClientData()->getStaticMapMonitor());
@@ -1561,7 +1561,7 @@ TR_J9ServerVM::getClassFromCP(J9ConstantPool *cp)
       }
 
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getClassFromCP, cp);
+   stream->write(JITaaS::MessageType::VM_getClassFromCP, cp);
    TR_OpaqueClassBlock * clazz = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    if (clazz)
       {
@@ -1613,7 +1613,7 @@ J9ROMMethod *
 TR_J9ServerVM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    {
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_getROMMethodFromRAMMethod, ramMethod);
+   stream->write(JITaaS::MessageType::VM_getROMMethodFromRAMMethod, ramMethod);
    return std::get<0>(stream->read<J9ROMMethod *>());
    }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -705,7 +705,7 @@ TR_J9MethodBase::isBigDecimalMethod(J9Method * j9Method)
    */
    if (auto stream = TR::compInfoPT->getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isBigDecimalMethod, j9Method);
+      stream->write(JITaaS::MessageType::ResolvedMethod_isBigDecimalMethod, j9Method);
       return std::get<0>(stream->read<bool>());
       }
    return isBigDecimalMethod(J9_ROM_METHOD_FROM_RAM_METHOD(j9Method), J9_CLASS_FROM_METHOD(j9Method)->romClass);
@@ -765,7 +765,7 @@ TR_J9MethodBase::isBigDecimalConvertersMethod(J9Method * j9Method)
    {
    if (auto stream = TR::compInfoPT->getStream())
       {
-      stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isBigDecimalConvertersMethod, j9Method);
+      stream->write(JITaaS::MessageType::ResolvedMethod_isBigDecimalConvertersMethod, j9Method);
       return std::get<0>(stream->read<bool>());
       }
    return isBigDecimalConvertersMethod(J9_ROM_METHOD_FROM_RAM_METHOD(j9Method), J9_CLASS_FROM_METHOD(j9Method)->romClass);
@@ -2303,7 +2303,7 @@ TR_J9Method::TR_J9Method(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClaz
 
    TR_J9ServerVM *fej9 = (TR_J9ServerVM *)fe;
    JITaaS::J9ServerStream *stream = fej9->_compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::get_params_to_construct_TR_j9method, aClazz, cpIndex);
+   stream->write(JITaaS::MessageType::get_params_to_construct_TR_j9method, aClazz, cpIndex);
    const auto recv = stream->read<std::string, std::string, std::string>();
    const std::string str_className = std::get<0>(recv);
    const std::string str_name = std::get<1>(recv);
@@ -7515,7 +7515,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeCollectHandleNumArgsToCollect,
+            stream->write(JITaaS::MessageType::runFEMacro_invokeCollectHandleNumArgsToCollect,
                           thunkDetails->getHandleRef(), getCollectPosition);
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             collectArraySize = std::get<0>(recv);
@@ -7572,7 +7572,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeExplicitCastHandleConvertArgs, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeExplicitCastHandleConvertArgs, thunkDetails->getHandleRef());
             auto recv = stream->read<std::string>();
             std::string methodDescriptorString = std::get<0>(recv);
             methodDescriptorLength = methodDescriptorString.length();
@@ -7671,7 +7671,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
                if (auto stream = TR::CompilationInfo::getStream())
                   {
-                  stream->write(JITaaS::J9ServerMessageType::runFEMacro_targetTypeL, thunkDetails->getHandleRef(), argIndex);
+                  stream->write(JITaaS::MessageType::runFEMacro_targetTypeL, thunkDetails->getHandleRef(), argIndex);
                   auto recv = stream->read<TR_OpaqueClassBlock*>();
                   parmClass = std::get<0>(recv);
                   }
@@ -7746,10 +7746,10 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
             receiverHandle = std::get<0>(stream->read<uintptrj_t>());
             methodHandle = returnFromArchetype ? receiverHandle : walkReferenceChain(methodHandleExpression, receiverHandle);
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeILGenMacrosInvokeExactAndFixup, methodHandle);
+            stream->write(JITaaS::MessageType::runFEMacro_invokeILGenMacrosInvokeExactAndFixup, methodHandle);
             auto recv = stream->read<std::string>();
             std::string methodDescriptorString = std::get<0>(recv);
             methodDescriptorLength = methodDescriptorString.length();
@@ -7854,7 +7854,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeArgumentMoverHandlePermuteArgs, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeArgumentMoverHandlePermuteArgs, thunkDetails->getHandleRef());
             std::string methodDescString = std::get<0>(stream->read<std::string>());
             methodDescriptorLength = methodDescString.size();
             nextHandleSignature = (char*)alloca(methodDescriptorLength+1);
@@ -7895,7 +7895,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokePermuteHandlePermuteArgs, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokePermuteHandlePermuteArgs, thunkDetails->getHandleRef());
 
             // Do the client-side operations
             auto recv = stream->read<int32_t, std::vector<int32_t>>();
@@ -8042,7 +8042,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeGuardWithTestHandleNumGuardArgs, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeGuardWithTestHandleNumGuardArgs, thunkDetails->getHandleRef());
             numGuardArgs = std::get<0>(stream->read<int32_t>());
             }
          else
@@ -8075,7 +8075,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeInsertHandle, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeInsertHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             insertionIndex = std::get<0>(recv);
             numArguments = std::get<1>(recv);
@@ -8128,7 +8128,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeDirectHandleDirectCall, thunkDetails->getHandleRef(), isInterface, isVirtual);
+            stream->write(JITaaS::MessageType::runFEMacro_invokeDirectHandleDirectCall, thunkDetails->getHandleRef(), isInterface, isVirtual);
             auto recv = stream->read<TR_OpaqueMethodBlock*, int64_t>();
             j9method = std::get<0>(recv);
             vmSlot = std::get<1>(recv);
@@ -8281,7 +8281,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeSpreadHandleArrayArg, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeSpreadHandleArrayArg, thunkDetails->getHandleRef());
             auto recv = stream->read<J9ArrayClass *, int32_t, UDATA, J9Class *, std::string, bool>();
             arrayJ9Class = std::get<0>(recv);
             spreadPosition = std::get<1>(recv);
@@ -8383,7 +8383,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_SpreadHandle_numArgsAfterSpreadArray;
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeSpreadHandle, thunkDetails->getHandleRef(), getSpreadPos);
+            stream->write(JITaaS::MessageType::runFEMacro_invokeSpreadHandle, thunkDetails->getHandleRef(), getSpreadPos);
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             numArguments = std::get<0>(recv);
             numNextArguments = std::get<1>(recv);
@@ -8435,7 +8435,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeFoldHandle, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeFoldHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<std::vector<int32_t>, int32_t, int32_t>();
 
             std::vector<int32_t> indices = std::get<0>(recv);
@@ -8535,7 +8535,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeFoldHandle2, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeFoldHandle2, thunkDetails->getHandleRef());
             foldPosition = std::get<0>(stream->read<int32_t>());
             }
          else
@@ -8614,7 +8614,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeFinallyHandle, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeFinallyHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, std::string>();
             numArgsPassToFinallyTarget = std::get<0>(recv);
             std::string methodDescriptorString = std::get<1>(recv);
@@ -8690,7 +8690,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeFilterArgumentsHandle2, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeFilterArgumentsHandle2, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, int32_t, int32_t>();
             numArguments = std::get<0>(recv);
             startPos = std::get<1>(recv);
@@ -8746,7 +8746,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          if (comp()->isOutOfProcessCompilation())
             {
             auto stream = TR::CompilationInfo::getStream();
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeFilterArgumentsHandle, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeFilterArgumentsHandle, thunkDetails->getHandleRef());
             auto recv = stream->read<int32_t, std::string, std::vector<uintptrj_t>>();
             startPos = std::get<0>(recv);
             std::string nextSigStr = std::get<1>(recv);
@@ -8887,7 +8887,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeCatchHandle, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_invokeCatchHandle, thunkDetails->getHandleRef());
             numCatchArguments = std::get<0>(stream->read<int32_t>());
             }
          else
@@ -8915,11 +8915,11 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
             uintptrj_t receiverHandle = std::get<0>(stream->read<uintptrj_t>());
             uintptrj_t methodHandle     = walkReferenceChain(pop(), receiverHandle);
 
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_invokeILGenMacros, methodHandle);
+            stream->write(JITaaS::MessageType::runFEMacro_invokeILGenMacros, methodHandle);
             parameterCount = std::get<0>(stream->read<int32_t>());
             }
          else
@@ -8947,7 +8947,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
             uintptrj_t receiverHandle = std::get<0>(stream->read<uintptrj_t>());
             uintptrj_t array            = walkReferenceChain(pop(), receiverHandle);
             arrayLength = (int32_t)fej9->getArrayLengthInElements(array);
@@ -8981,7 +8981,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (auto stream = TR::CompilationInfo::getStream())
             {
-            stream->write(JITaaS::J9ServerMessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
+            stream->write(JITaaS::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
             uintptrj_t receiverHandle = std::get<0>(stream->read<uintptrj_t>());
             uintptrj_t baseObject       = walkReferenceChain(baseObjectNode, receiverHandle);
             TR_ASSERT(fieldSym->getDataType() == TR::Int32, "ILGenMacros.getField expecting int field; found load of %s", comp()->getDebug()->getName(symRef));

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -65,7 +65,7 @@ TR_ResolvedJ9JITaaSServerMethod::TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethod
    TR_ResolvedJ9Method* owningMethodMirror = owningMethod ? ((TR_ResolvedJ9JITaaSServerMethod*) owningMethod)->_remoteMirror : NULL;
 
    // If in AOT mode, will actually create relocatable version of resolved method on the client
-   _stream->write(JITaaS::J9ServerMessageType::mirrorResolvedJ9Method, aMethod, owningMethodMirror, vTableSlot, fej9->isAOT_DEPRECATED_DO_NOT_USE());
+   _stream->write(JITaaS::MessageType::mirrorResolvedJ9Method, aMethod, owningMethodMirror, vTableSlot, fej9->isAOT_DEPRECATED_DO_NOT_USE());
    auto recv = _stream->read<TR_ResolvedJ9JITaaSServerMethodInfo>();
    auto &methodInfo = std::get<0>(recv);
 
@@ -116,7 +116,7 @@ void
 TR_ResolvedJ9JITaaSServerMethod::setRecognizedMethodInfo(TR::RecognizedMethod rm)
    {
    TR_ResolvedJ9Method::setRecognizedMethodInfo(rm);
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_setRecognizedMethodInfo, _remoteMirror, rm);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_setRecognizedMethodInfo, _remoteMirror, rm);
    _stream->read<JITaaS::Void>();
    }
 
@@ -134,7 +134,7 @@ TR_ResolvedJ9JITaaSServerMethod::staticAttributes(TR::Compilation * comp, I_32 c
    if(!getCachedFieldAttributes(cpIndex, attributes, isStatic))
       {
       // make a remote call, if attributes are not cached
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_staticAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_staticAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
       auto recv = _stream->read<TR_J9MethodFieldAttributes>();
       attributes = std::get<0>(recv);
 
@@ -173,7 +173,7 @@ TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp
             return it->second;
          }
       }
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getClassFromConstantPool, _remoteMirror, cpIndex, returnClassForAOT);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getClassFromConstantPool, _remoteMirror, cpIndex, returnClassForAOT);
    TR_OpaqueClassBlock *resolvedClass = std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
    if (resolvedClass)
       {
@@ -187,7 +187,7 @@ TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp
 TR_OpaqueClassBlock *
 TR_ResolvedJ9JITaaSServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getDeclaringClassFromFieldOrStatic, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getDeclaringClassFromFieldOrStatic, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
    }
 
@@ -217,7 +217,7 @@ TR_ResolvedJ9JITaaSServerMethod::classOfStatic(I_32 cpIndex, bool returnClassFor
    if (compInfoPT->getCachedNullClassOfStatic((TR_OpaqueClassBlock *) _ramClass, cpIndex))
       return NULL;
 
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_classOfStatic, _remoteMirror, cpIndex, returnClassForAOT);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_classOfStatic, _remoteMirror, cpIndex, returnClassForAOT);
    TR_OpaqueClassBlock *classOfStatic = std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
    if (classOfStatic)
       {
@@ -265,7 +265,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
          !comp->ilGenRequest().details().isMethodHandleThunk() && // cmvc 195373
          performTransformation(comp, "Setting as unresolved virtual call cpIndex=%d\n",cpIndex) ) || ignoreRtResolve)
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedPossiblyPrivateVirtualMethodAndMirror, (TR_ResolvedMethod *) _remoteMirror, literals(), cpIndex);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedPossiblyPrivateVirtualMethodAndMirror, (TR_ResolvedMethod *) _remoteMirror, literals(), cpIndex);
       auto recv = _stream->read<J9Method *, UDATA, bool, TR_ResolvedJ9JITaaSServerMethodInfo>();
       J9Method *ramMethod = std::get<0>(recv);
       UDATA vTableIndex = std::get<1>(recv);
@@ -520,7 +520,7 @@ TR_ResolvedJ9JITaaSServerMethod::fieldAttributes(TR::Compilation * comp, I_32 cp
    if(!getCachedFieldAttributes(cpIndex, attributes, isStatic))
       {
       // make a remote call, if attributes are not cached
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_fieldAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_fieldAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
       auto recv = _stream->read<TR_J9MethodFieldAttributes>();
       attributes = std::get<0>(recv);
 
@@ -547,7 +547,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedStaticMethod(TR::Compilation * comp,
    if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::Static, (TR_OpaqueClassBlock *) _ramClass, cpIndex), this, &resolvedMethod, unresolvedInCP)) 
       return resolvedMethod;
 
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedStaticMethodAndMirror, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedStaticMethodAndMirror, _remoteMirror, cpIndex);
    auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo, bool>();
    J9Method * ramMethod = std::get<0>(recv); 
    if (unresolvedInCP)
@@ -614,7 +614,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedSpecialMethod(TR::Compilation * comp
    if (unresolvedInCP)
       *unresolvedInCP = true;
 
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror, _remoteMirror, cpIndex);
    auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo>();
    J9Method * ramMethod = std::get<0>(recv);
    auto methodInfo = std::get<1>(recv);
@@ -664,7 +664,7 @@ TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9Method( TR::Compilati
 uint32_t
 TR_ResolvedJ9JITaaSServerMethod::classCPIndexOfMethod(uint32_t methodCPIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_classCPIndexOfMethod, _remoteMirror, methodCPIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_classCPIndexOfMethod, _remoteMirror, methodCPIndex);
    return std::get<0>(_stream->read<uint32_t>());
    }
 
@@ -678,7 +678,7 @@ TR_ResolvedJ9JITaaSServerMethod::startAddressForJittedMethod()
       }
    else // Otherwise ask the client for it
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_startAddressForJittedMethod, _remoteMirror);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_startAddressForJittedMethod, _remoteMirror);
       return std::get<0>(_stream->read<void *>());
       }
    }
@@ -686,7 +686,7 @@ TR_ResolvedJ9JITaaSServerMethod::startAddressForJittedMethod()
 char *
 TR_ResolvedJ9JITaaSServerMethod::localName(U_32 slotNumber, U_32 bcIndex, I_32 &len, TR_Memory *trMemory)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_localName, _remoteMirror, slotNumber, bcIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_localName, _remoteMirror, slotNumber, bcIndex);
    const std::string nameString = std::get<0>(_stream->read<std::string>());
    len = nameString.length();
    char *out = (char*) trMemory->allocateHeapMemory(len);
@@ -697,7 +697,7 @@ TR_ResolvedJ9JITaaSServerMethod::localName(U_32 slotNumber, U_32 bcIndex, I_32 &
 TR_OpaqueClassBlock *
 TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(I_32 cpIndex, UDATA *pITableIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedInterfaceMethod_2, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedInterfaceMethod_2, _remoteMirror, cpIndex);
    auto recv = _stream->read<TR_OpaqueClassBlock *, UDATA>();
    *pITableIndex = std::get<1>(recv);
    auto result = std::get<0>(recv);
@@ -720,7 +720,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(TR::Compilation * co
    if (compInfoPT->getCachedResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::Interface, clazz, cpIndex, classObject), this, &resolvedMethod))
       return resolvedMethod;
    
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedInterfaceMethodAndMirror_3, getPersistentIdentifier(), classObject, cpIndex, _remoteMirror);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedInterfaceMethodAndMirror_3, getPersistentIdentifier(), classObject, cpIndex, _remoteMirror);
    auto recv = _stream->read<bool, J9Method*, TR_ResolvedJ9JITaaSServerMethodInfo>();
    bool resolved = std::get<0>(recv);
    J9Method *ramMethod = std::get<1>(recv);
@@ -775,7 +775,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(TR::Compilation * co
 U_32
 TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * classObject, I_32 cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedInterfaceMethodOffset, _remoteMirror, classObject, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedInterfaceMethodOffset, _remoteMirror, classObject, cpIndex);
    auto recv = _stream->read<U_32>();
    return std::get<0>(recv);
    }
@@ -802,7 +802,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(TR::Compilat
          return resolvedMethod;
 
       // query for resolved method and create its mirror at the same time
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror, _remoteMirror, cpIndex);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror, _remoteMirror, cpIndex);
       auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo>();
       auto j9method = std::get<0>(recv);
       auto methodInfo = std::get<1>(recv);
@@ -830,14 +830,14 @@ TR_ResolvedJ9JITaaSServerMethod::startAddressForJNIMethod(TR::Compilation *comp)
    // For fastJNI methods, we have the address cached
    if (_jniProperties)
       return _jniTargetAddress;
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_startAddressForJNIMethod, _remoteMirror);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_startAddressForJNIMethod, _remoteMirror);
    return std::get<0>(_stream->read<void *>());
    }
 
 void *
 TR_ResolvedJ9JITaaSServerMethod::startAddressForInterpreterOfJittedMethod()
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_startAddressForInterpreterOfJittedMethod, _remoteMirror);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_startAddressForInterpreterOfJittedMethod, _remoteMirror);
    return std::get<0>(_stream->read<void *>());
    }
 
@@ -856,7 +856,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp
       return resolvedMethod;
 
    // Remote call finds RAM method at offset and creates a resolved method at the client
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve, (TR_ResolvedJ9Method *) getRemoteMirror());
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve, (TR_ResolvedJ9Method *) getRemoteMirror());
    auto recv = _stream->read<TR_OpaqueMethodBlock *, TR_ResolvedJ9JITaaSServerMethodInfo>();
    auto ramMethod = std::get<0>(recv);
    auto &methodInfo = std::get<1>(recv);
@@ -927,7 +927,7 @@ TR_ResolvedJ9JITaaSServerMethod::getRemoteROMString(int32_t &len, void *basePtr,
       size_t offsetFromROMClass = (uint8_t*) basePtr - (uint8_t*) romClassPtr();
       std::string offsetsStr((char*) offsets.begin(), offsets.size() * sizeof(size_t));
       
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getRemoteROMString, _remoteMirror, offsetFromROMClass, offsetsStr);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_getRemoteROMString, _remoteMirror, offsetFromROMClass, offsetsStr);
          {
          // reaquire the monitor
          OMR::CriticalSection getRemoteROMClass(threadCompInfo->getClientData()->getROMMapMonitor()); 
@@ -1088,7 +1088,7 @@ TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, 
    // only make a query if a string hasn't been cached
    if (!isCached)
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_fieldOrStaticName, _remoteMirror, cpIndex);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_fieldOrStaticName, _remoteMirror, cpIndex);
          {
          // reaquire the monitor
          OMR::CriticalSection getRemoteROMClass(threadCompInfo->getClientData()->getROMMapMonitor()); 
@@ -1105,7 +1105,7 @@ void *
 TR_ResolvedJ9JITaaSServerMethod::stringConstant(I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
    auto recv = _stream->read<void *, bool, bool>();
 
    _isUnresolvedStr.insert({cpIndex, TR_IsUnresolvedString(std::get<1>(recv), std::get<2>(recv))});
@@ -1122,7 +1122,7 @@ TR_ResolvedJ9JITaaSServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeF
       }
    else
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex, optimizeForAOT);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex, optimizeForAOT);
       return std::get<0>(_stream->read<bool>());
       }
    }
@@ -1146,7 +1146,7 @@ TR_ResolvedJ9JITaaSServerMethod::isSubjectToPhaseChange(TR::Compilation *comp)
       }
    else
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isSubjectToPhaseChange, _remoteMirror);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_isSubjectToPhaseChange, _remoteMirror);
       return std::get<0>(_stream->read<bool>());
       // JITaaS TODO: cache the JitState when we create  TR_ResolvedJ9JITaaSServerMethod
       // This may not behave exactly like the non-JITaaS due to timing differences
@@ -1161,7 +1161,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedHandleMethod(TR::Compilation * comp,
    return 0;
 #else
 
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedHandleMethod, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedHandleMethod, _remoteMirror, cpIndex);
    auto recv = _stream->read<TR_OpaqueMethodBlock *, std::string, bool>();
    auto dummyInvokeExact = std::get<0>(recv);
    auto signature = std::get<1>(recv);
@@ -1176,14 +1176,14 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedHandleMethod(TR::Compilation * comp,
 void *
 TR_ResolvedJ9JITaaSServerMethod::methodTypeTableEntryAddress(int32_t cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_methodTypeTableEntryAddress, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_methodTypeTableEntryAddress, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<void*>());
    }
 
 bool
 TR_ResolvedJ9JITaaSServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isUnresolvedMethodTypeTableEntry, _remoteMirror, cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_isUnresolvedMethodTypeTableEntry, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
 #endif
@@ -1191,14 +1191,14 @@ TR_ResolvedJ9JITaaSServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpInde
 bool
 TR_ResolvedJ9JITaaSServerMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isUnresolvedCallSiteTableEntry, _remoteMirror, callSiteIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_isUnresolvedCallSiteTableEntry, _remoteMirror, callSiteIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
 void *
 TR_ResolvedJ9JITaaSServerMethod::callSiteTableEntryAddress(int32_t callSiteIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_callSiteTableEntryAddress, _remoteMirror, callSiteIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_callSiteTableEntryAddress, _remoteMirror, callSiteIndex);
    return std::get<0>(_stream->read<void*>());
    }
 
@@ -1213,7 +1213,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedDynamicMethod(TR::Compilation * comp
 
    J9Class    *ramClass = constantPoolHdr();
    J9ROMClass *romClass = romClassPtr();
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getResolvedDynamicMethod, callSiteIndex, ramClass);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getResolvedDynamicMethod, callSiteIndex, ramClass);
    auto recv = _stream->read<TR_OpaqueMethodBlock*, std::string, bool>();
    TR_OpaqueMethodBlock *dummyInvokeExact = std::get<0>(recv);
    std::string signature = std::get<1>(recv);
@@ -1228,7 +1228,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedDynamicMethod(TR::Compilation * comp
 bool
 TR_ResolvedJ9JITaaSServerMethod::shouldFailSetRecognizedMethodInfoBecauseOfHCR()
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_shouldFailSetRecognizedMethodInfoBecauseOfHCR, _remoteMirror);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_shouldFailSetRecognizedMethodInfoBecauseOfHCR, _remoteMirror);
    return std::get<0>(_stream->read<bool>());
    }
 
@@ -1262,7 +1262,7 @@ TR_ResolvedJ9JITaaSServerMethod::isSameMethod(TR_ResolvedMethod * m2)
 
       bool sameMethodHandle;
 
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isSameMethod, thisHandleLocation, otherHandleLocation);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_isSameMethod, thisHandleLocation, otherHandleLocation);
       sameMethodHandle = std::get<0>(_stream->read<bool>());
 
       if (sameMethodHandle)
@@ -1291,7 +1291,7 @@ TR_ResolvedJ9JITaaSServerMethod::isInlineable(TR::Compilation *comp)
    // This assumes knowledge of how the original is implemented
    if (comp->getOption(TR_FullSpeedDebug) && comp->getOption(TR_EnableOSR))
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isInlineable, _remoteMirror);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_isInlineable, _remoteMirror);
       return std::get<0>(_stream->read<bool>());
       }
    else
@@ -1306,28 +1306,28 @@ TR_ResolvedJ9JITaaSServerMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Co
    // set the variable in the server IProfiler
    TR_ResolvedJ9Method::setWarmCallGraphTooBig(bcIndex, comp);
    // set it on the client IProfiler too, in case a server crashes, client will still have the correct value
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_setWarmCallGraphTooBig, _remoteMirror, bcIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_setWarmCallGraphTooBig, _remoteMirror, bcIndex);
    _stream->read<JITaaS::Void>();
    }
 
 void
 TR_ResolvedJ9JITaaSServerMethod::setVirtualMethodIsOverridden()
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_setVirtualMethodIsOverridden, _remoteMirror);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_setVirtualMethodIsOverridden, _remoteMirror);
    _stream->read<JITaaS::Void>();
    }
 
 bool
 TR_ResolvedJ9JITaaSServerMethod::methodIsNotzAAPEligible()
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_methodIsNotzAAPEligible, _remoteMirror);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_methodIsNotzAAPEligible, _remoteMirror);
    return std::get<0>(_stream->read<bool>());
    }
 void
 TR_ResolvedJ9JITaaSServerMethod::setClassForNewInstance(J9Class *c)
    {
    _j9classForNewInstance = c;
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_setClassForNewInstance, _remoteMirror, c);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_setClassForNewInstance, _remoteMirror, c);
    _stream->read<JITaaS::Void>();
    }
 
@@ -1720,7 +1720,7 @@ TR_ResolvedJ9JITaaSServerMethod::cacheResolvedMethodsCallees()
       return;
 
    // 2. Send a remote query to mirror all uncached resolved methods
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getMultipleResolvedMethods, (TR_ResolvedJ9Method *) _remoteMirror, methodTypes, cpIndices);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getMultipleResolvedMethods, (TR_ResolvedJ9Method *) _remoteMirror, methodTypes, cpIndices);
    auto recv = _stream->read<std::vector<J9Method *>, std::vector<uint32_t>, std::vector<TR_ResolvedJ9JITaaSServerMethodInfo>>();
 
    // 3. Cache all received resolved methods
@@ -1755,9 +1755,9 @@ TR_ResolvedJ9JITaaSServerMethod::validateMethodFieldAttributes(const TR_J9Method
    if (attributes.isUnresolvedInCP()) 
       return true;
    if (!isStatic)
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_fieldAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_fieldAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
    else
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_staticAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
+      _stream->write(JITaaS::MessageType::ResolvedMethod_staticAttributes, _remoteMirror, cpIndex, isStore, needAOTValidation);
    auto recv = _stream->read<TR_J9MethodFieldAttributes>();
    auto clientAttributes = std::get<0>(recv);
    bool equal = attributes == clientAttributes;
@@ -1883,7 +1883,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::storeValidationRecordIfNecessary(TR:
    TR_AOTStats *aotStats = ((TR_JitPrivateConfig *)fej9->_jitConfig->privateConfig)->aotStats;
    bool isStatic = (reloKind == TR_ValidateStaticField);
 
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedRelocatableMethod_storeValidationRecordIfNecessary, ramMethod, constantPool, cpIndex, isStatic, definingClass);
+   _stream->write(JITaaS::MessageType::ResolvedRelocatableMethod_storeValidationRecordIfNecessary, ramMethod, constantPool, cpIndex, isStatic, definingClass);
    // 1. RAM class of ramMethod
    // 2. defining class
    // 3. class chain
@@ -2019,7 +2019,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::createResolvedMethodFromJ9Method(TR:
 
    // This message will create a remote mirror.
    // Calling constructor would be simpler, but we would have to make another message to update stats
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, getRemoteMirror(), j9method, cpIndex, vTableSlot);
+   _stream->write(JITaaS::MessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, getRemoteMirror(), j9method, cpIndex, vTableSlot);
    auto recv = _stream->read<TR_ResolvedJ9JITaaSServerMethodInfo, bool, bool, bool>();
    auto methodInfo = std::get<0>(recv);
    // These parameters are only needed to update AOT stats. 
@@ -2247,7 +2247,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedFieldInCP(I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM))
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getUnresolvedFieldInCP, getRemoteMirror(), cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getUnresolvedFieldInCP, getRemoteMirror(), cpIndex);
    return std::get<0>(_stream->read<bool>());
 #else
    return true;
@@ -2257,14 +2257,14 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedFieldInCP(I_32 cpIndex)
 bool
 TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedStaticMethodInCP(int32_t cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getUnresolvedStaticMethodInCP, getRemoteMirror(), cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getUnresolvedStaticMethodInCP, getRemoteMirror(), cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
 bool
 TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedSpecialMethodInCP(I_32 cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getUnresolvedSpecialMethodInCP, getRemoteMirror(), cpIndex);
+   _stream->write(JITaaS::MessageType::ResolvedMethod_getUnresolvedSpecialMethodInCP, getRemoteMirror(), cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
@@ -2295,7 +2295,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedVirtualMethodInCP(int32
 UDATA
 TR_ResolvedRelocatableJ9JITaaSServerMethod::getFieldType(J9ROMConstantPoolItem * CP, int32_t cpIndex)
    {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedRelocatableMethod_getFieldType, cpIndex, getRemoteMirror());
+   _stream->write(JITaaS::MessageType::ResolvedRelocatableMethod_getFieldType, cpIndex, getRemoteMirror());
    auto recv = _stream->read<UDATA>();
    return (std::get<0>(recv));
    }
@@ -2315,7 +2315,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::fieldAttributes(TR::Compilation * co
    TR_J9MethodFieldAttributes attributes;
    if (!getCachedFieldAttributes(cpIndex, attributes, isStatic))
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedRelocatableMethod_fieldAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);
+      _stream->write(JITaaS::MessageType::ResolvedRelocatableMethod_fieldAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);
       auto recv = _stream->read<TR_J9MethodFieldAttributes, TR_OpaqueClassBlock *>();
       attributes = std::get<0>(recv);
       definingClass = std::get<1>(recv);
@@ -2398,7 +2398,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::staticAttributes(TR::Compilation * c
    TR_J9MethodFieldAttributes attributes;
    if(!getCachedFieldAttributes(cpIndex, attributes, isStatic))
       {
-      _stream->write(JITaaS::J9ServerMessageType::ResolvedRelocatableMethod_staticAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);
+      _stream->write(JITaaS::MessageType::ResolvedRelocatableMethod_staticAttributes, getRemoteMirror(), cpIndex, isStore, needAOTValidation);
       auto recv = _stream->read<TR_J9MethodFieldAttributes, TR_OpaqueClassBlock *>();
       attributes = std::get<0>(recv);
       definingClass = std::get<1>(recv);

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -61,20 +61,20 @@ public:
       if (getVersionCheckStatus() == NOT_DONE)
          {
          _cMsg.set_version(getJITaaSVersion());
-         write(J9ServerMessageType::compilationRequest, args...);
+         write(MessageType::compilationRequest, args...);
          _cMsg.clear_version();
          }
       else // getVersionCheckStatus() == PASSED
          {
          _cMsg.clear_version(); // the compatibility check is done. We clear the version to save message size.
-         write(J9ServerMessageType::compilationRequest, args...);
+         write(MessageType::compilationRequest, args...);
          }
       }
 
    Status waitForFinish();
 
    template <typename ...T>
-   void write(J9ServerMessageType type, T... args)
+   void write(MessageType type, T... args)
       {
       _cMsg.set_type(type);
       setArgs<T...>(_cMsg.mutable_data(), args...);
@@ -82,7 +82,7 @@ public:
       writeBlocking(_cMsg);
       }
 
-   J9ServerMessageType read()
+   MessageType read()
       {
       readBlocking(_sMsg);
       return _sMsg.type();
@@ -97,10 +97,10 @@ public:
    void shutdown();
 
    template <typename ...T>
-   void writeError(J9ServerMessageType type, T... args)
+   void writeError(MessageType type, T... args)
       {
       _cMsg.set_type(type);
-      if (type == J9ServerMessageType::compilationAbort)
+      if (type == MessageType::compilationAbort)
          _cMsg.mutable_data()->clear_data();
       else
          setArgs<T...>(_cMsg.mutable_data(), args...);

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -79,7 +79,7 @@ J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, st
    {
    try
       {
-      write(J9ServerMessageType::compilationCode, statusCode, codeCache, dataCache, chTableData,
+      write(MessageType::compilationCode, statusCode, codeCache, dataCache, chTableData,
             classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr, resolvedMethodsForPersistIprofileInfo);
       finish();
       }

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -51,7 +51,7 @@ public:
       }
 
    template <typename ...T>
-   void write(J9ServerMessageType type, T... args)
+   void write(MessageType type, T... args)
       {
       setArgs<T...>(_sMsg.mutable_data(), args...);
       _sMsg.set_type(type);
@@ -62,7 +62,7 @@ public:
    std::tuple<T...> read()
       {
       readBlocking(_cMsg);
-      if (_cMsg.type() == J9ServerMessageType::compilationAbort)
+      if (_cMsg.type() == MessageType::compilationAbort)
          throw StreamCancel(_cMsg.type());
       // We are expecting the response type (_cMsg.type()) to be the same as the request type (_sMsg.type())
       if (_cMsg.type() != _sMsg.type())
@@ -75,7 +75,7 @@ public:
    std::tuple<T...> readCompileRequest()
       {
       readBlocking(_cMsg);
-      if (_cMsg.type() == JITaaS::J9ServerMessageType::clientTerminate)
+      if (_cMsg.type() == JITaaS::MessageType::clientTerminate)
          {
          uint64_t clientId = std::get<0>(getRecvData<uint64_t>());
          throw JITaaS::StreamCancel(_cMsg.type(), clientId);
@@ -84,9 +84,9 @@ public:
          {
          throw StreamVersionIncompatible(getJITaaSVersion(), _cMsg.version());
          }
-      if (_cMsg.type() != JITaaS::J9ServerMessageType::compilationRequest)
+      if (_cMsg.type() != JITaaS::MessageType::compilationRequest)
          {
-         throw JITaaS::StreamMessageTypeMismatch(JITaaS::J9ServerMessageType::compilationRequest, _cMsg.type());
+         throw JITaaS::StreamMessageTypeMismatch(JITaaS::MessageType::compilationRequest, _cMsg.type());
          }
       return getArgs<T...>(_cMsg.mutable_data());
       }

--- a/runtime/compiler/rpc/StreamTypes.hpp
+++ b/runtime/compiler/rpc/StreamTypes.hpp
@@ -48,15 +48,15 @@ private:
 class StreamCancel: public virtual std::exception
    {
 public:
-   StreamCancel(J9ServerMessageType type, uint64_t clientId=0) : _type(type), _clientId(clientId) { }
+   StreamCancel(MessageType type, uint64_t clientId=0) : _type(type), _clientId(clientId) { }
    virtual const char* what() const throw()
       {
-      if (_type == J9ServerMessageType::clientTerminate)
+      if (_type == MessageType::clientTerminate)
          return "Client session terminated at client's request";
       else
          return "Compilation cancelled by client";
       }
-   J9ServerMessageType getType() const
+   MessageType getType() const
       {
       return _type;
       }
@@ -65,7 +65,7 @@ public:
       return _clientId;
       }
 private:
-   J9ServerMessageType _type;
+   MessageType _type;
    uint64_t _clientId;
    };
 
@@ -84,7 +84,7 @@ public:
 class StreamMessageTypeMismatch: public virtual std::exception
    {
 public:
-   StreamMessageTypeMismatch(J9ServerMessageType serverType, J9ServerMessageType clientType)
+   StreamMessageTypeMismatch(MessageType serverType, MessageType clientType)
       {
       _message = "server expected mesasge type " + std::to_string(serverType) + " received " + std::to_string(clientType);
       }

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -45,7 +45,7 @@ message AnyData
    repeated Any data = 1;
    }
 
-enum J9ServerMessageType
+enum MessageType
    {
    compilationCode = 0;
    mirrorResolvedJ9Method = 1;
@@ -297,13 +297,13 @@ enum J9ServerMessageType
 
 message J9ServerMessage
    {
-   J9ServerMessageType type = 1;
+   MessageType type = 1;
    AnyData data = 2;
    }
 
 message J9ClientMessage
    {
-   J9ServerMessageType type = 1;
+   MessageType type = 1;
    AnyData data = 2;
    uint64 version = 3;
    }

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -147,7 +147,7 @@ TR_JITaaSIProfiler::searchForMethodSample(TR_OpaqueMethodBlock *omb, int32_t buc
       {
       return NULL;
       }
-   stream->write(JITaaS::J9ServerMessageType::IProfiler_searchForMethodSample, omb);
+   stream->write(JITaaS::MessageType::IProfiler_searchForMethodSample, omb);
    const std::string entryStr = std::get<0>(stream->read<std::string>());
    if (entryStr.empty())
       {
@@ -203,7 +203,7 @@ TR_JITaaSIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
          // sanity check
          // Ask the client again and see if the two sources of information match
          auto stream = TR::CompilationInfo::getStream();
-         stream->write(JITaaS::J9ServerMessageType::IProfiler_profilingSample, method, byteCodeIndex, (uintptrj_t)1);
+         stream->write(JITaaS::MessageType::IProfiler_profilingSample, method, byteCodeIndex, (uintptrj_t)1);
          auto recv = stream->read<std::string, bool, bool>();
          const std::string ipdata = std::get<0>(recv);
          bool wholeMethod = std::get<1>(recv); // indicates whether the client has sent info for entire method
@@ -239,7 +239,7 @@ TR_JITaaSIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
    // Now ask the client
    //
    auto stream = TR::CompilationInfo::getStream();
-   stream->write(JITaaS::J9ServerMessageType::IProfiler_profilingSample, method, byteCodeIndex, (uintptrj_t)(_useCaching ? 0 : 1));
+   stream->write(JITaaS::MessageType::IProfiler_profilingSample, method, byteCodeIndex, (uintptrj_t)(_useCaching ? 0 : 1));
    auto recv = stream->read<std::string, bool, bool>();
    const std::string ipdata = std::get<0>(recv);
    bool wholeMethod = std::get<1>(recv); // indicates whether the client sent info for entire method
@@ -373,7 +373,7 @@ int32_t
 TR_JITaaSIProfiler::getMaxCallCount()
    {
    auto stream = TR::CompilationInfo::getStream();
-   stream->write(JITaaS::J9ServerMessageType::IProfiler_getMaxCallCount, JITaaS::Void());
+   stream->write(JITaaS::MessageType::IProfiler_getMaxCallCount, JITaaS::Void());
    return std::get<0>(stream->read<int32_t>());
    }
 
@@ -569,11 +569,11 @@ TR_JITaaSClientIProfiler::serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodB
          intptrj_t writtenBytes = serializeIProfilerMethodEntries(pcEntries, numEntries, (uintptr_t)&buffer[0], methodStart);
          TR_ASSERT(writtenBytes == bytesFootprint, "BST doesn't match expected footprint");
          // send the information to the server
-         client->write(JITaaS::J9ServerMessageType::IProfiler_profilingSample, buffer, true, usePersistentCache);
+         client->write(JITaaS::MessageType::IProfiler_profilingSample, buffer, true, usePersistentCache);
          }
       else if (!numEntries && !abort)// Empty IProfiler data for this method
          {
-         client->write(JITaaS::J9ServerMessageType::IProfiler_profilingSample, std::string(), true, usePersistentCache);
+         client->write(JITaaS::MessageType::IProfiler_profilingSample, std::string(), true, usePersistentCache);
          }
 
       // release any entry that has been locked by us
@@ -767,7 +767,7 @@ TR_JITaaSIProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, 
    if (sendRemoteMessage)
       {
       auto stream = TR::CompilationInfo::getStream();
-      stream->write(JITaaS::J9ServerMessageType::IProfiler_setCallCount, method, bcIndex, count);
+      stream->write(JITaaS::MessageType::IProfiler_setCallCount, method, bcIndex, count);
       stream->read<JITaaS::Void>();
       }
    }

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -108,7 +108,7 @@ TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *st
    if (auto stream = TR::CompilationInfo::getStream())
       {
       TR_ASSERT(TR::comp(), "Must be used during compilation when calling getJittedBodyInfoFromPC on the server");
-      stream->write(JITaaS::J9ServerMessageType::Recompilation_getJittedBodyInfoFromPC, startPC);
+      stream->write(JITaaS::MessageType::Recompilation_getJittedBodyInfoFromPC, startPC);
       auto recv = stream->read<std::string, std::string>();
       auto &bodyInfoStr = std::get<0>(recv);
       auto &methodInfoStr = std::get<1>(recv);


### PR DESCRIPTION
Dropping "J9" to make it not specific to OpenJ9. (OMR)
Dropping "Server" to make it not specific to server. (client)

[skip ci]
Issue: #6272

Signed-off-by: Harry Yu <harryyu1994@gmail.com>