### PR TITLE
Exit promptly when an exception is set

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -741,6 +741,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 					|| (0 == strncmp(packageName, JAVASLASH, sizeof(JAVASLASH) - 1))
 				) {
 					vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, J9NLS_VM_ONLY_BOOT_PLATFORM_CLASSLOADER_DEFINE_PKG_JAVA);
+					goto done;
 				}
 #undef JAVASLASH
 #undef JAVADOT
@@ -826,6 +827,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 			}
 		}
 	}
+done:
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
 	omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
 #else


### PR DESCRIPTION
#### Exit promptly when an exception is set ####

After an exception is set, code shall exit promptly otherwise GC might collect objects and cause intermittent crash.

This PR fixes an internal test which failed with following:
```
Unhandled exception
Type=Segmentation error vmState=0x0002000f
```

Reviewer: @gacholio 
FYI: @DanHeidinga @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>