### PR TITLE
Replace JITAAS_ENABLE_SSL with JITSERVER_ENABLE_SSL

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -132,8 +132,8 @@ ifeq ($(HOST_ARCH),x)
         CX_FLAGS+=-m64 -fPIC
     endif
 
-    ifneq ($(JITAAS_ENABLE_SSL),)
-        CX_DEFINES+=JITAAS_ENABLE_SSL
+    ifneq ($(JITSERVER_ENABLE_SSL),)
+        CX_DEFINES+=JITSERVER_ENABLE_SSL
     endif
 endif
 
@@ -521,7 +521,7 @@ PROTO_CMD?=protoc
 
 CXX_DEFINES+=GOOGLE_PROTOBUF_NO_RTTI
 
-ifeq ($(JITAAS_ENABLE_SSL),)
+ifeq ($(JITSERVER_ENABLE_SSL),)
     SOLINK_SLINK+=protobuf
 else
     SOLINK_SLINK+=protobuf ssl
@@ -552,4 +552,4 @@ else
             CXX_INCLUDES+=$(subst -I,,$(OPENSSL_CFLAGS))
         endif
     endif # OPENSSL_CFLAGS
-endif # JITAAS_ENABLE_SSL
+endif # JITSERVER_ENABLE_SSL

--- a/runtime/compiler/rpc/J9Client.cpp
+++ b/runtime/compiler/rpc/J9Client.cpp
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h> /// gethostname, read, write
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/err.h>
 #endif
 
@@ -53,7 +53,7 @@ const int ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
 // This is called during startup from rossa.cpp
 void ClientStream::static_init(TR::PersistentInfo *info)
    {
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    if (!CommunicationStream::useSSL(info))
       return;
 
@@ -125,7 +125,7 @@ void ClientStream::static_init(TR::PersistentInfo *info)
 #endif
    }
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 SSL_CTX *ClientStream::_sslCtx;
 #endif
 
@@ -188,7 +188,7 @@ int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs
    return sockfd;
    }
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    {
    if (!ctx)
@@ -261,7 +261,7 @@ ClientStream::ClientStream(TR::PersistentInfo *info)
    initStream(connfd, ssl);
    _numConnectionsOpened++;
    }
-#else // JITAAS_ENABLE_SSL
+#else // JITSERVER_ENABLE_SSL
 ClientStream::ClientStream(TR::PersistentInfo *info)
    : CommunicationStream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
    {

--- a/runtime/compiler/rpc/J9Client.hpp
+++ b/runtime/compiler/rpc/J9Client.hpp
@@ -30,7 +30,7 @@
 #include "ilgen/J9IlGeneratorMethodDetails.hpp"
 #include "rpc/J9Stream.hpp"
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/ssl.h>
 class SSLOutputStream;
 class SSLInputStream;
@@ -145,7 +145,7 @@ private:
    static const uint64_t RETRY_COMPATIBILITY_INTERVAL;
    static const int INCOMPATIBILITY_COUNT_LIMIT;
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    static SSL_CTX *_sslCtx;
 #endif
    };

--- a/runtime/compiler/rpc/J9Server.cpp
+++ b/runtime/compiler/rpc/J9Server.cpp
@@ -37,7 +37,7 @@
 #include "env/VerboseLog.hpp"
 #include "env/TRMemory.hpp"
 #include "rpc/SSLProtobufStream.hpp"
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/err.h>
 #endif
 
@@ -46,7 +46,7 @@ namespace JITServer
 int ServerStream::_numConnectionsOpened = 0;
 int ServerStream::_numConnectionsClosed = 0;
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 ServerStream::ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    : CommunicationStream(),
    _msTimeout(timeout)
@@ -54,7 +54,7 @@ ServerStream::ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    initStream(connfd, ssl);
    _numConnectionsOpened++;
    }
-#else // JITAAS_ENABLE_SSL
+#else // JITSERVER_ENABLE_SSL
 ServerStream::ServerStream(int connfd, uint32_t timeout)
    : CommunicationStream(),
    _msTimeout(timeout)
@@ -83,7 +83,7 @@ ServerStream::finishCompilation(uint32_t statusCode, std::string codeCache, std:
       }
    }
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 SSL_CTX *createSSLContext(TR::PersistentInfo *info)
    {
    SSL_CTX *ctx = SSL_CTX_new(SSLv23_server_method());
@@ -224,7 +224,7 @@ acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
 void
 serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info)
    {
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    SSL_CTX *sslCtx = NULL;
    if (CommunicationStream::useSSL(info))
       {
@@ -296,7 +296,7 @@ serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentIn
             TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error accepting connection: errno=%d", errno);
          continue;
          }
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
       BIO *bio = NULL;
       if (sslCtx && !acceptOpenSSLConnection(sslCtx, connfd, bio))
          continue;
@@ -309,7 +309,7 @@ serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentIn
       }
 
    // TODO This will never be called - if the server actually shuts down properly then we should do this
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    if (sslCtx)
       {
       SSL_CTX_free(sslCtx);

--- a/runtime/compiler/rpc/J9Server.hpp
+++ b/runtime/compiler/rpc/J9Server.hpp
@@ -28,7 +28,7 @@
 #include "rpc/J9Stream.hpp"
 #include "env/CHTable.hpp"
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/ssl.h>
 class SSLOutputStream;
 class SSLInputStream;
@@ -40,7 +40,7 @@ namespace JITServer
 class ServerStream : CommunicationStream
    {
 public:
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    ServerStream(int connfd, BIO *ssl, uint32_t timeout);
 #else
    ServerStream(int connfd, uint32_t timeout);

--- a/runtime/compiler/rpc/J9Stream.hpp
+++ b/runtime/compiler/rpc/J9Stream.hpp
@@ -42,7 +42,7 @@ using namespace google::protobuf::io;
 class CommunicationStream
    {
 public:
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    static bool useSSL(TR::PersistentInfo *info)
       {
       return (info->getJITaaSSslKeys().size() || info->getJITaaSSslCerts().size() || info->getJITaaSSslRootCerts().size());
@@ -68,7 +68,7 @@ protected:
    CommunicationStream()
       : _inputStream(NULL),
       _outputStream(NULL),
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
       _ssl(NULL),
       _sslInputStream(NULL),
       _sslOutputStream(NULL),
@@ -79,14 +79,14 @@ protected:
       // which initializes these variables
       }
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    void initStream(int connfd, BIO *ssl)
 #else
    void initStream(int connfd)
 #endif
    {
       _connfd = connfd;
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
       _ssl = ssl;
       if (_ssl)
          {
@@ -115,7 +115,7 @@ protected:
          _outputStream->~ZeroCopyOutputStream();
          TR_Memory::jitPersistentFree(_outputStream);
          }
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
       if (_ssl)
          {
          _sslInputStream->~SSLInputStream();
@@ -160,7 +160,7 @@ protected:
             throw JITServer::StreamFailure("JITaaS I/O error: writing to stream");
          // codedOutputStream must be dropped before calling flush
          }
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
       if (_ssl ? !((CopyingOutputStreamAdaptor*)_outputStream)->Flush()
                : !((FileOutputStream*)_outputStream)->Flush())
 #else
@@ -175,7 +175,7 @@ protected:
    J9ServerMessage _sMsg;
    J9ClientMessage _cMsg;
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
    BIO *_ssl; // SSL connection, null if not using SSL
    SSLInputStream *_sslInputStream;
    SSLOutputStream *_sslOutputStream;

--- a/runtime/compiler/rpc/SSLProtobufStream.hpp
+++ b/runtime/compiler/rpc/SSLProtobufStream.hpp
@@ -23,7 +23,7 @@
 #ifndef SSL_PROTOBUF_STREAM_HPP
 #define SSL_PROTOBUF_STREAM_HPP
 
-#if defined(JITAAS_ENABLE_SSL)
+#if defined(JITSERVER_ENABLE_SSL)
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -86,5 +86,5 @@ private:
    BIO *_ssl;
    };
 
-#endif // JITAAS_ENABLE_SSL
+#endif // JITSERVER_ENABLE_SSL
 #endif // SSL_PROTOBUF_STREAM_HPP


### PR DESCRIPTION
Replace JITAAS_ENABLE_SSL with JITSERVER_ENABLE_SSL

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>