### PR TITLE
Add missing ifdefs for Harmony artifacts

### DIFF
--- a/runtime/ddr/ddrtable.c
+++ b/runtime/ddr/ddrtable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,9 @@ extern const J9DDRStructDefinition *getJITAutomatedStructTable(struct OMRPortLib
 extern const J9DDRStructDefinition *getOmrStructTable(struct OMRPortLibrary *portLib);
 extern const J9DDRStructDefinition *getVMStructTable(struct OMRPortLibrary *portLib);
 extern const J9DDRStructDefinition *getStackWalkerStructTable(struct OMRPortLibrary *portLib);
+#if defined(J9VM_OPT_HARMONY)
 extern const J9DDRStructDefinition *getHyPortStructTable(struct OMRPortLibrary *portLib);
+#endif /* J9VM_OPT_HARMONY */
 extern const J9DDRStructDefinition *getJ9PortStructTable(struct OMRPortLibrary *portLib);
 extern const J9DDRStructDefinition *getGCStructTable(struct OMRPortLibrary *portLib);
 extern const J9DDRStructDefinition *getDDR_CPPStructTable(struct OMRPortLibrary *portLib);
@@ -54,7 +56,9 @@ initializeDDRComponents(OMRPortLibrary *portLib)
 		list[i++] = getVMStructTable(portLib);
 		list[i++] = getStackWalkerStructTable(portLib);
 		list[i++] = getGCStructTable(portLib);
+#if defined(J9VM_OPT_HARMONY)
 		list[i++] = getHyPortStructTable(portLib);
+#endif /* J9VM_OPT_HARMONY */
 		list[i++] = getJ9PortStructTable(portLib);
 		list[i++] = getAlgorithmVersionStructTable();
 		list[i++] = getJITStructTable();

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -116,7 +116,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<objects>
 			<object name="algorithm_versions"/>
 			<object name="ddrcppsupportblob"/>
-			<object name="hyportddrblob"/>
+			<object name="hyportddrblob">
+				<include-if condition="spec.flags.opt_harmony"/>
+			</object>
 			<object name="jitddrblob"/>
 			<object name="jitflagsddr"/>
 			<object name="omrddrblob"/>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2897,11 +2897,13 @@ typedef struct J9VMInterface {
 	struct J9PortLibrary * portLibrary;
 } J9VMInterface;
 
+#if defined(J9VM_OPT_HARMONY)
 typedef struct HarmonyVMInterface {
 	struct VMInterfaceFunctions_* functions;
 	struct J9JavaVM* javaVM;
 	struct HyPortLibrary* portLibrary;
 } HarmonyVMInterface;
+#endif /* J9VM_OPT_HARMONY */
 
 typedef struct J9CheckJNIData {
 	UDATA options;
@@ -5096,7 +5098,9 @@ typedef struct J9JavaVM {
 	UDATA j2seVersion;
 	void* zipCachePool;
 	struct J9VMInterface vmInterface;
+#if defined(J9VM_OPT_HARMONY)
 	struct HarmonyVMInterface harmonyVMInterface;
+#endif /* J9VM_OPT_HARMONY */
 	UDATA dynamicLoadClassAllocationIncrement;
 	struct J9TranslationBufferSet* dynamicLoadBuffers;
 	struct J9JImageIntf *jimageIntf;


### PR DESCRIPTION
This is part of https://github.com/eclipse/openj9/issues/529

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>