### PR TITLE
Check packages in unnamed module when creating module.

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -64,7 +64,7 @@ static UDATA addMulPackageDefinitions(J9VMThread * currentThread, J9Module * fro
 static void removeMulPackageDefinitions(J9VMThread * currentThread, J9Module * fromModule, const char* const* packages, U_32 packagesIndex);
 static UDATA addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, const char* const* packages, U_32 numPackages, jstring version);
 static BOOLEAN isPackageDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char *packageName);
-static BOOLEAN areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char* const* packages, U_32 numPackages);
+static BOOLEAN areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char* const* packages, U_32 numPackages, BOOLEAN checkUnnamedModule);
 static UDATA exportPackageToAll(J9VMThread * currentThread, J9Module * fromModule, const char *package);
 static UDATA exportPackageToAllUnamed(J9VMThread * currentThread, J9Module * fromModule, const char *package);
 static UDATA exportPackageToModule(J9VMThread * currentThread, J9Module * fromModule, const char *package, J9Module * toModule);
@@ -79,8 +79,8 @@ static void freePackage(J9VMThread * currentThread, J9Package * j9package);
 static J9ClassLoader * getModuleObjectClassLoader(J9VMThread * currentThread, j9object_t moduleObject);
 static J9Module * createModule(J9VMThread * currentThread, j9object_t moduleObject, J9ClassLoader * classLoader, j9object_t moduleName);
 static J9Module * getJ9Module(J9VMThread * currentThread, jobject module);
-static BOOLEAN isModuleNameValid(j9object_t moduleName);
-static BOOLEAN isModuleJavaBase(j9object_t moduleName);
+static BOOLEAN isModuleNameValid(J9VMThread * currentThread, j9object_t moduleName);
+static BOOLEAN isModuleJavaBase(J9VMThread * currentThread, j9object_t moduleName);
 static BOOLEAN isModuleNameGood(j9object_t moduleName);
 static UDATA allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Module * toModule);
 static void trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *j9FromMod, J9Module *j9ToMod);
@@ -417,7 +417,15 @@ addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, const cha
 	J9ClassLoader * const classLoader = fromModule->classLoader;
 
 	UDATA retval = ERRCODE_GENERAL_FAILURE;
-	if (!areNoPackagesDefined(currentThread, classLoader, packages, numPackages)) {
+	int checkUnnamedModule =
+			(classLoader != currentThread->javaVM->systemClassLoader)
+					|| !isModuleJavaBase(currentThread, fromModule->moduleName);
+	/* the bootstrap classloader is exempt from unnamed module checks
+	 * because it may place classes in the unnamed
+	 * module before java.base is created.
+	 */
+	if (!areNoPackagesDefined(currentThread, classLoader, packages, numPackages, checkUnnamedModule))
+	{
 		retval = ERRCODE_PACKAGE_ALREADY_DEFINED;
 	} else if (isModuleDefined(currentThread, fromModule)) {
 		retval = ERRCODE_MODULE_ALREADY_DEFINED;
@@ -454,19 +462,23 @@ isPackageDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const 
 }
 
 static BOOLEAN
-areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char* const* packages, U_32 numPackages)
+areNoPackagesDefined(J9VMThread * currentThread, J9ClassLoader * classLoader, const char* const* packages, U_32 numPackages, BOOLEAN checkUnnamedModule)
 {
 	BOOLEAN success = TRUE;
+	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 
 	if (NULL != packages) {
 		U_32 const arrayLength = numPackages;
 		if (0 != arrayLength) {
 			U_32 i = 0;
-			for (i = 0; i < arrayLength; i++) {
+			for (i = 0; success && (i < arrayLength); i++) {
 				const char *packageName = packages[i];
 				if (isPackageDefined(currentThread, classLoader, packageName)) {
 					success = FALSE;
-					break;
+				} else if (checkUnnamedModule
+						&& vmFuncs->isAnyClassLoadedFromPackage(classLoader, (U_8*) packageName, strlen(packageName))
+				) {
+					success = FALSE;
 				}
 			}
 		}
@@ -550,10 +562,10 @@ getJ9Module(J9VMThread * currentThread, jobject module)
 }
 
 static BOOLEAN
-isModuleJavaBase(j9object_t moduleName)
+isModuleJavaBase(J9VMThread * currentThread, j9object_t moduleName)
 {
-	/** @todo compare against string 'java.base' */
-	return FALSE;
+	return (0 != currentThread->javaVM->internalVMFunctions->compareStringToUTF8(currentThread, moduleName, FALSE,
+			(const U_8 *) "java.base", strlen("java.base")));
 }
 
 static BOOLEAN
@@ -564,13 +576,15 @@ isModuleNameGood(j9object_t moduleName)
 }
 
 static BOOLEAN
-isModuleNameValid(j9object_t moduleName)
+isModuleNameValid(J9VMThread * currentThread, j9object_t moduleName)
 {
 	BOOLEAN retval = FALSE;
 
 	if (NULL != moduleName) {
-		if (!isModuleJavaBase(moduleName)) {
+		if (!isModuleJavaBase(currentThread, moduleName)) {
 			retval = isModuleNameGood(moduleName);
+		} else {
+			retval = TRUE;
 		}
 	}
 
@@ -750,7 +764,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 
 		if (NULL == moduleName) {
 			vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, J9NLS_VM_MODULE_IS_UNNAMED);
-		} else if (!isModuleNameValid(moduleName)) {
+		} else if (!isModuleNameValid(currentThread, moduleName)) {
 			vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, J9NLS_VM_MODULE_NAME_IS_INVALID);
 		} else if (NULL == classLoader) {
 			/* An exception should be pending if classLoader is null */


### PR DESCRIPTION
Ensure the classloader (unless it is the bootstrap loader) has not loaded any
of the packages into its unnamed module.
Exempt bootloader from unnamed module checks.

Fixes https://github.com/eclipse/openj9/issues/6462

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>