### PR TITLE
Disable arraycopy transformations for AArch64

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1598,6 +1598,11 @@ onLoadInternal(
    // OpenJ9 issue #5917 tracks the work to enable.
    //
    TR::Options::getCmdLineOptions()->setOption(TR_DisableDynamicLoopTransfer);
+
+   // ArrayCopy transformations are not available in AArch64 yet.
+   // OpenJ9 issue #6438 tracks the work to enable.
+   //
+   TR::Options::getCmdLineOptions()->setOption(TR_DisableArrayCopyOpts);
 #endif
 
 #if defined(TR_HOST_POWER)


### PR DESCRIPTION
The backend is not yet capable of handling `arraycopy` and `ArrayCHK` opcodes.

Issue #6438 has been created to track their implementation.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>