### PR TITLE
Communication layer cleanup in JITServer code

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -448,7 +448,7 @@ public:
                                void *oldStartPC, TR_FrontEnd *vm=0, TR_MethodToBeCompiled *entry=NULL, TR::Compilation *comp=NULL);
    static void endMethodHandleThunkCompilation(J9VMThread *vmThread, TR_J9VMBase *trvm, uintptrj_t *handleRef, uintptrj_t *argRef, void *startPC);
 
-   static JITaaS::J9ServerStream *getStream();
+   static JITaaS::ServerStream *getStream();
    static bool isInterpreted(J9Method *method) { return !isCompiled(method); }
    static bool isCompiled(J9Method *method)
       {
@@ -612,7 +612,7 @@ public:
 
    TR_MethodToBeCompiled *addMethodToBeCompiled(TR::IlGeneratorMethodDetails &details, void *pc, CompilationPriority priority,
       bool async, TR_OptimizationPlan *optPlan, bool *queued, TR_YesNoMaybe methodIsInSharedCache);
-   TR_MethodToBeCompiled *addOutOfProcessMethodToBeCompiled(JITaaS::J9ServerStream *stream);
+   TR_MethodToBeCompiled *addOutOfProcessMethodToBeCompiled(JITaaS::ServerStream *stream);
    void                   queueEntry(TR_MethodToBeCompiled *entry);
    void                   recycleCompilationEntry(TR_MethodToBeCompiled *cur);
    void                   requeueOutOfProcessEntry(TR_MethodToBeCompiled *entry);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10855,7 +10855,7 @@ TR::CompilationInfoPerThreadBase::processException(
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS StreamVersionIncompatible: %s", e.what());
       _methodBeingCompiled->_compErrCode = compilationStreamVersionIncompatible;
       }
-   catch (const JITaaS::ServerCompFailure &e)
+   catch (const JITaaS::ServerCompilationFailure &e)
       {
       // no need to set error code here because error code is set
       // in remoteCompile when the compilation failed

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1369,7 +1369,7 @@ TR::CompilationInfo::getMethodBytecodeSize(const J9ROMMethod * romMethod)
    return (romMethod->bytecodeSizeHigh << 16) + romMethod->bytecodeSizeLow;
    }
 
-JITaaS::J9ServerStream *
+JITaaS::ServerStream *
 TR::CompilationInfo::getStream()
    {
    return (TR::compInfoPT) ? TR::compInfoPT->getStream() : NULL;
@@ -3278,13 +3278,13 @@ void TR::CompilationInfo::stopCompilationThreads()
       {
       if (getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
          {
-         fprintf(stderr, "Number of connections opened = %u\n", JITaaS::J9ServerStream::_numConnectionsOpened);
-         fprintf(stderr, "Number of connections closed = %u\n", JITaaS::J9ServerStream::_numConnectionsClosed);
+         fprintf(stderr, "Number of connections opened = %u\n", JITaaS::ServerStream::_numConnectionsOpened);
+         fprintf(stderr, "Number of connections closed = %u\n", JITaaS::ServerStream::_numConnectionsClosed);
          }
       else if (getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
          {
-         fprintf(stderr, "Number of connections opened = %u\n", JITaaS::J9ClientStream::_numConnectionsOpened);
-         fprintf(stderr, "Number of connections closed = %u\n", JITaaS::J9ClientStream::_numConnectionsClosed);
+         fprintf(stderr, "Number of connections opened = %u\n", JITaaS::ClientStream::_numConnectionsOpened);
+         fprintf(stderr, "Number of connections closed = %u\n", JITaaS::ClientStream::_numConnectionsClosed);
          }
       }
 
@@ -3413,7 +3413,7 @@ void TR::CompilationInfo::stopCompilationThreads()
       {
       try
          {
-         JITaaS::J9ClientStream client(getPersistentInfo());
+         JITaaS::ClientStream client(getPersistentInfo());
          client.writeError(JITaaS::MessageType::clientTerminate, getPersistentInfo()->getJITaaSId());
          }
       catch (const JITaaS::StreamFailure &e)
@@ -3654,7 +3654,7 @@ IDATA J9THREAD_PROC protectedCompilationThreadProc(J9PortLibrary *, TR::Compilat
    return 0;
    }
 
-JITaaS::J9ServerStream *
+JITaaS::ServerStream *
 TR::CompilationInfoPerThread::getStream()
    {
    return (_methodBeingCompiled) ? _methodBeingCompiled->_stream : NULL;
@@ -3958,10 +3958,10 @@ TR::CompilationInfoPerThread::processEntries()
    static bool enableJITaaSPerCompConn = feGetEnv("TR_EnableJITaaSPerCompConn") ? true : false;
    if (compInfo->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE && !enableJITaaSPerCompConn)
       {
-      JITaaS::J9ClientStream *client = getClientStream();
+      JITaaS::ClientStream *client = getClientStream();
       if (client)
          {
-         client->~J9ClientStream();
+         client->~ClientStream();
          TR_Memory::jitPersistentFree(client);
          setClientStream(NULL);
          }
@@ -6775,7 +6775,7 @@ TR::CompilationInfoPerThreadBase::shouldPerformLocalComp(const TR_MethodToBeComp
    //
    if (entry->_optimizationPlan->getOptLevel() <= cold &&
       (TR::Options::getCmdLineOptions()->getOption(TR_EnableJITaaSHeuristics) || localColdCompilations) || 
-      !JITaaS::J9ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)))
+      !JITaaS::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)))
       doLocalComp = true;
 
    return doLocalComp;
@@ -12488,7 +12488,7 @@ TR::CompilationInfoPerThread::updateLastLocalGCCounter()
 // entry is queued we do not know any details about the compilation request.
 // The method needs to be executed with compilation monitor in hand
 TR_MethodToBeCompiled *
-TR::CompilationInfo::addOutOfProcessMethodToBeCompiled(JITaaS::J9ServerStream *stream)
+TR::CompilationInfo::addOutOfProcessMethodToBeCompiled(JITaaS::ServerStream *stream)
    {
    TR_MethodToBeCompiled *entry = getCompilationQueueEntry(); // allocate a new entry
    if (entry)

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -68,7 +68,7 @@ struct TR_MethodToBeCompiled;
 class TR_ResolvedMethod;
 class TR_RelocationRuntime;
 class ClientSessionData;
-namespace JITaaS { class J9ClientStream; }
+namespace JITaaS { class ClientStream; }
 
 enum CompilationThreadState
    {
@@ -248,8 +248,8 @@ class CompilationInfoPerThreadBase
    void                   setClientData(ClientSessionData *data) { _cachedClientDataPtr = data; }
    ClientSessionData     *getClientData() { return _cachedClientDataPtr; }
 
-   void                   setClientStream(JITaaS::J9ClientStream *stream) { _clientStream = stream; }
-   JITaaS::J9ClientStream *getClientStream() { return _clientStream; }
+   void                   setClientStream(JITaaS::ClientStream *stream) { _clientStream = stream; }
+   JITaaS::ClientStream *getClientStream() { return _clientStream; }
 
    protected:
 
@@ -279,7 +279,7 @@ class CompilationInfoPerThreadBase
 
    // JITaaS
    ClientSessionData * _cachedClientDataPtr;
-   JITaaS::J9ClientStream * _clientStream;
+   JITaaS::ClientStream * _clientStream;
 
 private:
    void logCompilationSuccess(
@@ -378,7 +378,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    void                   setServerVM(TR_J9ServerVM *vm) { _serverVM = vm; }
    TR_J9SharedCacheServerVM *getSharedCacheServerVM() { return _sharedCacheServerVM; }
    void                   setSharedCacheServerVM(TR_J9SharedCacheServerVM *vm) { _sharedCacheServerVM = vm; }
-   JITaaS::J9ServerStream  *getStream();
+   JITaaS::ServerStream  *getStream();
    J9ROMClass            *getAndCacheRemoteROMClass(J9Class *, TR_Memory *trMemory=NULL);
    J9ROMClass            *getRemoteROMClassIfCached(J9Class *);
    void                   addThunkToBeRelocated(void *thunk, std::string signature);

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2540,7 +2540,6 @@ remoteCompile(
    std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended;
    std::string logFileStr;
    std::string svmSymbolToIdStr;
-   JITaaS::Status status;
    std::vector<TR_ResolvedJ9Method*> resolvedMirrorMethodsPersistIPInfo;
    try
       {
@@ -2594,8 +2593,6 @@ remoteCompile(
       if (statusCode == compilationStreamVersionIncompatible)
          throw JITaaS::StreamVersionIncompatible();
       client->setVersionCheckStatus();
-      
-      status = client->waitForFinish();
       }
    catch (const JITaaS::StreamFailure &e)
       {
@@ -2615,7 +2612,7 @@ remoteCompile(
       }
 
    TR_MethodMetaData *metaData = NULL;
-   if (status.ok() && (statusCode == compilationOK || statusCode == compilationNotNeeded))
+   if (statusCode == compilationOK || statusCode == compilationNotNeeded)
       {
       try
          {
@@ -2729,7 +2726,7 @@ remoteCompile(
    else
       {
       compInfoPT->getMethodBeingCompiled()->_compErrCode = statusCode;
-      compiler->failCompilation<JITaaS::ServerCompFailure>("JITaaS compilation failed.");
+      compiler->failCompilation<JITaaS::ServerCompilationFailure>("JITaaS compilation failed.");
       }
 
    if (enableJITaaSPerCompConn && client)

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -170,13 +170,13 @@ class ClientSessionData
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassByNameMap() { return _classByNameMap; }
    PersistentUnorderedMap<J9Class *, UDATA *> & getClassClainDataCache() { return _classChainDataMap; }
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock*> & getConstantPoolToClassMap() { return _constantPoolToClassMap; }
-   void processUnloadedClasses(JITaaS::J9ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes);
+   void processUnloadedClasses(JITaaS::ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes);
    TR::Monitor *getROMMapMonitor() { return _romMapMonitor; }
    TR::Monitor *getClassMapMonitor() { return _classMapMonitor; }
    TR::Monitor *getClassChainDataMapMonitor() { return _classChainDataMapMonitor; }
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
-   VMInfo *getOrCacheVMInfo(JITaaS::J9ServerStream *stream);
+   VMInfo *getOrCacheVMInfo(JITaaS::ServerStream *stream);
    void clearCaches(); // destroys _chTableClassMap, _romClassMap and _J9MethodMap
    TR_AddressSet& getUnloadedClassAddresses()
       {
@@ -287,7 +287,7 @@ class ClientSessionHT
 
 size_t methodStringLength(J9ROMMethod *);
 std::string packROMClass(J9ROMClass *, TR_Memory *);
-bool handleServerMessage(JITaaS::J9ClientStream *, TR_J9VM *);
+bool handleServerMessage(JITaaS::ClientStream *, TR_J9VM *);
 TR_MethodMetaData *remoteCompile(J9VMThread *, TR::Compilation *, TR_ResolvedMethod *,
       J9Method *, TR::IlGeneratorMethodDetails &, TR::CompilationInfoPerThreadBase *);
 TR_MethodMetaData *remoteCompilationEnd(J9VMThread * vmThread, TR::Compilation *comp, TR_ResolvedMethod * compilee, J9Method * method,
@@ -438,10 +438,10 @@ class JITaaSHelpers
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
    static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
-   static J9ROMClass *getRemoteROMClass(J9Class *, JITaaS::J9ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
+   static J9ROMClass *getRemoteROMClass(J9Class *, JITaaS::ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
    static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory);
-   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::J9ServerStream *stream, ClassInfoDataType dataType,  void *data);
-   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::J9ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::ServerStream *stream, ClassInfoDataType dataType,  void *data);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2);
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
    //purgeCache function can only be used inside the JITaaSCompilationThread.cpp file.
    //It is a templated function, calling it outside the JITaaSCompilationThread.cpp will give linking error. 

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -39,7 +39,7 @@
 
 namespace TR { class CompilationInfoPerThreadBase; }
 class TR_OptimizationPlan;
-namespace JITaaS { class J9ServerStream; }
+namespace JITaaS { class ServerStream; }
 namespace TR { class Monitor; }
 struct J9JITConfig;
 struct J9VMThread;
@@ -123,7 +123,7 @@ struct TR_MethodToBeCompiled
    bool                   _hasIncrementedNumCompThreadsCompilingHotterMethods;
    uint8_t                _jitStateWhenQueued;
    bool                   _remoteCompReq; // comp request should be sent remotely to JITaaS server
-   JITaaS::J9ServerStream  *_stream; // a non-NULL field denotes an out-of-process compilation request
+   JITaaS::ServerStream  *_stream; // a non-NULL field denotes an out-of-process compilation request
    char                  *_clientOptions;
    size_t                _clientOptionsSize;
    TR_Hotness            _origOptLevel; // used to cache original optLevel when transforming a remote sync compilation to a local cheap one

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1604,7 +1604,7 @@ onLoadInternal(
    
    if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
       {
-      JITaaS::J9Stream::initVersion();
+      JITaaS::CommunicationStream::initVersion();
 
       // Allocate the hashtable that holds information about clients
       compInfo->setClientSessionHT(ClientSessionHT::allocate());
@@ -1634,7 +1634,7 @@ onLoadInternal(
 
       // Try to initialize SSL
       JITaaS::ClientStream::static_init(compInfo->getPersistentInfo());
-      JITaaS::J9Stream::initVersion();
+      JITaaS::CommunicationStream::initVersion();
       }
 
 #if defined(TR_HOST_S390)

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1633,7 +1633,7 @@ onLoadInternal(
          PersistentUnorderedMap<TR_OpaqueClassBlock*, uint8_t>::allocator_type(TR::Compiler->persistentAllocator())));
 
       // Try to initialize SSL
-      JITaaS::J9ClientStream::static_init(compInfo->getPersistentInfo());
+      JITaaS::ClientStream::static_init(compInfo->getPersistentInfo());
       JITaaS::J9Stream::initVersion();
       }
 

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -34,7 +34,7 @@
 class TR_J9VMBase;
 class TR_ResolvedMethod;
 namespace TR { class CompilationInfo; }
-namespace JITaaS { class J9ServerStream; }
+namespace JITaaS { class ServerStream; }
 
 class TR_J9SharedCache : public TR_SharedCache
    {
@@ -202,11 +202,11 @@ public:
 
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
 
-   void setStream(JITaaS::J9ServerStream *stream) { _stream = stream; }
+   void setStream(JITaaS::ServerStream *stream) { _stream = stream; }
    virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
 
 private:
-   JITaaS::J9ServerStream *_stream;
+   JITaaS::ServerStream *_stream;
    };
 
 #endif

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -36,7 +36,7 @@
 void
 TR_J9ServerVM::getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getResolvedMethodsAndMirror, classPointer);
    auto recv = stream->read<J9Method *, std::vector<TR_ResolvedJ9JITaaSServerMethodInfo>>();
    auto methodsInClass = std::get<0>(recv);
@@ -56,7 +56,7 @@ TR_J9ServerVM::getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassB
 bool
 TR_J9ServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isClassLibraryMethod, method, vettedForAOT);
    return std::get<0>(stream->read<bool>());
    }
@@ -64,7 +64,7 @@ TR_J9ServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedFor
 bool
 TR_J9ServerVM::isClassLibraryClass(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isClassLibraryClass, clazz);
    return std::get<0>(stream->read<bool>());
    }
@@ -74,7 +74,7 @@ TR_J9ServerVM::getSuperClass(TR_OpaqueClassBlock *clazz)
    {
    TR_OpaqueClassBlock *parentClass = NULL;
 
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_PARENT_CLASS, (void *)&parentClass);
    return parentClass;
    }
@@ -147,7 +147,7 @@ TR_J9ServerVM::isInstanceOf(TR_OpaqueClassBlock *a, TR_OpaqueClassBlock *b, bool
 bool
 TR_J9ServerVM::isInterfaceClass(TR_OpaqueClassBlock *clazzPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isInterfaceClass, clazzPointer);
    return std::get<0>(stream->read<bool>());
    }
@@ -155,7 +155,7 @@ TR_J9ServerVM::isInterfaceClass(TR_OpaqueClassBlock *clazzPointer)
 bool
 TR_J9ServerVM::isClassFinal(TR_OpaqueClassBlock *clazzPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isClassFinal, clazzPointer);
    return std::get<0>(stream->read<bool>());
    }
@@ -163,7 +163,7 @@ TR_J9ServerVM::isClassFinal(TR_OpaqueClassBlock *clazzPointer)
 bool
 TR_J9ServerVM::isAbstractClass(TR_OpaqueClassBlock *clazzPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isAbstractClass, clazzPointer);
    return std::get<0>(stream->read<bool>());
    }
@@ -183,7 +183,7 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
       return it->second;
    }
    // classname not found; ask the client and cache the answer
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getSystemClassFromClassName, className, isVettedForAOT);
    TR_OpaqueClassBlock * clazz = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    if (clazz)
@@ -212,7 +212,7 @@ TR_J9ServerVM::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
          }
       }
 
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isMethodTracingEnabled, method);
    return std::get<0>(stream->read<bool>());
    }
@@ -220,7 +220,7 @@ TR_J9ServerVM::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
 bool
 TR_J9ServerVM::canMethodEnterEventBeHooked()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return vmInfo->_canMethodEnterEventBeHooked;
    }
@@ -228,7 +228,7 @@ TR_J9ServerVM::canMethodEnterEventBeHooked()
 bool
 TR_J9ServerVM::canMethodExitEventBeHooked()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return vmInfo->_canMethodExitEventBeHooked;
    }
@@ -240,7 +240,7 @@ TR_J9ServerVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    if (!javaLangClass)
       {
       // If value is not cached, fetch it from client and cache it
-      JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
       stream->write(JITaaS::MessageType::VM_getClassClassPointer, objectClassPointer);
       javaLangClass = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
       _compInfoPT->getClientData()->setJavaLangClassPtr(javaLangClass); // cache value for later
@@ -265,7 +265,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims)
    {
    TR_OpaqueClassBlock *baseComponentClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_NUMBER_DIMENSIONS, &numDims, JITaaSHelpers::CLASSINFO_BASE_COMPONENT_CLASS, (void *)&baseComponentClass);
 
   return baseComponentClass;
@@ -275,7 +275,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass)
    {
    TR_OpaqueClassBlock *leafComponentClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)arrayClass, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_LEAF_COMPONENT_CLASS, (void *)&leafComponentClass);
    return leafComponentClass;
    }
@@ -318,7 +318,7 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_Resolve
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    std::string str(sig, length);
    stream->write(JITaaS::MessageType::VM_getClassFromSignature, str, method, isVettedForAOT);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
@@ -327,7 +327,7 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_OpaqueM
 void *
 TR_J9ServerVM::getSystemClassLoader()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return vmInfo->_systemClassLoader;
    }
@@ -335,7 +335,7 @@ TR_J9ServerVM::getSystemClassLoader()
 bool
 TR_J9ServerVM::jitFieldsAreSame(TR_ResolvedMethod * method1, I_32 cpIndex1, TR_ResolvedMethod * method2, I_32 cpIndex2, int32_t isStatic)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
 
    // Pass pointers to client mirrors of the ResolvedMethod objects instead of local objects
    TR_ResolvedJ9JITaaSServerMethod *serverMethod1 = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(method1);
@@ -433,7 +433,7 @@ TR_J9ServerVM::cacheField(J9Class *ramClass, int32_t cpIndex, J9Class *declaring
 bool
 TR_J9ServerVM::jitStaticsAreSame(TR_ResolvedMethod *method1, I_32 cpIndex1, TR_ResolvedMethod *method2, I_32 cpIndex2)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
 
    // Pass pointers to client mirrors of the ResolvedMethod objects instead of local objects
    TR_ResolvedJ9JITaaSServerMethod *serverMethod1 = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(method1);
@@ -462,7 +462,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass)
    {
    TR_OpaqueClassBlock *componentClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)arrayClass, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_COMPONENT_CLASS, (void *)&componentClass);
    return componentClass;
    }
@@ -471,7 +471,7 @@ bool
 TR_J9ServerVM::classHasBeenReplaced(TR_OpaqueClassBlock *clazz)
    {
    uintptrj_t classDepthAndFlags = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
    return ((classDepthAndFlags & J9AccClassHotSwappedOut) != 0);
    }
@@ -482,7 +482,7 @@ TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
    if(!clazz)
       return false;
    uintptrj_t classDepthAndFlags = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    bool dataFromCache = JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
    
    if(dataFromCache)
@@ -509,7 +509,7 @@ bool
 TR_J9ServerVM::compiledAsDLTBefore(TR_ResolvedMethod *method)
    {
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto mirror = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method)->getRemoteMirror();
    stream->write(JITaaS::MessageType::VM_compiledAsDLTBefore, static_cast<TR_ResolvedMethod *>(mirror));
    return std::get<0>(stream->read<bool>());
@@ -523,7 +523,7 @@ TR_J9ServerVM::compiledAsDLTBefore(TR_ResolvedMethod *method)
 char *
 TR_J9ServerVM::getClassNameChars(TR_OpaqueClassBlock * ramClass, int32_t & length)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassNameChars, ramClass);
    const std::string className = std::get<0>(stream->read<std::string>());
    char * classNameChars = (char*) _compInfoPT->getCompilation()->trMemory()->allocateMemory(className.length(), heapAlloc);
@@ -536,7 +536,7 @@ TR_J9ServerVM::getClassNameChars(TR_OpaqueClassBlock * ramClass, int32_t & lengt
 uintptrj_t
 TR_J9ServerVM::getOverflowSafeAllocSize()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return static_cast<uintptrj_t>(vmInfo->_overflowSafeAllocSize);
    }
@@ -544,7 +544,7 @@ TR_J9ServerVM::getOverflowSafeAllocSize()
 bool
 TR_J9ServerVM::isThunkArchetype(J9Method * method)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isThunkArchetype, method);
    return std::get<0>(stream->read<bool>());
    }
@@ -560,7 +560,7 @@ static J9UTF8 *str2utf8(char *string, int32_t length, TR_Memory *trMemory, TR_Al
 int32_t
 TR_J9ServerVM::printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_printTruncatedSignature, method);
    auto recv = stream->read<std::string, std::string, std::string>();
    const std::string classNameStr = std::get<0>(recv);
@@ -576,7 +576,7 @@ TR_J9ServerVM::printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMe
 bool
 TR_J9ServerVM::isPrimitiveClass(TR_OpaqueClassBlock * clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isPrimitiveClass, clazz);
    return std::get<0>(stream->read<bool>());
    }
@@ -585,12 +585,12 @@ bool
 TR_J9ServerVM::isClassInitialized(TR_OpaqueClassBlock * clazz)
    {
    bool isClassInitialized = false;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_INITIALIZED, (void *)&isClassInitialized);
 
    if (!isClassInitialized)
       {
-      JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
       stream->write(JITaaS::MessageType::VM_isClassInitialized, clazz);
       isClassInitialized = std::get<0>(stream->read<bool>());
       if (isClassInitialized)
@@ -618,7 +618,7 @@ TR_J9ServerVM::getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method)
          return osrFrameSizeRomMethod(it->second._romMethod);
          }
       }
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getOSRFrameSizeInBytes, method);
    return std::get<0>(stream->read<UDATA>());
    }
@@ -628,7 +628,7 @@ TR_J9ServerVM::getByteOffsetToLockword(TR_OpaqueClassBlock * clazz)
    {
 #if defined (J9VM_THR_LOCK_NURSERY)
    uint32_t byteOffsetToLockword = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_BYTE_OFFSET_TO_LOCKWORD, (void *)&byteOffsetToLockword);
    return byteOffsetToLockword;
 #else
@@ -639,7 +639,7 @@ TR_J9ServerVM::getByteOffsetToLockword(TR_OpaqueClassBlock * clazz)
 bool
 TR_J9ServerVM::isString(TR_OpaqueClassBlock * clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isString1, clazz);
    return std::get<0>(stream->read<bool>());
    }
@@ -648,7 +648,7 @@ void *
 TR_J9ServerVM::getMethods(TR_OpaqueClassBlock * clazz)
    {
    J9Method *methodsOfClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *) clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_METHODS_OF_CLASS, (void *) &methodsOfClass); 
    return methodsOfClass;
    }
@@ -663,7 +663,7 @@ TR_J9ServerVM::getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * cl
 /*uint32_t
 TR_J9ServerVM::getNumMethods(TR_OpaqueClassBlock * clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getNumMethods, clazz);
    return std::get<0>(stream->read<uint32_t>());
    }
@@ -671,7 +671,7 @@ TR_J9ServerVM::getNumMethods(TR_OpaqueClassBlock * clazz)
 uint32_t
 TR_J9ServerVM::getNumInnerClasses(TR_OpaqueClassBlock * clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getNumInnerClasses, clazz);
    return std::get<0>(stream->read<uint32_t>());
    }*/
@@ -680,7 +680,7 @@ TR_J9ServerVM::isPrimitiveArray(TR_OpaqueClassBlock *clazz)
    {
    uint32_t modifiers = 0;
    TR_OpaqueClassBlock * componentClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_ROMCLASS_MODIFIERS, (void *)&modifiers, JITaaSHelpers::CLASSINFO_COMPONENT_CLASS, (void *)&componentClass);
 
    if (!J9_ARE_ALL_BITS_SET(modifiers, J9AccClassArray))
@@ -695,7 +695,7 @@ uint32_t
 TR_J9ServerVM::getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz)
    {
    uintptrj_t totalInstanceSize = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_TOTAL_INSTANCE_SIZE, (void *)&totalInstanceSize);
 
    uint32_t objectSize = sizeof(J9Object) + (uint32_t)totalInstanceSize;
@@ -705,7 +705,7 @@ TR_J9ServerVM::getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getObjectClass(uintptrj_t objectPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getObjectClass, objectPointer);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
@@ -713,7 +713,7 @@ TR_J9ServerVM::getObjectClass(uintptrj_t objectPointer)
 uintptrj_t
 TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptrj_t fieldAddress)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getStaticReferenceFieldAtAddress, fieldAddress);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -721,7 +721,7 @@ TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptrj_t fieldAddress)
 bool
 TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_stackWalkerMaySkipFrames, method, clazz);
    return std::get<0>(stream->read<bool>());
    }
@@ -730,7 +730,7 @@ bool
 TR_J9ServerVM::hasFinalFieldsInClass(TR_OpaqueClassBlock *clazz)
    {
    bool classHasFinalFields = false;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_HAS_FINAL_FIELDS, (void *)&classHasFinalFields);
 
    return classHasFinalFields;
@@ -743,7 +743,7 @@ TR_J9ServerVM::sampleSignature(TR_OpaqueMethodBlock * aMethod, char *buf, int32_
    // in the superclass it would be null if it was not needed, but here we always need it.
    // so we just get it out of the compilation.
    TR_Memory *trMemory = _compInfoPT->getCompilation()->trMemory();
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassNameSignatureFromMethod, (J9Method*) aMethod);
    auto recv = stream->read<std::string, std::string, std::string>();
    const std::string str_className = std::get<0>(recv);
@@ -764,7 +764,7 @@ TR_OpaqueClassBlock *
 TR_J9ServerVM::getHostClass(TR_OpaqueClassBlock *clazz)
    {
    TR_OpaqueClassBlock *hostClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_HOST_CLASS, (void *)&hostClass);
 
    return hostClass;
@@ -773,7 +773,7 @@ TR_J9ServerVM::getHostClass(TR_OpaqueClassBlock *clazz)
 intptrj_t
 TR_J9ServerVM::getStringUTF8Length(uintptrj_t objectPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getStringUTF8Length, objectPointer);
    return std::get<0>(stream->read<intptrj_t>());
    }
@@ -788,7 +788,7 @@ TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock *cl
 bool
 TR_J9ServerVM::classInitIsFinished(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_classInitIsFinished, clazz);
    return std::get<0>(stream->read<bool>());
    }
@@ -796,7 +796,7 @@ TR_J9ServerVM::classInitIsFinished(TR_OpaqueClassBlock *clazz)
 int32_t
 TR_J9ServerVM::getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getNewArrayTypeFromClass, clazz);
    return std::get<0>(stream->read<int32_t>());
    }
@@ -804,7 +804,7 @@ TR_J9ServerVM::getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz)
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromNewArrayType(int32_t arrayType)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassFromNewArrayType, arrayType);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
@@ -813,7 +813,7 @@ bool
 TR_J9ServerVM::isCloneable(TR_OpaqueClassBlock *clazzPointer)
    {
    uintptrj_t classDepthAndFlags = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazzPointer, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
    return ((classDepthAndFlags & J9AccClassCloneable) != 0);
    }
@@ -823,12 +823,12 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
    {
    uint32_t modifiers = 0;
    bool isClassInitialized = false;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_INITIALIZED, (void *)&isClassInitialized, JITaaSHelpers::CLASSINFO_ROMCLASS_MODIFIERS, (void *)&modifiers);
 
   if (!isClassInitialized)
      {
-     JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+     JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
      stream->write(JITaaS::MessageType::VM_isClassInitialized, clazz);
      isClassInitialized = std::get<0>(stream->read<bool>());
      if (isClassInitialized)
@@ -851,7 +851,7 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    TR_OpaqueClassBlock *arrayClass = NULL;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)componentClass, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_ARRAY_CLASS, (void *)&arrayClass);
    if (!arrayClass)
@@ -875,7 +875,7 @@ TR_J9ServerVM::getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentCla
 J9Class *
 TR_J9ServerVM::matchRAMclassFromROMclass(J9ROMClass *clazz, TR::Compilation *comp)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_matchRAMclassFromROMclass, clazz);
    return std::get<0>(stream->read<J9Class *>());
    }
@@ -897,7 +897,7 @@ TR_J9ServerVM::getCurrentLocalsMapForDLT(TR::Compilation *comp)
 uintptrj_t
 TR_J9ServerVM::getReferenceFieldAtAddress(uintptrj_t fieldAddress)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getReferenceFieldAtAddress, fieldAddress);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -905,7 +905,7 @@ TR_J9ServerVM::getReferenceFieldAtAddress(uintptrj_t fieldAddress)
 uintptrj_t
 TR_J9ServerVM::getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getVolatileReferenceFieldAt, objectPointer, fieldOffset);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -913,7 +913,7 @@ TR_J9ServerVM::getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t 
 int32_t
 TR_J9ServerVM::getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getInt32FieldAt, objectPointer, fieldOffset);
    return std::get<0>(stream->read<int32_t>());
    }
@@ -921,7 +921,7 @@ TR_J9ServerVM::getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
 int64_t
 TR_J9ServerVM::getInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getInt64FieldAt, objectPointer, fieldOffset);
    return std::get<0>(stream->read<int64_t>());
    }
@@ -929,7 +929,7 @@ TR_J9ServerVM::getInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset)
 void
 TR_J9ServerVM::setInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t newValue)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_setInt64FieldAt, objectPointer, fieldOffset, newValue);
    stream->read<JITaaS::Void>();
    }
@@ -937,7 +937,7 @@ TR_J9ServerVM::setInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset,
 bool
 TR_J9ServerVM::compareAndSwapInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t oldValue, int64_t newValue)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_compareAndSwapInt64FieldAt, objectPointer, fieldOffset, oldValue, newValue);
    return std::get<0>(stream->read<bool>());
    }
@@ -945,7 +945,7 @@ TR_J9ServerVM::compareAndSwapInt64FieldAt(uintptrj_t objectPointer, uintptrj_t f
 intptrj_t
 TR_J9ServerVM::getArrayLengthInElements(uintptrj_t objectPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getArrayLengthInElements, objectPointer);
    return std::get<0>(stream->read<intptrj_t>());
    }
@@ -953,7 +953,7 @@ TR_J9ServerVM::getArrayLengthInElements(uintptrj_t objectPointer)
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromJavaLangClass(uintptrj_t objectPointer)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassFromJavaLangClass, objectPointer);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
@@ -961,7 +961,7 @@ TR_J9ServerVM::getClassFromJavaLangClass(uintptrj_t objectPointer)
 UDATA
 TR_J9ServerVM::getOffsetOfClassFromJavaLangClassField()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getOffsetOfClassFromJavaLangClassField, JITaaS::Void());
    return std::get<0>(stream->read<UDATA>());
    }
@@ -969,7 +969,7 @@ TR_J9ServerVM::getOffsetOfClassFromJavaLangClassField()
 uintptrj_t
 TR_J9ServerVM::getConstantPoolFromMethod(TR_OpaqueMethodBlock *method)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getConstantPoolFromMethod, method);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -977,7 +977,7 @@ TR_J9ServerVM::getConstantPoolFromMethod(TR_OpaqueMethodBlock *method)
 uintptrj_t
 TR_J9ServerVM::getConstantPoolFromClass(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getConstantPoolFromClass, clazz);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -985,7 +985,7 @@ TR_J9ServerVM::getConstantPoolFromClass(TR_OpaqueClassBlock *clazz)
 uintptrj_t
 TR_J9ServerVM::getProcessID()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return vmInfo->_processID;
    }
@@ -993,7 +993,7 @@ TR_J9ServerVM::getProcessID()
 UDATA
 TR_J9ServerVM::getIdentityHashSaltPolicy()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getIdentityHashSaltPolicy, JITaaS::Void());
    return std::get<0>(stream->read<UDATA>());
    }
@@ -1001,7 +1001,7 @@ TR_J9ServerVM::getIdentityHashSaltPolicy()
 UDATA
 TR_J9ServerVM::getOffsetOfJLThreadJ9Thread()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getOffsetOfJLThreadJ9Thread, JITaaS::Void());
    return std::get<0>(stream->read<UDATA>());
    }
@@ -1009,7 +1009,7 @@ TR_J9ServerVM::getOffsetOfJLThreadJ9Thread()
 bool
 TR_J9ServerVM::scanReferenceSlotsInClassForOffset(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, int32_t offset)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_scanReferenceSlotsInClassForOffset, clazz, offset);
    return std::get<0>(stream->read<bool>());
    }
@@ -1017,7 +1017,7 @@ TR_J9ServerVM::scanReferenceSlotsInClassForOffset(TR::Compilation *comp, TR_Opaq
 int32_t
 TR_J9ServerVM::findFirstHotFieldTenuredClassOffset(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_findFirstHotFieldTenuredClassOffset, clazz);
    return std::get<0>(stream->read<int32_t>());
    }
@@ -1025,7 +1025,7 @@ TR_J9ServerVM::findFirstHotFieldTenuredClassOffset(TR::Compilation *comp, TR_Opa
 TR_OpaqueMethodBlock *
 TR_J9ServerVM::getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, I_32 virtualCallOffset, bool ignoreRtResolve)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve);
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
    }
@@ -1058,7 +1058,7 @@ TR_J9ServerVM::sameClassLoaders(TR_OpaqueClassBlock * class1, TR_OpaqueClassBloc
    {
    void *class1Loader = NULL;
    void *class2Loader = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)class1, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_LOADER, (void *)&class1Loader);
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)class2, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_LOADER, (void *)&class2Loader);
 
@@ -1072,7 +1072,7 @@ TR_J9ServerVM::isUnloadAssumptionRequired(TR_OpaqueClassBlock *clazz, TR_Resolve
    uint32_t extraModifiers = 0;
    void *classLoader = NULL;
    void *classOfMethodLoader = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
 
    if (clazz == classOfMethod)
       return false;
@@ -1100,7 +1100,7 @@ TR_J9ServerVM::isUnloadAssumptionRequired(TR_OpaqueClassBlock *clazz, TR_Resolve
 uint32_t
 TR_J9ServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, char *fieldName, uint32_t fieldLen, char *sig, uint32_t sigLen, UDATA options)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getInstanceFieldOffset, clazz, std::string(fieldName, fieldLen), std::string(sig, sigLen), options);
    return std::get<0>(stream->read<uint32_t>());
    }
@@ -1108,7 +1108,7 @@ TR_J9ServerVM::getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, char *fieldNam
 int32_t
 TR_J9ServerVM::getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, bool &hashCodeComputed)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getJavaLangClassHashCode, clazz);
    auto recv = stream->read<int32_t, bool>();
    hashCodeComputed = std::get<1>(recv);
@@ -1119,7 +1119,7 @@ bool
 TR_J9ServerVM::hasFinalizer(TR_OpaqueClassBlock *clazz)
    {
    uintptrj_t classDepthAndFlags = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
 
    return ((classDepthAndFlags & (J9AccClassFinalizeNeeded | J9AccClassOwnableSynchronizer)) != 0);
@@ -1128,7 +1128,7 @@ TR_J9ServerVM::hasFinalizer(TR_OpaqueClassBlock *clazz)
 uintptrj_t
 TR_J9ServerVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassDepthAndFlagsValue, clazz);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -1136,7 +1136,7 @@ TR_J9ServerVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz)
 uintptrj_t
 TR_J9ServerVM::getClassFlagsValue(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::ClassEnv_classFlagsValue, clazz);
    return std::get<0>(stream->read<uintptrj_t>());
    }
@@ -1144,7 +1144,7 @@ TR_J9ServerVM::getClassFlagsValue(TR_OpaqueClassBlock *clazz)
 TR_OpaqueMethodBlock *
 TR_J9ServerVM::getMethodFromName(char *className, char *methodName, char *signature)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getMethodFromName, std::string(className, strlen(className)),
          std::string(methodName, strlen(methodName)), std::string(signature, strlen(signature)));
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
@@ -1153,7 +1153,7 @@ TR_J9ServerVM::getMethodFromName(char *className, char *methodName, char *signat
 TR_OpaqueMethodBlock *
 TR_J9ServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *methodName, char *signature, TR_OpaqueClassBlock *callingClass)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getMethodFromClass, methodClass, std::string(methodName, strlen(methodName)),
          std::string(signature, strlen(signature)), callingClass);
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
@@ -1162,7 +1162,7 @@ TR_J9ServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, char *method
 bool
 TR_J9ServerVM::isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_isClassVisible, sourceClass, destClass);
    return std::get<0>(stream->read<bool>());
    }
@@ -1172,7 +1172,7 @@ TR_J9ServerVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, void 
    {
    TR_J9VMBase::setJ2IThunk(signatureChars, signatureLength, thunkptr, comp);
    std::string signature(signatureChars, signatureLength);
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_setJ2IThunk, thunkptr, signature);
    stream->read<JITaaS::Void>();
    return thunkptr;
@@ -1181,7 +1181,7 @@ TR_J9ServerVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, void 
 void
 TR_J9ServerVM::markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t alignFromStart)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_markClassForTenuredAlignment, clazz, alignFromStart);
    stream->read<JITaaS::Void>();
    }
@@ -1189,7 +1189,7 @@ TR_J9ServerVM::markClassForTenuredAlignment(TR::Compilation *comp, TR_OpaqueClas
 int32_t *
 TR_J9ServerVM::getReferenceSlotsInClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getReferenceSlotsInClass, clazz);
    std::string slotsStr = std::get<0>(stream->read<std::string>());
    if (slotsStr == "")
@@ -1204,7 +1204,7 @@ TR_J9ServerVM::getReferenceSlotsInClass(TR::Compilation *comp, TR_OpaqueClassBlo
 uint32_t
 TR_J9ServerVM::getMethodSize(TR_OpaqueMethodBlock *method)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getMethodSize, method);
    return std::get<0>(stream->read<uint32_t>());
    }
@@ -1212,7 +1212,7 @@ TR_J9ServerVM::getMethodSize(TR_OpaqueMethodBlock *method)
 void *
 TR_J9ServerVM::addressOfFirstClassStatic(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_addressOfFirstClassStatic, clazz);
    return std::get<0>(stream->read<void *>());
    }
@@ -1220,7 +1220,7 @@ TR_J9ServerVM::addressOfFirstClassStatic(TR_OpaqueClassBlock *clazz)
 void *
 TR_J9ServerVM::getStaticFieldAddress(TR_OpaqueClassBlock *clazz, unsigned char *fieldName, uint32_t fieldLen, unsigned char *sig, uint32_t sigLen)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getStaticFieldAddress, clazz, std::string(reinterpret_cast<char*>(fieldName), fieldLen), std::string(reinterpret_cast<char*>(sig), sigLen));
    return std::get<0>(stream->read<void *>());
    }
@@ -1228,7 +1228,7 @@ TR_J9ServerVM::getStaticFieldAddress(TR_OpaqueClassBlock *clazz, unsigned char *
 int32_t
 TR_J9ServerVM::getInterpreterVTableSlot(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getInterpreterVTableSlot, method, clazz);
    return std::get<0>(stream->read<int32_t>());
    }
@@ -1236,7 +1236,7 @@ TR_J9ServerVM::getInterpreterVTableSlot(TR_OpaqueMethodBlock *method, TR_OpaqueC
 void
 TR_J9ServerVM::revertToInterpreted(TR_OpaqueMethodBlock *method)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_revertToInterpreted, method);
    stream->read<JITaaS::Void>();
    }
@@ -1244,7 +1244,7 @@ TR_J9ServerVM::revertToInterpreted(TR_OpaqueMethodBlock *method)
 void *
 TR_J9ServerVM::getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *clazz)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getLocationOfClassLoaderObjectPointer, clazz);
    return std::get<0>(stream->read<void *>());
    }
@@ -1253,7 +1253,7 @@ bool
 TR_J9ServerVM::isOwnableSyncClass(TR_OpaqueClassBlock *clazz)
    {
    uintptrj_t classDepthAndFlags = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
 
    return ((classDepthAndFlags & J9AccClassOwnableSynchronizer) != 0);
@@ -1271,7 +1271,7 @@ TR_J9ServerVM::getClassFromMethodBlock(TR_OpaqueMethodBlock *method)
          }
       }
 
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassFromMethodBlock, method);
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
@@ -1279,7 +1279,7 @@ TR_J9ServerVM::getClassFromMethodBlock(TR_OpaqueMethodBlock *method)
 U_8 *
 TR_J9ServerVM::fetchMethodExtendedFlagsPointer(J9Method *method)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_fetchMethodExtendedFlagsPointer, method);
    return std::get<0>(stream->read<U_8 *>());
    }
@@ -1287,7 +1287,7 @@ TR_J9ServerVM::fetchMethodExtendedFlagsPointer(J9Method *method)
 void *
 TR_J9ServerVM::getStaticHookAddress(int32_t event)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getStaticHookAddress, event);
    return std::get<0>(stream->read<void *>());
    }
@@ -1295,7 +1295,7 @@ TR_J9ServerVM::getStaticHookAddress(int32_t event)
 bool
 TR_J9ServerVM::stringEquals(TR::Compilation *comp, uintptrj_t* stringLocation1, uintptrj_t*stringLocation2, int32_t& result)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_stringEquals, stringLocation1, stringLocation2);
    auto recv = stream->read<int32_t, bool>();
    result = std::get<0>(recv);
@@ -1305,7 +1305,7 @@ TR_J9ServerVM::stringEquals(TR::Compilation *comp, uintptrj_t* stringLocation1, 
 bool
 TR_J9ServerVM::getStringHashCode(TR::Compilation *comp, uintptrj_t* stringLocation, int32_t& result)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getStringHashCode, stringLocation);
    auto recv = stream->read<int32_t, bool>();
    result = std::get<0>(recv);
@@ -1315,7 +1315,7 @@ TR_J9ServerVM::getStringHashCode(TR::Compilation *comp, uintptrj_t* stringLocati
 int32_t
 TR_J9ServerVM::getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getLineNumberForMethodAndByteCodeIndex, method, bcIndex);
    return std::get<0>(stream->read<int32_t>());
    }
@@ -1323,7 +1323,7 @@ TR_J9ServerVM::getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *meth
 TR_OpaqueMethodBlock *
 TR_J9ServerVM::getObjectNewInstanceImplMethod()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getObjectNewInstanceImplMethod, JITaaS::Void());
    return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
    }
@@ -1331,7 +1331,7 @@ TR_J9ServerVM::getObjectNewInstanceImplMethod()
 uintptrj_t
 TR_J9ServerVM::getBytecodePC(TR_OpaqueMethodBlock *method, TR_ByteCodeInfo &bcInfo)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getBytecodePC, method);
    uintptrj_t methodStart = std::get<0>(stream->read<uintptrj_t>());
    return methodStart + (uintptrj_t)(bcInfo.getByteCodeIndex());
@@ -1341,7 +1341,7 @@ bool
 TR_J9ServerVM::isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz)
    {
    void *classLoader = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_CLASS_LOADER, (void *)&classLoader);
 
    return (classLoader == getSystemClassLoader());
@@ -1351,7 +1351,7 @@ void
 TR_J9ServerVM::setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp)
    {
    TR_J9VMBase::setInvokeExactJ2IThunk(thunkptr, comp);
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_setInvokeExactJ2IThunk, thunkptr);
    stream->read<JITaaS::Void>();
    }
@@ -1377,7 +1377,7 @@ TR_J9ServerVM::needsInvokeExactJ2IThunk(TR::Node *callNode, TR::Compilation *com
 TR_ResolvedMethod *
 TR_J9ServerVM::createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptrj_t *methodHandleLocation, TR_ResolvedMethod *owningMethod)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_createMethodHandleArchetypeSpecimen, methodHandleLocation);
    auto recv = stream->read<TR_OpaqueMethodBlock*, std::string>();
    TR_OpaqueMethodBlock *archetype = std::get<0>(recv);
@@ -1394,7 +1394,7 @@ TR_J9ServerVM::createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptrj
 bool
 TR_J9ServerVM::getArrayLengthOfStaticAddress(void *ptr, int32_t &length)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getArrayLengthOfStaticAddress, ptr);
    auto recv = stream->read<bool, int32_t>();
    length = std::get<1>(recv);
@@ -1404,7 +1404,7 @@ TR_J9ServerVM::getArrayLengthOfStaticAddress(void *ptr, int32_t &length)
 intptrj_t
 TR_J9ServerVM::getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getVFTEntry, clazz, offset);
    return std::get<0>(stream->read<intptrj_t>());
    }
@@ -1421,7 +1421,7 @@ TR_J9ServerVM::isClassArray(TR_OpaqueClassBlock *klass)
       {
       // otherwise, do it remote
       TR_ASSERT(_compInfoPT, "must have either compInfoPT or Compiler");
-      JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
       stream->write(JITaaS::MessageType::VM_isClassArray, klass);
       return std::get<0>(stream->read<bool>());
       }
@@ -1473,7 +1473,7 @@ TR_J9ServerVM::instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass)
             // to correctly deal with these cases on the server, need to call
             // getComponentFromArrayClass multiple times, or getLeafComponentTypeFromArrayClass.
             // each call requires a remote message, faster and easier to call instanceOfOrCheckCast on the client
-            JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+            JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
             stream->write(JITaaS::MessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
             return std::get<0>(stream->read<bool>());
             }
@@ -1483,7 +1483,7 @@ TR_J9ServerVM::instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass)
       }
 
    // instance class is not cached, make a remote call
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
    return std::get<0>(stream->read<bool>());
    }
@@ -1491,7 +1491,7 @@ TR_J9ServerVM::instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass)
 bool
 TR_J9ServerVM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_transformJlrMethodInvoke, callerMethod, callerClass);
    return std::get<0>(stream->read<bool>());
    }
@@ -1500,7 +1500,7 @@ bool
 TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
    {
    uintptrj_t extraModifiers = 0;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)j9clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_ROMCLASS_EXTRAMODIFIERS, (void *)&extraModifiers);
 
    return (J9_ARE_ALL_BITS_SET(extraModifiers, J9AccClassAnonClass));
@@ -1509,7 +1509,7 @@ TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
 TR_IProfiler *
 TR_J9ServerVM::getIProfiler()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto * vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    if (!vmInfo->_isIProfilerEnabled)
       return NULL;
@@ -1538,7 +1538,7 @@ TR_J9ServerVM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType a
       }
 
    // value at the static address is not cached, ask the client
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_dereferenceStaticAddress, staticAddress, addressType);
    auto data =  std::get<0>(stream->read<TR_StaticFinalData>());
    // cache the result
@@ -1560,7 +1560,7 @@ TR_J9ServerVM::getClassFromCP(J9ConstantPool *cp)
          return it->second;
       }
 
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getClassFromCP, cp);
    TR_OpaqueClassBlock * clazz = std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    if (clazz)
@@ -1588,7 +1588,7 @@ uintptrj_t
 TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz)
    {
    J9ROMClass *remoteRomClass = NULL;
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *) clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_REMOTE_ROM_CLASS, (void *) &remoteRomClass);
    return (uintptrj_t) remoteRomClass;
    }
@@ -1596,7 +1596,7 @@ TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * c
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getClassFromNewArrayTypeNonNull(int32_t arrayType)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return vmInfo->_arrayTypeClasses[arrayType - 4];
    }
@@ -1604,7 +1604,7 @@ TR_J9ServerVM::getClassFromNewArrayTypeNonNull(int32_t arrayType)
 bool
 TR_J9ServerVM::isStringCompressionEnabledVM()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
    return vmInfo->_stringCompressionEnabled;
    }
@@ -1612,7 +1612,7 @@ TR_J9ServerVM::isStringCompressionEnabledVM()
 J9ROMMethod *
 TR_J9ServerVM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::VM_getROMMethodFromRAMMethod, ramMethod);
    return std::get<0>(stream->read<J9ROMMethod *>());
    }
@@ -1620,7 +1620,7 @@ TR_J9ServerVM::getROMMethodFromRAMMethod(J9Method *ramMethod)
 bool
 TR_J9ServerVM::getReportByteCodeInfoAtCatchBlock()
    {
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    return _compInfoPT->getClientData()->getOrCacheVMInfo(stream)->_reportByteCodeInfoAtCatchBlock;
    }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2302,7 +2302,7 @@ TR_J9Method::TR_J9Method(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClaz
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 
    TR_J9ServerVM *fej9 = (TR_J9ServerVM *)fe;
-   JITaaS::J9ServerStream *stream = fej9->_compInfoPT->getMethodBeingCompiled()->_stream;
+   JITaaS::ServerStream *stream = fej9->_compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::MessageType::get_params_to_construct_TR_j9method, aClazz, cpIndex);
    const auto recv = stream->read<std::string, std::string, std::string>();
    const std::string str_className = std::get<0>(recv);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -277,7 +277,7 @@ public:
    void cacheResolvedMethodsCallees();
 
 protected:
-   JITaaS::J9ServerStream *_stream;
+   JITaaS::ServerStream *_stream;
    J9Class *_ramClass; // client pointer to RAM class
    UnorderedMap<uint32_t, TR_J9MethodFieldAttributes> _fieldAttributesCache;
    UnorderedMap<uint32_t, TR_J9MethodFieldAttributes> _staticAttributesCache;

--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -42,16 +42,16 @@
 namespace JITaaS
 {
 
-int J9ClientStream::_numConnectionsOpened = 0;
-int J9ClientStream::_numConnectionsClosed = 0;
-int J9ClientStream::_incompatibilityCount = 0;
-uint64_t J9ClientStream::_incompatibleStartTime = 0;
-const uint64_t J9ClientStream::RETRY_COMPATIBILITY_INTERVAL = 10000; //ms
-const int J9ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
+int ClientStream::_numConnectionsOpened = 0;
+int ClientStream::_numConnectionsClosed = 0;
+int ClientStream::_incompatibilityCount = 0;
+uint64_t ClientStream::_incompatibleStartTime = 0;
+const uint64_t ClientStream::RETRY_COMPATIBILITY_INTERVAL = 10000; //ms
+const int ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
 
 // Create SSL context, load certs and keys. Only needs to be done once.
 // This is called during startup from rossa.cpp
-void J9ClientStream::static_init(TR::PersistentInfo *info)
+void ClientStream::static_init(TR::PersistentInfo *info)
    {
 #if defined(JITAAS_ENABLE_SSL)
    if (!J9Stream::useSSL(info))
@@ -126,7 +126,7 @@ void J9ClientStream::static_init(TR::PersistentInfo *info)
    }
 
 #if defined(JITAAS_ENABLE_SSL)
-SSL_CTX *J9ClientStream::_sslCtx;
+SSL_CTX *ClientStream::_sslCtx;
 #endif
 
 int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs)
@@ -253,7 +253,7 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    return bio;
    }
 
-J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
+ClientStream::ClientStream(TR::PersistentInfo *info)
    : J9Stream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
@@ -262,7 +262,7 @@ J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
    _numConnectionsOpened++;
    }
 #else // JITAAS_ENABLE_SSL
-J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
+ClientStream::ClientStream(TR::PersistentInfo *info)
    : J9Stream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());

--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -271,17 +271,4 @@ J9ClientStream::J9ClientStream(TR::PersistentInfo *info)
    }
 #endif
 
-Status
-J9ClientStream::waitForFinish()
-   {
-   // any error would have thrown earlier
-   return Status::OK;
-   }
-
-void
-J9ClientStream::shutdown()
-   {
-   // destructor is used instead
-   }
-
 };

--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -54,10 +54,10 @@ const int ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
 void ClientStream::static_init(TR::PersistentInfo *info)
    {
 #if defined(JITAAS_ENABLE_SSL)
-   if (!J9Stream::useSSL(info))
+   if (!CommunicationStream::useSSL(info))
       return;
 
-   J9Stream::initSSL();
+   CommunicationStream::initSSL();
 
    SSL_CTX *ctx = SSL_CTX_new(SSLv23_client_method());
    if (!ctx)
@@ -254,7 +254,7 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    }
 
 ClientStream::ClientStream(TR::PersistentInfo *info)
-   : J9Stream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
+   : CommunicationStream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    BIO *ssl = openSSLConnection(_sslCtx, connfd);
@@ -263,7 +263,7 @@ ClientStream::ClientStream(TR::PersistentInfo *info)
    }
 #else // JITAAS_ENABLE_SSL
 ClientStream::ClientStream(TR::PersistentInfo *info)
-   : J9Stream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
+   : CommunicationStream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    initStream(connfd);

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -44,13 +44,13 @@ enum VersionCheckStatus
    PASSED = 1,
    };
 
-class J9ClientStream : J9Stream
+class ClientStream : J9Stream
    {
 public:
    static void static_init(TR::PersistentInfo *info);
 
-   J9ClientStream(TR::PersistentInfo *info);
-   virtual ~J9ClientStream()
+   ClientStream(TR::PersistentInfo *info);
+   virtual ~ClientStream()
       {
       _numConnectionsClosed++;
       }

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -44,7 +44,7 @@ enum VersionCheckStatus
    PASSED = 1,
    };
 
-class ClientStream : J9Stream
+class ClientStream : CommunicationStream
    {
 public:
    static void static_init(TR::PersistentInfo *info);

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -71,8 +71,6 @@ public:
          }
       }
 
-   Status waitForFinish();
-
    template <typename ...T>
    void write(MessageType type, T... args)
       {
@@ -93,8 +91,6 @@ public:
       {
       return getArgs<T...>(_sMsg.mutable_data());
       }
-
-   void shutdown();
 
    template <typename ...T>
    void writeError(MessageType type, T... args)

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -43,11 +43,11 @@
 
 namespace JITaaS
 {
-int J9ServerStream::_numConnectionsOpened = 0;
-int J9ServerStream::_numConnectionsClosed = 0;
+int ServerStream::_numConnectionsOpened = 0;
+int ServerStream::_numConnectionsClosed = 0;
 
 #if defined(JITAAS_ENABLE_SSL)
-J9ServerStream::J9ServerStream(int connfd, BIO *ssl, uint32_t timeout)
+ServerStream::ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    : J9Stream(),
    _msTimeout(timeout)
    {
@@ -55,7 +55,7 @@ J9ServerStream::J9ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    _numConnectionsOpened++;
    }
 #else // JITAAS_ENABLE_SSL
-J9ServerStream::J9ServerStream(int connfd, uint32_t timeout)
+ServerStream::ServerStream(int connfd, uint32_t timeout)
    : J9Stream(),
    _msTimeout(timeout)
    {
@@ -66,7 +66,7 @@ J9ServerStream::J9ServerStream(int connfd, uint32_t timeout)
 
 
 void
-J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData,
+ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData,
                                  std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended,
                                  std::string logFileStr, std::string symbolToIdStr,
                                  std::vector<TR_ResolvedJ9Method*> resolvedMethodsForPersistIprofileInfo)
@@ -301,9 +301,9 @@ serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentIn
       if (sslCtx && !acceptOpenSSLConnection(sslCtx, connfd, bio))
          continue;
 
-      J9ServerStream *stream = new (PERSISTENT_NEW) J9ServerStream(connfd, bio, timeoutMs);
+      ServerStream *stream = new (PERSISTENT_NEW) ServerStream(connfd, bio, timeoutMs);
 #else
-      J9ServerStream *stream = new (PERSISTENT_NEW) J9ServerStream(connfd, timeoutMs);
+      ServerStream *stream = new (PERSISTENT_NEW) ServerStream(connfd, timeoutMs);
 #endif
       compiler->compile(stream);
       }

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -36,7 +36,6 @@
 #include "control/Options.hpp"
 #include "env/VerboseLog.hpp"
 #include "env/TRMemory.hpp"
-#include "env/j9method.h"
 #include "rpc/SSLProtobufStream.hpp"
 #if defined(JITAAS_ENABLE_SSL)
 #include <openssl/err.h>
@@ -65,11 +64,6 @@ J9ServerStream::J9ServerStream(int connfd, uint32_t timeout)
    }
 #endif
 
-// J9Stream destructor is used instead
-void
-J9ServerStream::finish()
-   {
-   }
 
 void
 J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std::string dataCache, CHTableCommitData chTableData,
@@ -81,7 +75,6 @@ J9ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, st
       {
       write(MessageType::compilationCode, statusCode, codeCache, dataCache, chTableData,
             classesThatShouldNotBeNewlyExtended, logFileStr, symbolToIdStr, resolvedMethodsForPersistIprofileInfo);
-      finish();
       }
    catch (std::exception &e)
       {
@@ -229,7 +222,7 @@ acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
 #endif
 
 void
-J9CompileServer::buildAndServe(J9BaseCompileDispatcher *compiler, TR::PersistentInfo *info)
+serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info)
    {
 #if defined(JITAAS_ENABLE_SSL)
    SSL_CTX *sslCtx = NULL;

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -48,7 +48,7 @@ int ServerStream::_numConnectionsClosed = 0;
 
 #if defined(JITAAS_ENABLE_SSL)
 ServerStream::ServerStream(int connfd, BIO *ssl, uint32_t timeout)
-   : J9Stream(),
+   : CommunicationStream(),
    _msTimeout(timeout)
    {
    initStream(connfd, ssl);
@@ -56,7 +56,7 @@ ServerStream::ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    }
 #else // JITAAS_ENABLE_SSL
 ServerStream::ServerStream(int connfd, uint32_t timeout)
-   : J9Stream(),
+   : CommunicationStream(),
    _msTimeout(timeout)
    {
    initStream(connfd);
@@ -226,9 +226,9 @@ serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentIn
    {
 #if defined(JITAAS_ENABLE_SSL)
    SSL_CTX *sslCtx = NULL;
-   if (J9Stream::useSSL(info))
+   if (CommunicationStream::useSSL(info))
       {
-      J9Stream::initSSL();
+      CommunicationStream::initSSL();
       sslCtx = createSSLContext(info);
       }
 #endif

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -37,15 +37,15 @@ class TR_ResolvedJ9Method;
 
 namespace JITaaS
 {
-class J9ServerStream : J9Stream
+class ServerStream : J9Stream
    {
 public:
 #if defined(JITAAS_ENABLE_SSL)
-   J9ServerStream(int connfd, BIO *ssl, uint32_t timeout);
+   ServerStream(int connfd, BIO *ssl, uint32_t timeout);
 #else
-   J9ServerStream(int connfd, uint32_t timeout);
+   ServerStream(int connfd, uint32_t timeout);
 #endif
-   virtual ~J9ServerStream() 
+   virtual ~ServerStream() 
       {
       _numConnectionsClosed++;
       }
@@ -126,7 +126,7 @@ private:
 class BaseCompileDispatcher
    {
 public:
-   virtual void compile(J9ServerStream *stream) = 0;
+   virtual void compile(ServerStream *stream) = 0;
    };
 
 

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -97,7 +97,8 @@ public:
       return getArgs<T...>(_cMsg.mutable_data());
       }
 
-   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", CHTableCommitData chTableData = {},
+   void finishCompilation(uint32_t statusCode, std::string codeCache = "", std::string dataCache = "", 
+                          CHTableCommitData chTableData = {},
                           std::vector<TR_OpaqueClassBlock*> classesThatShouldNotBeNewlyExtended = {},
                           std::string logFileStr = "", std::string symbolToIdStr = "",
                           std::vector<TR_ResolvedJ9Method*> = {});
@@ -114,34 +115,22 @@ public:
    static int _numConnectionsClosed;
 
 private:
-   void finish();
-
    uint32_t _msTimeout;
    uint64_t _clientId;
    };
 
-//
-// Inherited class is starting point for the received compilation request
-//
-class J9BaseCompileDispatcher
+
+// Abstract class defining the interface for the compilation handler
+// Typically, an user would derive this class and provide an implementation for "compile()"
+// An instance of the derived class needs to be passed to serveRemoteCompilationRequests which internally calls "compile()"
+class BaseCompileDispatcher
    {
 public:
    virtual void compile(J9ServerStream *stream) = 0;
    };
 
-class J9CompileServer
-   {
-public:
-   ~J9CompileServer()
-      {
-      }
 
-   void buildAndServe(J9BaseCompileDispatcher *compiler, TR::PersistentInfo *info);
-
-private:
-   void serve(J9BaseCompileDispatcher *compiler, uint32_t timeout);
-   bool waitOnQueue();
-   };
+void serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info);
 
 }
 

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -37,7 +37,7 @@ class TR_ResolvedJ9Method;
 
 namespace JITaaS
 {
-class ServerStream : J9Stream
+class ServerStream : CommunicationStream
    {
 public:
 #if defined(JITAAS_ENABLE_SSL)

--- a/runtime/compiler/rpc/J9Stream.cpp
+++ b/runtime/compiler/rpc/J9Stream.cpp
@@ -27,9 +27,9 @@
 
 namespace JITaaS
 {
-uint32_t J9Stream::CONFIGURATION_FLAGS = 0;
+uint32_t CommunicationStream::CONFIGURATION_FLAGS = 0;
 
-void J9Stream::initVersion()
+void CommunicationStream::initVersion()
    {
    if (TR::Compiler->target.is64Bit() && TR::Options::useCompressedPointers())
       {

--- a/runtime/compiler/rpc/J9Stream.cpp
+++ b/runtime/compiler/rpc/J9Stream.cpp
@@ -20,8 +20,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <google/protobuf/io/zero_copy_stream_impl.h>	
-#include "rpc/ProtobufTypeConvert.hpp"
-#include "rpc/J9Stream.hpp"
 
-uint32_t JITaaS::J9Stream::CONFIGURATION_FLAGS = 0;
+#include "rpc/J9Stream.hpp"
+#include "env/CompilerEnv.hpp" // for TR::Compiler->target.is64Bit()
+#include "control/Options.hpp" // TR::Options::useCompressedPointers()
+
+namespace JITaaS
+{
+uint32_t J9Stream::CONFIGURATION_FLAGS = 0;
+
+void J9Stream::initVersion()
+   {
+   if (TR::Compiler->target.is64Bit() && TR::Options::useCompressedPointers())
+      {
+      CONFIGURATION_FLAGS |= JITaaSCompressedRef;
+      }
+   }
+};

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -39,7 +39,7 @@ enum JITaaSCompatibilityFlags
 
 using namespace google::protobuf::io;
 
-class J9Stream
+class CommunicationStream
    {
 public:
 #if defined(JITAAS_ENABLE_SSL)
@@ -65,7 +65,7 @@ public:
       }
 
 protected:
-   J9Stream()
+   CommunicationStream()
       : _inputStream(NULL),
       _outputStream(NULL),
 #if defined(JITAAS_ENABLE_SSL)
@@ -103,7 +103,7 @@ protected:
          }
       }
 
-   virtual ~J9Stream()
+   virtual ~CommunicationStream()
       {
       if (_inputStream)
          {

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -23,10 +23,11 @@
 #ifndef J9_STREAM_HPP
 #define J9_STREAM_HPP
 
+#include <google/protobuf/io/zero_copy_stream_impl.h> // for ZeroCopyInputStream
+#include "rpc/ProtobufTypeConvert.hpp"
 #include "rpc/SSLProtobufStream.hpp"
 #include "env/TRMemory.hpp"
-#include "env/CompilerEnv.hpp"
-#include "control/Options.hpp"
+
 
 namespace JITaaS
 {
@@ -55,13 +56,8 @@ public:
       }
 #endif
 
-   static void initVersion()
-      {
-      if (TR::Compiler->target.is64Bit() && TR::Options::useCompressedPointers())
-         {
-         CONFIGURATION_FLAGS |= JITaaSCompressedRef;
-         }
-      }
+   static void initVersion();
+  
 
    static uint64_t getJITaaSVersion()
       {

--- a/runtime/compiler/rpc/ProtobufTypeConvert.hpp
+++ b/runtime/compiler/rpc/ProtobufTypeConvert.hpp
@@ -42,10 +42,11 @@ namespace JITaaS
       operator bool() const { return false; }
    };
 
-   // This struct and global is used as a hacky replacement for run-time type information (rtti), which is not enabled in our build.
-   // Every instance of this struct gets a unique identifier assigned to it (assuming constructors run in serial)
-   // It is inteneded to be used by holding a static instance of it within a templated class, so that each template instantiation
-   // gets a different unique ID.
+   // This struct and global is used as a replacement for run-time type information (rtti), 
+   // which is not supported in our build.
+   // Every instance of this struct gets a unique ID assigned to it (assuming constructors run serially)
+   // It is intended to be used by holding a static instance of it within a templated class, 
+   // so that each template instantiation gets a different unique ID.
    extern uint64_t typeCount;
    struct TypeID
       {
@@ -143,8 +144,9 @@ namespace JITaaS
       static inline Any::TypeCase typeCase() { return Any::kVectorV; }
       };
    // tuple
-   // using getArgs and setArgs here is perhaps a bit heavyweight, but it does allow non-primitives to be sent,
-   // which we can't do with vectors right now. (should be trivial to add support for though, just forward declare and use ProtoBufTypeConvert)
+   // Using getArgs and setArgs here is perhaps a bit heavyweight, but it does allow non-primitives to be sent,
+   // which we can't do with vectors right now.
+   // (should be trivial to add support for though, just forward declare and use ProtoBufTypeConvert)
    template <typename... T> struct AnyPrimitive<const std::tuple<T...>>
       {
       static inline std::tuple<T...> read(const Any *msg)

--- a/runtime/compiler/rpc/StreamTypes.hpp
+++ b/runtime/compiler/rpc/StreamTypes.hpp
@@ -29,17 +29,11 @@
 
 namespace JITaaS
 {
-struct Status
-   {
-   const static Status OK;
-   bool ok() { return true; }
-   };
-
 class StreamFailure: public virtual std::exception
    {
 public:
    StreamFailure() : _message("Generic stream failure") { }
-   StreamFailure(std::string message) : _message(message) { }
+   StreamFailure(const std::string &message) : _message(message) { }
    virtual const char* what() const throw() { return _message.c_str(); }
 private:
    std::string _message;
@@ -78,7 +72,7 @@ class StreamOOO : public virtual std::exception
 class StreamTypeMismatch: public virtual StreamFailure
    {
 public:
-   StreamTypeMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "Type mismatch: %s", message.c_str()); }
+   StreamTypeMismatch(const std::string &message) : StreamFailure(message) { TR_ASSERT(false, "Type mismatch: %s", message.c_str()); }
    };
 
 class StreamMessageTypeMismatch: public virtual std::exception
@@ -99,7 +93,7 @@ private:
 class StreamVersionIncompatible: public virtual std::exception
    {
 public:
-   StreamVersionIncompatible() : _message("server incompatible") { }
+   StreamVersionIncompatible() : _message("client/server incompatibility detected") { }
    StreamVersionIncompatible(uint64_t serverVersion, uint64_t clientVersion)
       {
       _message = "server expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
@@ -115,14 +109,14 @@ private:
 class StreamArityMismatch: public virtual StreamFailure
    {
 public:
-   StreamArityMismatch(std::string message) : StreamFailure(message) { TR_ASSERT(false, "Arity mismatch: %s", message.c_str()); }
+   StreamArityMismatch(const std::string &message) : StreamFailure(message) { TR_ASSERT(false, "Arity mismatch: %s", message.c_str()); }
    };
 
-class ServerCompFailure: public virtual std::exception
+class ServerCompilationFailure: public virtual std::exception
    {
 public:
-   ServerCompFailure() : _message("Generic JITaaS server compilation failure") { }
-   ServerCompFailure(std::string message) : _message(message) { }
+   ServerCompilationFailure() : _message("Generic JITaaS server compilation failure") { }
+   ServerCompilationFailure(const std::string &message) : _message(message) { }
    virtual const char* what() const throw() { return _message.c_str(); }
 private:
    std::string _message;

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -28,7 +28,7 @@
 
 // Routine called when a new connection request has been received at the server
 // Executed by the dispatcher thread
-void J9CompileDispatcher::compile(JITaaS::J9ServerStream *stream)
+void J9CompileDispatcher::compile(JITaaS::ServerStream *stream)
    {
    TR::CompilationInfo * compInfo = getCompilationInfo(_jitConfig);
 

--- a/runtime/compiler/runtime/CompileService.hpp
+++ b/runtime/compiler/runtime/CompileService.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/CompileService.hpp
+++ b/runtime/compiler/runtime/CompileService.hpp
@@ -55,7 +55,7 @@ class J9CompileDispatcher : public JITaaS::BaseCompileDispatcher
 public:
    J9CompileDispatcher(J9JITConfig *jitConfig) : _jitConfig(jitConfig) { }
 
-   void compile(JITaaS::J9ServerStream *stream) override;
+   void compile(JITaaS::ServerStream *stream) override;
 
 private:
    J9JITConfig *_jitConfig;

--- a/runtime/compiler/runtime/CompileService.hpp
+++ b/runtime/compiler/runtime/CompileService.hpp
@@ -50,16 +50,15 @@ private:
    };
 
 
-class J9CompileDispatcher : public JITaaS::J9BaseCompileDispatcher
+class J9CompileDispatcher : public JITaaS::BaseCompileDispatcher
 {
 public:
-   J9CompileDispatcher(J9JITConfig *jitConfig, J9VMThread *vmThread) : _jitConfig(jitConfig), _vmThread(vmThread) { }
+   J9CompileDispatcher(J9JITConfig *jitConfig) : _jitConfig(jitConfig) { }
 
    void compile(JITaaS::J9ServerStream *stream) override;
 
 private:
    J9JITConfig *_jitConfig;
-   J9VMThread *_vmThread;
 };
 
 

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -540,7 +540,7 @@ TR_JITaaSClientIProfiler::serializeIProfilerMethodEntries(uintptrj_t *pcEntries,
 
 // Code executed at the client to serialize IProfiler info for an entire method
 bool
-TR_JITaaSClientIProfiler::serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::J9ClientStream *client, bool usePersistentCache)
+TR_JITaaSClientIProfiler::serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::ClientStream *client, bool usePersistentCache)
    {
    TR::StackMemoryRegion stackMemoryRegion(*comp->trMemory());
    uint32_t numEntries = 0;

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -28,7 +28,7 @@
 
 namespace JITaaS
 {
-class J9ClientStream;
+class ClientStream;
 }
 
 struct TR_ContiguousIPMethodData
@@ -103,7 +103,7 @@ class TR_JITaaSClientIProfiler : public TR_IProfiler
       uint32_t walkILTreeForIProfilingEntries(uintptrj_t *pcEntries, uint32_t &numEntries, TR_J9ByteCodeIterator *bcIterator,
                                               TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort, TR::Compilation *comp);
       uintptr_t serializeIProfilerMethodEntries(uintptrj_t *pcEntries, uint32_t numEntries, uintptr_t memChunk, uintptrj_t methodStartAddress);
-      bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::J9ClientStream *client, bool usePersistentCache);
+      bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::ClientStream *client, bool usePersistentCache);
       std::string serializeIProfilerMethodEntry(TR_OpaqueMethodBlock *omb);
    };
 

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -61,10 +61,9 @@ static int32_t J9THREAD_PROC listenerThreadProc(void * entryarg)
 
    j9thread_set_name(j9thread_self(), "JITaaS Server Listener");
 
-   JITaaS::J9CompileServer server;
-   J9CompileDispatcher handler(jitConfig, listenerThread);
+   J9CompileDispatcher handler(jitConfig);
    TR::PersistentInfo *info = getCompilationInfo(jitConfig)->getPersistentInfo();
-   server.buildAndServe(&handler, info);
+   JITaaS::serveRemoteCompilationRequests(&handler, info);
 
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Detaching JITaaSServer listening thread");


### PR DESCRIPTION
- Removed a few stale/unused methods
- Changed names of classes/fields to remove "J9" particle
- Pushed some #include from hpp files into cpp files