### PR TITLE
AArch64: Fix the curly bracket in TreeEvaluator::newObjectEvaluator()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -149,7 +149,7 @@ J9::ARM64::TreeEvaluator::checkcastEvaluator(TR::Node *node, TR::CodeGenerator *
 
 TR::Register *
 J9::ARM64::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   }
+   {
    TR::ILOpCodes opCode = node->getOpCodeValue();
    TR::Node::recreate(node, TR::acall);
    TR::Register *targetRegister = directCallEvaluator(node, cg);


### PR DESCRIPTION
This commits fixes the curly bracket in
J9::ARM64::TreeEvaluator::newObjectEvaluator() that causes a build
break.

Fixes: #6387

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>