### PR TITLE
AArch64: Use separate compilation thread by default

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1094,10 +1094,8 @@ void TR::CompilationInfo::setAllCompilationsShouldBeInterrupted()
 
 bool TR::CompilationInfo::useSeparateCompilationThread()
    {
-#if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || (defined(TR_HOST_POWER)) || defined(TR_HOST_ARM))
    if (!TR::Options::getCmdLineOptions()->getOption(TR_AOT))
       return !TR::Options::getCmdLineOptions()->getOption(TR_DisableCompilationThread);
-#endif
    return TR::Options::getCmdLineOptions()->getOption(TR_EnableCompilationThread);
    }
 


### PR DESCRIPTION
This commit adds "defined(TR_HOST_ARM64)" to
TR::CompilationInfo::useSeparateCompilationThread() so that AArch64
uses a separate compilation thread in the same way as other platforms.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>