### PR TITLE
Get rid of calls to extra_L in BruteArgumentMoverHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/BruteArgumentMoverHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BruteArgumentMoverHandle.java
@@ -137,11 +137,11 @@ final class BruteArgumentMoverHandle extends ArgumentMoverHandle {
 	final Object[] extra;
 
 	// Save a level of indirection for the first few objects.
-	Object   extra_L0;
-	Object   extra_L1;
-	Object   extra_L2;
-	Object   extra_L3;
-	Object   extra_L4;
+	final Object   extra_L0;
+	final Object   extra_L1;
+	final Object   extra_L2;
+	final Object   extra_L3;
+	final Object   extra_L4;
 
 	// Save a couple of levels of indirection for inserted ints.
 	// Also, mark as non-final so we leave the loads in the residual code.
@@ -393,6 +393,8 @@ final class BruteArgumentMoverHandle extends ArgumentMoverHandle {
 		return result;
 	}
 
+	static native int permuteArgs(int argPlaceholder, Object extra_L0, Object extra_L1, Object extra_L2, Object extra_L3, Object extra_L4, Object[] extra);
+
 	@FrameIteratorSkip
 	private final int invokeExact_thunkArchetype_X(int argPlaceholder) {
 		if (ILGenMacros.isShareableThunk()) {
@@ -403,7 +405,7 @@ final class BruteArgumentMoverHandle extends ArgumentMoverHandle {
 		}
 		return ILGenMacros.invokeExact_X(
 			next,
-			permuteArgs(argPlaceholder));
+			permuteArgs(argPlaceholder, this.extra_L0, this.extra_L1, this.extra_L2, this.extra_L3, this.extra_L4, this.extra));
 	}
 
 	// }}} JIT support

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -932,6 +932,7 @@
    x10JITHelpers_checkHighBounds,
 
    // JSR292
+   java_lang_invoke_BruteArgumentMoverHandle_permuteArgs,
    java_lang_invoke_ArgumentMoverHandle_permuteArgs,
    java_lang_invoke_AsTypeHandle_convertArgs,
    java_lang_invoke_CatchHandle_numCatchTargetArgsToPassThrough,

--- a/runtime/compiler/env/JSR292Methods.h
+++ b/runtime/compiler/env/JSR292Methods.h
@@ -46,6 +46,7 @@
 #define JSR292_forGenericInvokeSig "(Ljava/lang/invoke/MethodType;Z)Ljava/lang/invoke/MethodHandle;"
 
 #define JSR292_ArgumentMoverHandle  "java/lang/invoke/ArgumentMoverHandle"
+#define JSR292_BruteArgumentMoverHandle  "java/lang/invoke/BruteArgumentMoverHandle"
 
 #define JSR292_StaticFieldGetterHandle "java/lang/invoke/StaticFieldGetterHandle"
 #define JSR292_StaticFieldSetterHandle "java/lang/invoke/StaticFieldSetterHandle"

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3984,6 +3984,12 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {  TR::unknownMethod}
       };
 
+   static X BruteArgumentMoverHandleMethods[] =
+      {
+      {  TR::java_lang_invoke_BruteArgumentMoverHandle_permuteArgs,     11, "permuteArgs",   (int16_t)-1, "*"},
+      {  TR::unknownMethod}
+      };
+
    static X PermuteHandleMethods[] =
       {
       {x(TR::java_lang_invoke_PermuteHandle_permuteArgs, "permuteArgs", "(I)I")},
@@ -4508,6 +4514,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       { "org/apache/harmony/luni/platform/OSMemory", OSMemoryMethods },
       { "java/util/concurrent/atomic/AtomicBoolean", JavaUtilConcurrentAtomicBooleanMethods },
       { "java/util/concurrent/atomic/AtomicInteger", JavaUtilConcurrentAtomicIntegerMethods },
+      { "java/lang/invoke/BruteArgumentMoverHandle", BruteArgumentMoverHandleMethods },
       { 0 }
       };
 
@@ -7473,6 +7480,31 @@ getMethodHandleThunkDetails(TR_J9ByteCodeIlGenerator *ilgen, TR::Compilation *co
    return NULL;
    }
 
+static TR::DataType typeFromSig(char sig)
+   {
+   switch (sig)
+      {
+      case 'L':
+      case '[':
+         return TR::Address;
+      case 'I':
+      case 'Z':
+      case 'B':
+      case 'S':
+      case 'C':
+         return TR::Int32;
+      case 'J':
+         return TR::Int64;
+      case 'F':
+         return TR::Float;
+      case 'D':
+         return TR::Double;
+      default:
+         break;
+      }
+   return TR::NoType;
+   }
+
 bool
 TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
    {
@@ -7487,8 +7519,9 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
    char *nextHandleSignature = NULL;
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe();
+   TR::RecognizedMethod rm = symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod();
 
-   switch (symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
+   switch (rm)
       {
       case TR::java_lang_invoke_CollectHandle_numArgsToPassThrough:
       case TR::java_lang_invoke_CollectHandle_numArgsToCollect:
@@ -7813,6 +7846,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          }
          return true;
       case TR::java_lang_invoke_ArgumentMoverHandle_permuteArgs:
+      case TR::java_lang_invoke_BruteArgumentMoverHandle_permuteArgs:
          {
          J9::MethodHandleThunkDetails *thunkDetails = getMethodHandleThunkDetails(this, comp(), symRef);
          if (!thunkDetails)
@@ -7852,10 +7886,19 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          TR::Node *originalArgs;
          char * oldSignature;
          char * newSignature;
+         TR::Node* extraArrayNode = NULL;
+         TR::Node* extraL[5];
+         if (rm == TR::java_lang_invoke_BruteArgumentMoverHandle_permuteArgs)
+            {
+            extraArrayNode = pop();
+            for (int i=4; i>=0; i--)
+                extraL[i] = pop();
+            }
 
             {
             TR::VMAccessCriticalSection invokePermuteHandlePermuteArgs(fej9);
             uintptrj_t methodHandle = *thunkDetails->getHandleRef();
+
             uintptrj_t permuteArray = fej9->getReferenceField(methodHandle, "permute", "[I");
 
             // Create temporary placeholder to cause argument expressions to be expanded
@@ -7889,6 +7932,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                   char *argType = nthSignatureArgument(i, nextHandleSignature+1);
                   char  extraName[10];
                   char *extraSignature;
+
                   switch (argType[0])
                      {
                      case 'L':
@@ -7901,12 +7945,33 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                         extraSignature = artificialSignature(stackAlloc, "(L" JSR292_ArgumentMoverHandle ";I).@", nextHandleSignature, i);
                         break;
                      }
+
                   if (comp()->getOption(TR_TraceILGen))
                      traceMsg(comp(), "  permuteArgs:   %d: call to %s.%s%s\n", argIndex, JSR292_ArgumentMoverHandle, extraName, extraSignature);
-                  TR::SymbolReference *extra = comp()->getSymRefTab()->methodSymRefFromName(_methodSymbol, JSR292_ArgumentMoverHandle, extraName, extraSignature, TR::MethodSymbol::Static);
-                  loadAuto(TR::Address, 0);
-                  loadConstant(TR::iconst, argIndex);
-                  genInvokeDirect(extra);
+
+                  // Get the argument type of next handle
+                  TR::DataType dataType = typeFromSig(argType[0]);
+
+                  if (dataType == TR::Address && extraArrayNode)
+                     {
+                     if (-1 - argIndex < 5)
+                        {
+                        push(extraL[-1-argIndex]);
+                        }
+                     else
+                        {
+                        push(extraArrayNode);
+                        loadConstant(TR::iconst, -1 - argIndex);
+                        loadArrayElement(TR::Address, comp()->il.opCodeForIndirectArrayLoad(TR::Address), false);
+                        }
+                     }
+                  else
+                     {
+                     TR::SymbolReference *extra = comp()->getSymRefTab()->methodSymRefFromName(_methodSymbol, JSR292_ArgumentMoverHandle, extraName, extraSignature, TR::MethodSymbol::Static);
+                     loadAuto(TR::Address, 0);
+                     loadConstant(TR::iconst, argIndex);
+                     genInvokeDirect(extra);
+                     }
                   }
                }
             if (comp()->getOption(TR_TraceILGen))


### PR DESCRIPTION
When an extra argument needed by `next` handle is reference type, we
don't need to generate a call to `extra_L` to get that argument as no
conversion is needed. Also, inliner will have problem inlining this call
when there are multiple calls generated for the same bytecode.

#4837

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>