### PR TITLE
Use unbreakpointed ROM method for metadata queries

### DIFF
--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ J9::VMMethodEnv::startPC(TR_OpaqueMethodBlock *method)
 uintptr_t
 J9::VMMethodEnv::bytecodeStart(TR_OpaqueMethodBlock *method)
    {
-   J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+   J9ROMMethod *romMethod = getOriginalROMMethod((J9Method *)method);
    return (uintptr_t)(J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
    }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1569,7 +1569,7 @@ int32_t *TR_J9VMBase::getCurrentLocalsMapForDLT(TR::Compilation *comp)
 
    numBundles = (numBundles+31)/32;
    currentBundles = (int32_t *)comp->trMemory()->allocateHeapMemory(numBundles * sizeof(int32_t));
-   jitConfig->javaVM->localMapFunction(_portLibrary, J9_CLASS_FROM_METHOD(j9method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(j9method), comp->getDltBcIndex(), (U_32 *)currentBundles, NULL, NULL, NULL);
+   jitConfig->javaVM->localMapFunction(_portLibrary, J9_CLASS_FROM_METHOD(j9method)->romClass, getOriginalROMMethod(j9method), comp->getDltBcIndex(), (U_32 *)currentBundles, NULL, NULL, NULL);
 #endif
 
    return currentBundles;

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 2017, 2019 IBM Corp. and others
  *
@@ -164,7 +163,7 @@ Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 		if (NULL == frame) {
 			vmFuncs->setHeapOutOfMemoryError(vmThread);
 		} else {
-			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState->method);
+			J9ROMMethod *romMethod = getOriginalROMMethod(walkState->method);
 			J9Class *ramClass = J9_CLASS_FROM_METHOD(walkState->method);
 			J9ROMClass *romClass = ramClass->romClass;
 			J9ClassLoader* classLoader = ramClass->classLoader;
@@ -176,7 +175,7 @@ Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 
 			/* set the class object if requested */
 			if (J9_ARE_ANY_BITS_SET((UDATA) walkState->userData1, RETAIN_CLASS_REFERENCE)) {
-				j9object_t classObject =J9VM_J9CLASS_TO_HEAPCLASS(ramClass);
+				j9object_t classObject = J9VM_J9CLASS_TO_HEAPCLASS(ramClass);
 				J9VMJAVALANGSTACKWALKERSTACKFRAMEIMPL_SET_DECLARINGCLASS(vmThread, frame, classObject);
 			}
 

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -303,7 +303,7 @@ getMethodParametersAsArray(JNIEnv *env, jobject jlrExecutable)
 	if (NULL != executableID) {
 		PORT_ACCESS_FROM_VMC(vmThread);
 		J9Method *ramMethod = executableID->method;
-		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
+		J9ROMMethod * romMethod = getOriginalROMMethod(ramMethod);
 		U_8 numberOfParameters = computeArgCount(romMethod);
 		J9MethodParametersData * parametersData = getMethodParametersFromROMMethod(romMethod);
 		U_8 index = 0;

--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -524,7 +524,7 @@ jvmtiGetBytecodes(jvmtiEnv* env,
 	ENSURE_NON_NULL(bytecode_count_ptr);
 	ENSURE_NON_NULL(bytecodes_ptr);
 
-	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
+	romMethod = getOriginalROMMethod(((J9JNIMethodID *) method)->method);
 	if (romMethod->modifiers & J9AccNative) {
 		JVMTI_ERROR(JVMTI_ERROR_NATIVE_METHOD);
 	}

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getConstantPool/gcp001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getConstantPool/gcp001.c
@@ -222,7 +222,7 @@ testGetConstantPool_classLoad(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thre
 		jint i; 
 
 		for (i = 0; i < methodCount; ++i) {
-			J9UTF8 *romMethodName;
+			char *methodName = NULL;
 			jmethodID method = methods[i];
 			jlocation start;
 			jlocation end;
@@ -250,11 +250,15 @@ testGetConstantPool_classLoad(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thre
 				continue;
 			}
 
-			romMethodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method));
-			if (strncmp((const char *) romMethodName->data, "<clinit>", romMethodName->length)) {
+			err = (*jvmti_env)->GetMethodName(jvmti_env, method, &methodName, NULL, NULL);
+			if (err != JVMTI_ERROR_NONE) {
+				j9tty_printf(PORTLIB, "\t%s\n", errorName(jvmti_env, thread, err, "!!! Failed to get method name"));
+				goto done;
+			} 
+
+			if (0 != strcmp(methodName, "<clinit>")) {
 				continue;
 			}
-
 
 			err = (*jvmti_env)->GetBytecodes(jvmti_env, method, &size, &bytecodes);
 			if (err != JVMTI_ERROR_NONE) {

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -123,7 +123,7 @@ static char *
 getMethodName(J9Method * m)
 {
 	static char buf[512];
-	J9UTF8 * n = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(m));
+	J9UTF8 * n = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(m)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(m));
 	memcpy(buf, J9UTF8_DATA(n), J9UTF8_LENGTH(n));
 	buf[J9UTF8_LENGTH(n)] = 0;
 	return buf;


### PR DESCRIPTION
Various calls are using the ROM method from the RAM method without
backing it up to the unbreakpointed version (which is required for many
queries which assume the ROM method is within the ROM class).

Fix the required calls to use the unbreakpointed method.

Fixes: #6225

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>