### PR TITLE
Implement jcmd

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticProperties.java
+++ b/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticProperties.java
@@ -349,7 +349,9 @@ public class DiagnosticProperties {
 	 * @return DiagnosticProperties object
 	 */
 	public static DiagnosticProperties makeCommandSucceeded() {
-		return makeStatusProperties(false, null); // $NON-NLS-1$
+		DiagnosticProperties props = makeStatusProperties(false, null);
+		props.put(DIAGNOSTICS_STRING_RESULT, "Command succeeded"); //$NON-NLS-1$
+		return props; // $NON-NLS-1$
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticUtils.java
@@ -48,6 +48,11 @@ public class DiagnosticUtils {
 	 */
 
 	/**
+	 * Print help text
+	 */
+	public static final String DIAGNOSTICS_HELP = "help"; //$NON-NLS-1$
+
+	/**
 	 * Run Get the stack traces and other thread information.
 	 */
 	public static final String DIAGNOSTICS_THREAD_PRINT = "Thread.print"; //$NON-NLS-1$
@@ -79,6 +84,7 @@ public class DiagnosticUtils {
 	private static final String THREAD_LOCKED_SYNCHRONIZERS_OPTION = "-l"; //$NON-NLS-1$
 
 	private static final Map<String, Function<String, DiagnosticProperties>> commandTable;
+	private static final Map<String, String> helpTable;
 
 	/**
 	 * Create the command to run the heapHisto command
@@ -104,6 +110,18 @@ public class DiagnosticUtils {
 		String cmd = lockedSynchronizers
 				? DIAGNOSTICS_THREAD_PRINT + DIAGNOSTICS_OPTION_SEPARATOR + THREAD_LOCKED_SYNCHRONIZERS_OPTION
 				: DIAGNOSTICS_THREAD_PRINT;
+		return cmd;
+	}
+
+	/**
+	 * Convert the command line options into attach API diagnostic command format
+	 * @param options List of command line arguments
+	 * @param skip Number of options to omit from the beginning of the list
+	 * 
+	 * @return formatted string
+	 */
+	public static String makeJcmdCommand(String[] options, int skip) {
+		String cmd = String.join(DIAGNOSTICS_OPTION_SEPARATOR, Arrays.asList(options).subList(skip, options.length));
 		return cmd;
 	}
 
@@ -199,12 +217,67 @@ public class DiagnosticUtils {
 		VM.globalGC();
 		return DiagnosticProperties.makeCommandSucceeded();
 	}
+	
+	private static DiagnosticProperties doHelp(String diagnosticCommand) {
+		String[] parts = diagnosticCommand.split(DIAGNOSTICS_OPTION_SEPARATOR);
+		/* print a list of the available commands */
+		StringWriter buffer = new StringWriter(500);
+		PrintWriter bufferPrinter = new PrintWriter(buffer);
+		if (DIAGNOSTICS_HELP.equals(parts[0])) {
+			if (parts.length == 1) {
+				/* print a list of commands */
+				commandTable.keySet().stream().sorted().forEach(s -> bufferPrinter.println(s));
+			} else if (parts.length == 2) {
+				String helpText = helpTable.getOrDefault(parts[1], "No help available"); //$NON-NLS-1$
+				bufferPrinter.printf("%s: ", parts[1]); //$NON-NLS-1$
+				bufferPrinter.printf(helpText);
+			}
+		} else {
+			bufferPrinter.print("Invalid command: " + diagnosticCommand); //$NON-NLS-1$
+		}
+		return DiagnosticProperties.makeStringResult(buffer.toString());
 
+	}
+
+	/* Help strings for the jcmd utilities */
+	@SuppressWarnings("nls")
+	private static final String DIAGNOSTICS_HELP_HELP = "Show help for a command%n"
+			+ " Format: help <command>%n"
+			+ " If no command is supplied, print the list of available commands on the target JVM.%n";
+	
+	@SuppressWarnings("nls")
+	private static final String DIAGNOSTICS_GC_CLASS_HISTOGRAM_HELP = "Obtain heap information about a Java process%n"
+			+ " Format: " + DIAGNOSTICS_GC_CLASS_HISTOGRAM + " [options]%n"
+			+ " Options: -all : include all objects, including dead objects%n"
+			+ "NOTE: this utility may significantly affect the performance of the target VM.%n";
+	
+	@SuppressWarnings("nls")
+	private static final String DIAGNOSTICS_GC_RUN_HELP = "Run the garbage collector.%n"
+			+ " Format: " + DIAGNOSTICS_GC_RUN + "%n"
+			+ "NOTE: this utility may significantly affect the performance of the target VM.%n";
+	
+	@SuppressWarnings("nls")
+	private static final String DIAGNOSTICS_THREAD_PRINT_HELP = "List thread information.%n"
+			+ " Format: " + DIAGNOSTICS_THREAD_PRINT + " [options]%n"
+			+ " Options: -l : print information about ownable synchronizers%n";
+	
+	/* Initialize the command and help text tables */
 	static {
 		commandTable = new HashMap<>();
+		helpTable = new HashMap<>();
+		
+		commandTable.put(DIAGNOSTICS_HELP, DiagnosticUtils::doHelp);
+		helpTable.put(DIAGNOSTICS_HELP, DIAGNOSTICS_HELP_HELP);
+		
 		commandTable.put(DIAGNOSTICS_GC_CLASS_HISTOGRAM, DiagnosticUtils::getHeapStatistics);
+		helpTable.put(DIAGNOSTICS_GC_CLASS_HISTOGRAM, DIAGNOSTICS_GC_CLASS_HISTOGRAM_HELP);
+		
 		commandTable.put(DIAGNOSTICS_GC_RUN, s -> runGC());
+		helpTable.put(DIAGNOSTICS_GC_RUN, DIAGNOSTICS_GC_RUN_HELP);
+		
 		commandTable.put(DIAGNOSTICS_THREAD_PRINT, DiagnosticUtils::getThreadInfo);
+		helpTable.put(DIAGNOSTICS_THREAD_PRINT, DIAGNOSTICS_THREAD_PRINT_HELP);
 	}
+
 
 }

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/attacher/AttacherDiagnosticsProvider.java
@@ -38,8 +38,6 @@ import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
 /**
  * This class allows a Attach API attacher to query a target JVM about
  * diagnostic information such as JIT compilation, threads, classes, etc.
- * Instances must be created using the getDiagnostics() factory method.
- *
  */
 public class AttacherDiagnosticsProvider {
 

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jcmd.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jcmd.java
@@ -1,0 +1,99 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics.tools;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.tools.attach.VirtualMachineDescriptor;
+import com.sun.tools.attach.spi.AttachProvider;
+
+import openj9.tools.attach.diagnostics.attacher.AttacherDiagnosticsProvider;
+import openj9.tools.attach.diagnostics.base.DiagnosticUtils;
+
+/**
+ * Jcmd A tool for running diagnostic commands on another Java process
+ *
+ */
+public class Jcmd {
+
+	@SuppressWarnings("nls")
+	private static final String HELPTEXT = "jcmd: run diagnostic command on another Java process%n"
+			+ " Format:%n"
+			+ "    jcmd <vmid> <arguments>%n"
+			+ " Arguments:%n"
+			+ "    <vmid>: Attach API VM ID as shown in jps or other Attach API-based tools.%n"
+			+ "    command[command arguments]: command from the list returned by \"-help\"%n"
+			+ "    -help: print the list of diagnostic commands%n"
+			+ "    -J: supply arguments to the Java VM running jcmd%n"
+			+ " NOTE: this utility may significantly affect the performance of the target JVM.%n"
+			+ "     The available diagnostic commands is determined by%n"
+			+ "     the target VM and may vary between VMs.%n";
+	@SuppressWarnings("nls")
+	private static final String[] HELP_OPTIONS = {"-h", "help", "-help", "--help"};
+
+	/**
+	 * @param args Application arguments.  See help text for details.
+	 */
+	public static void main(String[] args) {
+		String command = null;
+		/* An empty argument list is a request for a list of VMs */
+		final String firstArgument = (0 == args.length) ? "-l" : args[0]; //$NON-NLS-1$
+		if ("-l".equals(firstArgument)) { //$NON-NLS-1$
+			List<AttachProvider> providers = AttachProvider.providers();
+			AttachProvider myProvider = null;
+			if (!providers.isEmpty()) {
+				myProvider = providers.get(0);
+			}
+			if (null == myProvider) {
+				System.err.println("no attach providers available"); //$NON-NLS-1$
+			} else {
+				for (VirtualMachineDescriptor vmd : myProvider.listVirtualMachines()) {
+					StringBuilder outputBuffer = new StringBuilder(vmd.id());
+					Util.getTargetInformation(myProvider, vmd, false, false, true, outputBuffer);
+					System.out.println(outputBuffer.toString());
+				}
+			}
+		} else if ((args.length == 1) && (null != firstArgument) && Arrays.stream(HELP_OPTIONS).anyMatch(firstArgument::equals)) {	
+			System.out.printf(HELPTEXT);
+		} else {
+			String vmid = firstArgument;
+			AttacherDiagnosticsProvider diagProvider = new AttacherDiagnosticsProvider();
+			command = DiagnosticUtils.makeJcmdCommand(args, 1);
+			try {
+				diagProvider.attach(vmid);
+				try {
+					Util.runCommandAndPrintResult(diagProvider, command, command); // $NON-NLS-1$
+				} finally {
+					diagProvider.detach();
+				}
+			} catch (IOException e) {
+				Util.handleCommandException(vmid, e);
+				System.out.printf(HELPTEXT);
+			}
+		}
+	}
+
+}

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstack.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstack.java
@@ -83,20 +83,7 @@ public class Jstack {
 					out.println(diagProvider.getAgentProperties());
 				}
 			} catch (Exception e) {
-				System.err.printf("Error getting data from %s", vmid); //$NON-NLS-1$
-				final String msg = e.getMessage();
-				if (null == msg) {
-					System.err.println();
-				} else {
-					if (msg.matches(IPC.INCOMPATIBLE_JAVA_VERSION)) {
-						System.err.println(": incompatible target JVM"); //$NON-NLS-1$
-					} else {
-						System.err.printf(": %s%n", msg); //$NON-NLS-1$
-					}
-				}
-				if (DiagnosticProperties.isDebug) {
-					e.printStackTrace();
-				}
+				Util.handleCommandException(vmid, e);
 			} finally {
 				try {
 					diagProvider.detach();
@@ -112,7 +99,7 @@ public class Jstack {
 		boolean okay = true;
 		printProperties = DiagnosticProperties.isDebug;
 		printSynchronizers = false;
-		final String HELPTEXT = "jstack: listing thread information about another Java process%n"
+		final String HELPTEXT = "jstack: list thread information about another Java process%n"
 				+ " Usage:%n"
 				+ "    jstack <vmid>*%n"
 				+ "        <vmid>: Attach API VM ID as shown in jps or other Attach API-based tools%n"

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -634,6 +634,28 @@
 	</test>
 
 	<test>
+		<testCaseName>TestJcmd</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
+	-Dcom.ibm.tools.attach.timeout=15000 \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJcmd \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		 </impls>
+	</test>
+
+	<test>
 		<testCaseName>TestFileLocking_SE80</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/AttachApiTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/AttachApiTest.java
@@ -28,11 +28,14 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import org.openj9.test.util.PlatformInfo;
@@ -200,6 +203,7 @@ abstract class AttachApiTest {
 		ArrayList<String> cmdLine = new ArrayList<>();
 		cmdLine.add(commandName);
 		cmdLine.addAll(args);
+		log(cmdLine.stream().collect(Collectors.joining(" ", "command line: ", "")));
 		ProcessBuilder jpsProcess = new ProcessBuilder(cmdLine);
 		Process proc = jpsProcess.start();
 		List<String> outputLines = Collections.emptyList();
@@ -210,6 +214,18 @@ abstract class AttachApiTest {
 			/* ignore */
 		}
 		return outputLines;
+	}
+
+	protected List<String> runCommandAndLogOutput(List<String> commandLineOptions) throws IOException {
+		List<String> jpsOutput = runCommand(commandLineOptions);
+		StringWriter buff = new StringWriter();
+		PrintWriter buffWriter = new PrintWriter(buff);
+		jpsOutput.forEach(s -> {
+			buffWriter.println(s);
+		});
+		buffWriter.flush();
+		log(buff.toString());
+		return jpsOutput;
 	}
 
 	/**

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.attachAPI;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.openj9.test.util.PlatformInfo;
+import org.openj9.test.util.StringUtilities;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import static org.openj9.test.attachAPI.TargetManager.getVmId;
+
+@Test(groups = { "level.extended" })
+public class TestJcmd extends AttachApiTest {
+
+	private static final String EXPECTED_STRING_FOUND = "Expected string found"; //$NON-NLS-1$
+	private static final String HELP_COMMAND = "help"; //$NON-NLS-1$
+	private static final String THREAD_PRINT = "Thread.print"; //$NON-NLS-1$
+	private static final String GC_RUN = "GC.run"; //$NON-NLS-1$
+	private static final String GC_CLASS_HISTOGRAM = "GC.class_histogram"; //$NON-NLS-1$
+	private static final String JCMD_COMMAND = "jcmd"; //$NON-NLS-1$
+	private static String[] JCMD_COMMANDS = { GC_CLASS_HISTOGRAM, GC_RUN, THREAD_PRINT, HELP_COMMAND };
+
+	/*
+	 * Contains strings expected to be contained in the outputs of various commands
+	 */
+	private static Map<String, String> commandExpectedOutputs;
+
+	/**
+	 * Test various ways of printing the help text, including undocumented but
+	 * plausible variants
+	 * 
+	 * @throws IOException on error
+	 */
+	@Test
+	public void testJcmdHelps() throws IOException {
+		@SuppressWarnings("nls")
+		String[] HELP_OPTIONS = { "-h", HELP_COMMAND, "-help", "--help" };
+		for (String helpOption : HELP_OPTIONS) {
+			List<String> jcmdOutput = runCommandAndLogOutput(Collections.singletonList(helpOption));
+			/* Sample of the text from Jcmd.HELPTEXT */
+			String expectedString = "run diagnostic command"; //$NON-NLS-1$
+			Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Help text corrupt: " + jcmdOutput); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * Test help for various commands
+	 * @throws IOException on error
+	 */
+	@Test
+	public void testCommandHelps() throws IOException {
+		for (String command : JCMD_COMMANDS) {
+			List<String> args = new ArrayList<>();
+			args.add(getVmId());
+			args.add(HELP_COMMAND);
+			args.add(command);
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			String expectedString = command + ":"; //$NON-NLS-1$
+			log("Expected string: " + expectedString); //$NON-NLS-1$
+			Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Help text corrupt: " + jcmdOutput); //$NON-NLS-1$
+			log(EXPECTED_STRING_FOUND);
+		}
+	}
+
+	@Test
+	public void testListVms() throws IOException {
+		String myId = getVmId();
+		List<String> args = new ArrayList<>();
+		List<String> jcmdOutput = runCommandAndLogOutput(args);
+		Optional<String> searchResult = StringUtilities.searchSubstring(myId, jcmdOutput);
+		String errorMessage = "My VMID missing from VM list"; //$NON-NLS-1$
+		assertTrue(searchResult.isPresent(), errorMessage);
+		args.add("-l"); //$NON-NLS-1$
+		jcmdOutput = runCommandAndLogOutput(args);
+		searchResult = StringUtilities.searchSubstring(myId, jcmdOutput);
+		assertTrue(searchResult.isPresent(), errorMessage + jcmdOutput);
+		log(EXPECTED_STRING_FOUND);
+	}
+
+	@Test
+	public void testCommandNoOptions() throws IOException {
+		for (String command : JCMD_COMMANDS) {
+			List<String> args = new ArrayList<>();
+			args.add(getVmId());
+			args.add(command);
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			String expectedString = commandExpectedOutputs.getOrDefault(command, "Test error: expected output not defined"); //$NON-NLS-1$
+			log("Expected string: " + expectedString); //$NON-NLS-1$
+			Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Expected string not found " + expectedString); //$NON-NLS-1$
+			log(EXPECTED_STRING_FOUND);
+		}
+	}
+
+	@Test
+	public void testThreadPrint() throws IOException {
+		String LockedSyncsOption = "-l"; //$NON-NLS-1$
+		@SuppressWarnings("nls")
+		String[] options = {"", LockedSyncsOption, LockedSyncsOption + "=true", LockedSyncsOption + "=false"};
+		for (String option : options) {
+			List<String> args = new ArrayList<>();
+			args.add(getVmId());
+			args.add(THREAD_PRINT);
+			if (!option.isEmpty()) {
+				args.add(option);
+			}
+			boolean addSynchronizers = !option.endsWith("false") && !option.isEmpty(); //$NON-NLS-1$
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			String expectedString = "Locked ownable synchronizers"; //$NON-NLS-1$
+			log("Expected string: " + expectedString); //$NON-NLS-1$
+			Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+			assertEquals(searchResult.isPresent(), addSynchronizers, "Output contains locked synchronizer information: " + expectedString); //$NON-NLS-1$
+			log(EXPECTED_STRING_FOUND);
+		}
+	}
+
+	@Test
+	public void testClassHistogramAll() throws IOException {
+		List<String> args = new ArrayList<>();
+		args.add(getVmId());
+		args.add(GC_CLASS_HISTOGRAM);
+		args.add("-all"); //$NON-NLS-1$
+		List<String> jcmdOutput = runCommandAndLogOutput(args);
+		String expectedString = commandExpectedOutputs.getOrDefault(GC_CLASS_HISTOGRAM, "Test error: expected output not defined"); //$NON-NLS-1$
+		log("Expected string: " + expectedString); //$NON-NLS-1$
+		Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+		assertTrue(searchResult.isPresent(), "Expected string not found: " + expectedString); //$NON-NLS-1$
+		log(EXPECTED_STRING_FOUND);
+	}
+
+	@BeforeMethod
+	protected void setUp(Method testMethod) {
+		testName = testMethod.getName();
+		log("------------------------------------\nstarting " + testName); //$NON-NLS-1$
+	}
+
+	@BeforeSuite
+	protected void setupSuite() {
+		assertTrue(PlatformInfo.isOpenJ9(), "This test is valid only on OpenJ9"); //$NON-NLS-1$
+		getJdkUtilityPath(JCMD_COMMAND);
+		commandExpectedOutputs = new HashMap<>();
+		commandExpectedOutputs.put(HELP_COMMAND, THREAD_PRINT);
+		commandExpectedOutputs.put(GC_CLASS_HISTOGRAM, "java.util.HashMap"); //$NON-NLS-1$
+		commandExpectedOutputs.put(GC_RUN, "Command succeeded"); //$NON-NLS-1$
+		commandExpectedOutputs.put(THREAD_PRINT, "Attach API wait loop"); //$NON-NLS-1$
+	}
+
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -102,6 +102,12 @@
 		</classes>
 	</test>
 	
+	<test name="TestJcmd">
+		<classes>
+			<class name="org.openj9.test.attachAPI.TestJcmd"/>
+		</classes>
+	</test>
+	
 	<test name="TestFileLocking">
 		<classes>
 			<class name="org.openj9.test.fileLock.TestFileLocking"/>


### PR DESCRIPTION
Add front-end class.  Add help functions for both the utility per se and the target commands.
Add test cases.

This is the first part which adds the framework for running diagnostic
commands. It provides the capabailities of jps, jmap, and jstack via the jcmd
utility.  Later changesets will add further commands using this framework and
more options for the front-end command.

Depends on launchers; pull requests for same:

- [ ] https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/323
- [ ] https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/198
- [ ] https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/67
- [ ] https://github.com/ibmruntimes/openj9-openjdk-jdk13/pull/7
- [ ] https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/127

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>