### PR TITLE
Replace J9JIT_INTERP_VTABLE_OFFSET with VMEnv::getInterpreterVTableOffset()

### DIFF
--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -483,4 +483,10 @@ bool
 J9::VMEnv::isSelectiveMethodEnterExitEnabled(TR::Compilation *comp)
    {
    return comp->fej9()->isSelectiveMethodEnterExitEnabled();
+   }
+
+size_t
+J9::VMEnv::getInterpreterVTableOffset()
+   {
+   return sizeof(J9Class);
    }

--- a/runtime/compiler/env/J9VMEnv.hpp
+++ b/runtime/compiler/env/J9VMEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,6 +115,7 @@ public:
    uintptrj_t thisThreadGetEvacuateTopAddressOffset(TR::Compilation *comp);
    uintptrj_t thisThreadGetGSOperandAddressOffset(TR::Compilation *comp);
    uintptrj_t thisThreadGetGSHandlerAddressOffset(TR::Compilation *comp);
+   size_t getInterpreterVTableOffset();
 
    };
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5870,7 +5870,7 @@ TR_J9VMBase::isBeingCompiled(TR_OpaqueMethodBlock * method, void * startPC)
 U_32
 TR_J9VMBase:: virtualCallOffsetToVTableSlot(U_32 offset)
    {
-   return J9JIT_INTERP_VTABLE_OFFSET - offset;
+   return TR::Compiler->vm.getInterpreterVTableOffset() - offset;
    }
 
 void *
@@ -5905,7 +5905,7 @@ TR_J9VMBase::getInterpreterVTableSlot(TR_OpaqueMethodBlock * mBlock, TR_OpaqueCl
 int32_t
 TR_J9VMBase::getVTableSlot(TR_OpaqueMethodBlock * mBlock, TR_OpaqueClassBlock * clazz)
    {
-   return J9JIT_INTERP_VTABLE_OFFSET - getInterpreterVTableSlot(mBlock, clazz);
+   return TR::Compiler->vm.getInterpreterVTableOffset() - getInterpreterVTableSlot(mBlock, clazz);
    }
 uint64_t
 TR_J9VMBase::getUSecClock()

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5405,7 +5405,7 @@ TR_ResolvedJ9Method::startAddressForJITInternalNativeMethod()
 int32_t
 TR_ResolvedJ9Method::virtualCallSelector(U_32 cpIndex)
    {
-   return -(int32_t)(vTableSlot(cpIndex) - J9JIT_INTERP_VTABLE_OFFSET);
+   return -(int32_t)(vTableSlot(cpIndex) - TR::Compiler->vm.getInterpreterVTableOffset());
    }
 
 bool
@@ -6445,7 +6445,7 @@ TR_ResolvedJ9Method::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * clas
       vTableOffset = jitGetInterfaceVTableOffsetFromCP(_fe->vmThread(), cp(), cpIndex, TR::Compiler->cls.convertClassOffsetToClassPtr(classObject));
       }
 
-   return (J9JIT_INTERP_VTABLE_OFFSET - vTableOffset);
+   return (TR::Compiler->vm.getInterpreterVTableOffset() - vTableOffset);
 #endif
    }
 
@@ -7223,7 +7223,7 @@ TR_J9VMBase::getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, I_32 vi
    // the classObject is the fixed type of the this pointer.  The result of this method is going to be
    // used to call the virtual function directly.
    //
-   // virtualCallOffset = -(vTableSlot(vmMethod, cpIndex) - J9JIT_INTERP_VTABLE_OFFSET);
+   // virtualCallOffset = -(vTableSlot(vmMethod, cpIndex) - TR::Compiler->vm.getInterpreterVTableOffset());
    //
    if (isInterfaceClass(classObject))
       return 0;
@@ -8126,8 +8126,8 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                 }
             else if (isVirtual)
                {
-               TR_OpaqueMethodBlock **vtable = (TR_OpaqueMethodBlock**)(((uintptrj_t)fej9->getClassFromJavaLangClass(jlClass)) + J9JIT_INTERP_VTABLE_OFFSET);
-               int32_t index = (int32_t)((vmSlot - J9JIT_INTERP_VTABLE_OFFSET) / sizeof(vtable[0]));
+               TR_OpaqueMethodBlock **vtable = (TR_OpaqueMethodBlock**)(((uintptrj_t)fej9->getClassFromJavaLangClass(jlClass)) + TR::Compiler->vm.getInterpreterVTableOffset());
+               int32_t index = (int32_t)((vmSlot - TR::Compiler->vm.getInterpreterVTableOffset()) / sizeof(vtable[0]));
                j9method = vtable[index];
                }
             else
@@ -8176,7 +8176,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          if (isVirtual)
             {
-            callNode->getSymbolReference()->setOffset(-(vmSlot - J9JIT_INTERP_VTABLE_OFFSET));
+            callNode->getSymbolReference()->setOffset(-(vmSlot - TR::Compiler->vm.getInterpreterVTableOffset()));
             genTreeTop(genNullCheck(callNode));
             }
          else

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -640,7 +640,7 @@ static U_32 vftOffsetFromPC (J9Method *method, uintptrj_t pc)
    UDATA vTableSlot = ((J9RAMVirtualMethodRef *)literals)[cpIndex].methodIndexAndArgCount >> 8;
    TR_ASSERT(vTableSlot, "vTableSlot called for unresolved method");
 
-   return (U_32) (J9JIT_INTERP_VTABLE_OFFSET - vTableSlot);
+   return (U_32) (TR::Compiler->vm.getInterpreterVTableOffset() - vTableSlot);
    }
 
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1259,7 +1259,7 @@ TR_RelocationRecordConstantPoolWithIndex::getAbstractMethodFromCP(TR_RelocationR
 
    if (abstractClass && method)
       {
-      int32_t vftSlot = (int32_t)(-(vTableOffset - J9JIT_INTERP_VTABLE_OFFSET));
+      int32_t vftSlot = (int32_t)(-(vTableOffset - TR::Compiler->vm.getInterpreterVTableOffset()));
       TR_PersistentCHTable * chTable = reloRuntime->getPersistentInfo()->getPersistentCHTable();
       TR_ResolvedMethod *callerResolvedMethod = fe->createResolvedMethod(trMemory, callerMethod, NULL);
 


### PR DESCRIPTION
Changing the macro J9JIT_INTERP_VTABLE_OFFSET to an VMEnv API.
The reason for the change is that in the JITServer scenario, JITServer would want
JITClient's interpreterVtableOffset instead of its own, and we can later overload/modify
the VMEnv API to achieve that in the JITServer codebase.

Issue: #6351

Signed-off-by: Harry Yu <harryyu1994@gmail.com>