### PR TITLE
Add -Xmso default change on 64-bit z/OS to 0.14.0 release notes

### DIFF
--- a/doc/release-notes/0.14/0.14.md
+++ b/doc/release-notes/0.14/0.14.md
@@ -113,7 +113,7 @@ information, see <a href="https://www.eclipse.org/openj9/docs/xxjitinlinewatches
 </tr>
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5156">#5156</a></td>
-<td valign="top">Change to the default native stack size</td>
+<td valign="top">Change to the default native stack size (set by -Xmso)</td>
 <td valign="top">OpenJDK8 and later (64-bit z/OS® only)</td>
 <td valign="top">The default size is changed from 384 KB to 1 MB, see <a href="https://www.eclipse.org/openj9/docs/openj9_defaults/">Default settings for the OpenJ9 VM</a>. </td>
 </tr>

--- a/doc/release-notes/0.14/0.14.md
+++ b/doc/release-notes/0.14/0.14.md
@@ -112,6 +112,12 @@ information, see <a href="https://www.eclipse.org/openj9/docs/xshareclasses/">-X
 information, see <a href="https://www.eclipse.org/openj9/docs/xxjitinlinewatches/">-XX:[+|-]JITInlineWatches</a>. </td>
 </tr>
 
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/5156">#5156</a></td>
+<td valign="top">Change to the default native stack size</td>
+<td valign="top">OpenJDK8 and later (64-bit z/OS® only)</td>
+<td valign="top">The default size is changed from 384 KB to 1 MB, see <a href="https://www.eclipse.org/openj9/docs/openj9_defaults/">Default settings for the OpenJ9 VM</a>. </td>
+</tr>
+
 </table>
 
 


### PR DESCRIPTION
See https://github.com/eclipse/openj9-docs/issues/295

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>

[skip ci]