### PR TITLE
Fix runtime resolve for static methods

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -568,6 +568,7 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
          vmInfo._processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
+         vmInfo._invokeWithArgumentsHelperMethod = J9VMJAVALANGINVOKEMETHODHANDLE_INVOKEWITHARGUMENTSHELPER_METHOD(fe->getJ9JITConfig()->javaVM);
          client->write(response, vmInfo);
          }
          break;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -157,6 +157,7 @@ class ClientSessionData
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;
       TR_ProcessorFeatureFlags _processorFeatureFlags;
+      J9Method *_invokeWithArgumentsHelperMethod;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)


### PR DESCRIPTION
`TR_ResolvedJ9JITaaSServerMethod::getResolvedStaticMethod`
was incorrectly determining when to resolve a method.
Fix it by making behavior identical to non-JITaaS version.
