### PR TITLE
Fix ifcmp folding

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3592,8 +3592,12 @@ TR_J9ByteCodeIlGenerator::genIfImpl(TR::ILOpCodes nodeop)
    TR::Node * second = pop();
    TR::Node * first = pop();
 
+   static char *disableIfFolding = feGetEnv("TR_DisableIfFolding");
+   bool trace = comp()->getOption(TR_TraceILGen);
+
    TR::DataType type = first->getDataType();
-   if (branchBC > _bcIndex &&
+   if (!disableIfFolding &&
+       branchBC > _bcIndex &&
        first->getOpCode().isLoadConst() &&
        second->getOpCode().isLoadConst() &&
        type != TR::Address &&
@@ -3629,15 +3633,30 @@ TR_J9ByteCodeIlGenerator::genIfImpl(TR::ILOpCodes nodeop)
 
       if (_blocksToInline)
          {
-         if (comp()->getOption(TR_TraceILGen))
+         if (trace)
             traceMsg(comp(), "Not folding the if because of partial inlining\n");
          }
       else
          {
-         if (comp()->getOption(TR_TraceILGen))
+         if (trace)
             traceMsg(comp(), "%s\n", branchTaken ? "taking the branch" : "fall through");
 
-         return branchTaken ? branchBC : fallThruBC;
+         if (branchTaken)
+            {
+            // Folding the if is equivalent to turning it into a goto. We can't just return
+            // branchBC because there can be arbitrary bytecodes between the `if` and branchBC.
+            // To get a correct CFG, a goto is required.
+            //
+            return genGoto(branchBC);
+            }
+         else
+            {
+            // In this case, folding the if is equivalent to removing the if bytecode. The fall
+            // through bytecodes can live in the same block as there is no branch out after the
+            // folding.
+            //
+            return fallThruBC;
+            }
          }
       }
 


### PR DESCRIPTION
There can be abitrary bytecodes between an `if` bytecode and its branch
target, some of which don't belong to the if's fall through block. When
folding the `if` to its branch target, we need to turn the it into a
`goto` such that the CFG is correctly constructed. There is no such
problem folding the `if` to its fall through as there is no bytecode in
between.

The following is an example. If we were to fold the `if` at bytecode
index 5 to its branch target 19, current implemenation will result in an
edge between the fall through block for the first `if` and its `else`
block, which means that `s` will always be 2 regardless of the value of
`condition1`. This commit will fix this issue.

```
if (condition1) {
   if (condition2) {
   s = 1;
   }
} else {
  s = 2;
}
return;
```
bytecodes
```
  0: iload_1
  1: ifeq          15
  4: iload_2
  5: ifeq          19
  8: iconst_1
  9: putstatic     #2                  // Field s:I
 12: goto          19
 15: iconst_2
 16: putstatic     #2                  // Field s:I
 19: return
```

closes #6421 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>