### PR TITLE
Fix NULL class dereference from VP isAssignableFrom folding

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -469,8 +469,9 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                   if (isInstanceOfResult == TR_yes)
                      assignable = 1;
                   }
-               else
+               else if (secondClassChildConstraint->getClassType()->asResolvedClass())
                   {
+                  TR_ASSERT_FATAL(firstClass != NULL && secondClass != NULL, "isAssignableFrom replacement at compile-time requires two class pointers - got %p and %p", firstClass, secondClass);
                   TR_YesNoMaybe isInstanceOfResult = comp()->fej9()->isInstanceOf(secondClass, firstClass, false, true);
                   if (isInstanceOfResult == TR_maybe)
                      {
@@ -480,6 +481,12 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                      }
                   else if (isInstanceOfResult == TR_yes)
                      assignable = 1;
+                  }
+               else
+                  {
+                  if (trace())
+                     traceMsg(comp(), "The second child class type is not resolved at compile-time, quit transforming Class.isAssignableFrom\n");
+                  return;
                   }
                transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, assignable, firstClassChildGlobal && secondClassChildGlobal, true);
                TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "constrainCall/(%s)", signature));


### PR DESCRIPTION
Value propagation contains code to perform compile-time evaluations of a number
of Java APIs. One of these is Class.isAssignableFrom. I have observed a bug
where this API receives an UnresolvedClassConstraint as the constraint for the
second child of the isAssignableFrom call. The code currently assumes that any
ClassType will be able to return a non-NULL pointer from getClass - this is not
the case for an UnresolvedClassConstraint. When a NULL class pointer is
returned the pointer will be dereferenced leading to a crash.

This change restricts folding to the family of ResolvedClassConstraints which
should have a non-NULL class pointer from getClass. Folding will be skipped for
all other kinds of ClassType since these cannot supply a class pointer for
compile-time evaluation.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>