### PR TITLE
Add default socket connection timeout as 1s

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4175,6 +4175,8 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
       // retrials of compilations from JPQ are not going to work correctly
       entry._reqFromJProfilingQueue = false;
 
+      entry.unsetRemoteCompReq(); // remote compilation decisions do not carry over from one retrial to the next
+
       compInfo->debugPrint("\trequeueing interrupted compilation request", details, compThread);
 
       // After releasing the monitors and vm access below, we will loop back to the head of the loop, and retry the

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1101,7 +1101,7 @@ static bool JITaaSParseOptionsCommon(char **options, char delimiter, TR::Compila
    {
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
 
-   uint32_t port, timeout;
+   uint32_t port, timeoutMs;
    if (try_scan(options, "sslKey="))
       {
       char * fileName = scan_to_delim(PORTLIB, options, delimiter);
@@ -1127,8 +1127,10 @@ static bool JITaaSParseOptionsCommon(char **options, char delimiter, TR::Compila
       }
    else if (getJITaaSNumericOptionFromCommandLineOptions(options, delimiter, "port=", &port))
       compInfo->getPersistentInfo()->setJITaaSServerPort(port);
-   else if (getJITaaSNumericOptionFromCommandLineOptions(options, delimiter, "timeout=", &timeout))
-      compInfo->getPersistentInfo()->setJITaaSTimeout(timeout);
+   else if (getJITaaSNumericOptionFromCommandLineOptions(options, delimiter, "timeout=", &timeoutMs))
+      {
+      compInfo->getPersistentInfo()->setJITaaSTimeout(timeoutMs);
+      }
    else // option not known
       {
       if (*unRecognizedOptions != *options)
@@ -2287,13 +2289,14 @@ J9::Options::setupJITaaSOptions()
 
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       {
-      if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS Server Mode. Port: %d",
-               compInfo->getPersistentInfo()->getJITaaSServerPort());
-      else if (compInfo->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS Client Mode. Server address: %s port: %d",
-               compInfo->getPersistentInfo()->getJITaaSServerAddress().c_str(),
-               compInfo->getPersistentInfo()->getJITaaSServerPort());
+      TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
+      if (persistentInfo->getJITaaSMode() == SERVER_MODE)
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS Server Mode. Port: %d. Connection Timeout %ums",
+               persistentInfo->getJITaaSServerPort(), persistentInfo->getJITaaSTimeout());
+      else if (persistentInfo->getJITaaSMode() == CLIENT_MODE)
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS Client Mode. Server address: %s port: %d. Connection Timeout %ums",
+               persistentInfo->getJITaaSServerAddress().c_str(), persistentInfo->getJITaaSServerPort(),
+               persistentInfo->getJITaaSTimeout());
       }
    }
 

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -64,6 +64,7 @@ struct TR_MethodToBeCompiled
    bool isAotLoad() const { return _doAotLoad; }
    bool isRemoteCompReq() const { return _remoteCompReq; } // at the client
    void setRemoteCompReq() { _remoteCompReq = true; }
+   void unsetRemoteCompReq() { _remoteCompReq = false; }
    bool isOutOfProcessCompReq() const { return _stream != NULL; } // at the server
    uint64_t getClientUID() const;
    void cleanupJITaaS();

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,7 +128,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITaaSMode(NONJITaaS_MODE),
          _JITaaSServerAddress("localhost"),
          _JITaaSServerPort(38400),
-         _timeout(0),
+         _timeoutMs(1000),
       OMR::PersistentInfoConnector(pm)
       {}
 
@@ -293,8 +293,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    void setJITaaSMode(JITaaSModes m) { _JITaaSMode = m; }
    const std::string &getJITaaSServerAddress() const { return _JITaaSServerAddress; }
    void setJITaaSServerAddress(char *addr) { _JITaaSServerAddress = addr; }
-   uint32_t getJITaaSTimeout() { return _timeout; }
-   void setJITaaSTimeout(uint32_t t) { _timeout = t; }
+   uint32_t getJITaaSTimeout() { return _timeoutMs; }
+   void setJITaaSTimeout(uint32_t t) { _timeoutMs = t; }
    uint32_t getJITaaSServerPort() const { return _JITaaSServerPort; }
    void setJITaaSServerPort(uint32_t port) { _JITaaSServerPort = port; }
    uint64_t getJITaaSId() { return _JITaaSId; }
@@ -392,7 +392,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    std::string _JITaaSServerAddress;
    uint32_t _JITaaSServerPort;
    uint64_t _JITaaSId;
-   uint32_t _timeout;
+   uint32_t _timeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
    std::string _sslRootCerts;
    // SoA key pairs
    // We use std::vector here to avoid an annoying include loop.

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -74,9 +74,9 @@ public:
       @param timeout timeout value (ms) to be set for connfd
    */
 #if defined(JITSERVER_ENABLE_SSL)
-   ServerStream(int connfd, BIO *ssl, uint32_t timeout);
+   ServerStream(int connfd, BIO *ssl);
 #else
-   ServerStream(int connfd, uint32_t timeout);
+   ServerStream(int connfd);
 #endif
    virtual ~ServerStream() 
       {


### PR DESCRIPTION

1. The default connection timeout value is set as 1s in `PersistentInfo`.
- It can be changed by setting `-XX:JITaaSClient:timeout=<value>` or
`-XX:JITaaSServer:timeout=<value>`.
- It’s passed to `ClientStream` and `ServerStream` when connection is established.

2. `_remoteCompReq` needs to be cleared when retrying local compilation
after remote server connection failure. Otherwise although it’s decided to retry with
local compilation instead of remote compilation, the client still ends up sending
remote request on the very first method that already failed remote compilation.

3. Since there is no need to store timeout value outside PersistentInfo,
remove the old timeout fields from` ClientStream` and `ServerStream`.

4. Add vlog where `failCompilation` happens.

Issue #6130

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>