### PR TITLE
AArch64: Implementation of newObjectEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -49,8 +49,8 @@ extern void TEMPORARY_initJ9ARM64TreeEvaluatorTable(TR::CodeGenerator *cg)
    // TODO:ARM64: Enable when Implemented: tet[TR::instanceof] = TR::TreeEvaluator::instanceofEvaluator;
    tet[TR::checkcast] = TR::TreeEvaluator::checkcastEvaluator;
    tet[TR::checkcastAndNULLCHK] = TR::TreeEvaluator::checkcastAndNULLCHKEvaluator;
-   // TODO:ARM64: Enable when Implemented: tet[TR::New] = TR::TreeEvaluator::newObjectEvaluator;
-   // TODO:ARM64: Enable when Implemented: tet[TR::variableNew] = TR::TreeEvaluator::newObjectEvaluator;
+   tet[TR::New] = TR::TreeEvaluator::newObjectEvaluator;
+   tet[TR::variableNew] = TR::TreeEvaluator::newObjectEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::newarray] = TR::TreeEvaluator::newArrayEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::anewarray] = TR::TreeEvaluator::anewArrayEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::variableNewArray] = TR::TreeEvaluator::anewArrayEvaluator;
@@ -135,3 +135,14 @@ J9::ARM64::TreeEvaluator::checkcastEvaluator(TR::Node *node, TR::CodeGenerator *
 
    return targetRegister;
    }
+
+TR::Register *
+J9::ARM64::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::ILOpCodes opCode = node->getOpCodeValue();
+   TR::Node::recreate(node, TR::acall);
+   TR::Register *targetRegister = directCallEvaluator(node, cg);
+   TR::Node::recreate(node, opCode);
+   return targetRegister;
+   }
+

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -66,6 +66,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *checkcastAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *checkcastEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+
+   static TR::Register *newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    };
 
 }


### PR DESCRIPTION
Implementation of newObjectEvaluator for AArch64.
For now newObjectEvaluator only punts to VM helper through directCallEvaluator.
New and variableNew set to newObjectEvaluator in tree evaluator table.

Signed-off-by: Michael Flawn <mflawn@unb.ca>