### PR TITLE
Fix incorrect assert in TR_RelocationRecord::setReloFlags

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -572,7 +572,7 @@ TR_RelocationRecord::flags(TR_RelocationTarget *reloTarget)
 void
 TR_RelocationRecord::setReloFlags(TR_RelocationTarget *reloTarget, uint8_t reloFlags)
    {
-   TR_ASSERT((reloFlags & ~FLAGS_RELOCATION_FLAG_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
+   TR_ASSERT_FATAL((reloFlags & FLAGS_RELOCATION_FLAG_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
    uint8_t crossPlatFlags = flags(reloTarget);
    uint8_t flags = crossPlatFlags | (reloFlags & ~FLAGS_RELOCATION_FLAG_MASK);
    reloTarget->storeUnsigned8b(flags, (uint8_t *) &_record->_flags);


### PR DESCRIPTION
The assert should be checking that reloFlags do not overlap
with cross-platform flags, but it was actually checking
that reloFlags do not overlap with non-cross-platform flags,
so it was always incorrectly triggered.
