### PR TITLE
Add a missing J2I thunk pointer relocation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -786,48 +786,16 @@ TR::CompilationInfoPerThread::getAndCacheRemoteROMClass(J9Class *clazz, TR_Memor
    }
 
 void
-TR::CompilationInfoPerThread::addThunkToBeRelocated(void *thunk, std::string signature)
+TR::CompilationInfoPerThread::addThunkToBeRelocated(const std::string &serializedThunk, const std::string &signature)
    {
-   _thunksToBeRelocated.emplace_back(thunk, signature);
+   _thunksToBeRelocated.emplace_back(serializedThunk, signature);
    }
 
 void
-TR::CompilationInfoPerThread::addInvokeExactThunkToBeRelocated(TR_J2IThunk *thunk)
+TR::CompilationInfoPerThread::addInvokeExactThunkToBeRelocated(const std::string &serializedThunk)
    {
-   _invokeExactThunksToBeRelocated.emplace_back(thunk);
+   _invokeExactThunksToBeRelocated.emplace_back(serializedThunk);
    }
-
-void *
-j9ThunkInvokeExactHelperFromTerseSignature(void * jitConfig, UDATA signatureLength, char *signatureChars)
-{
-   TR_RuntimeHelper helper;
-
-   switch (signatureChars[signatureLength - 1]) {
-      case 'V':
-         helper = TR_icallVMprJavaSendInvokeExact0;
-         break;
-      case 'F':
-         helper = TR_icallVMprJavaSendInvokeExactF;
-         break;
-      case 'D':
-         helper = TR_icallVMprJavaSendInvokeExactD;
-         break;
-      case 'J':
-         helper = TR_icallVMprJavaSendInvokeExactJ;
-         break;
-      case '[':
-         /* intentional fall-through */
-      case 'L':
-         helper = TR_icallVMprJavaSendInvokeExactL;
-         break;
-      default:
-         helper = TR_icallVMprJavaSendInvokeExact1;
-         break;
-   }
-   TR::SymbolReference *symRef = TR::comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
-
-   return symRef->getMethodAddress();
-}
 
 void
 TR::CompilationInfoPerThread::relocateThunks()
@@ -835,48 +803,55 @@ TR::CompilationInfoPerThread::relocateThunks()
    TR_ASSERT(_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT, "Should be called in JITServer client mode only");
 
    TR_J9VMBase *fe = _vm;
+   
+   // Compute the total amount of memory required for all thunks
+   size_t totalThunkSize = 0;
    for (auto p : _thunksToBeRelocated)
       {
-      void *thunk = (U_8 *)p.first - (U_8 *)TR::compInfoPT->reloRuntime()->aotMethodHeaderEntry()->compileMethodCodeStartPC + (U_8 *)TR::compInfoPT->reloRuntime()->newMethodCodeStart();
-      std::string signature = p.second;
-      void *vmHelper = j9ThunkVMHelperFromSignature(fe->_jitConfig, signature.size(), &signature[0]);
-      TR::compInfoPT->reloRuntime()->reloTarget()->performThunkRelocation((uint8_t*) thunk, (UDATA)vmHelper);
-      // Always need to call base version of setJ2IThunk, even in AOT mode
-      fe->TR_J9VMBase::setJ2IThunk(&signature[0], signature.size(), thunk, TR::comp());
-      if (_vm->_compInfoPT->getCompilation()->compileRelocatableCode())
-         // For AOT compilation, also need to call TR_J9SharedCacheVM version of the method
-         _vm->setJ2IThunk(&signature[0], signature.size(), thunk, TR::comp());
+      const std::string &serializedThunk = p.first;
+      totalThunkSize += serializedThunk.size();
+      }
+   for (const std::string serializedThunk : _invokeExactThunksToBeRelocated)
+      {
+      totalThunkSize += serializedThunk.size();
+      }
+
+   uint8_t *coldCode;
+   TR::CodeCache *codeCache = reloRuntime()->codeCache();
+   // Allocate code cache for all thunks in one call, if there is not enough space, can fail early
+   uint8_t *thunkStart = TR::CodeCacheManager::instance()->allocateCodeMemory(totalThunkSize, 0, &codeCache, &coldCode, true);
+   if (!thunkStart)
+      {
+      codeCache->unreserve();
+      compInfoPT->getCompilation()->failCompilation<TR::CodeCacheError>("Failed to allocate code cache");
+      }
+
+   for (auto p : _thunksToBeRelocated)
+      {
+      const std::string &serializedThunk = p.first;
+      std::string &signature = p.second;
+
+      memcpy(thunkStart, serializedThunk.data(), serializedThunk.size());
+      // The first 8 bytes hold the offset to arguments
+      uint8_t *thunkAddress = thunkStart + 8;
+
+      void *vmHelper = j9ThunkVMHelperFromSignature(_jitConfig, signature.size(), &signature[0]);
+      compInfoPT->reloRuntime()->reloTarget()->performThunkRelocation(thunkAddress, (UDATA)vmHelper);
+      // Ideally, should use signature.data() here, but setJ2IThunk has non-const pointer
+      // as argument, and it uses it to invoke a VM function that also takes non-const pointer.
+      fe->TR_J9VMBase::setJ2IThunk(&signature[0], signature.size(), thunkAddress, TR::comp());
+
+      thunkStart += serializedThunk.size();
       }
    _thunksToBeRelocated.clear();
-   for (TR_J2IThunk *thunk : _invokeExactThunksToBeRelocated)
+
+   for (const std::string serializedThunk : _invokeExactThunksToBeRelocated)
       {
-      TR_J2IThunk *realThunk = (TR_J2IThunk *)((U_8 *)thunk - (U_8 *)TR::compInfoPT->reloRuntime()->aotMethodHeaderEntry()->compileMethodCodeStartPC + (U_8 *)TR::compInfoPT->reloRuntime()->newMethodCodeStart());
-      char *signature = realThunk->terseSignature();
-      void *vmHelper = j9ThunkInvokeExactHelperFromTerseSignature(fe->_jitConfig, strlen(signature), signature);
-      *(UDATA *)(realThunk->entryPoint() + 2) = (UDATA) vmHelper; // JITaaS TODO: This is amd64 specific
+      TR_J2IThunk *realThunk = reinterpret_cast<TR_J2IThunk *>(thunkStart);
+      memcpy(realThunk, serializedThunk.data(), serializedThunk.size());
+      compInfoPT->reloRuntime()->reloTarget()->performInvokeExactJ2IThunkRelocation(realThunk);
       fe->setInvokeExactJ2IThunk(realThunk, TR::comp());
-      }
-   _invokeExactThunksToBeRelocated.clear();
-   }
-
-void
-TR::CompilationInfoPerThread::persistThunksToSCC(const J9JITDataCacheHeader *cacheEntry, uint8_t *existingCode)
-   {
-   TR_ASSERT(_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT, "Should be called in JITServer client mode only");
-   TR_ASSERT(_vm->isAOT_DEPRECATED_DO_NOT_USE(), "Should be for AOT mode only");
-
-   TR_AOTMethodHeader * aotMethodHeaderEntry = (TR_AOTMethodHeader *)(cacheEntry + 1); // skip the header J9JITDataCacheHeader
-   for (auto p : _thunksToBeRelocated)
-      {
-      void *thunk = (U_8 *)p.first - (U_8 *)aotMethodHeaderEntry->compileMethodCodeStartPC + (U_8 *)existingCode;
-      std::string signature = p.second;
-      _vm->setJ2IThunk(&signature[0], signature.size(), thunk, TR::comp());
-      }
-   _thunksToBeRelocated.clear();
-   for (TR_J2IThunk *thunk : _invokeExactThunksToBeRelocated)
-      {
-      TR_J2IThunk *realThunk = (TR_J2IThunk *)((U_8 *)thunk - (U_8 *)aotMethodHeaderEntry->compileMethodCodeStartPC + (U_8 *)existingCode);
-      _vm->setInvokeExactJ2IThunk(realThunk, TR::comp());
+      thunkStart += serializedThunk.size();
       }
    _invokeExactThunksToBeRelocated.clear();
    }

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -381,10 +381,9 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    JITServer::ServerStream  *getStream();
    J9ROMClass            *getAndCacheRemoteROMClass(J9Class *, TR_Memory *trMemory=NULL);
    J9ROMClass            *getRemoteROMClassIfCached(J9Class *);
-   void                   addThunkToBeRelocated(void *thunk, std::string signature);
-   void                   addInvokeExactThunkToBeRelocated(TR_J2IThunk *thunk);
+   void                   addThunkToBeRelocated(const std::string &serializedThunk, const std::string &signature);
+   void                   addInvokeExactThunkToBeRelocated(const std::string &serializedThunk);
    void                   relocateThunks();
-   void                   persistThunksToSCC(const J9JITDataCacheHeader *cacheEntry, uint8_t * existingCode);
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() { return _classesThatShouldNotBeNewlyExtended; }
    uint32_t               getLastLocalGCCounter() { return _lastLocalGCCounter; }
    void                   updateLastLocalGCCounter(); 
@@ -406,10 +405,10 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    bool                   _initializationSucceeded;
    bool                   _isDiagnosticThread;
    CpuSelfThreadUtilization _compThreadCPU;
-   typedef TR::typed_allocator<std::pair<void *, std::string>, TR::PersistentAllocator&> ThunkVectorAllocator;
-   std::vector<std::pair<void *, std::string>, ThunkVectorAllocator> _thunksToBeRelocated;
-   typedef TR::typed_allocator<TR_J2IThunk *, TR::PersistentAllocator&> InvokeExactThunkVectorAllocator;
-   std::vector<TR_J2IThunk *, InvokeExactThunkVectorAllocator> _invokeExactThunksToBeRelocated;
+   typedef TR::typed_allocator<std::pair<std::string, std::string>, TR::PersistentAllocator&> ThunkVectorAllocator;
+   std::vector<std::pair<std::string, std::string>, ThunkVectorAllocator> _thunksToBeRelocated;
+   typedef TR::typed_allocator<std::string, TR::PersistentAllocator&> InvokeExactThunkVectorAllocator;
+   std::vector<std::string, InvokeExactThunkVectorAllocator> _invokeExactThunksToBeRelocated;
    // The following hastable caches <classLoader,classname> --> <J9Class> mappings
    // The cache only lives during a compilation due to class unloading concerns
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -52,10 +52,11 @@ TR_J2IThunk::allocate(
    int16_t terseSignatureBufLength = thunkTable->terseSignatureLength(signature)+1;
    int16_t totalSize = (int16_t)sizeof(TR_J2IThunk) + codeSize + terseSignatureBufLength;
    TR_J2IThunk *result;
-   if (TR::comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-       result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, false, true);
+   if (cg->comp()->isOutOfProcessCompilation())
+      // Don't need to use code cache because the entire thunk will be copied and sent to the client 
+      result = (TR_J2IThunk*)cg->comp()->trMemory()->allocateMemory(totalSize, heapAlloc);
    else
-       result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
+      result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
    result->_codeSize  = codeSize;
    result->_totalSize = totalSize;
    thunkTable->getTerseSignature(result->terseSignature(), terseSignatureBufLength, signature);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -127,6 +127,7 @@ public:
    virtual uint8_t *allocateCodeMemory(TR::Compilation * comp, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t ** coldCode, bool isMethodHeaderNeeded) override;
    virtual bool sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *) override;
    virtual bool isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *) override;
+   virtual void *getJ2IThunk(char *signatureChars, uint32_t signatureLength,  TR::Compilation *comp) override;
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp) override;
    virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *clazz, char *fieldName, uint32_t fieldLen, char *sig, uint32_t sigLen, UDATA options) override;
    virtual int32_t getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, bool &hashCodeComputed) override;

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1784,12 +1784,6 @@ TR_RelocationRecordThunks::relocateAndRegisterThunk(
    uintptr_t cpIndex,
    uint8_t *reloLocation)
    {
-   // XXX: Currently all thunks are batch-relocated elsewhere for JITaaS
-   if (reloRuntime->fej9()->_compInfoPT->getMethodBeingCompiled()->isRemoteCompReq() && 
-      !reloRuntime->fej9()->_compInfoPT->getMethodBeingCompiled()->isAotLoad())
-      {
-      return 0;
-      }
 
    J9JITConfig *jitConfig = reloRuntime->jitConfig();
    J9JavaVM *javaVM = reloRuntime->jitConfig()->javaVM;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -72,6 +72,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/CompilationRuntime.hpp"
+#include "control/CompilationThread.hpp"
 
 TR_RelocationRuntime::TR_RelocationRuntime(J9JITConfig *jitCfg)
    {
@@ -441,6 +442,14 @@ TR_RelocationRuntime::relocateAOTCodeAndData(U_8 *tempDataStart,
    _newMethodCodeStart = codeStart;
 
    reloLogger()->relocationDump();
+
+   if (_comp->isRemoteCompilation())
+      {
+      if (!_comp->compileRelocatableCode() || TR::CompilationInfo::canRelocateMethod(_comp))
+         {
+         fej9()->_compInfoPT->relocateThunks();
+         }
+      }
 
    if (_exceptionTableCacheEntry->type == J9_JIT_DCE_EXCEPTION_INFO)
       {

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -240,6 +240,12 @@ TR_RelocationTarget::performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmH
    TR_ASSERT(0, "Error: performThunkRelocation not implemented in relocation target base class");
    }
 
+void
+TR_RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk)
+   {
+   TR_ASSERT(0, "Error: performInvokeExactJ2IThunkRelocation not implemented in relocation target base class");
+   }
+
 uint8_t *
 TR_RelocationTarget::arrayCopyHelperAddress(J9JavaVM *javaVM)
    {

--- a/runtime/compiler/runtime/RelocationTarget.hpp
+++ b/runtime/compiler/runtime/RelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@
 class TR_OpaqueClassBlock;
 class TR_RelocationRecord;
 class TR_RelocationRuntimeLogger;
+class TR_J2IThunk;
 
 // TR_RelocationTarget defines how a platform target implements the individual steps of processing
 //    relocation records.
@@ -133,6 +134,15 @@ class TR_RelocationTarget
       virtual uint32_t loadCPIndex(uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
       virtual void performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmHelper);
+      
+      /**
+       * @brief Identifies the correct runtime helper based on thunk signature and relocates helper
+       * address. Needed for JITServer.
+       *
+       * @param thunk Pointer to a thunk to be relocated.
+       */
+      virtual void performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk);
+
       virtual uint8_t *arrayCopyHelperAddress(J9JavaVM *javaVM);
 
       virtual void patchNonVolatileFieldMemoryFence(J9ROMFieldShape* resolvedField, UDATA cpAddr, U_8 descriptorByte, U_8 *instructionAddress, U_8 *snippetStartAddress, J9JavaVM *javaVM);

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -544,10 +544,7 @@ uint8_t *TR::AMD64PrivateLinkage::generateVirtualIndirectThunk(TR::Node *callNod
    if (fej9->storeOffsetToArgumentsInVirtualIndirectThunks())
       {
       codeSize += 8;
-      // JITaaS TODO: for JITaaS we need this to be in code memory.
-      // it should be fine for nonJITaaS as well but it hurts footprint
-      //thunk = (uint8_t *)comp->trMemory()->allocateMemory(codeSize, heapAlloc);
-      thunk = (uint8_t *)cg()->allocateCodeMemory(codeSize, true);
+      thunk = (uint8_t *)comp->trMemory()->allocateMemory(codeSize, heapAlloc);
       cursor = thunkEntry = thunk + 8; // 4 bytes holding the size of storeArguments
       }
    else

--- a/runtime/compiler/x/runtime/X86RelocationTarget.cpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,7 @@
 #include "runtime/MethodMetaData.h"
 #include "runtime/RelocationRuntime.hpp"
 #include "runtime/RelocationTarget.hpp"
+#include "env/J2IThunk.hpp"
 
 uint8_t *
 TR_X86RelocationTarget::eipBaseForCallOffset(uint8_t *reloLocation)
@@ -93,6 +94,47 @@ TR_X86RelocationTarget::performThunkRelocation(uint8_t *thunkAddress, uintptr_t 
    {
    int32_t *thunkRelocationData = (int32_t *)(thunkAddress - sizeof(int32_t));
    *(UDATA *) (thunkAddress + *thunkRelocationData + 2) = vmHelper;
+   }
+
+void *
+j9ThunkInvokeExactHelperFromTerseSignature(UDATA signatureLength, char *signatureChars)
+   {
+   TR_RuntimeHelper helper;
+
+   switch (signatureChars[signatureLength - 1])
+      {
+      case 'V':
+         helper = TR_icallVMprJavaSendInvokeExact0;
+         break;
+      case 'F':
+         helper = TR_icallVMprJavaSendInvokeExactF;
+         break;
+      case 'D':
+         helper = TR_icallVMprJavaSendInvokeExactD;
+         break;
+      case 'J':
+         helper = TR_icallVMprJavaSendInvokeExactJ;
+         break;
+      case '[':
+         /* intentional fall-through */
+      case 'L':
+         helper = TR_icallVMprJavaSendInvokeExactL;
+         break;
+      default:
+         helper = TR_icallVMprJavaSendInvokeExact1;
+         break;
+      }
+   TR::SymbolReference *symRef = TR::comp()->getSymRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+
+   return symRef->getMethodAddress();
+   }
+
+void
+TR_X86RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk)
+   {
+   char *signature = thunk->terseSignature();
+   void *vmHelper = j9ThunkInvokeExactHelperFromTerseSignature(strlen(signature), signature);
+   *(UDATA *)(thunk->entryPoint() + 2) = (UDATA) vmHelper;
    }
 
 bool TR_AMD64RelocationTarget::useTrampoline(uint8_t * helperAddress, uint8_t *baseLocation)

--- a/runtime/compiler/x/runtime/X86RelocationTarget.hpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,7 @@ class TR_X86RelocationTarget : public TR_RelocationTarget
       
 
       virtual void performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmHelper);
+      virtual void performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk);
 
       virtual bool useTrampoline(uint8_t * helperAddress, uint8_t *baseLocation) { return false; }
 


### PR DESCRIPTION
`TR::CompilationInfoPerThread::relocateThunks()` relocates
J2I thunks, but it doesn't relocate thunk pointers.
That is normally done by `TR_J2IVirtualThunkPointer` relocation,
but we disabled that relocation for JITaaS, since we assumed that
`relocateThunks` does the same thing.
I fixed it by enabling this relocation.
Also added a missing relocation for invokeExactJ2IThunk.
