### PR TITLE
Disable EDO on AArch64

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2445,6 +2445,11 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    // OpenJ9 issue #6443 tracks the work to enable.
    //
    self()->setOption(TR_DisableArraySetOpts);
+
+   // EDO catch block profiling support is not available in AArch64 yet.
+   // OpenJ9 issue #6538 tracks the work to enable.
+   //
+   self()->setOption(TR_DisableEDO);
 #endif
 
    return true;


### PR DESCRIPTION
Explicitly disable EDO catch block profiling on AArch64 until backend
support is implemented.  The issue to track enabling the work is #6538.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>