### PR TITLE
Fix fetching of unloaded class ranges

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -271,7 +271,8 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
       case MessageType::getUnloadedClassRanges:
          {
          auto unloadedClasses = comp->getPersistentInfo()->getUnloadedClassAddresses();
-         std::vector<TR_AddressRange> ranges(unloadedClasses->getNumberOfRanges());
+         std::vector<TR_AddressRange> ranges;
+         ranges.reserve(unloadedClasses->getNumberOfRanges());
             {
             OMR::CriticalSection getAddressSetRanges(assumptionTableMutex);
             unloadedClasses->getRanges(ranges);


### PR DESCRIPTION
On the client, when vector that will store
class ranges to be sent is initialized, the constructor
used preallocates `unloadedClasses->getNumberOfRanges()`
items and sets them to some default value.
However, when `insert` is called in `unloadedClasses->getRanges`,
it appends class ranges to the end of default values, not replacing
them. Thus, the resulting vector is twice the expected length,
and contains invalid values, which may result in persistent memory
overflow on the server.
