### PR TITLE
Disable special.system tests jdk11 plinux, enable jdk8 xlinux

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -142,6 +142,8 @@ ppc64le_linux:
       13: 'CC=gcc-7 CXX=g++-7'
       next: 'CC=gcc-7 CXX=g++-7'
   excluded_tests:
+    11:
+      ? special.system
     12:
       ? special.system
     13:
@@ -297,8 +299,6 @@ x86-64_linux:
       13: 'source /opt/rh/devtoolset-7/enable'
       next: 'source /opt/rh/devtoolset-7/enable'
   excluded_tests:
-    8:
-      ? special.system
     11:
       ? special.system
     12:


### PR DESCRIPTION
We don't have the machine capacity to test both jdk8 and jdk11 plinux.

Fixes #6600

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>