### PR TITLE
Enable XL C/C++ 13.1 compiler for Linux PPC BE

### DIFF
--- a/buildspecs/linux_ppc-64.spec
+++ b/buildspecs/linux_ppc-64.spec
@@ -57,8 +57,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_req.arch1" value="arch:64bit"/>
 		<property name="graph_req.aux0" value=""/>
 		<property name="graph_req.aux1" value=""/>
-		<property name="graph_req.build" value="build:java8sr5fp27+"/>
-		<property name="graph_req.build2" value="build:java8sr5fp27+"/>
+		<property name="graph_req.build" value="build:java8sr6fp5+"/>
+		<property name="graph_req.build2" value="build:java8sr6fp5+"/>
 		<property name="graph_req.machine" value="{$machine_mapping.ppc64$}"/>
 		<property name="graph_req.machine.test" value="{$spec.property.graph_req.machine$}"/>
 		<property name="graph_req.os" value="{$machine_mapping.linux$}"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs.spec
@@ -58,8 +58,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_req.arch1" value="arch:64bit"/>
 		<property name="graph_req.aux0" value=""/>
 		<property name="graph_req.aux1" value=""/>
-		<property name="graph_req.build" value="build:java8sr5fp27+"/>
-		<property name="graph_req.build2" value="build:java8sr5fp27+"/>
+		<property name="graph_req.build" value="build:java8sr6fp5+"/>
+		<property name="graph_req.build2" value="build:java8sr6fp5+"/>
 		<property name="graph_req.machine" value="{$machine_mapping.ppc64$}"/>
 		<property name="graph_req.machine.test" value="{$spec.property.graph_req.machine$}"/>
 		<property name="graph_req.os" value="{$machine_mapping.linux$}"/>

--- a/buildspecs/linux_ppc.spec
+++ b/buildspecs/linux_ppc.spec
@@ -57,8 +57,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_req.arch1" value=""/>
 		<property name="graph_req.aux0" value=""/>
 		<property name="graph_req.aux1" value=""/>
-		<property name="graph_req.build" value="build:java8sr5fp27+"/>
-		<property name="graph_req.build2" value="build:java8sr5fp27+"/>
+		<property name="graph_req.build" value="build:java8sr6fp5+"/>
+		<property name="graph_req.build2" value="build:java8sr6fp5+"/>
 		<property name="graph_req.machine" value="{$machine_mapping.ppc64$}"/>
 		<property name="graph_req.machine.test" value="{$machine_mapping.ppc$}"/>
 		<property name="graph_req.os" value="{$machine_mapping.linux$}"/>

--- a/runtime/compiler/build/toolcfg/gnu-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu-xlc/common.mk
@@ -85,7 +85,10 @@ CX_FLAGS_DEBUG+=-g -qfullpath
 
 CX_DEFAULTOPT=-O3
 CX_OPTFLAG?=$(CX_DEFAULTOPT)
-CX_FLAGS_PROD+=$(CX_OPTFLAG) -qdebug=nscrep
+CX_FLAGS_PROD+=$(CX_OPTFLAG)
+ifneq (,$(findstring ppc64le,$(PLATFORM)))
+   CX_FLAGS_PROD+=-qdebug=nscrep
+endif
 
 ifdef ENABLE_SIMD_LIB
     CX_DEFINES+=ENABLE_SPMD_SIMD
@@ -109,6 +112,13 @@ endif
 ifeq ($(BUILD_CONFIG),prod)
     CX_DEFINES+=$(CX_DEFINES_PROD)
     CX_FLAGS+=$(CX_FLAGS_PROD)
+    ifeq (,$(findstring ppc64le,$(PLATFORM)))
+        # big endian
+        C_FLAGS+=-qdebug=nscrep
+        # work-around for XL C/C++ 13.1 compiler bug
+        # related to multiple inheritance
+        CXX_FLAGS+=-qdebug=NETHUNK
+    endif
 endif
 
 C_CMD?=$(CC)

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -567,7 +567,7 @@ MHInterpreter$(UMA_DOT_O):MHInterpreter.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
 
 endif
-<#if uma.spec.flags.env_littleEndian.enabled && !uma.spec.flags.env_gcc.enabled>
+<#if uma.spec.type.linux && !uma.spec.flags.env_gcc.enabled>
 # special handling of fltconv.c
 # This is a work around for a compiler defect (see JAZZ 76038)
 fltconv$(UMA_DOT_O):fltconv.c


### PR DESCRIPTION
Update graph_req.build2 property to compile pLinux SDK with XL C/C++ 13.1.
Add -qdebug=NETHUNK to C++ flags. This is a work-around for a compiler
bug related to multiple inheritance (work-around for segmentation fault
when trying to load from vtable).
Work around PPC xlc 13 float conversion bug: include BE in the existing
workaround in targets.mk.ftl.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>