### PR TITLE
Invoke DomainCombiner.combine() for embedded AccessControlContext

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/Test_AccessControlContext.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/Test_AccessControlContext.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.security;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
Apply trusted DomainCombiner.combine() from closest doPrivileged frame
to ProtectionDomain instances to be checked later including those
context from embedded AccessControlContext such as
AccessControlContext.doPrivilegedAcc and
AccessControlContext.nextStackAcc.

Added a testcase which caused StackOverflowError without this PR.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>