### PR TITLE
Increase Artifactory cleanup to 50 days

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -56,7 +56,7 @@ artifactory_server: 'ci-eclipse-openj9'
 artifactory_repo: 'ci-eclipse-openj9'
 artifactory_num_artifacts: 30
 # This is being used for the cleanup script
-artifactory_days_to_keep_artifacts: 30
+artifactory_days_to_keep_artifacts: 50
 artifactory_manual_cleanup: true
 #========================================#
 # Miscellaneous settings


### PR DESCRIPTION
- As per OpenJ9 Community call.
- Nightly is currently set to 40 days so set
  time-based cleanup to 50 days.
- Current usage is 50% so we should have space.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>