### PR TITLE
Disable SVM for AOT loads if the original compile did not use SVM

### DIFF
--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -238,10 +238,8 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
       }
 
    // Check the flags related to the symbol validation manager
-   if (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_UsesSymbolValidationManager)
-      {
-      comp->setOption(TR_UseSymbolValidationManager);
-      }
+   bool usesSVM = _aotMethodHeaderEntry->flags & TR_AOTMethodHeader_UsesSymbolValidationManager;
+   options->setOption(TR_UseSymbolValidationManager, usesSVM);
 
    if ((_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_TMDisabled) && !comp->getOption(TR_DisableTM))
       {


### PR DESCRIPTION
Use a flag from AOT method header to determine whether the compilation
used SVM and set `TR_UseSymbolValidationManager` option to the same
value before any relocations get done.
Without this change, we will segfault if the original compilation was
done without SVM, but the load has `-Xjit:useSymbolValidationManager`
set.