### PR TITLE
ValueTypes: Add support for flattened arrays

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -179,6 +179,8 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_getLockwordAddress,
 	j9gc_objaccess_cloneObject,
 	j9gc_objaccess_copyObjectFields,
+	j9gc_objaccess_copyObjectFieldsToArrayElement,
+	j9gc_objaccess_copyObjectFieldsFromArrayElement,
 	j9gc_objaccess_cloneIndexableObject,
 	j9gc_objaccess_asConstantPoolObject,
 #if defined(J9VM_GC_REALTIME)

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1108,6 +1108,43 @@ MM_ObjectAccessBarrier::indexableStoreI64(J9VMThread *vmThread, J9IndexableObjec
 }
 
 /**
+ * Copy object fields into flattened array element
+ *
+ * @param vmThread thread token
+ * @param arrayClazz array J9Class
+ * @param srcObject object whose fields will be copied
+ * @param arrayRef array object
+ * @param index index of array element where fields are copied to
+ */
+void
+MM_ObjectAccessBarrier::copyObjectFieldsToArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t srcObject, J9IndexableObject *arrayRef, I_32 index)
+{
+	UDATA const objectHeaderSize = J9VMTHREAD_OBJECT_HEADER_SIZE(vmThread);
+	U_8 *elementAddress = (U_8*)indexableEffectiveAddress(vmThread, arrayRef, index, J9ARRAYCLASS_GET_STRIDE(arrayClazz));
+	IDATA elementOffset = (elementAddress - (U_8*)arrayRef);
+	copyObjectFields(vmThread, J9GC_J9OBJECT_CLAZZ_THREAD(srcObject, vmThread), srcObject, objectHeaderSize, (j9object_t) arrayRef, elementOffset);
+}
+
+/**
+ * Copy object fields into flattened array element
+ *
+ * @param vmThread thread token
+ * @param arrayClazz array J9Class
+ * @param destObject object where array element fields will be copied to
+ * @param arrayRef array object
+ * @param index index of array element where fields are copied to
+ */
+void
+MM_ObjectAccessBarrier::copyObjectFieldsFromArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t destObject, J9IndexableObject *arrayRef, I_32 index)
+{
+	UDATA const objectHeaderSize = J9VMTHREAD_OBJECT_HEADER_SIZE(vmThread);
+	U_8 *elementAddress = (U_8*)indexableEffectiveAddress(vmThread, arrayRef, index, J9ARRAYCLASS_GET_STRIDE(arrayClazz));
+	IDATA elementOffset = (elementAddress - (U_8*)arrayRef);
+	copyObjectFields(vmThread, J9GC_J9OBJECT_CLAZZ_THREAD(destObject, vmThread), (j9object_t) arrayRef, elementOffset, destObject, objectHeaderSize);
+}
+
+
+/**
  * Read a static field.
  * @param srcSlot The static field slot.
  * @param isVolatile non-zero if the field is volatile.

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -200,6 +200,8 @@ public:
 	virtual void indexableStoreI32(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 destIndex, I_32 value, bool isVolatile=false);
 	virtual void indexableStoreU64(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 destIndex, U_64 value, bool isVolatile=false);
 	virtual void indexableStoreI64(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 destIndex, I_64 value, bool isVolatile=false);
+	virtual void copyObjectFieldsToArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t srcObject, J9IndexableObject *arrayRef, I_32 index);
+	virtual void copyObjectFieldsFromArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t destObject, J9IndexableObject *arrayRef, I_32 index);
 
 #if defined(J9VM_GC_ARRAYLETS)
 	enum {

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -619,6 +619,26 @@ j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Obj
 }
 
 /**
+ * Called by Interpreter during aastore of a flattend array
+ */
+void
+j9gc_objaccess_copyObjectFieldsToArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t srcObject, J9IndexableObject *arrayRef, I_32 index)
+{
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->copyObjectFieldsToArrayElement(vmThread, arrayClazz, srcObject, arrayRef, index);
+}
+
+/**
+ * Called by Interpreter during aaload of a flattend array
+ */
+void
+j9gc_objaccess_copyObjectFieldsFromArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t destObject, J9IndexableObject *arrayRef, I_32 index)
+{
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->copyObjectFieldsFromArrayElement(vmThread, arrayClazz, destObject, arrayRef, index);
+}
+
+/**
  * Called by certain specs to clone objects. See J9VMObjectAccessBarrier#cloneArray:into:sizeInElements:class:
  */
 void

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -97,6 +97,8 @@ extern J9_CFUNC void j9gc_objaccess_indexableStoreAddress(J9VMThread *vmThread, 
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_cloneObject(J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject);
 extern J9_CFUNC void j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset);
+extern J9_CFUNC void j9gc_objaccess_copyObjectFieldsToArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t srcObject, J9IndexableObject *arrayRef, I_32 index);
+extern J9_CFUNC void j9gc_objaccess_copyObjectFieldsFromArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t destObject, J9IndexableObject *arrayRef, I_32 index);
 extern J9_CFUNC j9object_t j9gc_objaccess_asConstantPoolObject(J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags);
 extern J9_CFUNC jvmtiIterationControl j9mm_iterate_heaps(J9JavaVM *vm, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl(*func)(J9JavaVM *vm, struct J9MM_IterateHeapDescriptor *heapDesc, void *userData), void *userData);
 extern J9_CFUNC int gcStartupHeapManagement(J9JavaVM * vm);

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -378,6 +378,19 @@ public:
 		copyObjectFields(currentThread, objectClass, original, mixedObjectGetHeaderSize(), copy, mixedObjectGetHeaderSize());
 	}
 
+	VMINLINE void 
+	copyObjectFieldsToArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t srcObject, J9IndexableObject *arrayRef, UDATA index)
+	{
+		/* TODO optimizations for non-arraylet path will be added in the future */
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFieldsToArrayElement(vmThread, arrayClazz, srcObject, arrayRef, (I_32)index);
+	}
+	
+	VMINLINE void 
+	copyObjectFieldsFromArrayElement(J9VMThread *vmThread, J9Class *arrayClazz, j9object_t destObject, J9IndexableObject *arrayRef, UDATA index)
+	{
+		/* TODO optimizations for non-arraylet path will be added in the future */
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFieldsFromArrayElement(vmThread, arrayClazz, destObject, arrayRef, (I_32)index);
+	}
 
 	/**
 	 * Copy valueType from sourceObject to destObject

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4359,6 +4359,8 @@ typedef struct J9MemoryManagerFunctions {
 	j9objectmonitor_t*  ( *j9gc_objaccess_getLockwordAddress)(struct J9VMThread *vmThread, j9object_t object) ;
 	void  ( *j9gc_objaccess_cloneObject)(struct J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject) ;
 	void ( *j9gc_objaccess_copyObjectFields)(struct J9VMThread *vmThread, J9Class* valueClass, j9object_t srcObject, UDATA srcOffset, j9object_t destObject, UDATA destOffset) ;
+	void ( *j9gc_objaccess_copyObjectFieldsToArrayElement)(struct J9VMThread *vmThread, J9Class *arrayClazz, j9object_t srcObject, J9IndexableObject *arrayRef, I_32 index) ;
+	void ( *j9gc_objaccess_copyObjectFieldsFromArrayElement)(struct J9VMThread *vmThread, J9Class *arrayClazz, j9object_t destObject, J9IndexableObject *arrayRef, I_32 index) ;
 	void  ( *j9gc_objaccess_cloneIndexableObject)(struct J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject) ;
 	j9object_t  ( *j9gc_objaccess_asConstantPoolObject)(struct J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags) ;
 #if defined(J9VM_GC_REALTIME)

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2877,8 +2877,9 @@ fail:
 				ramArrayClass->arity = arity;
 				ramArrayClass->componentType = elementClass;
 				ramArrayClass->module = leafComponentType->module;
+				ramArrayClass->classFlags |= ((J9ClassIsValueType | J9ClassIsFlattened) & elementClass->classFlags);
 				
-				if (J9_IS_J9CLASS_VALUETYPE(elementClass) && J9_IS_J9CLASS_FLATTENED(elementClass)) {
+				if (J9_IS_J9CLASS_FLATTENED(elementClass)) {
 					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));
 					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -109,9 +109,11 @@ public class ValueTypeTests {
 	static int[] defaultPointPositions1 = {0xFFEEFFEE, 0xAABBAABB};
 	static int[] defaultPointPositions2 = {0xCCDDCCDD, 0x33443344};
 	static int[] defaultPointPositions3 = {0x43211234, 0xABCDDCBA};
+	static int[] defaultPointPositionsEmpty = {0, 0};
 	static int[][] defaultLinePositions1 = {defaultPointPositions1, defaultPointPositions2};
 	static int[][] defaultLinePositions2 = {defaultPointPositions2, defaultPointPositions3};
 	static int[][] defaultLinePositions3 = {defaultPointPositions1, defaultPointPositions3};
+	static int[][] defaultLinePositionsEmpty = {defaultPointPositionsEmpty, defaultPointPositionsEmpty};
 	static int[][][] defaultTrianglePositions = {defaultLinePositions1, defaultLinePositions2, defaultLinePositions3};
 	static long defaultLong = Long.MAX_VALUE;
 	static int defaultInt = Integer.MAX_VALUE;
@@ -121,6 +123,7 @@ public class ValueTypeTests {
 	static int[] defaultPointPositionsNew = {0xFF112233, 0xFF332211};
 	static int[][] defaultLinePositionsNew = {defaultPointPositionsNew, defaultPointPositions1};
 	static int[][][] defaultTrianglePositionsNew = {defaultLinePositionsNew, defaultLinePositions3, defaultLinePositions1};
+	static int[][][] defaultTrianglePositionsEmpty = {defaultLinePositionsEmpty, defaultLinePositionsEmpty, defaultLinePositionsEmpty};
 	static long defaultLongNew = -1234123L;
 	static int defaultIntNew = -1234123234;
 	static double defaultDoubleNew = -123412341.21341234d;
@@ -692,6 +695,37 @@ public class ValueTypeTests {
 		}
 		
 		checkEqualTriangle2D(triangle2D, defaultTrianglePositionsNew);
+	}
+	
+	
+	@Test(priority=4)
+	static public void testCreateArrayTriangle2D() throws Throwable {
+		Object arrayObject = Array.newInstance(triangle2DClass, 10);
+		Object triangle1 = createTriangle2D(defaultTrianglePositions);
+		Object triangle2 = createTriangle2D(defaultTrianglePositionsNew);
+		Object triangleEmpty = createTriangle2D(defaultTrianglePositionsEmpty);
+		
+		Array.set(arrayObject, 0, triangle1);
+		Array.set(arrayObject, 1, triangleEmpty);
+		Array.set(arrayObject, 2, triangle2);
+		Array.set(arrayObject, 3, triangleEmpty);
+		Array.set(arrayObject, 4, triangle1);
+		Array.set(arrayObject, 5, triangleEmpty);
+		Array.set(arrayObject, 6, triangle2);
+		Array.set(arrayObject, 7, triangleEmpty);
+		Array.set(arrayObject, 8, triangle1);
+		Array.set(arrayObject, 9, triangleEmpty);
+		
+		checkEqualTriangle2D(Array.get(arrayObject, 0), defaultTrianglePositions);
+		checkEqualTriangle2D(Array.get(arrayObject, 1), defaultTrianglePositionsEmpty);
+		checkEqualTriangle2D(Array.get(arrayObject, 2), defaultTrianglePositionsNew);
+		checkEqualTriangle2D(Array.get(arrayObject, 3), defaultTrianglePositionsEmpty);
+		checkEqualTriangle2D(Array.get(arrayObject, 4), defaultTrianglePositions);
+		checkEqualTriangle2D(Array.get(arrayObject, 5), defaultTrianglePositionsEmpty);
+		checkEqualTriangle2D(Array.get(arrayObject, 6), defaultTrianglePositionsNew);
+		checkEqualTriangle2D(Array.get(arrayObject, 7), defaultTrianglePositionsEmpty);
+		checkEqualTriangle2D(Array.get(arrayObject, 8), defaultTrianglePositions);
+		checkEqualTriangle2D(Array.get(arrayObject, 9), defaultTrianglePositionsEmpty);
 	}
 
 	/*


### PR DESCRIPTION
Add support for flattened arrays

This PR add support for reading and writing to flattened arrays 
(aaload and aastore). It also adds a new method to the barrier 
APIs to retrieve the offset of a flattened array element.

Related #5021

Based on Aidan Ha's work in 
#5344

Signed-off-by: tajila <atobia@ca.ibm.com>