### PR TITLE
Add archive diagnostic files when compile fails

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -438,6 +438,7 @@ def set_sdk_variables() {
     TEST_FILENAME = "native-test-libs.tar.gz"
     echo "Using SDK_FILENAME = ${SDK_FILENAME}"
     echo "Using TEST_FILENAME = ${TEST_FILENAME}"
+    DIAGNOSTICS_FILENAME = "${JOB_NAME}-${BUILD_NUMBER}-${DATESTAMP}-diagnostics.tar.gz"
 }
 
 def get_date() {
@@ -494,6 +495,7 @@ def set_artifactory_config() {
         env.ARTIFACTORY_NUM_ARTIFACTS = VARIABLES.artifactory_num_artifacts
         env.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS = VARIABLES.artifactory_days_to_keep_artifacts // This is being used by the cleanup script
         env.ARTIFACTORY_MANUAL_CLEANUP = VARIABLES.artifactory_manual_cleanup // This is being used by the cleanup script
+        env.ARTIFACTORY_UPLOAD_DIR = "${ARTIFACTORY_REPO}/${JOB_NAME}/${BUILD_ID}/"
         echo "Using artifactory server/repo: ${ARTIFACTORY_SERVER} / ${ARTIFACTORY_REPO}"
         echo "Keeping '${ARTIFACTORY_NUM_ARTIFACTS}' artifacts"
         echo "Artifactory Manual Cleanup: ${env.ARTIFACTORY_MANUAL_CLEANUP}"

--- a/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
@@ -56,10 +56,11 @@ timeout(time: 10, unit: 'HOURS') {
                 cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
             }
         }
-    }
-    stage ('Queue') {
-        node("${NODE}") {
-            buildFile.build_all()
+
+        stage ('Queue') {
+            node("${NODE}") {
+                buildFile.build_all()
+            }
         }
     }
 }


### PR DESCRIPTION
- Catch compile failures and tar any diagnostic files
- Diagnostic files include
   - core.*.dmp
   - javacore.*.txt
   - Snap.*.trc
   - jitdump.*.dmp
- Upload to Artifactory if set otherwise archive to
  Jenkins master.

Fixes #6331
Depends #6346 
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>