### PR TITLE
Reduce initialization costs of management beans

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,14 +66,16 @@ public final class BufferPoolMXBeanImpl implements BufferPoolMXBean {
 		return list;
 	}
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	private final BufferPool pool;
 
+	private final String poolName;
+
 	private BufferPoolMXBeanImpl(BufferPool pool, String poolName) {
 		super();
-		this.objectName = ManagementUtils.createObjectName(ManagementUtils.BUFFERPOOL_MXBEAN_DOMAIN_TYPE, poolName);
 		this.pool = pool;
+		this.poolName = poolName;
 	}
 
 	/**
@@ -105,6 +107,9 @@ public final class BufferPoolMXBeanImpl implements BufferPoolMXBean {
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementUtils.BUFFERPOOL_MXBEAN_DOMAIN_TYPE, poolName);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
@@ -59,7 +59,7 @@ public final class BufferPoolMXBeanImpl implements BufferPoolMXBean {
 
 	/**
 	 * Get the list of all buffer pool beans.
-	 * 
+	 *
 	 * @return the list of all buffer pool beans
 	 */
 	public static List<BufferPoolMXBean> getBufferPoolMXBeans() {

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ClassLoadingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ClassLoadingMXBeanImpl.java
@@ -31,117 +31,117 @@ import javax.management.ObjectName;
  * Runtime type for {@link ClassLoadingMXBean}.
  * <p>
  * There is only ever one instance of this class in a virtual machine.
- * The type does no need to be modeled as a DynamicMBean, as it is structured 
+ * The type does no need to be modeled as a DynamicMBean, as it is structured
  * statically, without attributes, operations, notifications, etc, configured,
- * on the fly. The StandardMBean model is sufficient for the bean type.  
+ * on the fly. The StandardMBean model is sufficient for the bean type.
  * </p>
  * @since 1.5
  */
 public final class ClassLoadingMXBeanImpl implements ClassLoadingMXBean {
 
-    private static final ClassLoadingMXBeanImpl instance = new ClassLoadingMXBeanImpl();
+	private static final ClassLoadingMXBeanImpl instance = new ClassLoadingMXBeanImpl();
 
-    private final ObjectName objectName;
+	private final ObjectName objectName;
 
-    /**
-     * Constructor intentionally private to prevent instantiation by others.
-     * Sets the metadata for this bean.
-     */
-    private ClassLoadingMXBeanImpl() {
-        super();
-        objectName = ManagementUtils.createObjectName(ManagementFactory.CLASS_LOADING_MXBEAN_NAME);
-    }
+	/**
+	 * Constructor intentionally private to prevent instantiation by others.
+	 * Sets the metadata for this bean.
+	 */
+	private ClassLoadingMXBeanImpl() {
+		super();
+		objectName = ManagementUtils.createObjectName(ManagementFactory.CLASS_LOADING_MXBEAN_NAME);
+	}
 
-    /**
-     * Singleton accessor method.
-     * 
-     * @return the <code>ClassLoadingMXBeanImpl</code> singleton.
-     */
+	/**
+	 * Singleton accessor method.
+	 *
+	 * @return the <code>ClassLoadingMXBeanImpl</code> singleton.
+	 */
 	public static ClassLoadingMXBeanImpl getInstance() {
-        return instance;
-    }
+		return instance;
+	}
 
-    /**
-     * @return the number of loaded classes
-     * @see #getLoadedClassCount()
-     */
-    private native int getLoadedClassCountImpl();
+	/**
+	 * @return the number of loaded classes
+	 * @see #getLoadedClassCount()
+	 */
+	private native int getLoadedClassCountImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
+	@Override
 	public int getLoadedClassCount() {
-        return this.getLoadedClassCountImpl();
-    }
+		return this.getLoadedClassCountImpl();
+	}
 
-    /**
-     * @return the total number of classes that have been loaded
-     * @see #getTotalLoadedClassCount()
-     */
-    private native long getTotalLoadedClassCountImpl();
+	/**
+	 * @return the total number of classes that have been loaded
+	 * @see #getTotalLoadedClassCount()
+	 */
+	private native long getTotalLoadedClassCountImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
+	@Override
 	public long getTotalLoadedClassCount() {
-        return this.getTotalLoadedClassCountImpl();
-    }
+		return this.getTotalLoadedClassCountImpl();
+	}
 
-    /**
-     * @return the total number of unloaded classes
-     * @see #getUnloadedClassCount()
-     */
-    private native long getUnloadedClassCountImpl();
+	/**
+	 * @return the total number of unloaded classes
+	 * @see #getUnloadedClassCount()
+	 */
+	private native long getUnloadedClassCountImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public long getUnloadedClassCount() {
-        return this.getUnloadedClassCountImpl();
-    }
+	@Override
+	public long getUnloadedClassCount() {
+		return this.getUnloadedClassCountImpl();
+	}
 
-    /**
-     * @return true if running in verbose mode
-     * @see #isVerbose()
-     */
-    private native boolean isVerboseImpl();
+	/**
+	 * @return true if running in verbose mode
+	 * @see #isVerbose()
+	 */
+	private native boolean isVerboseImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public boolean isVerbose() {
-        return this.isVerboseImpl();
-    }
+	@Override
+	public boolean isVerbose() {
+		return this.isVerboseImpl();
+	}
 
-    /**
-     * @param value true to put the class loading system into verbose
-     * mode, false to take the class loading system out of verbose mode.
-     * @see #setVerbose(boolean)
-     */
-    private native void setVerboseImpl(boolean value);
+	/**
+	 * @param value true to put the class loading system into verbose
+	 * mode, false to take the class loading system out of verbose mode.
+	 * @see #setVerbose(boolean)
+	 */
+	private native void setVerboseImpl(boolean value);
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public void setVerbose(boolean value) {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(ManagementPermissionHelper.MPCONTROL);
-        }
-        this.setVerboseImpl(value);
-    }
+	@Override
+	public void setVerbose(boolean value) {
+		SecurityManager security = System.getSecurityManager();
+		if (security != null) {
+			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
+		}
+		this.setVerboseImpl(value);
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public ObjectName getObjectName() {
-        return objectName;
-    }
+	@Override
+	public ObjectName getObjectName() {
+		return objectName;
+	}
 
 }

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ClassLoadingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ClassLoadingMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ public final class ClassLoadingMXBeanImpl implements ClassLoadingMXBean {
 
 	private static final ClassLoadingMXBeanImpl instance = new ClassLoadingMXBeanImpl();
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Constructor intentionally private to prevent instantiation by others.
@@ -49,7 +49,6 @@ public final class ClassLoadingMXBeanImpl implements ClassLoadingMXBean {
 	 */
 	private ClassLoadingMXBeanImpl() {
 		super();
-		objectName = ManagementUtils.createObjectName(ManagementFactory.CLASS_LOADING_MXBEAN_NAME);
 	}
 
 	/**
@@ -141,6 +140,9 @@ public final class ClassLoadingMXBeanImpl implements ClassLoadingMXBean {
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementFactory.CLASS_LOADING_MXBEAN_NAME);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
@@ -31,9 +31,9 @@ import javax.management.ObjectName;
  * Runtime type for {@link CompilationMXBean}
  * <p>
  * There is only ever one instance of this class in a virtual machine.
- * The type does no need to be modeled as a DynamicMBean, as it is structured 
+ * The type does no need to be modeled as a DynamicMBean, as it is structured
  * statically, without attributes, operations, notifications, etc, configured,
- * on the fly. The StandardMBean model is sufficient for the bean type.  
+ * on the fly. The StandardMBean model is sufficient for the bean type.
  * </p>
  * @since 1.5
  */
@@ -45,14 +45,14 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 
 	/**
 	 * Query whether the VM is running with a JIT compiler enabled.
-	 * 
+	 *
 	 * @return true if a JIT is enabled, false otherwise
 	 */
 	private static native boolean isJITEnabled();
 
 	/**
 	 * Constructor intentionally private to prevent instantiation by others.
-	 * Sets the metadata for this bean. 
+	 * Sets the metadata for this bean.
 	 */
 	private CompilationMXBeanImpl() {
 		super();
@@ -61,7 +61,7 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 
 	/**
 	 * Singleton accessor method.
-	 * 
+	 *
 	 * @return the <code>ClassLoadingMXBeanImpl</code> singleton.
 	 */
 	public static CompilationMXBeanImpl getInstance() {

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/CompilationMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 
 	private static final CompilationMXBeanImpl instance = isJITEnabled() ? new CompilationMXBeanImpl() : null;
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Query whether the VM is running with a JIT compiler enabled.
@@ -56,7 +56,6 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 	 */
 	private CompilationMXBeanImpl() {
 		super();
-		objectName = ManagementUtils.createObjectName(ManagementFactory.COMPILATION_MXBEAN_NAME);
 	}
 
 	/**
@@ -114,6 +113,9 @@ public final class CompilationMXBeanImpl implements CompilationMXBean {
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementFactory.COMPILATION_MXBEAN_NAME);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/GarbageCollectorMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/GarbageCollectorMXBeanImpl.java
@@ -41,15 +41,15 @@ import javax.management.openmbean.CompositeData;
  * <code>java.lang.management.GarbageCollectorMXBean</code>, this class also
  * provides an implementation of most of the IBM extension interface
  * <code>com.ibm.lang.management.GarbageCollectorMXBean</code>.
- * The type does not need to be modeled as a DynamicMBean, as it is structured 
+ * The type does not need to be modeled as a DynamicMBean, as it is structured
  * statically, without attributes, operations, notifications, etc., configured,
- * on the fly. The StandardMBean model is sufficient for the bean type.  
+ * on the fly. The StandardMBean model is sufficient for the bean type.
  * </p>
  * @since 1.5
  */
 public class GarbageCollectorMXBeanImpl
 		extends MemoryManagerMXBeanImpl
-        implements GarbageCollectorMXBean, NotificationEmitter {
+		implements GarbageCollectorMXBean, NotificationEmitter {
 
 	/**
 	 * The delegate for all notification management.
@@ -126,7 +126,7 @@ public class GarbageCollectorMXBeanImpl
 	/**
 	 * Returns the amount of heap memory used by objects that are managed
 	 * by the collector corresponding to this bean object.
-	 * 
+	 *
 	 * @return memory used in bytes
 	 * @see #getMemoryUsed()
 	 */
@@ -229,7 +229,7 @@ public class GarbageCollectorMXBeanImpl
 
 	/**
 	 * Send notifications to registered listeners. This will be called at the end of Garbage Collections.
-	 * 
+	 *
 	 * @param notification For this type of bean the user data will consist of
 	 *     a {@link CompositeData} instance that represents
 	 *     a {@link com.sun.management.GarbageCollectionNotificationInfo} object

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LazyDelegatingNotifier.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LazyDelegatingNotifier.java
@@ -1,0 +1,110 @@
+/*[INCLUDE-IF Sidecar17]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.java.lang.management.internal;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanNotificationInfo;
+import javax.management.Notification;
+import javax.management.NotificationBroadcasterSupport;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+
+/**
+ * A class that lazily delegates to NotificationBroadcasterSupport.
+ */
+class LazyDelegatingNotifier implements NotificationEmitter {
+
+	private static final UnaryOperator<NotificationBroadcasterSupport> creator() {
+		return new UnaryOperator<NotificationBroadcasterSupport>() {
+			@Override
+			public NotificationBroadcasterSupport apply(NotificationBroadcasterSupport support) {
+				return (support != null) ? support : new NotificationBroadcasterSupport();
+			}
+		};
+	}
+
+	private final AtomicReference<NotificationBroadcasterSupport> reference;
+
+	LazyDelegatingNotifier() {
+		super();
+		reference = new AtomicReference<>();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void addNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback)
+			throws IllegalArgumentException {
+		createAndGet().addNotificationListener(listener, filter, handback);
+	}
+
+	private NotificationBroadcasterSupport createAndGet() {
+		NotificationBroadcasterSupport notifier = reference.get();
+
+		return (notifier != null) ? notifier : reference.updateAndGet(creator());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public MBeanNotificationInfo[] getNotificationInfo() {
+		return createAndGet().getNotificationInfo();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public final void removeNotificationListener(NotificationListener listener) throws ListenerNotFoundException {
+		createAndGet().removeNotificationListener(listener);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public final void removeNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback)
+			throws ListenerNotFoundException {
+		createAndGet().removeNotificationListener(listener, filter, handback);
+	}
+
+	/**
+	 * Send notifications to registered listeners.
+	 *
+	 * @param notification a notification to be sent
+	 */
+	public final void sendNotification(Notification notification) {
+		NotificationBroadcasterSupport notifier = reference.get();
+
+		if (notifier != null) {
+			notifier.sendNotification(notification);
+		}
+	}
+
+}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -23,14 +23,16 @@
 package com.ibm.java.lang.management.internal;
 
 import java.lang.management.PlatformLoggingMXBean;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+/*[IF Sidecar19-SE]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-/*[IF !Sidecar19-SE]
+import java.util.Optional;
+/*[ELSE]*/
 import java.util.logging.LoggingMXBean;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -38,7 +40,6 @@ import java.util.logging.Logger;
 /*[ENDIF]*/
 
 import javax.management.ObjectName;
-import javax.management.StandardMBean;
 
 /**
  * Runtime type for {@link java.lang.management.PlatformLoggingMXBean}.
@@ -46,84 +47,106 @@ import javax.management.StandardMBean;
  * @since 1.5
  */
 public final class LoggingMXBeanImpl
-		extends StandardMBean
+/*[IF !Sidecar19-SE]*/
+		extends javax.management.StandardMBean
+/*[ENDIF]*/
 		implements
-/*[IF !Sidecar19-SE]
+/*[IF !Sidecar19-SE]*/
 			LoggingMXBean,
 /*[ENDIF]*/
 			PlatformLoggingMXBean {
 
-	private static final LoggingMXBeanImpl instance;
+	private static final LoggingMXBeanImpl instance = createInstance();
 
-/*[IF Sidecar19-SE]*/
-	private static final Method logManager_getLogManager;
-	private static final Method logManager_getLogger;
-	private static final Method logManager_getLoggerNames;
-	private static final Method logger_getLevel;
-	private static final Method logger_getParent;
-	private static final Method logger_getName;
-	private static final Method logger_setLevel;
-	private static final Method level_getName;
-	private static final Method level_parse;
-	private static final String logManager_LOGGING_MXBEAN_NAME;
-/*[ENDIF]*/
+	private static LoggingMXBeanImpl createInstance() {
+		/*[IF Sidecar19-SE]*/
+		final Optional<Module> java_logging = ModuleLayer.boot().findModule("java.logging"); //$NON-NLS-1$
 
-	static {
-/*[IF Sidecar19-SE]*/
-		try {
-			Module java_logging = ModuleLayer.boot().findModule("java.logging").get(); //$NON-NLS-1$
-			Class<?>[] logClasses = AccessController.doPrivileged((PrivilegedAction<Class<?>[]>)
-				() -> new Class[] {
-					Class.forName(java_logging, "java.util.logging.LogManager"), //$NON-NLS-1$
-					Class.forName(java_logging, "java.util.logging.Logger"), //$NON-NLS-1$
-					Class.forName(java_logging, "java.util.logging.Level") //$NON-NLS-1$
-				});
-			Class<?> logManagerClass = logClasses[0];
-			Class<?> loggerClass = logClasses[1];
-			Class<?> levelClass = logClasses[2];
-
-			logManager_getLogManager = logManagerClass.getMethod("getLogManager"); //$NON-NLS-1$
-			logManager_getLogger = logManagerClass.getMethod("getLogger", String.class); //$NON-NLS-1$
-			logManager_getLoggerNames = logManagerClass.getMethod("getLoggerNames"); //$NON-NLS-1$
-			logger_getLevel = loggerClass.getMethod("getLevel"); //$NON-NLS-1$
-			logger_getParent = loggerClass.getMethod("getParent"); //$NON-NLS-1$
-			logger_getName = loggerClass.getMethod("getName"); //$NON-NLS-1$
-			logger_setLevel = loggerClass.getMethod("setLevel", levelClass); //$NON-NLS-1$
-			level_getName = levelClass.getMethod("getName"); //$NON-NLS-1$
-			level_parse = levelClass.getMethod("parse", String.class); //$NON-NLS-1$
-			logManager_LOGGING_MXBEAN_NAME = logManagerClass.getField("LOGGING_MXBEAN_NAME").get(null).toString(); //$NON-NLS-1$
-		} catch (Exception e) {
-			throw handleError(e);
+		if (!java_logging.isPresent()) {
+			return null;
 		}
-/*[ENDIF]*/
 
-		/* Initialize class */
-		instance = new LoggingMXBeanImpl();
+		PrivilegedAction<LoggingMXBeanImpl> action = new PrivilegedAction<LoggingMXBeanImpl>() {
+			@Override
+			public LoggingMXBeanImpl run() {
+				try {
+					return new LoggingMXBeanImpl(java_logging.get());
+				} catch (Exception e) {
+					throw handleError(e);
+				}
+			}
+		};
+
+		return AccessController.doPrivileged(action);
+		/*[ELSE]
+		return new LoggingMXBeanImpl();
+		/*[ENDIF]*/
 	}
+
+	/*[IF Sidecar19-SE]*/
+	private final String logManager_LOGGING_MXBEAN_NAME;
+	private final Method logManager_getLogManager;
+	private final Method logManager_getLogger;
+	private final Method logManager_getLoggerNames;
+
+	private final Method level_getName;
+	private final Method level_parse;
+
+	private final Method logger_getLevel;
+	private final Method logger_getName;
+	private final Method logger_getParent;
+	private final Method logger_setLevel;
+	/*[ENDIF]*/
 
 	/**
 	 * the object name
 	 */
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Constructor intentionally private to prevent instantiation by others.
-	 * Sets the metadata for this bean.
 	 */
+	/*[IF Sidecar19-SE]*/
+	private LoggingMXBeanImpl(Module logging) throws Exception {
+		super();
+
+		Class<?> managerClass = Class.forName(logging, "java.util.logging.LogManager"); //$NON-NLS-1$
+
+		logManager_LOGGING_MXBEAN_NAME = (String) managerClass.getField("LOGGING_MXBEAN_NAME").get(null); //$NON-NLS-1$
+		logManager_getLogManager = managerClass.getMethod("getLogManager"); //$NON-NLS-1$
+		logManager_getLogger = managerClass.getMethod("getLogger", String.class); //$NON-NLS-1$
+		logManager_getLoggerNames = managerClass.getMethod("getLoggerNames"); //$NON-NLS-1$
+
+		Class<?> levelClass = Class.forName(logging, "java.util.logging.Level"); //$NON-NLS-1$
+
+		level_getName = levelClass.getMethod("getName"); //$NON-NLS-1$
+		level_parse = levelClass.getMethod("parse", String.class); //$NON-NLS-1$
+
+		Class<?> loggerClass = Class.forName(logging, "java.util.logging.Logger"); //$NON-NLS-1$
+
+		logger_getLevel = loggerClass.getMethod("getLevel"); //$NON-NLS-1$
+		logger_getName = loggerClass.getMethod("getName"); //$NON-NLS-1$
+		logger_getParent = loggerClass.getMethod("getParent"); //$NON-NLS-1$
+		logger_setLevel = loggerClass.getMethod("setLevel", levelClass); //$NON-NLS-1$
+	}
+	/*[ELSE]*/
 	private LoggingMXBeanImpl() {
 		super(PlatformLoggingMXBean.class, true);
-/*[IF Sidecar19-SE]*/
-		objectName = ManagementUtils.createObjectName(logManager_LOGGING_MXBEAN_NAME);
-/*[ELSE]
-		objectName = ManagementUtils.createObjectName(LogManager.LOGGING_MXBEAN_NAME);
-/*[ENDIF]*/
 	}
+	/*[ENDIF]*/
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+/*[IF Sidecar19-SE]*/
+			objectName = ManagementUtils.createObjectName(logManager_LOGGING_MXBEAN_NAME);
+/*[ELSE]*/
+			objectName = ManagementUtils.createObjectName(LogManager.LOGGING_MXBEAN_NAME);
+/*[ENDIF]*/
+		}
 		return objectName;
 	}
 
@@ -195,7 +218,7 @@ public final class LoggingMXBeanImpl
 		} catch (Exception e) {
 			throw handleError(e);
 		}
-/*[ELSE]
+/*[ELSE]*/
 		enumeration = LogManager.getLogManager().getLoggerNames();
 /*[ENDIF]*/
 		if (enumeration != null) {
@@ -276,7 +299,7 @@ public final class LoggingMXBeanImpl
 			} catch (Exception e) {
 				throw handleError(e);
 			}
-/*[ELSE]
+/*[ELSE]*/
 			Level newLevel = Level.parse(levelName);
 			logger.setLevel(newLevel);
 /*[ENDIF]*/
@@ -288,33 +311,26 @@ public final class LoggingMXBeanImpl
 	}
 
 /*[IF Sidecar19-SE]*/
-	private static Object getLoggerFromName(String loggerName) throws Exception {
+	private Object getLoggerFromName(String loggerName) throws Exception {
 		Object logManagerInstance = logManager_getLogManager.invoke(null);
 		return logManager_getLogger.invoke(logManagerInstance, loggerName);
 	}
 
 	/* Handle error thrown by method invoke as internal error */
-	private static InternalError handleError(Exception cause) {
-		handleInvocationTargetException(cause);
+	private static InternalError handleError(Exception error) {
+		// invoke throws InvocationTargetException if the method it is invoking throws an error.
+		// Unwrap that error for this class to maintain its specification.
+		if (error instanceof InvocationTargetException) {
+			Throwable cause = error.getCause();
 
-		InternalError err = new InternalError(cause.toString());
-		err.initCause(cause);
-		throw err;
-	}
-
-	/* invoke throws InvocationTargetException if the method it is invoking
-	 * throws an error. This method unwraps that error for this class to maintain
-	 * its specification.
-	 */
-	private static void handleInvocationTargetException(Exception cause) {
-		if (cause instanceof InvocationTargetException) {
-			Throwable wrappedCause = cause.getCause();
-			if (wrappedCause instanceof Error) {
-				throw (Error)wrappedCause;
-			} else if (wrappedCause instanceof RuntimeException) {
-				throw (RuntimeException)wrappedCause;
+			if (cause instanceof Error) {
+				throw (Error) cause;
+			} else if (cause instanceof RuntimeException) {
+				throw (RuntimeException) cause;
 			}
 		}
+
+		throw new InternalError(error.toString(), error);
 	}
 /*[ENDIF]*/
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -66,12 +66,11 @@ public final class LoggingMXBeanImpl
 	private static final Method level_getName;
 	private static final Method level_parse;
 	private static final String logManager_LOGGING_MXBEAN_NAME;
-/*[ENDIF]*/	
+/*[ENDIF]*/
 
 	static {
 /*[IF Sidecar19-SE]*/
 		try {
-
 			Module java_logging = ModuleLayer.boot().findModule("java.logging").get(); //$NON-NLS-1$
 			Class<?>[] logClasses = AccessController.doPrivileged((PrivilegedAction<Class<?>[]>)
 				() -> new Class[] {
@@ -82,7 +81,7 @@ public final class LoggingMXBeanImpl
 			Class<?> logManagerClass = logClasses[0];
 			Class<?> loggerClass = logClasses[1];
 			Class<?> levelClass = logClasses[2];
-			
+
 			logManager_getLogManager = logManagerClass.getMethod("getLogManager"); //$NON-NLS-1$
 			logManager_getLogger = logManagerClass.getMethod("getLogger", String.class); //$NON-NLS-1$
 			logManager_getLoggerNames = logManagerClass.getMethod("getLoggerNames"); //$NON-NLS-1$
@@ -93,16 +92,15 @@ public final class LoggingMXBeanImpl
 			level_getName = levelClass.getMethod("getName"); //$NON-NLS-1$
 			level_parse = levelClass.getMethod("parse", String.class); //$NON-NLS-1$
 			logManager_LOGGING_MXBEAN_NAME = logManagerClass.getField("LOGGING_MXBEAN_NAME").get(null).toString(); //$NON-NLS-1$
-
 		} catch (Exception e) {
 			throw handleError(e);
 		}
-/*[ENDIF]*/		
-		
+/*[ENDIF]*/
+
 		/* Initialize class */
 		instance = new LoggingMXBeanImpl();
 	}
-	
+
 	/**
 	 * the object name
 	 */
@@ -116,7 +114,7 @@ public final class LoggingMXBeanImpl
 		super(PlatformLoggingMXBean.class, true);
 /*[IF Sidecar19-SE]*/
 		objectName = ManagementUtils.createObjectName(logManager_LOGGING_MXBEAN_NAME);
-/*[ELSE]		
+/*[ELSE]
 		objectName = ManagementUtils.createObjectName(LogManager.LOGGING_MXBEAN_NAME);
 /*[ENDIF]*/
 	}
@@ -148,23 +146,23 @@ public final class LoggingMXBeanImpl
 /*[IF Sidecar19-SE]*/
 		try {
 			Object logger = getLoggerFromName(loggerName);
-/*[ELSE]	
+/*[ELSE]
 			Logger logger = LogManager.getLogManager().getLogger(loggerName);
-/*[ENDIF]*/			
-			
+/*[ENDIF]*/
+
 			if (logger != null) {
 				// The named Logger exists. Now attempt to obtain its log level.
 /*[IF Sidecar19-SE]*/
 				Object level = logger_getLevel.invoke(logger);
-/*[ELSE]					
+/*[ELSE]
 				Level level = logger.getLevel();
-/*[ENDIF]*/					
+/*[ENDIF]*/
 				if (level != null) {
 /*[IF Sidecar19-SE]*/
-					result = (String)level_getName.invoke(level);
-/*[ELSE]	
+					result = (String) level_getName.invoke(level);
+/*[ELSE]
 					result = level.getName();
-/*[ENDIF]*/	
+/*[ENDIF]*/
 				} else {
 					// A null return from getLevel() means that the Logger
 					// is inheriting its log level from an ancestor. Return an
@@ -177,7 +175,7 @@ public final class LoggingMXBeanImpl
 			throw handleError(e);
 		}
 /*[ENDIF]*/
-		
+
 		return result;
 	}
 
@@ -197,12 +195,12 @@ public final class LoggingMXBeanImpl
 		} catch (Exception e) {
 			throw handleError(e);
 		}
-/*[ELSE]	
+/*[ELSE]
 		enumeration = LogManager.getLogManager().getLoggerNames();
-/*[ENDIF]*/	
+/*[ENDIF]*/
 		if (enumeration != null) {
 			while (enumeration.hasMoreElements()) {
-				result.add((String)enumeration.nextElement());
+				result.add((String) enumeration.nextElement());
 			}
 		}
 
@@ -219,21 +217,21 @@ public final class LoggingMXBeanImpl
 /*[IF Sidecar19-SE]*/
 		try {
 			Object logger = getLoggerFromName(loggerName);
-/*[ELSE]		
+/*[ELSE]
 			Logger logger = LogManager.getLogManager().getLogger(loggerName);
 /*[ENDIF]*/
 			if (logger != null) {
 				// The named Logger exists. Now attempt to obtain its parent.
 /*[IF Sidecar19-SE]*/
 				Object parent = logger_getParent.invoke(logger);
-/*[ELSE]	
+/*[ELSE]
 				Logger parent = logger.getParent();
 /*[ENDIF]*/
 				if (parent != null) {
 					// There is a parent
 /*[IF Sidecar19-SE]*/
-					result = (String)logger_getName.invoke(parent);
-/*[ELSE]	
+					result = (String) logger_getName.invoke(parent);
+/*[ELSE]
 					result = parent.getName();
 /*[ENDIF]*/
 				} else {
@@ -246,7 +244,7 @@ public final class LoggingMXBeanImpl
 			throw handleError(e);
 		}
 /*[ENDIF]*/
-		
+
 		return result;
 	}
 
@@ -262,10 +260,10 @@ public final class LoggingMXBeanImpl
 		} catch (Exception e) {
 			throw handleError(e);
 		}
-/*[ELSE]	
+/*[ELSE]
 		final Logger logger = LogManager.getLogManager().getLogger(loggerName);
-/*[ENDIF]*/	
-		
+/*[ENDIF]*/
+
 		if (logger != null) {
 			// The named Logger exists. Now attempt to set its level. The
 			// below attempt to parse a Level from the supplied levelName
@@ -278,11 +276,10 @@ public final class LoggingMXBeanImpl
 			} catch (Exception e) {
 				throw handleError(e);
 			}
-/*[ELSE]	
+/*[ELSE]
 			Level newLevel = Level.parse(levelName);
 			logger.setLevel(newLevel);
 /*[ENDIF]*/
-			
 		} else {
 			// Named Logger does not exist.
 			/*[MSG "K05E7", "Unable to find Logger with name {0}."]*/
@@ -295,16 +292,16 @@ public final class LoggingMXBeanImpl
 		Object logManagerInstance = logManager_getLogManager.invoke(null);
 		return logManager_getLogger.invoke(logManagerInstance, loggerName);
 	}
-	
+
 	/* Handle error thrown by method invoke as internal error */
 	private static InternalError handleError(Exception cause) {
 		handleInvocationTargetException(cause);
-		
+
 		InternalError err = new InternalError(cause.toString());
 		err.initCause(cause);
 		throw err;
 	}
-	
+
 	/* invoke throws InvocationTargetException if the method it is invoking
 	 * throws an error. This method unwraps that error for this class to maintain
 	 * its specification.
@@ -320,4 +317,5 @@ public final class LoggingMXBeanImpl
 		}
 	}
 /*[ENDIF]*/
+
 }

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -197,7 +197,6 @@ public final class ManagementUtils {
 		}
 	}
 
-
 	/**
 	 * Convenience method to converts an array of <code>String</code> to a
 	 * <code>List&lt;String&gt;</code>.

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -24,13 +24,8 @@ package com.ibm.java.lang.management.internal;
 
 import java.io.IOException;
 import java.lang.management.GarbageCollectorMXBean;
-import java.lang.management.LockInfo;
-import java.lang.management.MemoryNotificationInfo;
 import java.lang.management.MemoryType;
-import java.lang.management.MemoryUsage;
-import java.lang.management.MonitorInfo;
 import java.lang.management.RuntimeMXBean;
-import java.lang.management.ThreadInfo;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -42,8 +37,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 /*[IF !Sidecar19-SE]*/
 import java.lang.management.ManagementFactory;
 import java.lang.management.PlatformManagedObject;
@@ -810,6 +803,7 @@ public final class ManagementUtils {
 			}
 		}
 
+		/*[IF] DEBUG */
 		private static void checkNames(Collection<? extends PlatformManagedObject> beans, ObjectName pattern) {
 			for (PlatformManagedObject bean : beans) {
 				ObjectName objectName = bean.getObjectName();
@@ -827,6 +821,7 @@ public final class ManagementUtils {
 				}
 			}
 		}
+		/*[ENDIF]*/
 
 		private static <T extends PlatformManagedObject> Component<T> create(String objectNamePattern, T bean) {
 			return new Component<>(objectNamePattern, bean);
@@ -874,7 +869,9 @@ public final class ManagementUtils {
 			if (bean == null) {
 				this.beansByName = Collections.emptyMap();
 			} else {
+				/*[IF] DEBUG */
 				checkNames(Collections.singleton(bean), name);
+				/*[ENDIF]*/
 				this.beansByName = Collections.singletonMap(name, bean);
 			}
 			this.interfaceTypes = new HashSet<>();
@@ -884,6 +881,7 @@ public final class ManagementUtils {
 		private Component(String objectNamePattern, Collection<? extends T> beans) {
 			super();
 
+			/*[IF] DEBUG */
 			ObjectName pattern = Metadata.makeObjectName(objectNamePattern);
 
 			if (!pattern.isPattern()) {
@@ -891,6 +889,7 @@ public final class ManagementUtils {
 			}
 
 			checkNames(beans, pattern);
+			/*[ENDIF]*/
 
 			this.beansByName = new HashMap<>(beans.size());
 			this.interfaceTypes = new HashSet<>();

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -49,6 +49,7 @@ import java.util.ServiceLoader;
 /*[ELSE]
 import com.ibm.oti.shared.SharedClassStatistics;
 /*[ENDIF]*/
+
 /**
  * Runtime type for {@link MemoryMXBean}.
  * <p>
@@ -66,7 +67,7 @@ import com.ibm.oti.shared.SharedClassStatistics;
  * protected
  * <code>handleNotification(javax.management.NotificationListener, javax.management.Notification, java.lang.Object)</code>
  * method cannot be overridden for any custom notification behavior. However,
- * taking the agile mantra of <b>YAGNI </b> to heart, it was decided that the
+ * taking the agile mantra of <b>YAGNI</b> to heart, it was decided that the
  * default implementation of that method will suffice until new requirements
  * prove otherwise.
  * </p>
@@ -99,7 +100,7 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 	private final List<MemoryPoolMXBean> managedPoolList;
 
 	private final ObjectName objectName;
-	
+
 	/*[IF Sidecar19-SE]*/
 	private final SharedClassProvider sharedClassServiceProvider;
 	/*[ENDIF]*/
@@ -135,7 +136,7 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 
 	private void setManagedMemoryPoolsForManagers() {
 		Iterator<MemoryManagerMXBean> iterManager = memoryManagerList.iterator();
-		
+
 		while (iterManager.hasNext()) {
 			MemoryManagerMXBeanImpl beanManager = (MemoryManagerMXBeanImpl) iterManager.next();
 
@@ -154,24 +155,24 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 				}
 			}
 		}
-    }
+	}
 
-    /**
-     * Singleton accessor method.
-     * 
-     * @return the <code>ClassLoadingMXBeanImpl</code> singleton.
-     */
+	/**
+	 * Singleton accessor method.
+	 *
+	 * @return the <code>ClassLoadingMXBeanImpl</code> singleton.
+	 */
 	public static MemoryMXBeanImpl getInstance() {
-        return instance;
-    }
+		return instance;
+	}
 
-    /**
-     * Instantiates MemoryManagerMXBean and GarbageCollectorMXBean instance(s)
-     * for the current VM configuration and stores them in memoryManagerList.
-     */
-    private native void createMemoryManagers();
+	/**
+	 * Instantiates MemoryManagerMXBean and GarbageCollectorMXBean instance(s)
+	 * for the current VM configuration and stores them in memoryManagerList.
+	 */
+	private native void createMemoryManagers();
 
-    private void createMemoryManagerHelper(String name, int internalID, boolean isGC) {
+	private void createMemoryManagerHelper(String name, int internalID, boolean isGC) {
 		String domain = isGC
 				? ManagementFactory.GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE
 				: ManagementFactory.MEMORY_MANAGER_MXBEAN_DOMAIN_TYPE;
@@ -196,13 +197,13 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 		return new GarbageCollectorMXBeanImpl(objName, name, internalID, this);
 	}
 
-    /**
-     * Retrieves the list of memory manager beans in the system.
-     * 
-     * @param copy indicates whether a copy of the list should be returned
-     * 
-     * @return the list of <code>MemoryManagerMXBean</code> instances
-     */
+	/**
+	 * Retrieves the list of memory manager beans in the system.
+	 *
+	 * @param copy indicates whether a copy of the list should be returned
+	 *
+	 * @return the list of <code>MemoryManagerMXBean</code> instances
+	 */
 	public List<MemoryManagerMXBean> getMemoryManagerMXBeans(boolean copy) {
 		List<MemoryManagerMXBean> list = memoryManagerList;
 
@@ -228,19 +229,19 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 		return result;
 	}
 
-    /**
-     * Instantiate the MemoryPoolMXBeans representing the memory managed by
-     * this manager, and store them in the managedPoolList.
-     */
-    private native void createMemoryPools();
-    
-    private void createMemoryPoolHelper(String name, int internalID, boolean isHeap) {
+	/**
+	 * Instantiate the MemoryPoolMXBeans representing the memory managed by
+	 * this manager, and store them in the managedPoolList.
+	 */
+	private native void createMemoryPools();
+
+	private void createMemoryPoolHelper(String name, int internalID, boolean isHeap) {
 		managedPoolList.add(makeMemoryPoolBean(name, isHeap ? MemoryType.HEAP : MemoryType.NON_HEAP, internalID));
 	}
 
 	/**
 	 * Create a new MemoryPoolMXBean.
-	 * 
+	 *
 	 * @param name the name of the memory pool
 	 * @param internalID an internal id number representing the memory pool
 	 * @param type the type of the memory pool
@@ -262,22 +263,22 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 
 		return copy ? new ArrayList<>(list) : list;
 	}
-    
+
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public void gc() {
 		System.gc();
-    }
+	}
 
-    /**
-     * @param constructor MemoryUsage Constructor
-     * @return an instance of {@link MemoryUsage} which can be interrogated by
-     *         the caller.
-     * @see #getHeapMemoryUsage()
-     */
-    private native MemoryUsage getHeapMemoryUsageImpl(Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
+	/**
+	 * @param constructor MemoryUsage Constructor
+	 * @return an instance of {@link MemoryUsage} which can be interrogated by
+	 *         the caller.
+	 * @see #getHeapMemoryUsage()
+	 */
+	private native MemoryUsage getHeapMemoryUsageImpl(Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
 
 	/**
 	 * {@inheritDoc}
@@ -289,76 +290,76 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 		} else {
 			return null;
 		}
-    }
+	}
 
-    /**
-     * @param constructor MemoryUsage Constructor
-     * @return an instance of {@link MemoryUsage} which can be interrogated by
-     *         the caller.
-     * @see #getNonHeapMemoryUsage()
-     */
-    private native MemoryUsage getNonHeapMemoryUsageImpl(Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
+	/**
+	 * @param constructor MemoryUsage Constructor
+	 * @return an instance of {@link MemoryUsage} which can be interrogated by
+	 *         the caller.
+	 * @see #getNonHeapMemoryUsage()
+	 */
+	private native MemoryUsage getNonHeapMemoryUsageImpl(Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public MemoryUsage getNonHeapMemoryUsage() {
-    	if (null != memUsageConstructor) {
-    		return this.getNonHeapMemoryUsageImpl(MemoryUsage.class, memUsageConstructor);
-    	} else {
-    		return null;
-    	}
-    }
+	@Override
+	public MemoryUsage getNonHeapMemoryUsage() {
+		if (null != memUsageConstructor) {
+			return this.getNonHeapMemoryUsageImpl(MemoryUsage.class, memUsageConstructor);
+		} else {
+			return null;
+		}
+	}
 
-    /**
-     * @return the number of objects awaiting finalization.
-     * @see #getObjectPendingFinalizationCount()
-     */
-    private native int getObjectPendingFinalizationCountImpl();
+	/**
+	 * @return the number of objects awaiting finalization.
+	 * @see #getObjectPendingFinalizationCount()
+	 */
+	private native int getObjectPendingFinalizationCountImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public int getObjectPendingFinalizationCount() {
-        return this.getObjectPendingFinalizationCountImpl();
-    }
+	@Override
+	public int getObjectPendingFinalizationCount() {
+		return this.getObjectPendingFinalizationCountImpl();
+	}
 
-    /**
-     * @return <code>true</code> if verbose output is being produced ;
-     *         <code>false</code> otherwise.
-     * @see #isVerbose()
-     */
-    private native boolean isVerboseImpl();
+	/**
+	 * @return <code>true</code> if verbose output is being produced ;
+	 *         <code>false</code> otherwise.
+	 * @see #isVerbose()
+	 */
+	private native boolean isVerboseImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public boolean isVerbose() {
-        return this.isVerboseImpl();
-    }
+	@Override
+	public boolean isVerbose() {
+		return this.isVerboseImpl();
+	}
 
-    /**
-     * @param value
-     *            <code>true</code> enables verbose output ;
-     *            <code>false</code> disables verbose output.
-     * @see #setVerbose(boolean)
-     */
-    private native void setVerboseImpl(boolean value);
+	/**
+	 * @param value
+	 *            <code>true</code> enables verbose output ;
+	 *            <code>false</code> disables verbose output.
+	 * @see #setVerbose(boolean)
+	 */
+	private native void setVerboseImpl(boolean value);
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public void setVerbose(boolean value) {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(ManagementPermissionHelper.MPCONTROL);
-        }
-        this.setVerboseImpl(value);
-    }
+	@Override
+	public void setVerbose(boolean value) {
+		SecurityManager security = System.getSecurityManager();
+		if (security != null) {
+			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
+		}
+		this.setVerboseImpl(value);
+	}
 
 	/**
 	 * @return value of -Xmx in bytes
@@ -429,55 +430,55 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 	public boolean isSetMaxHeapSizeSupported() {
 		return this.isSetMaxHeapSizeSupportedImpl();
 	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-    @Override
-    public void removeNotificationListener(NotificationListener listener,
-            NotificationFilter filter, Object handback)
-            throws ListenerNotFoundException {
-        notifier.removeNotificationListener(listener, filter, handback);
-    }
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public void addNotificationListener(NotificationListener listener,
-            NotificationFilter filter, Object handback)
-            throws IllegalArgumentException {
-        notifier.addNotificationListener(listener, filter, handback);
-    }
+	@Override
+	public void removeNotificationListener(NotificationListener listener,
+			NotificationFilter filter, Object handback)
+			throws ListenerNotFoundException {
+		notifier.removeNotificationListener(listener, filter, handback);
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public void removeNotificationListener(NotificationListener listener)
-            throws ListenerNotFoundException {
-        notifier.removeNotificationListener(listener);
-    }
+	@Override
+	public void addNotificationListener(NotificationListener listener,
+			NotificationFilter filter, Object handback)
+			throws IllegalArgumentException {
+		notifier.addNotificationListener(listener, filter, handback);
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public MBeanNotificationInfo[] getNotificationInfo() {
-        // We know what kinds of notifications we can emit whereas the
-        // notifier delegate does not. So, for this method, no delegating.
-        // Instead respond using our own metadata.
-        MBeanNotificationInfo[] notifications = new MBeanNotificationInfo[1];
-        String[] notifTypes = new String[2];
-        notifTypes[0] = java.lang.management.MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED;
-        notifTypes[1] = java.lang.management.MemoryNotificationInfo.MEMORY_COLLECTION_THRESHOLD_EXCEEDED;
-        notifications[0] = new MBeanNotificationInfo(notifTypes,
-                javax.management.Notification.class.getName(),
-                "Memory Notification"); //$NON-NLS-1$
-        return notifications;
-    }
+	@Override
+	public void removeNotificationListener(NotificationListener listener)
+			throws ListenerNotFoundException {
+		notifier.removeNotificationListener(listener);
+	}
 
-    /*
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public MBeanNotificationInfo[] getNotificationInfo() {
+		// We know what kinds of notifications we can emit whereas the
+		// notifier delegate does not. So, for this method, no delegating.
+		// Instead respond using our own metadata.
+		MBeanNotificationInfo[] notifications = new MBeanNotificationInfo[1];
+		String[] notifTypes = new String[2];
+		notifTypes[0] = java.lang.management.MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED;
+		notifTypes[1] = java.lang.management.MemoryNotificationInfo.MEMORY_COLLECTION_THRESHOLD_EXCEEDED;
+		notifications[0] = new MBeanNotificationInfo(notifTypes,
+				javax.management.Notification.class.getName(),
+				"Memory Notification"); //$NON-NLS-1$
+		return notifications;
+	}
+
+	/*
 	 * Send notifications to registered listeners. This will be called when
 	 * either of the following situations occur: <ol><li> With the method
 	 * {@link java.lang.management.MemoryPoolMXBean#isUsageThresholdSupported()}
@@ -493,7 +494,7 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 	 * will be
 	 * {@link MemoryNotificationInfo#MEMORY_COLLECTION_THRESHOLD_EXCEEDED}.
 	 * </ol>
-	 * 
+	 *
 	 * @param notification For this type of bean the user data will consist of a
 	 * {@link CompositeData} instance that represents a
 	 * {@link MemoryNotificationInfo} object.
@@ -737,7 +738,7 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 		return SharedClassStatistics.freeSpaceBytes();
 		/*[ENDIF]*/
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -748,11 +749,11 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 	private native String getGCModeImpl();
 
 	/**
-     * Returns the amount of CPU time spent in the GC by the master thread, in milliseconds.
-     * 
-     * @return CPU time used in milliseconds
-     * @see #getGCMasterThreadCpuUsed()
-     */
+	 * Returns the amount of CPU time spent in the GC by the master thread, in milliseconds.
+	 *
+	 * @return CPU time used in milliseconds
+	 * @see #getGCMasterThreadCpuUsed()
+	 */
 	private native long getGCMasterThreadCpuUsedImpl();
 
 	/**
@@ -763,11 +764,11 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 	}
 
 	/**
-     * Returns the amount of CPU time spent in the GC by all slave threads, in milliseconds.
-     * 
-     * @return CPU time used in milliseconds
-     * @see #getGCSlaveThreadsCpuUsed()
-     */
+	 * Returns the amount of CPU time spent in the GC by all slave threads, in milliseconds.
+	 *
+	 * @return CPU time used in milliseconds
+	 * @see #getGCSlaveThreadsCpuUsed()
+	 */
 	private native long getGCSlaveThreadsCpuUsedImpl();
 
 	/**
@@ -779,7 +780,7 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 
 	/**
 	 * Returns the maximum number of GC worker threads.
-	 * 
+	 *
 	 * @return maximum number of GC worker threads
 	 * @see #getMaximumGCThreads()
 	 */
@@ -794,7 +795,7 @@ public class MemoryMXBeanImpl implements MemoryMXBean, NotificationEmitter {
 
 	/**
 	 * Returns the number of GC slave threads that participated in the most recent collection.
-	 * 
+	 *
 	 * @return number of active GC worker threads
 	 * @see #getCurrentGCThreads()
 	 */

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryManagerMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryManagerMXBeanImpl.java
@@ -33,9 +33,9 @@ import javax.management.ObjectName;
  * Runtime type for {@link MemoryManagerMXBean}.
  * <p>
  * There is only ever one instance of this class in a virtual machine.
- * The type does not need to be modeled as a DynamicMBean, as it is structured 
+ * The type does not need to be modeled as a DynamicMBean, as it is structured
  * statically, without attributes, operations, notifications, etc., configured,
- * on the fly. The StandardMBean model is sufficient for the bean type.  
+ * on the fly. The StandardMBean model is sufficient for the bean type.
  * </p>
  * @since 1.5
  */
@@ -53,11 +53,11 @@ public class MemoryManagerMXBeanImpl implements MemoryManagerMXBean {
 	private final ObjectName objectName;
 
 	/**
-	 * Sets the metadata for this bean. 
+	 * Sets the metadata for this bean.
 	 * @param objectName
-	 * @param name 
+	 * @param name
 	 * @param id
-	 * @param memBean 
+	 * @param memBean
 	 */
 	MemoryManagerMXBeanImpl(ObjectName objectName, String name, int id, MemoryMXBeanImpl memBean) {
 		super();
@@ -66,11 +66,11 @@ public class MemoryManagerMXBeanImpl implements MemoryManagerMXBean {
 		this.id = id;
 		this.managedPoolList = new LinkedList<>();
 	}
-    
-    /**
-     * add managed pool for this bean 
-     * @param poolBean	managed pool bean
-     */
+
+	/**
+	 * add managed pool for this bean
+	 * @param poolBean managed pool bean
+	 */
 	protected void addMemoryPool(MemoryPoolMXBean poolBean) {
 		managedPoolList.add(poolBean);
 	}
@@ -83,12 +83,12 @@ public class MemoryManagerMXBeanImpl implements MemoryManagerMXBean {
 
 	/**
 	 * Retrieves the list of memory pool beans managed by this manager.
-	 * 
+	 *
 	 * @return the list of <code>MemoryPoolMXBean</code> instances
 	 */
 	List<MemoryPoolMXBean> getMemoryPoolMXBeans() {
-        return managedPoolList;
-    }
+		return managedPoolList;
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryManagerMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryManagerMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,8 @@ import javax.management.ObjectName;
  */
 public class MemoryManagerMXBeanImpl implements MemoryManagerMXBean {
 
+	private final String domainName;
+
 	private final String name;
 
 	/**
@@ -50,18 +52,17 @@ public class MemoryManagerMXBeanImpl implements MemoryManagerMXBean {
 
 	private final List<MemoryPoolMXBean> managedPoolList;
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Sets the metadata for this bean.
-	 * @param objectName
+	 * @param domainName
 	 * @param name
 	 * @param id
-	 * @param memBean
 	 */
-	MemoryManagerMXBeanImpl(ObjectName objectName, String name, int id, MemoryMXBeanImpl memBean) {
+	MemoryManagerMXBeanImpl(String domainName, String name, int id) {
 		super();
-		this.objectName = objectName;
+		this.domainName = domainName;
 		this.name = name;
 		this.id = id;
 		this.managedPoolList = new LinkedList<>();
@@ -124,6 +125,9 @@ public class MemoryManagerMXBeanImpl implements MemoryManagerMXBean {
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(domainName, name);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryPoolMXBeanImpl.java
@@ -65,40 +65,40 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 
 	/**
 	 * Sets the metadata for this bean.
-	 * 
+	 *
 	 * @param name
 	 * @param type
 	 * @param id
-	 * @param memBean 
+	 * @param memBean
 	 */
 	protected MemoryPoolMXBeanImpl(String name, MemoryType type, int id, MemoryMXBeanImpl memBean) {
 		super();
 		objectName = ManagementUtils.createObjectName(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, name);
-        this.name = name;
-        this.type = type;
-        this.id = id;
-        this.memBean = memBean;
-    }
+		this.name = name;
+		this.type = type;
+		this.id = id;
+		this.memBean = memBean;
+	}
 
-    /**
-     * @param constructor MemoryUsage Constructor
-     * @return a {@link java.lang.management.MemoryUsage} object that may be interrogated by the
-     *         caller to determine the details of the memory usage. Returns
-     *         <code>null</code> if the virtual machine does not support this
-     *         method.
-     * @see #getCollectionUsage()
-     */
-    private native MemoryUsage getCollectionUsageImpl(int id, Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
+	/**
+	 * @param constructor MemoryUsage Constructor
+	 * @return a {@link java.lang.management.MemoryUsage} object that may be interrogated by the
+	 *         caller to determine the details of the memory usage. Returns
+	 *         <code>null</code> if the virtual machine does not support this
+	 *         method.
+	 * @see #getCollectionUsage()
+	 */
+	private native MemoryUsage getCollectionUsageImpl(int id, Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public MemoryUsage getCollectionUsage() {
-    	if (null != memUsageConstructor) {
-    		return this.getCollectionUsageImpl(id, MemoryUsage.class, memUsageConstructor);
-    	} else {
-    		return null;
+	@Override
+	public MemoryUsage getCollectionUsage() {
+		if (null != memUsageConstructor) {
+			return this.getCollectionUsageImpl(id, MemoryUsage.class, memUsageConstructor);
+		} else {
+			return null;
 		}
 	}
 
@@ -112,7 +112,7 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 
 	/**
 	 * To satisfy com.ibm.lang.management.MemoryPoolMXBean.
-	 * 
+	 *
 	 * @return a {@link java.lang.management.MemoryUsage} containing the usage details for the memory
 	 *         pool just before the most recent collection occurred. Returns
 	 *         <code>null</code> if the virtual machine does not support this method.
@@ -131,33 +131,33 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public long getCollectionUsageThreshold() {
-        if (!isCollectionUsageThresholdSupported()) {
-        	/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
-        }
-        return this.getCollectionUsageThresholdImpl(id);
-    }
+	@Override
+	public long getCollectionUsageThreshold() {
+		if (!isCollectionUsageThresholdSupported()) {
+			/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
+		}
+		return this.getCollectionUsageThresholdImpl(id);
+	}
 
-    /**
-     * @return a count of the number of times that the collection usage
-     *         threshold has been surpassed.
-     * @see #getCollectionUsageThresholdCount()
-     */
-    private native long getCollectionUsageThresholdCountImpl(int id);
+	/**
+	 * @return a count of the number of times that the collection usage
+	 *         threshold has been surpassed.
+	 * @see #getCollectionUsageThresholdCount()
+	 */
+	private native long getCollectionUsageThresholdCountImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public long getCollectionUsageThresholdCount() {
-        if (!isCollectionUsageThresholdSupported()) {
-        	/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
-        }
-        return this.getCollectionUsageThresholdCountImpl(id);
-    }
+	@Override
+	public long getCollectionUsageThresholdCount() {
+		if (!isCollectionUsageThresholdSupported()) {
+			/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
+		}
+		return this.getCollectionUsageThresholdCountImpl(id);
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -200,250 +200,250 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 	 *         the pool is therefore considered to be invalid).
 	 * @see #getPeakUsage()
 	 */
-    private native MemoryUsage getPeakUsageImpl(int id, Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
+	private native MemoryUsage getPeakUsageImpl(int id, Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public MemoryUsage getPeakUsage() {
-        return this.getPeakUsageImpl(id, MemoryUsage.class, memUsageConstructor);
-    }
+	public MemoryUsage getPeakUsage() {
+		return this.getPeakUsageImpl(id, MemoryUsage.class, memUsageConstructor);
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public MemoryType getType() {
-        return this.type;
-    }
+	public MemoryType getType() {
+		return this.type;
+	}
 
-    /**
-     * @param constructor MemoryUsage Constructor
-     * @return an instance of {@link java.lang.management.MemoryUsage} that can be interrogated by
-     *         the caller to determine details on the pool's current memory
-     *         usage. A <code>null</code> value will be returned if the memory
-     *         pool no longer exists (in which case it is considered to be
-     *         invalid).
-     * @see #getUsage()
-     */
-    private native MemoryUsage getUsageImpl(int id, Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
+	/**
+	 * @param constructor MemoryUsage Constructor
+	 * @return an instance of {@link java.lang.management.MemoryUsage} that can be interrogated by
+	 *         the caller to determine details on the pool's current memory
+	 *         usage. A <code>null</code> value will be returned if the memory
+	 *         pool no longer exists (in which case it is considered to be
+	 *         invalid).
+	 * @see #getUsage()
+	 */
+	private native MemoryUsage getUsageImpl(int id, Class<MemoryUsage> clazz, Constructor<MemoryUsage> constructor);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public MemoryUsage getUsage() {
-        return this.getUsageImpl(id, MemoryUsage.class, memUsageConstructor);
-    }
+	public MemoryUsage getUsage() {
+		return this.getUsageImpl(id, MemoryUsage.class, memUsageConstructor);
+	}
 
-    /**
-     * @return the usage threshold in bytes. The default value as set by the
-     *         virtual machine depends on the platform the virtual machine is
-     *         running on. will be zero.
-     * @see #getUsageThreshold()
-     */
-    private native long getUsageThresholdImpl(int id);
+	/**
+	 * @return the usage threshold in bytes. The default value as set by the
+	 *         virtual machine depends on the platform the virtual machine is
+	 *         running on. will be zero.
+	 * @see #getUsageThreshold()
+	 */
+	private native long getUsageThresholdImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public long getUsageThreshold() {
-        if (!isUsageThresholdSupported()) {
-        	/*[MSG "K05EF", "VM does not support usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
-        }
-        return this.getUsageThresholdImpl(id);
-    }
+	public long getUsageThreshold() {
+		if (!isUsageThresholdSupported()) {
+			/*[MSG "K05EF", "VM does not support usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
+		}
+		return this.getUsageThresholdImpl(id);
+	}
 
-    /**
-     * @return a count of the number of times that the usage threshold has been
-     *         surpassed.
-     * @see #getUsageThresholdCount()
-     */
-    private native long getUsageThresholdCountImpl(int id);
+	/**
+	 * @return a count of the number of times that the usage threshold has been
+	 *         surpassed.
+	 * @see #getUsageThresholdCount()
+	 */
+	private native long getUsageThresholdCountImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public long getUsageThresholdCount() {
-        if (!isUsageThresholdSupported()) {
-        	/*[MSG "K05EF", "VM does not support usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
-        }
-        return this.getUsageThresholdCountImpl(id);
-    }
+	public long getUsageThresholdCount() {
+		if (!isUsageThresholdSupported()) {
+			/*[MSG "K05EF", "VM does not support usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
+		}
+		return this.getUsageThresholdCountImpl(id);
+	}
 
-    /**
-     * @return <code>true</code> if the collection usage threshold was
-     *         surpassed after the latest garbage collection run, otherwise
-     *         <code>false</code>.
-     * @see #isCollectionUsageThresholdExceeded()
-     */
-    private native boolean isCollectionUsageThresholdExceededImpl(int id);
+	/**
+	 * @return <code>true</code> if the collection usage threshold was
+	 *         surpassed after the latest garbage collection run, otherwise
+	 *         <code>false</code>.
+	 * @see #isCollectionUsageThresholdExceeded()
+	 */
+	private native boolean isCollectionUsageThresholdExceededImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public boolean isCollectionUsageThresholdExceeded() {
-        if (!isCollectionUsageThresholdSupported()) {
-        	/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
-        }
-        return this.isCollectionUsageThresholdExceededImpl(id);
-    }
+	public boolean isCollectionUsageThresholdExceeded() {
+		if (!isCollectionUsageThresholdSupported()) {
+			/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
+		}
+		return this.isCollectionUsageThresholdExceededImpl(id);
+	}
 
-    /**
-     * @return <code>true</code> if supported, <code>false</code> otherwise.
-     * @see #isCollectionUsageThresholdSupported()
-     */
-    private native boolean isCollectionUsageThresholdSupportedImpl(int id);
+	/**
+	 * @return <code>true</code> if supported, <code>false</code> otherwise.
+	 * @see #isCollectionUsageThresholdSupported()
+	 */
+	private native boolean isCollectionUsageThresholdSupportedImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public boolean isCollectionUsageThresholdSupported() {
-        return this.isCollectionUsageThresholdSupportedImpl(id);
-    }
+	public boolean isCollectionUsageThresholdSupported() {
+		return this.isCollectionUsageThresholdSupportedImpl(id);
+	}
 
-    /**
-     * @return <code>true</code> if the usage threshold has been surpassed,
-     *         otherwise <code>false</code>.
-     * @see #isUsageThresholdExceeded()
-     */
-    private native boolean isUsageThresholdExceededImpl(int id);
+	/**
+	 * @return <code>true</code> if the usage threshold has been surpassed,
+	 *         otherwise <code>false</code>.
+	 * @see #isUsageThresholdExceeded()
+	 */
+	private native boolean isUsageThresholdExceededImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public boolean isUsageThresholdExceeded() {
-        if (!isUsageThresholdSupported()) {
-        	/*[MSG "K05EF", "VM does not support usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
-        }
-        return this.isUsageThresholdExceededImpl(id);
-    }
+	public boolean isUsageThresholdExceeded() {
+		if (!isUsageThresholdSupported()) {
+			/*[MSG "K05EF", "VM does not support usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
+		}
+		return this.isUsageThresholdExceededImpl(id);
+	}
 
-    /**
-     * @return <code>true</code> if supported, <code>false</code> otherwise.
-     * @see #isUsageThresholdSupported()
-     */
-    private native boolean isUsageThresholdSupportedImpl(int id);
+	/**
+	 * @return <code>true</code> if supported, <code>false</code> otherwise.
+	 * @see #isUsageThresholdSupported()
+	 */
+	private native boolean isUsageThresholdSupportedImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public boolean isUsageThresholdSupported() {
-        return this.isUsageThresholdSupportedImpl(id);
-    }
+	public boolean isUsageThresholdSupported() {
+		return this.isUsageThresholdSupportedImpl(id);
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public boolean isValid() {
-        return true;
-    }
+	public boolean isValid() {
+		return true;
+	}
 
-    /**
-     * @see #resetPeakUsage()
-     */
-    private native void resetPeakUsageImpl(int id);
+	/**
+	 * @see #resetPeakUsage()
+	 */
+	private native void resetPeakUsageImpl(int id);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public void resetPeakUsage() {
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(ManagementPermissionHelper.MPCONTROL);
-        }
-       	this.resetPeakUsageImpl(id);
-    }
+	public void resetPeakUsage() {
+		SecurityManager security = System.getSecurityManager();
+		if (security != null) {
+			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
+		}
+		this.resetPeakUsageImpl(id);
+	}
 
-    /**
-     * @param threshold
-     *            the size of the new collection usage threshold expressed in
-     *            bytes.
-     * @see #setCollectionUsageThreshold(long)
-     */
-    private native void setCollectionUsageThresholdImpl(int id, long threshold);
+	/**
+	 * @param threshold
+	 *            the size of the new collection usage threshold expressed in
+	 *            bytes.
+	 * @see #setCollectionUsageThreshold(long)
+	 */
+	private native void setCollectionUsageThresholdImpl(int id, long threshold);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public void setCollectionUsageThreshold(long threshold) {
-        if (!isCollectionUsageThresholdSupported()) {
-        	/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
-        }
+	public void setCollectionUsageThreshold(long threshold) {
+		if (!isCollectionUsageThresholdSupported()) {
+			/*[MSG "K05EE", "VM does not support collection usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EE")); //$NON-NLS-1$
+		}
 
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(ManagementPermissionHelper.MPCONTROL);
-        }
+		SecurityManager security = System.getSecurityManager();
+		if (security != null) {
+			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
+		}
 
-        if (threshold < 0) {
-        	/*[MSG "K05FE", "Collection usage threshold cannot be negative."]*/
-            throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05FE")); //$NON-NLS-1$
-        }
+		if (threshold < 0) {
+			/*[MSG "K05FE", "Collection usage threshold cannot be negative."]*/
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05FE")); //$NON-NLS-1$
+		}
 
-        if (exceedsMaxPoolSize(threshold)) {
-        	/*[MSG "K05FF", "Collection usage threshold cannot exceed maximum amount of memory for pool."]*/
-            throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05FF")); //$NON-NLS-1$
-        }
-        this.setCollectionUsageThresholdImpl(id, threshold);
-    }
+		if (exceedsMaxPoolSize(threshold)) {
+			/*[MSG "K05FF", "Collection usage threshold cannot exceed maximum amount of memory for pool."]*/
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05FF")); //$NON-NLS-1$
+		}
+		this.setCollectionUsageThresholdImpl(id, threshold);
+	}
 
-    /**
-     * @param threshold
-     *            the size of the new usage threshold expressed in bytes.
-     * @see #setUsageThreshold(long)
-     */
-    private native void setUsageThresholdImpl(int id, long threshold);
+	/**
+	 * @param threshold
+	 *            the size of the new usage threshold expressed in bytes.
+	 * @see #setUsageThreshold(long)
+	 */
+	private native void setUsageThresholdImpl(int id, long threshold);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-    public void setUsageThreshold(long threshold) {
-        if (!isUsageThresholdSupported()) {
-        	/*[MSG "K05EF", "VM does not support usage threshold."]*/
-            throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
-        }
+	public void setUsageThreshold(long threshold) {
+		if (!isUsageThresholdSupported()) {
+			/*[MSG "K05EF", "VM does not support usage threshold."]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05EF")); //$NON-NLS-1$
+		}
 
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(ManagementPermissionHelper.MPCONTROL);
-        }
+		SecurityManager security = System.getSecurityManager();
+		if (security != null) {
+			security.checkPermission(ManagementPermissionHelper.MPCONTROL);
+		}
 
-        if (threshold < 0) {
-        	/*[MSG "K05F0", "Usage threshold cannot be negative."]*/
-            throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05F0")); //$NON-NLS-1$
-        }
+		if (threshold < 0) {
+			/*[MSG "K05F0", "Usage threshold cannot be negative."]*/
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05F0")); //$NON-NLS-1$
+		}
 
-        if (exceedsMaxPoolSize(threshold)) {
-        	/*[MSG "K05F1", "Usage threshold cannot exceed maximum amount of memory for pool."]*/
-            throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05F1")); //$NON-NLS-1$
-        }
-        this.setUsageThresholdImpl(id, threshold);
-    }
+		if (exceedsMaxPoolSize(threshold)) {
+			/*[MSG "K05F1", "Usage threshold cannot exceed maximum amount of memory for pool."]*/
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05F1")); //$NON-NLS-1$
+		}
+		this.setUsageThresholdImpl(id, threshold);
+	}
 
-     /**
-     * @param value
-     * @return <code>true</code> if <code>value</code> is greater than the
-     *         maximum size of the corresponding memory pool. <code>false</code>
-     *         if <code>value</code> does not exceed the maximum memory pool
-     *         size or else no memory pool maximum size has been defined.
-     */
+	 /**
+	 * @param value
+	 * @return <code>true</code> if <code>value</code> is greater than the
+	 *         maximum size of the corresponding memory pool. <code>false</code>
+	 *         if <code>value</code> does not exceed the maximum memory pool
+	 *         size or else no memory pool maximum size has been defined.
+	 */
 	private boolean exceedsMaxPoolSize(long value) {
 		MemoryUsage m = getUsage();
 		return ((-1 != m.getMax()) && (0 != m.getMax()) && (m.getMax() < value));

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryPoolMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 
 	private final MemoryMXBeanImpl memBean;
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Sets the metadata for this bean.
@@ -73,7 +73,6 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 	 */
 	protected MemoryPoolMXBeanImpl(String name, MemoryType type, int id, MemoryMXBeanImpl memBean) {
 		super();
-		objectName = ManagementUtils.createObjectName(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, name);
 		this.name = name;
 		this.type = type;
 		this.id = id;
@@ -454,6 +453,9 @@ public class MemoryPoolMXBeanImpl implements MemoryPoolMXBean {
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, name);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/OperatingSystemMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/OperatingSystemMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2016 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,6 @@ package com.ibm.java.lang.management.internal;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
-import javax.management.MBeanNotificationInfo;
-import javax.management.NotificationBroadcasterSupport;
 import javax.management.ObjectName;
 
 /**
@@ -34,7 +32,7 @@ import javax.management.ObjectName;
  *
  * @since 1.5
  */
-public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport implements OperatingSystemMXBean {
+public class OperatingSystemMXBeanImpl extends LazyDelegatingNotifier implements OperatingSystemMXBean {
 
 	private static final OperatingSystemMXBeanImpl instance = new OperatingSystemMXBeanImpl();
 
@@ -47,7 +45,7 @@ public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport im
 		return instance;
 	}
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Constructor intentionally private to prevent instantiation by others.
@@ -55,7 +53,6 @@ public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport im
 	 */
 	protected OperatingSystemMXBeanImpl() {
 		super();
-		objectName = ManagementUtils.createObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
 	}
 
 	/**
@@ -86,16 +83,10 @@ public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport im
 	 * {@inheritDoc}
 	 */
 	@Override
-	public MBeanNotificationInfo[] getNotificationInfo() {
-		// This base implementation doesn't provide for any notifications.
-		return new MBeanNotificationInfo[0];
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
 	public final ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/OperatingSystemMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/OperatingSystemMXBeanImpl.java
@@ -40,7 +40,7 @@ public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport im
 
 	/**
 	 * Singleton accessor method.
-	 * 
+	 *
 	 * @return the {@link OperatingSystemMXBeanImpl} singleton.
 	 */
 	public static OperatingSystemMXBeanImpl getInstance() {
@@ -63,22 +63,22 @@ public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport im
 	 */
 	@Override
 	public final String getArch() {
-        return System.getProperty("os.arch"); //$NON-NLS-1$
-    }
+		return System.getProperty("os.arch"); //$NON-NLS-1$
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public final int getAvailableProcessors() {
-        return Runtime.getRuntime().availableProcessors();
-    }
+	@Override
+	public final int getAvailableProcessors() {
+		return Runtime.getRuntime().availableProcessors();
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public final String getName() {
+	@Override
+	public final String getName() {
 		return System.getProperty("os.name"); //$NON-NLS-1$
 	}
 
@@ -102,25 +102,25 @@ public class OperatingSystemMXBeanImpl extends NotificationBroadcasterSupport im
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
+	@Override
 	public final double getSystemLoadAverage() {
 		return this.getSystemLoadAverageImpl();
 	}
 
-    /**
-     * @return the time-averaged value of the sum of the number of runnable
-     *         entities running on the available processors together with the
-     *         number of runnable entities ready and queued to run on the
-     *         available processors.
-     * @see #getSystemLoadAverage()
-     */
-    private native double getSystemLoadAverageImpl();
+	/**
+	 * @return the time-averaged value of the sum of the number of runnable
+	 *         entities running on the available processors together with the
+	 *         number of runnable entities ready and queued to run on the
+	 *         available processors.
+	 * @see #getSystemLoadAverage()
+	 */
+	private native double getSystemLoadAverageImpl();
 
 	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public final String getVersion() {
+	@Override
+	public final String getVersion() {
 		return System.getProperty("os.version"); //$NON-NLS-1$
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
@@ -41,7 +41,7 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 
 	private static final RuntimeMXBean instance = new RuntimeMXBeanImpl();
 
-	private final ObjectName objectName;
+	private ObjectName objectName;
 
 	/**
 	 * Constructor intentionally private to prevent instantiation by others.
@@ -49,7 +49,6 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 	 */
 	protected RuntimeMXBeanImpl() {
 		super();
-		objectName = ManagementUtils.createObjectName(ManagementFactory.RUNTIME_MXBEAN_NAME);
 	}
 
 	/**
@@ -233,6 +232,9 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 	 */
 	@Override
 	public final ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementFactory.RUNTIME_MXBEAN_NAME);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/RuntimeMXBeanImpl.java
@@ -54,7 +54,7 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 
 	/**
 	 * Singleton accessor method.
-	 * 
+	 *
 	 * @return the <code>RuntimeMXBeanImpl</code> singleton.
 	 */
 	public static RuntimeMXBean getInstance() {
@@ -238,7 +238,7 @@ public class RuntimeMXBeanImpl implements RuntimeMXBean {
 
 	public static void checkMonitorPermission() {
 		SecurityManager security = System.getSecurityManager();
-		
+
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
 		}

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -61,7 +61,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 
 	/**
 	 * Singleton accessor method.
-	 * 
+	 *
 	 * @return the <code>ThreadMXBeanImpl</code> singleton.
 	 */
 	public static ThreadMXBean getInstance() {
@@ -271,7 +271,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	/**
 	 * Create ThreadInfo objects containing ThreadInfoBase objects.
 	 * @param infoBases containers for the actual thread information
-	 * @return ThreadInfo array whose elements wrap the elements of infoBases 
+	 * @return ThreadInfo array whose elements wrap the elements of infoBases
 	 */
 	private static ThreadInfo[] makeThreadInfos(ThreadInfoBase[] infoBases) {
 		PrivilegedAction<ThreadInfo[]> action = () -> Arrays.stream(infoBases)
@@ -287,7 +287,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 * Assumes that caller has already carried out error checking on the
 	 * <code>id</code> and <code>maxDepth</code> arguments.
 	 * </p>
-	 * 
+	 *
 	 * @param ids
 	 *            thread ids
 	 * @param lockedMonitors
@@ -378,7 +378,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 * Assumes that caller has already carried out error checking on the
 	 * <code>id</code> and <code>maxDepth</code> arguments.
 	 * </p>
-	 * 
+	 *
 	 * @param id
 	 *            thread id
 	 * @param maxStackDepth
@@ -694,7 +694,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		return dumpAllThreadsCommon(lockedMonitors, lockedSynchronizers, maxDepth);
 	}
 	/*[ENDIF]*/ // Java10
-	
+
 	/**
 	 * @param lockedMonitors
 	 *            if <code>true</code> then include details of locked object
@@ -714,10 +714,10 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	/**
 	 * Answers an array of instances of the ThreadInfoBase
 	 * class according to ids.
-	 * 
+	 *
 	 * @param ids
 	 *            thread ids
-	 * @param maxStackDepth 
+	 * @param maxStackDepth
 	 *            the max stack depth
 	 * @param getLockedMonitors
 	 *            if <code>true</code> attempt to set the returned
@@ -728,7 +728,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 *            <code>ThreadInfo</code> with details of ownable
 	 *            synchronizers locked by the specified thread
 	 * @return array of ThreadInfoBase
-	 */   
+	 */
 	private native ThreadInfoBase[] getMultiThreadInfoImpl(long[] ids, int maxStackDepth,
 			boolean getLockedMonitors, boolean getLockedSynchronizers);
 
@@ -798,7 +798,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 				return myHandle;
 			}
 		});
-	}	
+	}
 
 	/**
 	 * Wrap a ThreadInfoBase object in a ThreadInfo object.
@@ -826,4 +826,5 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		}
 		return newThreadInfo;
 	}
+
 }

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -47,8 +47,9 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	private static Boolean isThreadCpuTimeEnabled = null;
 	private static Boolean isThreadCpuTimeSupported = null;
 
-	private final ObjectName objectName;
 	private static final MethodHandle threadInfoConstructorHandle = getThreadInfoConstructorHandle();
+
+	private ObjectName objectName;
 
 	/**
 	 * Protected constructor to limit instantiation.
@@ -56,7 +57,6 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	protected ThreadMXBeanImpl() {
 		super();
-		objectName = ManagementUtils.createObjectName(ManagementFactory.THREAD_MXBEAN_NAME);
 	}
 
 	/**
@@ -778,6 +778,9 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public ObjectName getObjectName() {
+		if (objectName == null) {
+			objectName = ManagementUtils.createObjectName(ManagementFactory.THREAD_MXBEAN_NAME);
+		}
 		return objectName;
 	}
 

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -61,7 +61,7 @@ final class DefaultPlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.addInterface(java.lang.management.OperatingSystemMXBean.class)
 			.register(allComponents);
 
-		/* LoggingMXBeanImpl depends on java.logging. If java.logging is not 
+		/* LoggingMXBeanImpl depends on java.logging. If java.logging is not
 		 * available exclude this component.
 		 */
 		if (ModuleLayer.boot().findModule("java.logging").isPresent()) { //$NON-NLS-1$

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -49,32 +49,40 @@ final class DefaultPlatformMBeanProvider extends sun.management.spi.PlatformMBea
 		List<PlatformComponent<Object>> allComponents = new ArrayList<>();
 
 		// register standard singleton beans
-		ComponentBuilder.create(ClassLoadingMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.CLASS_LOADING_MXBEAN_NAME, ClassLoadingMXBeanImpl.getInstance())
 			.addInterface(java.lang.management.ClassLoadingMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(MemoryMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBeanImpl.getInstance())
 			.addInterface(java.lang.management.MemoryMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(OperatingSystemMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, OperatingSystemMXBeanImpl.getInstance())
 			.addInterface(java.lang.management.OperatingSystemMXBean.class)
 			.register(allComponents);
 
-		/* LoggingMXBeanImpl depends on java.logging. If java.logging is not
-		 * available exclude this component.
+		LoggingMXBeanImpl logging = LoggingMXBeanImpl.getInstance();
+
+		/*
+		 * The logging bean will be included only if the java.logging module is present.
 		 */
-		if (ModuleLayer.boot().findModule("java.logging").isPresent()) { //$NON-NLS-1$
-			ComponentBuilder.create(LoggingMXBeanImpl.getInstance())
+		if (logging != null) {
+			/*
+			 * This is the publicly documented name of the logging bean.
+			 * We can't refer to LogManager.LOGGING_MXBEAN_NAME
+			 * because the java.logging module is not accessible here.
+			 */
+			String LOGGING_MXBEAN_NAME = "java.util.logging:type=Logging"; //$NON-NLS-1$
+			ComponentBuilder.create(LOGGING_MXBEAN_NAME, logging)
 				.addInterface(java.lang.management.PlatformLoggingMXBean.class)
 				.register(allComponents);
 		}
 
-		ComponentBuilder.create(RuntimeMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.RUNTIME_MXBEAN_NAME, RuntimeMXBeanImpl.getInstance())
 			.addInterface(java.lang.management.RuntimeMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(ThreadMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.THREAD_MXBEAN_NAME, ThreadMXBeanImpl.getInstance())
 			.addInterface(java.lang.management.ThreadMXBean.class)
 			.register(allComponents);
 
@@ -84,24 +92,64 @@ final class DefaultPlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.register(allComponents);
 
 		// register beans with zero or more instances
-		ComponentBuilder.create(ManagementUtils.BUFFERPOOL_MXBEAN_DOMAIN_TYPE, BufferPoolMXBeanImpl.getBufferPoolMXBeans())
-			.addInterface(java.lang.management.BufferPoolMXBean.class)
-			.register(allComponents);
 
-		ComponentBuilder.create(ManagementFactory.GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE, MemoryMXBeanImpl.getInstance().getGarbageCollectorMXBeans())
-			.addInterface(java.lang.management.GarbageCollectorMXBean.class)
-			.addInterface(java.lang.management.MemoryManagerMXBean.class)
-			.register(allComponents);
+		{
+			List<BufferPoolMXBean> beans = BufferPoolMXBeanImpl.getBufferPoolMXBeans();
+			int beanCount = beans.size();
+			List<String> names = new ArrayList<>(beanCount);
 
-		ComponentBuilder.create(ManagementFactory.MEMORY_MANAGER_MXBEAN_DOMAIN_TYPE,
-				// exclude garbage collector beans handled above
-				excluding(MemoryMXBeanImpl.getInstance().getMemoryManagerMXBeans(false), java.lang.management.GarbageCollectorMXBean.class))
-			.addInterface(java.lang.management.MemoryManagerMXBean.class)
-			.register(allComponents);
+			for (BufferPoolMXBean bean : beans) {
+				names.add(bean.getName());
+			}
 
-		ComponentBuilder.create(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, MemoryMXBeanImpl.getInstance().getMemoryPoolMXBeans(false))
-			.addInterface(java.lang.management.MemoryPoolMXBean.class)
-			.register(allComponents);
+			ComponentBuilder.create(ManagementUtils.BUFFERPOOL_MXBEAN_DOMAIN_TYPE, names, beans)
+				.addInterface(java.lang.management.BufferPoolMXBean.class)
+				.register(allComponents);
+		}
+
+		{
+			List<GarbageCollectorMXBean> beans = MemoryMXBeanImpl.getInstance().getGarbageCollectorMXBeans();
+			int beanCount = beans.size();
+			List<String> names = new ArrayList<>(beanCount);
+
+			for (GarbageCollectorMXBean bean : beans) {
+				names.add(bean.getName());
+			}
+
+			ComponentBuilder.create(ManagementFactory.GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE, names, beans)
+				.addInterface(java.lang.management.GarbageCollectorMXBean.class)
+				.addInterface(java.lang.management.MemoryManagerMXBean.class)
+				.register(allComponents);
+		}
+
+		{
+			// exclude garbage collector beans handled above
+			List<MemoryManagerMXBean> beans = excluding(MemoryMXBeanImpl.getInstance().getMemoryManagerMXBeans(false), java.lang.management.GarbageCollectorMXBean.class);
+			int beanCount = beans.size();
+			List<String> names = new ArrayList<>(beanCount);
+
+			for (MemoryManagerMXBean bean : beans) {
+				names.add(bean.getName());
+			}
+
+			ComponentBuilder.create(ManagementFactory.MEMORY_MANAGER_MXBEAN_DOMAIN_TYPE, names, beans)
+				.addInterface(java.lang.management.MemoryManagerMXBean.class)
+				.register(allComponents);
+		}
+
+		{
+			List<MemoryPoolMXBean> beans = MemoryMXBeanImpl.getInstance().getMemoryPoolMXBeans(false);
+			int beanCount = beans.size();
+			List<String> names = new ArrayList<>(beanCount);
+
+			for (MemoryPoolMXBean bean : beans) {
+				names.add(bean.getName());
+			}
+
+			ComponentBuilder.create(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, names, beans)
+				.addInterface(java.lang.management.MemoryPoolMXBean.class)
+				.register(allComponents);
+		}
 
 		components = Collections.unmodifiableList(allComponents);
 	}

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/CpuUtilizationHelper.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/CpuUtilizationHelper.java
@@ -31,12 +31,12 @@ final class CpuUtilizationHelper implements CpuLoadCalculationConstants {
 	SysinfoCpuTime latestTime = null;
 
 	/**
-	 * Returns the CPU utilization, i.e. fraction of the time spent in user or system/privileged mode, since the last call to getSystemCpuLoad() on this object.  
+	 * Returns the CPU utilization, i.e. fraction of the time spent in user or system/privileged mode, since the last call to getSystemCpuLoad() on this object.
 	 * To compute load over different concurrent intervals, create separate objects.
 	 * If insufficient time (less than 10 ms) has elapsed since a previous call on this object, or
 	 * if an operating system error has occurred, e.g. clock rollover, ERROR_VALUE is returned.
-	 * If this operation is not supported due to insufficient user privilege, return INSUFFICIENT_PRIVILEGE. 
-	 * If this operation is not supported on this platform, return UNSUPPORTED_VALUE. 
+	 * If this operation is not supported due to insufficient user privilege, return INSUFFICIENT_PRIVILEGE.
+	 * If this operation is not supported on this platform, return UNSUPPORTED_VALUE.
 	 * INTERNAL_ERROR indicates an internal problem.
 	 * This is not guaranteed to return the same value as reported by operating system
 	 * utilities such as Unix "top" or Windows task manager.
@@ -72,15 +72,15 @@ final class CpuUtilizationHelper implements CpuLoadCalculationConstants {
 			} else {
 				interimTime = latestTime;
 				/*
-				 * either the latest time or the interim time are bogus. 
-				 * Discard the interim value and try with the oldest value. 
+				 * either the latest time or the interim time are bogus.
+				 * Discard the interim value and try with the oldest value.
 				 */
 			}
 		}
 
 		if ((latestTime.getTimestamp() - oldestTime.getTimestamp()) >= MINIMUM_INTERVAL) {
 			cpuLoad = calculateCpuLoad(latestTime, oldestTime);
-			if (cpuLoad < 0) { /* the stats look bogus.  Discard them */
+			if (cpuLoad < 0) { /* the stats look bogus. Discard them */
 				oldestTime = latestTime;
 			}
 		}

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/CpuUtilizationHelper.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/CpuUtilizationHelper.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 2001, 2016 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,9 +22,9 @@
  *******************************************************************************/
 package com.ibm.lang.management.internal;
 
-import com.ibm.lang.management.CpuLoadCalculationConstants;
+import static com.ibm.lang.management.CpuLoadCalculationConstants.*;
 
-final class CpuUtilizationHelper implements CpuLoadCalculationConstants {
+final class CpuUtilizationHelper {
 
 	SysinfoCpuTime oldestTime = null;
 	SysinfoCpuTime interimTime = null;

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedGarbageCollectorMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedGarbageCollectorMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 package com.ibm.lang.management.internal;
 
 import javax.management.MBeanNotificationInfo;
-import javax.management.ObjectName;
 
 import com.ibm.java.lang.management.internal.GarbageCollectorMXBeanImpl;
 import com.ibm.lang.management.GarbageCollectorMXBean;
@@ -45,8 +44,8 @@ public final class ExtendedGarbageCollectorMXBeanImpl
 		extends GarbageCollectorMXBeanImpl
 		implements GarbageCollectorMXBean {
 
-	ExtendedGarbageCollectorMXBeanImpl(ObjectName objectName, String name, int id, ExtendedMemoryMXBeanImpl memBean) {
-		super(objectName, name, id, memBean);
+	ExtendedGarbageCollectorMXBeanImpl(String domainName, String name, int id, ExtendedMemoryMXBeanImpl memBean) {
+		super(domainName, name, id, memBean);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedGarbageCollectorMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedGarbageCollectorMXBeanImpl.java
@@ -44,7 +44,7 @@ import java.util.List;
 public final class ExtendedGarbageCollectorMXBeanImpl
 		extends GarbageCollectorMXBeanImpl
 		implements GarbageCollectorMXBean {
-	
+
 	ExtendedGarbageCollectorMXBeanImpl(ObjectName objectName, String name, int id, ExtendedMemoryMXBeanImpl memBean) {
 		super(objectName, name, id, memBean);
 	}
@@ -77,11 +77,10 @@ public final class ExtendedGarbageCollectorMXBeanImpl
 	 * @see #getLastGcInfo()
 	 */
 	private native GcInfo getLastGcInfoImpl(int id);
- 
+
 	static GcInfo buildGcInfo(long index, long startTime, long endTime,
 							long[] initialSize, long[] preUsed, long[] preCommitted, long[] preMax,
 							long[] postUsed, long[] postCommitted, long[] postMax) {
-
 		/* retrieve the names of MemoryPools*/
 		List<MemoryPoolMXBean> memoryPoolList = ManagementFactory.getMemoryPoolMXBeans();
 		String[] poolNames = new String[memoryPoolList.size()];
@@ -89,12 +88,13 @@ public final class ExtendedGarbageCollectorMXBeanImpl
 		for (MemoryPoolMXBean bean : memoryPoolList) {
 			poolNames[idx++] = bean.getName();
 		}
-		Map<String,MemoryUsage> usageBeforeGc = new HashMap<>(poolNames.length); 
-		Map<String,MemoryUsage> usageAfterGc = new HashMap<>(poolNames.length);
+		Map<String, MemoryUsage> usageBeforeGc = new HashMap<>(poolNames.length);
+		Map<String, MemoryUsage> usageAfterGc = new HashMap<>(poolNames.length);
 		for (int count = 0; count < poolNames.length; ++count) {
-			usageBeforeGc.put(poolNames[count], new MemoryUsage(initialSize[count], preUsed[count],  preCommitted[count],  preMax[count]));
+			usageBeforeGc.put(poolNames[count], new MemoryUsage(initialSize[count], preUsed[count], preCommitted[count], preMax[count]));
 			usageAfterGc.put(poolNames[count], new MemoryUsage(initialSize[count], postUsed[count], postCommitted[count], postMax[count]));
 		}
 		return GcInfoUtil.newGcInfoInstance(index, startTime, endTime, usageBeforeGc, usageAfterGc);
 	}
+
 }

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedMemoryMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedMemoryMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,10 @@ package com.ibm.lang.management.internal;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.management.ObjectName;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
 
 import com.ibm.java.lang.management.internal.MemoryMXBeanImpl;
 import com.ibm.lang.management.MemoryMXBean;
@@ -44,15 +46,41 @@ public final class ExtendedMemoryMXBeanImpl extends MemoryMXBeanImpl implements 
 		return instance;
 	}
 
-	private final MemoryNotificationThread notificationThread;
+	/*
+	 * This remembers whether the notification thread has been started:
+	 * There's no point in sending notifications before we have any listeners.
+	 */
+	private final AtomicBoolean notificationThreadStarted;
 
 	private ExtendedMemoryMXBeanImpl() {
 		super();
-		notificationThread = new MemoryNotificationThread(this);
-		notificationThread.setDaemon(true);
-		notificationThread.setName("MemoryMXBean notification dispatcher"); //$NON-NLS-1$
-		notificationThread.setPriority(Thread.NORM_PRIORITY + 1);
-		notificationThread.start();
+		notificationThreadStarted = new AtomicBoolean();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void addNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback)
+			throws IllegalArgumentException {
+		// Start the notification thread when we have our first listener.
+		startNotificationThread();
+		super.addNotificationListener(listener, filter, handback);
+	}
+
+	/**
+	 * Ensure the notification thread is running.
+	 */
+	@Override
+	protected void startNotificationThread() {
+		if (!notificationThreadStarted.getAndSet(true)) {
+			Thread notifier = new MemoryNotificationThread(this);
+
+			notifier.setDaemon(true);
+			notifier.setName("MemoryMXBean notification dispatcher"); //$NON-NLS-1$
+			notifier.setPriority(Thread.NORM_PRIORITY + 1);
+			notifier.start();
+		}
 	}
 
 	/**
@@ -82,8 +110,8 @@ public final class ExtendedMemoryMXBeanImpl extends MemoryMXBeanImpl implements 
 	 * {@inheritDoc}
 	 */
 	@Override
-	protected GarbageCollectorMXBean makeGCBean(ObjectName objName, String name, int internalID) {
-		return new ExtendedGarbageCollectorMXBeanImpl(objName, name, internalID, this);
+	protected GarbageCollectorMXBean makeGCBean(String domainName, String name, int internalID) {
+		return new ExtendedGarbageCollectorMXBeanImpl(domainName, name, internalID, this);
 	}
 
 	/**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedMemoryMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedMemoryMXBeanImpl.java
@@ -49,14 +49,14 @@ public final class ExtendedMemoryMXBeanImpl extends MemoryMXBeanImpl implements 
 	private ExtendedMemoryMXBeanImpl() {
 		super();
 		notificationThread = new MemoryNotificationThread(this);
-    	notificationThread.setDaemon(true);
-    	notificationThread.setName("MemoryMXBean notification dispatcher"); //$NON-NLS-1$
+		notificationThread.setDaemon(true);
+		notificationThread.setName("MemoryMXBean notification dispatcher"); //$NON-NLS-1$
 		notificationThread.setPriority(Thread.NORM_PRIORITY + 1);
 		notificationThread.start();
 	}
 
 	/**
-	 * Deprecated.  Use getTotalPhysicalMemorySize().
+	 * Deprecated. Use getTotalPhysicalMemorySize().
 	 */
 	/*[IF Sidecar19-SE]
 	@Deprecated(forRemoval = true, since = "1.8")

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
@@ -38,7 +38,7 @@ import com.ibm.lang.management.TotalPhysicalMemoryNotificationInfo;
 
 /**
  * Runtime type for {@link com.ibm.lang.management.OperatingSystemMXBean}.
- * 
+ *
  * @author sonchakr, sridevi
  * @since 1.7.1
  */
@@ -49,7 +49,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	private static final ExtendedOperatingSystemMXBeanImpl instance = new ExtendedOperatingSystemMXBeanImpl();
 
 	/*
-	 * Maintain 3 distinct sampling points of timestamps and CPU times (in static fields). 
+	 * Maintain 3 distinct sampling points of timestamps and CPU times (in static fields).
 	 * They are used in the getProcessCpuLoad calculations.
 	 */
 	private static long oldTime = -1;
@@ -63,7 +63,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 
 	/**
 	 * Singleton accessor method.
-	 * 
+	 *
 	 * @return the {@link com.ibm.lang.management.internal.ExtendedOperatingSystemMXBeanImpl} singleton.
 	 */
 	public static ExtendedOperatingSystemMXBeanImpl getInstance() {
@@ -77,8 +77,8 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	/**
 	 * Used to identify emulated hardware (z/OS only)
 	 *
-	 * @param hwModel The hardware model number 
-	 * @return True if hwModel is in the list of hardware model numbers indicating 
+	 * @param hwModel The hardware model number
+	 * @return True if hwModel is in the list of hardware model numbers indicating
 	 * emulated hardware. False otherwise
 	 */
 	private static boolean isZosHardwareEmulated(String hwModel) {
@@ -106,7 +106,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	private HwEmulResult isHwEmulated = HwEmulResult.UNKNOWN;
 
 	/**
-	 * Protected  Constructor to prevent instantiation by others, but let subclasses use it.
+	 * Protected constructor to prevent instantiation by others, but let subclasses use it.
 	 */
 	ExtendedOperatingSystemMXBeanImpl() {
 		super();
@@ -129,13 +129,13 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	private native boolean isDLPAREnabled();
 
 	/**
-	 * Helper Function to validate the timing information in the two 
+	 * Helper Function to validate the timing information in the two
 	 * records and calculate the CPU utilization
 	 * per CPU over that interval.
-	 * @param	endTs Timestamp at the end of the interval.
-	 * @param	endCpuTime Cpu time consumed at the end of the interval.
-	 * @param	startTs Timestamp at the beginning of the interval.
-	 * @param	startCpuTime Cpu time sampled at the onset of the interval.
+	 * @param endTs Timestamp at the end of the interval.
+	 * @param endCpuTime Cpu time consumed at the end of the interval.
+	 * @param startTs Timestamp at the beginning of the interval.
+	 * @param startCpuTime Cpu time sampled at the onset of the interval.
 	 * @return number in [0.0, 1.0], or ERROR_VALUE in case of error
 	 */
 	private double calculateProcessCpuLoad(long endTs, long endCpuTime, long startTs, long startCpuTime) {
@@ -184,8 +184,8 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * Retrieve hardware model
 	 *
 	 * @return String containing the hardware model. NULL in case of an error.
-	 * @throws UnsupportedOperationException if the operation is not implemented on this platform. 
-	 * UnsupportedOperationException will also be thrown if the operation is implemented but it 
+	 * @throws UnsupportedOperationException if the operation is not implemented on this platform.
+	 * UnsupportedOperationException will also be thrown if the operation is implemented but it
 	 * cannot be performed because the system does not satisfy all the requirements, for example,
 	 * an OS service is not installed.
 	 */
@@ -198,8 +198,8 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * Retrieve hardware model
 	 *
 	 * @return String containing the hardware model. NULL in case of an error.
-	 * @throws UnsupportedOperationException if the operation is not implemented on this platform. 
-	 * UnsupportedOperationException will also be thrown if the operation is implemented but it 
+	 * @throws UnsupportedOperationException if the operation is not implemented on this platform.
+	 * UnsupportedOperationException will also be thrown if the operation is implemented but it
 	 * cannot be performed because the system does not satisfy all the requirements, for example,
 	 * an OS service is not installed.
 	 */
@@ -234,7 +234,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 			return CpuLoadCalculationConstants.ERROR_VALUE;
 		}
 
-		/* If a sufficiently long interval has elapsed since last sampling, calculate using 
+		/* If a sufficiently long interval has elapsed since last sampling, calculate using
 		 * the most recent value in the history.
 		 */
 		if ((latestTime - interimTime) >= CpuLoadCalculationConstants.MINIMUM_INTERVAL) {
@@ -256,18 +256,18 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 				interimTime = latestTime;
 				interimCpuTime = latestCpuTime;
 				/*
-				 * either the latest time or the interim time are bogus. 
-				 * Discard the interim value and try with the oldest value. 
+				 * either the latest time or the interim time are bogus.
+				 * Discard the interim value and try with the oldest value.
 				 */
 			}
 		}
 		if ((latestTime - oldTime) >= CpuLoadCalculationConstants.MINIMUM_INTERVAL) {
-			processCpuLoad = calculateProcessCpuLoad(latestTime, 
-					latestCpuTime, 
+			processCpuLoad = calculateProcessCpuLoad(latestTime,
+					latestCpuTime,
 					oldTime,
 					oldCpuTime);
 			if (processCpuLoad < 0) {
-				/* the stats look bogus.  Discard them */
+				/* the stats look bogus. Discard them */
 				oldTime = latestTime;
 				oldCpuTime = latestCpuTime;
 			}
@@ -304,7 +304,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * Returns total amount of time the process has been scheduled or
 	 * executed so far in both kernel and user modes. Returns -1 if the
 	 * value is unavailable on this platform or in the case of an error.
-	 * 
+	 *
 	 * @return process cpu ime in 1 ns units
 	 * @see #getProcessCpuTime()
 	 */
@@ -339,7 +339,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * Returns the amount of physical memory being used by the process
 	 * in bytes. Returns -1 if the value is unavailable on this platform
 	 * or in the case of an error.
-	 * 
+	 *
 	 * @return amount of physical memory being used by the process in bytes
 	 * @see #getProcessPrivateMemorySize()
 	 */
@@ -357,7 +357,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * Returns the amount of private memory used by the process in bytes.
 	 * Returns -1 if the value is unavailable on this platform or in the
 	 * case of an error.
-	 * 
+	 *
 	 * @return amount of private memory used by the process in bytes
 	 * @see #getProcessPrivateMemorySize()
 	 */
@@ -387,7 +387,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * Returns the amount of virtual memory used by the process in bytes,
 	 * including physical memory and swap space. Returns -1 if the value
 	 * is unavailable on this platform or in the case of an error.
-	 * 
+	 *
 	 * @return amount of virtual memory used by the process in bytes
 	 * @see #getCommittedVirtualMemorySize()
 	 */
@@ -462,7 +462,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 				if (isEmuTmp) {
 					isHwEmulated = HwEmulResult.YES;
 				} else {
-					isHwEmulated = HwEmulResult.NO; 
+					isHwEmulated = HwEmulResult.NO;
 				}
 			} else {
 				if (null == hwModel) {
@@ -533,7 +533,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 			throw new NullPointerException(com.ibm.oti.util.Msg.getString("K056B")); //$NON-NLS-1$
 		}
 
-		/* Check the array received for a NULL slot. If an unallocated slot is hit, throw 
+		/* Check the array received for a NULL slot. If an unallocated slot is hit, throw
 		 * a NullPointerException indicating this.
 		 */
 		for (ProcessorUsage p : procUsageArr) {
@@ -615,13 +615,13 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 
 	/**
 	 * Do lazy initialization of the precision value.
-	 * By default, precision is 1 ns.  The user can override this by -Dcom.ibm.lang.management.OperatingSystemMXBean.isCpuTime100ns=true
+	 * By default, precision is 1 ns. The user can override this by -Dcom.ibm.lang.management.OperatingSystemMXBean.isCpuTime100ns=true
 	 */
 	private final static class CpuTimePrecisionHolder {
 		static final int precision = getPrecision();
 		static final int NS_SCALE_FACTOR = 100;
 		static final int NO_SCALE_FACTOR = 1;
-		
+
 		private static int getPrecision() {
 			boolean is100ns = Boolean.getBoolean("com.ibm.lang.management.OperatingSystemMXBean.isCpuTime100ns"); //$NON-NLS-1$
 			int precisionVaue = is100ns ? NO_SCALE_FACTOR : NS_SCALE_FACTOR; /* if 1 ns resolution, scale the result up by 100 */

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -113,7 +113,7 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.addInterfaceIf(com.ibm.lang.management.MemoryPoolMXBean.class, true)
 			.addInterface(java.lang.management.MemoryPoolMXBean.class)
 			.register(allComponents);
-		
+
 		components = Collections.unmodifiableList(allComponents);
 	}
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -56,12 +56,12 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 		 */
 
 		// register OpenJ9 extensions of standard singleton beans
-		ComponentBuilder.create(ExtendedMemoryMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.MEMORY_MXBEAN_NAME, ExtendedMemoryMXBeanImpl.getInstance())
 			.addInterface(com.ibm.lang.management.MemoryMXBean.class)
 			.addInterface(java.lang.management.MemoryMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(ExtendedOperatingSystemMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, ExtendedOperatingSystemMXBeanImpl.getInstance())
 			.addInterface(com.ibm.lang.management.OperatingSystemMXBean.class)
 			.addInterface(com.sun.management.OperatingSystemMXBean.class)
 			.addInterface(java.lang.management.OperatingSystemMXBean.class)
@@ -69,26 +69,26 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.addInterfaceIf(com.sun.management.UnixOperatingSystemMXBean.class, ManagementUtils.isRunningOnUnix())
 			.register(allComponents);
 
-		ComponentBuilder.create(ExtendedRuntimeMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.RUNTIME_MXBEAN_NAME, ExtendedRuntimeMXBeanImpl.getInstance())
 			.addInterface(com.ibm.lang.management.RuntimeMXBean.class)
 			.addInterface(java.lang.management.RuntimeMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(ExtendedThreadMXBeanImpl.getInstance())
+		ComponentBuilder.create(ManagementFactory.THREAD_MXBEAN_NAME, ExtendedThreadMXBeanImpl.getInstance())
 			.addInterface(com.ibm.lang.management.ThreadMXBean.class)
 			.addInterface(java.lang.management.ThreadMXBean.class)
 			.register(allComponents);
 
 		// register OpenJ9-specific singleton beans
-		ComponentBuilder.create(GuestOS.getInstance())
+		ComponentBuilder.create("com.ibm.virtualization.management:type=GuestOS", GuestOS.getInstance()) //$NON-NLS-1$
 			.addInterface(com.ibm.virtualization.management.GuestOSMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(HypervisorMXBeanImpl.getInstance())
+		ComponentBuilder.create("com.ibm.virtualization.management:type=Hypervisor", HypervisorMXBeanImpl.getInstance()) //$NON-NLS-1$
 			.addInterface(com.ibm.virtualization.management.HypervisorMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(JvmCpuMonitor.getInstance())
+		ComponentBuilder.create("com.ibm.lang.management:type=JvmCpuMonitor", JvmCpuMonitor.getInstance()) //$NON-NLS-1$
 			.addInterface(JvmCpuMonitorMXBean.class)
 			.register(allComponents);
 
@@ -96,23 +96,44 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 		 * available exclude this component.
 		 */
 		if (ModuleLayer.boot().findModule("openj9.jvm").isPresent()) { //$NON-NLS-1$
-			ComponentBuilder.create(OpenJ9DiagnosticsMXBeanImpl.getInstance())
+			ComponentBuilder.create("openj9.lang.management:type=OpenJ9Diagnostics", OpenJ9DiagnosticsMXBeanImpl.getInstance()) //$NON-NLS-1$
 				.addInterface(OpenJ9DiagnosticsMXBean.class)
 				.register(allComponents);
 		}
 
 		// register beans with zero or more instances
-		ComponentBuilder.create(ManagementFactory.GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE, ExtendedMemoryMXBeanImpl.getInstance().getGarbageCollectorMXBeans())
-			.addInterfaceIf(com.ibm.lang.management.GarbageCollectorMXBean.class, true)
-			.addInterfaceIf(com.sun.management.GarbageCollectorMXBean.class, true)
-			.addInterface(java.lang.management.GarbageCollectorMXBean.class)
-			.addInterface(java.lang.management.MemoryManagerMXBean.class)
-			.register(allComponents);
 
-		ComponentBuilder.create(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, ExtendedMemoryMXBeanImpl.getInstance().getMemoryPoolMXBeans(false))
-			.addInterfaceIf(com.ibm.lang.management.MemoryPoolMXBean.class, true)
-			.addInterface(java.lang.management.MemoryPoolMXBean.class)
-			.register(allComponents);
+		{
+			List<java.lang.management.GarbageCollectorMXBean> beans = ExtendedMemoryMXBeanImpl.getInstance().getGarbageCollectorMXBeans();
+			int beanCount = beans.size();
+			List<String> names = new ArrayList<>(beanCount);
+
+			for (java.lang.management.GarbageCollectorMXBean bean : beans) {
+				names.add(bean.getName());
+			}
+
+			ComponentBuilder.create(ManagementFactory.GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE, names, beans)
+				.addInterfaceIf(com.ibm.lang.management.GarbageCollectorMXBean.class, true)
+				.addInterfaceIf(com.sun.management.GarbageCollectorMXBean.class, true)
+				.addInterface(java.lang.management.GarbageCollectorMXBean.class)
+				.addInterface(java.lang.management.MemoryManagerMXBean.class)
+				.register(allComponents);
+		}
+
+		{
+			List<java.lang.management.MemoryPoolMXBean> beans = ExtendedMemoryMXBeanImpl.getInstance().getMemoryPoolMXBeans(false);
+			int beanCount = beans.size();
+			List<String> names = new ArrayList<>(beanCount);
+
+			for (java.lang.management.MemoryPoolMXBean bean : beans) {
+				names.add(bean.getName());
+			}
+
+			ComponentBuilder.create(ManagementFactory.MEMORY_POOL_MXBEAN_DOMAIN_TYPE, names, beans)
+				.addInterfaceIf(com.ibm.lang.management.MemoryPoolMXBean.class, true)
+				.addInterface(java.lang.management.MemoryPoolMXBean.class)
+				.register(allComponents);
+		}
 
 		components = Collections.unmodifiableList(allComponents);
 	}

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
@@ -47,6 +47,7 @@ import openj9.lang.management.ConfigurationUnavailableException;
  * </p>
  */
 public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBean {
+
 	private final static OpenJ9DiagnosticsMXBeanImpl instance;
 
 /*[IF Sidecar19-SE]*/
@@ -75,7 +76,6 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 					Class.forName(openj9_jvm, "com.ibm.jvm.InvalidDumpOptionException"), //$NON-NLS-1$
 					Class.forName(openj9_jvm, "com.ibm.jvm.DumpConfigurationUnavailableException"), //$NON-NLS-1$
 				});
-
 
 			Class<?> dumpClass = classes[0];
 			invalidDumpOptionExClass = classes[1];
@@ -106,11 +106,11 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 	public void resetDumpOptions() throws ConfigurationUnavailableException {
 		checkManagementSecurityPermission();
 		try {
-/*[IF Sidecar19-SE]*/
+			/*[IF Sidecar19-SE]*/
 			dump_resetDumpOptions.invoke(null);
-/*[ELSE]
+			/*[ELSE]
 			Dump.resetDumpOptions();
-/*[ENDIF]*/
+			/*[ENDIF]*/
 		} catch (Exception e) {
 			handleDumpConfigurationUnavailableException(e);
 			throw handleError(e);
@@ -124,11 +124,11 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 	public void setDumpOptions(String dumpOptions) throws InvalidOptionException, ConfigurationUnavailableException {
 		checkManagementSecurityPermission();
 		try {
-/*[IF Sidecar19-SE]*/
+			/*[IF Sidecar19-SE]*/
 			dump_setDumpOptions.invoke(null, dumpOptions);
-/*[ELSE]
+			/*[ELSE]
 			Dump.setDumpOptions(dumpOptions);
-/*[ENDIF]*/
+			/*[ENDIF]*/
 		} catch (Exception e) {
 			handleInvalidDumpOptionException(e);
 			handleDumpConfigurationUnavailableException(e);
@@ -143,7 +143,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 	public void triggerDump(String dumpAgent) throws IllegalArgumentException {
 		checkManagementSecurityPermission();
 		switch (dumpAgent) {
-/*[IF Sidecar19-SE]*/
+		/*[IF Sidecar19-SE]*/
 		case "java": //$NON-NLS-1$
 			try {
 				dump_JavaDump.invoke(null);
@@ -172,7 +172,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 				throw handleError(e);
 			}
 			break;
-/*[ELSE]
+		/*[ELSE]
 		case "java": //$NON-NLS-1$
 			Dump.JavaDump();
 			break;
@@ -185,13 +185,12 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 		case "snap": //$NON-NLS-1$
 			Dump.SnapDump();
 			break;
-/*[ENDIF]*/
+		/*[ENDIF]*/
 		default:
 			/*[MSG "K0663", "Invalid or Unsupported Dump Agent cannot be triggered"]*/
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0663")); //$NON-NLS-1$
 		}
 	}
-
 
 	/**
 	 * {@inheritDoc}
@@ -201,10 +200,10 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 		String fileName = null;
 		checkManagementSecurityPermission();
 		switch (dumpAgent) {
-/*[IF Sidecar19-SE]*/
+		/*[IF Sidecar19-SE]*/
 		case "java": //$NON-NLS-1$
 			try {
-				fileName = (String)dump_javaDumpToFile.invoke(null, fileNamePattern);
+				fileName = (String) dump_javaDumpToFile.invoke(null, fileNamePattern);
 			} catch (Exception e) {
 				handleInvalidDumpOptionException(e);
 				throw handleError(e);
@@ -212,7 +211,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 			break;
 		case "heap": //$NON-NLS-1$
 			try {
-				fileName = (String)dump_heapDumpToFile.invoke(null, fileNamePattern);
+				fileName = (String) dump_heapDumpToFile.invoke(null, fileNamePattern);
 			} catch (Exception e) {
 				handleInvalidDumpOptionException(e);
 				throw handleError(e);
@@ -220,7 +219,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 			break;
 		case "system": //$NON-NLS-1$
 			try {
-				fileName = (String)dump_systemDumpToFile.invoke(null, fileNamePattern);
+				fileName = (String) dump_systemDumpToFile.invoke(null, fileNamePattern);
 			} catch (Exception e) {
 				handleInvalidDumpOptionException(e);
 				throw handleError(e);
@@ -228,13 +227,13 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 			break;
 		case "snap": //$NON-NLS-1$
 			try {
-				fileName = (String)dump_snapDumpToFile.invoke(null, fileNamePattern);
+				fileName = (String) dump_snapDumpToFile.invoke(null, fileNamePattern);
 			} catch (Exception e) {
 				handleInvalidDumpOptionException(e);
 				throw handleError(e);
 			}
 			break;
-/*[ELSE]
+		/*[ELSE]
 		case "java": //$NON-NLS-1$
 			try {
 				fileName = Dump.javaDumpToFile(fileNamePattern);
@@ -267,14 +266,13 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 				throw handleError(e);
 			}
 			break;
-/*[ENDIF]*/
+		/*[ENDIF]*/
 		default:
 			/*[MSG "K0663", "Invalid or Unsupported Dump Agent cannot be triggered"]*/
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0663")); //$NON-NLS-1$
 		}
 		return fileName;
 	}
-
 
 	/**
 	 * {@inheritDoc}
@@ -284,14 +282,13 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 		String dumpOptions = "heap:opts=CLASSIC"; //$NON-NLS-1$
 		checkManagementSecurityPermission();
 		try {
-/*[IF Sidecar19-SE]*/
-			String fileName = (String)dump_triggerDump.invoke(null, dumpOptions);
-/*[ELSE]
+			/*[IF Sidecar19-SE]*/
+			String fileName = (String) dump_triggerDump.invoke(null, dumpOptions);
+			/*[ELSE]
 			String fileName = Dump.triggerDump(dumpOptions);
-/*[ENDIF]*/
+			/*[ENDIF]*/
 			return fileName;
 		} catch (Exception e) {
-
 			handleInvalidDumpOptionException(e);
 			throw handleError(e);
 		}
@@ -300,7 +297,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 	private static void checkManagementSecurityPermission() {
 		/* Check the caller has Management Permission. */
 		SecurityManager manager = System.getSecurityManager();
-		if( manager != null ) {
+		if (manager != null) {
 			manager.checkPermission(ManagementPermissionHelper.MPCONTROL);
 		}
 	}
@@ -329,46 +326,45 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 	@Override
 	public ObjectName getObjectName() {
 		try {
-			ObjectName name = new ObjectName("openj9.lang.management:type=OpenJ9Diagnostics");  //$NON-NLS-1$
+			ObjectName name = new ObjectName("openj9.lang.management:type=OpenJ9Diagnostics"); //$NON-NLS-1$
 			return name;
 		} catch (MalformedObjectNameException e) {
 			return null;
 		}
 	}
 
-
 	/* Handle error thrown by method invoke as internal error */
 	private static InternalError handleError(Exception cause) {
-/*[IF Sidecar19-SE]*/
+		/*[IF Sidecar19-SE]*/
 		handleInvocationTargetException(cause);
-/*[ENDIF]*/
+		/*[ENDIF]*/
 		InternalError err = new InternalError(cause.toString());
 		err.initCause(cause);
 		throw err;
 	}
 
 	private static void handleInvalidDumpOptionException(Exception cause) throws InvalidOptionException {
-/*[IF Sidecar19-SE]*/
+		/*[IF Sidecar19-SE]*/
 		if (invalidDumpOptionExClass.isInstance(cause.getCause())) {
 			throw new InvalidOptionException("Error in dump options specified", cause.getCause());
 		}
-/*[ELSE]
+		/*[ELSE]
 		if (cause instanceof InvalidDumpOptionException) {
 			throw new InvalidOptionException("Error in dump options specified", cause);
 		}
-/*[ENDIF]*/
+		/*[ENDIF]*/
 	}
 
 	private static void handleDumpConfigurationUnavailableException(Exception cause) throws ConfigurationUnavailableException {
-/*[IF Sidecar19-SE]*/
+		/*[IF Sidecar19-SE]*/
 		if (dumpConfigurationUnavailableExClass.isInstance(cause.getCause())) {
-			throw new ConfigurationUnavailableException("Dump configuration cannot be changed while a dump is in progress", cause.getCause());
+			throw new ConfigurationUnavailableException("Dump configuration cannot be changed while a dump is in progress", cause.getCause()); //$NON-NLS-1$
 		}
-/*[ELSE]
+		/*[ELSE]
 		if (cause instanceof DumpConfigurationUnavailableException) {
 			throw new ConfigurationUnavailableException("Dump configuration cannot be changed while a dump is in progress", cause);
 		}
-/*[ENDIF]*/
+		/*[ENDIF]*/
 	}
 
 	/* invoke throws InvocationTargetException if the method it is invoking
@@ -387,5 +383,5 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 		}
 	}
 /*[ENDIF]*/
-}
 
+}


### PR DESCRIPTION
* provide object names (as strings) to `ComponentBuilder.create()`
* defer creation of `ObjectName` objects
* refactor notifications through `LazyDelegatingNotifier`
* remove useless class `ComponentBuilder.Missing`
* defer loading of the `SharedClassProvider`
* replace lambdas with anonymous classes
* don't force loading `CpuLoadCalculationConstants` unnecessarily
* don't start `MemoryNotificationThread` prematurely
* use `Objects.requireNonNull()` where appropriate
* don't pre-allocate a MemoryUsage instance in `ExtendedOperatingSystemMXBeanImpl`

Fixes #5373