### PR TITLE
Define new Pre- and PostEscapeAnalysis passes

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -26,6 +26,8 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/optimizer/DataAccessAccelerator.cpp \
     compiler/optimizer/DynamicLiteralPool.cpp \
     compiler/optimizer/EscapeAnalysis.cpp \
+    compiler/optimizer/PreEscapeAnalysis.cpp \
+    compiler/optimizer/PostEscapeAnalysis.cpp \
     compiler/optimizer/FearPointAnalysis.cpp \
     compiler/optimizer/HCRGuardAnalysis.cpp \
     compiler/optimizer/IdiomRecognition.cpp \

--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -57,6 +57,8 @@ j9jit_files(
 	optimizer/OSRGuardAnalysis.cpp
 	optimizer/OSRGuardInsertion.cpp
 	optimizer/OSRGuardRemoval.cpp
+	optimizer/PreEscapeAnalysis.cpp
+	optimizer/PostEscapeAnalysis.cpp
 	optimizer/ProfileGenerator.cpp
 	optimizer/SequentialStoreSimplifier.cpp
 	optimizer/SignExtendLoads.cpp

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -56,6 +56,8 @@
 #include "optimizer/SwitchAnalyzer.hpp"
 #include "optimizer/DynamicLiteralPool.hpp"
 #include "optimizer/EscapeAnalysis.hpp"
+#include "optimizer/PreEscapeAnalysis.hpp"
+#include "optimizer/PostEscapeAnalysis.hpp"
 #include "optimizer/DataAccessAccelerator.hpp"
 #include "optimizer/IsolatedStoreElimination.hpp"
 #include "optimizer/LoopAliasRefiner.hpp"
@@ -763,8 +765,12 @@ J9::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *method
       new (comp->allocator()) TR::OptimizationManager(self(), TR_LocalNewInitialization::create, OMR::explicitNewInitialization);
    _opts[OMR::redundantMonitorElimination] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR::MonitorElimination::create, OMR::redundantMonitorElimination);
+   _opts[OMR::preEscapeAnalysis] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_PreEscapeAnalysis::create, OMR::preEscapeAnalysis);
    _opts[OMR::escapeAnalysis] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_EscapeAnalysis::create, OMR::escapeAnalysis);
+   _opts[OMR::postEscapeAnalysis] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_PostEscapeAnalysis::create, OMR::postEscapeAnalysis);
    _opts[OMR::isolatedStoreElimination] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_IsolatedStoreElimination::create, OMR::isolatedStoreElimination);
    _opts[OMR::localLiveVariablesForGC] =

--- a/runtime/compiler/optimizer/PostEscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/PostEscapeAnalysis.cpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "il/Block.hpp"
+#include "il/TreeTop.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/SymbolReference.hpp"
+#include "optimizer/PostEscapeAnalysis.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/OptimizationManager.hpp"
+
+int32_t TR_PostEscapeAnalysis::perform()
+   {
+   if (comp()->getOSRMode() != TR::voluntaryOSR)
+      {
+      if (comp()->trace(OMR::escapeAnalysis))
+         {
+         traceMsg(comp(), "Special handling of OSR points is not possible outside of voluntary OSR - nothing to do\n");
+         }
+      return 0;
+      }
+   if (optimizer()->getOptimization(OMR::escapeAnalysis)->numPassesCompleted() != 0)
+      {
+      if (comp()->trace(OMR::escapeAnalysis))
+         {
+         traceMsg(comp(), "EA has self enabled - skipping clean-up\n");
+         }
+      return 0;
+      }
+
+   for (TR::Block *block = comp()->getStartBlock(); block != NULL; block = block->getNextBlock())
+      {
+      if (!block->isOSRInduceBlock())
+         continue;
+
+      for (TR::TreeTop *itr = block->getEntry(), *end = block->getExit(); itr != end; itr = itr->getNextTreeTop())
+         {
+         // Remove any fake prepareForOSR calls that were added to OSR
+         // induction blocks by TR_PreEscapeAnalysis
+         if (itr->getNode()->getNumChildren() == 1
+             && itr->getNode()->getFirstChild()->getOpCodeValue() == TR::call
+             && itr->getNode()->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
+            {
+            dumpOptDetails(comp(), " Removing fake call prepareForOSR n%dn from induction block_%d\n", itr->getNode()->getFirstChild()->getGlobalIndex(), block->getNumber());
+            itr = itr->getPrevTreeTop();
+            if (optimizer()->getUseDefInfo() != NULL)
+               {
+               optimizer()->setUseDefInfo(NULL);
+               }
+            if (optimizer()->getValueNumberInfo())
+               {
+               optimizer()->setValueNumberInfo(NULL);
+               }
+            TR::TransformUtil::removeTree(comp(), itr->getNextTreeTop());
+            }
+         }
+      }
+
+   if (comp()->trace(OMR::escapeAnalysis))
+      {
+      comp()->dumpMethodTrees("Trees after Post-Escape Analysis");
+      }
+
+   return 1;
+   }
+
+const char *
+TR_PostEscapeAnalysis::optDetailString() const throw()
+   {
+   return "O^O POST ESCAPE ANALYSIS: ";
+   }

--- a/runtime/compiler/optimizer/PostEscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/PostEscapeAnalysis.hpp
@@ -28,6 +28,13 @@
 
 namespace TR { class Block; }
 
+/**
+ * The \c TR_PostEscapeAnalysis optimization performs a simple
+ * clean up pass over the trees to remove fake \c prepareForOSR calls
+ * that were added by \ref TR_PreEscapeAnalysis.
+ *
+ * \see TR_PreEscapeAnalysis,TR_EscapeAnalysis
+ */
 class TR_PostEscapeAnalysis : public TR::Optimization
    {
    public:

--- a/runtime/compiler/optimizer/PostEscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/PostEscapeAnalysis.hpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef VIRTUALGUARDHEADMERGER_INCL
+#define VIRTUALGUARDHEADMERGER_INCL
+
+#include <stdint.h>                           // for int32_t
+#include "optimizer/Optimization.hpp"         // for Optimization
+#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+
+namespace TR { class Block; }
+
+class TR_PostEscapeAnalysis : public TR::Optimization
+   {
+   public:
+   TR_PostEscapeAnalysis(TR::OptimizationManager *manager)
+      : TR::Optimization(manager)
+      {}
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) TR_PostEscapeAnalysis(manager);
+      }
+
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   private:
+   };
+
+#endif

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "optimizer/PreEscapeAnalysis.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/OptimizationManager.hpp"
+
+int32_t TR_PreEscapeAnalysis::perform()
+   {
+   if (comp()->getOSRMode() != TR::voluntaryOSR)
+      {
+      if (comp()->trace(OMR::escapeAnalysis))
+         {
+         traceMsg(comp(), "Special handling of OSR points is not possible outside of voluntary OSR - nothing to do\n");
+         }
+      return 0;
+      }
+   if (optimizer()->getOptimization(OMR::escapeAnalysis)->numPassesCompleted() > 0)
+      {
+      if (comp()->trace(OMR::escapeAnalysis))
+         {
+         traceMsg(comp(), "EA has self-enabled, setup not required on subsequent passes - skipping preEscapeAnalysis\n");
+         }
+      return 0;
+      }
+
+   _loads = new (comp()->trMemory()->currentStackRegion()) NodeDeque(NodeDequeAllocator(comp()->trMemory()->currentStackRegion()));
+
+   for (TR::Block *block = comp()->getStartBlock(); block != NULL; block = block->getNextBlock())
+      {
+      if (!block->isOSRInduceBlock())
+         continue;
+
+      for (TR::TreeTop *itr = block->getEntry(), *end = block->getExit(); itr != end; itr = itr->getNextTreeTop())
+         {
+         if (itr->getNode()->getNumChildren() == 1
+             && itr->getNode()->getFirstChild()->getOpCodeValue() == TR::call
+             && itr->getNode()->getFirstChild()->getSymbolReference()->isOSRInductionHelper())
+            {
+            _loads->clear();
+            if (optimizer()->getUseDefInfo() != NULL)
+               {
+               optimizer()->setUseDefInfo(NULL);
+               }
+            if (optimizer()->getValueNumberInfo())
+               {
+               optimizer()->setValueNumberInfo(NULL);
+               }
+            insertFakePrepareForOSR(block, itr->getNode()->getFirstChild());
+            break;
+            }
+         }
+      }
+
+   if (comp()->trace(OMR::escapeAnalysis))
+      {
+      comp()->dumpMethodTrees("Trees after Pre-Escape Analysis");
+      }
+
+   return 1;
+   }
+
+void TR_PreEscapeAnalysis::insertFakePrepareForOSR(TR::Block *block, TR::Node *induceCall)
+   {
+   TR_ByteCodeInfo &bci = induceCall->getByteCodeInfo();
+
+   int32_t inlinedIndex = bci.getCallerIndex();
+   int32_t byteCodeIndex = bci.getByteCodeIndex();
+   TR_OSRCompilationData *osrCompilationData = comp()->getOSRCompilationData();
+
+   // Gather all live autos and pending pushes at this point for inlined methods in _loads
+   // This ensures objects that EA can stack allocate will be heapified if OSR is induced
+   while (inlinedIndex > -1)
+      {
+      TR::ResolvedMethodSymbol *rms = comp()->getInlinedResolvedMethodSymbol(inlinedIndex);
+      TR_OSRMethodData *methodData = osrCompilationData->findOSRMethodData(inlinedIndex, rms);
+      processAutosAndPendingPushes(rms, methodData, byteCodeIndex);
+      byteCodeIndex = comp()->getInlinedCallSite(inlinedIndex)._byteCodeInfo.getByteCodeIndex();
+      inlinedIndex = comp()->getInlinedCallSite(inlinedIndex)._byteCodeInfo.getCallerIndex();
+      }
+
+   // handle the outermost method
+      {
+      TR_OSRMethodData *methodData = osrCompilationData->findOSRMethodData(-1, comp()->getMethodSymbol());
+      processAutosAndPendingPushes(comp()->getMethodSymbol(), methodData, byteCodeIndex);
+      }
+
+   // Create fake call to prepareForOSR with references to all live autos and pending pushes
+   TR::Node *fakePrepare = TR::Node::createWithSymRef(induceCall, TR::call, _loads->size(), comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_prepareForOSR, false, false, true));
+   int idx = 0;
+   for (auto itr = _loads->begin(), end = _loads->end(); itr != end; ++itr)
+      {
+      (*itr)->setByteCodeInfo(induceCall->getByteCodeInfo());
+      fakePrepare->setAndIncChild(idx++, *itr);
+      }
+   dumpOptDetails(comp(), " Adding fake prepare n%dn to OSR induction block_%d\n", fakePrepare->getGlobalIndex(), block->getNumber());
+   block->getLastRealTreeTop()->insertBefore(
+      TR::TreeTop::create(comp(), TR::Node::create(induceCall, TR::treetop, 1, fakePrepare)));
+   }
+
+void TR_PreEscapeAnalysis::processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex)
+   {
+   processSymbolReferences(rms->getAutoSymRefs(), methodData->getLiveRangeInfo(byteCodeIndex));
+   processSymbolReferences(rms->getPendingPushSymRefs(), methodData->getPendingPushLivenessInfo(byteCodeIndex));
+   }
+
+void TR_PreEscapeAnalysis::processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs)
+   {
+   for (int i = 0; symbolReferences && i < symbolReferences->size(); i++)
+      {
+      List<TR::SymbolReference> autosList = (*symbolReferences)[i];
+      ListIterator<TR::SymbolReference> autosIt(&autosList);
+      for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext())
+         {
+         TR::AutomaticSymbol *p = symRef->getSymbol()->getAutoSymbol();
+         if (p && p->getDataType() == TR::Address && (deadSymRefs == NULL || !deadSymRefs->isSet(symRef->getReferenceNumber())))
+            {
+            _loads->push_back(TR::Node::createWithSymRef(TR::aload, 0, symRef));
+            }
+         }
+      }
+   }
+
+const char *
+TR_PreEscapeAnalysis::optDetailString() const throw()
+   {
+   return "O^O PRE ESCAPE ANALYSIS: ";
+   }

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.hpp
@@ -32,9 +32,21 @@ typedef TR::typed_allocator<TR::Node *, TR::Region &> NodeDequeAllocator;
 typedef std::deque<TR::Node *, NodeDequeAllocator> NodeDeque;
 
 /**
- * Pass over trees before Escape Analysis if Voluntary OSR is
- * enabled.
- * @see TR_EscapeAnalysis
+ * The \c TR_PreEscapeAnalysis optimization looks for calls to
+ * \c OSRInductionHelper and adds a fake \c prepareForOSR call
+ * that references all live auto symrefs and pending pushes.  Any object
+ * that ends up as a candidate for stack allocation that appears to be
+ * used by such a fake \c prepareForOSR call can be heapified at that
+ * point.
+ *
+ * During \ref TR_EscapeAnalysis (EA) itself, those references on
+ * \c prepareForOSR calls are marked as ignoreable for the purposes
+ * of determining whether an object can be stack allocated.
+ *
+ * After EA, the \ref TR_PostEscapeAnalysis pass will remove the fake
+ * calls to \c prepareForOSR.
+ *
+ * \see TR_EscapeAnalysis,TR_PostEscapeAnalysis
  */
 class TR_PreEscapeAnalysis : public TR::Optimization
    {
@@ -51,9 +63,54 @@ class TR_PreEscapeAnalysis : public TR::Optimization
    virtual const char * optDetailString() const throw();
 
    private:
+
+   /**
+    * Used by \ref insertFakePrepareForOSR to gather \c aloads of autos and
+    * pending pushes.
+    */
    NodeDeque *_loads;
+
+   /**
+    * Create a "fake" \c prepareForOSR call that gathers references to all
+    * live autos and pending pushes.
+    *
+    * \param[in] block An OSR induce block containing the call represented by
+    *            \c induceCall.  The fake \c prepareForOSR call that is
+    *            generated will be added at the end of this block.
+    * \param[in] induceCall The call to the OSR induction helper in \c block.
+    *            Used as the source of byte code info for the fake
+    *            \c prepareForOSR
+    */
    void insertFakePrepareForOSR(TR::Block *block, TR::Node *induceCall);
+
+   /**
+    * Gather live autos and pending pushes at the point of a call to the OSR
+    * induction helper in the context of an inlined method or the outermost
+    * method.  Create an \c aload reference to each such auto or pending push.
+    *
+    * \c aloads are gathered in \ref _loads.
+    *
+    * \param[in] rms The method whose live autos and pending pushes are to be
+    *                processed
+    * \param[in] methodData \ref TR_OSRMethodData at this point in the
+    *                relevant method
+    * \param[in] byteCodeIndex The bytecode index at this point inside the
+    *                relevant method
+    */
    void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
+
+   /**
+    * Create \c aload references to each live symbol reference among those
+    * listed in the \c symbolReferences argument.
+    *
+    * \c aloads are gathered in \ref _loads.
+    *
+    * \param[in] symbolReferences \ref TR_Array<> of symbol references for
+    *               autos or pending pushes
+    * \param[in] deadSymRefs Liveness info for \c symbolReferences - a
+    *               \ref TR_BitVector of symbols that are not live at the
+    *               relevant point
+    */
    void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs);
    };
 

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.hpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef PREESCAPEANALYSIS_INCL
+#define PREESCAPEANLAYSIS_INCL
+
+#include <stdint.h>                           // for int32_t
+#include "optimizer/Optimization.hpp"         // for Optimization
+#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+
+namespace TR { class Block; class Node; }
+
+typedef TR::typed_allocator<TR::Node *, TR::Region &> NodeDequeAllocator;
+typedef std::deque<TR::Node *, NodeDequeAllocator> NodeDeque;
+
+/**
+ * Pass over trees before Escape Analysis if Voluntary OSR is
+ * enabled.
+ * @see TR_EscapeAnalysis
+ */
+class TR_PreEscapeAnalysis : public TR::Optimization
+   {
+   public:
+   TR_PreEscapeAnalysis(TR::OptimizationManager *manager)
+      : TR::Optimization(manager)
+      {}
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) TR_PreEscapeAnalysis(manager);
+      }
+
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   private:
+   NodeDeque *_loads;
+   void insertFakePrepareForOSR(TR::Block *block, TR::Node *induceCall);
+   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
+   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs);
+   };
+
+#endif


### PR DESCRIPTION
This change defines new optimization passes, preEscapeAnalysis and postEscapeAnalysis, that are designed to help Escape Analysis (EA) do a better job under voluntary OSR.

The new `preEscapeAnalysis` optimization looks for calls to `OSRInductionHelper` and adds a fake `prepareForOSR` call that references all live auto symrefs and pending pushes.  The goal is that any object that ends up as a candidate for stack allocation that appears to be used by such a fake `prepareForOSR` call can be heapified by EA at that point.  That will be delivered in a subsequent change to EA.

After EA, the `postEscapeAnalysis` pass will remove the fake calls to `prepareForOSR`.

These changes are a proper subset of the changes that were previously pull requested and reviewed under pull request #5737.  The changes to EA that take advantage of the work that PreEscapeAnalysis performs require that pass to actually run.  In order to do that, PreEscapeAnslysis and PostEscapeAnalysis need to be added to the optimization strategies that run EA in OMR, and in order to do, the optimizations need to exist.  Hence, this pull request.

Submitted on behalf of Andrew Craik <ajcraik@ca.ibm.com>

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>