### PR TITLE
Implement J9::Compilation::needRelocationsForStatics

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1415,3 +1415,8 @@ J9::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
    return self()->getOption(TR_EnableFieldWatch);
    }
 
+bool
+J9::Compilation::needRelocationsForStatics()
+   {
+   return self()->fej9()->needRelocationsForStatics();
+   }

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -319,6 +319,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
 
+   bool needRelocationsForStatics();
 private:
    enum CachedClassPointerId
       {


### PR DESCRIPTION
Overriding the OMR implementation of this method to do the
same thing as `J9::CodeGenerator::needRelocationsForStatics`.
This is done in preparation to replacing all calls to codegen
method with calls to compilation method.