### PR TITLE
Correctly size CONSTANT_MethodHandle_info at 4 bytes

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -2623,7 +2623,7 @@ jvmtiGetConstantPool_addMethodHandle(jvmtiGcp_translation *translation, UDATA cp
 		return JVMTI_ERROR_OUT_OF_MEMORY;
 	}
 
-	translation->totalSize += 5;
+	translation->totalSize += 4;
 	translation->cp[*sunCpIndex] = htEntry;
 	(*sunCpIndex)++;
 


### PR DESCRIPTION
JVMTI getConstantPool calls were incorrectly sizing the
CONSTANT_MethodHandle_info at 5 bytes instead of 4.

Correct structure is:
```
CONSTANT_MethodHandle_info {
  u1 tag;
  u1 reference_kind;
  u2 reference_index;
}
```

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>