### PR TITLE
Prepare networking files to be merged in master

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2899,7 +2899,7 @@ J9::CodeGenerator::processRelocations()
 void J9::CodeGenerator::addExternalRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::ExternalRelocationPositionRequest where)
    {
    TR_ASSERT(generatingFileName, "External relocation location has improper NULL filename specified");
-   if (self()->comp()->compileRelocatableCode() || self()->comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (self()->comp()->compileRelocatableCode() || self()->comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       TR::RelocationDebugInfo *genData = new(self()->trHeapMemory()) TR::RelocationDebugInfo;
       genData->file = generatingFileName;
@@ -2911,7 +2911,7 @@ void J9::CodeGenerator::addExternalRelocation(TR::Relocation *r, const char *gen
 
 void J9::CodeGenerator::addExternalRelocation(TR::Relocation *r, TR::RelocationDebugInfo* info, TR::ExternalRelocationPositionRequest where)
    {
-   if (self()->comp()->compileRelocatableCode() || self()->comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (self()->comp()->compileRelocatableCode() || self()->comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       TR_ASSERT(info, "External relocation location does not have associated debug information");
       r->setDebugInfo(info);
@@ -2987,7 +2987,7 @@ void
 J9::CodeGenerator::jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
-   if (self()->comp()->compileRelocatableCode() || self()->comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (self()->comp()->compileRelocatableCode() || self()->comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)firstInstruction, 0, TR_HCR, self()),
                                  __FILE__,__LINE__, NULL);

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -975,6 +975,14 @@ public:
    static void storeAOTInSharedCache(J9VMThread *vmThread, J9ROMMethod *romMethod, const U_8 *dataStart, UDATA dataSize, const U_8 *codeStart, UDATA codeSize, TR::Compilation *comp, J9JITConfig *jitConfig, TR_MethodToBeCompiled *entry);
 #endif
    static bool canRelocateMethod(TR::Compilation * comp);
+#if defined(JITSERVER_SUPPORT)
+   const PersistentVector<std::string> &getJITServerSslKeys() const { return _sslKeys; }
+   void  addJITServerSslKey(const std::string &key) { _sslKeys.push_back(key); }
+   const PersistentVector<std::string> &getJITServerSslCerts() const { return _sslCerts; }
+   void  addJITServerSslCert(const std::string &cert) { _sslCerts.push_back(cert); }
+   const std::string &getJITServerSslRootCerts() const { return _sslRootCerts; }
+   void  setJITServerSslRootCerts(const std::string &cert) { _sslRootCerts = cert; }
+#endif
 
    static int32_t         VERY_SMALL_QUEUE;
    static int32_t         SMALL_QUEUE;
@@ -1175,6 +1183,11 @@ private:
    uint8_t _chTableUpdateFlags;
    // number of local gc cycles done
    uint32_t _localGCCounter = 0;
+#if defined(JITSERVER_SUPPORT)
+   std::string                   _sslRootCerts;
+   PersistentVector<std::string> _sslKeys;
+   PersistentVector<std::string> _sslCerts;
+#endif
    }; // CompilationInfo
 }
 

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -67,7 +67,7 @@ J9::Recompilation::setupMethodInfo()
    // NOTE: cannot use _compilation->isOutOfProcessCompilation here, because this
    // method is called from within OMR::Compilation() constructor, before 
    // _isOutOfProcessCompilation is set
-   if (comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(TR::compInfoPT);
       _methodInfo = compInfoPT->getRecompilationMethodInfo();

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2569,7 +2569,7 @@ remoteCompile(
             "Client sending compReq seqNo=%u to server for method %s @ %s.",
             seqNo, compiler->signature(), compiler->getHotnessName());
          }
-      client->buildCompileRequest(TR::comp()->getPersistentInfo()->getJITaaSId(), romMethodOffset,
+      client->buildCompileRequest(TR::comp()->getPersistentInfo()->getClientUID(), romMethodOffset,
                                  method, clazz, *compInfoPT->getMethodBeingCompiled()->_optimizationPlan, detailsStr, details.getType(), unloadedClasses,
                                  classInfoTuple, optionsStr, recompMethodInfoStr, seqNo, useAotCompilation);
       // re-acquire VM access and check for possible class unloading
@@ -3018,7 +3018,7 @@ void printJITaaSCHTableStats(J9JITConfig *jitConfig, TR::CompilationInfo *compIn
 #ifdef COLLECT_CHTABLE_STATS
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
    j9tty_printf(PORTLIB, "JITaaS CHTable Statistics:\n");
-   if (compInfo->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {
       TR_JITaaSClientPersistentCHTable *table = (TR_JITaaSClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
       j9tty_printf(PORTLIB, "Num updates sent: %d (1 per compilation)\n", table->_numUpdates);
@@ -3030,7 +3030,7 @@ void printJITaaSCHTableStats(J9JITConfig *jitConfig, TR::CompilationInfo *compIn
          j9tty_printf(PORTLIB, "Total update bytes: %d. Compilation max: %d. Average per compilation: %f\n", table->_updateBytes, table->_maxUpdateBytes, table->_updateBytes / float(table->_numUpdates));
          }
       }
-   else if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   else if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       TR_JITaaSServerPersistentCHTable *table = (TR_JITaaSServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
       j9tty_printf(PORTLIB, "Num updates received: %d (1 per compilation)\n", table->_numUpdates);
@@ -3048,7 +3048,7 @@ void printJITaaSCHTableStats(J9JITConfig *jitConfig, TR::CompilationInfo *compIn
 void printJITaaSCacheStats(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo)
    {
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
-   if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       auto clientSessionHT = compInfo->getClientSessionHT();
       clientSessionHT->printStats();

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -334,8 +334,8 @@ j9jit_testarossa_err(
                }
             }
          }
-      // Do not allow local compilations in JITaaS server mode
-      if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+      // Do not allow local compilations in JITServer server mode
+      if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          return 0;
       }
 
@@ -1503,11 +1503,11 @@ onLoadInternal(
 
    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling))
       {
-      if (persistentMemory->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+      if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->iProfiler = TR_JITaaSIProfiler::allocate(jitConfig);
          }
-      else if (persistentMemory->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
+      else if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
          {
          ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->iProfiler = TR_JITaaSClientIProfiler::allocate(jitConfig);
          }
@@ -1586,11 +1586,11 @@ onLoadInternal(
       }
 
    TR_PersistentCHTable *chtable;
-   if (persistentMemory->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       chtable = new (PERSISTENT_NEW) TR_JITaaSServerPersistentCHTable(persistentMemory);
       }
-   else if (persistentMemory->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
+   else if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {
       chtable = new (PERSISTENT_NEW) TR_JITaaSClientPersistentCHTable(persistentMemory);
       }
@@ -1602,7 +1602,7 @@ onLoadInternal(
       return -1;
    persistentMemory->getPersistentInfo()->setPersistentCHTable(chtable);
    
-   if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       JITServer::CommunicationStream::initVersion();
 
@@ -1624,7 +1624,7 @@ onLoadInternal(
          return -1;
          }
       }
-   else if (compInfo->getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
+   else if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {
       compInfo->setUnloadedClassesTempList(new (PERSISTENT_NEW) PersistentVector<TR_OpaqueClassBlock*>(
          PersistentVector<TR_OpaqueClassBlock*>::allocator_type(TR::Compiler->persistentAllocator())));
@@ -1814,10 +1814,10 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
          {
          javaVM->sharedClassConfig->runtimeFlags &= ~J9SHR_RUNTIMEFLAG_ENABLE_AOT;
          TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
-         if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+         if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
             {
             // TODO: Format the error message to use j9nls_printf
-            fprintf(stderr, "Aborting Compilation: SCC/AOT must be enabled and can be stored in JITaaS Server Mode.");
+            fprintf(stderr, "Aborting Compilation: SCC/AOT must be enabled and can be stored in JITServer Server Mode.");
             return -1;
             }
          }
@@ -1825,10 +1825,10 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
          {
          TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
          TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
-         if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+         if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
             {
             // TODO: Format the error message to use j9nls_printf
-            fprintf(stderr, "Aborting Compilation: SCC/AOT must be enabled and can be stored in JITaaS Server Mode.");
+            fprintf(stderr, "Aborting Compilation: SCC/AOT must be enabled and can be stored in JITServer Server Mode.");
             return -1;
             }
          }        

--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,7 @@ TR_J2IThunk::allocate(
    int16_t terseSignatureBufLength = thunkTable->terseSignatureLength(signature)+1;
    int16_t totalSize = (int16_t)sizeof(TR_J2IThunk) + codeSize + terseSignatureBufLength;
    TR_J2IThunk *result;
-   if (TR::comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (TR::comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
        result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, false, true);
    else
        result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -593,7 +593,7 @@ TR_J9VMBase::get(J9JITConfig * jitConfig, J9VMThread * vmThread, VM_TYPE vmType)
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
       if (vmType==J9_SERVER_VM || vmType==J9_SHARED_CACHE_SERVER_VM)
          {
-         TR_ASSERT(vmWithoutThreadInfo->_compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE, "J9_SERVER_VM and J9_SHARED_CACHE_SERVER_VM should only be instantiated in JITaaS SERVER_MODE");
+         TR_ASSERT(vmWithoutThreadInfo->_compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER, "J9_SERVER_VM and J9_SHARED_CACHE_SERVER_VM should only be instantiated in JITServer::SERVER mode");
          TR::CompilationInfoPerThread *compInfoPT = NULL;
          // Get the compInfoPT from the cached J9_VM with thread info
          // or search using the compInfo from the J9_VM without thread info
@@ -736,10 +736,10 @@ TR_J9VMBase::TR_J9VMBase(
 
    _sharedCache = NULL;
    if (TR::Options::sharedClassCache() ||
-       (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE))
+       (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER))
       // shared classes and AOT must be enabled, or we should be on the JITaaS server with remote AOT enabled
       {
-      if (compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+      if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          _sharedCache = new (PERSISTENT_NEW) TR_J9JITaaSServerSharedCache(this);
       else
          _sharedCache = new (PERSISTENT_NEW) TR_J9SharedCache(this);
@@ -764,7 +764,7 @@ TR_J9VMBase::freeSharedCache()
    {
    if (_sharedCache)        // shared classes and AOT must be enabled
       {
-      if (_compInfo && (_compInfo->getPersistentInfo()->getJITaaSMode() != SERVER_MODE))
+      if (_compInfo && (_compInfo->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER))
          {
          TR_ASSERT(TR::Options::sharedClassCache(), "Found shared cache with option disabled");
          }

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1574,13 +1574,13 @@ TR_J9ServerVM::getClassFromCP(J9ConstantPool *cp)
 void
 TR_J9ServerVM::reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding)
 {
-    // Not necessary in JITaaS server mode
+    // Not necessary in JITServer server mode
 }
 
 intptrj_t
 TR_J9ServerVM::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference * symRef, void * callSite)
 {
-    // Not necessary in JITaaS server mode, return the call's PC so that the call will not appear to require a trampoline
+    // Not necessary in JITServer server mode, return the call's PC so that the call will not appear to require a trampoline
     return (intptrj_t)callSite;
 }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2296,7 +2296,7 @@ TR_J9Method::TR_J9Method(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClaz
    _fullSignature = NULL;
    }
 
-TR_J9Method::TR_J9Method(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClazz, uintptr_t cpIndex, bool isJITaaSServerMode)
+TR_J9Method::TR_J9Method(TR_FrontEnd * fe, TR_Memory * trMemory, J9Class * aClazz, uintptr_t cpIndex, bool JITServerMode)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -199,7 +199,7 @@ class TR_J9Method : public TR_J9MethodBase
    {
 public:
    TR_J9Method(TR_FrontEnd *trvm, TR_Memory *, J9Class * aClazz, uintptr_t cpIndex);
-   TR_J9Method(TR_FrontEnd *trvm, TR_Memory *, J9Class * aClazz, uintptr_t cpIndex, bool isJITaaSServerMode);
+   TR_J9Method(TR_FrontEnd *trvm, TR_Memory *, J9Class * aClazz, uintptr_t cpIndex, bool JITServerMode);
    TR_J9Method(TR_FrontEnd *trvm, TR_Memory *, TR_OpaqueMethodBlock * aMethod);
 
 protected:

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -276,7 +276,7 @@ bool TR_J9ByteCodeIlGenerator::internalGenIL()
                      return true;
                      }
                   // JITaaS FIXME: Bypass bug where this doesn't work if it's not the system class loader.
-                  else if (comp()->getPersistentInfo()->getJITaaSMode() != SERVER_MODE)
+                  else if (comp()->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER)
                      {
                      createGeneratedFirstBlock();
                      loadSymbol(TR::aload, symRefTab()->findOrCreateClassLoaderSymbolRef(caller));

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -24,6 +24,7 @@
 #include "CommunicationStream.hpp"
 #include "env/CompilerEnv.hpp" // for TR::Compiler->target.is64Bit()
 #include "control/Options.hpp" // TR::Options::useCompressedPointers()
+#include "control/CompilationRuntime.hpp"
 
 namespace JITServer
 {
@@ -36,4 +37,14 @@ void CommunicationStream::initVersion()
       CONFIGURATION_FLAGS |= JITaaSCompressedRef;
       }
    }
+
+#if defined(JITSERVER_ENABLE_SSL)
+bool CommunicationStream::useSSL()
+   {
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+   return (compInfo->getJITServerSslKeys().size() ||
+           compInfo->getJITServerSslCerts().size() ||
+           compInfo->getJITServerSslRootCerts().size());
+   }
+#endif
 };

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -28,7 +28,6 @@
 #include "net/SSLProtobufStream.hpp"
 #include "env/TRMemory.hpp"
 
-
 namespace JITServer
 {
 enum JITaaSCompatibilityFlags
@@ -43,11 +42,7 @@ class CommunicationStream
    {
 public:
 #if defined(JITSERVER_ENABLE_SSL)
-   static bool useSSL(TR::PersistentInfo *info)
-      {
-      return (info->getJITaaSSslKeys().size() || info->getJITaaSSslCerts().size() || info->getJITaaSSslRootCerts().size());
-      }
-
+   static bool useSSL();
    static void initSSL()
       {
       SSL_load_error_strings();

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1156,7 +1156,7 @@ J9::TransformUtil::transformIndirectLoadChainAt(TR::Compilation *comp, TR::Node 
    // bypass this method, because baseReferenceLocation is often an address of a pointer
    // on server's stack, which causes a segfault when getStaticReferenceFieldAtAddress is called
    // on the client.
-   if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       return false;
       }

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -1137,8 +1137,8 @@ J9::PersistentInfo::ensureUnloadedAddressSetsAreInitialized()
       {
       return true;
       }
-   // In JITaaS server mode unloaded addresses are maintained per client
-   else if (getJITaaSMode() != SERVER_MODE)
+   // In JITServer server mode unloaded addresses are maintained per client
+   else if (getRemoteCompilationMode() != JITServer::SERVER)
       {
       int32_t maxUnloadedAddressRanges = TR::Options::getCmdLineOptions()->getMaxUnloadedAddressRanges();
       if (maxUnloadedAddressRanges < 1)
@@ -1160,7 +1160,7 @@ J9::PersistentInfo::isUnloadedClass(
       void *v,
       bool yesIReallyDontCareAboutHCR)
    {
-   if (getJITaaSMode() != SERVER_MODE)
+   if (getRemoteCompilationMode() != JITServer::SERVER)
       {
       OMR::CriticalSection isUnloadedClass(assumptionTableMutex);
       return _unloadedClassAddresses && _unloadedClassAddresses->mayContain((uintptrj_t)v);
@@ -1193,7 +1193,7 @@ J9::PersistentInfo::isObsoleteClass(void *v, TR_FrontEnd *fe)
 bool
 J9::PersistentInfo::isInUnloadedMethod(uintptrj_t address)
    {
-   TR_ASSERT(getJITaaSMode() != SERVER_MODE, "JITaaS server does not maintain unloaded method ranges, this method should not be called");
+   TR_ASSERT(getRemoteCompilationMode() != JITServer::SERVER, "JITServer does not maintain unloaded method ranges, this method should not be called");
    OMR::CriticalSection isInUnloadedMethod(assumptionTableMutex);
    return _unloadedMethodAddresses && _unloadedMethodAddresses->mayContain(address);
    }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -176,7 +176,7 @@ createExceptionTable(
          *(uint32_t *)cursor = e->_instructionEndPC, cursor += 4;
          *(uint32_t *)cursor = e->_instructionHandlerPC, cursor += 4;
          *(uint32_t *)cursor = e->_catchType, cursor += 4;
-         if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE() || comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+         if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE() || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
             *(uintptrj_t *)cursor = (uintptrj_t)e->_byteCodeInfo.getCallerIndex(), cursor += sizeof(uintptrj_t);
          else
             *(uintptrj_t *)cursor = (uintptrj_t)e->_method->resolvedMethodAddress(), cursor += sizeof(uintptrj_t);
@@ -1077,7 +1077,7 @@ populateBodyInfo(
    //
    if (recompInfo)
       {
-      if (vm->isAOT_DEPRECATED_DO_NOT_USE() || comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+      if (vm->isAOT_DEPRECATED_DO_NOT_USE() || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          // The allocation for the Persistent Method Info and the Persistent Jitted Body Info used to be allocated with the exception table.
          // Exception tables are now being reaped on method recompilation.  As these need to be persistent, we need to allocate them separately.
@@ -1139,7 +1139,7 @@ populateBodyInfo(
       }
    else
       {
-      if (vm->isAOT_DEPRECATED_DO_NOT_USE() || comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+      if (vm->isAOT_DEPRECATED_DO_NOT_USE() || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
          TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
@@ -1218,7 +1218,7 @@ static void populateInlineCalls(
           traceMsg(comp, "inlineIdx %d, callSiteCursor %p, inlinedCallSite->methodInfo = %p\n", i, callSiteCursor, inlinedCallSite->_methodInfo);
           }
 
-      if (!vm->isAOT_DEPRECATED_DO_NOT_USE() && TR::comp()->getPersistentInfo()->getJITaaSMode() != SERVER_MODE) // For AOT, we should only have returned resolved info about a method if the method came from same class loaders.
+      if (!vm->isAOT_DEPRECATED_DO_NOT_USE() && TR::comp()->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER) // For AOT, we should only have returned resolved info about a method if the method came from same class loaders.
          {
          TR_OpaqueClassBlock *clazzOfInlinedMethod = vm->getClassFromMethodBlock(inlinedCallSite->_methodInfo);
          if (comp->fej9()->isUnloadAssumptionRequired(clazzOfInlinedMethod, comp->getCurrentMethod()))
@@ -1472,13 +1472,13 @@ createMethodMetaData(
    data->registerSaveDescription = comp->cg()->getRegisterSaveDescription();
 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
-   bool isJITaaSMode = comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE;
-   if (vm->isAOT_DEPRECATED_DO_NOT_USE() || isJITaaSMode)
+   bool isJITServer = comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER;
+   if (vm->isAOT_DEPRECATED_DO_NOT_USE() || isJITServer)
       {
       TR::CodeCache * codeCache = comp->cg()->getCodeCache(); // MCT
 
       /* Align code caches */
-      if (!isJITaaSMode)
+      if (!isJITServer)
          codeCache->alignWarmCodeAlloc(3);
 
       J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
@@ -1558,7 +1558,7 @@ createMethodMetaData(
    populateInlineCalls(comp, vm, data, callSiteCursor, numberOfMapBytes);
 
    if (!(vm->_jitConfig->runtimeFlags & J9JIT_TOSS_CODE) && !vm->isAOT_DEPRECATED_DO_NOT_USE() &&
-       comp->getPersistentInfo()->getJITaaSMode() != SERVER_MODE)
+       comp->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER)
       {
       TR_TranslationArtifactManager *artifactManager = TR_TranslationArtifactManager::getGlobalArtifactManager();
       TR_TranslationArtifactManager::CriticalSection updateMetaData;

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <stddef.h>
 #include <stdint.h>
+#include <vector>
 #include "env/RuntimeAssumptionTable.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -47,7 +47,7 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _fej9((TR_J9VM *)TR_J9VMBase::get(
         _vmThread->javaVM->jitConfig,
         _vmThread,
-        TR::CompilationInfo::get()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE ?
+        TR::CompilationInfo::get()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER ?
            TR_J9VMBase::J9_SERVER_VM : TR_J9VMBase::DEFAULT_VM)),
      _trMemory(_comp->trMemory()),
      _chTable(_comp->getPersistentInfo()->getPersistentCHTable()),

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -949,7 +949,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
          // XXX: Ugly, not sure how this was supposed to work but for AOT (and now JITaaS) we do direct calls
 	 // through snippets, except the method we're calling might already be compiled, in which case getMethodAddress()
 	 // returns the compiled code entrypoint instead of the RAM method... how did AOT not hit this?
-         intptrj_t ramMethod = comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE && !methodSymbol->isInterpreted() ?
+         intptrj_t ramMethod = comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER && !methodSymbol->isInterpreted() ?
                                (intptr_t)methodSymRef->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod()->getPersistentIdentifier() :
 			       (intptr_t)methodSymbol->getMethodAddress();
 

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1743,7 +1743,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
                int32_t signatureLen = strlen(j2iSignature);
                virtualThunk = fej9->getJ2IThunk(j2iSignature, signatureLen, comp());
                // in server mode, we always need to regenerate the thunk inside the code cache for this compilation
-               if (!virtualThunk || comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+               if (!virtualThunk || comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
                   {
                   virtualThunk = fej9->setJ2IThunk(j2iSignature, signatureLen,
                      generateVirtualIndirectThunk(
@@ -1765,7 +1765,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
          {
          virtualThunk = fej9->getJ2IThunk(methodSymbol->getMethod(), comp());
          // in server mode, we always need to regenerate the thunk inside the code cache for this compilation
-         if (!virtualThunk || comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+         if (!virtualThunk || comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
             virtualThunk = fej9->setJ2IThunk(methodSymbol->getMethod(), generateVirtualIndirectThunk(callNode), comp());
          }
 


### PR DESCRIPTION

Change JITaaS related names in `PersistentInfo` which are
referenced by `ClientStream` and `ServerStream`.
Change SSL key/cert `std::vector` to `PersistentVector` and move
them out of `PersistentInfo` to `CompilationInfo`.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>