### PR TITLE
Disable recompilation for AArch64

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2436,6 +2436,11 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       }
 
 #if defined(TR_HOST_ARM64)
+   // Recompilation support is not available in AArch64 yet.
+   // OpenJ9 issue #6607 tracks the work to enable.
+   //
+   self()->setAllowRecompilation(false);
+
    // Internal Pointers support is not available in AArch64 yet.
    // OpenJ9 issue #6367 tracks the work to enable.
    //


### PR DESCRIPTION
Recompilation support is not yet available for AArch64.  OpenJ9
issue #6607 tracks the work to enable.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>