### PR TITLE
Refactor inlineIndexableObject allocation

### DIFF
--- a/runtime/gc_include/ObjectAllocationAPI.hpp
+++ b/runtime/gc_include/ObjectAllocationAPI.hpp
@@ -53,123 +53,9 @@ public:
 	 * Function members
 	 */
 private:
-protected:
-public:
-
-	/**
-	 * Create an instance.
-	 */
-	MM_ObjectAllocationAPI(J9VMThread *currentThread)
-		: _gcAllocationType(currentThread->javaVM->gcAllocationType)
-#if defined(J9VM_GC_BATCH_CLEAR_TLH)
-		, _initializeSlotsOnTLHAllocate(currentThread->javaVM->initializeSlotsOnTLHAllocate)
-#endif /* J9VM_GC_BATCH_CLEAR_TLH */
-		, _objectAlignmentInBytes(currentThread->omrVMThread->_vm->_objectAlignmentInBytes)
-#if defined (J9VM_GC_SEGREGATED_HEAP)
-		, _sizeClasses(currentThread->javaVM->realtimeSizeClasses)
-#endif /* J9VM_GC_SEGREGATED_HEAP */
-	{}
 
 	VMINLINE j9object_t
-	inlineAllocateObject(J9VMThread *currentThread, J9Class *clazz, bool initializeSlots = true, bool memoryBarrier = true)
-	{
-		j9object_t instance = NULL;
-#if defined(J9VM_GC_THREAD_LOCAL_HEAP) || defined(J9VM_GC_SEGREGATED_HEAP)
-		bool initializeLockWord = initializeSlots
-			&& J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(clazz), J9ClassReservableLockWordInit);
-
-		/* Calculate the size of the object */
-		UDATA const headerSize = J9VMTHREAD_MIXED_HEADER_SIZE(currentThread);
-		UDATA dataSize = clazz->totalInstanceSize;
-		UDATA allocateSize = (dataSize + headerSize + _objectAlignmentInBytes - 1) & ~(UDATA)(_objectAlignmentInBytes - 1);
-		if (allocateSize < J9_GC_MINIMUM_OBJECT_SIZE) {
-			allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;
-		}
-
-		/* Allocate the object */
-		switch(_gcAllocationType) {
-#if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-		case OMR_GC_ALLOCATION_TYPE_TLH:
-			if (allocateSize <= ((UDATA) currentThread->heapTop - (UDATA) currentThread->heapAlloc)) {
-				U_8 *heapAlloc = currentThread->heapAlloc;
-				UDATA afterAlloc = (UDATA)heapAlloc + allocateSize;
-				currentThread->heapAlloc = (U_8 *)afterAlloc;
-#if defined(J9VM_GC_TLH_PREFETCH_FTA)
-				currentThread->tlhPrefetchFTA -= allocateSize;
-#endif /* J9VM_GC_TLH_PREFETCH_FTA */
-				instance = (j9object_t) heapAlloc;
-#if defined(J9VM_GC_BATCH_CLEAR_TLH)
-				/* Do not zero the TLH if it is already zero'd */
-				initializeSlots = initializeSlots && _initializeSlotsOnTLHAllocate;
-#endif /* J9VM_GC_BATCH_CLEAR_TLH */
-			} else {
-				return NULL;
-			}
-			break;
-#endif /* J9VM_GC_THREAD_LOCAL_HEAP */
-
-#if defined(J9VM_GC_SEGREGATED_HEAP)
-		case OMR_GC_ALLOCATION_TYPE_SEGREGATED:
-			/* ensure the allocation will fit in a small size */
-			if (allocateSize <= J9VMGC_SIZECLASSES_MAX_SMALL_SIZE_BYTES) {
-
-				/* fetch the size class based on the allocation size */
-				UDATA slotsRequested = allocateSize / sizeof(UDATA);
-				UDATA sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
-
-				/* Ensure the cache for the current size class is not empty. */
-				J9VMGCSegregatedAllocationCacheEntry *cacheEntry =
-						(J9VMGCSegregatedAllocationCacheEntry *)((UDATA)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
-								+ (sizeClassIndex * sizeof(J9VMGCSegregatedAllocationCacheEntry)));
-				UDATA cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
-
-				if (cellSize <= ((UDATA) cacheEntry->top - (UDATA) cacheEntry->current)) {
-					instance = (j9object_t) cacheEntry->current;
-					cacheEntry->current = (UDATA *) ((UDATA) cacheEntry->current + cellSize);
-					/* The metronome pre write barrier might scan this object - always zero it */
-					initializeSlots = true;
-				} else {
-					return NULL;
-				}
-			} else {
-				return NULL;
-			}
-			break;
-#endif /* J9VM_GC_SEGREGATED_HEAP */
-
-		default:
-			return NULL;
-		}
-
-		/* Initialize the object */
-		if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread)) {
-			J9NonIndexableObjectCompressed *objectHeader = (J9NonIndexableObjectCompressed*) instance;
-			objectHeader->clazz = (U_32)(UDATA)clazz;
-			if (initializeSlots) {
-				memset(objectHeader + 1, 0, dataSize);
-			}
-			if (initializeLockWord) {
-				*(U_32*)J9OBJECT_MONITOR_EA(currentThread, instance) = OBJECT_HEADER_LOCK_RESERVED;
-			}
-		} else {
-			J9NonIndexableObjectFull *objectHeader = (J9NonIndexableObjectFull*) instance;
-			objectHeader->clazz = (UDATA)clazz;
-			if (initializeSlots) {
-				memset(objectHeader + 1, 0, dataSize);
-			}
-			if (initializeLockWord) {
-				*(UDATA*)J9OBJECT_MONITOR_EA(currentThread, instance) = OBJECT_HEADER_LOCK_RESERVED;
-			}
-		}
-		if (memoryBarrier) {
-			VM_AtomicSupport::writeBarrier();
-		}
-#endif /* J9VM_GC_THREAD_LOCAL_HEAP || J9VM_GC_SEGREGATED_HEAP */
-		return instance;
-	}
-
-	VMINLINE j9object_t
-	inlineAllocateIndexableObject(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
+	inlineAllocateIndexableObjectImpl(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, UDATA dataSize, bool validSize, bool initializeSlots = true, bool memoryBarrier = true)
 	{
 		j9object_t instance = NULL;
 
@@ -177,9 +63,8 @@ public:
 		if (0 != size) {
 			/* Contiguous Array */
 
-
 #if !defined(J9VM_ENV_DATA64)
-			if (!sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE / J9ARRAYCLASS_GET_STRIDE(arrayClass))))
+			if (validSize)
 #endif /* J9VM_ENV_DATA64 */
 			{
 				/* Calculate the size of the object */
@@ -352,6 +237,144 @@ public:
 		}
 
 		return instance;
+	}
+
+protected:
+public:
+
+	/**
+	 * Create an instance.
+	 */
+	MM_ObjectAllocationAPI(J9VMThread *currentThread)
+		: _gcAllocationType(currentThread->javaVM->gcAllocationType)
+#if defined(J9VM_GC_BATCH_CLEAR_TLH)
+		, _initializeSlotsOnTLHAllocate(currentThread->javaVM->initializeSlotsOnTLHAllocate)
+#endif /* J9VM_GC_BATCH_CLEAR_TLH */
+		, _objectAlignmentInBytes(currentThread->omrVMThread->_vm->_objectAlignmentInBytes)
+#if defined (J9VM_GC_SEGREGATED_HEAP)
+		, _sizeClasses(currentThread->javaVM->realtimeSizeClasses)
+#endif /* J9VM_GC_SEGREGATED_HEAP */
+	{}
+
+	VMINLINE j9object_t
+	inlineAllocateObject(J9VMThread *currentThread, J9Class *clazz, bool initializeSlots = true, bool memoryBarrier = true)
+	{
+		j9object_t instance = NULL;
+#if defined(J9VM_GC_THREAD_LOCAL_HEAP) || defined(J9VM_GC_SEGREGATED_HEAP)
+		bool initializeLockWord = initializeSlots
+			&& J9_ARE_ANY_BITS_SET(J9CLASS_EXTENDED_FLAGS(clazz), J9ClassReservableLockWordInit);
+
+		/* Calculate the size of the object */
+		UDATA const headerSize = J9VMTHREAD_MIXED_HEADER_SIZE(currentThread);
+		UDATA dataSize = clazz->totalInstanceSize;
+		UDATA allocateSize = (dataSize + headerSize + _objectAlignmentInBytes - 1) & ~(UDATA)(_objectAlignmentInBytes - 1);
+		if (allocateSize < J9_GC_MINIMUM_OBJECT_SIZE) {
+			allocateSize = J9_GC_MINIMUM_OBJECT_SIZE;
+		}
+
+		/* Allocate the object */
+		switch(_gcAllocationType) {
+#if defined(J9VM_GC_THREAD_LOCAL_HEAP)
+		case OMR_GC_ALLOCATION_TYPE_TLH:
+			if (allocateSize <= ((UDATA) currentThread->heapTop - (UDATA) currentThread->heapAlloc)) {
+				U_8 *heapAlloc = currentThread->heapAlloc;
+				UDATA afterAlloc = (UDATA)heapAlloc + allocateSize;
+				currentThread->heapAlloc = (U_8 *)afterAlloc;
+#if defined(J9VM_GC_TLH_PREFETCH_FTA)
+				currentThread->tlhPrefetchFTA -= allocateSize;
+#endif /* J9VM_GC_TLH_PREFETCH_FTA */
+				instance = (j9object_t) heapAlloc;
+#if defined(J9VM_GC_BATCH_CLEAR_TLH)
+				/* Do not zero the TLH if it is already zero'd */
+				initializeSlots = initializeSlots && _initializeSlotsOnTLHAllocate;
+#endif /* J9VM_GC_BATCH_CLEAR_TLH */
+			} else {
+				return NULL;
+			}
+			break;
+#endif /* J9VM_GC_THREAD_LOCAL_HEAP */
+
+#if defined(J9VM_GC_SEGREGATED_HEAP)
+		case OMR_GC_ALLOCATION_TYPE_SEGREGATED:
+			/* ensure the allocation will fit in a small size */
+			if (allocateSize <= J9VMGC_SIZECLASSES_MAX_SMALL_SIZE_BYTES) {
+
+				/* fetch the size class based on the allocation size */
+				UDATA slotsRequested = allocateSize / sizeof(UDATA);
+				UDATA sizeClassIndex = _sizeClasses->sizeClassIndex[slotsRequested];
+
+				/* Ensure the cache for the current size class is not empty. */
+				J9VMGCSegregatedAllocationCacheEntry *cacheEntry =
+						(J9VMGCSegregatedAllocationCacheEntry *)((UDATA)currentThread + J9_VMTHREAD_SEGREGATED_ALLOCATION_CACHE_OFFSET
+								+ (sizeClassIndex * sizeof(J9VMGCSegregatedAllocationCacheEntry)));
+				UDATA cellSize = _sizeClasses->smallCellSizes[sizeClassIndex];
+
+				if (cellSize <= ((UDATA) cacheEntry->top - (UDATA) cacheEntry->current)) {
+					instance = (j9object_t) cacheEntry->current;
+					cacheEntry->current = (UDATA *) ((UDATA) cacheEntry->current + cellSize);
+					/* The metronome pre write barrier might scan this object - always zero it */
+					initializeSlots = true;
+				} else {
+					return NULL;
+				}
+			} else {
+				return NULL;
+			}
+			break;
+#endif /* J9VM_GC_SEGREGATED_HEAP */
+
+		default:
+			return NULL;
+		}
+
+		/* Initialize the object */
+		if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread)) {
+			J9NonIndexableObjectCompressed *objectHeader = (J9NonIndexableObjectCompressed*) instance;
+			objectHeader->clazz = (U_32)(UDATA)clazz;
+			if (initializeSlots) {
+				memset(objectHeader + 1, 0, dataSize);
+			}
+			if (initializeLockWord) {
+				*(U_32*)J9OBJECT_MONITOR_EA(currentThread, instance) = OBJECT_HEADER_LOCK_RESERVED;
+			}
+		} else {
+			J9NonIndexableObjectFull *objectHeader = (J9NonIndexableObjectFull*) instance;
+			objectHeader->clazz = (UDATA)clazz;
+			if (initializeSlots) {
+				memset(objectHeader + 1, 0, dataSize);
+			}
+			if (initializeLockWord) {
+				*(UDATA*)J9OBJECT_MONITOR_EA(currentThread, instance) = OBJECT_HEADER_LOCK_RESERVED;
+			}
+		}
+		if (memoryBarrier) {
+			VM_AtomicSupport::writeBarrier();
+		}
+#endif /* J9VM_GC_THREAD_LOCAL_HEAP || J9VM_GC_SEGREGATED_HEAP */
+		return instance;
+	}
+
+	VMINLINE j9object_t
+	inlineAllocateIndexableValueTypeObject(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
+	{
+		UDATA dataSize = ((UDATA)size) * J9ARRAYCLASS_GET_STRIDE(arrayClass);
+		bool validSize = true;
+#if !defined(J9VM_ENV_DATA64)
+		validSize = !sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE / J9ARRAYCLASS_GET_STRIDE(arrayClass)));
+#endif /* J9VM_ENV_DATA64 */
+		return inlineAllocateIndexableObjectImpl(currentThread, arrayClass, size, dataSize, validSize, initializeSlots, memoryBarrier);
+	}
+
+	VMINLINE j9object_t
+	inlineAllocateIndexableObject(J9VMThread *currentThread, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
+	{
+		UDATA scale = ((J9ROMArrayClass*)(arrayClass->romClass))->arrayShape;
+		UDATA dataSize = ((UDATA)size) << scale;
+		bool validSize = true;
+#if !defined(J9VM_ENV_DATA64)
+		validSize = !sizeCheck || (size < ((U_32)J9_MAXIMUM_INDEXABLE_DATA_SIZE >> scale));
+#endif /* J9VM_ENV_DATA64 */
+		return inlineAllocateIndexableObjectImpl(currentThread, arrayClass, size, dataSize, validSize, initializeSlots, memoryBarrier);
 	}
 
 };

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -780,7 +780,17 @@ done:
 	static VMINLINE j9object_t
 	allocateIndexableObject(J9VMThread *currentThread, MM_ObjectAllocationAPI *objectAllocate, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
 	{
-		j9object_t instance = objectAllocate->inlineAllocateIndexableObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
+		j9object_t instance = NULL;
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+			instance = objectAllocate->inlineAllocateIndexableValueTypeObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
+		} else
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+		{
+			instance = objectAllocate->inlineAllocateIndexableObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
+		}
+
 		if (NULL == instance) {
 			instance = currentThread->javaVM->memoryManagerFunctions->J9AllocateIndexableObject(currentThread, arrayClass, size, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
 			if (J9_UNEXPECTED(NULL == instance)) {

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1055,7 +1055,17 @@ obj:;
 	VMINLINE j9object_t
 	allocateIndexableObject(REGISTER_ARGS_LIST, J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
 	{
-		j9object_t instance = _objectAllocate.inlineAllocateIndexableObject(_currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
+		j9object_t instance = NULL;
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (J9_IS_J9CLASS_FLATTENED(arrayClass)) {
+			instance = _objectAllocate.inlineAllocateIndexableValueTypeObject(_currentThread, arrayClass, (U_32)size, initializeSlots, memoryBarrier, sizeCheck);
+		} else
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+		{
+			instance = _objectAllocate.inlineAllocateIndexableObject(_currentThread, arrayClass, (U_32)size, initializeSlots, memoryBarrier, sizeCheck);
+		}
+
 		if (NULL == instance) {
 			updateVMStruct(REGISTER_ARGS);
 			instance = _vm->memoryManagerFunctions->J9AllocateIndexableObject(_currentThread, arrayClass, size, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
@@ -3095,7 +3105,16 @@ done:
 		}
 		if (flags & J9AccClassArray) {
 			U_32 size = J9INDEXABLEOBJECT_SIZE(_currentThread, original);
-			copy = _objectAllocate.inlineAllocateIndexableObject(_currentThread, objectClass, size, false, false, false);
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+				copy = _objectAllocate.inlineAllocateIndexableValueTypeObject(_currentThread, objectClass, size, false, false, false);
+			} else
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+			{
+				copy = _objectAllocate.inlineAllocateIndexableObject(_currentThread, objectClass, size, false, false, false);
+			}
+
 			if (NULL == copy) {
 				pushObjectInSpecialFrame(REGISTER_ARGS, original);
 				updateVMStruct(REGISTER_ARGS);
@@ -7469,7 +7488,16 @@ retry:
 		if (J9_EXPECTED(NULL != resolvedClass)) {
 			J9Class *arrayClass = resolvedClass->arrayClass;
 			if (J9_EXPECTED(NULL != arrayClass)) {
-				j9object_t instance = _objectAllocate.inlineAllocateIndexableObject(_currentThread, arrayClass, (U_32)size);
+				j9object_t instance = NULL;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				if (J9_IS_J9CLASS_FLATTENED(arrayClass)) {
+					instance = _objectAllocate.inlineAllocateIndexableValueTypeObject(_currentThread, arrayClass, (U_32)size);
+				} else
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+				{
+					instance = _objectAllocate.inlineAllocateIndexableObject(_currentThread, arrayClass, (U_32)size);
+				}
+
 				if (NULL == instance) {
 					updateVMStruct(REGISTER_ARGS);
 					instance = _vm->memoryManagerFunctions->J9AllocateIndexableObject(_currentThread, arrayClass, (U_32)size, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);

--- a/runtime/vm/FastJNI_java_lang_J9VMInternals.cpp
+++ b/runtime/vm/FastJNI_java_lang_J9VMInternals.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,7 +69,15 @@ Fast_java_lang_J9VMInternals_primitiveClone(J9VMThread *currentThread, j9object_
 	}
 	if (flags & J9AccClassArray) {
 		U_32 size = J9INDEXABLEOBJECT_SIZE(currentThread, original);
-		copy = objectAllocate.inlineAllocateIndexableObject(currentThread, objectClass, size, false, false, false);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+			copy = objectAllocate.inlineAllocateIndexableValueTypeObject(currentThread, objectClass, size, false, false, false);
+		} else
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+		{
+			copy = objectAllocate.inlineAllocateIndexableObject(currentThread, objectClass, size, false, false, false);
+		}
+
 		if (NULL == copy) {
 			VM_VMHelpers::pushObjectInSpecialFrame(currentThread, original);
 			copy = currentThread->javaVM->memoryManagerFunctions->J9AllocateIndexableObject(currentThread, objectClass, size, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);


### PR DESCRIPTION
Refactor inlineIndexableObject allocation

Split the `inlineAllocateIndexableObject` API in to the 
value-type and non-valueType version. The valueType version will
perform a `stride * index` calculation to determine the array 
size. The non-valueType version will use the more optimal shape 
and shift calculation to determine the array size.

Signed-off-by: tajila <atobia@ca.ibm.com>