### PR TITLE
JITServer compilation fixes

### DIFF
--- a/runtime/compiler/compiler.mk
+++ b/runtime/compiler/compiler.mk
@@ -54,9 +54,18 @@ ifeq ($(PLATFORM),ppc64-linux64-clang)
     endif
 endif
 
+ifeq ($(PLATFORM),s390-linux-gcc)
+     export JITSERVER_SUPPORT=1
+endif
+
+ifeq ($(PLATFORM),s390-linux64-gcc)
+    export JITSERVER_SUPPORT=1
+endif
+
 ifeq ($(PLATFORM),s390-zos-vacpp)
     export JITSERVER_SUPPORT=1
 endif
+
 ifeq ($(PLATFORM),s390-zos64-vacpp)
     export JITSERVER_SUPPORT=1
 

--- a/runtime/compiler/compiler.mk
+++ b/runtime/compiler/compiler.mk
@@ -55,20 +55,14 @@ ifeq ($(PLATFORM),ppc64-linux64-clang)
 endif
 
 ifeq ($(PLATFORM),s390-linux-gcc)
-     export JITSERVER_SUPPORT=1
+    export JITSERVER_SUPPORT=1
 endif
 
 ifeq ($(PLATFORM),s390-linux64-gcc)
     export JITSERVER_SUPPORT=1
 endif
 
-ifeq ($(PLATFORM),s390-zos-vacpp)
-    export JITSERVER_SUPPORT=1
-endif
-
 ifeq ($(PLATFORM),s390-zos64-vacpp)
-    export JITSERVER_SUPPORT=1
-
     ifeq (default,$(origin CC))
         export CC=/usr/lpp/cbclib/xlc/bin/xlc
     endif

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11637,6 +11637,8 @@ TR::CompilationInfo::storeAOTInSharedCache(
                 * to send two different buffers to store in cache and also as no one queries either code data / metadata for
                 * method, clean up the share classs cache API.
                 */
+               const J9JITDataCacheHeader *aotMethodHeader = reinterpret_cast<const J9JITDataCacheHeader *>(dataStart);
+               TR_AOTMethodHeader *aotMethodHeaderEntry = const_cast<TR_AOTMethodHeader *>(reinterpret_cast<const TR_AOTMethodHeader *>(aotMethodHeader + 1));
                aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_CompressedMethodInCache;
                memcpy(compressedData, dataStart, aotMethodHeaderSize);
                metadataToStore = (const U_8*) compressedData;


### PR DESCRIPTION
After a recent rebase on the master and the introduction of the `JITSERVER_SUPPORT` flag, JITServer was not compiling on certain platforms. This PR addresses those problems.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>