### PR TITLE
WIP: Remove references of deprecated IL opcodes in OpenJ9

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -2635,7 +2635,6 @@ J9::CodeGenerator::printNVVMIR(
       }
    else if (node->getOpCodeValue() == TR::bneg || node->getOpCodeValue() == TR::sneg ||
             node->getOpCodeValue() == TR::ineg || node->getOpCodeValue() == TR::lneg ||
-            node->getOpCodeValue() == TR::iuneg || node->getOpCodeValue() == TR::luneg ||
             node->getOpCodeValue() == TR::fneg || node->getOpCodeValue() == TR::dneg)
       {
       getNodeName(node->getChild(0), name0, self()->comp());

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3362,7 +3362,7 @@ TR_J9VMBase::lowerMethodHook(TR::Compilation * comp, TR::Node * root, TR::TreeTo
          TR::Node::createif(TR::ificmpne,
             TR::Node::create(TR::iand, 2,
                TR::Node::create(TR::bu2i, 1,
-                  TR::Node::createWithSymRef(root, TR::buload, 0, new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), addressSym))),
+                  TR::Node::createWithSymRef(root, TR::bload, 0, new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), addressSym))),
                TR::Node::create(root, TR::iconst, 0, J9HOOK_FLAG_HOOKED)),
             TR::Node::create(root, TR::iconst, 0, 0)));
 
@@ -3383,7 +3383,7 @@ TR_J9VMBase::lowerMethodHook(TR::Compilation * comp, TR::Node * root, TR::TreeTo
          TR::TreeTop * selectedTest = TR::TreeTop::create(comp,
             TR::Node::createif(TR::ificmpne,
                TR::Node::create(TR::bu2i, 1,
-                  TR::Node::createWithSymRef(root, TR::buload, 0, new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), extendedFlagsSym))),
+                  TR::Node::createWithSymRef(root, TR::bload, 0, new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), extendedFlagsSym))),
                TR::Node::create(root, TR::iconst, 0, 0)));
 
          result = selectedTest;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -303,7 +303,7 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
          case J9BCdaload: loadArrayElement(TR::Double);                             _bcIndex += 1; break;
          case J9BCaaload: loadArrayElement(TR::Address);                            _bcIndex += 1; break;
          case J9BCbaload: loadArrayElement(TR::Int8);             genUnary(TR::b2i); _bcIndex += 1; break;
-         case J9BCcaload: loadArrayElement(TR::Int16, TR::cloadi); genUnary(TR::su2i); _bcIndex += 1; break;
+         case J9BCcaload: loadArrayElement(TR::Int16);            genUnary(TR::su2i); _bcIndex += 1; break;
          case J9BCsaload: loadArrayElement(TR::Int16);            genUnary(TR::s2i); _bcIndex += 1; break;
 
          case J9BCiloadw: loadAuto(TR::Int32,  next2Bytes()); _bcIndex += 3; break;
@@ -358,7 +358,7 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
          case J9BCdastore:                   storeArrayElement(TR::Double);           _bcIndex += 1; break;
          case J9BCaastore:                   storeArrayElement(TR::Address);          _bcIndex += 1; break;
          case J9BCbastore: genUnary(TR::i2b); storeArrayElement(TR::Int8);             _bcIndex += 1; break;
-         case J9BCcastore: genUnary(TR::i2s); storeArrayElement(TR::Int16, TR::cstorei);_bcIndex += 1; break;
+         case J9BCcastore: genUnary(TR::i2s); storeArrayElement(TR::Int16);            _bcIndex += 1; break;
          case J9BCsastore: genUnary(TR::i2s); storeArrayElement(TR::Int16);            _bcIndex += 1; break;
 
          case J9BCistorew: storeAuto(TR::Int32,  next2Bytes()); _bcIndex += 3; break;

--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -285,11 +285,7 @@ bool TR_DynamicLiteralPool::transformLitPoolConst(TR::Node *grandParent, TR::Nod
       case TR::iconst:
       case TR::lconst:
       case TR::bconst:
-      case TR::cconst:
       case TR::sconst:
-      case TR::iuconst:
-      case TR::luconst:
-      case TR::buconst:
          if (transformNeeded(grandParent, parent, child))
             {
             if (performTransformation(comp(), "%s Large non-float Constant\n", optDetailString()))
@@ -372,22 +368,6 @@ bool TR_DynamicLiteralPool::transformNeeded(TR::Node *grandParent, TR::Node *par
       else
          {
          TR::ILOpCodes oldOpCode = child->getOpCodeValue();
-         if (oldOpCode == TR::iuconst &&
-             (parentOpCode.isAdd() || parentOpCode.isSub()))
-            {
-            TR::Node::recreate(child, TR::iconst);
-            }
-         else if (oldOpCode == TR::luconst &&
-             (parentOpCode.isAdd() || parentOpCode.isSub()))
-            {
-            TR::Node::recreate(child, TR::lconst);
-            }
-         else if (oldOpCode == TR::cconst &&
-             (parentOpCode.isAdd() || parentOpCode.isSub()))
-            {
-            TR::Node::recreate(child, TR::sconst);
-            }
-
          bool needs = (cg()->arithmeticNeedsLiteralFromPool(child));
          TR::Node::recreate(child, oldOpCode);
          return needs;

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1268,7 +1268,6 @@ TR_CISCGraph::addOpc2CISCNode(TR_CISCNode *n)
             if (!n->isValidOtherInfo()) break;
             // else fall through
          case TR_variable:
-         case TR::cconst:
          case TR::sconst:
          case TR::iconst:
          case TR::bconst:
@@ -2442,9 +2441,6 @@ TR_CISCTransformer::addAllSubNodes(TR_CISCGraph *const graph, TR::Block *const b
             {
             case TR::iconst:
                val = node->getInt();
-               break;
-            case TR::cconst:
-               val = node->getConst<uint16_t>();
                break;
             case TR::sconst:
                val = node->getShortInt();
@@ -6226,11 +6222,9 @@ TR_CISCTransformer::compareTrNodeTree(TR::Node *a, TR::Node *b)
       {
       switch(a->getOpCodeValue())
          {
-         case TR::iuconst:
          case TR::iconst:
             if (a->getUnsignedInt() != b->getUnsignedInt()) return false;
             break;
-         case TR::luconst:
          case TR::lconst:
             if (a->getUnsignedLongInt() != b->getUnsignedLongInt()) return false;
             break;
@@ -6244,14 +6238,10 @@ TR_CISCTransformer::compareTrNodeTree(TR::Node *a, TR::Node *b)
             if (a->getDouble() != b->getDouble()) return false;
             break;
          case TR::bconst:
-         case TR::buconst:
             if (a->getUnsignedByte() != b->getUnsignedByte()) return false;
             break;
          case TR::sconst:
             if (a->getShortInt() != b->getShortInt()) return false;
-            break;
-         case TR::cconst:
-            if (a->getConst<uint16_t>() != b->getConst<uint16_t>()) return false;
             break;
          default:
             return false;
@@ -6594,7 +6584,6 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                switch(n->getOpcode())
                   {
                   case TR::ifbcmpeq:
-                  case TR::ifsucmpeq:
                   case TR::ificmpeq:
                      takenBV.empty();
                      ntakenBV = *bv[tID];
@@ -6605,7 +6594,6 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                         }
                      break;
                   case TR::ifbcmpne:
-                  case TR::ifsucmpne:
                   case TR::ificmpne:
                      takenBV = *bv[tID];
                      ntakenBV.empty();

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -6863,7 +6863,6 @@ TR_CISCTransformer::analyzeCharBoolTable(TR_CISCNode *boolTable, uint8_t *table6
       case TR::su2i:
          if (defNode->isOptionalNode()) defNode = defNode->getChild(0);
          // fall through
-      case TR::cloadi:
          defBV.setAll(0, 65535);
          break;
       default:

--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -169,7 +169,6 @@ public:
          switch(_opcode)
             {
             case TR::iconst:
-            case TR::cconst:
             case TR::sconst:
             case TR::bconst:
             case TR::lconst:

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -387,7 +387,7 @@ createIdiomByteArrayStoreInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_
 TR_PCISCNode *
 createIdiomCharArrayLoadInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_PCISCNode *pred, TR_PCISCNode *base, TR_PCISCNode *index, TR_PCISCNode *cmah, TR_PCISCNode *const2)
    {
-   return createIdiomArrayLoadInLoop(tgt, ctrl, dagId, pred, TR::cloadi, TR::Int16, base, index, cmah, const2);
+   return createIdiomArrayLoadInLoop(tgt, ctrl, dagId, pred, TR::sloadi, TR::Int16, base, index, cmah, const2);
    }
 
 //*****************************************************************************************
@@ -420,7 +420,7 @@ createIdiomArrayStoreBodyInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_
       }
    else
       {
-      i2c = new (PERSISTENT_NEW) TR_PCISCNode(tgt->trMemory(),
+            i2c = new (PERSISTENT_NEW) TR_PCISCNode(tgt->trMemory(),
                                               (opcode == TR::cstorei) ? (TR_CISCOps)TR::i2s : TR_conversion,
                                               (opcode == TR::cstorei) ? TR::Int16 : TR::NoType,
                                               tgt->incNumNodes(),  dagId,   1,   1, pred); tgt->addNode(i2c);
@@ -440,7 +440,7 @@ createIdiomArrayStoreBodyInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_
 TR_PCISCNode *
 createIdiomCharArrayStoreBodyInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_PCISCNode *pred, TR_PCISCNode *addr, TR_PCISCNode *storeval)
    {
-   return createIdiomArrayStoreBodyInLoop(tgt, ctrl, dagId, pred, TR::cstorei, TR::Int16, addr, storeval);
+   return createIdiomArrayStoreBodyInLoop(tgt, ctrl, dagId, pred, TR::sstorei, TR::Int16, addr, storeval);
    }
 
 //*****************************************************************************************
@@ -464,7 +464,7 @@ createIdiomArrayStoreInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_PCIS
 TR_PCISCNode *
 createIdiomCharArrayStoreInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_PCISCNode *pred, TR_PCISCNode *base, TR_PCISCNode *index, TR_PCISCNode *cmah, TR_PCISCNode *const2, TR_PCISCNode *storeval)
    {
-   return createIdiomArrayStoreInLoop(tgt, ctrl, dagId, pred, TR::cstorei, TR::Int16, base, index, cmah, const2, storeval);
+   return createIdiomArrayStoreInLoop(tgt, ctrl, dagId, pred, TR::sstorei, TR::Int16, base, index, cmah, const2, storeval);
    }
 
 //*****************************************************************************************

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -420,9 +420,7 @@ createIdiomArrayStoreBodyInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_
       }
    else
       {
-            i2c = new (PERSISTENT_NEW) TR_PCISCNode(tgt->trMemory(),
-                                              (opcode == TR::cstorei) ? (TR_CISCOps)TR::i2s : TR_conversion,
-                                              (opcode == TR::cstorei) ? TR::Int16 : TR::NoType,
+            i2c = new (PERSISTENT_NEW) TR_PCISCNode(tgt->trMemory(), TR_conversion, TR::NoType,
                                               tgt->incNumNodes(),  dagId,   1,   1, pred); tgt->addNode(i2c);
       i2c->setIsOptionalNode();
       pred = i2c;

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -9201,7 +9201,6 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       {
       case TR::ificmpne:
       case TR::ifbcmpne:
-      case TR::ifsucmpne:
       case TR::ifscmpne:
       case TR::iflcmpne:
       case TR::ifacmpne:

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -1954,7 +1954,7 @@ makeTRT2ByteGraph(TR::Compilation *c, int32_t ctrl)
    TR_PCISCNode *nullChk = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::NULLCHK, TR::NoType,  tgt->incNumNodes(), 1, 1, 1, entry, charArray); tgt->addNode(nullChk); // optional
    TR_PCISCNode *bndChk = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::BNDCHK, TR::NoType,  tgt->incNumNodes(), 1, 1, 2, nullChk, arrayLen, iv);
    tgt->addNode(bndChk); // optional
-   TR_PCISCNode *arrayLoad  = createIdiomArrayLoadInLoop(tgt, ctrl, 1, bndChk, TR::cloadi, TR::Int16,  charArray, iv, aHeader, mulFactor);
+   TR_PCISCNode *arrayLoad  = createIdiomArrayLoadInLoop(tgt, ctrl, 1, bndChk, TR::sloadi, TR::Int16,  charArray, iv, aHeader, mulFactor);
    TR_PCISCNode *c2iNode  = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::su2i, TR::Int32,  tgt->incNumNodes(), 1, 1, 1, arrayLoad, arrayLoad);  tgt->addNode(c2iNode);
    TR_PCISCNode *boolTable  = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR_booltable, TR::NoType, tgt->incNumNodes(), 1, 2, 1, c2iNode, c2iNode);  tgt->addNode(boolTable);
    TR_PCISCNode *ivStore  = createIdiomDecVarInLoop(tgt, ctrl, 1, boolTable, iv, increment);
@@ -4641,7 +4641,7 @@ makeCopyingTRTOInduction1Graph(TR::Compilation *c, int32_t ctrl, int32_t pattern
    TR_PCISCNode *c1  = createIdiomArrayRelatedConst(tgt, ctrl, tgt->incNumNodes(), 4, 1);                    // element size
    TR_PCISCNode *c2  = createIdiomArrayRelatedConst(tgt, ctrl, tgt->incNumNodes(), 3, 2);                    // element size
    TR_PCISCNode *ent = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR_entrynode, TR::NoType, tgt->incNumNodes(),  2,   1,   0);        tgt->addNode(ent);
-   TR_PCISCNode *n2  = createIdiomArrayLoadInLoop(tgt, ctrl, 1,   ent, TR::cloadi, TR::Int16,  v0, v1, cmah0, c2);
+   TR_PCISCNode *n2  = createIdiomArrayLoadInLoop(tgt, ctrl, 1,   ent, TR::sloadi, TR::Int16,  v0, v1, cmah0, c2);
    TR_PCISCNode *n3  = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR_conversion, TR::NoType, tgt->incNumNodes(), 1,   1,   1,   n2, n2);  tgt->addNode(n3);
    TR_PCISCNode *n4  = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR_booltable, TR::NoType, tgt->incNumNodes(),  1,   2,   1,   n3, n3);  tgt->addNode(n4);  // optional
    TR_PCISCNode *n5, *nn0, *op1, *n6;
@@ -6331,7 +6331,7 @@ makeMemCpyByteToCharGraph(TR::Compilation *c, int32_t ctrl)
    TR_PCISCNode *nl23= new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::bu2i, TR::Int32,      tgt->incNumNodes(),  1,   1,   1,   nl22, nl22); tgt->addNode(nl23);
    TR_PCISCNode *ns2 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::ior, TR::Int32,       tgt->incNumNodes(),  1,   1,   2,   nl23, nl14, nl23); tgt->addNode(ns2);
    TR_PCISCNode *ns3 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::i2s, TR::Int16,       tgt->incNumNodes(),  1,   1,   1,   ns2, ns2); tgt->addNode(ns3);
-   TR_PCISCNode *ns4 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::cstorei, TR::Int16,   tgt->incNumNodes(),  1,   1,   2,   ns3, ns1, ns3); tgt->addNode(ns4);
+   TR_PCISCNode *ns4 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::sstorei, TR::Int16,   tgt->incNumNodes(),  1,   1,   2,   ns3, ns1, ns3); tgt->addNode(ns4);
    TR_PCISCNode *n6  = createIdiomDecVarInLoop(tgt, ctrl, 1, ns4, v1, cm2);
    TR_PCISCNode *n7  = createIdiomDecVarInLoop(tgt, ctrl, 1, n6, v3, cm1);
    TR_PCISCNode *n8  = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::ificmpge, TR::NoType,  tgt->incNumNodes(),  1,   2,   2,   n7, v4, vorc);  tgt->addNode(n8);
@@ -6400,7 +6400,7 @@ makeMemCpyCharToByteGraph(TR::Compilation *c, int32_t ctrl)
    TR_PCISCNode *ns11= createIdiomArrayAddressInLoop(tgt, ctrl, 1, ns10, v2, ns10);
    TR_PCISCNode *nl0 = createIdiomArrayAddressIndexTreeInLoop(tgt, ctrl, 1, ns11, v1, cmah, c2);
    TR_PCISCNode *nl1 = createIdiomArrayAddressInLoop(tgt, ctrl, 1, nl0, v0, nl0);
-   TR_PCISCNode *nl2 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::cloadi, TR::Int16,    tgt->incNumNodes(),  1,   1,   1,   nl1, nl1); tgt->addNode(nl2);
+   TR_PCISCNode *nl2 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::sloadi, TR::Int16,    tgt->incNumNodes(),  1,   1,   1,   nl1, nl1); tgt->addNode(nl2);
    TR_PCISCNode *cvt0, *cvt1;
    if ((ctrl & CISCUtilCtl_BigEndian))
       {
@@ -6639,7 +6639,7 @@ makeMemCpyByteToCharBndchkGraph(TR::Compilation *c, int32_t ctrl)
    TR_PCISCNode *nl23= new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::bu2i, TR::Int32,      tgt->incNumNodes(),  1,   1,   1,   nl22, nl22); tgt->addNode(nl23);
    TR_PCISCNode *ns2 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::iadd, TR::Int32,      tgt->incNumNodes(),  1,   1,   2,   nl23, nl14, nl23); tgt->addNode(ns2);
    TR_PCISCNode *ns3 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::i2s, TR::Int16,       tgt->incNumNodes(),  1,   1,   1,   ns2, ns2); tgt->addNode(ns3);
-   TR_PCISCNode *ns4 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::cstorei, TR::Int16,   tgt->incNumNodes(),  1,   1,   2,   ns3, ns1, ns3); tgt->addNode(ns4);
+   TR_PCISCNode *ns4 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::sstorei, TR::Int16,   tgt->incNumNodes(),  1,   1,   2,   ns3, ns1, ns3); tgt->addNode(ns4);
    TR_PCISCNode *n6  = createIdiomDecVarInLoop(tgt, ctrl, 1, ns4, v3, cm1);
    TR_PCISCNode *n7  = createIdiomDecVarInLoop(tgt, ctrl, 1, n6, v4, cm1);
    TR_PCISCNode *n8  = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::ificmpge, TR::NoType,  tgt->incNumNodes(),  1,   2,   2,   n7, v4, vorc);  tgt->addNode(n8);
@@ -7223,7 +7223,7 @@ makeMEMCPYChar2ByteGraph2(TR::Compilation *c, int32_t ctrl)
    TR_PCISCNode *ns11= createIdiomArrayAddressInLoop(tgt, ctrl, 1, ns10, v2, ns10);
    TR_PCISCNode *nl0 = createIdiomArrayAddressIndexTreeInLoop(tgt, ctrl, 1, ns11, lv1, cmah, c2);
    TR_PCISCNode *nl1 = createIdiomArrayAddressInLoop(tgt, ctrl, 1, nl0, v0, nl0);
-   TR_PCISCNode *nl2 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::cloadi, TR::Int16,    tgt->incNumNodes(),  1,   1,   1,   nl1, nl1); tgt->addNode(nl2);
+   TR_PCISCNode *nl2 = new (PERSISTENT_NEW) TR_PCISCNode(c->trMemory(), TR::sloadi, TR::Int16,    tgt->incNumNodes(),  1,   1,   1,   nl1, nl1); tgt->addNode(nl2);
    TR_PCISCNode *cvt0, *cvt1;
    if ((ctrl & CISCUtilCtl_BigEndian))
       {

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1099,7 +1099,7 @@ static TR::TreeTop* generateArraycopyFromSequentialStores(TR::Compilation* comp,
       {
       switch(numBytes)
          {
-         case 2: opcode = TR::cstorei; break;
+         case 2: opcode = TR::sstorei; break;
          case 4: opcode = TR::istorei; break;
          case 8: opcode = TR::lstorei; break;
          default: TR_ASSERT(0, " number of bytes unexpected\n"); break;
@@ -1760,18 +1760,19 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                break;
                }
             case 2:
-               {
-               opcode = TR::cstorei;
-               int32_t constValue = (int32_t)arrayset.getConstant();
-               if (istoreNode->getOpCodeValue() == TR::bstorei)
-                  {
-                  uint8_t byteConstValue = (uint8_t) constValue;
-                  constValue = (int32_t) byteConstValue;
-                  constValue = ((constValue << 8) | constValue);
-                  }
+               {	
+               opcode = TR::sstorei;	
+               int32_t constValue = (int32_t)arrayset.getConstant();	
+               if (istoreNode->getOpCodeValue() == TR::bstorei ||	
+                   istoreNode->getOpCodeValue() == TR::bustorei)	
+                  {	
+                  uint8_t byteConstValue = (uint8_t) constValue;	
+                  constValue = (int32_t) byteConstValue;	
+                  constValue = ((constValue << 8) | constValue);	
+                  }	
 
-               constValueNode = TR::Node::cconst(istoreNode, constValue);
-               break;
+                constValueNode = TR::Node::cconst(istoreNode, constValue);	
+               break;	
                }
             case 4:
                {
@@ -1783,7 +1784,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                   constValue = (int32_t) byteConstValue;
                   constValue = ((constValue << 24) | (constValue << 16) | (constValue << 8) | constValue);
                   }
-               else if ((istoreNode->getOpCodeValue() == TR::cstorei) || (istoreNode->getOpCodeValue() == TR::sstorei))
+               else if (istoreNode->getOpCodeValue() == TR::sstorei)
                   {
                   uint16_t shortConstValue = (uint16_t) constValue;
                   constValue = (int32_t) shortConstValue;
@@ -1807,7 +1808,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                   longConstValue = ((longConstValue << 56) | (longConstValue << 48) | (longConstValue << 40) | (longConstValue << 32) |
                                     (longConstValue << 24) | (longConstValue << 16) | (longConstValue << 8) | longConstValue);
                   }
-               else if ((istoreNode->getOpCodeValue() == TR::cstorei) || (istoreNode->getOpCodeValue() == TR::sstorei))
+               else if (istoreNode->getOpCodeValue() == TR::sstorei)
                   {
                   uint16_t shortConstValue = (uint16_t) longConstValue;
                   longConstValue = (int64_t) shortConstValue;

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1763,8 +1763,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                {
                opcode = TR::cstorei;
                int32_t constValue = (int32_t)arrayset.getConstant();
-               if (istoreNode->getOpCodeValue() == TR::bstorei ||
-                   istoreNode->getOpCodeValue() == TR::bustorei)
+               if (istoreNode->getOpCodeValue() == TR::bstorei)
                   {
                   uint8_t byteConstValue = (uint8_t) constValue;
                   constValue = (int32_t) byteConstValue;
@@ -1778,8 +1777,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                {
                opcode = TR::istorei;
                int32_t constValue = (int32_t)arrayset.getConstant();
-               if (istoreNode->getOpCodeValue() == TR::bstorei ||
-                   istoreNode->getOpCodeValue() == TR::bustorei)
+               if (istoreNode->getOpCodeValue() == TR::bstorei)
                   {
                   uint8_t byteConstValue = (uint8_t) constValue;
                   constValue = (int32_t) byteConstValue;
@@ -1802,8 +1800,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                int64_t longConstValue = (int64_t) constValue;
                constValueNode = TR::Node::create(istoreNode, TR::lconst, 0, 0);
 
-               if (istoreNode->getOpCodeValue() == TR::bstorei ||
-                   istoreNode->getOpCodeValue() == TR::bustorei)
+               if (istoreNode->getOpCodeValue() == TR::bstorei)
                   {
                   uint8_t byteConstValue = (uint8_t) longConstValue;
                   longConstValue = (int64_t) byteConstValue;
@@ -2271,8 +2268,8 @@ static TR::TreeTop * reduceArrayLoad(TR_ArrayShiftTreeCollection * storeTrees, T
          // between 2 and 3 bytes go into here, and we will transform the first 2 bytes
          newDataType = TR::Int16;
          numValidTrees = 2 / storeTrees->getTree(0)->getRootNode()->getOpCode().getSize();
-         storeOpCode = TR::cstorei;
-         loadOpCode = TR::cloadi;
+         storeOpCode = TR::sstorei;
+         loadOpCode = TR::sloadi;
          }
 
       if (numValidTrees < 2 ||

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -693,7 +693,6 @@ bool TR_ShiftedValueTree::process(TR::Node* loadNode)
       case TR::l2b: shift = true;  _valueSize = 8; shiftCode = TR::lushr; altShiftCode = TR::lshr; constCode = TR::iconst; break;
       case TR::bload:
       case TR::bconst:
-      case TR::cconst:
       case TR::sconst:
       case TR::iconst:
       case TR::lconst: shift = false; _valueSize = 1; _shiftValue = 0; break;
@@ -720,7 +719,6 @@ bool TR_ShiftedValueTree::process(TR::Node* loadNode)
          _valNode = loadNode->getFirstChild()->getFirstChild();
          switch(constCode)
             {
-            case TR::cconst: _shiftValue = shiftVal->getConst<uint16_t>(); break;
             case TR::sconst: _shiftValue = shiftVal->getShortInt(); break;
             case TR::iconst: _shiftValue = shiftVal->getInt(); break;
             case TR::lconst: _shiftValue = shiftVal->getLongInt(); break;
@@ -965,7 +963,6 @@ int64_t TR_arraycopySequentialStores::constVal()
       switch (_val[entry]->getValNode()->getOpCodeValue())
          {
          case TR::bconst: curVal = (uint64_t) (_val[entry]->getValNode()->getByte() & 0xFF); break;
-         case TR::cconst: curVal = (uint64_t) (_val[entry]->getValNode()->getConst<uint16_t>() & 0xFF); break;
          case TR::sconst: curVal = (uint64_t) (_val[entry]->getValNode()->getShortInt() & 0xFF); break;
          case TR::iconst: curVal = (uint64_t) (_val[entry]->getValNode()->getInt() & 0xFF); break;
          case TR::lconst: curVal = (uint64_t) (_val[entry]->getValNode()->getLongInt() & 0xFF); break;


### PR DESCRIPTION
Remove deprecated IL opcodes listed in eclipse/omr#2657 in OpenJ9. 
Note:
- There are `luadd` and `lusub` still remain in `walker.cpp` as simply replace those by `ladd` and `lsub` would cause errors in internal testing. Need to investigate on how to correctly remove them in the future.
- The change of ```i2c = new (PERSISTENT_NEW) TR_PCISCNode(tgt->trMemory(), TR_conversion, TR::NoType, tgt->incNumNodes(),  dagId,   1,   1, pred); ``` in `runtime/compiler/optimizer/IdiomRecognitionUtils.cpp` has passed both internal functionality and performance testings.

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com