### PR TITLE
Override J9::Compilation::needRelocationsForStatics

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4839,13 +4839,6 @@ J9::CodeGenerator::needClassAndMethodPointerRelocations()
    return self()->fej9()->needClassAndMethodPointerRelocations();
    }
 
-
-bool
-J9::CodeGenerator::needRelocationsForStatics()
-   {
-   return self()->fej9()->needRelocationsForStatics();
-   }
-
 bool
 J9::CodeGenerator::needRelocationsForBodyInfoData()
    {

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -169,7 +169,6 @@ public:
                                           TR::Node *node);
 
    bool needClassAndMethodPointerRelocations();
-   bool needRelocationsForStatics();
    bool needRelocationsForBodyInfoData();
    bool needRelocationsForPersistentInfoData();
 

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1404,3 +1404,8 @@ J9::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
    return self()->getOption(TR_EnableFieldWatch);
    }
 
+bool
+J9::Compilation::needRelocationsForStatics()
+   {
+   return fej9()->needRelocationsForStatics();
+   }

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -325,6 +325,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
 
+   bool needRelocationsForStatics();
 private:
    enum CachedClassPointerId
       {


### PR DESCRIPTION
A while ago I added a new query `needRelocationsForStatics`
to OMR, which always returns true.
The plan was to override that query in OpenJ9 so that we don't
require relocation of statics for regular JITServer compilations.
For some reason I did not do that, which led to issue #6688,
i.e. we add a relocation for unresolved static field during a
non-AOT compilation, fail to relocate (because unresolved), and
fail compilation. Fixing this now.
Also, remove a similar query `J9::CodeGenerator::needRelocationsForStatics`, since it does the same thing but comp object is better suited for it.

Fixes #6688