### PR TITLE
Fix clientSessionData nullptr issue

### DIFF
--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -143,7 +143,7 @@ public:
       The server will check whether its version matches the client's version and throw
       `StreamVersionIncompatible` if it doesn't.
 
-      Exceptions thrown: StreamInterrupted, StreamConnectionTerminate, StreamClientSessionTerminate, StreamVersionIncompatible, StreamMessageTypeMismatch
+      Exceptions thrown: StreamConnectionTerminate, StreamClientSessionTerminate, StreamVersionIncompatible, StreamMessageTypeMismatch
  
       @return Returns a tuple with information sent by the client
    */
@@ -158,10 +158,6 @@ public:
 
       switch (_cMsg.type())
          {
-         case MessageType::compilationInterrupted:
-            {
-            throw StreamInterrupted();
-            }
          case MessageType::connectionTerminate:
             {
             throw StreamConnectionTerminate();


### PR DESCRIPTION
readCompileRequest() is not supposed to handle StreamInterrupted.
readCompileRequest() is meant to receive messages from buildCompileRequest() and buildCompileRequest() only. 
buildCompileRequest() does not trigger StreamInterrupted.
writeError() is the one that can trigger StreamInterrupted and it's supposed to be handled in read() instead of readCompileRequest.
This issue occurred because of out-of-order messages, where a writeError() message was received before buildCompileRequest()'s message to readCompileRequest(). We should throw a StreamMessageTypeMismatch instead of StreamInterrupted when this happens.

Issue: #6687

Signed-off-by: Harry Yu <harryyu1994@gmail.com>