### PR TITLE
CMake: Add missing ppc code gen source files

### DIFF
--- a/runtime/compiler/p/codegen/CMakeLists.txt
+++ b/runtime/compiler/p/codegen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,22 +21,24 @@
 ################################################################################
 
 j9jit_files(
-	p/codegen/J9UnresolvedDataSnippet.cpp
-	p/codegen/J9CodeGenerator.cpp
-	p/codegen/J9TreeEvaluator.cpp
-	p/codegen/GenerateInstructions.cpp
-	p/codegen/J9PPCSnippet.cpp
-	p/codegen/J9AheadOfTimeCompile.cpp
-	p/codegen/PPCPrivateLinkage.cpp
-	p/codegen/PPCJNILinkage.cpp
-	p/codegen/InterfaceCastSnippet.cpp
 	p/codegen/CallSnippet.cpp
-	p/codegen/StackCheckFailureSnippet.cpp
 	p/codegen/DFPTreeEvaluator.cpp
-	p/codegen/J9PPCInstruction.cpp
 	p/codegen/ForceRecompilationSnippet.cpp
+	p/codegen/GenerateInstructions.cpp
+	p/codegen/InterfaceCastSnippet.cpp
+	p/codegen/J9AheadOfTimeCompile.cpp
+	p/codegen/J9CodeGenerator.cpp
+	p/codegen/J9PPCInstruction.cpp
+	p/codegen/J9PPCSnippet.cpp
+	p/codegen/J9PPCWatchedInstanceFieldSnippet.cpp
+	p/codegen/J9PPCWatchedStaticFieldSnippet.cpp
+	p/codegen/J9TreeEvaluator.cpp
+	p/codegen/J9UnresolvedDataSnippet.cpp
+	p/codegen/PPCJNILinkage.cpp
+	p/codegen/PPCPrivateLinkage.cpp
 	p/codegen/PPCRecompilation.cpp
 	p/codegen/PPCRecompilationSnippet.cpp
+	p/codegen/StackCheckFailureSnippet.cpp
 	p/codegen/Trampoline.cpp
 	${omr_SOURCE_DIR}/compiler/p/env/OMRDebugEnv.cpp
 )


### PR DESCRIPTION
9PPCWatchedInstanceFieldSnippet and J9PPCWatchedStaticFieldSnippet were
missing from the CMakeLists. Also sorted the source list

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>