### PR TITLE
Check if array Class contain unflattened flattenables and set default values for unflattened fields

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2892,6 +2892,9 @@ fail:
 						J9ARRAYCLASS_SET_STRIDE(ramClass, J9_VALUETYPE_FLATTENED_SIZE(elementClass));
 					}
 				} else {
+					if (J9_IS_J9CLASS_VALUETYPE(elementClass)) {
+						ramArrayClass->classFlags |= J9ClassContainsUnflattenedFlattenables;
+					}
 					J9ARRAYCLASS_SET_STRIDE(ramClass, (((UDATA) 1) << (((J9ROMArrayClass*)romClass)->arrayShape & 0x0000FFFF)));
 				}
 			} else if (J9ROMCLASS_IS_PRIMITIVE_TYPE(ramClass->romClass)) {

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1367,6 +1367,79 @@ public class ValueTypeTests {
 		}
 	}
 
+	/*
+	 * Create Array Objects with Point Class without initialization
+	 * The array should be set to a Default Value.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInPointArray() throws Throwable {
+		Object pointArray = Array.newInstance(point2DClass, 10);
+		for (int i = 0; i < 10; i++) {
+			Object pointObject = Array.get(pointArray, i);
+			assertNotNull(pointObject);
+		}
+	}
+
+	/*
+	 * Create Array Objects with Flattened Line without initialization
+	 * Check the fields of each element in arrays. No field should be NULL.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInLineArray() throws Throwable {
+		Object flattenedLineArray = Array.newInstance(flattenedLine2DClass, 10);
+		for (int i = 0; i < 10; i++) {
+			Object lineObject = Array.get(flattenedLineArray, i);
+			assertNotNull(lineObject);
+			assertNotNull(getFlatSt.invoke(lineObject));
+			assertNotNull(getFlatEn.invoke(lineObject));
+		}
+	}
+
+	/*
+	 * Create Array Objects with triangle class without initialization
+	 * Check the fields of each element in arrays. No field should be NULL.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInTriangleArray() throws Throwable {
+		Object triangleArray = Array.newInstance(triangle2DClass, 10);
+		for (int i = 0; i < 10; i++) {
+			Object triangleObject = Array.get(triangleArray, i);
+			assertNotNull(triangleObject);
+			assertNotNull(getV1.invoke(triangleObject));
+			assertNotNull(getV2.invoke(triangleObject));
+			assertNotNull(getV3.invoke(triangleObject));
+		}
+	}
+
+	/*
+	 * Create an Array Object with assortedValueWithLongAlignment class without initialization
+	 * Check the fields of each element in arrays. No field should be NULL.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInAssortedValueWithLongAlignmentArray() throws Throwable {
+		Object assortedValueWithLongAlignmentArray = Array.newInstance(assortedValueWithLongAlignmentClass, 10);
+		for (int i = 0; i < 10; i++) {
+			Object assortedValueWithLongAlignmentObject = Array.get(assortedValueWithLongAlignmentArray, i);
+			assertNotNull(assortedValueWithLongAlignmentObject);
+			for (int j = 0; j < 7; j++) {
+				assertNotNull(assortedValueWithLongAlignmentGetterAndWither[j][0].invoke(assortedValueWithLongAlignmentObject));
+			}
+		}
+	}
+
+	/*
+	 * Create an assortedRefWithLongAlignment Array
+	 * Since it's ref type, the array should be filled with nullptrs
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInassortedRefWithLongAlignmentArray() throws Throwable {
+		Object assortedRefWithLongAlignmentArray = Array.newInstance(assortedRefWithLongAlignmentClass, 10);
+		for (int i = 0; i < 10; i++) {
+			Object assortedRefWithLongAlignmentObject = Array.get(assortedRefWithLongAlignmentArray, i);
+			assertNull(assortedRefWithLongAlignmentObject);
+		}
+	}
+
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {
 		try {
 			return lookup.findVirtual(clazz, "get"+fieldName, MethodType.methodType(fieldType));


### PR DESCRIPTION
1. If array element is value type and unflattened, set the J9ClassContainsUnflattenedFlattenables flag for the array ram class.
2. If the flag is set for an array class, initialize the slots with default value of the class.
3. Create tests to check if the default value is set for value type arrays.

Signed-off-by: thomasli <Xinhai.Li@ibm.com>