### PR TITLE
AArch64: Enable DIVCHK

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -48,6 +48,8 @@ J9::ARM64::CodeGenerator::CodeGenerator() :
       TEMPORARY_initJ9ARM64TreeEvaluatorTable(cg);
       initTreeEvaluatorTable = true;
       }
+
+   cg->setSupportsDivCheck();
    }
 
 TR::Linkage *


### PR DESCRIPTION
This commit enables generation of DIVCHK on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>