### PR TITLE
Reduce AOT load failures

### DIFF
--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -311,8 +311,7 @@ TR_PersistentCHTable::findClassInfo(TR_OpaqueClassBlock * classId)
 TR_PersistentClassInfo *
 TR_PersistentCHTable::findClassInfoAfterLocking(TR_OpaqueClassBlock *classId,
       TR::Compilation *comp,
-      bool returnClassInfoForAOT,
-      bool validate)
+      bool returnClassInfoForAOT)
    {
    // for AOT do not use the class hierarchy
    if (comp->compileRelocatableCode() && !returnClassInfoForAOT)
@@ -324,13 +323,6 @@ TR_PersistentCHTable::findClassInfoAfterLocking(TR_OpaqueClassBlock *classId,
       return NULL;
 
    TR_PersistentClassInfo *classInfo = findClassInfoAfterLocking(classId, comp->fe(), returnClassInfoForAOT);
-   if (classInfo &&
-       comp->compileRelocatableCode() &&
-       comp->getOption(TR_UseSymbolValidationManager) &&
-       validate)
-      {
-      comp->getSymbolValidationManager()->addClassInfoIsInitializedRecord(classId, classInfo->isInitialized());
-      }
    return classInfo;
    }
 
@@ -412,7 +404,7 @@ TR_ResolvedMethod * TR_PersistentCHTable::findSingleImplementer(
 
 
 
-   TR_PersistentClassInfo * classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(thisClass, comp, true, validate);
+   TR_PersistentClassInfo * classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(thisClass, comp, true);
    if (!classInfo)
       {
       return 0;
@@ -462,7 +454,7 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
       return 0;
       }
 
-   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, true, validate);
+   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, true);
    if (!classInfo)
       {
       return 0;
@@ -568,7 +560,7 @@ TR_PersistentCHTable::findSingleAbstractImplementer(
    if (comp->getOption(TR_DisableCHOpts))
       return 0;
    bool allowForAOT = comp->getOption(TR_UseSymbolValidationManager);
-   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, allowForAOT, validate);
+   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, allowForAOT);
    if (!classInfo) return 0;
 
    if (TR::Compiler->cls.isInterfaceClass(comp, thisClass))
@@ -613,7 +605,7 @@ TR_PersistentCHTable::findSingleConcreteSubClass(
 
    bool allowForAOT = comp->getOption(TR_UseSymbolValidationManager);
 
-   TR_PersistentClassInfo *classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(opaqueClass, comp, allowForAOT, validate);
+   TR_PersistentClassInfo *classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(opaqueClass, comp, allowForAOT);
    if (classInfo)
       {
       TR_ScratchList<TR_PersistentClassInfo> subClasses(comp->trMemory());

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -50,7 +50,7 @@ class TR_PersistentCHTable
 
    TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId);
 
-   TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false, bool validate = true);
+   TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false);
    TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR_FrontEnd *, bool returnClassInfoForAOT = false);
 
    void dumpMethodCounts(TR_FrontEnd *fe, TR_Memory &trMemory);         // A routine to dump initial method compilation counts

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -36,6 +36,22 @@
 
 extern TR::Monitor *assumptionTableMutex;
 
+bool
+TR_PersistentClassInfo::isInitialized(bool validate)
+   {
+   bool initialized = ((((uintptr_t) _classId) & 1) == 0);
+   TR::Compilation *comp = TR::comp();
+   if (comp &&
+       comp->compileRelocatableCode() &&
+       comp->getOption(TR_UseSymbolValidationManager) &&
+       validate &&
+       initialized)
+      {
+      initialized = comp->getSymbolValidationManager()->addClassInfoIsInitializedRecord(_classId, initialized);
+      }
+   return initialized;
+   }
+
 void
 TR_PersistentClassInfo::setInitialized(TR_PersistentMemory * persistentMemory)
    {

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -69,7 +69,7 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
     }
 
    TR_OpaqueClassBlock *getClassId() { return (TR_OpaqueClassBlock *) (((uintptr_t) _classId) & ~(uintptr_t)1); }
-   bool isInitialized()  { return ((((uintptr_t) _classId) & 1) == 0); }
+   bool isInitialized(bool validate = true);
    void setInitialized(TR_PersistentMemory *);
 
    // HCR

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1385,7 +1385,7 @@ TR::SymbolValidationManager::validateClassInfoIsInitializedRecord(uint16_t class
       _chTable->findClassInfoAfterLocking(clazz, _comp, true);
 
    if (classInfo)
-      initialized = classInfo->isInitialized();
+      initialized = classInfo->isInitialized(false);
 
    bool valid = (!wasInitialized || initialized);
    return valid;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -794,6 +794,15 @@ private:
    void setSymbolOfID(uint16_t id, void *symbol, TR::SymbolType type);
    void defineGuaranteedID(void *symbol, TR::SymbolType type);
 
+   /**
+    * @brief Heuristic to determine whether a class is worth remembering (and hence
+    *        worth considering during optimization) in an AOT compilation.
+    *
+    * @param clazz : The class being considered
+    * @return true if worth remembering, false otherwise.
+    */
+   bool isClassWorthRemembering(TR_OpaqueClassBlock *clazz);
+
    /* Monotonically increasing IDs */
    uint16_t _symbolID;
 
@@ -881,6 +890,8 @@ private:
    typedef TR::typed_allocator<ClassFromAnyCPIndex, TR::Region&> ClassFromAnyCPIndexAlloc;
    typedef std::set<ClassFromAnyCPIndex, LessClassFromAnyCPIndex, ClassFromAnyCPIndexAlloc> ClassFromAnyCPIndexSet;
    ClassFromAnyCPIndexSet _classesFromAnyCPIndex;
+
+   TR_OpaqueClassBlock *_jlthrowable;
    };
 
 }


### PR DESCRIPTION
This PR consists of a set of improvements to help reduce AOT load failures. The two main changes (that apply only during an AOT compilation) are:

1. Prevent the compiler from "seeing" classes that are or inherit from `java/lang/Throwable`
2. Only store `ClassInfoIsInitialized` SVM records when the `isInitialized()` query is called (as opposed to storing it preemptively when `findClassInfoAfterLocking` is called).