### PR TITLE
Fix the releases sorting in the pipeline summary

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -503,7 +503,7 @@ def get_sorted_releases() {
     def unsortedReleases = variableFile.get_build_releases(BUILD_SPECS)
     def sortedReleases = []
 
-    for (release in RELEASES) {
+    for (release in CURRENT_RELEASES) {
         if (unsortedReleases.contains(release)) {
             sortedReleases.add(release)
         }


### PR DESCRIPTION
Sort the build releases in the pipeline summary table in ascending
order.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>