### PR TITLE
Add git reference repo to checkout scm to Jenkins pipelines

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
@@ -31,7 +31,23 @@ timeout(time: 10, unit: 'HOURS') {
     timestamps {
         node(SETUP_LABEL) {
             try{
-                checkout scm
+                def gitConfig = scm.getUserRemoteConfigs().get(0)
+                def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+
+                if (gitConfig.getCredentialsId()) {
+                    remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
+                }
+
+                checkout changelog: false,
+                        poll: false,
+                        scm: [$class: 'GitSCM',
+                        branches: [[name: scm.branches[0].name]],
+                        doGenerateSubmoduleConfigurations: false,
+                        extensions: [[$class: 'CloneOption',
+                                      reference: "${HOME}/openjdk_cache"]],
+                        submoduleCfg: [],
+                        userRemoteConfigs: [remoteConfigParameters]]
+
                 variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'
                 variableFile.set_job_variables('build')
                 buildFile = load 'buildenv/jenkins/common/build.groovy'

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -167,7 +167,23 @@ try {
         timestamps {
             node(SETUP_LABEL) {
                 try {
-                    checkout scm
+                    def gitConfig = scm.getUserRemoteConfigs().get(0)
+                    def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+
+                    if (gitConfig.getCredentialsId()) {
+                        remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
+                    }
+
+                    checkout changelog: false,
+                            poll: false,
+                            scm: [$class: 'GitSCM',
+                            branches: [[name: scm.branches[0].name]],
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions: [[$class: 'CloneOption',
+                                          reference: "${HOME}/openjdk_cache"]],
+                            submoduleCfg: [],
+                            userRemoteConfigs: [remoteConfigParameters]]
+
                     variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'
                     buildFile = load 'buildenv/jenkins/common/pipeline-functions.groovy'
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
@@ -32,7 +32,24 @@ timestamps {
     node(SETUP_LABEL) {
         try{
             currentBuild.description = "<a href=\"${RUN_DISPLAY_URL}\">Blue Ocean</a>"
-            checkout scm
+
+            def gitConfig = scm.getUserRemoteConfigs().get(0)
+            def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+
+            if (gitConfig.getCredentialsId()) {
+                remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
+            }
+
+            checkout changelog: false,
+                    poll: false,
+                    scm: [$class: 'GitSCM',
+                    branches: [[name: scm.branches[0].name]],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[$class: 'CloneOption',
+                                  reference: "${HOME}/openjdk_cache"]],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [remoteConfigParameters]]
+
             variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'
             variableFile.set_job_variables('pipeline')
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -29,7 +29,7 @@ if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
 if (!binding.hasVariable('SCM_URL')) SCM_URL = 'https://github.com/eclipse/openj9.git'
 if (!binding.hasVariable('SCM_BRANCH')) SCM_BRANCH = 'refs/heads/master'
-if (!binding.hasVariable('LIGHTWEIGHT_CHECKOUT')) LIGHTWEIGHT_CHECKOUT = false
+if (!binding.hasVariable('SCM_REFSPEC')) SCM_REFSPEC = 'refs/heads/*:refs/remotes/origin/*'
 
 if (jobType == 'build') {
     pipelineScript = 'buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy'
@@ -50,10 +50,15 @@ pipelineJob("$JOB_NAME") {
                         refspec('$SCM_REFSPEC')
                     }
                     branch('$SCM_BRANCH')
+                    extensions {
+                        cloneOptions {
+                            reference('$HOME/openjdk_cache')
+                        }
+                        wipeOutWorkspace()
+                    }
                 }
             }
             scriptPath(pipelineScript)
-            lightweight(LIGHTWEIGHT_CHECKOUT)
         }
     }
     logRotator {
@@ -91,7 +96,7 @@ pipelineJob("$JOB_NAME") {
         stringParam('PERSONAL_BUILD')
         stringParam('CUSTOM_DESCRIPTION')
         stringParam('SCM_BRANCH', SCM_BRANCH)
-        stringParam('SCM_REFSPEC')
+        stringParam('SCM_REFSPEC', SCM_REFSPEC)
 
         if (jobType == 'pipeline'){
             stringParam('TESTS_TARGETS')


### PR DESCRIPTION
Update checkout scm to:
- use reference repository when cloning to reduce the clone time, network and local storage costs.
- add wipe repository to force a full clone when before regenerating the pipelines to avoid failures
due to Jenkins files updates.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>