### PR TITLE
Add dumping commands to jcmd

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
@@ -1,10 +1,4 @@
 /*[INCLUDE-IF Sidecar16]*/
-package com.ibm.tools.attach.target;
-
-import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
-import static com.ibm.tools.attach.target.IPC.LOGGING_ENABLED;
-import static com.ibm.tools.attach.target.IPC.loggingStatus;
-
 /*******************************************************************************
  * Copyright (c) 2009, 2019 IBM Corp. and others
  *
@@ -26,6 +20,12 @@ import static com.ibm.tools.attach.target.IPC.loggingStatus;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+package com.ibm.tools.attach.target;
+
+import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
+import static com.ibm.tools.attach.target.IPC.LOGGING_ENABLED;
+import static com.ibm.tools.attach.target.IPC.loggingStatus;
 
 import java.io.File;
 import java.io.IOException;
@@ -145,15 +145,7 @@ public class AttachHandler extends Thread {
 		 *  Java 5: disabled by default on all platforms 
 		 */
 		/*[PR Jazz 59196 LIR: Disable attach API by default on z/OS (31972)]*/
-		boolean enableAttach = true;
-		String osName = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("os.name"); //$NON-NLS-1$
-		if (null != osName) {
-			if (osName.equalsIgnoreCase("z/OS")) { //$NON-NLS-1$
-				enableAttach = false;
-			} else if (osName.startsWith("Windows")) { //$NON-NLS-1$
-				IPC.isWindows = true;
-			}
-		}
+		boolean enableAttach = !IPC.isZOS;
 		/* the system property overrides the default */
 		String enableAttachProp = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("com.ibm.tools.attach.enable");  //$NON-NLS-1$
 		if (null != enableAttachProp) {

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -79,8 +79,28 @@ public class IPC {
 	/**
 	 * True if operating system is Windows.
 	 */
-	public static boolean isWindows = false;
+	public final static boolean isWindows;
 
+	/**
+	 * True if operating system is z/OS.
+	 */
+	public final static boolean isZOS;
+
+	static {
+		String osName = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("os.name"); //$NON-NLS-1$
+		boolean tempIsZos = false;
+		boolean tempIsWindows = false;
+		if (null != osName) {
+			if (osName.equalsIgnoreCase("z/OS")) { //$NON-NLS-1$
+				tempIsZos = true;
+			} else if (osName.startsWith("Windows")) { //$NON-NLS-1$
+				tempIsWindows = true;
+			}
+		}
+		isZOS = tempIsZos;
+		isWindows = tempIsWindows;
+	}
+	
 	private static Random randomGen; /* Cleanup. this is used by multiple threads */
 	
 	/* loggingStatus may be seen to be LOGGING_ENABLED before logStream is initialized,

--- a/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticProperties.java
+++ b/jcl/src/java.base/share/classes/openj9/tools/attach/diagnostics/base/DiagnosticProperties.java
@@ -306,7 +306,11 @@ public class DiagnosticProperties {
 		StringWriter buff = new StringWriter(1000);
 		try (PrintWriter buffWriter = new PrintWriter(buff)) {
 			if (Boolean.parseBoolean(getPropertyOrNull(IPC.PROPERTY_DIAGNOSTICS_ERROR))) {
-				buffWriter.printf("Error: %s%n", getString(IPC.PROPERTY_DIAGNOSTICS_ERRORTYPE)); //$NON-NLS-1$
+				String errorType = getPropertyOrNull(IPC.PROPERTY_DIAGNOSTICS_ERRORTYPE);
+				if (null == errorType) {
+					errorType = "No error type available"; //$NON-NLS-1$
+				}
+				buffWriter.printf("Error: %s%n", errorType); //$NON-NLS-1$
 				String msg = getPropertyOrNull(IPC.PROPERTY_DIAGNOSTICS_ERRORMSG);
 				if (null != msg) {
 					buffWriter.println(msg);
@@ -374,9 +378,10 @@ public class DiagnosticProperties {
 		props.put(IPC.PROPERTY_DIAGNOSTICS_ERROR, Boolean.toString(true));
 		props.put(IPC.PROPERTY_DIAGNOSTICS_ERRORTYPE, e.getClass().getName());
 		String msg = e.getMessage();
-		if (null != msg) {
-			props.put(IPC.PROPERTY_DIAGNOSTICS_ERRORMSG, msg);
+		if (null == msg) {
+			msg = String.format("Error at %s", e.getStackTrace()[0].toString()); //$NON-NLS-1$
 		}
+		props.put(IPC.PROPERTY_DIAGNOSTICS_ERRORMSG, msg);
 		return props;
 	}
 
@@ -390,6 +395,7 @@ public class DiagnosticProperties {
 	public static DiagnosticProperties makeStatusProperties(boolean error, String msg) {
 		DiagnosticProperties props = new DiagnosticProperties();
 		props.put(IPC.PROPERTY_DIAGNOSTICS_ERROR, Boolean.toString(error));
+		props.put(IPC.PROPERTY_DIAGNOSTICS_ERRORTYPE, "Error in command"); //$NON-NLS-1$
 		if (null != msg) {
 			props.put(IPC.PROPERTY_DIAGNOSTICS_ERRORMSG, msg);
 		}

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -23,8 +23,10 @@
 package org.openj9.test.attachAPI;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -46,17 +48,26 @@ import static org.openj9.test.attachAPI.TargetManager.getVmId;
 public class TestJcmd extends AttachApiTest {
 
 	private static final String EXPECTED_STRING_FOUND = "Expected string found"; //$NON-NLS-1$
+
+	private static final String JCMD_COMMAND = "jcmd"; //$NON-NLS-1$
+
+	private static final String DUMP_HEAP = "Dump.heap"; //$NON-NLS-1$
+	private static final String DUMP_JAVA = "Dump.java"; //$NON-NLS-1$
+	private static final String DUMP_SNAP = "Dump.snap"; //$NON-NLS-1$
+	private static final String DUMP_SYSTEM = "Dump.system"; //$NON-NLS-1$
+	private static final String GC_CLASS_HISTOGRAM = "GC.class_histogram"; //$NON-NLS-1$
+	private static final String GC_HEAP_DUMP = "GC.heap_dump"; //$NON-NLS-1$
+	private static final String GC_RUN = "GC.run"; //$NON-NLS-1$
 	private static final String HELP_COMMAND = "help"; //$NON-NLS-1$
 	private static final String THREAD_PRINT = "Thread.print"; //$NON-NLS-1$
-	private static final String GC_RUN = "GC.run"; //$NON-NLS-1$
-	private static final String GC_CLASS_HISTOGRAM = "GC.class_histogram"; //$NON-NLS-1$
-	private static final String JCMD_COMMAND = "jcmd"; //$NON-NLS-1$
-	private static String[] JCMD_COMMANDS = { GC_CLASS_HISTOGRAM, GC_RUN, THREAD_PRINT, HELP_COMMAND };
+	private static String[] JCMD_COMMANDS = {DUMP_HEAP, DUMP_JAVA, DUMP_SNAP,
+			DUMP_SYSTEM, GC_CLASS_HISTOGRAM, GC_HEAP_DUMP, GC_RUN, HELP_COMMAND, THREAD_PRINT};
 
 	/*
 	 * Contains strings expected to be contained in the outputs of various commands
 	 */
 	private static Map<String, String> commandExpectedOutputs;
+	private File userDir;
 
 	/**
 	 * Test various ways of printing the help text, including undocumented but
@@ -122,7 +133,7 @@ public class TestJcmd extends AttachApiTest {
 			String expectedString = commandExpectedOutputs.getOrDefault(command, "Test error: expected output not defined"); //$NON-NLS-1$
 			log("Expected string: " + expectedString); //$NON-NLS-1$
 			Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
-			assertTrue(searchResult.isPresent(), "Expected string not found " + expectedString); //$NON-NLS-1$
+			assertTrue(searchResult.isPresent(), "Expected string \"" + expectedString + "\" not found"); //$NON-NLS-1$ //$NON-NLS-2$
 			log(EXPECTED_STRING_FOUND);
 		}
 	}
@@ -163,6 +174,48 @@ public class TestJcmd extends AttachApiTest {
 		log(EXPECTED_STRING_FOUND);
 	}
 
+	@Test
+	public void testDumps() throws IOException {
+		@SuppressWarnings("nls")
+		String[][] commandsAndDumpTypes = {{DUMP_HEAP, "Heap"}, {GC_HEAP_DUMP, "Heap"}, {DUMP_JAVA, "Java"}, {DUMP_SNAP, "Snap"}, {DUMP_SYSTEM, "System"}};
+		for (String[] commandAndDumpName : commandsAndDumpTypes) {
+			TargetManager tgt = new TargetManager(TestConstants.TARGET_VM_CLASS, null,
+					Collections.emptyList(), Collections.singletonList("-Xmx10M")); //$NON-NLS-1$
+			tgt.syncWithTarget();
+			String targetId = tgt.targetId;
+			assertNotNull(targetId, "target did not launch"); //$NON-NLS-1$
+			String dumpType = commandAndDumpName[1];
+			@SuppressWarnings("nls")
+			File dumpFileLocation = new File(userDir, "my" + dumpType + "Dump");
+			dumpFileLocation.delete();
+			try {
+				String dumpFilePath = dumpFileLocation.getAbsolutePath();
+				List<String> args = new ArrayList<>();
+				args.add(targetId);
+				String command = commandAndDumpName[0];
+				log("test " + command); //$NON-NLS-1$
+				args.add(command);
+				args.add(dumpFilePath);
+				List<String> jcmdOutput = runCommandAndLogOutput(args);
+
+				assertTrue(dumpFileLocation.exists(), "dump file " + dumpFilePath + "missing"); //$NON-NLS-1$//$NON-NLS-2$
+				String expectedString = "Dump written to " + dumpFilePath; //$NON-NLS-1$
+				log("Expected jcmd output string: " + expectedString); //$NON-NLS-1$
+				Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+				assertTrue(searchResult.isPresent(), "Expected string not found in jcmd output: " + expectedString); //$NON-NLS-1$
+				log(EXPECTED_STRING_FOUND + " in jcmd output: " + expectedString); //$NON-NLS-1$
+
+				expectedString = dumpType + " dump written to " + dumpFilePath; //$NON-NLS-1$
+				searchResult = StringUtilities.searchSubstring(expectedString,tgt.getTargetErrReader().lines());
+				assertTrue(searchResult.isPresent(), "Expected string not found in target standard error: " + expectedString); //$NON-NLS-1$
+				log(EXPECTED_STRING_FOUND + " in target standard error: " + expectedString); //$NON-NLS-1$
+			} finally {
+				tgt.terminateTarget();
+				dumpFileLocation.delete();
+			}
+		}
+	}
+
 	@BeforeMethod
 	protected void setUp(Method testMethod) {
 		testName = testMethod.getName();
@@ -172,12 +225,20 @@ public class TestJcmd extends AttachApiTest {
 	@BeforeSuite
 	protected void setupSuite() {
 		assertTrue(PlatformInfo.isOpenJ9(), "This test is valid only on OpenJ9"); //$NON-NLS-1$
+		userDir = new File(System.getProperty("user.dir")); //$NON-NLS-1$
 		getJdkUtilityPath(JCMD_COMMAND);
 		commandExpectedOutputs = new HashMap<>();
 		commandExpectedOutputs.put(HELP_COMMAND, THREAD_PRINT);
 		commandExpectedOutputs.put(GC_CLASS_HISTOGRAM, "java.util.HashMap"); //$NON-NLS-1$
 		commandExpectedOutputs.put(GC_RUN, "Command succeeded"); //$NON-NLS-1$
 		commandExpectedOutputs.put(THREAD_PRINT, "Attach API wait loop"); //$NON-NLS-1$
+		/* add the expected outputs for dump commands with no arguments */
+		String WRONG_NUMBER_OF_ARGUMENTS = "Error: wrong number of arguments"; //$NON-NLS-1$
+		commandExpectedOutputs.put(DUMP_HEAP, WRONG_NUMBER_OF_ARGUMENTS);
+		commandExpectedOutputs.put(GC_HEAP_DUMP, WRONG_NUMBER_OF_ARGUMENTS);
+		commandExpectedOutputs.put(DUMP_JAVA, WRONG_NUMBER_OF_ARGUMENTS);
+		commandExpectedOutputs.put(DUMP_SNAP, WRONG_NUMBER_OF_ARGUMENTS);
+		commandExpectedOutputs.put(DUMP_SYSTEM, WRONG_NUMBER_OF_ARGUMENTS);
 	}
 
 }

--- a/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
@@ -232,13 +232,13 @@ class TargetManager {
 	}
 
 	public TargetManager(String cmdName, String targetId,
-			List<String> vmArgs, ArrayList<String> appArgs) {
+			List<String> vmArgs, List<String> appArgs) {
 		this.targetId = targetId;
 		this.proc = launchTarget(cmdName, targetId, null, vmArgs, appArgs);
 	}
 
 	public TargetManager(String cmdName, String targetId, String displayName,
-			List<String> vmArgs, ArrayList<String> appArgs) {
+			List<String> vmArgs, List<String> appArgs) {
 		this.targetId = targetId;
 		this.proc = launchTarget(cmdName, targetId, displayName, vmArgs,
 				appArgs);

--- a/test/functional/TestUtilities/src/org/openj9/test/util/StringUtilities.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/StringUtilities.java
@@ -22,8 +22,10 @@
 
 package org.openj9.test.util;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Utility methods for String input and output.
@@ -37,11 +39,20 @@ public class StringUtilities {
 	 * @param haystack list of Strings to search
 	 * @return Optional which is either empty or contains matching string 
 	 */
-	public static Optional<String> searchSubstring(String needle, List<String> haystack) {
-		return haystack.stream().filter(s -> s.contains(needle)).findFirst();
+	public static Optional<String> searchSubstring(String needle, Collection<String> haystack) {
+		return searchSubstring(needle, haystack.stream());
 	}
 	
-
+	/**
+	 * Find the first occurrence of a substring in a list of Strings.
+	 * @param needle pattern for which to search
+	 * @param haystack list of Strings to search
+	 * @return Optional which is either empty or contains matching string 
+	 */
+	public static Optional<String> searchSubstring(String needle, Stream<String> haystack) {
+		return haystack.filter(s -> s.contains(needle)).findFirst();
+	}
+	
 	/**
 	 * Determine if a pattern (needle) matches exactly  in a list of Strings.
 	 * @param needle pattern for which to search


### PR DESCRIPTION
Support various forms of dumps via jcmd.  Include the legacy format for heap dumps.
Clean up some whitespace and other tidying.

Add unit tests.

This is part of https://github.com/eclipse/openj9/issues/5164

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>