### PR TITLE
Update JITServer verbose log names

### DIFF
--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitaas/run/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitaas/run/Dockerfile
@@ -40,6 +40,6 @@
 
 FROM openj9-jitaas-build:latest
 
-ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:+StartAsJITServer", "-Xjit:verbose={jitaas}"]
+ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:+StartAsJITServer", "-Xjit:verbose={JITServer}"]
 
 EXPOSE 38400

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitaas/run/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitaas/run/Dockerfile
@@ -40,6 +40,6 @@
 
 FROM openj9-jitaas-build:latest
 
-ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:+StartAsJITServer", "-Xjit:verbose={jitaas}"]
+ENTRYPOINT ["/root/j2sdk-image/jre/bin/java", "-XX:+StartAsJITServer", "-Xjit:verbose={JITServer}"]
 
 EXPOSE 38400

--- a/doc/compiler/jitserver/Usage.md
+++ b/doc/compiler/jitserver/Usage.md
@@ -47,22 +47,22 @@ You might have noticed that running the client without any server to connect to 
 
 With verbose logging, if a client connects successfully then server output should look something like this:
 ```
-$ java -XX:+StartAsJITServer -Xjit:verbose=\{JITaaS\}
+$ java -XX:+StartAsJITServer -Xjit:verbose=\{JITServer\}
 
-#JITaaS: JITServer in Server Mode. Port: 38400
-#JITaaS: Started JITServer listener thread: 0000000001B8DE00
+#JITServer: JITServer in Server Mode. Port: 38400
+#JITServer: Started JITServer listener thread: 0000000001B8DE00
 JITServer ready to accept incoming requests
 
-#JITaaS: Server allocated data for a new clientUID 7273413081043723869
-#JITaaS: Server received request to compile sun/reflect/Reflection.getCallerClass @ cold
-#JITaaS: Server queued compilation for sun/reflect/Reflection.getCallerClass
-#JITaaS: Server cached clientSessionData=00007FFFDA1973E0 for clientUID=7273413081043723869 compThreadID=0
-#JITaaS: Server has successfully compiled sun/reflect/Reflection.getCallerClass()Ljava/lang/Class;
-#JITaaS: Server received request to compile java/lang/Double.longBitsToDouble @ cold
-#JITaaS: Server queued compilation for java/lang/Double.longBitsToDouble
-#JITaaS: Server cached clientSessionData=00007FFFDA1973E0 for clientUID=7273413081043723869 compThreadID=1
-#JITaaS: Server has successfully compiled java/lang/Double.longBitsToDouble(J)D
-#JITaaS: Server received request to compile java/lang/System.getEncoding @ cold
+#JITServer: Server allocated data for a new clientUID 7273413081043723869
+#JITServer: Server received request to compile sun/reflect/Reflection.getCallerClass @ cold
+#JITServer: Server queued compilation for sun/reflect/Reflection.getCallerClass
+#JITServer: Server cached clientSessionData=00007FFFDA1973E0 for clientUID=7273413081043723869 compThreadID=0
+#JITServer: Server has successfully compiled sun/reflect/Reflection.getCallerClass()Ljava/lang/Class;
+#JITServer: Server received request to compile java/lang/Double.longBitsToDouble @ cold
+#JITServer: Server queued compilation for java/lang/Double.longBitsToDouble
+#JITServer: Server cached clientSessionData=00007FFFDA1973E0 for clientUID=7273413081043723869 compThreadID=1
+#JITServer: Server has successfully compiled java/lang/Double.longBitsToDouble(J)D
+#JITServer: Server received request to compile java/lang/System.getEncoding @ cold
 ...
 ```
 

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -74,7 +74,7 @@ struct TR_JitPrivateConfig;
 struct TR_MethodToBeCompiled;
 template <typename T> class TR_PersistentArray;
 typedef J9JITExceptionTable TR_MethodMetaData;
-class ClientSessionHT; // JITaaS TODO: maybe move all JITaaS specific stuff in an extension for CompInfo
+class ClientSessionHT; // JITaaS TODO: maybe move all JITServer specific stuff in an extension for CompInfo
 
 #if defined(JITSERVER_SUPPORT)
 namespace JITServer { class ServerStream; }
@@ -501,11 +501,11 @@ public:
       return (intptrj_t)method->extra;
       }
    static int32_t getJ9MethodVMExtra(J9Method *method) {
-   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITaaS server");
+   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITServer");
       return (int32_t)((intptrj_t)method->extra);
       }
    static uint32_t getJ9MethodJITExtra(J9Method *method) {
-   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITaaS server");
+   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITServer");
       TR_ASSERT((intptrj_t)method->extra & J9_STARTPC_NOT_TRANSLATED, "MethodExtra Already Jitted!");
       return (uint32_t)((uintptrj_t)method->extra >> 32);
       }
@@ -533,16 +533,16 @@ public:
          }
       }
    static bool setJ9MethodExtraAtomic(J9Method *method, intptrj_t oldValue, intptrj_t newValue) {
-   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITaaS server");
+   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITServer");
       return oldValue == VM_AtomicSupport::lockCompareExchange((UDATA*)&method->extra, oldValue, newValue);
       }
    static bool setJ9MethodExtraAtomic(J9Method *method, intptrj_t newValue) {
-   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITaaS server");
+   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITServer");
       intptrj_t oldValue = (intptrj_t)method->extra;
       return setJ9MethodExtraAtomic(method, oldValue, newValue);
       }
    static bool setJ9MethodVMExtra(J9Method *method, int32_t value) {
-   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITaaS server");
+   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITServer");
       intptrj_t oldValue = (intptrj_t)method->extra;
       //intptrj_t newValue = oldValue & (intptrj_t)~J9_INVOCATION_COUNT_MASK;
       //newValue |= (intptrj_t)value;
@@ -584,7 +584,7 @@ public:
       return success;
       }
    static void setInitialInvocationCountUnsynchronized(J9Method *method, int32_t value) {
-   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITaaS server");
+   TR_ASSERT(!TR::CompilationInfo::getStream(), "not yet implemented for JITServer");
       value = (value << 1) | 1;
       if (value < 0)
           value = INT_MAX;
@@ -644,7 +644,7 @@ public:
    static int32_t getCompThreadSuspensionThreshold(int32_t threadID) { return _compThreadSuspensionThresholds[threadID]; }
 
    // updateNumUsableCompThreads() is called before startCompilationThread() to update TR::Options::_numUsableCompilationThreads
-   // based on if it is on the JITaas client side or the server side.
+   // based on if it is on the JITClient side or the JITServer side.
    void updateNumUsableCompThreads(int32_t &numUsableCompThreads);
    bool allocateCompilationThreads(int32_t numUsableCompThreads);
    void freeAllCompilationThreads();
@@ -954,7 +954,7 @@ public:
    bool getSuspendThreadDueToLowPhysicalMemory() const { return _suspendThreadDueToLowPhysicalMemory; }
    void setSuspendThreadDueToLowPhysicalMemory(bool b) { _suspendThreadDueToLowPhysicalMemory = b; }
 
-   // for JITaaS
+   // for JITServer
    ClientSessionHT *getClientSessionHT() { return _clientSessionHT; }
    void setClientSessionHT(ClientSessionHT *ht) { _clientSessionHT = ht; }
    PersistentVector<TR_OpaqueClassBlock*> *getUnloadedClassesTempList() { return _unloadedClassesTempList; }
@@ -1181,13 +1181,13 @@ private:
    bool _suspendThreadDueToLowPhysicalMemory;
    TR_InterpreterSamplingTracking *_interpSamplTrackingInfo;
 
-   // JITaaS hashtable that holds session information about JITaaS clients
+   // JITServer hashtable that holds session information about JITClients
    ClientSessionHT *_clientSessionHT;
-   // JITaaS list of classes unloaded 
+   // JITServer list of classes unloaded 
    PersistentVector<TR_OpaqueClassBlock*> *_unloadedClassesTempList;
    TR::Monitor *_sequencingMonitor; // used for ordering outgoing messages at the client
    uint32_t _compReqSeqNo; // seqNo for outgoing messages at the client
-   // JITaaS table of newly extended classes
+   // JITServer table of newly extended classes
    PersistentUnorderedMap<TR_OpaqueClassBlock*, uint8_t> *_newlyExtendedClasses;
    uint8_t _chTableUpdateFlags;
    // number of local gc cycles done

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2064,7 +2064,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
    TR::IlGeneratorMethodDetails & details = entry->getMethodDetails();
    J9Method *method = details.getMethod();
 
-   // The JITaaS server should not retry compilations on it's own,
+   // The JITServer should not retry compilations on it's own,
    // it should let the client make that decision
    if (entry->isOutOfProcessCompReq())
       return false;
@@ -3459,8 +3459,8 @@ void TR::CompilationInfo::stopCompilationThreads()
          {
          JITaaSHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary));
          // catch the stream failure exception if the server dies before the dummy message is send for termination.
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS StreamFailure (server unreachable before the termination message was sent): %s", e.what());
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamFailure (server unreachable before the termination message was sent): %s", e.what());
          }
       }
    }
@@ -6816,7 +6816,7 @@ TR::CompilationInfoPerThreadBase::shouldPerformLocalComp(const TR_MethodToBeComp
    // they are supposed to be cheap with respect to memory and CPU.
    //
    if (!entry->_useAotCompilation && entry->_optimizationPlan->getOptLevel() <= cold &&
-      (TR::Options::getCmdLineOptions()->getOption(TR_EnableJITaaSHeuristics) || localColdCompilations) || 
+      (TR::Options::getCmdLineOptions()->getOption(TR_EnableJITServerHeuristics) || localColdCompilations) ||
       !JITServer::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)) ||
       (!JITaaSHelpers::isServerAvailable() && !JITaaSHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))))
       doLocalComp = true;
@@ -7081,7 +7081,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
       }
    else if (!entry->isOutOfProcessCompReq())
       {
-      // This is used for JIT compilations and AOT loads on the client side or non-JITaaS
+      // This is used for JIT compilations and AOT loads on the client side or non-JITServer
       _vm = TR_J9VMBase::get(_jitConfig, vmThread);
       entry->_useAotCompilation = false;
 
@@ -7101,7 +7101,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
              !entry->isJNINative() &&
              !details.isNewInstanceThunk() &&
              !details.isMethodHandleThunk() &&
-             TR::Options::getCmdLineOptions()->getOption(TR_EnableJITaaSHeuristics) &&
+             TR::Options::getCmdLineOptions()->getOption(TR_EnableJITServerHeuristics) &&
              !TR::Options::getCmdLineOptions()->getOption(TR_DisableUpgradingColdCompilations) &&
              TR::Options::getCmdLineOptions()->allowRecompilation())
             {
@@ -7177,7 +7177,7 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
                                                        bool eligibleForRelocatableCompile,
                                                        TR_RelocationRuntime *reloRuntime)
    {
-   // JITaaS cleanup tasks
+   // JITServer cleanup tasks
    if (_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       ((TR::CompilationInfoPerThread*)this)->getClassesThatShouldNotBeNewlyExtended()->clear();
@@ -7280,7 +7280,7 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
    else // compilation will not be retried, either because it succeeded or because we don't want to
       {
       TR_PersistentJittedBodyInfo *bodyInfo;
-      // JITaaS: Can not acquire the jitted body info on the server
+      // JITServer: Can not acquire the jitted body info on the server
       if (!entry->isOutOfProcessCompReq() && entry->isDLTCompile() && !startPC && TR::CompilationInfo::isCompiled(method) && // DLT compilation that failed too many times
          (bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(method->extra)))  // do not use entry->_oldStartPC which is probably 0. Use the most up-to-date startPC
          bodyInfo->getMethodInfo()->setHasFailedDLTCompRetrials(true);
@@ -7404,7 +7404,7 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
       //
       if (_compiler->cg() && _compiler->cg()->getCodeCache())
          {
-         // For JITaaS SERVER we should wipe this method from the code cache
+         // For JITServer we should wipe this method from the code cache
          if (_compInfo.getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
             _compiler->cg()->getCodeCache()->resetCodeCache();
             
@@ -7740,7 +7740,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
       // filters to see if compilation is to be suppressed.
 
       TR_FilterBST *filterInfo = NULL;
-      // JITaaS: methodCanBeCompiled check should have been done on the client, skip it on the server.
+      // JITServer: methodCanBeCompiled check should have been done on the client, skip it on the server.
       if (!details.isRemoteMethod() && !that->methodCanBeCompiled(p->trMemory(), vm, compilee, filterInfo))
          {
          that->_methodBeingCompiled->_compErrCode = compilationRestrictedMethod;
@@ -7788,7 +7788,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
          // If the options come from a remote party, skip the setup options process
          if (that->_methodBeingCompiled->_clientOptions != NULL)
             {
-            TR_ASSERT(that->_methodBeingCompiled->isOutOfProcessCompReq(), "Options are already provided only for JITaaS server");
+            TR_ASSERT(that->_methodBeingCompiled->isOutOfProcessCompReq(), "Options are already provided only for JITServer");
             options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, that, vm, p->trMemory());
             options->setLogFileForClientOptions();
             }
@@ -7896,7 +7896,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 
                TR_ASSERT(vm->isAOT_DEPRECATED_DO_NOT_USE(), "assertion failure");
 
-               // Do not delay relocations for JITaaS_SERVER
+               // Do not delay relocations for JITServer
                if (that->getCompilationInfo()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
                   options->setOption(TR_DisableDelayRelocationForAOTCompilations);
                }
@@ -8766,7 +8766,7 @@ TR::CompilationInfoPerThreadBase::compile(
       // Compile the method
       //
 
-      // For local AOT and JITaaS we need to reserve a data cache to ensure contiguous memory
+      // For local AOT and JITServer we need to reserve a data cache to ensure contiguous memory
       // For TOSS_CODE we need to reserve a data cache so that we know what dataCache
       // to reset when throwing the data away
       //
@@ -9795,9 +9795,9 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
          }
       else if (entry && entry->isOutOfProcessCompReq())
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
                   "compThreadID=%d has failed to compile a DLT method", entry->_compInfoPT->getCompThreadId());
             }
          int8_t compErrCode = entry->_compErrCode;
@@ -10110,7 +10110,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                   }
                }
             }
-         else // Non-AOT compilation and JITaaS remote JIT/AOT compilations
+         else // Non-AOT compilation and JITServer remote JIT/AOT compilations
             {
             if (trvm->isAOT_DEPRECATED_DO_NOT_USE() && !TR::CompilationInfo::canRelocateMethod(comp))
                {
@@ -10165,9 +10165,9 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
 
       if (entry && entry->isOutOfProcessCompReq())
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
                   "compThreadID=%d has failed to compile", entry->_compInfoPT->getCompThreadId());
             }
          static bool breakAfterFailedCompile = feGetEnv("TR_breakAfterFailedCompile") != NULL;
@@ -10193,9 +10193,9 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
 
       if (entry && entry->isOutOfProcessCompReq())
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
                   "compThreadID=%d has failed to recompile", entry->_compInfoPT->getCompThreadId());
             }
          int8_t compErrCode = entry->_compErrCode;
@@ -10955,26 +10955,26 @@ TR::CompilationInfoPerThreadBase::processException(
       }
    catch (const JITServer::StreamFailure &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITServer StreamFailure: %s", e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamFailure: %s", e.what());
       _methodBeingCompiled->_compErrCode = compilationStreamFailure;
       }
    catch (const JITServer::StreamInterrupted &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITServer StreamInterrupted: %s", e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamInterrupted: %s", e.what());
       _methodBeingCompiled->_compErrCode = compilationStreamInterrupted;
       }
    catch (const JITServer::StreamVersionIncompatible &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITServer StreamVersionIncompatible: %s", e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamVersionIncompatible: %s", e.what());
       _methodBeingCompiled->_compErrCode = compilationStreamVersionIncompatible;
       }
    catch (const JITServer::StreamMessageTypeMismatch &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITServer StreamMessageTypeMismatch: %s", e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamMessageTypeMismatch: %s", e.what());
       _methodBeingCompiled->_compErrCode = compilationStreamMessageTypeMismatch;
       }
    catch (const JITServer::ServerCompilationFailure &e)
@@ -12689,7 +12689,7 @@ TR::CompilationInfoPerThread::updateLastLocalGCCounter()
    _lastLocalGCCounter = getCompilationInfo()->getLocalGCCounter();
    }
 
-// This method is executed by the JITaaS server to queue a placeholder for
+// This method is executed by the JITServer to queue a placeholder for
 // a compilation request received from the client. At the time the new
 // entry is queued we do not know any details about the compilation request.
 // The method needs to be executed with compilation monitor in hand

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -7072,8 +7072,8 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
       TR_Listener *listener = ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->listener;
       listener->startListenerThread(javaVM);
 
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Started JITServer listener thread: %p ", listener->getListenerThread());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Started JITServer listener thread: %p ", listener->getListenerThread());
 
       if (jitConfig->samplingFrequency != 0)
          {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2313,14 +2313,14 @@ J9::Options::setupJITServerOptions()
 
       }
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       {
       TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
       if (persistentInfo->getRemoteCompilationMode() == JITServer::SERVER)
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITServer Server Mode. Port: %d. Connection Timeout %ums",
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Server Mode. Port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerPort(), persistentInfo->getSocketTimeout());
       else if (persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT)
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITServer Client Mode. Server address: %s port: %d. Connection Timeout %ums",
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Client Mode. Server address: %s port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerAddress().c_str(), persistentInfo->getJITServerPort(),
                persistentInfo->getSocketTimeout());
       }
@@ -2931,7 +2931,7 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::Co
    
    // receive rtResolve
    // NOTE: this relies on rtResolve being the last option in clientOptions
-   // the J9JIT_RUNTIME_RESOLVE flag from JITServer client
+   // the J9JIT_RUNTIME_RESOLVE flag from JITClient
    // On JITServer, we store this value for each client in ClientSessionData
    bool rtResolve = (bool) *((uint8_t *) options + clientOptionsSize - sizeof(bool));
    compInfoPT->getClientData()->setRtResolve(rtResolve);
@@ -3064,9 +3064,9 @@ J9::Options::writeLogFileFromServer(const std::string& logFileContent)
    int32_t MAX_SUFFIX_LENGTH = 23;
    if (len + MAX_SUFFIX_LENGTH > FILENAME_MAX_SIZE)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          {
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Trace log not genereted due to filename being too long");
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Trace log not genereted due to filename being too long");
          }
       return 0; // may overflow the buffer
       }

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -259,8 +259,8 @@ static bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JI
           (response != MessageType::compilationFailure))
          client->writeError(JITServer::MessageType::compilationInterrupted, 0 /* placeholder */);
 
-      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Interrupting remote compilation (interruptReason %u) in handleServerMessage of %s @ %s",
+      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Interrupting remote compilation (interruptReason %u) in handleServerMessage of %s @ %s", 
                                                           interruptReason, comp->signature(), comp->getHotnessName());
       comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted in handleServerMessage");
       }
@@ -2534,7 +2534,7 @@ static bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JI
          break;
       default:
          // It is vital that this remains a hard error during dev!
-         TR_ASSERT(false, "JITaaS: handleServerMessage received an unknown message type: %d\n", response);
+         TR_ASSERT(false, "JITServer: handleServerMessage received an unknown message type: %d\n", response);
       }
    return done;
    }
@@ -2584,7 +2584,7 @@ remoteCompile(
             }
          else
             {
-            if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+            if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
                TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
                   "Server is not available. Retry with local compilation for %s @ %s", compiler->signature(), compiler->getHotnessName());
             compiler->failCompilation<JITServer::StreamFailure>("Server is not available, should retry with local compilation.");
@@ -2593,14 +2593,14 @@ remoteCompile(
       catch (const JITServer::StreamFailure &e)
          {
          JITaaSHelpers::postStreamFailure(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary));
-         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
             TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
                "JITServer::StreamFailure: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
          compiler->failCompilation<JITServer::StreamFailure>(e.what());
          }
       catch (const std::bad_alloc &e)
          {
-         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
             TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
                "std::bad_alloc: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
          compiler->failCompilation<std::bad_alloc>(e.what());
@@ -2648,9 +2648,9 @@ remoteCompile(
       // message just in case we block in the write operation   
       releaseVMAccess(vmThread);
 
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          {
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
             "Client sending compReq seqNo=%u to server for method %s @ %s.",
             seqNo, compiler->signature(), compiler->getHotnessName());
          }
@@ -2663,7 +2663,7 @@ remoteCompile(
       if (interruptReason)
          {
          auto comp = compInfoPT->getCompilation();
-         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
              TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Interrupting remote compilation (interruptReason %u) in remoteCompile of %s @ %s",
                  interruptReason, comp->signature(), comp->getHotnessName());
 
@@ -2714,7 +2714,7 @@ remoteCompile(
       TR_Memory::jitPersistentFree(client);
       compInfoPT->setClientStream(NULL);
 
-      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
           TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
             "JITServer::StreamFailure: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
       compiler->failCompilation<JITServer::StreamFailure>(e.what());
@@ -2726,14 +2726,14 @@ remoteCompile(
       compInfoPT->setClientStream(NULL);
       JITServer::ClientStream::incrementIncompatibilityCount(OMRPORT_FROM_J9PORT(compInfoPT->getJitConfig()->javaVM->portLibrary));
 
-      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
           TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
             "JITServer::StreamVersionIncompatible: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
       compiler->failCompilation<JITServer::StreamVersionIncompatible>(e.what());
       }
    catch (const JITServer::StreamMessageTypeMismatch &e)
       {
-      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
          TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
             "JITServer::StreamMessageTypeMismatch: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
       compiler->failCompilation<JITServer::StreamMessageTypeMismatch>(e.what());
@@ -2777,7 +2777,7 @@ remoteCompile(
                auto it = newlyExtendedClasses->find(clazz);
                if (it != newlyExtendedClasses->end() && (it->second & (1 << TR::compInfoPT->getCompThreadId())))
                   {
-                  if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
+                  if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
                      TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Class that should not be newly extended was extended when compiling %s", compiler->signature());
                   compiler->failCompilation<J9::CHTableCommitFailure>("Class that should not be newly extended was extended");
                   }
@@ -2789,7 +2789,7 @@ remoteCompile(
                TR_JITaaSClientPersistentCHTable *table = (TR_JITaaSClientPersistentCHTable*) TR::comp()->getPersistentInfo()->getPersistentCHTable();
                table->_numCommitFailures += 1;
 #endif
-               if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
+               if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
                   {
                   TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Failure while committing chtable for %s", compiler->signature());
                   }
@@ -2799,14 +2799,11 @@ remoteCompile(
 
 
          TR_ASSERT(!metaData || !metaData->startColdPC, "coldPC should be null");
-
+         // As a debugging feature, a local compilation can be performed immediately after a remote compilation.
+         // Each of them has logs with the same compilationSequenceNumber
          int compilationSequenceNumber = compiler->getOptions()->writeLogFileFromServer(logFileStr);
-         if (TR::Options::getCmdLineOptions()->getOption(TR_EnableJITaaSDoLocalCompilesForRemoteCompiles) && compilationSequenceNumber)
+         if (TR::Options::getCmdLineOptions()->getOption(TR_JITServerFollowRemoteCompileWithLocalCompile) && compilationSequenceNumber)
             {
-            // if compilationSequenceNumber is not 0, vlog from server is enabled
-            // double compile is also controlled by TR_EnableJITaaSDoubleCompile option
-            // try to perform an equivalent local compilation and generate vlog
-            // append the same compilationSequenceNumber in the filename
             intptr_t rtn = 0;
             compiler->getOptions()->setLogFileForClientOptions(compilationSequenceNumber);
             if ((rtn = compiler->compile()) != COMPILATION_SUCCEEDED)
@@ -2817,10 +2814,10 @@ remoteCompile(
             compiler->getOptions()->closeLogFileForClientOptions();
             }
 
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
             TR_VerboseLog::writeLineLocked(
-               TR_Vlog_JITaaS,
+               TR_Vlog_JITServer,
                "Client successfully loaded method %s @ %s following compilation request. [metaData=%p, startPC=%p]",
                compiler->signature(),
                compiler->getHotnessName(),
@@ -2830,11 +2827,11 @@ remoteCompile(
          }
       catch (const std::exception &e)
          {
-         // Log for JITaaS mode and re-throw
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         // Log for JITClient mode and re-throw
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
             TR_VerboseLog::writeLineLocked(
-               TR_Vlog_JITaaS,
+               TR_Vlog_JITServer,
                "Client failed to load method %s @ %s following compilation request.",
                compiler->signature(),
                compiler->getHotnessName()
@@ -2847,10 +2844,10 @@ remoteCompile(
       {
       compInfoPT->getMethodBeingCompiled()->_compErrCode = statusCode;
 
-      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITaaS, TR_VerboseCompilationDispatch))
+      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
           TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
             "JITServer::ServerCompilationFailure: errCode %u for %s @ %s", statusCode, compiler->signature(), compiler->getHotnessName());
-      compiler->failCompilation<JITServer::ServerCompilationFailure>("JITaaS compilation failed.");
+      compiler->failCompilation<JITServer::ServerCompilationFailure>("JITServer compilation failed.");
       }
 
    if (enableJITaaSPerCompConn && client)
@@ -2897,10 +2894,10 @@ remoteCompilationEnd(
 
       if (!relocatedMetaData)
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-                                           "JITaaS Relocation failure: %d",
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                           "JITServer Relocation failure: %d",
                                            compInfoPT->reloRuntime()->returnCode());
             }
          // relocation failed, fail compilation
@@ -2936,11 +2933,11 @@ remoteCompilationEnd(
          TR_ASSERT_FATAL(comp->cg(), "CodeGenerator must be allocated");
          int32_t returnCode = 0;
 
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
             {
             TR_VerboseLog::writeLineLocked(
-               TR_Vlog_JITaaS,
-               "Applying JITaaS remote AOT relocations to newly AOT compiled body for %s @ %s",
+               TR_Vlog_JITServer,
+               "Applying JITServer remote AOT relocations to newly AOT compiled body for %s @ %s",
                comp->signature(),
                comp->getHotnessName()
                );
@@ -2971,9 +2968,9 @@ remoteCompilationEnd(
 
          if (relocatedMetaData) 
             {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
                {
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "JITaaS Client successfully relocated metadata for %s", comp->signature());
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITClient successfully relocated metadata for %s", comp->signature());
                }
 
             if (J9_EVENT_IS_HOOKED(jitConfig->javaVM->hookInterface, J9HOOK_VM_DYNAMIC_CODE_LOAD))
@@ -2983,10 +2980,10 @@ remoteCompilationEnd(
             }
          else
             {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
                {
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-                                              "JITaaS Relocation failure: %d",
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                              "JITServer Relocation failure: %d",
                                               compInfoPT->reloRuntime()->returnCode());
                }
             // relocation failed, fail compilation
@@ -3041,7 +3038,7 @@ outOfProcessCompilationEnd(
    OMR::CodeCacheMethodHeader *codeCacheHeader = (OMR::CodeCacheMethodHeader*)codeStart;
 
    TR_DataCache *dataCache = (TR_DataCache*)comp->getReservedDataCache();
-   TR_ASSERT(dataCache, "A dataCache must be reserved for JITaaS compilations\n");
+   TR_ASSERT(dataCache, "A dataCache must be reserved for JITServer compilations\n");
    J9JITDataCacheHeader *dataCacheHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
    J9JITExceptionTable *metaData = compInfoPT->getMetadata();
 
@@ -3082,9 +3079,9 @@ outOfProcessCompilationEnd(
                                      );
    compInfoPT->clearPerCompilationCaches();
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       {
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d has successfully compiled %s",
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d has successfully compiled %s",
          compInfoPT->getCompThreadId(), compInfoPT->getCompilation()->signature());
       }
    }
@@ -3092,7 +3089,7 @@ outOfProcessCompilationEnd(
 void printJITaaSMsgStats(J9JITConfig *jitConfig)
    {
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
-   j9tty_printf(PORTLIB, "JITaaS Server Message Type Statistics:\n");
+   j9tty_printf(PORTLIB, "JITServer Message Type Statistics:\n");
    j9tty_printf(PORTLIB, "Type# #called TypeName\n");
    const ::google::protobuf::EnumDescriptor *descriptor = JITServer::MessageType_descriptor();
    for (int i = 0; i < JITServer::MessageType_ARRAYSIZE; ++i)
@@ -3106,7 +3103,7 @@ void printJITaaSCHTableStats(J9JITConfig *jitConfig, TR::CompilationInfo *compIn
    {
 #ifdef COLLECT_CHTABLE_STATS
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
-   j9tty_printf(PORTLIB, "JITaaS CHTable Statistics:\n");
+   j9tty_printf(PORTLIB, "JITServer CHTable Statistics:\n");
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {
       TR_JITaaSClientPersistentCHTable *table = (TR_JITaaSClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
@@ -3203,8 +3200,8 @@ ClientSessionData::~ClientSessionData()
 void
 ClientSessionData::processUnloadedClasses(JITServer::ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes)
    {
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server will process a list of %u unloaded classes for clientUID %llu", (unsigned)classes.size(), (unsigned long long)_clientUID);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server will process a list of %u unloaded classes for clientUID %llu", (unsigned)classes.size(), (unsigned long long)_clientUID);
    //Vector to hold the list of the unloaded classes and the corresponding data needed for purging the Caches
    std::vector<ClassUnloadedData> unloadedClasses;
    unloadedClasses.reserve(classes.size());
@@ -3560,13 +3557,13 @@ ClientSessionHT::findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, b
          {
          _clientSessionMap[clientUID] = clientData;
          *newSessionWasCreated = true;
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server allocated data for a new clientUID %llu", (unsigned long long)clientUID);
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server allocated data for a new clientUID %llu", (unsigned long long)clientUID);
          }
       else
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "ERROR: Server could not allocate client session data");
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "ERROR: Server could not allocate client session data");
          // should we throw bad_alloc here?
          }
       }
@@ -3657,8 +3654,8 @@ ClientSessionHT::purgeOldDataIfNeeded()
          if (iter->second->getInUse() == 0 &&
              crtTime - iter->second->getTimeOflastAccess() > OLD_AGE)
             {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server will purge session data for clientUID %llu", (unsigned long long)iter->first);
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server will purge session data for clientUID %llu", (unsigned long long)iter->first);
             ClientSessionData::destroy(iter->second); // delete the client data
             _clientSessionMap.erase(iter); // delete the mapping from the hashtable
             }
@@ -4126,8 +4123,8 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
       entry.getMonitor()->enter();
       clientSession->getSequencingMonitor()->exit(); // release monitor before waiting
       const int64_t waitTimeMillis = 1000; // TODO: create an option for this
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d (entry=%p) doing a timed wait for %d ms",
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d (entry=%p) doing a timed wait for %d ms",
          getCompThreadId(), &entry, (int32_t)waitTimeMillis);
 
       intptr_t monitorStatus = entry.getMonitor()->wait_timed(waitTimeMillis, 0); // 0 or J9THREAD_TIMED_OUT
@@ -4136,8 +4133,8 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
          entry.getMonitor()->exit();
          clientSession->getSequencingMonitor()->enter();
 
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Parked compThreadID=%d (entry=%p) seqNo=%u was notified.",
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Parked compThreadID=%d (entry=%p) seqNo=%u was notified.",
                getCompThreadId(), &entry, seqNo);
          // will verify condition again to see if expectedSeqNo has advanced enough
          }
@@ -4145,8 +4142,8 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
          {
          entry.getMonitor()->exit();
          TR_ASSERT(monitorStatus == J9THREAD_TIMED_OUT, "Unexpected monitor state");
-         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITaaS, TR_VerbosePerformance))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d timed-out while waiting for seqNo=%d (entry=%p)", 
+         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITServer, TR_VerbosePerformance))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d timed-out while waiting for seqNo=%d (entry=%p)",
                getCompThreadId(), clientSession->getExpectedSeqNo(), &entry);
         
          // The simplest thing is to delete the cached data for the session and start fresh
@@ -4182,8 +4179,8 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
                {
                ((TR::CompilationInfoPerThreadRemote*)(nextWaitingEntry->_compInfoPT))->setWaitToBeNotified(true);
                }
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
                   "compThreadID=%d has cleared the session caches for clientUID=%llu expectedSeqNo=%u detachedEntry=%p",
                   getCompThreadId(), clientSession->getClientUID(), clientSession->getExpectedSeqNo(), detachedEntry);
             }
@@ -4191,8 +4188,8 @@ TR::CompilationInfoPerThreadRemote::waitForMyTurn(ClientSessionData *clientSessi
             {
             // Wait until all active threads have been drained
             // and the head of the list has cleared the caches
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
                   "compThreadID=%d which previously timed-out will go to sleep again. Possible reasons numActiveThreads=%d waitToBeNotified=%d",
                   getCompThreadId(), clientSession->getNumActiveThreads(), getWaitToBeNotified());
             }
@@ -4217,8 +4214,8 @@ TR::CompilationInfoPerThreadRemote::updateSeqNo(ClientSessionData *clientSession
          {
          clientSession->notifyAndDetachFirstWaitingThread();
 
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d notifying out-of-sequence thread %d for clientUID=%llu seqNo=%u (entry=%p)",
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d notifying out-of-sequence thread %d for clientUID=%llu seqNo=%u (entry=%p)",
                getCompThreadId(), nextEntry->_compInfoPT->getCompThreadId(), (unsigned long long)clientSession->getClientUID(), nextWaitingSeqNo, nextEntry);
          }
       }
@@ -4301,8 +4298,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          throw std::bad_alloc();
 
       setClientData(clientSession); // Cache the session data into CompilationInfoPerThreadRemote object
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d %s clientSessionData=%p for clientUID=%llu seqNo=%u",
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d %s clientSessionData=%p for clientUID=%llu seqNo=%u",
             getCompThreadId(), sessionDataWasEmpty ? "created" : "found", clientSession, (unsigned long long)clientId, seqNo);
       } // end critical section
 
@@ -4315,8 +4312,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       if (seqNo > clientSession->getExpectedSeqNo()) // out of order messages
          {
          // park this request until the missing ones arrive
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Out-of-sequence msg detected for clientUID=%llu seqNo=%u > expectedSeqNo=%u. Parking compThreadID=%d (entry=%p)",
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Out-of-sequence msg detected for clientUID=%llu seqNo=%u > expectedSeqNo=%u. Parking compThreadID=%d (entry=%p)",
             (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo(), getCompThreadId(), &entry);
 
          waitForMyTurn(clientSession, entry);
@@ -4327,8 +4324,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          // This could happen for instance for the very first message that arrives late.
          // In that case, the second message would have created the client session and 
          // written its own seqNo into expectedSeqNo. We should avoid processing stale updates
-         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITaaS, TR_VerbosePerformance))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Discarding older msg for clientUID=%llu seqNo=%u < expectedSeqNo=%u compThreadID=%d",
+         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompFailure, TR_VerboseJITServer, TR_VerbosePerformance))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Discarding older msg for clientUID=%llu seqNo=%u < expectedSeqNo=%u compThreadID=%d",
             (unsigned long long)clientId, seqNo, clientSession->getExpectedSeqNo(), getCompThreadId());
          clientSession->getSequencingMonitor()->exit();
          throw JITServer::StreamOOO();
@@ -4424,8 +4421,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const JITServer::StreamFailure &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream failed while compThreadID=%d was reading the compilation request: %s", 
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Stream failed while compThreadID=%d was reading the compilation request: %s",
             getCompThreadId(), e.what());
 
       abortCompilation = true;
@@ -4439,8 +4436,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const JITServer::StreamVersionIncompatible &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream version incompatible: %s", e.what()); 
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Stream version incompatible: %s", e.what());
 
       stream->writeError(compilationStreamVersionIncompatible);
       abortCompilation = true;
@@ -4454,16 +4451,16 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const JITServer::StreamMessageTypeMismatch &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream message type mismatch: %s", e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Stream message type mismatch: %s", e.what());
 
       stream->writeError(compilationStreamMessageTypeMismatch);
       abortCompilation = true;
       }
    catch (const JITServer::StreamConnectionTerminate &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream connection terminated by JITClient on stream %p while compThreadID=%d was reading the compilation request: %s",
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Stream connection terminated by JITClient on stream %p while compThreadID=%d was reading the compilation request: %s",
             stream, getCompThreadId(), e.what());
 
       abortCompilation = true;
@@ -4476,8 +4473,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const JITServer::StreamClientSessionTerminate &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream client session terminated by JITClient on compThreadID=%d: %s", getCompThreadId(), e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Stream client session terminated by JITClient on compThreadID=%d: %s", getCompThreadId(), e.what());
 
       abortCompilation = true;
       deleteClientSessionData(e.getClientId(), compInfo, compThread);
@@ -4491,8 +4488,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const JITServer::StreamInterrupted &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream interrupted by JITClient while compThreadID=%d was reading the compilation request: %s",
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Stream interrupted by JITClient while compThreadID=%d was reading the compilation request: %s",
             getCompThreadId(), e.what());
 
       abortCompilation = true;
@@ -4514,8 +4511,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       }
    catch (const std::bad_alloc &e)
       {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server out of memory in processEntry: %s", e.what());
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server out of memory in processEntry: %s", e.what());
       stream->writeError(compilationLowPhysicalMemory);
       abortCompilation = true;
       }
@@ -4533,13 +4530,13 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       if (_recompilationMethodInfo)
          TR_Memory::jitPersistentFree(_recompilationMethodInfo);
 
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      if (TR::Options::getVerboseOption(TR_VerboseJITServer))
          {
          if (getClientData())
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d did an early abort for clientUID=%llu seqNo=%u",
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d did an early abort for clientUID=%llu seqNo=%u",
                getCompThreadId(), getClientData()->getClientUID(), getSeqNo());
          else
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d did an early abort",
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d did an early abort",
                getCompThreadId());
          }
 
@@ -4561,8 +4558,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             bool result = compInfo->getClientSessionHT()->deleteClientSession(clientId, false);
             if (result)
                {
-               if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,"client (%llu) deleted", (unsigned long long)clientId);
+               if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,"client (%llu) deleted", (unsigned long long)clientId);
                }
             }
          setClientData(NULL);
@@ -4617,8 +4614,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    if (getClientData()->getInUse() == 0)
       {
       bool deleted = compInfo->getClientSessionHT()->deleteClientSession(clientId, false);
-      if (deleted && TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,"client (%llu) deleted", (unsigned long long)clientId);
+      if (deleted && TR::Options::getVerboseOption(TR_VerboseJITServer))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,"client (%llu) deleted", (unsigned long long)clientId);
       }
 
    setClientData(NULL); // Reset the pointer to the cached client session data
@@ -4871,15 +4868,15 @@ TR::CompilationInfoPerThreadRemote::deleteClientSessionData(uint64_t clientId, T
    {
    compInfo->acquireCompMonitor(compThread); //need to acquire compilation monitor for both deleting the client data and the setting the thread state to COMPTHREAD_SIGNAL_SUSPEND.
    bool result = compInfo->getClientSessionHT()->deleteClientSession(clientId, true);
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       {
       if (!result)
          {
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,"Message to delete Client (%llu) received. Data for client not deleted", (unsigned long long)clientId);
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,"Message to delete Client (%llu) received. Data for client not deleted", (unsigned long long)clientId);
          }
       else
          {
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,"Message to delete Client (%llu) received. Data for client deleted", (unsigned long long)clientId);
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,"Message to delete Client (%llu) received. Data for client deleted", (unsigned long long)clientId);
          }
       }
    compInfo->releaseCompMonitor(compThread);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1123,7 +1123,7 @@ onLoadInternal(
    if (persistentMemory == NULL)
       return -1;
 
-   // JITaaS: persistentCHTable used to be inited here, but we have to move it after JITaaS commandline opts
+   // JITServer: persistentCHTable used to be inited here, but we have to move it after JITServer commandline opts
    // setting it to null here to catch anything that assumes it's set between here and the new init code.
    persistentMemory->getPersistentInfo()->setPersistentCHTable(NULL);
 
@@ -1634,14 +1634,14 @@ onLoadInternal(
       if (!((TR_JitPrivateConfig*)(jitConfig->privateConfig))->listener)
          {
          // warn that Listener was not allocated
-         j9tty_printf(PORTLIB, "JITaaS Listener not allocated, abort.\n");
+         j9tty_printf(PORTLIB, "JITServer Listener not allocated, abort.\n");
          return -1; 
          }
       ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->statisticsThread = TR_StatisticsThread::allocate();
       if (!((TR_JitPrivateConfig*)(jitConfig->privateConfig))->statisticsThread)
          {
          // warn that Statistics Thread was not allocated
-         j9tty_printf(PORTLIB, "JITaaS Statistics thread not allocated, abort.\n");
+         j9tty_printf(PORTLIB, "JITServer Statistics thread not allocated, abort.\n");
          return -1;
          }
       }

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -817,8 +817,8 @@ TR_J9JITaaSServerSharedCache::rememberClass(J9Class *clazz, bool create)
       auto it = cache.find(clazz);
       if (it != cache.end())
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Chain exists (%p) so nothing to store \n", it->second);
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Chain exists (%p) so nothing to store \n", it->second);
          return it->second;
          }
       }
@@ -828,8 +828,8 @@ TR_J9JITaaSServerSharedCache::rememberClass(J9Class *clazz, bool create)
       {
       if (!create)
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "not asked to create but could create, returning non-null \n");
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "not asked to create but could create, returning non-null \n");
          }
       else
          {

--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -123,8 +123,8 @@ int ClientStream::static_init(TR::PersistentInfo *info)
 
    _sslCtx = ctx;
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
 #endif
    return 0;
    }
@@ -148,7 +148,7 @@ int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs
 
    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
    if (sockfd < 0)
-      throw StreamFailure("Cannot create socket for JITaaS");
+      throw StreamFailure("Cannot create socket for JITServer");
 
    int flag = 1;
    if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void*)&flag, sizeof(flag)) < 0)
@@ -251,8 +251,8 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
       throw JITServer::StreamFailure("Failed to set BIO SSL");
       }
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
                                                       connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
    return bio;
    }

--- a/runtime/compiler/net/ServerStream.cpp
+++ b/runtime/compiler/net/ServerStream.cpp
@@ -72,7 +72,8 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
       exit(1);
       }
 
-   SSL_CTX_set_session_id_context(ctx, (const unsigned char*) "JITaaS", 6);
+   const char *sessionIDContext = "JITServer";
+   SSL_CTX_set_session_id_context(ctx, (const unsigned char*)sessionIDContext, strlen(sessionIDContext));
 
    if (SSL_CTX_set_ecdh_auto(ctx, 1) != 1)
       {
@@ -144,8 +145,8 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
    // verify server identity using standard method
    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
 
    return ctx;
    }
@@ -153,8 +154,8 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
 static bool
 handleOpenSSLConnectionError(int connfd, SSL *&ssl, BIO *&bio, const char *errMsg)
 {
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "%s: errno=%d", errMsg, errno);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "%s: errno=%d", errMsg, errno);
    ERR_print_errors_fp(stderr);
 
    close(connfd);
@@ -193,8 +194,8 @@ acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
    if (BIO_set_ssl(bio, ssl, true) != 1)
       return handleOpenSSLConnectionError(connfd, ssl, bio, "Error setting BIO SSL");
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
                                                      connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
    return true;
    }
@@ -259,8 +260,8 @@ ServerStream::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR
       int connfd = accept(sockfd, (struct sockaddr *)&cli_addr, &clilen);
       if (connfd < 0)
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error accepting connection: errno=%d", errno);
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Error accepting connection: errno=%d", errno);
          continue;
          }
 

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -202,8 +202,8 @@ public:
          }
       catch (std::exception &e)
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Could not finish compilation: %s", e.what());
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Could not finish compilation: %s", e.what());
          }
       }
 

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -32,8 +32,8 @@ void J9CompileDispatcher::compile(JITServer::ServerStream *stream)
    TR::CompilationInfo * compInfo = getCompilationInfo(_jitConfig);
 
    TR_MethodToBeCompiled *entry = NULL;
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server received request for stream %p", stream);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server received request for stream %p", stream);
       {
       // Grab the compilation monitor to queue this entry and notify a compilation thread
       OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -164,7 +164,7 @@ TR_JITaaSIProfiler::profilingSample(uintptrj_t pc, uintptrj_t data, bool addIt, 
    if (addIt)
       return NULL; // Server should not create any samples
 
-   TR_ASSERT(false, "not implemented for JITaaS");
+   TR_ASSERT(false, "not implemented for JITServer");
    return NULL;
    }
 

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -68,8 +68,8 @@ static int32_t J9THREAD_PROC listenerThreadProc(void * entryarg)
 
    // Note: the following code will never be executed, because 
    // serveRemoteCompilationRequests() is executed "forever"
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Detaching JITaaSServer listening thread");
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Detaching JITServer listening thread");
 
    vm->internalVMFunctions->DetachCurrentThread((JavaVM *) vm);
    listener->getListenerMonitor()->enter();

--- a/runtime/compiler/runtime/StatisticsThread.cpp
+++ b/runtime/compiler/runtime/StatisticsThread.cpp
@@ -63,10 +63,10 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
 
    if (rc != JNI_OK)
       {
-      return JNI_ERR; // attaching the JITaaS Statistics thread failed
+      return JNI_ERR; // attaching the JITServer Statistics thread failed
       }
 
-   j9thread_set_name(j9thread_self(), "JITaaS Server Statistics Thread");
+   j9thread_set_name(j9thread_self(), "JITServer Statistics Thread");
 
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);
    TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
@@ -99,12 +99,12 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
                vmCpuUsage = cpuUtil->getVmCpuUsage();
                }
             TR_VerboseLog::vlogAcquire();
-            TR_VerboseLog::writeLine(TR_Vlog_JITaaS, "Number of clients : %u", compInfo->getClientSessionHT()->size());
-            TR_VerboseLog::writeLine(TR_Vlog_JITaaS, "Total compilation threads : %d", compInfo->getNumUsableCompilationThreads());
-            TR_VerboseLog::writeLine(TR_Vlog_JITaaS, "Active compilation threads : %d",compInfo->getNumCompThreadsActive());
+            TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Number of clients : %u", compInfo->getClientSessionHT()->size());
+            TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Total compilation threads : %d", compInfo->getNumUsableCompilationThreads());
+            TR_VerboseLog::writeLine(TR_Vlog_JITServer, "Active compilation threads : %d",compInfo->getNumCompThreadsActive());
             if (cpuUtil->isFunctional())
                {
-               TR_VerboseLog::writeLine(TR_Vlog_JITaaS, "CpuLoad %d%% (AvgUsage %d%%) JvmCpu %d%%", cpuUsage, avgCpuUsage, vmCpuUsage);
+               TR_VerboseLog::writeLine(TR_Vlog_JITServer, "CpuLoad %d%% (AvgUsage %d%%) JvmCpu %d%%", cpuUsage, avgCpuUsage, vmCpuUsage);
                }
             TR_VerboseLog::vlogRelease();
             lastStatistics = crtTime;
@@ -113,8 +113,8 @@ static int32_t J9THREAD_PROC statisticsThreadProc(void * entryarg)
       // This thread has been interrupted or StatisticsThreadExitFlag flag was set
       }
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Detaching JITaaSServer statistics thread");
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Detaching JITServer statistics thread");
 
    // Will reach here only if the StatisticsThreadExitFlag is set from the StopStatisticsThread.
    vm->internalVMFunctions->DetachCurrentThread((JavaVM *) vm);
@@ -145,7 +145,7 @@ TR_StatisticsThread::startStatisticsThread(J9JavaVM *javaVM)
                                                                javaVM->jitConfig,
                                                                J9THREAD_CATEGORY_SYSTEM_JIT_THREAD))
          { // cannot create the statistics thread
-         j9tty_printf(PORTLIB, "Error: Unable to create JITaaS Statistics Thread.\n");
+         j9tty_printf(PORTLIB, "Error: Unable to create JITServer Statistics Thread.\n");
          TR::Monitor::destroy(_statisticsThreadMonitor);
          _statisticsThreadMonitor = NULL;
          }
@@ -157,13 +157,13 @@ TR_StatisticsThread::startStatisticsThread(J9JavaVM *javaVM)
          _statisticsThreadMonitor->exit();
          if (!getStatisticsThread())
             {
-            j9tty_printf(PORTLIB, "Error: JITaaS Statistics Thread attach failed.\n");
+            j9tty_printf(PORTLIB, "Error: JITServer Statistics Thread attach failed.\n");
             }
          }
       }
    else
       {
-      j9tty_printf(PORTLIB, "Error: Unable to create JITaaS Statistics Monitor\n");
+      j9tty_printf(PORTLIB, "Error: Unable to create JITServer Statistics Monitor\n");
       }
    }
 


### PR DESCRIPTION
With the update from eclipse/omr#4173
Replace the following JITaaS related names: 
`TR_VerboseJITaaS` => `TR_VerboseJITServer`
`TR_Vlog_JITaaS` => `TR_Vlog_JITServer` 
`-Xjit:verbose={JITaaS}` => `-Xjit:verbose={JITServer}`
`TR_EnableJITaaSHeuristics` => `TR_EnableJITServerHeuristics` 
`TR_EnableJITaaSDoLocalCompilesForRemoteCompiles` => `TR_JITServerFollowRemoteCompileWithLocalCompile`

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>