### PR TITLE
Fix compile errors with xlc 16 on AIX

### DIFF
--- a/runtime/port/unix/j9process.c
+++ b/runtime/port/unix/j9process.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -151,7 +151,11 @@ setNonBlocking(int fd)
 #else
 	int nbio = 1;
 	
+#if defined(AIXPPC)
+	rc = ioctl(fd, (int)FIONBIO, &nbio);
+#else /* defined(AIXPPC) */
 	rc = ioctl(fd, FIONBIO, &nbio);
+#endif /* defined(AIXPPC) */
 #endif /* defined(J9ZOS390) */
 	
 	return rc;

--- a/runtime/port/unix/j9sock.c
+++ b/runtime/port/unix/j9sock.c
@@ -2376,7 +2376,7 @@ j9sock_readfrom(struct J9PortLibrary *portLibrary, j9socket_t sock, uint8_t *buf
  *            by @ref j9sock_fdset_size().
  * @param[in] readfd The j9fdset_t representing the descriptor to be checked to see if data can be read without blocking.
  * @param[in] writefd The j9fdset_t representing the descriptor to be checked to see if data can be written without blocking.
- * @param[in] exceptfd_notSupported Not supported, must either by NULL or empty
+ * @param[in] exceptfd_notSupported Not supported, must either by NULL or empty. Must be NULL on AIX or z/OS.
  * @param[in] timeout Pointer to the timeout (a j9timeval struct).
  *
  * @return	Number of socket descriptors that are ready, otherwise return the (negative) error code.
@@ -2408,16 +2408,14 @@ j9sock_select(struct J9PortLibrary *portLibrary, int32_t nfds, j9fdset_t readfd,
 		rc = J9PORT_ERROR_SOCKET_ARGSINVALID;
 	} else {
 
-		if (NULL != exceptfd_notSupported) {
+		if ((NULL != exceptfd_notSupported)
 #if defined(LINUX) || defined(OSX)
-			if (-1 != exceptfd_notSupported->fd) {
-#else
-			if (NULL != &exceptfd_notSupported->handle) {
+			&& (-1 != exceptfd_notSupported->fd)
 #endif
-				rc = omrerror_set_last_error_with_message(J9PORT_ERROR_SOCKET_ARGSINVALID, "exceptfd_notSupported cannot contain a valid fd");
-				Trc_PRT_sock_j9sock_select_Exit(rc);
-				return rc;
-			}
+		) {
+			rc = omrerror_set_last_error_with_message(J9PORT_ERROR_SOCKET_ARGSINVALID, "exceptfd_notSupported cannot contain a valid fd");
+			Trc_PRT_sock_j9sock_select_Exit(rc);
+			return rc;
 		}
 
 #if defined(LINUX) || defined(OSX)
@@ -3941,7 +3939,7 @@ disconnectSocket(struct J9PortLibrary *portLibrary, j9socket_t sock, socklen_t f
   	Trc_PRT_sock_disconnectSocket_Entry(sock, fromlen);
 
 	/* must use AF_INET with an INADDR_ANY to disconnect a socket on AIX, and can not use port 0 */
-	j9sock_sockaddr_init6(portLibrary, &sockaddrP, INADDR_ANY, fromlen, J9ADDR_FAMILY_AFINET4, 1, 0, 0, sock);
+	j9sock_sockaddr_init6(portLibrary, &sockaddrP, (uint8_t *)INADDR_ANY, fromlen, J9ADDR_FAMILY_AFINET4, 1, 0, 0, sock);
 
 	rc = connectSocket(portLibrary, sock, &sockaddrP, fromlen);
 

--- a/runtime/port/unix/j9sock.c
+++ b/runtime/port/unix/j9sock.c
@@ -2596,8 +2596,12 @@ j9sock_set_nonblocking(struct J9PortLibrary *portLibrary, j9socket_t socketP, BO
 	uint32_t param = nonblocking;
 
 	Trc_PRT_sock_j9sock_setnonblocking_Entry(socketP, nonblocking);
-	/* set the socket to non blocking or block as requested */	
+	/* set the socket to non blocking or block as requested */
+#if defined(AIXPPC)
+	rc = ioctl (SOCKET_CAST(socketP), (int)FIONBIO, &param);
+#else /* defined(AIXPPC) */
 	rc = ioctl (SOCKET_CAST(socketP), FIONBIO, &param);
+#endif /* defined(AIXPPC) */
 	
 	if (rc < 0)	{
 		rc = errno;


### PR DESCRIPTION
Fixes the following
```
15:41:06  /opt/IBM/xlC/16.1.0/bin/xlclang -DOPENJ9_BUILD -O3 -DIPv6_FUNCTION_SUPPORT -g -s -q64 -qlanglvl=extended0x -qarch=ppc -qalias=noansi -qxflag=LTOL:LTOL0 -qsuppress=1506-1108 -qxlcompatmacros -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE -DRS6000 -DAIXPPC -D_LARGE_FILES -DPPC64 -qhalt=w -I. -I../omr/port/aix64 -I../omr/port/aix -I../omr/port/unix_include -I../omr/port/ -I../omr/port/common -I../oti -I../include -Iaix64 -Iaix -Isysvipc -Iunix_include -Iunix -Iinclude -Icommon -I../nls -I../omr/include_core  -DJ9PORT_LIBRARY_DEFINE  -DUT_DIRECT_TRACE_REGISTRATION -DTR_HOST_POWER -c -o j9process.o unix/j9process.c
15:41:07  unix/j9process.c:154:17: error: implicit conversion from 'unsigned long' to 'int' changes value from 18446744071562356350 to -2147195266 [-Werror,-Wconstant-conversion]
15:41:07          rc = ioctl(fd, FIONBIO, &nbio);
15:41:07               ~~~~~     ^~~~~~~
15:41:07  /usr/include/sys/ioctl.h:378:18: note: expanded from macro 'FIONBIO'
15:41:07  #define FIONBIO         _IOW('f', 126, int)     /* set/clear non-blocking i/o */
15:41:07                          ^~~~~~~~~~~~~~~~~~~
15:41:07  /usr/include/sys/ioctl.h:172:66: note: expanded from macro '_IOW'
15:41:07  #define _IOW(x,y,t)     (IOC_IN|((sizeof(t)&IOCPARM_MASK)<<16)|(x<<8)|y)
15:41:07                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
...
15:41:07  /opt/IBM/xlC/16.1.0/bin/xlclang -DOPENJ9_BUILD -O3 -DIPv6_FUNCTION_SUPPORT -g -s -q64 -qlanglvl=extended0x -qarch=ppc -qalias=noansi -qxflag=LTOL:LTOL0 -qsuppress=1506-1108 -qxlcompatmacros -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE -DRS6000 -DAIXPPC -D_LARGE_FILES -DPPC64 -qhalt=w -I. -I../omr/port/aix64 -I../omr/port/aix -I../omr/port/unix_include -I../omr/port/ -I../omr/port/common -I../oti -I../include -Iaix64 -Iaix -Isysvipc -Iunix_include -Iunix -Iinclude -Icommon -I../nls -I../omr/include_core  -DJ9PORT_LIBRARY_DEFINE  -DUT_DIRECT_TRACE_REGISTRATION -DTR_HOST_POWER -c -o j9sock.o unix/j9sock.c
15:41:07  unix/j9sock.c:2415:40: error: comparison of address of 'exceptfd_notSupported->handle' not equal to a null pointer is always true [-Werror,-Wtautological-pointer-compare]
15:41:07                          if (NULL != &exceptfd_notSupported->handle) {
15:41:07                              ~~~~     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
15:41:07  unix/j9sock.c:2600:36: error: implicit conversion from 'unsigned long' to 'int' changes value from 18446744071562356350 to -2147195266 [-Werror,-Wconstant-conversion]
15:41:07          rc = ioctl (SOCKET_CAST(socketP), FIONBIO, &param);
15:41:07               ~~~~~                        ^~~~~~~
15:41:07  /usr/include/sys/ioctl.h:378:18: note: expanded from macro 'FIONBIO'
15:41:07  #define FIONBIO         _IOW('f', 126, int)     /* set/clear non-blocking i/o */
15:41:07                          ^~~~~~~~~~~~~~~~~~~
15:41:07  /usr/include/sys/ioctl.h:172:66: note: expanded from macro '_IOW'
15:41:07  #define _IOW(x,y,t)     (IOC_IN|((sizeof(t)&IOCPARM_MASK)<<16)|(x<<8)|y)
15:41:07                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
15:41:08  unix/j9sock.c:3940:49: error: expression which evaluates to zero treated as a null pointer constant of type 'uint8_t *' (aka 'unsigned char *') [-Werror,-Wnon-literal-null-conversion]
15:41:08          j9sock_sockaddr_init6(portLibrary, &sockaddrP, INADDR_ANY, fromlen, J9ADDR_FAMILY_AFINET4, 1, 0, 0, sock);
15:41:08                                                         ^~~~~~~~~~
15:41:08  /usr/include/netinet/in.h:231:21: note: expanded from macro 'INADDR_ANY'
15:41:08  #define INADDR_ANY              (uint32_t)0x00000000
15:41:08                                  ^~~~~~~~~~~~~~~~~~~~
15:41:08  3 errors generated.
15:41:08  Error while processing unix/j9sock.c.
15:41:08  ../makelib/targets.mk:285: recipe for target 'j9sock.o' failed
15:41:08  gmake[5]: *** [j9sock.o] Error 1
```