### PR TITLE
Refactor JProfilingValue

### DIFF
--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -276,9 +276,9 @@ static const OptimizationStrategy coldStrategyOpts[] =
    { OMR::compactNullChecks,                         OMR::IfEnabled                  },
    { OMR::signExtendLoadsGroup,                      OMR::IfEnabled                  },
    { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
-   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::trivialDeadTreeRemoval,                                               },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfAOTAndEnabled            },
+   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::globalLiveVariablesForGC,                  OMR::IfAggressiveLiveness  },
    { OMR::profilingGroup,                            OMR::IfProfiling                },
    { OMR::regDepCopyRemoval                                                     },
@@ -360,8 +360,8 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::arraysetStoreElimination                                              },
    { OMR::checkcastAndProfiledGuardCoalescer                                    },
    { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
-   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                  },
+   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::globalDeadStoreGroup,                                                 },
    { OMR::rematerialization                                                     },
    { OMR::compactNullChecks,                         OMR::IfEnabled                  }, // cleanup at the end
@@ -396,8 +396,8 @@ static const OptimizationStrategy reducedWarmStrategyOpts[] =
    { OMR::treeSimplification,                        OMR::MarkLastRun                 },
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // cleanup at the end
    { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
-   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                  },
+   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::endOpts                                                               }
    };
 
@@ -458,8 +458,8 @@ const OptimizationStrategy hotStrategyOpts[] =
    { OMR::arraycopyTransformation      },
    { OMR::checkcastAndProfiledGuardCoalescer                              },
    { OMR::jProfilingRecompLoopTest,              OMR::IfLoops                  },
-   { OMR::jProfilingValue,                           OMR::MustBeDone           },
    { OMR::tacticalGlobalRegisterAllocatorGroup,  OMR::IfEnabled                },
+   { OMR::jProfilingValue,                           OMR::MustBeDone           },
    { OMR::globalDeadStoreElimination,            OMR::IfMoreThanOneBlock       }, // global dead store removal
    { OMR::deadTreesElimination                                            }, // cleanup after dead store removal
    { OMR::compactNullChecks                                               }, // cleanup at the end
@@ -539,8 +539,8 @@ const OptimizationStrategy scorchingStrategyOpts[] =
    { OMR::localValuePropagation,                 OMR::MarkLastRun              },
    { OMR::arraycopyTransformation      },
    { OMR::checkcastAndProfiledGuardCoalescer      },
-   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::tacticalGlobalRegisterAllocatorGroup,  OMR::IfEnabled   },
+   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::globalDeadStoreElimination,            OMR::IfMoreThanOneBlock }, // global dead store removal
    { OMR::deadTreesElimination                               }, // cleanup after dead store removal
    { OMR::compactNullChecks                                  }, // cleanup at the end
@@ -706,8 +706,8 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::treeSimplification,                        OMR::IfEnabledMarkLastRun       }, // Simplify non-normalized address computations introduced by prefetch insertion
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                  }, // final cleanup before opcode expansion
    { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
-   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                  },
+   { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::globalDeadStoreGroup,                                                 },
    { OMR::compactNullChecks,                         OMR::IfEnabled                  }, // cleanup at the end
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead anchors created by check/store removal

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -748,11 +748,10 @@ TR_ValueProfiler::addHashTableProfilingTrees(
    else
       {
       // Create a placeholder, which cannot be left in the jitted body
-      TR::SymbolReference *profiler = comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_jProfile32BitValue, false, false, true);
-      TR::Node *call = TR::Node::createWithSymRef(node, TR::call, 3, profiler);
+      TR::SymbolReference* profiler = comp()->getSymRefTab()->findOrCreateJProfileValuePlaceHolderSymbolRef();
+      TR::Node *call = TR::Node::createWithSymRef(node, TR::call, 2, profiler);
       call->setAndIncChild(0, (commonNode ? node : node->duplicateTree()));
       call->setAndIncChild(1, TR::Node::aconst(node, (uintptr_t) valueInfo));
-      call->setAndIncChild(2, TR::Node::iconst(node, 1));
       TR::TreeTop *callTree = TR::TreeTop::create(comp(), cursorTree, TR::Node::create(TR::treetop, 1, call));
       callTree->getNode()->setIsProfilingCode();
       }


### PR DESCRIPTION
With this commit following changes are made to the `jProfilingValue` optimization.
1. Refactor `addProfilingTrees` to use Post GRA Splitter.
2. Adds new `cleanUpAndAddProfilingCandidates` pass instead of `removeRedundantProfilingValueCalls` to remove redundant profiling candidates as well as profiling instanceOf/checkCast and target of virtual calls.
3. Move the `jProfilingValue` pass after GRA so significant amount of compilation time overhead can be lowered.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>