### PR TITLE
AArch64: Fixed missing type on newArrayEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -157,6 +157,7 @@ J9::ARM64::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *
    return targetRegister;
    }
 
+TR::Register *
 J9::ARM64::TreeEvaluator::newArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::ILOpCodes opCode = node->getOpCodeValue();


### PR DESCRIPTION
Merge conflict removed TR::Register * from newArrayEvaluator in AArch64

Signed-off-by: Michael Flawn <mflawn@unb.ca>