### PR TITLE
Build jniargtests with system linkage

### DIFF
--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -70,7 +70,7 @@ endif
 
 UMA_ZOS_FLAGS += -DJ9ZOS390 -DLONGLONG -DJ9VM_TIERED_CODE_CACHE -D_ALL_SOURCE -D_XOPEN_SOURCE_EXTENDED -DIBM_ATOE -D_POSIX_SOURCE
 UMA_ZOS_FLAGS += -I$(OMR_DIR)/util/a2e/headers $(UMA_OPTIMIZATION_FLAGS) $(UMA_OPTIMIZATION_LINKER_FLAGS) \
-	-Wc,"xplink,convlit(ISO8859-1),rostring,FLOAT(IEEE,FOLD,AFP),enum(4)" -Wa,goff -Wc,NOANSIALIAS -Wc,"inline(auto,noreport,600,5000)"
+	-Wc,"convlit(ISO8859-1),xplink,rostring,FLOAT(IEEE,FOLD,AFP),enum(4)" -Wa,goff -Wc,NOANSIALIAS -Wc,"inline(auto,noreport,600,5000)"
 UMA_ZOS_FLAGS += -Wc,"SERVICE(j${uma.buildinfo.build_date})" -Wc,"TARGET(zOSV1R13)"
 UMA_ZOS_FLAGS += -Wc,list,offset
 ifdef j9vm_env_data64
@@ -100,6 +100,14 @@ ifdef j9vm_jit_freeSystemStackPointer
   UMA_M4_FLAGS += -DJ9VM_JIT_FREE_SYSTEM_STACK_POINTER
 endif
 
+COMMA := ,
+
+# Compile jniargtestssystemlink with non-XPLINK (system) linkage
+ifeq ($(UMA_TARGET_NAME),jniargtestssystemlink)
+  UMA_ZOS_FLAGS := $(subst $(COMMA)xplink,,$(UMA_ZOS_FLAGS))
+  UMA_LINK_FLAGS := $(subst $(COMMA)xplink,,$(UMA_LINK_FLAGS))
+endif
+
 ifndef j9vm_env_data64
 ASFLAGS += -mzarch
 endif
@@ -124,7 +132,6 @@ endif
 
 # JAZZ103 49015 - compile with MRABIG debug option to reduce stack size required for -Xmt
 MRABIG = -Wc,"TBYDBG(-qdebug=MRABIG)"
-COMMA := ,
 SPECIALCXXFLAGS = $(filter-out -Wc$(COMMA)debug -O3,$(CXXFLAGS))
 NEW_OPTIMIZATION_FLAG = -O2 -Wc,"TBYDBG(-qdebug=lincomm:ptranl:tfbagg)" -Wc,"FEDBG(-qxflag=InlineDespiteVolatileInArgs)"
 BytecodeInterpreter.o : BytecodeInterpreter.cpp

--- a/runtime/tests/jniarg/cdefs.c
+++ b/runtime/tests/jniarg/cdefs.c
@@ -139,8 +139,9 @@ void JNICALL Java_JniArgTests_logRetValError( JNIEnv *p_env, jobject p_this, jst
 	retValFailures ++;
 }
 
-void JNICALL Java_JniArgTests_summary( JNIEnv *p_env, jobject p_this )
+jint JNICALL Java_JniArgTests_summary( JNIEnv *p_env, jobject p_this )
 {
+	jint rc = 0;
 	J9JavaVM *javaVM = getJ9JavaVM(p_env);
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
@@ -153,5 +154,11 @@ void JNICALL Java_JniArgTests_summary( JNIEnv *p_env, jobject p_this )
 	} else {
 		j9tty_printf( PORTLIB, "JNI ARG Tests PASSED\n" );
 	}
+
+	if ((argFailures + retValFailures) > 0) {
+		rc = 1;
+	}
+
+	return rc;
 }
 

--- a/runtime/tests/jniarg/jniargtests.h
+++ b/runtime/tests/jniarg/jniargtests.h
@@ -48,7 +48,7 @@ extern void cFailure_jboolean(J9PortLibrary *portLib, char *functionName, int in
 extern J9JavaVM *getJ9JavaVM(JNIEnv * env);
 
 void JNICALL Java_JniArgTests_logRetValError( JNIEnv *p_env, jobject p_this, jstring error_message );
-void JNICALL Java_JniArgTests_summary( JNIEnv *p_env, jobject p_this );
+jint JNICALL Java_JniArgTests_summary( JNIEnv *p_env, jobject p_this );
 
 /* Prototypes from args_01.c */
 jbyte JNICALL Java_JniArgTests_nativeBBrB( JNIEnv *p_env, jobject p_this, jbyte arg1, jbyte arg2 );

--- a/runtime/tests/jniargsystemlinkage/module.xml
+++ b/runtime/tests/jniargsystemlinkage/module.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+   Copyright (c) 2019, 2019 IBM Corp. and others
+
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which accompanies this
+   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+   or the Apache License, Version 2.0 which accompanies this distribution and
+   is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+   This Source Code may also be made available under the following
+   Secondary Licenses when the conditions for such availability set
+   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+   General Public License, version 2 with the GNU Classpath
+   Exception [1] and GNU General Public License, version 2 with the
+   OpenJDK Assembly Exception [2].
+
+   [1] https://www.gnu.org/software/classpath/license.html
+   [2] http://openjdk.java.net/legal/assembly-exception.html
+
+   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<module xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="../jniarg/exports.xml"/>
+
+  <exports group="all">
+    <export name="Java_JniArgTests_logRetValError"/>
+    <export name="Java_JniArgTests_summary"/>
+  </exports>
+
+  <artifact type="shared" name="jniargtestssystemlink" appendrelease="false">
+    <include-if condition="spec.flags.module_jniargtests and spec.zos_390.* and not spec.flags.J9VM_ENV_DATA64"/>
+    <options>
+      <option name="requiresPrimitiveTable"/>
+      <option name="prototypeHeaderFileNames" data="j9protos.h ../jniarg/jniargtests.h"/>
+    </options>
+    <phase>util j2se</phase>
+    <exports>
+      <group name="all"/>
+      <group name="generated"/>
+    </exports>
+    <includes>
+      <include path="j9include"/>
+      <include path="j9oti"/>
+    </includes>
+    <makefilestubs>
+      <makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+      <makefilestub data="UMA_DISABLE_DDRGEN=1"/>
+      <makefilestub data="CFLAGS := -Wc,DLL,EXPORTALL"/>
+    </makefilestubs>
+    <vpaths>
+      <vpath path="../jniarg" pattern="args_01.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_02.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_03.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_04.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_05.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_06.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_07.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_08.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_09.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="args_10.c" augmentObjects="true" type="relativepath"/>
+      <vpath path="../jniarg" pattern="cdefs.c" augmentObjects="true" type="relativepath"/>
+    </vpaths>
+  </artifact>
+</module>

--- a/test/functional/NativeTest/jniargtests/JniArgTests.java
+++ b/test/functional/NativeTest/jniargtests/JniArgTests.java
@@ -53,7 +53,7 @@ public class JniArgTests {
 	final boolean test_jboolean[] = {true, false};
 	
 	public static void main(String[] args) {
-		System.loadLibrary( "jniargtests" );
+		System.loadLibrary(args[0]);
 		JniArgTests jniArgTests = new JniArgTests();
 		jniArgTests.testBlock();
 		jniArgTests.testBlock();

--- a/test/functional/NativeTest/jniargtests/JniArgTests.java
+++ b/test/functional/NativeTest/jniargtests/JniArgTests.java
@@ -58,7 +58,8 @@ public class JniArgTests {
 		jniArgTests.testBlock();
 		jniArgTests.testBlock();
 		jniArgTests.testBlock();
-		jniArgTests.summary();
+		int rc = jniArgTests.summary();
+		System.exit(rc);
 	}
 
 	void testBlock() {
@@ -2805,8 +2806,7 @@ public class JniArgTests {
 
 	native void logRetValError(String arg);
 
- native void summary();
-
+ 	native int summary();
 
 	native byte nativeBBrB(byte arg1, byte arg2 );
 

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -42,11 +42,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>ctest</testCaseName>
@@ -69,11 +64,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jniargtests</testCaseName>
@@ -82,10 +72,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<variation>-Xjit:count=0</variation>
 			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(TEST_RESROOT)$(D)jniargtests$(D)jniargtests.jar$(Q) JniArgTests ; \
-	$(TEST_STATUS)</command>
+		<command>
+			$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(TEST_RESROOT)$(D)jniargtests$(D)jniargtests.jar$(Q) JniArgTests jniargtests; \
+			$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -99,11 +90,33 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
+	</test>
+	<test>
+		<testCaseName>jniargtestssystemlink</testCaseName>
+		<variations>
+			<variation>-Xint</variation>
+			<variation>-Xjit:count=0</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
+		</variations>
+		<platformRequirements>os.zos,bits.31</platformRequirements>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(TEST_RESROOT)$(D)jniargtests$(D)jniargtests.jar$(Q) JniArgTests jniargtestssystemlink; \
+	$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 	<test>
 		<testCaseName>vmtest</testCaseName>
@@ -126,11 +139,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jsigjnitest</testCaseName>
@@ -156,11 +164,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>gc_rwlocktest</testCaseName>
@@ -185,11 +188,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>gc_rwlocktest_win</testCaseName>
@@ -213,11 +211,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>11+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>shrtest_linux</testCaseName>


### PR DESCRIPTION
The fatal bug fixed in eclipse/omr#4154 was not caught during
automated testing because there currently do not exist JNI tests
which are built with non-XPLINK (system) linkage. To prevent such
obvious bugs from escaping into production we reuse the jniargtests
and compile them with system linkage on z/OS 31-bit.

We modify the existing Java test so it can run against custom native
libraries, then we build two native libraries on z/OS, one with
XPLINK which is already done today, and one with system linkage which
will exercise callouts to non-XPLINK natives.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>