### PR TITLE
WIP: Should not call destructor on null pointer

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -739,7 +739,7 @@ void TR::CompilationInfo::freeCompilationInfo(J9JITConfig *jitConfig)
    TR::CompilationInfo * compilationRuntime = _compilationRuntime;
    _compilationRuntime = NULL;
    TR::RawAllocator rawAllocator(jitConfig->javaVM);
-   _compilationRuntime->~CompilationInfo();
+   compilationRuntime->~CompilationInfo();
    rawAllocator.deallocate(compilationRuntime);
    }
 


### PR DESCRIPTION
For data member objects with non-primitive types,
calling CompilationInfo destructor on NULL pointer
could cause segmentation fault because this pointer
is already NULL when the object’s destructor is invoked.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>