### PR TITLE
Fix DIVCHK Evaluator Function Declaration

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -90,7 +90,8 @@ J9::ARM64::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(TR::
    TR_ASSERT_FATAL(false, "This helper implements platform specific code for Fieldwatch, which is currently not supported on ARM64 platforms.\n");
    }
 	
-TR::Register *J9::ARM64::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *
+J9::ARM64::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *divisor = node->getFirstChild()->getSecondChild();
    bool is64Bit = node->getFirstChild()->getType().isInt64();

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -48,7 +48,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    {
    public:
 
-   TR::Register * DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register * DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    
    /*
     * Generates instructions to fill in the J9JITWatchedStaticFieldData.fieldAddress, J9JITWatchedStaticFieldData.fieldClass for static fields,


### PR DESCRIPTION
Fix DIVCHK Evaluator Function Declaration

After the merge of #6055 and #6176, and rebasing the [eclipse/openj9](https://github.com/eclipse/openj9/), [eclipse/omr](https://github.com/eclipse/omr/) and [/ibmruntimes/openj9-openjdk-jdk11](https://github.com/ibmruntimes/openj9-openjdk-jdk11/) repositories off of the latest stable changes, with a clean/full build; it was revealed that there was an issue with the `DIVCHKEvaluator` function declaration in the `runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp` header file:

``` c++
/workspace/omropenj9/openj9-openjdk-jdk11/build/linux-aarch64-normal-server-release/vm/compiler/../compiler/aarch64/codegen/J9TreeEvaluator.cpp: In function ‘void TEMPORARY_initJ9ARM64TreeEvaluatorTable(TR::CodeGenerator*)’:
/workspace/omropenj9/openj9-openjdk-jdk11/build/linux-aarch64-normal-server-release/vm/compiler/../compiler/aarch64/codegen/J9TreeEvaluator.cpp:60:41: error: invalid use of non-static member function ‘TR::Register* J9::ARM64::TreeEvaluator::DIVCHKEvaluator(TR::Node*, TR::CodeGenerator*)’
    tet[TR::DIVCHK] = TR::TreeEvaluator::DIVCHKEvaluator;
                                         ^
```

This PR fixes this issue.

I'd recommend merging this fix as soon as is reasonably possible @0xdaryl. I suspect this will end up braking downstream `AdoptOpenJDK` builds.

FYI: @hsoontie.

Signed-off-by: Aaron Graham <aaron.graham@unb.ca>