### PR TITLE
Moving several SymbolReferenceTable functions to OpenJ9

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1688,6 +1688,76 @@ J9::SymbolReferenceTable::findOrCreateGlobalFragmentSymbolRef()
 
 
 TR::SymbolReference *
+J9::SymbolReferenceTable::createKnownStaticReferenceSymbolRef(void *dataAddress, TR::KnownObjectTable::Index knownObjectIndex)
+   {
+   char *name = "<known-static-reference>";
+   if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
+      {
+      name = (char*)trMemory()->allocateMemory(25, heapAlloc);
+      sprintf(name, "<known-obj%d>", knownObjectIndex);
+      }
+   TR::StaticSymbol * sym = TR::StaticSymbol::createNamed(trHeapMemory(), TR::Address, dataAddress,name);
+   return TR::SymbolReference::create(self(), sym, knownObjectIndex);
+   }
+
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateCurrentTimeMaxPrecisionSymbol()
+   {
+   if (!element(currentTimeMaxPrecisionSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_Helper);
+      sym->setHelper();
+
+      element(currentTimeMaxPrecisionSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), currentTimeMaxPrecisionSymbol, sym);
+      }
+   return element(currentTimeMaxPrecisionSymbol);
+   }
+
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateSinglePrecisionSQRTSymbol()
+   {
+   if (!element(singlePrecisionSQRTSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_Helper);
+      sym->setHelper();
+
+      element(singlePrecisionSQRTSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), singlePrecisionSQRTSymbol, sym);
+      }
+   return element(singlePrecisionSQRTSymbol);
+   }
+
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreatelong2StringSymbol()
+   {
+   if (!element(long2StringSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_Helper);
+      sym->setHelper();
+
+      element(long2StringSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), long2StringSymbol, sym);
+      }
+   return element(long2StringSymbol);
+   }
+
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreatebitOpMemSymbol()
+   {
+   if (!element(bitOpMemSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_Helper);
+      sym->setHelper();
+
+      element(bitOpMemSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), bitOpMemSymbol, sym);
+      }
+   return element(bitOpMemSymbol);
+   }
+
+
+TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateFragmentParentSymbolRef()
    {
    if (!element(fragmentParentSymbol))

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -187,6 +187,12 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateRamStaticsFromClassSymbolRef();
    TR::SymbolReference * findOrCreateGlobalFragmentSymbolRef();
    TR::SymbolReference * findOrCreateThreadDebugEventData(int32_t index);
+   TR::SymbolReference * createKnownStaticReferenceSymbolRef(void *address, TR::KnownObjectTable::Index knownObjectIndex=TR::KnownObjectTable::UNKNOWN);
+
+   TR::SymbolReference * findOrCreateCurrentTimeMaxPrecisionSymbol();
+   TR::SymbolReference * findOrCreateSinglePrecisionSQRTSymbol();
+   TR::SymbolReference * findOrCreatelong2StringSymbol();
+   TR::SymbolReference * findOrCreatebitOpMemSymbol();
 
    // optimizer (loop versioner)
    TR::SymbolReference * findOrCreateThreadLowTenureAddressSymbolRef();


### PR DESCRIPTION
Some of the methods in SymbolReferenceTable in OMR are used only by OpenJ9.

Fixes: [#3743](https://github.com/eclipse/omr/issues/3743) (in OMR repo)

Signed-off-by: Batyr Nuryyev <nuryyev@ualberta.ca>