### PR TITLE
(v0.15.0) Initialize fieldClassReg for static unresolved reads

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12760,10 +12760,14 @@ J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::CodeGene
          }
       else
          {
-         fieldClassReg = cg->allocateRegister();
          if (isWrite)
             {
+            fieldClassReg = cg->allocateRegister();
             generateRegMemInstruction(LRegMem(), node, fieldClassReg, generateX86MemoryReference(sideEffectRegister, fej9->getOffsetOfClassFromJavaLangClassField(), cg), cg);
+            }
+         else
+            {
+            fieldClassReg = sideEffectRegister;
             }
          classFlagsMemRef = generateX86MemoryReference(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
          }
@@ -12787,7 +12791,7 @@ J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::CodeGene
    deps->stopAddingConditions();
    generateLabelInstruction(LABEL, node, endLabel, deps, cg);
 
-   if (isInstanceField || (!isResolved) || isAOTCompile)
+   if (isInstanceField || (!isResolved && isWrite) || isAOTCompile)
       {
       cg->stopUsingRegister(fieldClassReg);
       }


### PR DESCRIPTION
When generating code for a watched field event, if an unresolved static field is being read, we do not intialize the fieldClassReg correctly. The fieldClassReg is used to test if a field is being watched. Failure to initialize this register correctly results in an invalid test being generated at runtime, causing a bug.

This commit correctly initializes the fieldClassReg for the missing corner case.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>