### PR TITLE
Fix caching of field/static attributes in AOT mode

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1906,12 +1906,12 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
          bool volatileP, isFinal, isPrivate, unresolvedInCP;
          bool result = method->fieldAttributes(comp, cpIndex, &fieldOffset, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
 
-         TR_J9MethodFieldAttributes attrs(static_cast<uintptr_t>(fieldOffset), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
-
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
          TR_OpaqueClassBlock *definingClass = compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), fe->_jitConfig->javaVM, constantPool, cpIndex, false);
 
-         client->write(response, attrs, definingClass);
+         TR_J9MethodFieldAttributes attrs(static_cast<uintptr_t>(fieldOffset), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result, definingClass);
+
+         client->write(response, attrs);
          }
          break;
       case MessageType::ResolvedRelocatableMethod_staticAttributes:
@@ -1925,12 +1925,13 @@ bool handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe)
          TR::DataType type;
          bool volatileP, isFinal, isPrivate, unresolvedInCP;
          bool result = method->staticAttributes(comp, cpIndex, &address, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
-         TR_J9MethodFieldAttributes attrs(reinterpret_cast<uintptr_t>(address), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
          TR_OpaqueClassBlock *definingClass = compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), fe->_jitConfig->javaVM, constantPool, cpIndex, true);
 
-         client->write(response, attrs, definingClass);
+         TR_J9MethodFieldAttributes attrs(reinterpret_cast<uintptr_t>(address), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result, definingClass);
+
+         client->write(response, attrs);
          }
          break;
 


### PR DESCRIPTION
When caching field attributes for AOT compialtions,
I forgot to also cache a defining class of the field,
which is required to create an SVM record.
Add defining class as an optional field to
`TR_J9MethodFieldAtttributes`.