### PR TITLE
Replace J9JIT_INTERP_VTABLE_OFFSET with VMEnv::getInterpreterVTableOffset()

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -567,13 +567,13 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
          vmInfo._processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
          vmInfo._invokeWithArgumentsHelperMethod = J9VMJAVALANGINVOKEMETHODHANDLE_INVOKEWITHARGUMENTSHELPER_METHOD(fe->getJ9JITConfig()->javaVM);
-
          vmInfo._noTypeInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false)->getMethodAddress();
          vmInfo._int64InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false)->getMethodAddress();
          vmInfo._int32InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact1, false, false, false)->getMethodAddress();
          vmInfo._addressInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactL, false, false, false)->getMethodAddress();
          vmInfo._floatInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false)->getMethodAddress();
          vmInfo._doubleInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false)->getMethodAddress();
+         vmInfo._interpreterVTableOffset = TR::Compiler->vm.getInterpreterVTableOffset();
          client->write(response, vmInfo);
          }
          break;
@@ -1347,7 +1347,7 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
          J9Method * ramMethod = 0;
          UDATA vTableIndex = (((J9RAMVirtualMethodRef*) literals)[cpIndex]).methodIndexAndArgCount;
          vTableIndex >>= 8;
-         if ((J9JIT_INTERP_VTABLE_OFFSET + sizeof(uintptrj_t)) == vTableIndex)
+         if ((TR::Compiler->vm.getInterpreterVTableOffset() + sizeof(uintptrj_t)) == vTableIndex)
             {
             TR::VMAccessCriticalSection resolveVirtualMethodRef(fe);
             vTableIndex = fe->_vmFunctionTable->resolveVirtualMethodRefInto(fe->vmThread(), cp, cpIndex,
@@ -2237,8 +2237,8 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
              }
          else if (isVirtual)
             {
-            TR_OpaqueMethodBlock **vtable = (TR_OpaqueMethodBlock**)(((uintptrj_t)fe->getClassFromJavaLangClass(jlClass)) + J9JIT_INTERP_VTABLE_OFFSET);
-            int32_t index = (int32_t)((vmSlot - J9JIT_INTERP_VTABLE_OFFSET) / sizeof(vtable[0]));
+            TR_OpaqueMethodBlock **vtable = (TR_OpaqueMethodBlock**)(((uintptrj_t)fe->getClassFromJavaLangClass(jlClass)) + TR::Compiler->vm.getInterpreterVTableOffset());
+            int32_t index = (int32_t)((vmSlot - TR::Compiler->vm.getInterpreterVTableOffset()) / sizeof(vtable[0]));
             j9method = vtable[index];
             }
          else

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -165,6 +165,7 @@ class ClientSessionData
       void *_addressInvokeExactThunkHelper;
       void *_floatInvokeExactThunkHelper;
       void *_doubleInvokeExactThunkHelper;
+      size_t _interpreterVTableOffset;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -38,6 +38,7 @@
 #include "j9cfg.h"
 #include "jilconsts.h"
 #include "vmaccess.h"
+#include "control/JITaaSCompilationThread.hpp"
 
 int64_t
 J9::VMEnv::maxHeapSizeInBytes()
@@ -488,5 +489,10 @@ J9::VMEnv::isSelectiveMethodEnterExitEnabled(TR::Compilation *comp)
 size_t
 J9::VMEnv::getInterpreterVTableOffset()
    {
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_interpreterVTableOffset;
+      }
    return sizeof(J9Class);
    }


### PR DESCRIPTION
J9JIT_INTERP_VTABLE_OFFSET is different on Java8 and Java11. We hit a problem doing
cross platform compilations with a Java11 JITServer and a Java8 JITClient. The Java11 JITServer
should be using Java8 JITClient's J9JIT_INTERP_VTABLE_OFFSET when generating code for it.
The Vtable offset will be sent and cached in the per-client VMInfo struct.

Issue: #6351
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>