### PR TITLE
Fix missing connectionTerminate handling

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -4408,20 +4408,25 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          clientSession->getSequencingMonitor()->exit();
          }
       abortCompilation = true;
-      if (!enableJITaaSPerCompConn || e.getType() == JITServer::MessageType::connectionTerminate)
-         {
-         // Delete server stream
-         stream->~ServerStream();
-         TR_Memory::jitPersistentFree(stream);
-         entry._stream = NULL;
-         }
-      if (e.getType() == JITServer::MessageType::clientTerminate)
-         {
-         deleteClientSessionData(e.getClientId(), compInfo, compThread);
-         // Delete server stream
-         stream->~ServerStream();
-         TR_Memory::jitPersistentFree(stream);
-         entry._stream = NULL;
+      if (!enableJITaaSPerCompConn) // JITServer TODO: remove the perCompConn mode
+         { 
+         if (e.getType() == JITServer::MessageType::connectionTerminate)
+            {
+            // Delete server stream
+            stream->~ServerStream();
+            TR_Memory::jitPersistentFree(stream);
+            entry._stream = NULL;
+            }
+         else if (e.getType() == JITServer::MessageType::clientTerminate)
+            {
+            deleteClientSessionData(e.getClientId(), compInfo, compThread);
+            // Delete server stream
+            stream->~ServerStream();
+            TR_Memory::jitPersistentFree(stream);
+            entry._stream = NULL;
+            }
+         // else e.getType() == JITServer::MessageType::compilationAbort
+         // we do not kill the connection in this case
          }
       }
    catch (const JITServer::StreamOOO &e)

--- a/runtime/compiler/net/ClientStream.hpp
+++ b/runtime/compiler/net/ClientStream.hpp
@@ -90,7 +90,7 @@ public:
       {
       if (getVersionCheckStatus() == NOT_DONE)
          {
-         _cMsg.set_version(getJITaaSVersion());
+         _cMsg.set_version(getJITServerVersion());
          write(MessageType::compilationRequest, args...);
          _cMsg.clear_version();
          }
@@ -143,13 +143,13 @@ public:
 
       Examples of error messages include 'compilationAbort' (e.g. when class unloading happens),
       'clientTerminate' (e.g. when the client is about to exit), 
-      and 'compilationTerminate' (e.g. when the client is closing the connection)
+      and 'connectionTerminate' (e.g. when the client is closing the connection)
    */
    template <typename ...T>
    void writeError(MessageType type, T... args)
       {
       _cMsg.set_type(type);
-      if (type == MessageType::compilationAbort)
+      if (type == MessageType::compilationAbort || type == MessageType::connectionTerminate)
          _cMsg.mutable_data()->clear_data();
       else
          setArgs<T...>(_cMsg.mutable_data(), args...);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -54,7 +54,7 @@ public:
    static void initVersion();
   
 
-   static uint64_t getJITaaSVersion()
+   static uint64_t getJITServerVersion()
       {
       return ((((uint64_t)CONFIGURATION_FLAGS) << 32) | (MAJOR_NUMBER << 24) | (MINOR_NUMBER << 8));
       }
@@ -134,12 +134,12 @@ protected:
       CodedInputStream codedInputStream(_inputStream);
       uint32_t messageSize;
       if (!codedInputStream.ReadLittleEndian32(&messageSize))
-         throw JITServer::StreamFailure("JITaaS I/O error: reading message size");
+         throw JITServer::StreamFailure("JITServer I/O error: reading message size");
       auto limit = codedInputStream.PushLimit(messageSize);
       if (!val.ParseFromCodedStream(&codedInputStream))
-         throw JITServer::StreamFailure("JITaaS I/O error: reading from stream");
+         throw JITServer::StreamFailure("JITServer I/O error: reading from stream");
       if (!codedInputStream.ConsumedEntireMessage())
-         throw JITServer::StreamFailure("JITaaS I/O error: did not receive entire message");
+         throw JITServer::StreamFailure("JITServer I/O error: did not receive entire message");
       codedInputStream.PopLimit(limit);
       }
    template <typename T>
@@ -152,7 +152,7 @@ protected:
          codedOutputStream.WriteLittleEndian32(messageSize);
          val.SerializeWithCachedSizes(&codedOutputStream);
          if (codedOutputStream.HadError())
-            throw JITServer::StreamFailure("JITaaS I/O error: writing to stream");
+            throw JITServer::StreamFailure("JITServer I/O error: writing to stream");
          // codedOutputStream must be dropped before calling flush
          }
 #if defined(JITSERVER_ENABLE_SSL)
@@ -161,7 +161,7 @@ protected:
 #else
       if (!((FileOutputStream*)_outputStream)->Flush())
 #endif
-         throw JITServer::StreamFailure("JITaaS I/O error: flushing stream");
+         throw JITServer::StreamFailure("JITServer I/O error: flushing stream");
       }
 
    int _connfd; // connection file descriptor

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -112,7 +112,7 @@ public:
    std::tuple<T...> read()
       {
       readBlocking(_cMsg);
-      if (_cMsg.type() == MessageType::compilationAbort)
+      if (_cMsg.type() == MessageType::compilationAbort || _cMsg.type() == MessageType::connectionTerminate)
          throw StreamCancel(_cMsg.type());
       // We are expecting the response type (_cMsg.type()) to be the same as the request type (_sMsg.type())
       if (_cMsg.type() != _sMsg.type())
@@ -153,9 +153,9 @@ public:
          throw StreamMessageTypeMismatch(MessageType::compilationRequest, _cMsg.type());
          }
 
-      if (_cMsg.version() != 0 && _cMsg.version() != getJITaaSVersion())
+      if (_cMsg.version() != 0 && _cMsg.version() != getJITServerVersion())
          {
-         throw StreamVersionIncompatible(getJITaaSVersion(), _cMsg.version());
+         throw StreamVersionIncompatible(getJITServerVersion(), _cMsg.version());
          }
       
       return getArgs<T...>(_cMsg.mutable_data());


### PR DESCRIPTION
- A patch for #6430 Inform JITServer when JITClient closes connections
  - #6430 caused a double free bug which is fixed by this change
- A few rename changes

[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>