### PR TITLE
Jenkins pipelines: Fix checkout scm for PR builds

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
@@ -33,15 +33,23 @@ timeout(time: 10, unit: 'HOURS') {
             try{
                 def gitConfig = scm.getUserRemoteConfigs().get(0)
                 def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+                def scmBranch = params.SCM_BRANCH
+                if (!scmBranch) {
+                    scmBranch = scm.branches[0].name
+                }
 
                 if (gitConfig.getCredentialsId()) {
                     remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
                 }
 
+                if (params.SCM_REFSPEC) {
+                    remoteConfigParameters.put("refspec", params.SCM_REFSPEC)
+                }
+
                 checkout changelog: false,
                         poll: false,
                         scm: [$class: 'GitSCM',
-                        branches: [[name: scm.branches[0].name]],
+                        branches: [[name: "${scmBranch}"]],
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [[$class: 'CloneOption',
                                       reference: "${HOME}/openjdk_cache"]],

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -169,15 +169,23 @@ try {
                 try {
                     def gitConfig = scm.getUserRemoteConfigs().get(0)
                     def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+                    def scmBranch = scm.branches[0].name
+                    if (params.sha1) {
+                        scmBranch = params.sha1
+                    }
 
                     if (gitConfig.getCredentialsId()) {
                         remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
                     }
 
+                    if (ghprbPullId) {
+                        remoteConfigParameters.put("refspec", "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge")
+                    }
+
                     checkout changelog: false,
                             poll: false,
                             scm: [$class: 'GitSCM',
-                            branches: [[name: scm.branches[0].name]],
+                            branches: [[name: "${scmBranch}"]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [[$class: 'CloneOption',
                                           reference: "${HOME}/openjdk_cache"]],

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
@@ -35,15 +35,23 @@ timestamps {
 
             def gitConfig = scm.getUserRemoteConfigs().get(0)
             def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+            def scmBranch = params.SCM_BRANCH
+            if (!scmBranch) {
+                scmBranch = scm.branches[0].name
+            }
 
             if (gitConfig.getCredentialsId()) {
                 remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
             }
 
+            if (params.SCM_REFSPEC) {
+                remoteConfigParameters.put("refspec", params.SCM_REFSPEC)
+            }
+
             checkout changelog: false,
                     poll: false,
                     scm: [$class: 'GitSCM',
-                    branches: [[name: scm.branches[0].name]],
+                    branches: [[name: "${scmBranch}"]],
                     doGenerateSubmoduleConfigurations: false,
                     extensions: [[$class: 'CloneOption',
                                   reference: "${HOME}/openjdk_cache"]],


### PR DESCRIPTION
- Fix branch for PR builds.
- Add refspecs to checkout scm to allow checkout from a PR branch.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>