### PR TITLE
Add missing `# END NON-TRANSLATABLE` comment

### DIFF
--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1443,6 +1443,7 @@ J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED=ValueTypes are only enabled with the 
 J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED.explanation=ValueTypes is an experimental feature and is not officially supported.
 J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_VALUE_TYPES_IS_NOT_SUPPORTED.user_response=Contact the provider of the classfile for a corrected version or use the -XX:+EnableValhalla option.
+# END NON-TRANSLATABLE
 
 J9NLS_CFR_ERR_PREVIEW_VERSION=Class file is a preview version but has the wrong major version or preview is not enabled.
 # START NON-TRANSLATABLE


### PR DESCRIPTION
fixes: #6496

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>