### PR TITLE
Add jdk version to JITServer compatibility flag

### DIFF
--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -25,6 +25,8 @@
 #include "env/CompilerEnv.hpp" // for TR::Compiler->target.is64Bit()
 #include "control/Options.hpp" // TR::Options::useCompressedPointers()
 #include "control/CompilationRuntime.hpp"
+#include "j9cfg.h" // for JAVA_SPEC_VERSION
+
 
 namespace JITServer
 {
@@ -34,8 +36,9 @@ void CommunicationStream::initVersion()
    {
    if (TR::Compiler->target.is64Bit() && TR::Options::useCompressedPointers())
       {
-      CONFIGURATION_FLAGS |= JITaaSCompressedRef;
+      CONFIGURATION_FLAGS |= JITServerCompressedRef;
       }
+   CONFIGURATION_FLAGS |= JAVA_SPEC_VERSION & JITServerJavaVersionMask;
    }
 
 #if defined(JITSERVER_ENABLE_SSL)

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -30,9 +30,10 @@
 
 namespace JITServer
 {
-enum JITaaSCompatibilityFlags
+enum JITServerCompatibilityFlags
    {
-   JITaaSCompressedRef = 0x00000001,
+   JITServerJavaVersionMask    = 0x00000FFF,
+   JITServerCompressedRef      = 0x00001000,
    };
 // list of features that client and server must match in order for remote compilations to work
 


### PR DESCRIPTION
We do not support cross-compilation between different jdk versions at the moment

Issue: #6351
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>