### PR TITLE
Enable jniargtests to run with the JIT

### DIFF
--- a/test/functional/NativeTest/jniargtests/JniArgTests.java
+++ b/test/functional/NativeTest/jniargtests/JniArgTests.java
@@ -56,6 +56,8 @@ public class JniArgTests {
 		System.loadLibrary( "jniargtests" );
 		JniArgTests jniArgTests = new JniArgTests();
 		jniArgTests.testBlock();
+		jniArgTests.testBlock();
+		jniArgTests.testBlock();
 		jniArgTests.summary();
 	}
 

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -78,11 +78,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<test>
 		<testCaseName>jniargtests</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>-Xint</variation>
 			<variation>-Xjit:count=0</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(TEST_RESROOT)$(D)jniargtests$(D)jniargtests.jar$(Q) JniArgTests ; \
 	$(TEST_STATUS)</command>
 		<levels>


### PR DESCRIPTION
The `-Xint` argument to the JVM was hardcoded in the test playlist
which overrides any preceding `-Xjit` option. The effect of this was
that we are running the jniargtests under the interpreter always. In
addition the way the test is currently structured, running with
`-Xjit:count=0` is not as useful, since many things will be unresolved,
and the native JNI thunks will not have been compiled until the test
has been executed at least once. We correct this by executing the test
block several times.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>