### PR TITLE
Parsing Command line option for tenureBytesDeviationBoost

### DIFF
--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -233,6 +233,17 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 	}
 
 #if defined(J9VM_GC_MODRON_SCAVENGER)
+
+	if(try_scan(scan_start, "tenureBytesDeviationBoost=")) {
+		UDATA value;
+		if(!scan_udata_helper(javaVM, scan_start, &value, "tenureBytesDeviationBoost=")) {
+			goto _error;
+		}
+
+		extensions->tenureBytesDeviationBoost = value / (float)10.0; 
+		goto _exit;
+	}
+
 	if(try_scan(scan_start, "scavenge")) {
 		extensions->configurationOptions._forceOptionScavenge = true;
 		extensions->scavengerEnabled = true;


### PR DESCRIPTION
- example usage: -Xgc:tenureBytesDeviationBoost=25 , will result in a 2.5 boost to the deviation.
- Refer to https://github.com/eclipse/omr/pull/4134
- Currently waiting for OMR change to promote

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>