### PR TITLE
(v0.15.0) Added command line option for concurrentKickoffTenuringHeadroom

### DIFF
--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -245,6 +245,20 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 		goto _exit;
 	}
 
+	if(try_scan(scan_start, "concurrentKickoffTenuringHeadroom=")) {
+		UDATA value = 0;
+		if(!scan_udata_helper(javaVM, scan_start, &value, "concurrentKickoffTenuringHeadroom=")) {
+			goto _error;
+		}
+		if(value > 100) {
+			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_INTEGER_OUT_OF_RANGE, "concurrentKickoffTenuringHeadroom=", (UDATA)0, (UDATA)100);
+			goto _error;
+		}
+		extensions->concurrentKickoffTenuringHeadroom = ((float)value) / 100.0f;
+		goto _exit;
+	}
+
+
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/* Parsing of concurrentScavengeBackground/Slack must happen before concurrentScavenge, since the later option is a substring of the former(s).
 	 * However, there is no effective limitation on relative order of these options in a command line. */


### PR DESCRIPTION
- Added command line option to set value of `concurrentKickoffTenuringHeadroom`
- Value must be between 0-100
- Is set by using Xgc:concurrentKickoffTenuringHeadroom=<value>
- Dependant on https://github.com/eclipse/omr/pull/4050
- Waiting for IBM integration builds to pass

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>