### PR TITLE
Deal with FIXMEs for JITServer

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1056,9 +1056,7 @@ uint8_t *
 TR_J9ServerVM::allocateCodeMemory(TR::Compilation * comp, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t ** coldCode, bool isMethodHeaderNeeded)
    {
    uint8_t *warmCode = TR_J9VM::allocateCodeMemory(comp, warmCodeSize, coldCodeSize, coldCode, isMethodHeaderNeeded);
-   // JITaaS FIXME: why is this code needed? Shouldn't this be done when reserving?
-   if (!comp->getRelocatableMethodCodeStart())
-      comp->setRelocatableMethodCodeStart(warmCode - sizeof(OMR::CodeCacheMethodHeader));
+   TR_ASSERT_FATAL(comp->getRelocatableMethodCodeStart(), "Should have set relocatable method code start by this point");
    return warmCode;
    }
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -277,8 +277,7 @@ bool TR_J9ByteCodeIlGenerator::internalGenIL()
                      genTreeTop(TR::Node::create(method()->returnOpCode(), 1, pop()));
                      return true;
                      }
-                  // JITaaS FIXME: Bypass bug where this doesn't work if it's not the system class loader.
-                  else if (comp()->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER)
+                  else
                      {
                      createGeneratedFirstBlock();
                      loadSymbol(TR::aload, symRefTab()->findOrCreateClassLoaderSymbolRef(caller));

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -294,8 +294,14 @@ TR_JITaaSIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
             if (storage->ID == TR_IPBCD_CALL_GRAPH)
                {
                U_8* pc = (U_8*)entry->getPC();
-               if ((*pc == JBinvokeinterface2) && (*(pc + 2) == JBinvokeinterface)) // FIXME: must test the length of the method
-                  bci += 2;
+               uint32_t methodSize = TR::Compiler->mtd.bytecodeSize(method); 
+               TR_ASSERT(bci < methodSize, "Bytecode index can't be higher than the methodSize: bci=%u methodSize=%u", bci, methodSize);
+               if (*pc == JBinvokeinterface2)
+                  {
+                  TR_ASSERT(bci + 2 < methodSize, "Bytecode index can't be higher than the methodSize: bci=%u methodSize=%u", bci, methodSize);
+                  if (*(pc + 2) == JBinvokeinterface)
+                     bci += 2;
+                  }
                }
             if (usePersistentCache && !clientSessionData->cacheIProfilerInfo(method, bci, entry))
                {
@@ -345,8 +351,14 @@ TR_JITaaSIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
             if (storage->ID == TR_IPBCD_CALL_GRAPH)
                {
                U_8* pc = (U_8*)entry->getPC();
-               if ((*pc == JBinvokeinterface2) && (*(pc + 2) == JBinvokeinterface)) // FIXME: must test the length of the method
-                  bci += 2;
+               uint32_t methodSize = TR::Compiler->mtd.bytecodeSize(method); 
+               TR_ASSERT(bci < methodSize, "Bytecode index can't be higher than the methodSize: bci=%u methodSize=%u", bci, methodSize);
+               if (*pc == JBinvokeinterface2)
+                  {
+                  TR_ASSERT(bci + 2 < methodSize, "Bytecode index can't be higher than the methodSize: bci=%u methodSize=%u", bci, methodSize);
+                  if (*(pc + 2) == JBinvokeinterface)
+                     bci += 2;
+                  }
                }
             if (bci == byteCodeIndex)
                {

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1409,7 +1409,8 @@ TR_JITaaSRelocationRuntime::allocateSpaceInCodeCache(UDATA codeSize)
 
    uint8_t *coldCode;
    U_8 *codeStart = manager->allocateCodeMemory(codeSize, 0, &_codeCache, &coldCode, false);
-   // JITaaS FIXME: I think this code is needed too
+
+   // JITServer FIXME: this code is probably needed, but everything works without it, so don't run it for now.
 #if 0
    // FIXME: the GC may unload classes if code caches have been switched
    if (compThreadID >= 0 && fej9->getCompilationShouldBeInterruptedFlag())


### PR DESCRIPTION
There are multiple JITServer FIXME instances across the codebase.
This commit deals with most of them.

The most significant one is enabling inlining of natives, if the class of method was loaded by a non-system class loader. In the past we probably were not able to get the correct client-side class loader pointer, but now we can do it.