### PR TITLE
Update J9Options to be merged into master

### DIFF
--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitaas/run/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitaas/run/Dockerfile
@@ -40,6 +40,6 @@
 
 FROM openj9-jitaas-build:latest
 
-ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:+StartAsJITServer", "-Xjit:verbose={JITServer}"]
+ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:StartAsJITServer", "-Xjit:verbose={JITServer}"]
 
 EXPOSE 38400

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitaas/run/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitaas/run/Dockerfile
@@ -40,6 +40,6 @@
 
 FROM openj9-jitaas-build:latest
 
-ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:+StartAsJITServer", "-Xjit:verbose={JITServer}"]
+ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:StartAsJITServer", "-Xjit:verbose={JITServer}"]
 
 EXPOSE 38400

--- a/doc/compiler/jitserver/Testing.md
+++ b/doc/compiler/jitserver/Testing.md
@@ -68,7 +68,7 @@ These are the steps to run the tests on your machine.
 
    Manually start the server if `JITAAS` TEST_FLAG is not used.
    ```
-   $JAVA_BIN/java -XX:+StartAsJITServer
+   $JAVA_BIN/java -XX:StartAsJITServer
    ```
    ```
    make _sanity

--- a/doc/compiler/jitserver/Usage.md
+++ b/doc/compiler/jitserver/Usage.md
@@ -20,12 +20,12 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-JITServer adds an additional two *personas* to the `java` executable: client mode and server mode. There are two new command line options that can be used to select a persona: `-XX:+StartAsJITServer` and `-XX:+UseJITServer`.
+JITServer adds an additional two *personas* to the `java` executable: client mode and server mode. There are two new command line options that can be used to select a persona: `-XX:StartAsJITServer` and `-XX:+UseJITServer`.
 
 In server mode, the JVM will halt after startup and begin listening for compilation requests from clients. No Java application is given to the server on the command line.
 
 ```
-$ java -XX:+StartAsJITServer
+$ java -XX:StartAsJITServer
 
 JITServer ready to accept incoming requests
 ```
@@ -47,7 +47,7 @@ You might have noticed that running the client without any server to connect to 
 
 With verbose logging, if a client connects successfully then server output should look something like this:
 ```
-$ java -XX:+StartAsJITServer -Xjit:verbose=\{JITServer\}
+$ java -XX:StartAsJITServer -Xjit:verbose=\{JITServer\}
 
 #JITServer: JITServer in Server Mode. Port: 38400
 #JITServer: Started JITServer listener thread: 0000000001B8DE00
@@ -77,15 +77,15 @@ $ java -XX:+UseJITServer:server=example.com
 #### Port
 By default, communication occurs on port 38400. You can change this by specifying the `port` suboption as follows:
 ```
-$ java -XX:+StartAsJITServer:port=1234
-$ java -XX:+UseJITServer:port=1234 MyApplication
+$ java -XX:StartAsJITServer -XX:JITServerPort=1234
+$ java -XX:+UseJITServer -XX:JITServerPort=1234 MyApplication
 ```
 
 #### Timeout
 If your network connection is flaky, you may want to specify a timeout. By default there is no timeout. Timeout is given in milliseconds. Client and server timeouts do not need to match, but there's usually no reason for them to differ.
 ```
-$ java -XX:+StartAsJITServer:timeout=5000
-$ java -XX:+UseJITServer:timeout=5000 MyApplication
+$ java -XX:StartAsJITServer -XX:JITServerTimeout=5000
+$ java -XX:+UseJITServer -XX:JITServerTimeout=5000 MyApplication
 ```
 
 #### Encryption (TLS)
@@ -102,9 +102,9 @@ Make sure you specify localhost for the common name, but other fields don't matt
 
 On the server, there are two options `sslKey` and `sslCert`, which are used to specify the filenames of PEM-encoded keypair.
 ```
-$ java -XX:+StartAsJITServer:sslKey=key.pem,sslCert=cert.pem
+$ java -XX:StartAsJITServer -XX:JITServerSSLKey=key.pem -XX:JITServerSSLCert=cert.pem
 ```
 The client currently accepts a single option `sslRootCerts`, which is the filename of a PEM-encoded certificate chain.
 ```
-$ java -XX:+UseJITServer:sslRootCerts=cert.pem -version
+$ java -XX:+UseJITServer -XX:JITServerSSLRootCerts=cert.pem -version
 ```

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -345,15 +345,15 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    void openLogFiles(J9JITConfig *jitConfig);
 
 #if defined(JITSERVER_SUPPORT)
-   static const size_t FILENAME_MAX_SIZE = 1025;
-   static std::string packOptions(TR::Options *origOptions);
-   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT, TR_J9VMBase *fe, TR_Memory *trMemory);
-   static uint8_t *appendContent(char * &charPtr, uint8_t * curPos, size_t length);
-   static std::string packLogFile(TR::FILE *fp);
-   void setLogFileForClientOptions(int doubleCompile = 0);
-   void closeLogFileForClientOptions();
-   int writeLogFileFromServer(const std::string& logFileContent);
    void setupJITServerOptions();
+
+   static std::string packOptions(const TR::Options *origOptions);
+   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT,
+                                    TR_J9VMBase *fe, TR_Memory *trMemory);
+   static std::string packLogFile(TR::FILE *fp);
+   int writeLogFileFromServer(const std::string& logFileContent);
+   void setLogFileForClientOptions(int suffixNumber = 0);
+   void closeLogFileForClientOptions();
 #endif /* defined(JITSERVER_SUPPORT) */
    };
 

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -134,6 +134,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
          _socketTimeoutMs(1000),
+         _clientUID(0),
 #endif /* defined(JITSERVER_SUPPORT) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -394,8 +395,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    JITServer::RemoteCompilationModes _remoteCompilationMode; // JITServer::NONE, JITServer::CLIENT, JITServer::SERVER
    std::string _JITServerAddress;
    uint32_t    _JITServerPort;
-   uint64_t    _clientUID;
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
+   uint64_t    _clientUID;
 #endif /* defined(JITSERVER_SUPPORT) */
    };
 

--- a/test/TestConfig/testEnv.mk
+++ b/test/TestConfig/testEnv.mk
@@ -27,10 +27,10 @@ testEnvTeardown:
 
 ifneq (,$(findstring JITAAS,$(TEST_FLAG)))
 testEnvSetup:
-	$(TEST_JDK_HOME)$(D)bin$(D)java -XX:+StartAsJITServer &
+	$(TEST_JDK_HOME)$(D)bin$(D)java -XX:StartAsJITServer &
 
 testEnvTeardown:
-	pkill -9 -xf "$(TEST_JDK_HOME)$(D)bin$(D)java -XX:+StartAsJITServer"; true
+	pkill -9 -xf "$(TEST_JDK_HOME)$(D)bin$(D)java -XX:StartAsJITServer"; true
 
 RESERVED_OPTIONS += -XX:+UseJITServer
 endif


### PR DESCRIPTION
- JITServer option name change:
  === Server ===
  ```
  -XX:+StartAsJITServer:port= 38800,timeout=500,sslKey=key.pem,sslCert=cert.pem
  =>
  -XX:StartAsJITServer -XX:JITServerPort=38800 -XX:JITServerTimeout=500
  -XX:JITServerSSLKey=key.pem -XX:JITServerSSLCert=cert.pem
   ```
   === Client ===
   ```
  -XX:+UseJITServer:server=example.com,port=38800,timeout=500,sslRootCerts=cert.pem
  =>
  -XX:+UseJITServer -XX:JITServerAddress=example.com -XX:JITServerPort=38800
  -XX:JITServerTimeout=500 -XX:JITServerSSLRootCerts=cert.pem
  ```
- Guard PR #4032 change with `JITSERVER_SUPPORT` so that J9Options.cpp is ready to be merged into master.
- Move `appendContent()` out of J9::Options class to be a static function in J9Options.cpp.
- Define utility functions like `appendRegex()`, `unpackRegex()` etc. in J9Options.cpp to be static functions.
- Update format and add more comments for clarity.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>