### PR TITLE
Add comments to ClientStream and ServerStream classes

### DIFF
--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -255,7 +255,7 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    }
 
 ClientStream::ClientStream(TR::PersistentInfo *info)
-   : CommunicationStream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
+   : CommunicationStream(), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    BIO *ssl = openSSLConnection(_sslCtx, connfd);
@@ -264,7 +264,7 @@ ClientStream::ClientStream(TR::PersistentInfo *info)
    }
 #else // JITSERVER_ENABLE_SSL
 ClientStream::ClientStream(TR::PersistentInfo *info)
-   : CommunicationStream(), _timeout(info->getJITaaSTimeout()), _versionCheckStatus(NOT_DONE)
+   : CommunicationStream(),  _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITaaSServerAddress(), info->getJITaaSServerPort(), info->getJITaaSTimeout());
    initStream(connfd);

--- a/runtime/compiler/net/ServerStream.cpp
+++ b/runtime/compiler/net/ServerStream.cpp
@@ -54,8 +54,7 @@ ServerStream::ServerStream(int connfd, BIO *ssl, uint32_t timeout)
    }
 #else // JITSERVER_ENABLE_SSL
 ServerStream::ServerStream(int connfd, uint32_t timeout)
-   : CommunicationStream(),
-   _msTimeout(timeout)
+   : CommunicationStream()
    {
    initStream(connfd);
    _numConnectionsOpened++;
@@ -201,7 +200,7 @@ acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
 #endif
 
 void
-serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info)
+ServerStream::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info)
    {
 #if defined(JITSERVER_ENABLE_SSL)
    SSL_CTX *sslCtx = NULL;

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -35,11 +35,44 @@ class SSLOutputStream;
 class SSLInputStream;
 #endif
 
-namespace JITServer
+namespace JITServer 
 {
+class BaseCompileDispatcher;
+
+/**
+   @class ServerStream
+   @brief Implementation of the communication API for a server receiving JIT compilations requests
+
+   Typical usage:
+   1) Define a compilation handler by extending JITServer::BaseCompileDispatcher and providing
+      an implementation for abstract method "compile(JITServer::ServerStream *stream)"
+      This method will be called when a new connection request has been received at the server.
+   2) Create a dedicated thread that will listen for incoming connection requests
+   3) In this thread, instantiate a CompileDispatcher from a class defined in step (1)
+      E.g.:    J9CompileDispatcher handler(jitConfig);
+   4) Call  "ServerStream::serveRemoteCompilationRequests(&handler, persistentInfo);"
+      which will wait for a connection, accept the connection, create a ServerStream and call 
+      handler->compile(stream) for further processing, e.g. add the stream
+      to a compilation queue
+   5) On a different thread, extract the compilation entry from  the queue (which contains
+      the stream) and wait for a compilation request:
+         auto req = stream->readCompileRequest<....>();
+   6) At this point the server could query the client with:
+         stream->write(MessageType type, T... args);
+         auto recv = stream->read<....>();
+   7) When compilation is complete, the server responds with
+         finishCompilation(uint32_t statusCode, T... args)
+ */
 class ServerStream : CommunicationStream
    {
 public:
+   /**
+      @brief Constructor of ServerStream class
+
+      @param connfd socket descriptor for the communication channel
+      @param ssl  BIO for the SSL enabled stream
+      @param timeout timeout value (ms) to be set for connfd
+   */
 #if defined(JITSERVER_ENABLE_SSL)
    ServerStream(int connfd, BIO *ssl, uint32_t timeout);
 #else
@@ -49,7 +82,13 @@ public:
       {
       _numConnectionsClosed++;
       }
+ 
+   /**
+      @brief Send a message to the client
 
+      @param [in] type Message type to be sent
+      @param [in] args Variable number of additional paramaters to be sent
+   */
    template <typename ...T>
    void write(MessageType type, T... args)
       {
@@ -58,6 +97,17 @@ public:
       writeBlocking(_sMsg);
       }
 
+   /**
+      @brief Read a message from the client
+
+      The read operation is blocking, subject to a timeout.
+      If the message received is `compilationAbort` then an exception of type Streamcancel is thrown.
+      If the server detects an incompatibility with the client then a StreamMessageTypeMissmatch
+      exception is thrown.
+      Otherwise, the arguments sent by the client are returned as a tuple
+
+      @return Returns a tuple of arguments sent by the client
+   */
    template <typename ...T>
    std::tuple<T...> read()
       {
@@ -71,6 +121,20 @@ public:
       return getArgs<T...>(_cMsg.mutable_data());
       }
 
+   /**
+      @brief Function to read the compilation request from a client
+
+      This is the first type of message received after a connection is established.
+      The number and position of parameters in the template must match the
+      the one sent by the client. In order to ensure this, the client will embed
+      version information in the first message it sends after a connection is established.
+      The server will check whether its version matches the client's version and throw
+      `StreamVersionIncompatible` it is doesn't.
+
+      Exceptions thrown: StreamCancel, StreamVersionIncompatible,StreamMessageTypeMismatch
+ 
+      @return Returns a tuple with information sent by the client
+   */
    template <typename... T>
    std::tuple<T...> readCompileRequest()
       {
@@ -91,12 +155,22 @@ public:
       return getArgs<T...>(_cMsg.mutable_data());
       }
    
+   /**
+      @brief Extract the data from the received message and return it
+   */
    template <typename... T>
    std::tuple<T...> getRecvData()
       {
       return getArgs<T...>(_cMsg.mutable_data());
       }
 
+   /**
+      @brief Function invoked by server when compilation is completed
+
+      This should be the last message sent by a server as a response to a compilation request.
+      It must include a `statusCode` which can be indicative of an error and could include a 
+      variable number of parameters with compilation artifacts (including the compiled body).
+   */
    template <typename... T>
    void finishCompilation(uint32_t statusCode, T... args)
       {
@@ -120,26 +194,44 @@ public:
       return _clientId;
       }
 
+   /**
+      @brief Function called to deal with incoming connection requests
+
+      This function opens a socket, binds it and then waits for incoming connection
+      requests by using `accept()` in an infinite loop. Once a connection is accepted
+      a ServerStream object is created (receiving the newly opened socket descriptor as
+      a parameter) and passed to the compilation handler. Typically, the compilation
+      handler places the ServerStream object in a queue and returns immediately so that
+      other connection requests can be accepted.
+      Note: because the function does not return, it must be executed on a separate thread.
+
+      @param [in] compiler Object that defines the behavior when a new connection is accepted
+      @param [in] info Pointer to PersistentInfo which contains the port and the timeout value for the connection
+   */
+   static void serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info);
+
+   // Statistics
    static int _numConnectionsOpened;
    static int _numConnectionsClosed;
 
 private:
-   uint32_t _msTimeout;
-   uint64_t _clientId;
+   uint64_t _clientId;  // UID of client connected to this communication stream
    };
 
 
-// Abstract class defining the interface for the compilation handler
-// Typically, an user would derive this class and provide an implementation for "compile()"
-// An instance of the derived class needs to be passed to serveRemoteCompilationRequests which internally calls "compile()"
+/**
+   @class BaseCompileDispatcher
+   @brief Abstract class defining the interface for the compilation handler
+
+   Typically, an user would derive this class and provide an implementation for "compile()"
+   An instance of the derived class needs to be passed to serveRemoteCompilationRequests 
+   which internally calls "compile()"
+ */
 class BaseCompileDispatcher
    {
 public:
    virtual void compile(ServerStream *stream) = 0;
    };
-
-
-void serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR::PersistentInfo *info);
 
 }
 

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -63,7 +63,7 @@ static int32_t J9THREAD_PROC listenerThreadProc(void * entryarg)
 
    J9CompileDispatcher handler(jitConfig);
    TR::PersistentInfo *info = getCompilationInfo(jitConfig)->getPersistentInfo();
-   JITServer::serveRemoteCompilationRequests(&handler, info);
+   JITServer::ServerStream::serveRemoteCompilationRequests(&handler, info);
 
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Detaching JITaaSServer listening thread");


### PR DESCRIPTION
The comments describe the typical usage of the classes.
Also, deleted unused _timeout field.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>