### PR TITLE
Add JITServer test mode

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2107,8 +2107,14 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
                if (entry->_compilationAttemptsLeft == 1)
                   entry->_doNotUseAotCodeFromSharedCache = true;
                // Intentionally fall through next case
-            case compilationInterrupted:
             case compilationStreamFailure:
+               // This feature TR_RequireJITServer is used when we would like the client to fail when server crashes
+               if (feGetEnv("TR_RequireJITServer"))
+                  {
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "In mode TR_RequireJITServer, exit JITClient due to unavailable JITServer.");
+                  exit(25);
+                  }
+            case compilationInterrupted:
             case compilationCodeReservationFailure:
             case compilationRecoverableTrampolineFailure:
             case compilationIllegalCodeCacheSwitch:


### PR DESCRIPTION
We would like to crash the JITClient if JITServer is unavailable for testing purposes.
When JITServer crashes, JITClient will `exit(25)`
This feature is enabled with "TR_RequireJITServer".
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>