### PR TITLE
Use <makefilestubs> to export symbols in JVMTI tests

### DIFF
--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -100,18 +100,6 @@ ifdef j9vm_jit_freeSystemStackPointer
   UMA_M4_FLAGS += -DJ9VM_JIT_FREE_SYSTEM_STACK_POINTER
 endif
 
-# Static libraries that are included in a shared library require the
-# EXPORTALL option in order to export their symbols (e.g. JNI). This applies to zOS only.
-# The change is not made globally as it will export undesired symbols. Additional
-# target names may be added as needed.
-
-ifeq ($(UMA_TARGET_NAME),jvmti_test_agent)
-  UMA_ZOS_FLAGS += -Wc,DLL,EXPORTALL
-endif
-ifeq ($(UMA_TARGET_NAME),jvmti_test_src)
-  UMA_ZOS_FLAGS += -Wc,DLL,EXPORTALL
-endif
-
 ifndef j9vm_env_data64
 ASFLAGS += -mzarch
 endif

--- a/runtime/tests/jvmtitests/agent/module.xml
+++ b/runtime/tests/jvmtitests/agent/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2018 IBM Corp. and others
+  Copyright (c) 2001, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,5 +31,10 @@
 			<include path="j9include"/>
 			<include path="j9oti"/>
 		</includes>
+		<makefilestubs>
+			<makefilestub data="UMA_ZOS_FLAGS += -Wc,DLL,EXPORTALL">
+				<include-if condition="spec.zos_390.*"/>
+			</makefilestub>
+		</makefilestubs>
 	</artifact>
 </module>

--- a/runtime/tests/jvmtitests/src/module.xml
+++ b/runtime/tests/jvmtitests/src/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2018 IBM Corp. and others
+  Copyright (c) 2001, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,6 @@
 -->
 
 <module>
-
-
 	<artifact type="static" name="jvmti_test_src">
 		<include-if condition="spec.flags.test_jvmti" />
 		<phase>jvmti_tests</phase>
@@ -33,7 +31,6 @@
 			<include path="j9include"/>
 			<include path="j9oti"/>
 		</includes>
-
 		<makefilestubs>
 			<makefilestub data="CFLAGS+=-Fo$@">
 				<include-if condition="spec.win.*"/>
@@ -41,9 +38,9 @@
 			<makefilestub data="UMA_OBJECTS+=$(foreach suffix,$(UMA_SOURCE_SUFFIX_LIST),$(patsubst %$(suffix),%$(UMA_DOT_O),$(wildcard com/ibm/jvmti/tests/**/*$(suffix))))"/>
 			<makefilestub data="UMA_OBJECTS := $(UMA_OBJECTS:$(UMA_TARGET_NAME)exp$(UMA_DOT_O)=)"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="UMA_ZOS_FLAGS += -Wc,DLL,EXPORTALL">
+				<include-if condition="spec.zos_390.*"/>
+			</makefilestub>
 		</makefilestubs>
-
 	</artifact>
-
 </module>
-


### PR DESCRIPTION
Rather than using a special case in the global targets.mk for z/OS we
use `<makefilestubs>` to specify that we want to export all the symbols
in the compilation objects of the jvmti_test_src and jvmti_test_agent
targets.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>