### PR TITLE
Lock nursery is no longer optional

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -405,10 +405,6 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	 * @throws CorruptDataException
 	 */
 	private UDATA checkLockwordNeeded(J9ROMClassPointer romClass, J9ClassPointer ramSuperClass,J9ClassPointer instanceClass) throws CorruptDataException {
-		if (!J9BuildFlags.thr_lockNursery) {
-			return NO_LOCKWORD_NEEDED;
-		}
-
 		J9ClassPointer ramClassForRomClass = instanceClass;
 		while (!ramClassForRomClass.isNull() && (!romClass.equals(ramClassForRomClass.romClass()))) {
 			ramClassForRomClass = J9ClassHelper.superclass(ramClassForRomClass);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectMonitor_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectMonitor_V1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -253,19 +253,15 @@ class ObjectMonitor_V1 extends ObjectMonitor
 	{
 		lockword = J9ObjectMonitorPointer.NULL;
 		
-		if(J9BuildFlags.thr_lockNursery) {
-			// TODO : why isn't there a cast UDATA->IDATA?
-			IDATA lockOffset = new IDATA(J9ObjectHelper.clazz(object).lockOffset());
-			// TODO : why isn't there an int/long comparison
-			if(lockOffset.gte(new IDATA(0))) {
-				lockword = ObjectMonitorReferencePointer.cast(object.addOffset(lockOffset.longValue())).at(0);			
-			} else {
-				if (j9objectMonitor.notNull()) {
-					lockword = j9objectMonitor.alternateLockword();
-				}
-			}
+		// TODO : why isn't there a cast UDATA->IDATA?
+		IDATA lockOffset = new IDATA(J9ObjectHelper.clazz(object).lockOffset());
+		// TODO : why isn't there an int/long comparison
+		if(lockOffset.gte(new IDATA(0))) {
+			lockword = ObjectMonitorReferencePointer.cast(object.addOffset(lockOffset.longValue())).at(0);			
 		} else {
-			lockword = J9ObjectMonitorPointer.cast(J9ObjectHelper.monitor(object));
+			if (j9objectMonitor.notNull()) {
+				lockword = j9objectMonitor.alternateLockword();
+			}
 		}
 		
 		if(lockword.notNull()) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/RootScanner.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/RootScanner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -596,22 +596,10 @@ public abstract class RootScanner
 		while (vmThreadListIterator.hasNext()) {
 			J9VMThreadPointer walkThread = vmThreadListIterator.next();
 			
-			if (J9BuildFlags.thr_lockNursery) {
-				ObjectMonitorReferencePointer objectMonitorLookupCache = walkThread.objectMonitorLookupCacheEA();
-				for (long cacheIndex = 0; cacheIndex < J9VMThread.J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE; cacheIndex++) {
-					ObjectMonitorReferencePointer slotAddress = objectMonitorLookupCache.add(cacheIndex);
-					doMonitorLookupCacheSlot(slotAddress.at(0), slotAddress);
-				}
-			} else {
-				
-				/* Can't implement this because walkThread.cachedMonitor field does not exist as we've never had a vm29 spec yet with the condition: 
-				 * (!J9BuildFlags.thr_lockNursery && !J9BuildFlags.opt_realTimeLockingSupport)
-				 * 
-				 * // This cast is ugly but is technically what the c-code is doing 
-				 * ObjectMonitorReferencePointer cachedMonitorSlot = ObjectMonitorReferencePointer.cast(walkThread.cachedMonitorEA());
-				 * doMonitorLookupCacheSlot(walkThread.cachedMonitor(), cachedMonitorSlot);
-				 */
-				throw new UnsupportedOperationException("Not implemented");
+			ObjectMonitorReferencePointer objectMonitorLookupCache = walkThread.objectMonitorLookupCacheEA();
+			for (long cacheIndex = 0; cacheIndex < J9VMThread.J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE; cacheIndex++) {
+				ObjectMonitorReferencePointer slotAddress = objectMonitorLookupCache.add(cacheIndex);
+				doMonitorLookupCacheSlot(slotAddress.at(0), slotAddress);
 			}
 		}
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ObjectHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ObjectHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,14 +97,8 @@ public class J9ObjectHelper
 	
 	public static UDATA monitor(J9ObjectPointer objPointer) throws CorruptDataException 
 	{
-		if(J9BuildFlags.thr_lockNursery) {
-			// TODO : lockNursery support
-			throw new UnsupportedOperationException("lockNursery not supported yet");			
-		} else {
-			// TODO : non-lockNursery support
-			throw new UnsupportedOperationException("need a non-lockNursery blob");
-			//return new UDATA(getUDATAAtOffset(J9Object._monitorOffset_));
-		}
+		// TODO : lockNursery support
+		throw new UnsupportedOperationException("lockNursery not supported yet");			
 	}
 	
 	/**

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9ClassShapeCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9ClassShapeCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,10 +92,7 @@ public class J9ClassShapeCommand extends Command
 
 			String className = J9ClassHelper.getName(instanceClass);
 			J9VMThreadPointer mainThread = vm.mainThread();
-			boolean lockwordPrinted = true;
-			if (J9BuildFlags.thr_lockNursery) {
-				lockwordPrinted = false;
-			}
+			boolean lockwordPrinted = false;
 			CommandUtils.dbgPrint(out, "Instance fields in %s:\n", className);
 			CommandUtils.dbgPrint(out, "\noffset     name\tsignature\t(declaring class)\n");
 
@@ -124,19 +121,17 @@ public class J9ClassShapeCommand extends Command
 					boolean printField = true;
 					boolean isHiddenField = result.isHidden();
 
-					if (J9BuildFlags.thr_lockNursery) {
-						boolean isLockword = (isHiddenField && (result.getOffsetOrAddress().add(J9Object.SIZEOF).eq(superclass.lockOffset())));
+					boolean isLockword = (isHiddenField && (result.getOffsetOrAddress().add(J9Object.SIZEOF).eq(superclass.lockOffset())));
 
-						if (isLockword) {
-							/*
-							 * Print the lockword field if it is indeed the
-							 * lockword for this instanceClass and we haven't
-							 * printed it yet.
-							 */
-							printField = !lockwordPrinted && instanceClass.lockOffset().eq(superclass.lockOffset());
-							if (printField) {
-								lockwordPrinted = true;
-							}
+					if (isLockword) {
+						/*
+						 * Print the lockword field if it is indeed the
+						 * lockword for this instanceClass and we haven't
+						 * printed it yet.
+						 */
+						printField = !lockwordPrinted && instanceClass.lockOffset().eq(superclass.lockOffset());
+						if (printField) {
+							lockwordPrinted = true;
 						}
 					}
 					if (printField) {

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -1119,29 +1119,6 @@ static void genInitObjectHeader(TR::CodeGenerator  *cg,
    tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, (int32_t)TR::Compiler->om.offsetOfHeaderFlags(), cg);
    iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, temp1Reg, iCursor);
 #endif /* J9VM_INTERP_FLAGS_IN_CLASS_SLOT */
-
-   // Initialize monitor if required
-   int32_t monitorOffset;
-   bool initMonitor = false;
-#if !defined(J9VM_THR_LOCK_NURSERY)
-   monitorOffset = (int32_t)TMP_OFFSETOF_J9OBJECT_MONITOR;
-   initMonitor = true;
-#elif defined(J9VM_THR_LOCK_NURSERY_FAT_ARRAYS)
-   monitorOffset = (int32_t)TMP_OFFSETOF_J9INDEXABLEOBJECT_MONITOR;
-   // Initialize the monitor
-   // word for arrays that have a
-   // lock word
-   int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *)clazz);
-   if ((node->getOpCodeValue() != TR::New) &&
-         (lwOffset > 0))
-      initMonitor = true;
-#endif
-   if (initMonitor)
-      {
-      tempMR = new (cg->trHeapMemory()) TR::MemoryReference(resReg, monitorOffset, cg);
-      iCursor = generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, zeroReg, iCursor);
-      }
-
    }
 
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1547,13 +1547,8 @@ bool TR_J9VMBase::generateCompressedPointers()
 
 bool TR_J9VMBase::generateCompressedLockWord()
    {
-#if defined(J9VM_THR_LOCK_NURSERY)
    if (sizeof(j9objectmonitor_t) == 4)
       return true;
-#else
-   if (sizeof((((J9Object *)NULL)->monitor)) == 4)
-      return true;
-#endif
    return false;
    }
 
@@ -2107,16 +2102,12 @@ TR_J9VMBase::getWriteBarrierGCFlagMaskAsByte()
 int32_t
 TR_J9VMBase::getByteOffsetToLockword(TR_OpaqueClassBlock * clazzPointer)
    {
-#if defined (J9VM_THR_LOCK_NURSERY)
    J9JavaVM * jvm = _jitConfig->javaVM;
 
    if (clazzPointer == NULL)
       return 0;
 
    return TR::Compiler->cls.convertClassOffsetToClassPtr(clazzPointer)->lockOffset;
-#else
-   return TMP_OFFSETOF_J9OBJECT_MONITOR;
-#endif
    }
 
 bool
@@ -4402,10 +4393,7 @@ TR_J9VMBase::initializeLocalObjectFlags(TR::Compilation * comp, TR::Node * alloc
 
 bool TR_J9VMBase::hasTwoWordObjectHeader()
   {
-#if defined(J9VM_THR_LOCK_NURSERY)
   return true;
-#endif
-  return false;;
   }
 
 // Create trees to initialize the header of an object that is being created

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1397,10 +1397,10 @@ J9::ValuePropagation::innerConstrainAcall(TR::Node *node)
                         }
                      }
                   }
-               // Dynamic object clone is enabled only with FLAGS_IN_CLASS_SLOT and LOCK_NURSERY enabled
+               // Dynamic object clone is enabled only with FLAGS_IN_CLASS_SLOT enabled
                // as currenty codegen anewarray evaluator only supports this case for object header initialization.
-               // Even though all existing supported build config has these 2 falgs set, this ifdef serves as a safety precaution.
-#if defined(J9VM_INTERP_FLAGS_IN_CLASS_SLOT) && defined(J9VM_THR_LOCK_NURSERY)
+               // Even though all existing supported build config have this flag set, this ifdef serves as a safety precaution.
+#if defined(J9VM_INTERP_FLAGS_IN_CLASS_SLOT)
                else if ( constraint->getClassType()
                          && constraint->getClassType()->asResolvedClass() )
                   {

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -5866,7 +5866,6 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
    generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel, NULL);
    startLabel->setStartInternalControlFlow();
 
-#if defined (J9VM_THR_LOCK_NURSERY)
    if (lwOffset <= 0)
       {
       objectClassReg = cg->allocateRegister();
@@ -5960,7 +5959,6 @@ TR::Register *J9::Power::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::C
 
       numDeps = numDeps + 2;
       }
-#endif
 
    bool reserveLocking = false, normalLockWithReservationPreserving = false;
 
@@ -7083,24 +7081,6 @@ static void genInitObjectHeader(TR::Node *node, TR::Instruction *&iCursor, TR_Op
       opCode = TR::InstOpCode::stw;
       lockSize = 4;
       }
-
-#if !defined(J9VM_THR_LOCK_NURSERY)
-   // Init monitor
-   if (needZeroInit)
-      iCursor = generateMemSrc1Instruction(cg, opCode, node, new (cg->trHeapMemory()) TR::MemoryReference(resReg, TMP_OFFSETOF_J9OBJECT_MONITOR, lockSize, cg), zeroReg, iCursor);
-#endif
-#if defined(J9VM_THR_LOCK_NURSERY) && defined(J9VM_THR_LOCK_NURSERY_FAT_ARRAYS)
-   // Initialize the monitor
-   // word for arrays that have a
-   // lock word
-   int32_t lwOffset = fej9->getByteOffsetToLockword(clazz);
-   if (needZeroInit &&
-         (node->getOpCodeValue() != TR::New) &&
-         (lwOffset > 0) && !fej9->isPackedClass(classAddress))
-   iCursor = generateMemSrc1Instruction(cg, opCode, node,
-         new (cg->trHeapMemory()) TR::MemoryReference(resReg, TMP_OFFSETOF_J9INDEXABLEOBJECT_MONITOR, lockSize, cg),
-         zeroReg, iCursor);
-#endif
    }
 
 static void genAlignArray(TR::Node *node, TR::Instruction *&iCursor, bool isVariableLen, TR::Register *resReg, int32_t objectSize, int32_t dataBegin, TR::Register *dataSizeReg,
@@ -8522,7 +8502,6 @@ TR::Register *J9::Power::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Co
    generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel, NULL);
    startLabel->setStartInternalControlFlow();
 
-#if defined (J9VM_THR_LOCK_NURSERY)
    if (lwOffset <= 0)
       {
       objectClassReg = cg->allocateRegister();
@@ -8615,7 +8594,6 @@ TR::Register *J9::Power::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Co
 
       numDeps = numDeps + 2;
       }
-#endif
 
    bool reserveLocking = false, normalLockWithReservationPreserving = false;
 

--- a/runtime/compiler/ras/kca_offsets_generator.cpp
+++ b/runtime/compiler/ras/kca_offsets_generator.cpp
@@ -91,11 +91,7 @@ J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
       #else
 	  fprintf( file, "#define J9OBJECT_FLAGS             (0) // Does not exist!\n" );
       #endif
-      #if !defined(J9VM_THR_LOCK_NURSERY)
-      fprintf( file, "#define J9OBJECT_MONITOR           (%d)\n", offsetof(J9IndexableObjectContiguous,monitor) );
-      #else
       fprintf( file, "#define J9OBJECT_MONITOR           (0) // Does not exist!\n" );
-      #endif
       fprintf( file, "#define J9OBJECT_ARRAY_SIZE        (%d)\n", offsetof(J9IndexableObjectContiguous,size) );
 
       fprintf( file, "#define METADATA_CLASSNAME         (%d)\n", offsetof(J9JITExceptionTable,className) );

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -660,9 +660,6 @@ static void generateCommonLockNurseryCodes(TR::Node          *node,
                                      TR::Register      *objectReg
                                      )
    {
-#if !defined(J9VM_THR_LOCK_NURSERY)
-   TR_ASSERT(0, "the x86 evaluator requires lock nursery to be defined, otherwise you'll need to make sure the code below works");
-#endif
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
    if (comp->getOption(TR_EnableMonitorCacheLookup))

--- a/runtime/compiler/x/runtime/X86LockReservation.nasm
+++ b/runtime/compiler/x/runtime/X86LockReservation.nasm
@@ -75,18 +75,14 @@ eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
 ; lockword address => _rcx
 ; lockword value   => _rax
 %macro ObtainLockWordHelper 1 ; args: ObjAddr
-    %ifdef ASM_J9VM_THR_LOCK_NURSERY
-        %ifdef ASM_OMR_GC_COMPRESSED_POINTERS
-            mov  eax, [%1 + J9TR_J9Object_class]        ; receiver class
-        %else
-            mov _rax, [%1 + J9TR_J9Object_class]         ; receiver class
-        %endif
-        and _rax, eq_ObjectClassMask
-        mov _rax, [_rax + J9TR_J9Class_lockOffset]        ; offset of lock word in receiver class
-        lea _rcx, [%1 + _rax]                             ; load the address of object lock word
+    %ifdef ASM_OMR_GC_COMPRESSED_POINTERS
+        mov  eax, [%1 + J9TR_J9Object_class]        ; receiver class
     %else
-        lea _rcx, [%1 + eq_J9Monitor_LockWord]           ; load the address of object lock word
+        mov _rax, [%1 + J9TR_J9Object_class]         ; receiver class
     %endif
+    and _rax, eq_ObjectClassMask
+    mov _rax, [_rax + J9TR_J9Class_lockOffset]        ; offset of lock word in receiver class
+    lea _rcx, [%1 + _rax]                             ; load the address of object lock word
     %ifdef ASM_OMR_GC_COMPRESSED_POINTERS
         mov  eax, [_rcx]
     %else

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1315,15 +1315,11 @@ MM_ObjectAccessBarrier::getArrayObjectDataAddress(J9VMThread *vmThread, J9Indexa
  j9objectmonitor_t *
 MM_ObjectAccessBarrier::getLockwordAddress(J9VMThread *vmThread, J9Object *object)
 {
-#if defined(J9VM_THR_LOCK_NURSERY)
 	UDATA lockOffset = J9OBJECT_CLAZZ(vmThread, object)->lockOffset;
 	if ((IDATA) lockOffset < 0) {
 		return NULL;	
 	}
 	return (j9objectmonitor_t *)(((U_8 *)object) + lockOffset);
-#else /* J9VM_THR_LOCK_NURSERY */
-	return &(object->monitor);
-#endif /* J9VM_THR_LOCK_NURSERY */
 }
 
 /**
@@ -1423,7 +1419,6 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 			}
 		}
 
-#if defined(J9VM_THR_LOCK_NURSERY)
 		/* initialize lockword, if present */
 		lockwordAddress = getLockwordAddress(vmThread, destObject);
 		if (NULL != lockwordAddress) {
@@ -1433,7 +1428,6 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 				*lockwordAddress = 0;
 			}
 		}
-#endif /* J9VM_THR_LOCK_NURSERY */
 	}
 }
 
@@ -1463,13 +1457,11 @@ MM_ObjectAccessBarrier::cloneIndexableObject(J9VMThread *vmThread, J9IndexableOb
 		_extensions->indexableObjectModel.memcpyArray(destObject, srcObject);
 	}
 
-#if defined(J9VM_THR_LOCK_NURSERY)
 	/* zero lockword, if present */
 	lockwordAddress = getLockwordAddress(vmThread, (J9Object*) destObject);
 	if (NULL != lockwordAddress) {
 		*lockwordAddress = 0;
 	}
-#endif /* J9VM_THR_LOCK_NURSERY */
 
 	return;
 }

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2019 IBM Corp. and others
  *
@@ -734,15 +733,11 @@ MM_RootScanner::scanMonitorLookupCaches(MM_EnvironmentBase *env)
 	GC_VMThreadListIterator vmThreadListIterator(static_cast<J9JavaVM*>(_omrVM->_language_vm));
 	while (J9VMThread *walkThread = vmThreadListIterator.nextVMThread()) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-#if defined(J9VM_THR_LOCK_NURSERY)
 			j9objectmonitor_t *objectMonitorLookupCache = walkThread->objectMonitorLookupCache;
 			UDATA cacheIndex = 0;
 			for (; cacheIndex < J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE; cacheIndex++) {
 				doMonitorLookupCacheSlot(&objectMonitorLookupCache[cacheIndex]);
 			}
-#else
-			doMonitorLookupCacheSlot(&vmThread->cachedMonitor);
-#endif /* J9VM_THR_LOCK_NURSERY */
 		}
 	}
 	reportScanningEnded(RootScannerEntity_MonitorLookupCaches);

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -330,15 +330,11 @@ public:
 		if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
 			return NULL;
 		}
-#if defined(J9VM_THR_LOCK_NURSERY)
 		UDATA lockOffset = clazz->lockOffset;
 		if ((IDATA) lockOffset < 0) {
 			return NULL;
 		}
 		return (j9objectmonitor_t *)(((U_8 *)object) + lockOffset);
-#else /* J9VM_THR_LOCK_NURSERY */
-		return &(object->monitor);
-#endif /* J9VM_THR_LOCK_NURSERY */
 	}
 
 	VMINLINE void
@@ -354,7 +350,6 @@ public:
 		} else {
 			VM_ArrayCopyHelpers::primitiveArrayCopy(currentThread, original, 0, copy, 0, size, (((J9ROMArrayClass*)objectClass->romClass)->arrayShape & 0x0000FFFF));
 		}
-#if defined(J9VM_THR_LOCK_NURSERY)
 		if (copyLockword) {
 			/* zero lockword, if present */
 			j9objectmonitor_t *lockwordAddress = getLockwordAddress(currentThread, copy);
@@ -362,7 +357,6 @@ public:
 				*lockwordAddress = 0;
 			}
 		}
-#endif /* J9VM_THR_LOCK_NURSERY */
 #endif /* defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
 	}
 
@@ -418,13 +412,11 @@ public:
 				offset += referenceSize;
 			}
 		
-#if defined(J9VM_THR_LOCK_NURSERY)
 			/* zero lockword, if present */
 			j9objectmonitor_t *lockwordAddress = getLockwordAddress(vmThread, destObject);
 			if (NULL != lockwordAddress) {
 				*lockwordAddress = 0;
 			}
-#endif /* J9VM_THR_LOCK_NURSERY */
 
 			postBatchStoreObject(vmThread, destObject);
 		}

--- a/runtime/gc_realtime/RealtimeRootScanner.cpp
+++ b/runtime/gc_realtime/RealtimeRootScanner.cpp
@@ -291,15 +291,11 @@ MM_RealtimeRootScanner::scanMonitorLookupCaches(MM_EnvironmentBase *env)
 		MM_EnvironmentRealtime* walkThreadEnv = MM_EnvironmentRealtime::getEnvironment(walkThread->omrVMThread);
 		if (FALSE == walkThreadEnv->_monitorCacheCleared) {
 			if (FALSE == MM_AtomicOperations::lockCompareExchangeU32(&walkThreadEnv->_monitorCacheCleared, FALSE, TRUE)) {
-#if defined(J9VM_THR_LOCK_NURSERY)
 				j9objectmonitor_t *objectMonitorLookupCache = walkThread->objectMonitorLookupCache;
 				UDATA cacheIndex = 0;
 				for (; cacheIndex < J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE; cacheIndex++) {
 					doMonitorLookupCacheSlot(&objectMonitorLookupCache[cacheIndex]);
 				}
-#else
-				doMonitorLookupCacheSlot(&vmThread->cachedMonitor);
-#endif /* J9VM_THR_LOCK_NURSERY */
 				if (condYield()) {
 					vmThreadListIterator.reset(static_cast<J9JavaVM*>(_omrVM->_language_vm)->mainThread);
 				}

--- a/runtime/gc_structs/ClassStaticsDeclarationOrderIterator.hpp
+++ b/runtime/gc_structs/ClassStaticsDeclarationOrderIterator.hpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,10 +31,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "modron.h"
-
-#ifdef J9VM_THR_LOCK_NURSERY
 #include "locknursery.h"
-#endif
 
 #include "GCExtensions.hpp"
 

--- a/runtime/gc_structs/MixedObjectDeclarationOrderIterator.hpp
+++ b/runtime/gc_structs/MixedObjectDeclarationOrderIterator.hpp
@@ -31,13 +31,11 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "modron.h"
+#include "locknursery.h"
 
 #include "MixedObjectModel.hpp"
 #include "SlotObject.hpp"
-
-#ifdef J9VM_THR_LOCK_NURSERY
 #include "locknursery.h"
-#endif
 
 /**
  * Iterate over all slots in a mixed object which contain an object reference.

--- a/runtime/include/locknursery.h
+++ b/runtime/include/locknursery.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,6 @@
 #ifndef locknursery_h
 #define locknursery_h
 
-#if defined(J9VM_THR_LOCK_NURSERY)
-
 #define JAVA_LANG_CLASS_CLASSNAME 	"java/lang/Class"
 #define JAVA_LANG_STRING_CLASSNAME 	"java/lang/String"
 
@@ -43,9 +41,5 @@
 #else /* !defined(J9VM_OUT_OF_PROCESS) */
 #define ROM_FIELD_WALK_MODIFIERS(javavm) dbgReadU32((U_32*)&(javavm)->romFieldsWalkModifiers)
 #endif /* !defined(J9VM_OUT_OF_PROCESS) */
-#else /* defined(J9VM_THR_LOCK_NURSERY) */
-#define ROM_FIELD_WALK_MODIFIERS(javavm) 0
-
-#endif /* defined(J9VM_THR_LOCK_NURSERY) */
 
 #endif /* locknursery_h */

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -291,9 +291,6 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #if defined(J9VM_INTERP_COMPRESSED_OBJECT_HEADER)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER", 1) |
 #endif /* J9VM_INTERP_COMPRESSED_OBJECT_HEADER */
-#if defined(J9VM_THR_LOCK_NURSERY)
-			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_THR_LOCK_NURSERY", 1) |
-#endif /* J9VM_THR_LOCK_NURSERY */
 #if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_INTERP_SMALL_MONITOR_SLOT", 1) |
 #endif /* J9VM_INTERP_SMALL_MONITOR_SLOT */
@@ -509,9 +506,7 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			/* J9Class */
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_classLoader", offsetof(J9Class, classLoader)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_lastITable", offsetof(J9Class, lastITable)) |
-#if defined(J9VM_THR_LOCK_NURSERY)
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_lockOffset", offsetof(J9Class, lockOffset)) |
-#endif /* J9VM_THR_LOCK_NURSERY */
 			writeConstant(OMRPORTLIB, fd, "J9TR_ArrayClass_componentType", offsetof(J9ArrayClass, componentType)) |
 
 			/* J9ITable */

--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -68,15 +68,12 @@ public:
 	inlineGetLockAddress(J9VMThread *currentThread, j9object_t object)
 	{
 		j9objectmonitor_t *lockEA = NULL;
-#ifdef J9VM_THR_LOCK_NURSERY
 		if (!LN_HAS_LOCKWORD(currentThread, object)) {
 			J9ObjectMonitor *objectMonitor = J9_VM_FUNCTION(currentThread, monitorTableAt)(currentThread, object);
 			if (NULL != objectMonitor) {
 				lockEA = &(objectMonitor->alternateLockword);
 			}
-		} else
-#endif
-		{
+		} else {
 			lockEA = J9OBJECT_MONITOR_EA(currentThread, object);
 		}
 		return lockEA;
@@ -103,7 +100,6 @@ public:
 		j9objectmonitor_t lock = (j9objectmonitor_t)NULL;
 		J9ObjectMonitor *objectMonitor = NULL;
 
-#ifdef J9VM_THR_LOCK_NURSERY
 		if (!LN_HAS_LOCKWORD(currentThread, object)) {
 			objectMonitor = monitorTableAt(currentThread, object);
 			if (objectMonitor == NULL) {
@@ -113,9 +109,7 @@ public:
 			}
 			lock = objectMonitor->alternateLockword;
 		}
-		else
-#endif
-		{
+		else {
 			lock = J9OBJECT_MONITOR(currentThread, object);
 		}
 
@@ -261,10 +255,7 @@ done:
 	inlineFastObjectMonitorEnter(J9VMThread *currentThread, j9object_t object)
 	{
 		bool locked = false;
-#if defined(J9VM_THR_LOCK_NURSERY)
-		if (LN_HAS_LOCKWORD(currentThread, object))
-#endif /* J9VM_THR_LOCK_NURSERY */
-		{
+		if (LN_HAS_LOCKWORD(currentThread, object)) {
 			locked = inlineFastInitAndEnterMonitor(currentThread, J9OBJECT_MONITOR_EA(currentThread, object));
 		}
 		return locked;
@@ -282,10 +273,7 @@ done:
 	inlineFastObjectMonitorExit(J9VMThread *currentThread, j9object_t object)
 	{
 		bool unlocked = false;
-#if defined(J9VM_THR_LOCK_NURSERY)
-		if (LN_HAS_LOCKWORD(currentThread, object))
-#endif /* J9VM_THR_LOCK_NURSERY */
-		{
+		if (LN_HAS_LOCKWORD(currentThread, object)) {
 			j9objectmonitor_t *lockEA = J9OBJECT_MONITOR_EA(currentThread, object);
 
 			if ((j9objectmonitor_t)(UDATA)currentThread == *lockEA) {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1510,9 +1510,7 @@ typedef struct J9ObjectMonitor {
 	UDATA proDeflationCount;
 	UDATA antiDeflationCount;
 #endif /* J9VM_THR_SMART_DEFLATION */
-#if defined(J9VM_THR_LOCK_NURSERY)
 	j9objectmonitor_t alternateLockword;
-#endif /* J9VM_THR_LOCK_NURSERY */
 	U_32 hash;
 } J9ObjectMonitor;
 
@@ -4704,9 +4702,7 @@ typedef struct J9InternalVMFunctions {
 	UDATA  ( *queryLogOptions)(struct J9JavaVM *vm, I_32 buffer_size, void *options_buffer, I_32 *data_size) ;
 	UDATA  ( *setLogOptions)(struct J9JavaVM *vm, char *options) ;
 	void  ( *exitJavaThread)(struct J9JavaVM * vm) ;
-#if defined(J9VM_THR_LOCK_NURSERY)
 	void  ( *cacheObjectMonitorForLookup)(struct J9JavaVM* vm, struct J9VMThread* vmStruct, struct J9ObjectMonitor* objectMonitor) ;
-#endif /* J9VM_THR_LOCK_NURSERY */
 	void*  ( *jniArrayAllocateMemoryFromThread)(struct J9VMThread* vmThread, UDATA sizeInBytes) ;
 	void  ( *jniArrayFreeMemoryFromThread)(struct J9VMThread* vmThread, void* location) ;
 	void  (JNICALL *sendForGenericInvoke)(struct J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2008,7 +2008,6 @@ J9ObjectMonitor *
 monitorTableAt(J9VMThread* vmStruct, j9object_t object);
 
 
-#ifdef J9VM_THR_LOCK_NURSERY
 /**
 * @brief used to cache an J9ObjectMonitor in the vmthread structure so that
 *        we don't have to go to the monitor table to get it
@@ -2020,7 +2019,6 @@ monitorTableAt(J9VMThread* vmStruct, j9object_t object);
 void
 cacheObjectMonitorForLookup(J9JavaVM* vm, J9VMThread* vmStruct, J9ObjectMonitor* objectMonitor);
 
-#endif
 
 /* ---------------- PackageIDHashTable.c ---------------- */
 

--- a/runtime/tests/thread/testnatives/testnatives.c
+++ b/runtime/tests/thread/testnatives/testnatives.c
@@ -540,12 +540,9 @@ Java_com_ibm_j9_monitor_tests_TestNatives_getLockWordValue(JNIEnv* env, jobject 
 	vm->internalVMFunctions->internalEnterVMFromJNI((J9VMThread *)env);
 
 	obj = J9_JNI_UNWRAP_REFERENCE(lockwordObj);
-#if defined( J9VM_THR_LOCK_NURSERY )
 	if (!LN_HAS_LOCKWORD(currentThread, obj)) {
 		lock = 0 | OBJECT_HEADER_LOCK_INFLATED;
-	} else
-#endif
-	{
+	} else {
 		j9objectmonitor_t *lockEA = J9OBJECT_MONITOR_EA(currentThread, obj);
 		if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(currentThread)) {
 			lock = *(U_32*)lockEA;

--- a/runtime/util/moninfo.c
+++ b/runtime/util/moninfo.c
@@ -61,15 +61,11 @@ getObjectMonitorOwner(J9JavaVM *vm, J9VMThread *vmThread, j9object_t object, UDA
 	UDATA count = 0;
 	J9VMThread *owner = NULL;
 	j9objectmonitor_t lock;
-#ifdef J9VM_THR_LOCK_NURSERY
-	J9ObjectMonitor *objectMonitor;
-#endif
 
 	Trc_VMUtil_getObjectMonitorOwner_Entry(vm, object, pcount);
 
-#ifdef J9VM_THR_LOCK_NURSERY
 	if (!LN_HAS_LOCKWORD(vmThread,object)) {
-		objectMonitor = monitorTablePeek(vm, vmThread, object);
+		J9ObjectMonitor *objectMonitor = monitorTablePeek(vm, vmThread, object);
 		if (objectMonitor != NULL){
 			lock = objectMonitor->alternateLockword;
 		} else {
@@ -78,9 +74,6 @@ getObjectMonitorOwner(J9JavaVM *vm, J9VMThread *vmThread, j9object_t object, UDA
 	} else {
 		lock = J9OBJECT_MONITOR(vmThread, object);
 	}
-#else
-	lock = J9OBJECT_MONITOR(vmThread, object);
-#endif
 
 	if (J9_LOCK_IS_INFLATED(lock)) {
 		J9ThreadAbstractMonitor *monitor = getInflatedObjectMonitor(vm, vmThread, object, lock);

--- a/runtime/util/thrinfo.c
+++ b/runtime/util/thrinfo.c
@@ -71,12 +71,6 @@
 /* include the debug extension prototypes if we are being recompiled in dbgext/ */
 #include "dbggen.h"
 
-#ifndef J9VM_THR_LOCK_NURSERY
-/* The J9OBJECT_MONITOR_EA macro doesn't currently work OOP on Metronome VMs */
-#undef J9OBJECT_MONITOR_EA
-#define J9OBJECT_MONITOR_EA(token,obj) (&TMP_J9OBJECT_MONITOR(obj))
-#endif
-
 #endif /* J9VM_OUT_OF_PROCESS */
 
 
@@ -772,7 +766,6 @@ static j9objectmonitor_t
 getLockWord(J9VMThread *vmThread, j9object_t object)
 {
 	j9objectmonitor_t lockWord;
-#ifdef J9VM_THR_LOCK_NURSERY
 
 	if (LN_HAS_LOCKWORD(vmThread,object)) {
 		lockWord = READMON_ADDR(J9OBJECT_MONITOR_EA(vmThread, object));
@@ -784,9 +777,6 @@ getLockWord(J9VMThread *vmThread, j9object_t object)
 			lockWord = 0;
 		}
 	}
-#else
-	lockWord = READMON_ADDR(J9OBJECT_MONITOR_EA(vmThread, object));
-#endif
 
 	return lockWord;
 }

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -290,15 +290,12 @@ objectMonitorEnterNonBlocking(J9VMThread *currentThread, j9object_t object)
 			*lwEA = incremented;
 			/* no barrier is required in the recursive case */
 		} else {
-#if defined(J9VM_THR_LOCK_NURSERY)
 			/* check to see if object is unlocked (JIT did not do initial inline sequence due to insufficient static type info) */
 			if ((0 == (lock & ~OBJECT_HEADER_LOCK_RESERVED)) &&
 				VM_ObjectMonitor::inlineFastInitAndEnterMonitor(currentThread, lwEA, false, lock)
 			) {
 				/* compare and swap succeeded - barrier already performed */
-			} else
-#endif /* J9VM_THR_LOCK_NURSERY */
-			{
+			} else {
 				J9ObjectMonitor *objectMonitor = NULL;
 				/* check if the monitor is flat */
 				if (!J9_LOCK_IS_INFLATED(lock)) {
@@ -508,11 +505,7 @@ spinOnTryEnter(J9VMThread *currentThread, J9ObjectMonitor *objectMonitor, j9obje
 	UDATA _tryEnterSpinCount2 = tryEnterSpinCount2;
 
 	/* we have the monitor object from the lock word so prime the cache with the monitor so we do not later look it up from the monitor table */
-#if defined(J9VM_THR_LOCK_NURSERY)
 	cacheObjectMonitorForLookup(vm, currentThread, objectMonitor);
-#else /* J9VM_THR_LOCK_NURSERY */
-	currentThread->cachedMonitor = objectMonitor;
-#endif /* J9VM_THR_LOCK_NURSERY */
 
 	for (; _tryEnterYieldCount > 0; _tryEnterYieldCount--) {
 		for (_tryEnterSpinCount2 = tryEnterSpinCount2; _tryEnterSpinCount2 > 0; _tryEnterSpinCount2--) {

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2446,9 +2446,7 @@ fail:
 					ramClass->totalInstanceSize = classBeingRedefined->totalInstanceSize;
 					ramClass->backfillOffset = classBeingRedefined->backfillOffset;
 					ramClass->finalizeLinkOffset = classBeingRedefined->finalizeLinkOffset;
-#if defined(J9VM_THR_LOCK_NURSERY)
 					ramClass->lockOffset = classBeingRedefined->lockOffset;
-#endif
 				} else {
 					instanceDescription = allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].address;
 					iTable = allocationRequests[RAM_ITABLE_FRAGMENT].address;
@@ -2880,9 +2878,6 @@ fail:
 				ramArrayClass->componentType = elementClass;
 				ramArrayClass->module = leafComponentType->module;
 				
-#if defined(J9VM_THR_LOCK_NURSERY) && defined(J9VM_THR_LOCK_NURSERY_FAT_ARRAYS)
-				ramArrayClass->lockOffset = (UDATA)TMP_OFFSETOF_J9INDEXABLEOBJECT_MONITOR;
-#endif
 				if (J9_IS_J9CLASS_VALUETYPE(elementClass) && J9_IS_J9CLASS_FLATTENED(elementClass)) {
 					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));

--- a/runtime/vm/description.c
+++ b/runtime/vm/description.c
@@ -23,9 +23,7 @@
 #include "j9.h"
 #include "j9protos.h"
 #include "j9consts.h"
-#ifdef J9VM_THR_LOCK_NURSERY
 #include "rommeth.h"
-#endif
 #include "ut_j9vm.h"
 #include "vm_internal.h"
 #include "locknursery.h"
@@ -106,10 +104,8 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 		}
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
-#if defined( J9VM_THR_LOCK_NURSERY )
 		/* write lockword offset into ramClass */
 		ramClass->lockOffset =	walkState->lockOffset;
-#endif
 		ramClass->finalizeLinkOffset = walkState->finalizeLinkOffset;
 	}
 	
@@ -313,7 +309,6 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 UDATA
 checkLockwordNeeded(J9JavaVM *vm, J9ROMClass *romClass, J9Class *ramSuperClass, U_32 walkFlags )
 {
-#ifdef J9VM_THR_LOCK_NURSERY
 	J9ROMMethod* romMethod;
 	UDATA i;
 	J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
@@ -469,10 +464,6 @@ checkLockwordNeeded(J9JavaVM *vm, J9ROMClass *romClass, J9Class *ramSuperClass, 
 
 	/* We should never get here due to the checking done in jvmint */
 	return NO_LOCKWORD_NEEDED;
-
-#else
-	return NO_LOCKWORD_NEEDED;
-#endif
 }
 
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -291,9 +291,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	queryLogOptions,
 	setLogOptions,
 	exitJavaThread,
-#if defined(J9VM_THR_LOCK_NURSERY)
 	cacheObjectMonitorForLookup,
-#endif /* J9VM_THR_LOCK_NURSERY */
 	jniArrayAllocateMemoryFromThread,
 	jniArrayFreeMemoryFromThread,
 	sendForGenericInvoke,

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -96,9 +96,7 @@
 
 #include "j2sever.h"
 
-#ifdef J9VM_THR_LOCK_NURSERY
 #include "locknursery.h"
-#endif
 
 #include "vmargs_api.h"
 #include "rommeth.h"
@@ -694,9 +692,7 @@ freeJavaVM(J9JavaVM * vm)
 
 	freeNativeMethodBindTable(vm);
 	freeHiddenInstanceFieldsList(vm);
-#ifdef J9VM_THR_LOCK_NURSERY
 	cleanupLockwordConfig(vm);
-#endif
 
 	destroyJvmInitArgs(vm->portLibrary, vm->vmArgsArray);
 	vm->vmArgsArray = NULL;
@@ -2189,7 +2185,6 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			}
 #endif
 
-#ifdef J9VM_THR_LOCK_NURSERY
 			/* set the default mode */
 			vm->lockwordMode =LOCKNURSERY_ALGORITHM_ALL_BUT_ARRAY;
 
@@ -2207,7 +2202,6 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				printLockwordWhat(vm);
 			}
 
-#endif
 			break;
 
 		case BYTECODE_TABLE_SET:

--- a/runtime/vm/lockwordconfig.c
+++ b/runtime/vm/lockwordconfig.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,8 +24,6 @@
 #include "vm_api.h"
 #include "j9vmnls.h"
 #include "jvminit.h"
-
-#if defined(J9VM_THR_LOCK_NURSERY)
 #include "locknursery.h"
 
 
@@ -286,6 +284,3 @@ printLockwordWhat(J9JavaVM* jvm)
 		hashTableForEachDo(jvm->lockwordExceptions, exceptionPrintWhat , PORTLIB);
 	}
 }
-
-#endif /* defined(J9VM_THR_LOCK_NURSERY) */
-

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -41,7 +41,6 @@ objectMonitorExit(J9VMThread* vmStruct, j9object_t object)
 
 	Trc_VM_objectMonitorExit_Entry(vmStruct,object);
 
-#ifdef J9VM_THR_LOCK_NURSERY
 	if (!LN_HAS_LOCKWORD(vmStruct,object)) {
 		J9ObjectMonitor *objectMonitor = NULL;
 
@@ -52,9 +51,7 @@ objectMonitorExit(J9VMThread* vmStruct, j9object_t object)
 		}
 
 		lockEA = &(objectMonitor->alternateLockword);
-	} else 
-#endif /* J9VM_THR_LOCK_NURSERY */
-	{
+	} else {
 		lockEA = J9OBJECT_MONITOR_EA(vmStruct, object);
 	}
 	lock = *lockEA;
@@ -218,13 +215,9 @@ objectMonitorInflate(J9VMThread* vmStruct, j9object_t object, UDATA lock)
 	/* set the count to be the current thread's count */
 	((J9ThreadAbstractMonitor*)monitor)->count = J9_FLATLOCK_COUNT(lock);	
 
-#ifdef J9VM_THR_LOCK_NURSERY
 	if (!LN_HAS_LOCKWORD(vmStruct,object)) {
 			objectMonitor->alternateLockword = (j9objectmonitor_t)(UDATA)objectMonitor | OBJECT_HEADER_LOCK_INFLATED;
-	}
-	else
-#endif
-	{
+	} else {
 		J9OBJECT_SET_MONITOR(vmStruct, object, (j9objectmonitor_t)(UDATA)objectMonitor | OBJECT_HEADER_LOCK_INFLATED);
 	}
 
@@ -263,16 +256,13 @@ cancelLockReservation(J9VMThread* vmStruct)
 	Assert_VM_mustHaveVMAccess(vmStruct);
 
 	object = vmStruct->blockingEnterObject;
-#ifdef J9VM_THR_LOCK_NURSERY
 	if (!LN_HAS_LOCKWORD(vmStruct,object)) {
 		J9ObjectMonitor *objectMonitor = monitorTableAt(vmStruct, object);
 
 		Assert_VM_true(objectMonitor != NULL);
 
 		lock = objectMonitor->alternateLockword;
-	} else
-#endif
-	{
+	} else {
 		lock = *J9OBJECT_MONITOR_EA(vmStruct, object);
 	}
 
@@ -289,16 +279,13 @@ cancelLockReservation(J9VMThread* vmStruct)
 
 		/* refresh the object pointer, since we may have released VM access */
 		object = vmStruct->blockingEnterObject;
-#ifdef J9VM_THR_LOCK_NURSERY
 		if (!LN_HAS_LOCKWORD(vmStruct,object)) {
 			J9ObjectMonitor *objectMonitor = monitorTableAt(vmStruct, object);
 
 			Assert_VM_true(objectMonitor != NULL);
 
 			lockEA = &objectMonitor->alternateLockword;
-		} else
-#endif
-		{
+		} else {
 			lockEA = J9OBJECT_MONITOR_EA(vmStruct, object);
 		}
 

--- a/runtime/vm/threadhelp.cpp
+++ b/runtime/vm/threadhelp.cpp
@@ -243,7 +243,6 @@ getMonitorForWait(J9VMThread* vmThread, j9object_t object)
 	omrthread_monitor_t monitor;
 	J9ObjectMonitor * objectMonitor;
 
-#ifdef J9VM_THR_LOCK_NURSERY
 	if (!LN_HAS_LOCKWORD(vmThread,object)) {
 		objectMonitor = monitorTableAt(vmThread, object);
 
@@ -255,9 +254,7 @@ getMonitorForWait(J9VMThread* vmThread, j9object_t object)
 		}
 		lock = objectMonitor->alternateLockword;
 	} 
-	else 
-#endif
-	{
+	else {
 		lock = J9OBJECT_MONITOR(vmThread, object);
 	}
 

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -211,7 +211,6 @@ processXLogOptions(J9JavaVM * vm);
 
 
 /* ---------------- lockwordconfig.c ---------------- */
-#if defined(J9VM_THR_LOCK_NURSERY)
 /**
  * This method should be called to clean up the lockword configuration
  *
@@ -248,7 +247,6 @@ printLockwordWhat(J9JavaVM* jvm);
  */
 J9HashTable* readLocknurseryHashtable(J9HashTable* lockwordExceptions);
 #endif /* J9VM_OUT_OF_PROCESS */
-#endif /* J9VM_THR_LOCK_NURSERY */
 
 
 /* ------------------- stringhelpers.c ----------------- */


### PR DESCRIPTION
J9VM_THR_LOCK_NURSERY is defined in every build.
J9VM_THR_LOCK_NURSERY_FAT_ARRAYS is undefined in every build.

Remove ifdefs and dead code appropriately.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>