### PR TITLE
Implement TR_ResolveJ9JITaaSServerMethod::varHandleMethodTypeTableEntryAddress

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -462,7 +462,7 @@ J9::SymbolReferenceTable::findOrCreateVarHandleMethodTypeTableEntrySymbol(TR::Re
 
    TR::StaticSymbol *sym = TR::StaticSymbol::createMethodTypeTableEntry(trHeapMemory(),cpIndex);
    sym->setStaticAddress(entryLocation);
-   bool isUnresolved = *(j9object_t*)entryLocation == NULL;
+   bool isUnresolved = owningMethod->isUnresolvedVarHandleMethodTypeTableEntry(cpIndex);
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1,
                                                        isUnresolved ? _numUnresolvedSymbols++ : 0);
    if (isUnresolved)

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1579,6 +1579,20 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
          client->write(response, mirror->callSiteTableEntryAddress(callSiteIndex));
          }
          break;
+      case MessageType::ResolvedMethod_varHandleMethodTypeTableEntryAddress:
+         {
+         auto recv = client->getRecvData<TR_ResolvedJ9Method*, int32_t>();
+         auto mirror = std::get<0>(recv);
+         int32_t cpIndex = std::get<1>(recv);
+         client->write(response, mirror->varHandleMethodTypeTableEntryAddress(cpIndex));
+         }
+      case MessageType::ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry:
+         {
+         auto recv = client->getRecvData<TR_ResolvedJ9Method*, int32_t>();
+         auto mirror = std::get<0>(recv);
+         int32_t cpIndex = std::get<1>(recv);
+         client->write(response, mirror->isUnresolvedVarHandleMethodTypeTableEntry(cpIndex));
+         }
       case MessageType::ResolvedMethod_getResolvedDynamicMethod:
          {
          auto recv = client->getRecvData<int32_t, J9Class *>();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6201,6 +6201,12 @@ TR_ResolvedJ9Method::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
    return ramClass->varHandleMethodTypes + methodTypeIndex;
    }
 
+bool
+TR_ResolvedJ9Method::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
+   {
+   return *(j9object_t*)varHandleMethodTypeTableEntryAddress(cpIndex) == NULL;
+   }
+
 #if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
 void *
 TR_ResolvedJ9Method::methodTypeTableEntryAddress(int32_t cpIndex)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -422,6 +422,7 @@ public:
    virtual void *                methodTypeTableEntryAddress(int32_t cpIndex);
 #endif
    // J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING is always true and is planed to be cleaned up, always assume it's true
+   virtual bool                  isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                varHandleMethodTypeTableEntryAddress(int32_t cpIndex);
 
    virtual bool                  fieldsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1232,6 +1232,20 @@ TR_ResolvedJ9JITaaSServerMethod::callSiteTableEntryAddress(int32_t callSiteIndex
    return std::get<0>(_stream->read<void*>());
    }
 
+bool
+TR_ResolvedJ9JITaaSServerMethod::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
+   {
+   _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry, _remoteMirror, cpIndex);
+   return std::get<0>(_stream->read<bool>());
+   }
+
+void *
+TR_ResolvedJ9JITaaSServerMethod::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
+   {
+   _stream->write(JITServer::MessageType::ResolvedMethod_varHandleMethodTypeTableEntryAddress, _remoteMirror, cpIndex);
+   return std::get<0>(_stream->read<void*>());
+   }
+
 TR_ResolvedMethod *
 TR_ResolvedJ9JITaaSServerMethod::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callSiteIndex, bool * unresolvedInCP)
    {

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -256,6 +256,8 @@ public:
 #endif
    virtual bool isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) override;
    virtual void * callSiteTableEntryAddress(int32_t callSiteIndex) override;
+   virtual bool isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex) override;
+   virtual void * varHandleMethodTypeTableEntryAddress(int32_t cpIndex) override;
    virtual TR_ResolvedMethod * getResolvedDynamicMethod( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP) override;
    virtual bool isSameMethod(TR_ResolvedMethod *) override;
    virtual bool isInlineable(TR::Compilation *) override;

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -108,6 +108,8 @@ enum MessageType
    ResolvedMethod_stringConstant = 149;
    ResolvedMethod_getResolvedVirtualMethod = 150;
    ResolvedMethod_getMultipleResolvedMethods = 151;
+   ResolvedMethod_varHandleMethodTypeTableEntryAddress = 152;
+   ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry = 153;
 
    ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 160;
    ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 161;


### PR DESCRIPTION
This method needs to be a remote call on the server. Exposed while running java11.

Issue: #6437

Signed-off-by: Harry Yu <harryyu1994@gmail.com>