### PR TITLE
Fetch VM correctly in haltThreadForInspection

### DIFF
--- a/runtime/vm/VMAccess.cpp
+++ b/runtime/vm/VMAccess.cpp
@@ -1254,7 +1254,7 @@ _tryAgain:
 			omrthread_monitor_enter(vmThread->publicFlagsMutex);
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-			flushProcessWriteBuffers(vmThread->javaVM);
+			flushProcessWriteBuffers(currentThread->javaVM);
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 			VM_AtomicSupport::readWriteBarrier(); // necessary?
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */


### PR DESCRIPTION
The target thread may be dead, so its VM might be NULL. Using the
current thread to fetch the VM is always correct.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>