### PR TITLE
AArch64: Implementation of monexitEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -43,7 +43,7 @@ extern void TEMPORARY_initJ9ARM64TreeEvaluatorTable(TR::CodeGenerator *cg)
    // TODO:ARM64: Enable when Implemented: tet[TR::awrtbar] = TR::TreeEvaluator::awrtbarEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::awrtbari] = TR::TreeEvaluator::awrtbariEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::monent] = TR::TreeEvaluator::monentEvaluator;
-   // TODO:ARM64: Enable when Implemented: tet[TR::monexit] = TR::TreeEvaluator::monexitEvaluator;
+   tet[TR::monexit] = TR::TreeEvaluator::monexitEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::monexitfence] = TR::TreeEvaluator::monexitfenceEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::asynccheck] = TR::TreeEvaluator::asynccheckEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::instanceof] = TR::TreeEvaluator::instanceofEvaluator;
@@ -117,6 +117,16 @@ TR::Register *J9::ARM64::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::Code
    cg->evaluate(node->getFirstChild());
    cg->decReferenceCount(node->getFirstChild());
    return NULL;
+   }
+
+TR::Register *
+J9::ARM64::TreeEvaluator::monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::ILOpCodes opCode = node->getOpCodeValue();
+   TR::Node::recreate(node, TR::call);
+   TR::Register *targetRegister = directCallEvaluator(node, cg);
+   TR::Node::recreate(node, opCode);
+   return targetRegister;
    }
 
 TR::Register *

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -63,6 +63,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
     */
    static void generateTestAndReportFieldWatchInstructions(TR::CodeGenerator *cg, TR::Node *node, TR::Snippet *dataSnippet, bool isWrite, TR::Register *sideEffectRegister, TR::Register *valueReg, TR::Register *dataSnippetRegister);
 
+   static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+
    static TR::Register *checkcastAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *checkcastEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Implementation of monexitEvaluator for AArch64.
For now monexitEvaluator always punts to VM helper through directCallEvaluator.
Added to tree evaluator table.

Signed-off-by: Michael Flawn <mflawn@unb.ca>