### PR TITLE
Add code for AArch64 to ProcessorDetection.cpp

### DIFF
--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -448,6 +448,13 @@ portLibCall_getARMProcessorType()
    return tp;
    }
 
+static TR_Processor
+portLibCall_getARM64ProcessorType()
+   {
+   // ToDo: Add code for detecting processor type (Issue #6637)
+   return TR_DefaultARM64Processor;
+   }
+
 TR_Processor
 TR_J9VMBase::getPPCProcessorType()
    {
@@ -690,6 +697,13 @@ TR_J9VM::initializeProcessorType()
 
       TR_ASSERT(TR::Compiler->target.cpu.id() >= TR_FirstARMProcessor
              && TR::Compiler->target.cpu.id() <= TR_LastARMProcessor, "Not a valid ARM Processor Type");
+      }
+   else if (TR::Compiler->target.cpu.isARM64())
+      {
+      TR::Compiler->target.cpu.setProcessor(portLibCall_getARM64ProcessorType());
+
+      TR_ASSERT(TR::Compiler->target.cpu.id() >= TR_FirstARM64Processor
+             && TR::Compiler->target.cpu.id() <= TR_LastARM64Processor, "Not a valid ARM64 Processor Type");
       }
    else if (TR::Compiler->target.cpu.isPower())
       {


### PR DESCRIPTION
This commits adds code for AArch64 to ProcessorDetection.cpp.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>