### PR TITLE
Cache declaring classes of fields and statics on the server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3392,6 +3392,11 @@ ClientSessionData::ClassInfo::freeClassInfo()
       _jitFieldsCache->~TR_JitFieldsCache();
       jitPersistentFree(_jitFieldsCache);
       }
+   if (_fieldOrStaticDeclaringClassCache)
+      {
+      _fieldOrStaticDeclaringClassCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
+      jitPersistentFree(_fieldOrStaticDeclaringClassCache);
+      }
    }
 
 ClientSessionData::VMInfo *
@@ -3664,6 +3669,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct._constantPool = (J9ConstantPool *)std::get<18>(classInfo);
    classInfoStruct._jitFieldsCache = NULL;
    classInfoStruct.classFlags = std::get<19>(classInfo);
+   classInfoStruct._fieldOrStaticDeclaringClassCache = NULL;
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 
    uint32_t numMethods = romClass->romMethodCount;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -121,6 +121,7 @@ class ClientSessionData
       J9ConstantPool *_constantPool;
       TR_JitFieldsCache *_jitFieldsCache;
       uintptrj_t classFlags;
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_fieldOrStaticDeclaringClassCache;
       };
 
    struct J9MethodInfo


### PR DESCRIPTION
After the most recent merge with master,
message `ResolvedMethod_getDeclaringClassFromFieldOrStatic`
became the most frequent message, caused by PR #6025.
Reduce the number of messages by caching declaring class of a field
once we fetched it from the client the first time.
