### PR TITLE
AArch64: Fixed Syntax Error in newObjectEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -149,7 +149,7 @@ J9::ARM64::TreeEvaluator::checkcastEvaluator(TR::Node *node, TR::CodeGenerator *
 
 TR::Register *
 J9::ARM64::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   }
+   {
    TR::ILOpCodes opCode = node->getOpCodeValue();
    TR::Node::recreate(node, TR::acall);
    TR::Register *targetRegister = directCallEvaluator(node, cg);


### PR DESCRIPTION
Fixed brace mismatch from rebase in AArch64 newObjectEvaluator

Signed-off-by: Michael Flawn <mflawn@unb.ca>