### PR TITLE
Fix String.indexOf corner case where start == Integer.MAX_VALUE - 1

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -568,32 +568,31 @@ public final class JITHelpers {
 	}
 
 	/**
-	 * Searches in the source character array for the index of the target character array.
-	 * Both arrays must be Latin1 arrays consisting of compressible characters ranging from \u0000 to \u00FF.
-	 * The source and target character arrays have their lengths specified. The search for the array starts
-	 * at the specified offset and moves towards the end of source array.
+	 * Returns the first index of the target character array within the source character array starting from the specified
+	 * offset.
+	 *
+	 * <p>This API implicitly assumes the following:
+	 * <blockquote><pre>
+	 *     - s1Value != null
+	 *     - s2Value != null
+	 *     - 0 <= s1len <= s1Value.length * 2
+	 *     - 1 <= s2len <= s2Value.length * 2
+	 *     - 0 <= start < s1len
+	 * <blockquote><pre>
 	 * 
-	 * @param s1Value
-	 * 		 	the source character array to search in
-	 * @param s1len
-	 * 		    the length of the source array
-	 * @param s2Value
-	 * 			the target character array to search for
-	 * @param s2len
-	 * 			the length of the target array
-	 * @param start
-	 * 			the starting offset
-	 * 
-	 * @return the index of the target array inside the source array, or -1 if the target array is not found
-	 * */
+	 * @param s1Value the source character array to search in.
+	 * @param s1len   the length (in number of characters) of the source array.
+	 * @param s2Value the target character array to search for.
+	 * @param s2len   the length (in number of characters) of the target array.
+	 * @param start   the starting offset (in number of characters) to search from.
+	 * @return        the index (in number of characters) of the target array within the source array, or -1 if the
+	 *                target array is not found within the source array.
+	 */
 	public int intrinsicIndexOfStringLatin1(char[] s1Value, int s1len, char[] s2Value, int s2len, int start) {
 		char firstChar = byteToCharUnsigned(getByteFromArrayByIndex(s2Value, 0));
 
 		while (true) {
-			int i = -1;
-			if (start < s1len) {
-				i = intrinsicIndexOfLatin1(s1Value, (byte)firstChar, start, s1len);
-			}
+			int i = intrinsicIndexOfLatin1(s1Value, (byte)firstChar, start, s1len);
 						
 			// Handles subCount > count || start >= count
 			if (i == -1 || s2len + i > s1len) {
@@ -615,24 +614,26 @@ public final class JITHelpers {
 	}
 	
 	/**
-	 * Searches in the source character array for the index of the target character array.
-	 * Both arrays consisting of UTF16 characters.
-	 * The source and target character arrays have their lengths specified. The search for the array starts
-	 * at the specified offset and moves towards the end of source array.
+	 * Returns the first index of the target character array within the source character array starting from the specified
+	 * offset.
+	 *
+	 * <p>This API implicitly assumes the following:
+	 * <blockquote><pre>
+	 *     - s1Value != null
+	 *     - s2Value != null
+	 *     - 0 <= s1len <= s1Value.length
+	 *     - 1 <= s2len <= s2Value.length
+	 *     - 0 <= start < s1len
+	 * <blockquote><pre>
 	 * 
-	 * @param s1Value
-	 * 		 	the source character array to search in
-	 * @param s1len
-	 * 		    the length of the source array
-	 * @param s2Value
-	 * 			the target character array to search for
-	 * @param s2len
-	 * 			the length of the target array
-	 * @param start
-	 * 			the starting offset
-	 * 
-	 * @return the index of the target array inside the source array, or -1 if the target array is not found
-	 * */
+	 * @param s1Value the source character array to search in.
+	 * @param s1len   the length (in number of characters) of the source array.
+	 * @param s2Value the target character array to search for.
+	 * @param s2len   the length (in number of characters) of the target array.
+	 * @param start   the starting offset (in number of characters) to search from.
+	 * @return        the index (in number of characters) of the target array within the source array, or -1 if the
+	 *                target array is not found within the source array.
+	 */
 	public int intrinsicIndexOfStringUTF16(char[] s1Value, int s1len, char[] s2Value, int s2len, int start) {
 		char firstChar = s2Value[0];
 
@@ -640,7 +641,7 @@ public final class JITHelpers {
 			int i = intrinsicIndexOfUTF16(s1Value, firstChar, start, s1len);
 			
 			// Handles subCount > count || start >= count
-			if ((i == -1) || (s2len + i > s1len)) {
+			if (i == -1 || s2len + i > s1len) {
 				return -1;
 			}
 
@@ -657,19 +658,53 @@ public final class JITHelpers {
 			start = i + 1;
 		}
 	}
-	
+
+	/**
+	 * Returns the first index of the character within the source character array starting from the specified offset.
+	 *
+	 * <p>This API implicitly assumes the following:
+	 * <blockquote><pre>
+	 *     - array != null
+	 *     - 0 <= offset < length <= array.length * 1 (if array instanceof byte[])
+	 *     - 0 <= offset < length <= array.length * 2 (if array instanceof char[])
+	 * <blockquote><pre>
+	 * 
+	 * @param array  the source character array to search in.
+	 * @param ch     the character to search for.
+	 * @param offset the starting offset (in number of characters) to search from.
+	 * @param length the length (in number of characters) of the source array.
+	 * @return       the index (in number of characters) of \p ch within the source array, or -1 if \p ch is not found
+	 *               within the source array.
+	 */
 	public int intrinsicIndexOfLatin1(Object array, byte ch, int offset, int length) {
 		for (int i = offset; i < length; i++) {
-			if(getByteFromArrayByIndex(array, i) == ch) {
+			if (getByteFromArrayByIndex(array, i) == ch) {
 				return i;
 			}
 		}
 		return -1;
 	}
 
+	/**
+	 * Returns the first index of the character within the source character array starting from the specified offset.
+	 *
+	 * <p>This API implicitly assumes the following:
+	 * <blockquote><pre>
+	 *     - array != null
+	 *     - 0 <= offset < length <= array.length * 1 (if array instanceof byte[])
+	 *     - 0 <= offset < length <= array.length * 2 (if array instanceof char[])
+	 * <blockquote><pre>
+	 * 
+	 * @param array  the source character array to search in.
+	 * @param ch     the character to search for.
+	 * @param offset the starting offset (in number of characters) to search from.
+	 * @param length the length (in number of characters) of the source array.
+	 * @return       the index (in number of characters) of \p ch within the source array, or -1 if \p ch is not found
+	 *               within the source array.
+	 */
 	public int intrinsicIndexOfUTF16(Object array, char ch, int offset, int length) {
 		for (int i = offset; i < length; i++) {
-			if(getCharFromArrayByIndex(array, i) == ch) {
+			if (getCharFromArrayByIndex(array, i) == ch) {
 				return i;
 			}
 		}

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -6020,7 +6020,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int s2len = s2.lengthInternal();
 
 		if (s2len > 0) {
-			if (s2len + start > s1len) {
+			if (start > s1len - s2len) {
 				return -1;
 			}
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12323,15 +12323,15 @@ static TR::Register *inlineEncodeUTF16(TR::Node *node, TR::CodeGenerator *cg)
    return outputLenReg;
    }
 
-static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::CodeGenerator *cg)
+static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *cg, bool isLatin1)
    {
    auto vectorCompareOp = isLatin1 ? TR::InstOpCode::vcmpeubr : TR::InstOpCode::vcmpeuhr;
    auto scalarLoadOp = isLatin1 ? TR::InstOpCode::lbzx : TR::InstOpCode::lhzx;
 
-   TR::Register *arrObjectAddress = cg->evaluate(node->getChild(1));
-   TR::Register *targetScalar = cg->evaluate(node->getChild(2));
-   TR::Register *startIndex = cg->evaluate(node->getChild(3));
-   TR::Register *endIndex = cg->evaluate(node->getChild(4));
+   TR::Register *array = cg->evaluate(node->getChild(1));
+   TR::Register *ch = cg->evaluate(node->getChild(2));
+   TR::Register *offset = cg->evaluate(node->getChild(3));
+   TR::Register *length = cg->evaluate(node->getChild(4));
 
    TR::Register *cr0 = cg->allocateRegister(TR_CCR);
    TR::Register *cr6 = cg->allocateRegister(TR_CCR);
@@ -12364,13 +12364,13 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
    generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
 
    // Special case for empty strings, which always return -1
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cr0, startIndex, endIndex);
+   generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cr0, offset, length);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, notFoundLabel, cr0);
 
    // IMPORTANT: The upper 32 bits of a 64-bit register containing an int are undefined. Since the
    // indices are being passed in as ints, we must ensure that their upper 32 bits are not garbage.
-   generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, result, startIndex);
-   generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, endAddress, endIndex);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, result, offset);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, endAddress, length);
 
    if (!isLatin1)
       {
@@ -12379,13 +12379,13 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
       }
 
    if (node->getChild(3)->getReferenceCount() == 1)
-      srm->donateScratchRegister(startIndex);
+      srm->donateScratchRegister(offset);
    if (node->getChild(4)->getReferenceCount() == 1)
-      srm->donateScratchRegister(endIndex);
+      srm->donateScratchRegister(length);
 
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, arrAddress, arrObjectAddress, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, arrAddress, array, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
    if (node->getChild(1)->getReferenceCount() == 1)
-      srm->donateScratchRegister(arrObjectAddress);
+      srm->donateScratchRegister(array);
 
    // Handle the first character using a simple scalar compare. Otherwise, first character matches
    // would be slower than the old scalar comparison loop. This is a problem since first character
@@ -12397,7 +12397,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
 
       // Since we're going to do a load followed immediately by a comparison, we need to ensure that
       // the target scalar is zero-extended and *not* sign-extended.
-      generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, zxTargetScalar, targetScalar, 0, isLatin1 ? 0xff : 0xffff);
+      generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, zxTargetScalar, ch, 0, isLatin1 ? 0xff : 0xffff);
 
       generateTrg1MemInstruction(cg, scalarLoadOp, node, value, new (cg->trHeapMemory()) TR::MemoryReference(result, arrAddress, isLatin1 ? 1 : 2, cg));
       generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cr0, value, zxTargetScalar);
@@ -12419,9 +12419,9 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
 
    // Splat the value to be compared against and its bitwise complement into two vector registers
    // for later use
-   generateTrg1Src1Instruction(cg, TR::InstOpCode::mtvsrwz, node, targetVector, targetScalar);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::mtvsrwz, node, targetVector, ch);
    if (node->getChild(2)->getReferenceCount() == 1)
-      srm->donateScratchRegister(targetScalar);
+      srm->donateScratchRegister(ch);
    if (isLatin1)
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::vspltb, node, targetVector, targetVector, 7);
    else
@@ -12629,52 +12629,50 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
    if (!isLatin1)
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::srawi, node, result, result, 1);
 
+   TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 15 + srm->numAvailableRegisters(), cg->trMemory());
+
+   if (node->getChild(1)->getReferenceCount() != 1)
       {
-      TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 15 + srm->numAvailableRegisters(), cg->trMemory());
-
-      if (node->getChild(1)->getReferenceCount() != 1)
-         {
-         deps->addPostCondition(arrObjectAddress, TR::RealRegister::NoReg);
-         deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
-         }
-      if (node->getChild(2)->getReferenceCount() != 1)
-         deps->addPostCondition(targetScalar, TR::RealRegister::NoReg);
-      if (node->getChild(3)->getReferenceCount() != 1)
-         deps->addPostCondition(startIndex, TR::RealRegister::NoReg);
-      if (node->getChild(4)->getReferenceCount() != 1)
-         deps->addPostCondition(endIndex, TR::RealRegister::NoReg);
-
-      deps->addPostCondition(cr0, TR::RealRegister::cr0);
-      deps->addPostCondition(cr6, TR::RealRegister::cr6);
-
-      deps->addPostCondition(zeroRegister, TR::RealRegister::NoReg);
+      deps->addPostCondition(array, TR::RealRegister::NoReg);
       deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
-      deps->addPostCondition(result, TR::RealRegister::NoReg);
-      deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
-      deps->addPostCondition(arrAddress, TR::RealRegister::NoReg);
-      deps->addPostCondition(currentAddress, TR::RealRegister::NoReg);
-      deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
-      deps->addPostCondition(endAddress, TR::RealRegister::NoReg);
-
-      deps->addPostCondition(targetVector, TR::RealRegister::NoReg);
-      deps->addPostCondition(targetVectorNot, TR::RealRegister::NoReg);
-      deps->addPostCondition(searchVector, TR::RealRegister::NoReg);
-      deps->addPostCondition(permuteVector, TR::RealRegister::NoReg);
-
-      srm->addScratchRegistersToDependencyList(deps, true);
-
-      generateDepLabelInstruction(cg, TR::InstOpCode::label, node, endLabel, deps);
-
-      deps->stopUsingDepRegs(cg, result);
-
-      node->setRegister(result);
-
-      cg->decReferenceCount(node->getChild(0));
-      cg->decReferenceCount(node->getChild(1));
-      cg->decReferenceCount(node->getChild(2));
-      cg->decReferenceCount(node->getChild(3));
-      cg->decReferenceCount(node->getChild(4));
       }
+   if (node->getChild(2)->getReferenceCount() != 1)
+      deps->addPostCondition(ch, TR::RealRegister::NoReg);
+   if (node->getChild(3)->getReferenceCount() != 1)
+      deps->addPostCondition(offset, TR::RealRegister::NoReg);
+   if (node->getChild(4)->getReferenceCount() != 1)
+      deps->addPostCondition(length, TR::RealRegister::NoReg);
+
+   deps->addPostCondition(cr0, TR::RealRegister::cr0);
+   deps->addPostCondition(cr6, TR::RealRegister::cr6);
+
+   deps->addPostCondition(zeroRegister, TR::RealRegister::NoReg);
+   deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
+   deps->addPostCondition(result, TR::RealRegister::NoReg);
+   deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
+   deps->addPostCondition(arrAddress, TR::RealRegister::NoReg);
+   deps->addPostCondition(currentAddress, TR::RealRegister::NoReg);
+   deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
+   deps->addPostCondition(endAddress, TR::RealRegister::NoReg);
+
+   deps->addPostCondition(targetVector, TR::RealRegister::NoReg);
+   deps->addPostCondition(targetVectorNot, TR::RealRegister::NoReg);
+   deps->addPostCondition(searchVector, TR::RealRegister::NoReg);
+   deps->addPostCondition(permuteVector, TR::RealRegister::NoReg);
+
+   srm->addScratchRegistersToDependencyList(deps, true);
+
+   generateDepLabelInstruction(cg, TR::InstOpCode::label, node, endLabel, deps);
+
+   deps->stopUsingDepRegs(cg, result);
+
+   node->setRegister(result);
+
+   cg->decReferenceCount(node->getChild(0));
+   cg->decReferenceCount(node->getChild(1));
+   cg->decReferenceCount(node->getChild(2));
+   cg->decReferenceCount(node->getChild(3));
+   cg->decReferenceCount(node->getChild(4));
 
    return result;
    }
@@ -13582,7 +13580,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
          if (cg->getSupportsInlineStringIndexOf())
             {
-            resultReg = inlineIntrinsicIndexOf(node, true, cg);
+            resultReg = inlineIntrinsicIndexOf(node, cg, true);
             return true;
             }
          break;
@@ -13590,7 +13588,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
          if (cg->getSupportsInlineStringIndexOf())
             {
-            resultReg = inlineIntrinsicIndexOf(node, false, cg);
+            resultReg = inlineIntrinsicIndexOf(node, cg, false);
             return true;
             }
          break;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9328,15 +9328,15 @@ TR::Register *intOrLongClobberEvaluate(
  * \param node
  *   The tree node
  *
- * \param isLatin1
- *   True when the string is Latin1, False when the string is UTF16
- *
  * \param cg
  *   The Code Generator
  *
+ * \param isLatin1
+ *   True when the string is Latin1, False when the string is UTF16
+ *
  * Note that this version does not support discontiguous arrays
  */
-static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, bool isLatin1, TR::CodeGenerator* cg)
+static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isLatin1)
    {
    static uint8_t MASKOFSIZEONE[] =
       {
@@ -9370,10 +9370,10 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, bool isLatin1, TR::C
       shift = 1;
       }
 
-   auto address = cg->evaluate(node->getChild(1));
-   auto value = cg->evaluate(node->getChild(2));
+   auto array = cg->evaluate(node->getChild(1));
+   auto ch = cg->evaluate(node->getChild(2));
    auto offset = cg->evaluate(node->getChild(3));
-   auto size = cg->evaluate(node->getChild(4));
+   auto length = cg->evaluate(node->getChild(4));
 
    auto ECX = cg->allocateRegister();
    auto result = cg->allocateRegister();
@@ -9383,15 +9383,15 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, bool isLatin1, TR::C
 
    auto dependencies = generateRegisterDependencyConditions((uint8_t)7, (uint8_t)7, cg);
    dependencies->addPreCondition(ECX, TR::RealRegister::ecx, cg);
-   dependencies->addPreCondition(address, TR::RealRegister::NoReg, cg);
-   dependencies->addPreCondition(size, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(array, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(length, TR::RealRegister::NoReg, cg);
    dependencies->addPreCondition(result, TR::RealRegister::NoReg, cg);
    dependencies->addPreCondition(scratch, TR::RealRegister::NoReg, cg);
    dependencies->addPreCondition(scratchXMM, TR::RealRegister::NoReg, cg);
    dependencies->addPreCondition(valueXMM, TR::RealRegister::NoReg, cg);
    dependencies->addPostCondition(ECX, TR::RealRegister::ecx, cg);
-   dependencies->addPostCondition(address, TR::RealRegister::NoReg, cg);
-   dependencies->addPostCondition(size, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(array, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(length, TR::RealRegister::NoReg, cg);
    dependencies->addPostCondition(result, TR::RealRegister::NoReg, cg);
    dependencies->addPostCondition(scratch, TR::RealRegister::NoReg, cg);
    dependencies->addPostCondition(scratchXMM, TR::RealRegister::NoReg, cg);
@@ -9403,13 +9403,13 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, bool isLatin1, TR::C
    begLabel->setStartInternalControlFlow();
    endLabel->setEndInternalControlFlow();
 
-   generateRegRegInstruction(MOVDRegReg4, node, valueXMM, value, cg);
+   generateRegRegInstruction(MOVDRegReg4, node, valueXMM, ch, cg);
    generateRegMemInstruction(PSHUFBRegMem, node, valueXMM, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
 
    generateRegRegInstruction(MOV4RegReg, node, result, offset, cg);
 
    generateLabelInstruction(LABEL, node, begLabel, cg);
-   generateRegMemInstruction(LEARegMem(), node, scratch, generateX86MemoryReference(address, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+   generateRegMemInstruction(LEARegMem(), node, scratch, generateX86MemoryReference(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
    generateRegRegInstruction(MOVRegReg(), node, ECX, scratch, cg);
    generateRegImmInstruction(ANDRegImms(), node, scratch, ~(width - 1), cg);
    generateRegImmInstruction(ANDRegImms(), node, ECX, width - 1, cg);
@@ -9427,17 +9427,17 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, bool isLatin1, TR::C
       }
    generateRegImmInstruction(ADD4RegImms, node, result, width >> shift, cg);
    generateRegRegInstruction(SUB4RegReg, node, result, ECX, cg);
-   generateRegRegInstruction(CMP4RegReg, node, result, size, cg);
+   generateRegRegInstruction(CMP4RegReg, node, result, length, cg);
    generateLabelInstruction(JGE1, node, endLabel, cg);
 
    generateLabelInstruction(LABEL, node, loopLabel, cg);
-   generateRegMemInstruction(MOVDQURegMem, node, scratchXMM, generateX86MemoryReference(address, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+   generateRegMemInstruction(MOVDQURegMem, node, scratchXMM, generateX86MemoryReference(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
    generateRegRegInstruction(compareOp, node, scratchXMM, valueXMM, cg);
    generateRegRegInstruction(PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
    generateRegRegInstruction(TEST4RegReg, node, scratch, scratch, cg);
    generateLabelInstruction(JNE1, node, endLabel, cg);
    generateRegImmInstruction(ADD4RegImms, node, result, width >> shift, cg);
-   generateRegRegInstruction(CMP4RegReg, node, result, size, cg);
+   generateRegRegInstruction(CMP4RegReg, node, result, length, cg);
    generateLabelInstruction(JL1, node, loopLabel, cg);
    generateLabelInstruction(LABEL, node, endLabel, dependencies, cg);
 
@@ -9447,7 +9447,7 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, bool isLatin1, TR::C
       generateRegImmInstruction(SHR4RegImm1, node, scratch, shift, cg);
       }
    generateRegRegInstruction(ADDRegReg(), node, result, scratch, cg);
-   generateRegRegInstruction(CMPRegReg(), node, result, size, cg);
+   generateRegRegInstruction(CMPRegReg(), node, result, length, cg);
    generateRegMemInstruction(CMOVGERegMem(), node, result, generateX86MemoryReference(TR::Compiler->target.is32Bit() ? cg->findOrCreate4ByteConstant(node, -1) : cg->findOrCreate8ByteConstant(node, -1), cg), cg);
 
    cg->stopUsingRegister(ECX);
@@ -11637,12 +11637,12 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
          if (!cg->getSupportsInlineStringIndexOf())
             break;
          else
-            return inlineIntrinsicIndexOf(node, true, cg);
+            return inlineIntrinsicIndexOf(node, cg, true);
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
          if (!cg->getSupportsInlineStringIndexOf())
             break;
          else
-            return inlineIntrinsicIndexOf(node, false, cg);
+            return inlineIntrinsicIndexOf(node, cg, false);
       case TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Big:
       case TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Little:
          return TR::TreeEvaluator::encodeUTF16Evaluator(node, cg);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3801,7 +3801,7 @@ extern TR::Register *toLowerIntrinsic(TR::Node * node, TR::CodeGenerator * cg, b
 
 extern TR::Register* inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isCompressed);
 
-extern TR::Register *intrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isCompressed);
+extern TR::Register *inlineIntrinsicIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isLatin1);
 
 extern TR::Register *inlineDoubleMax(TR::Node *node, TR::CodeGenerator *cg);
 extern TR::Register *inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg);
@@ -4070,10 +4070,10 @@ J9::Z::CodeGenerator::inlineDirectCall(
       switch (methodSymbol->getRecognizedMethod())
          {
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
-            resultReg = intrinsicIndexOf(node, cg, true);
+            resultReg = inlineIntrinsicIndexOf(node, cg, true);
             return true;
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
-            resultReg = intrinsicIndexOf(node, cg, false);
+            resultReg = inlineIntrinsicIndexOf(node, cg, false);
             return true;
          case TR::java_lang_StringLatin1_indexOf:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:


### PR DESCRIPTION
When calling the `java.lang.String.indexOf` API with a `String`
argument and passing the starting offset to be `Integer.MAX_VALUE - 1`
we encounter an overflow when we test for the following condition:

```
if (start + s2len > s1len) {
    return -1;
}
```

This if statement checks that the there are enough characters from the
starting position the user specified for the substring to occur. i.e.
if the source string is "abcdefg" and the substring is "fghijk" and
start offset is 2 then because the length of the source string is 7 and
the length of the substring is 6, 2 + 6 > 7 so it is impossible for the
substring to be contained within the source string. We can return -1
immediately.

The problem with the if statement is if we pass a starting offset to be
`Integer.MAX_VALUE - 1` which is a valid input the addition in the if
statement overflows and we never enter the if block, even though we
should have had there been no overflow. This causes us to call the
JITHelpers intrinsic which has implicit assumptions about the arguments
and we end up dereferencing memory outside of the heap.

This commit fixes the overflow by using subtraction. We also take this
opportunity to document the implicit assumptions on the JIT intrinsics
that we make use of.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>