### PR TITLE
Send processor features from JITaaS client to server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -561,6 +561,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._readBarrierType = TR::Compiler->om.readBarrierType();
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
+         vmInfo._processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
          client->write(response, vmInfo);
          }
          break;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -28,6 +28,7 @@
 #include "rpc/J9Client.hpp"
 #include "env/PersistentCollections.hpp"
 #include "env/j9methodServer.hpp"
+#include "env/J9CPU.hpp"
 
 class TR_PersistentClassInfo;
 class TR_IPBytecodeHashTableEntry;
@@ -155,6 +156,7 @@ class ClientSessionData
       MM_GCReadBarrierType _readBarrierType;
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;
+      TR_ProcessorFeatureFlags _processorFeatureFlags;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,10 @@ public:
 
    TR_ProcessorFeatureFlags getProcessorFeatureFlags();
    bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+
+   uint32_t getX86ProcessorFeatureFlags();
+   uint32_t getX86ProcessorFeatureFlags2();
+   uint32_t getX86ProcessorFeatureFlags8();
 
    };
 


### PR DESCRIPTION
Client processor feature flags are stored in VMInfo and sent to the server.
Each client contains its own set of processor feature flags on the server which is used by the code generator. Server's code generator generates code according to client's feature flags.
Currently only enabled support for x86. Overloaded TR::Compiler->target.cpu.getX86ProcessorFeatureFlags() to return Client's processor feature flags instead of server's own processor feature flags.

[skip ci]
Issue: #6081

Signed-off-by: Harry Yu <harryyu1994@gmail.com>