### PR TITLE
Merge JITServer J9Options to master

### DIFF
--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,6 +37,9 @@ namespace J9 { typedef J9::Options OptionsConnector; }
 #include <stdint.h>
 #include "control/OptionsUtil.hpp"
 #include "env/jittypes.h"
+#if defined(JITSERVER_SUPPORT)
+namespace TR { class CompilationInfoPerThreadBase; }
+#endif /* defined(JITSERVER_SUPPORT) */
 
 namespace J9
 {
@@ -81,6 +84,13 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static int32_t _samplingFrequencyInIdleMode;
    static int32_t getSamplingFrequencyInIdleMode() {return _samplingFrequencyInIdleMode;}
+
+#if defined(JITSERVER_SUPPORT)
+   static int32_t _statisticsFrequency;
+   static int32_t getStatisticsFrequency() {return _statisticsFrequency;}
+
+   static uint32_t _compilationSequenceNumber;
+#endif /* defined(JITSERVER_SUPPORT) */
 
    static int32_t _samplingFrequencyInDeepIdleMode;
    static int32_t getSamplingFrequencyInDeepIdleMode() {return _samplingFrequencyInDeepIdleMode;}
@@ -333,6 +343,18 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    bool  showOptionsInEffect();
    bool  showPID();
    void openLogFiles(J9JITConfig *jitConfig);
+
+#if defined(JITSERVER_SUPPORT)
+   void setupJITServerOptions();
+
+   static std::string packOptions(const TR::Options *origOptions);
+   static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::CompilationInfoPerThreadBase* compInfoPT,
+                                    TR_J9VMBase *fe, TR_Memory *trMemory);
+   static std::string packLogFile(TR::FILE *fp);
+   int writeLogFileFromServer(const std::string& logFileContent);
+   void setLogFileForClientOptions(int suffixNumber = 0);
+   void closeLogFileForClientOptions();
+#endif /* defined(JITSERVER_SUPPORT) */
    };
 
 }

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -134,6 +134,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
          _socketTimeoutMs(1000),
+         _clientUID(0),
 #endif /* defined(JITSERVER_SUPPORT) */
       OMR::PersistentInfoConnector(pm)
       {}
@@ -394,8 +395,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    JITServer::RemoteCompilationModes _remoteCompilationMode; // JITServer::NONE, JITServer::CLIENT, JITServer::SERVER
    std::string _JITServerAddress;
    uint32_t    _JITServerPort;
-   uint64_t    _clientUID;
    uint32_t    _socketTimeoutMs; // timeout for communication sockets used in out-of-process JIT compilation
+   uint64_t    _clientUID;
 #endif /* defined(JITSERVER_SUPPORT) */
    };
 

--- a/test/TestConfig/testEnv.mk
+++ b/test/TestConfig/testEnv.mk
@@ -27,10 +27,10 @@ testEnvTeardown:
 
 ifneq (,$(findstring JITAAS,$(TEST_FLAG)))
 testEnvSetup:
-	$(TEST_JDK_HOME)$(D)bin$(D)java -XX:JITaaSServer &
+	$(TEST_JDK_HOME)$(D)bin$(D)java -XX:StartAsJITServer &
 
 testEnvTeardown:
-	pkill -9 -xf "$(TEST_JDK_HOME)$(D)bin$(D)java -XX:JITaaSServer"; true
+	pkill -9 -xf "$(TEST_JDK_HOME)$(D)bin$(D)java -XX:StartAsJITServer"; true
 
-RESERVED_OPTIONS += -XX:JITaaSClient
+RESERVED_OPTIONS += -XX:+UseJITServer
 endif


### PR DESCRIPTION
JITServer adds parsing `-XX:+StartAsJITServer` and
`-XX:+UseJITServer` options in J9Options. The code has dependency
on JITServer `ClientSessionData` and `VMJ9Server` which
have not been merged into master yet. To make it build with
`JITSERVER_SUPPORT`, `JITSERVER_TODO` is added to guard the code
that relies on other JITServer unmerged files.

J9Options.cpp in JITServer branch also includes dynamic allocation
of compilation threads(#4032), which is guarded with `JITSERVER_TODO`.

By default, the JITServer address is `locahost`, port `38400`.
Usage examples:
```
    $ java -XX:StartAsJITServer
    $ java -XX:+UseJITServer MyApplication
    
    $ java -XX:StartAsJITServer:port=1234
    $ java -XX:+UseJITServer:server=example.com,port=1234 MyApplication
```
Specify `-XX:-UseJITServer`disables JITServer.
If multiple options on the command line, the right most option takes effect.

More info can be found at https://github.com/eclipse/openj9/blob/jitaas/doc/compiler/jitaas/Usage.md#configuration

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>