### PR TITLE
Get Artifactory credentials from Artifactory object

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -323,6 +323,7 @@ def archive() {
                     server.publishBuildInfo buildInfo
                     // Write URL to env so that we can pull it from the upstream pipeline job
                     ARTIFACTORY_URL = server.getUrl()
+                    env.ARTIFACTORY_CREDS = server.getCredentialsId()
                     SDK_URL = "${ARTIFACTORY_URL}/${artifactory_upload_dir}${SDK_FILENAME}"
                     env.CUSTOMIZED_SDK_URL = SDK_URL
                     currentBuild.description += "<br><a href=${SDK_URL}>${SDK_FILENAME}</a>"

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -491,13 +491,10 @@ def set_artifactory_config() {
     if (ARTIFACTORY_SERVER) {
         env.ARTIFACTORY_SERVER = ARTIFACTORY_SERVER
         env.ARTIFACTORY_REPO = VARIABLES.artifactory_repo
-        // Set Creds to env so that the parent pipeline can retrieve them.
-        env.ARTIFACTORY_CREDS = VARIABLES.artifactory_creds
         env.ARTIFACTORY_NUM_ARTIFACTS = VARIABLES.artifactory_num_artifacts
         env.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS = VARIABLES.artifactory_days_to_keep_artifacts // This is being used by the cleanup script
         env.ARTIFACTORY_MANUAL_CLEANUP = VARIABLES.artifactory_manual_cleanup // This is being used by the cleanup script
         echo "Using artifactory server/repo: ${ARTIFACTORY_SERVER} / ${ARTIFACTORY_REPO}"
-        echo "Using artifactory credentials: ${ARTIFACTORY_CREDS}"
         echo "Keeping '${ARTIFACTORY_NUM_ARTIFACTS}' artifacts"
         echo "Artifactory Manual Cleanup: ${env.ARTIFACTORY_MANUAL_CLEANUP}"
     }

--- a/buildenv/jenkins/jobs/infrastructure/artifactory_cleanup.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/artifactory_cleanup.groovy
@@ -47,7 +47,7 @@ timestamps {
         def server = Artifactory.server artifactory_server
         def ARTIFACTORY_SERVER_URL = server.getUrl()
         def ARTIFACTORY_REPO = params.ARTIFACTORY_REPO ? params.ARTIFACTORY_REPO : env.ARTIFACTORY_REPO
-        def artifactoryCreds = env.ARTIFACTORY_CREDS
+        def artifactoryCreds = server.getCredentialsId()
         def ARTIFACTORY_NUM_ARTIFACTS = params.ARTIFACTORY_NUM_ARTIFACTS ? params.ARTIFACTORY_NUM_ARTIFACTS : env.ARTIFACTORY_NUM_ARTIFACTS
         def ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS = params.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS ? params.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS : env.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS
 

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -54,7 +54,6 @@ adoptopenjdk:
 #========================================#
 artifactory_server: 'ci-eclipse-openj9'
 artifactory_repo: 'ci-eclipse-openj9'
-artifactory_creds: 'ab89294b-5ba1-48e9-8c85-107daca5a2e9'
 artifactory_num_artifacts: 30
 # This is being used for the cleanup script
 artifactory_days_to_keep_artifacts: 30


### PR DESCRIPTION
- No longer need to hardcode the credentials in
  the variable file.
- The creds are already in the global config where the
  server is configured.
- https://www.jfrog.com/jira/browse/HAP-1167 resolved the
  issue of not being able to get it from the object

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>