### PR TITLE
Fix references to 0.15.0 to be 0.15.1

### DIFF
--- a/doc/release-notes/0.15/0.15.md
+++ b/doc/release-notes/0.15/0.15.md
@@ -143,7 +143,7 @@ recorded is specific to the application command line.</td>
 
 ## Known Issues
 
-The v0.15.0 release contains the following known issues and limitations:
+The v0.15.1 release contains the following known issues and limitations:
 
 <table cellpadding="4" cellspacing="0" summary="" width="100%" rules="all" frame="border" border="1">
 <thead align="left">
@@ -198,4 +198,4 @@ The v0.15.0 release contains the following known issues and limitations:
 
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.15.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.15.0).
+A full commit history for this release is available at [Eclipse OpenJ9 v0.15.1](https://github.com/eclipse/openj9/releases/tag/openj9-0.15.1).


### PR DESCRIPTION
The final tags for the release are 0.15.1

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>