### PR TITLE
Re-enable Deep Scan Optimization with fix and stats

### DIFF
--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -180,7 +180,11 @@ public:
 		{
 			UDATA classFlags = J9CLASS_FLAGS(clazz) & (J9AccClassReferenceMask | J9AccClassGCSpecial | J9AccClassOwnableSynchronizer);
 			if (0 == classFlags) {
-				result = SCAN_MIXED_OBJECT;
+				if (0 != clazz->selfReferencingField1) {
+					result = SCAN_MIXED_OBJECT_LINKED;
+				} else {
+					result = SCAN_MIXED_OBJECT;
+				}
 			} else {
 				if (0 != (classFlags & J9AccClassReferenceMask)) {
 					result = SCAN_REFERENCE_MIXED_OBJECT;

--- a/runtime/gc_trace/TgcParallel.cpp
+++ b/runtime/gc_trace/TgcParallel.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -250,8 +250,8 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 	tgcExtensions->printf("\n");
 	tgcExtensions->printf("Scavenger parallel and progress stats, timestamp=\"%s.%ld\"\n", timestamp, timeInMillis % 1000);
 
-	tgcExtensions->printf("          gc thrID     busy    stall   acquire   release   acquire   release   acquire     split avg split  alias to\n");
-	tgcExtensions->printf("                   (micros) (micros)  freelist  freelist  scanlist  scanlist      lock    arrays arraysize copycache\n");
+	tgcExtensions->printf("          gc thrID     busy    stall   acquire   release   acquire   release   acquire     split avg split  alias to    deep      total deepest\n");
+	tgcExtensions->printf("                   (micros) (micros)  freelist  freelist  scanlist  scanlist      lock    arrays arraysize copycache   lists  deep objs    list\n");
 
 	scavengeTotalTime = extensions->scavengerStats._endTime - extensions->scavengerStats._startTime;
 	uintptr_t gcCount = extensions->scavengerStats._gcCount;
@@ -267,7 +267,7 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 				if (0 != env->_scavengerStats._arraySplitCount) {
 					avgArraySplitAmount = env->_scavengerStats._arraySplitAmount / env->_scavengerStats._arraySplitCount;
 				}
-				tgcExtensions->printf("SCV.T %6zu  %4zu %8llu %8llu     %5zu     %5zu     %5zu     %5zu     %5zu     %5zu     %5zu   %7zu\n",
+				tgcExtensions->printf("SCV.T %6zu  %4zu %8llu %8llu     %5zu     %5zu     %5zu     %5zu     %5zu     %5zu     %5zu   %7zu  %6zu     %6zu  %6zu \n",
 					gcCount,
 					env->getSlaveID(),
 					j9time_hires_delta(0, scavengeTotalTime - env->_scavengerStats.getStallTime(), J9PORT_TIME_DELTA_IN_MICROSECONDS),
@@ -279,7 +279,10 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 					env->_scavengerStats._acquireListLockCount,
 					env->_scavengerStats._arraySplitCount,
 					avgArraySplitAmount,
-					env->_scavengerStats._aliasToCopyCacheCount);
+					env->_scavengerStats._aliasToCopyCacheCount,
+					env->_scavengerStats._totalDeepStructures,
+					env->_scavengerStats._totalObjsDeepScanned,
+					env->_scavengerStats._depthDeepestStructure);
 			}
 		}
 	}

--- a/runtime/vm/description.c
+++ b/runtime/vm/description.c
@@ -82,6 +82,7 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 	UDATA *shape;
 
 	J9UTF8 *className = J9ROMCLASS_CLASSNAME(ramClass->romClass);
+	BOOLEAN inheritedSelfReferencingFields = FALSE;
 
 #ifdef J9VM_GC_LEAF_BITS
 	UDATA leafTemp;
@@ -158,6 +159,8 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 #endif
 			}
 		}
+
+		inheritedSelfReferencingFields = (ramSuperClass->selfReferencingField1 != 0) ? TRUE : FALSE;
 	}
 
 	/* calculate the description for this class - walk object instance fields and 
@@ -170,12 +173,17 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 			U_8 *fieldSigBytes = J9UTF8_DATA(fieldSig);
 			U_16 fieldSigLength = J9UTF8_LENGTH(fieldSig);
 
-			/* If the field is self referencing then store the offset to it (at most 2). Self referencing fields are to be scanned with priority during GC */
-			if (((ramClass->selfReferencingField1 == 0) || (ramClass->selfReferencingField2 == 0)) && J9UTF8_DATA_EQUALS(J9UTF8_DATA(className), J9UTF8_LENGTH(className), fieldSigBytes + 1, fieldSigLength - 2)) {
-				if (ramClass->selfReferencingField1 == 0) {
-					ramClass->selfReferencingField1 = walkResult->offset + objectHeaderSize;
-				} else {
-					ramClass->selfReferencingField2 = walkResult->offset + objectHeaderSize;
+			/* If the field is self referencing then store the offset to it (at most 2). Self referencing fields
+			 * are to be scanned with priority during GC. Both self referencing fields must be from the same class.
+			 * If there are self referencing field offsets being inherited, then fields of this class should be ignored.
+			 */
+			if (!inheritedSelfReferencingFields && ((ramClass->selfReferencingField1 == 0) || (ramClass->selfReferencingField2 == 0))) {
+				if (J9UTF8_DATA_EQUALS(J9UTF8_DATA(className), J9UTF8_LENGTH(className), fieldSigBytes + 1, fieldSigLength - 2)) {
+					if (ramClass->selfReferencingField1 == 0) {
+						ramClass->selfReferencingField1 = walkResult->offset + objectHeaderSize;
+					} else {
+						ramClass->selfReferencingField2 = walkResult->offset + objectHeaderSize;
+					}
 				}
 			}
 


### PR DESCRIPTION
- Fixed issue with "heterogeneous" deep structure scanning _(links between derived classes with common parent)_ 
  - Issue when self referencing fields vary from object to object in link. This occurs when a superclass has a single self referencing field and the derived class has a distinct second one. The first field is inherited and the second is set when calculating the description of the class. This caused an issue when there were multiple different classes derived from the same superclass which were all linked with the common self referencing field from superclass. These objects would share only one self referencing fields while having a distinct second one. The optimization can only be provided with common fields. Hence, we must ignore the distinct fields

- Re-enable Deep Scan Optimization
  - return `SCAN_MIXED_OBJECT_LINKED` for objects with self referencing
fields

- Report TGC parallel stats for deep scan
  - The total number of deep structures that are scanned with priority
  - The total number of deep structure objs that are special treated
  - Length of longest deep structure

Signed-off-by: Salman Rana <salman.rana@ibm.com>