### PR TITLE
Updated Protobuf config options in Docker

### DIFF
--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -261,7 +261,7 @@ RUN cd /tmp \
   && tar -xzf protobuf-cpp-3.5.1.tar.gz \
   && rm -f protobuf-cpp-3.5.1.tar.gz \
   && cd /tmp/protobuf-3.5.1 \
-  && ./configure CFLAGS=-fPIC CXXFLAGS=-fPIC \
+  && ./configure --disable-shared --with-pic \
   && make \
   && make install \
   && cd .. \


### PR DESCRIPTION
Centos6.9 x86 Docker containers are being updated to use different
options when configuring Protobuf, as the new options will make
Protobuf more optimized.

Fixes #6819

Signed-off-by: Colton Mills <millscolt3@gmail.com>