### PR TITLE
Reduce number of messages for AOT compilations

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1725,7 +1725,6 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
    J9UTF8 *className = J9ROMCLASS_CLASSNAME(definingClass->romClass);
    traceMsg(comp, "\tdefiningClass name %.*s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 
-   J9ROMClass *romClass = NULL;
    void *classChain = NULL;
 
    // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
@@ -1748,7 +1747,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
          if ((*info)->_reloKind == reloKind)
             {
             if (isStatic)
-               inLocalList = (romClass == ((J9Class *)((*info)->_clazz))->romClass);
+               inLocalList = (definingClass->romClass == ((J9Class *)((*info)->_clazz))->romClass);
             else
                inLocalList = (classChain == (*info)->_classChain &&
                               cpIndex == (*info)->_cpIndex &&

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1883,42 +1883,63 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::storeValidationRecordIfNecessary(TR:
    TR_AOTStats *aotStats = ((TR_JitPrivateConfig *)fej9->_jitConfig->privateConfig)->aotStats;
    bool isStatic = (reloKind == TR_ValidateStaticField);
 
-   _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_storeValidationRecordIfNecessary, ramMethod, constantPool, cpIndex, isStatic, definingClass);
-   // 1. RAM class of ramMethod
-   // 2. defining class
-   // 3. class chain
-   auto recv = _stream->read<J9Class *, J9Class *, UDATA *>();
-
-   J9Class *clazz = std::get<0>(recv);
-   traceMsg(comp, "storeValidationRecordIfNecessary:\n");
-   traceMsg(comp, "\tconstantPool %p cpIndex %d\n", constantPool, cpIndex);
-   traceMsg(comp, "\treloKind %d isStatic %d\n", reloKind, isStatic);
-   J9UTF8 *methodClassName = J9ROMCLASS_CLASSNAME(TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) clazz));
-   traceMsg(comp, "\tmethod %p from class %p %.*s\n", ramMethod, clazz, J9UTF8_LENGTH(methodClassName), J9UTF8_DATA(methodClassName));
-   traceMsg(comp, "\tdefiningClass %p\n", definingClass);
-
-   if (!definingClass)
+   UDATA *classChain = NULL;
+   auto clientData = _fe->_compInfoPT->getClientData();
+   PersistentUnorderedMap<J9Class *, UDATA *> &classChainCache = clientData->getClassClainDataCache();
+   if (definingClass)
       {
-      definingClass = std::get<1>(recv);
-      traceMsg(comp, "\tdefiningClass recomputed from cp as %p\n", definingClass);
+      // if defining class is known, check if we already have a corresponding class chain cached
+      OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
+      auto it = classChainCache.find(definingClass);
+      if (it != classChainCache.end())
+         classChain = it->second;
       }
 
-   if (!definingClass)
+   if (!classChain)
       {
-      if (aotStats)
-         aotStats->numDefiningClassNotFound++;
-      return false;
+      _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_storeValidationRecordIfNecessary, ramMethod, constantPool, cpIndex, isStatic, definingClass);
+      // 1. RAM class of ramMethod
+      // 2. defining class
+      // 3. class chain
+      auto recv = _stream->read<J9Class *, J9Class *, UDATA *>();
+
+      J9Class *clazz = std::get<0>(recv);
+      traceMsg(comp, "storeValidationRecordIfNecessary:\n");
+      traceMsg(comp, "\tconstantPool %p cpIndex %d\n", constantPool, cpIndex);
+      traceMsg(comp, "\treloKind %d isStatic %d\n", reloKind, isStatic);
+      J9UTF8 *methodClassName = J9ROMCLASS_CLASSNAME(TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) clazz));
+      traceMsg(comp, "\tmethod %p from class %p %.*s\n", ramMethod, clazz, J9UTF8_LENGTH(methodClassName), J9UTF8_DATA(methodClassName));
+      traceMsg(comp, "\tdefiningClass %p\n", definingClass);
+
+      if (!definingClass)
+         {
+         definingClass = std::get<1>(recv);
+         traceMsg(comp, "\tdefiningClass recomputed from cp as %p\n", definingClass);
+         }
+
+      if (!definingClass)
+         {
+         if (aotStats)
+            aotStats->numDefiningClassNotFound++;
+         return false;
+         }
+
+      J9UTF8 *className = J9ROMCLASS_CLASSNAME(TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) definingClass));
+      traceMsg(comp, "\tdefiningClass name %.*s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className));
+
+      // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
+      classChain = std::get<2>(recv);
       }
-
-   J9UTF8 *className = J9ROMCLASS_CLASSNAME(TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) definingClass));
-   traceMsg(comp, "\tdefiningClass name %.*s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className));
-
-   J9ROMClass *romClass = NULL;
-   // all kinds of validations may need to rely on the entire class chain, so make sure we can build one first
-   void *classChain = (void *) std::get<2>(recv);
 
    if (!classChain)
       return false;
+
+      {
+      // class chain and defining class found, cache here
+      OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
+      classChainCache.insert(std::make_pair(definingClass, classChain));
+      }
+   
 
    bool inLocalList = false;
    TR::list<TR::AOTClassInfo*>* aotClassInfo = comp->_aotClassInfo;
@@ -1935,7 +1956,8 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::storeValidationRecordIfNecessary(TR:
          if ((*info)->_reloKind == reloKind)
             {
             if (isStatic)
-               inLocalList = (romClass == TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) ((*info)->_clazz)));
+               inLocalList = (TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) definingClass) ==
+                              TR::Compiler->cls.romClassOf((TR_OpaqueClassBlock *) ((*info)->_clazz)));
             else
                inLocalList = (classChain == (*info)->_classChain &&
                               cpIndex == (*info)->_cpIndex &&


### PR DESCRIPTION
`ResolvedRelocatableMethod_storeValidationRecordIfNecessary`
is the most frequent message when running in AOT mode.
Reduce the number of them by using class chain cache,
which already exists.
If the defining class is known and the class chain is already cached,
we don't need to make a remote call.
If it's not cached, make a remote call and cache the result.
