### PR TITLE
(v0.15.0) Remove extra rpaths in AIX shared libs

### DIFF
--- a/runtime/compiler/build/toolcfg/aix-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/aix-xlc/common.mk
@@ -193,7 +193,7 @@ IPP_FLAGS+=$(IPP_FLAGS_EXTRA)
 #
 SOLINK_CMD?=$(SHAREDLIB)
 
-SOLINK_FLAGS+=-p0 -bloadmap:lmap -brtl -bnoentry
+SOLINK_FLAGS+=-p0 -bloadmap:lmap -brtl -bnoentry -bnolibpath
 
 ifeq ($(HOST_BITS),64)
     SOLINK_FLAGS+=-X64

--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -128,7 +128,7 @@ else
   UMA_DLL_LINK_FLAGS += -q32
 endif
 # Link options like '-brtl', '-G', etc. must be prefixed by '-Wl,' to make xlc_r pass them through.
-UMA_DLL_LINK_FLAGS += -qmkshrobj -Wl,-brtl -Wl,-G -Wl,-bernotok -Wl,-bnoentry
+UMA_DLL_LINK_FLAGS += -qmkshrobj -Wl,-brtl -Wl,-G -Wl,-bernotok -Wl,-bnoentry -Wl,-bnolibpath
 UMA_DLL_LINK_FLAGS += -Wl,-bmap:$(UMA_TARGET_NAME).map
 UMA_DLL_LINK_FLAGS += -Wl,-bE:$(UMA_TARGET_NAME).exp
 


### PR DESCRIPTION
Add '-bnolibpath' to DLL link flags so that only the default library
paths are added to the loader section of those shared libraries being
built rather than the ones specified in '-L' flags, which can expose
system information.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Port of PR https://github.com/eclipse/openj9/pull/6490