### PR TITLE
Disable Deep Scan

### DIFF
--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -180,12 +180,7 @@ public:
 		{
 			UDATA classFlags = J9CLASS_FLAGS(clazz) & (J9AccClassReferenceMask | J9AccClassGCSpecial | J9AccClassOwnableSynchronizer);
 			if (0 == classFlags) {
-				/* TODO try an approach with a separate class flag */
-				if (0 != clazz->selfReferencingField1) {
-					result = SCAN_MIXED_OBJECT_LINKED;
-				} else {
-					result = SCAN_MIXED_OBJECT;
-				}
+				result = SCAN_MIXED_OBJECT;
 			} else {
 				if (0 != (classFlags & J9AccClassReferenceMask)) {
 					result = SCAN_REFERENCE_MIXED_OBJECT;


### PR DESCRIPTION
Temporarily disabling deep scan while working on a larger fix for it.

- Ignore `SCAN_MIXED_OBJECT_LINKED` scan type

Fixes: https://github.com/eclipse/openj9/issues/6393

Signed-off-by: Salman Rana <salman.rana@ibm.com>