### PR TITLE
Fix Insertion of allocationFence

### DIFF
--- a/runtime/compiler/env/j9field.h
+++ b/runtime/compiler/env/j9field.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,13 +36,14 @@ public:
    TR_ALLOC(TR_Memory::VMField)
    TR_VMField( TR::Compilation * comp, J9Class *aClazz, J9ROMFieldShape *fieldShape, TR_AllocationKind allocKind);
    int isReference();
-   void           print(TR_FrontEnd *fe, TR::FILE *outFile);
+   void              print(TR_FrontEnd *fe, TR::FILE *outFile);
 
-   char *         name;
-   char *         signature;
-   U_32           modifiers;
-   IDATA          offset;
-   J9Class *      ramClass;
+   char *            name;
+   char *            signature;
+   J9ROMFieldShape * shape;
+   U_32              modifiers;
+   IDATA             offset;
+   J9Class *         ramClass;
    };
 #endif
 

--- a/runtime/compiler/env/j9fieldsInfo.cpp
+++ b/runtime/compiler/env/j9fieldsInfo.cpp
@@ -54,6 +54,7 @@ TR_VMField::TR_VMField(TR::Compilation * comp, J9Class *aClazz, J9ROMFieldShape 
    ramClass = aClazz;
    modifiers = fieldShape->modifiers;
 
+   shape = fieldShape;
    nameUtf8 = J9ROMFIELDSHAPE_NAME(fieldShape);
    nPtr = (char *) J9UTF8_DATA(nameUtf8);
    sigUtf8 =  J9ROMFIELDSHAPE_SIGNATURE(fieldShape);

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -344,8 +344,6 @@ private:
       return TR::Compiler->cls.jitStaticsAreSame(_compilation, s1->getOwningMethod(_compilation), s1->getCPIndex(), s2->getOwningMethod(_compilation), s2->getCPIndex());
       }
 
-   bool isFinalFieldFromSuperClasses(J9Class *, int32_t);
-
    TR::Node * genNodeAndPopChildren(TR::ILOpCodes, int32_t, TR::SymbolReference *, int32_t = 0);
    TR::Node * genNodeAndPopChildren(TR::ILOpCodes, int32_t, TR::SymbolReference *, int32_t firstIndex, int32_t lastIndex);
 


### PR DESCRIPTION
When compiling methods that include calls to constructors that initialize private fields in some cases an allocationfence was not inserted after the call.

Previously, isFinalFieldFromSuperClasses was incorrectly comparing the instance size of the superclass and the size of the field offset.
This was due to padding that could occur, causing the size of the superclass instance to be greater than it's actual size within the derived class.

isFinalFieldFromSuperClasses is removed in exchange for newly created jitGetDeclaringClassOfROMField that returns the J9Class which declares the given ROM field.

Signed-off-by: Alen Badel <Alen.Badel@ibm.com>