### PR TITLE
Remove redundant character substitution.

### DIFF
--- a/runtime/port/win32/j9shsem.c
+++ b/runtime/port/win32/j9shsem.c
@@ -161,12 +161,6 @@ j9shsem_open(struct J9PortLibrary *portLibrary, struct j9shsem_handle **handle, 
 	omrstr_printf(baseFile, J9SH_MAXPATH, "%s_semaphore", semaphoreFullName);
 	omrmem_free_memory(semaphoreFullName);
 	Trc_PRT_shsem_j9shsem_open_builtsemname(baseFile);
-	for (i = 0; baseFile[i] != '\0' && i < J9SH_MAXPATH; i++) {
-		if (('\\' == baseFile[i]) || (':' == baseFile[i]) || (' ' == baseFile[i])) {
-			baseFile[i] = '_';
-		}
-	}
-	Trc_PRT_shsem_j9shsem_open_translatedsemname(baseFile);
 
 	shsem_handle = (*handle) = createsemHandle(portLibrary, params->setSize, baseFile);
 	if (!shsem_handle) {


### PR DESCRIPTION
Remove semaphore name translation which is already reduced to alphanumeric charactes such that the additional loop will never cause any substitution.

Signed-off-by: Rafael Winterhalter <rafael.wth@gmail.com>