### PR TITLE
Restore correct final field behaviour in old class files

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1441,6 +1441,22 @@ exit:
 		return (J9SFJNINativeMethodFrame*)((UDATA)currentThread->sp + (UDATA)currentThread->literals);
 	}
 
+	/**
+	 * Checks whether a class enforces the final field setting rules.
+	 * Classes which are class file version 53 or above enforce the rule
+	 * unless the class was defined in a way that exempts it from validation.
+	 *
+	 * @param ramClass[in] the J9Class to test
+	 *
+	 * @returns true if the class enforces the rules, false if not
+	 */
+	static VMINLINE bool
+	ramClassChecksFinalStores(J9Class *ramClass)
+	{
+		return (!J9CLASS_IS_EXEMPT_FROM_VALIDATION(ramClass))
+			&& (ramClass->romClass->majorVersion >= 53);
+	}
+
 };
 
 #endif /* VMHELPERS_HPP_ */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6376,7 +6376,7 @@ resolve:
 				}
 				/* Final field - ensure the running method is allowed to store */
 				if (J9_UNEXPECTED(!J9ROMMETHOD_ALLOW_FINAL_FIELD_WRITES(J9_ROM_METHOD_FROM_RAM_METHOD(_literals), J9AccStatic))) {
-					if (J9_UNEXPECTED(!J9CLASS_IS_EXEMPT_FROM_VALIDATION(ramConstantPool->ramClass))) {
+					if (J9_UNEXPECTED(VM_VMHelpers::ramClassChecksFinalStores(ramConstantPool->ramClass))) {
 						/* Store not allowed - run the resolve code to throw the exception */
 						goto resolve;
 					}
@@ -6586,7 +6586,7 @@ resolve:
 				}
 				/* Final field - ensure the running method is allowed to store */
 				if (J9_UNEXPECTED(!J9ROMMETHOD_ALLOW_FINAL_FIELD_WRITES(J9_ROM_METHOD_FROM_RAM_METHOD(_literals), 0))) {
-					if (J9_UNEXPECTED(!J9CLASS_IS_EXEMPT_FROM_VALIDATION(ramConstantPool->ramClass))) {
+					if (J9_UNEXPECTED(VM_VMHelpers::ramClassChecksFinalStores(ramConstantPool->ramClass))) {
 						/* Store not allowed - run the resolve code to throw the exception */
 						goto resolve;
 					}

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -71,7 +71,7 @@ finalFieldSetAllowed(J9VMThread *currentThread, bool isStatic, J9Method *method,
 	bool legal = true;
 	/* NULL method means do not do the access check */
 	if (NULL != method) {
-		if (!J9CLASS_IS_EXEMPT_FROM_VALIDATION(callerClass)) {
+		if (VM_VMHelpers::ramClassChecksFinalStores(callerClass)) {
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 			if (!J9ROMMETHOD_ALLOW_FINAL_FIELD_WRITES(romMethod, isStatic ? J9AccStatic : 0)) {
 				if (canRunJavaCode) {


### PR DESCRIPTION
Allow static and instance final fields to be set from any method in
class files prior to version 53.

Fixes: #6683

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>