### PR TITLE
Fix issues with connection interruptions

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -207,6 +207,7 @@ char *compilationErrorNames[]={
    "compilationStreamLostMessage", // 54
    "compilationStreamMessageTypeMismatch", // 55
    "compilationStreamVersionIncompatible", // 56
+   "compilationStreamInterrupted", // 57
    "compilationMaxError"
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -80,6 +80,7 @@ typedef enum {
    compilationStreamLostMessage                    = 54,
    compilationStreamMessageTypeMismatch            = 55,
    compilationStreamVersionIncompatible            = 56,
+   compilationStreamInterrupted                    = 57,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/net/ClientStream.hpp
+++ b/runtime/compiler/net/ClientStream.hpp
@@ -141,15 +141,15 @@ public:
    /**
       @brief Send an error message to the JITServer
 
-      Examples of error messages include 'compilationAbort' (e.g. when class unloading happens),
-      'clientTerminate' (e.g. when the client is about to exit), 
+      Examples of error messages include 'compilationInterrupted' (e.g. when class unloading happens),
+      'clientSessionTerminate' (e.g. when the client is about to exit), 
       and 'connectionTerminate' (e.g. when the client is closing the connection)
    */
    template <typename ...T>
    void writeError(MessageType type, T... args)
       {
       _cMsg.set_type(type);
-      if (type == MessageType::compilationAbort || type == MessageType::connectionTerminate)
+      if (type == MessageType::compilationInterrupted || type == MessageType::connectionTerminate)
          _cMsg.mutable_data()->clear_data();
       else
          setArgs<T...>(_cMsg.mutable_data(), args...);

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -37,27 +37,43 @@ private:
    std::string _message;
    };
 
-class StreamCancel: public virtual std::exception
+class StreamInterrupted: public virtual std::exception
    {
 public:
-   StreamCancel(MessageType type, uint64_t clientId=0) : _type(type), _clientId(clientId) { }
+   StreamInterrupted() { }
    virtual const char* what() const throw()
       {
-      if (_type == MessageType::clientTerminate)
-         return "Client session terminated at client's request";
-      else
-         return "Compilation cancelled by client";
+      return "Compilation interrupted at JITClient's request";
       }
-   MessageType getType() const
+   };
+
+class StreamConnectionTerminate: public virtual std::exception
+   {
+public:
+   StreamConnectionTerminate() { }
+   virtual const char* what() const throw()
       {
-      return _type;
+      return "Connection terminated at JITClient's request";
+      }
+   };
+
+class StreamClientSessionTerminate: public virtual std::exception
+   {
+public:
+   StreamClientSessionTerminate(uint64_t clientId) : _clientId(clientId)
+      {
+      _message = "JITClient session " + std::to_string(_clientId) + " terminated at JITClient's request";
+      }
+   virtual const char* what() const throw()
+      {
+      return _message.c_str();
       }
    uint64_t getClientId() const
       {
       return _clientId;
       }
 private:
-   MessageType _type;
+   std::string _message;
    uint64_t _clientId;
    };
 
@@ -76,9 +92,10 @@ public:
 class StreamMessageTypeMismatch: public virtual std::exception
    {
 public:
+   StreamMessageTypeMismatch() : _message("JITServer/JITClient message type mismatch detected") { }
    StreamMessageTypeMismatch(MessageType serverType, MessageType clientType)
       {
-      _message = "server expected mesasge type " + std::to_string(serverType) + " received " + std::to_string(clientType);
+      _message = "JITServer expected mesasge type " + std::to_string(serverType) + " received " + std::to_string(clientType);
       }
    virtual const char* what() const throw() 
       {
@@ -91,10 +108,10 @@ private:
 class StreamVersionIncompatible: public virtual std::exception
    {
 public:
-   StreamVersionIncompatible() : _message("client/server incompatibility detected") { }
+   StreamVersionIncompatible() : _message("JITServer/JITClient incompatibility detected") { }
    StreamVersionIncompatible(uint64_t serverVersion, uint64_t clientVersion)
       {
-      _message = "server expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
+      _message = "JITServer expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
       }
    virtual const char* what() const throw()
       {
@@ -113,7 +130,7 @@ public:
 class ServerCompilationFailure: public virtual std::exception
    {
 public:
-   ServerCompilationFailure() : _message("Generic JITaaS server compilation failure") { }
+   ServerCompilationFailure() : _message("Generic JITServer compilation failure") { }
    ServerCompilationFailure(const std::string &message) : _message(message) { }
    virtual const char* what() const throw() { return _message.c_str(); }
 private:

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -52,8 +52,8 @@ enum MessageType
    get_params_to_construct_TR_j9method = 2;
    getUnloadedClassRanges = 3;
    compilationRequest = 4; // type used when client sends remote compilation requests
-   compilationAbort = 5; // type used when client informs the server to abort the remote compilation
-   clientTerminate = 6; // type used when client process is about to terminate
+   compilationInterrupted = 5; // type used when client informs the server to abort the remote compilation
+   clientSessionTerminate = 6; // type used when client process is about to terminate
    connectionTerminate = 7; // type used when client informs the server to close the connection
 
    // For TR_ResolvedJ9JITaaSServerMethod methods


### PR DESCRIPTION
This change fixes improper handling of `StreamCancel` during out-of-process compilation on the JITServer. Summary of the issue: JITClient sends JITServer a `compilationInterrupted` message to tell server to abort the compilation. JITClient proceeds to do a new compilation on the same connection. JITServer receives the `compilationInterrupted` message and proceeds to send JITClient back an errorCode to inform the JITClient that compilation has been interrupted. JITClient sees the errorCode while doing the new compilation and aborts it. The fix is to disable JITServer from sending errorCode back to JITClient when the interruption is caused by the JITClient. Also I have noticed an improper handling of `StreamFailure`, instead of attempting to send an errorCode back to client when a `StreamFailure` is triggered during out-of-process compilation, JITServer needs to just clean up the stream and not send anything back to the client on an already dead connection.

This change also includes splitting `StreamCancel` up into 3 different dedicated exceptions to make the code cleaner. They are `StreamClientSessionTerminate`, `StreamConnectionTerminate` and `StreamInterrupted`. `StreamClientSessionTerminate` is an exception thrown on the JITServer when JITClient exits. In this case JITServer will clean up the client session data. `StreamConnectionTerminate` is an exception thrown on the JITServer when JITClient closes the connection. In this case JITServer will clean up the socket. `StreamInterrupted` is an exception thrown on the JITServer when JITClient interrupts the compilation. In this case, JITServer aborts the out-of-process compilation immediately, re-queue the connection and move on to the next compilation. JITClient will maintain the connection for new compilations in the `compilationInterrupted` case instead of closing down the connection (what we do previously).

Issue: #6644
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>