### PR TITLE
Fix out-of-bounds write in String.getBytes

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1784,7 +1784,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	@Deprecated(forRemoval=false, since="1.1")
 	public void getBytes(int start, int end, byte[] data, int index) {
-		if (0 <= start && start <= end && end <= lengthInternal()) {
+		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
 			// Check if the String is compressed
 			if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
 				compressedArrayCopy(value, start, data, index, end - start);
@@ -5756,7 +5756,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	@Deprecated
 	public void getBytes(int start, int end, byte[] data, int index) {
-		if (0 <= start && start <= end && end <= lengthInternal()) {
+		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
 			// Check if the String is compressed
 			if (enableCompression && (null == compressionFlag || count >= 0)) {
 				compressedArrayCopy(value, start, data, index, end - start);


### PR DESCRIPTION
The previous implementation of String.getBytes(int, int, byte[], int)
was not correctly performing a bounds check on the index parameter, nor
was it performing a null check on the data parameter.

Signed-off-by: Ben Thomas <ben@benthomas.ca>