### PR TITLE
Use cmake to build JITServer

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -68,6 +68,7 @@ add_custom_command(
 add_custom_target(j9jit_tracegen DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/env/ut_j9jit.h)
 
 # JITSERVER_SUPPORT and protobuf
+set(JITSERVER_SUPPORT ON)
 if(JITSERVER_SUPPORT)
 	message(STATUS "JITServer is supported")
 	add_definitions(-DJITSERVER_SUPPORT)

--- a/runtime/compiler/control/CMakeLists.txt
+++ b/runtime/compiler/control/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,3 +30,9 @@ j9jit_files(
 	control/MethodToBeCompiled.cpp
 	control/rossa.cpp
 )
+
+if(JITSERVER_SUPPORT)
+	j9jit_files(
+		control/JITServerCompilationThread.cpp
+	)
+endif()

--- a/runtime/compiler/env/CMakeLists.txt
+++ b/runtime/compiler/env/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,3 +58,12 @@ j9jit_files(
 	env/SystemSegmentProvider.cpp
 	env/VMJ9.cpp
 )
+
+if(JITSERVER_SUPPORT)
+	j9jit_files(
+		env/j9methodServer.cpp
+		env/JITaaSCHTable.cpp
+		env/JITaaSPersistentCHTable.cpp
+		env/VMJ9Server.cpp
+	)
+endif()

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,3 +59,12 @@ j9jit_files(
 j9jit_files(
 	${omr_SOURCE_DIR}/compiler/runtime/OMRRuntimeAssumptions.cpp
 )
+
+if(JITSERVER_SUPPORT)
+	j9jit_files(
+		runtime/CompileService.cpp
+		runtime/JITaaSIProfiler.cpp
+		runtime/Listener.cpp
+		runtime/StatisticsThread.cpp
+	)
+endif()


### PR DESCRIPTION

Add JITServer specific files to CMakeLists.txt.
By default, `set(JITSERVER_SUPPORT ON)` is added to `runtime/compiler/CMakeLists.txt` to enable cmake build on the jitaas/JITServer branch.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>