### PR TITLE
Set C/C++ flags for Protobuf

### DIFF
--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -288,7 +288,7 @@ RUN cd /tmp \
   && tar -xzf protobuf-cpp-3.5.1.tar.gz \
   && rm -f protobuf-cpp-3.5.1.tar.gz \
   && cd /tmp/protobuf-3.5.1 \
-  && ./configure \
+  && ./configure CFLAGS=-fPIC CXXFLAGS=-fPIC \
   && make \
   && make install \
   && cd .. \


### PR DESCRIPTION
Compile protobuf with PIC enabled on Linux x86 build system.

Issue: https://github.com/eclipse/openj9/issues/6092
[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>