### PR TITLE
Fix VSTRS loop indexing error by adding -1 to VLL

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -424,6 +424,9 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
       generateRRRInstruction(cg, TR::InstOpCode::getSubtractThreeRegOpCode(), node, loadLenReg, s1LenReg, s1VecStartIndexReg);
       generateRIEInstruction(cg, TR::InstOpCode::getCmpImmBranchRelOpCode(), node, loadLenReg, (int8_t)vectorSize, labelLoadLen16, TR::InstOpCode::COND_BNL);
       generateRRRInstruction(cg, TR::InstOpCode::getAddThreeRegOpCode(), node, tmpReg, s1ValueReg, s1VecStartIndexReg);
+      // Needs -1 because VLL's third operand is the highest index to load.
+      // e.g. If the load length is 8 bytes, the highest index is 7. Hence, the need for -1.
+      generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, loadLenReg, -1);
       generateVRSbInstruction(cg, TR::InstOpCode::VLL, node, s1PartialVReg, loadLenReg, generateS390MemoryReference(tmpReg, headerSize, cg));
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelLoadLenDone);
 


### PR DESCRIPTION
This commit fixes an incorrect vector load length used in the vector
string search loop.

The VLL instruction's third operand is a byte-index into vector
registers instead of a load length. The relationship is
Load-index=load-length-1. Incorrect load-index results in
an extra byte being loaded and may lead to a crash if the extra
byte is in an inaccessible area.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>