### PR TITLE
Remove stale methods from network communication code

### DIFF
--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -277,11 +277,4 @@ J9ClientStream::waitForFinish()
    // any error would have thrown earlier
    return Status::OK;
    }
-
-void
-J9ClientStream::shutdown()
-   {
-   // destructor is used instead
-   }
-
 };

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -94,8 +94,6 @@ public:
       return getArgs<T...>(_sMsg.mutable_data());
       }
 
-   void shutdown();
-
    template <typename ...T>
    void writeError(MessageType type, T... args)
       {

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -65,12 +65,6 @@ J9ServerStream::J9ServerStream(int connfd, uint32_t timeout)
    }
 #endif
 
-// J9Stream destructor is used instead
-void
-J9ServerStream::finish()
-   {
-   }
-
 void
 J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData,
                                  std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended,
@@ -81,7 +75,6 @@ J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, st
       {
       write(MessageType::compilationCode, statusCode, codeCache, dataCache, chTableData,
             classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr, resolvedMethodsForPersistIprofileInfo);
-      finish();
       }
    catch (std::exception &e)
       {

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -114,8 +114,6 @@ public:
    static int _numConnectionsClosed;
 
 private:
-   void finish();
-
    uint32_t _msTimeout;
    uint64_t _clientId;
    };
@@ -137,10 +135,6 @@ public:
       }
 
    void buildAndServe(J9BaseCompileDispatcher *compiler, TR::PersistentInfo *info);
-
-private:
-   void serve(J9BaseCompileDispatcher *compiler, uint32_t timeout);
-   bool waitOnQueue();
    };
 
 }

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -175,7 +175,7 @@ protected:
 
    int _connfd; // connection file descriptor
 
-   // re-usable message objects
+   // reusable message objects
    J9ServerMessage _sMsg;
    J9ClientMessage _cMsg;
 


### PR DESCRIPTION
Some methods in Stream classes are unused, delete them.