### PR TITLE
Disable GlobalRegisterAllocation on AArch64

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2450,6 +2450,13 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    // OpenJ9 issue #6538 tracks the work to enable.
    //
    self()->setOption(TR_DisableEDO);
+
+   // Full support for GRA is not available on AArch64 yet, mainly to
+   // work out all the subtleties with GlRegDeps.
+   //
+   // OpenJ9 issue #6606 tracks the work to enable.
+   //
+   self()->setDisabled(OMR::tacticalGlobalRegisterAllocator, true);
 #endif
 
    return true;


### PR DESCRIPTION
Full GlRegDep support is not ready yet.  Disable GRA until that support
can be rounded out.  Issue #6606 tracks the work to enable this.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>