### PR TITLE
Inform JITServer when client closes connections

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4075,6 +4075,8 @@ TR::CompilationInfoPerThread::processEntries()
       JITServer::ClientStream *client = getClientStream();
       if (client)
          {
+         // Inform the server that client is closing the connection with a connectionTerminate message
+         client->writeError(JITServer::MessageType::connectionTerminate, 0 /* placeholder */);
          client->~ClientStream();
          TR_Memory::jitPersistentFree(client);
          setClientStream(NULL);

--- a/runtime/compiler/net/ClientStream.hpp
+++ b/runtime/compiler/net/ClientStream.hpp
@@ -140,8 +140,9 @@ public:
    /**
       @brief Send an error message to the JITServer
 
-      Examples of error messages include 'compilationAbort' (e.g. when class unloading happens)
-      and `clientTerminate` (e.g. when the client is about to exit)
+      Examples of error messages include 'compilationAbort' (e.g. when class unloading happens),
+      'clientTerminate' (e.g. when the client is about to exit), 
+      and 'compilationTerminate' (e.g. when the client is closing the connection)
    */
    template <typename ...T>
    void writeError(MessageType type, T... args)

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -54,6 +54,7 @@ enum MessageType
    compilationRequest = 4; // type used when client sends remote compilation requests
    compilationAbort = 5; // type used when client informs the server to abort the remote compilation
    clientTerminate = 6; // type used when client process is about to terminate
+   connectionTerminate = 7; // type used when client informs the server to close the connection
 
    // For TR_ResolvedJ9JITaaSServerMethod methods
    ResolvedMethod_isJNINative = 100;


### PR DESCRIPTION
Currently client closes the connection without informing the JITServer, which results in JITServer re-queues already closed connections. (Once JITServer gets to these invalid sockets, we get "JITaaS I/O error: reading message size" streamFailure messages thrown). Added a new message type `JITServer::MessageType::connectionTerminate`. While `connectionTerminate` and `compilationAbort` both triggers `StreamCancel` on the JITServer, `connectionTerminate` tells the JITServer to close the connection and not requeue a new compilation. `compilationAbort` tells JITServer to abort the current compilation but requeue a new compilation on the same connection.

[skip ci]
Issue: #6360

Signed-off-by: Harry Yu <harryyu1994@gmail.com>