### PR TITLE
AArch64: Implementation of anewArrayEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -52,8 +52,8 @@ extern void TEMPORARY_initJ9ARM64TreeEvaluatorTable(TR::CodeGenerator *cg)
    tet[TR::New] = TR::TreeEvaluator::newObjectEvaluator;
    tet[TR::variableNew] = TR::TreeEvaluator::newObjectEvaluator;
    tet[TR::newarray] = TR::TreeEvaluator::newArrayEvaluator;
-   // TODO:ARM64: Enable when Implemented: tet[TR::anewarray] = TR::TreeEvaluator::anewArrayEvaluator;
-   // TODO:ARM64: Enable when Implemented: tet[TR::variableNewArray] = TR::TreeEvaluator::anewArrayEvaluator;
+   tet[TR::anewarray] = TR::TreeEvaluator::anewArrayEvaluator;
+   tet[TR::variableNewArray] = TR::TreeEvaluator::anewArrayEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::multianewarray] = TR::TreeEvaluator::multianewArrayEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::arraylength] = TR::TreeEvaluator::arraylengthEvaluator;
    // TODO:ARM64: Enable when Implemented: tet[TR::ResolveCHK] = TR::TreeEvaluator::resolveCHKEvaluator;
@@ -157,7 +157,18 @@ J9::ARM64::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *
    return targetRegister;
    }
 
+TR::Register *
 J9::ARM64::TreeEvaluator::newArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::ILOpCodes opCode = node->getOpCodeValue();
+   TR::Node::recreate(node, TR::acall);
+   TR::Register *targetRegister = directCallEvaluator(node, cg);
+   TR::Node::recreate(node, opCode);
+   return targetRegister;
+   }
+
+TR::Register *
+J9::ARM64::TreeEvaluator::anewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::ILOpCodes opCode = node->getOpCodeValue();
    TR::Node::recreate(node, TR::acall);

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -72,6 +72,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *newArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+
+   static TR::Register *anewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    };
 
 }


### PR DESCRIPTION
Implementation of anewArrayEvaluator for AArch64.
For now anewArrayEvaluator only punts to VM helper through directCallEvaluator.
variableNewArray, anewarray set to anewArrayEvaluator in tree evaluator table.

Signed-off-by: Michael Flawn <mflawn@unb.ca>