### PR TITLE
Fix spelling of offset

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
@@ -51,7 +51,7 @@ public class UnwindCode {
 		this.address = address;
 	}
 	
-	private byte getOffSet() throws MemoryFault {
+	private byte getOffset() throws MemoryFault {
 		byte offset = (byte)(process.getByteAt(OFFSET_CODEOFFSET + module.getLoadAddress() + address));
 		return offset;
 	}
@@ -204,7 +204,7 @@ public class UnwindCode {
 	
 	public String toString() {
 		try {
-			return String.format("Offset 0x%02x : ", getOffSet()) + formatOp();
+			return String.format("Offset 0x%02x : ", getOffset()) + formatOp();
 		} catch (MemoryFault e) {
 			return "MemoryFault: " + e.getMessage();
 		} catch (CorruptDataException e) {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/framework/tag/LineRule.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/framework/tag/LineRule.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,7 +80,7 @@ public abstract class LineRule implements ILineRule {
 	
 	// Support for offset calculation of a token, but 
 	// not currently used.
-	protected int fOffSet;
+	protected int fOffset;
 	private HashMap fTokenList;
 
 
@@ -88,7 +88,7 @@ public abstract class LineRule implements ILineRule {
 		fSource = new StringBuffer();
 		fCharSubSet = new StringBuffer();
 		fLineNumber = 0;
-		fOffSet = 0;
+		fOffset = 0;
 	}
 	
 	/**
@@ -167,7 +167,7 @@ public abstract class LineRule implements ILineRule {
 	 * @return generated token.
 	 */
 	protected IParserToken addToken(String type, String value) {
-		IParserToken token = TokenManager.getToken(value.length(), fOffSet, fLineNumber, type, value);
+		IParserToken token = TokenManager.getToken(value.length(), fOffset, fLineNumber, type, value);
 		addToken(token);
 		return token;
 	}
@@ -245,7 +245,7 @@ public abstract class LineRule implements ILineRule {
 			fCharSubSet.append(fSource.charAt(i));
 		}
 		fSource.delete(0, endIndex);
-		IParserToken token = TokenManager.getToken(fCharSubSet.length(), fOffSet, fLineNumber, type, fCharSubSet.toString());
+		IParserToken token = TokenManager.getToken(fCharSubSet.length(), fOffset, fLineNumber, type, fCharSubSet.toString());
 		addToken(token);
 		return token;
 	}
@@ -307,7 +307,7 @@ public abstract class LineRule implements ILineRule {
 	private IParserToken internalAddToken(String type, Matcher matcher) {
 		String value = null;
 		IParserToken token = null;
-		int offset = fOffSet;
+		int offset = fOffset;
 		if ((value = matchAndConsumeValue(matcher)) != null) {
 			token = TokenManager.getToken(value.length(), offset, fLineNumber, type, value);
 			fTokenList.put(token.getType(), token);

--- a/runtime/tests/algorithm/srphashtabletest.c
+++ b/runtime/tests/algorithm/srphashtabletest.c
@@ -90,7 +90,7 @@ hashFn(void *key, void *userData)
  * @param 	startOffset	Starting offset of the data. If it is -1, then it is reverse order and we start from the end.
  * @param	dataLength	The size of the data array.
  * @param 	i			Number of iterations to find the next/previous offset starting from startOffset/end.
- * @return	UDATA		New offSet.
+ * @return	UDATA		New offset.
  *
  */
 static UDATA dataOffset(UDATA startOffset, UDATA dataLength, UDATA i)


### PR DESCRIPTION
It was spelled 'offSet' (with a capital 'S' some places).