### PR TITLE
Track registered J2I thunks on the JITServer

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -381,9 +381,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    JITServer::ServerStream  *getStream();
    J9ROMClass            *getAndCacheRemoteROMClass(J9Class *, TR_Memory *trMemory=NULL);
    J9ROMClass            *getRemoteROMClassIfCached(J9Class *);
-   void                   addThunkToBeRelocated(const std::string &serializedThunk, const std::string &signature);
-   void                   addInvokeExactThunkToBeRelocated(const std::string &serializedThunk);
-   void                   relocateThunks();
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() { return _classesThatShouldNotBeNewlyExtended; }
    uint32_t               getLastLocalGCCounter() { return _lastLocalGCCounter; }
    void                   updateLastLocalGCCounter(); 
@@ -405,10 +402,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    bool                   _initializationSucceeded;
    bool                   _isDiagnosticThread;
    CpuSelfThreadUtilization _compThreadCPU;
-   typedef TR::typed_allocator<std::pair<std::string, std::string>, TR::PersistentAllocator&> ThunkVectorAllocator;
-   std::vector<std::pair<std::string, std::string>, ThunkVectorAllocator> _thunksToBeRelocated;
-   typedef TR::typed_allocator<std::string, TR::PersistentAllocator&> InvokeExactThunkVectorAllocator;
-   std::vector<std::string, InvokeExactThunkVectorAllocator> _invokeExactThunksToBeRelocated;
    // The following hastable caches <classLoader,classname> --> <J9Class> mappings
    // The cache only lives during a compilation due to class unloading concerns
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -159,6 +159,12 @@ class ClientSessionData
       bool _compressObjectReferences;
       TR_ProcessorFeatureFlags _processorFeatureFlags;
       J9Method *_invokeWithArgumentsHelperMethod;
+      void *_noTypeInvokeExactThunkHelper;
+      void *_int64InvokeExactThunkHelper;
+      void *_int32InvokeExactThunkHelper;
+      void *_addressInvokeExactThunkHelper;
+      void *_floatInvokeExactThunkHelper;
+      void *_doubleInvokeExactThunkHelper;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)
@@ -219,6 +225,10 @@ class ClientSessionData
    bool getRtResolve() { return _rtResolve; }
    void setRtResolve(bool rtResolve) { _rtResolve = rtResolve; }
 
+   TR::Monitor *getThunkSetMonitor() { return _thunkSetMonitor; }
+   PersistentUnorderedMap<std::pair<std::string, bool>, void *> &getRegisteredJ2IThunkMap() { return _registeredJ2IThunksMap; }
+   PersistentUnorderedSet<std::pair<std::string, bool>> &getRegisteredInvokeExactJ2IThunkSet() { return _registeredInvokeExactJ2IThunksSet; }
+
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -260,6 +270,9 @@ class ClientSessionData
    TR::Monitor *_staticMapMonitor;
    PersistentUnorderedMap<void *, TR_StaticFinalData> _staticFinalDataMap; // stores values at static final addresses in JVM
    bool _rtResolve; // treat all data references as unresolved
+   TR::Monitor *_thunkSetMonitor;
+   PersistentUnorderedMap<std::pair<std::string, bool>, void *> _registeredJ2IThunksMap; // stores a map of J2I thunks created for this client
+   PersistentUnorderedSet<std::pair<std::string, bool>> _registeredInvokeExactJ2IThunksSet; // stores a set of invoke exact J2I thunks created for this client
    }; // ClientSessionData
 
 // Hashtable that maps clientUID to a pointer that points to ClientSessionData

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8231,6 +8231,12 @@ TR_J9VMBase::isStringCompressionEnabledVM()
    return IS_STRING_COMPRESSION_ENABLED_VM(getJ9JITConfig()->javaVM);
    }
 
+void *
+TR_J9VMBase::getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType)
+   {
+   return glueSymRef->getMethodAddress();
+   }
+
 TR_OpaqueClassBlock *
 TR_J9VM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1014,6 +1014,7 @@ public:
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass);
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) { return false; }
    virtual bool isStringCompressionEnabledVM();
+   virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType);
 
 protected:
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -176,6 +176,7 @@ public:
    virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp) override;
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
    virtual bool getReportByteCodeInfoAtCatchBlock() override;
+   virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType) override;
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -228,6 +228,8 @@ enum MessageType
    VM_getClassFromCP = 304;
    VM_getROMMethodFromRAMMethod = 305;
    VM_getReferenceFieldAt = 306;
+   VM_getJ2IThunk = 307;
+   VM_needsInvokeExactJ2IThunk = 308;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -402,6 +402,7 @@ public:
       virtual bool isRomClassForMethodInSharedCache(J9Method *method, J9JavaVM *javaVM)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0; }
       virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method, J9JavaVM *javaVM)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!");  return TR_no; }
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9JavaVM *javaVM, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0; }
+      static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 
 private:
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize);

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -660,7 +660,7 @@ TR_J2IThunk *TR::AMD64PrivateLinkage::generateInvokeExactJ2IThunk(TR::Node *call
    //
    *(uint16_t *)cursor = 0xbf48;
    cursor += 2;
-   *(uint64_t *)cursor = (uintptrj_t)glueSymRef->getMethodAddress();
+   *(uint64_t *)cursor = (uintptrj_t) cg()->fej9()->getInvokeExactThunkHelperAddress(comp, glueSymRef, callNode->getDataType());
    cursor += 8;
 
    // Arg stores

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1744,7 +1744,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
                int32_t signatureLen = strlen(j2iSignature);
                virtualThunk = fej9->getJ2IThunk(j2iSignature, signatureLen, comp());
                // in server mode, we always need to regenerate the thunk inside the code cache for this compilation
-               if (!virtualThunk || comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+               if (!virtualThunk)
                   {
                   virtualThunk = fej9->setJ2IThunk(j2iSignature, signatureLen,
                      generateVirtualIndirectThunk(
@@ -1766,7 +1766,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
          {
          virtualThunk = fej9->getJ2IThunk(methodSymbol->getMethod(), comp());
          // in server mode, we always need to regenerate the thunk inside the code cache for this compilation
-         if (!virtualThunk || comp()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+         if (!virtualThunk)
             virtualThunk = fej9->setJ2IThunk(methodSymbol->getMethod(), generateVirtualIndirectThunk(callNode), comp());
          }
 

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -233,7 +233,7 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
       cursor += 2;
       }
 
-   *(uintptrj_t *) cursor = (uintptrj_t) dispatcherSymbol->getMethodAddress();
+   *(uintptrj_t *) cursor = (uintptrj_t) cg->fej9()->getInvokeExactThunkHelperAddress(comp, dispatcherSymbol, callNode->getDataType());
    cursor += sizeof(uintptrj_t);
 
    diagnostic("\n-- ( Created invokeExact J2I thunk " POINTER_PRINTF_FORMAT " for node " POINTER_PRINTF_FORMAT " )", thunk, callNode);


### PR DESCRIPTION
Previously, whenever a J2I thunk was needed,
JITServer would always create a new one and send it
to the client for registration with the VM.
However, if the thunk has already been registered, we would
just register it again and waste a remote message.

This PR adds tracking of registered thunks on the server per-client.
If a thunk is already registered, do not regenerate it on the server.
