### PR TITLE
Fix the exception for mismatched number of args

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2033,7 +2033,7 @@ bool TR::CompilationInfo::shouldAbortCompilation(TR_MethodToBeCompiled *entry, T
 
    if (entry->_unloadedMethod) // method was unloaded while we were trying to compile it
       {
-      TR_ASSERT(entry->_compErrCode == compilationInterrupted, "if method was unloaded we must return we an error code of compilationInterrupted");
+      TR_ASSERT(entry->_compErrCode == compilationInterrupted, "Received error code %u, expect compilationInterrupted when the method was unloaded", entry->_compErrCode);
       entry->_compErrCode = compilationNotNeeded; // change error code
       return true;
       }
@@ -9802,7 +9802,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
             }
          int8_t compErrCode = entry->_compErrCode;
          if (compErrCode != compilationStreamInterrupted && compErrCode != compilationStreamFailure)
-            entry->_stream->finishCompilation(compErrCode);
+            entry->_stream->writeError(compErrCode);
          }
 #endif // ifdef J9VM_JIT_DYNAMIC_LOOP_TRANSFER
       if (((jitConfig->runtimeFlags & J9JIT_TOSS_CODE) ||
@@ -9862,7 +9862,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
             {
             int8_t compErrCode = entry->_compErrCode;
             if (compErrCode != compilationStreamInterrupted && compErrCode != compilationStreamFailure)
-               entry->_stream->finishCompilation(compErrCode);
+               entry->_stream->writeError(compErrCode);
             }
          }
       return startPC;
@@ -10178,7 +10178,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
             }
          int8_t compErrCode = entry->_compErrCode;
          if (compErrCode != compilationStreamInterrupted && compErrCode != compilationStreamFailure)
-            entry->_stream->finishCompilation(compErrCode);
+            entry->_stream->writeError(compErrCode);
          }
       }
    else
@@ -10200,7 +10200,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
             }
          int8_t compErrCode = entry->_compErrCode;
          if (compErrCode != compilationStreamInterrupted && compErrCode != compilationStreamFailure)
-            entry->_stream->finishCompilation(compilationNotNeeded);
+            entry->_stream->writeError(compilationNotNeeded);
          }
       }
 

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -96,12 +96,12 @@ class ClientSessionData
       J9ROMClass *remoteRomClass; // pointer to the corresponding ROM class on the client
       J9Method *methodsOfClass;
       // Fields meaningful for arrays
-      TR_OpaqueClassBlock *baseComponentClass; 
+      TR_OpaqueClassBlock *baseComponentClass;
       int32_t numDimensions;
       PersistentUnorderedMap<TR_RemoteROMStringKey, std::string> *_remoteROMStringsCache; // cached strings from the client
       PersistentUnorderedMap<int32_t, std::string> *_fieldOrStaticNameCache;
       TR_OpaqueClassBlock *parentClass;
-      PersistentVector<TR_OpaqueClassBlock *> *interfaces; 
+      PersistentVector<TR_OpaqueClassBlock *> *interfaces;
       bool classHasFinalFields;
       uintptrj_t classDepthAndFlags;
       bool classInitialized;
@@ -249,16 +249,16 @@ class ClientSessionData
    TR::Monitor *_romMapMonitor;
    TR::Monitor *_classMapMonitor;
    TR::Monitor *_classChainDataMapMonitor;
-   // The following monitor is used to protect access to _expectedSeqNo and 
+   // The following monitor is used to protect access to _expectedSeqNo and
    // the list of out-of-sequence compilation requests (_OOSequenceEntryList)
    TR::Monitor *_sequencingMonitor;
    TR::Monitor *_constantPoolMapMonitor;
-   // Compilation requests that arrived out-of-sequence wait in 
+   // Compilation requests that arrived out-of-sequence wait in
    // _OOSequenceEntryList for their turn to be processed
    TR_MethodToBeCompiled *_OOSequenceEntryList;
    uint32_t _expectedSeqNo; // used for ordering compilation requests from the same client
    uint32_t _maxReceivedSeqNo; // the largest seqNo received from this client
-   int8_t  _inUse;  // Number of concurrent compilations from the same client 
+   int8_t  _inUse;  // Number of concurrent compilations from the same client
                     // Accessed with compilation monitor in hand
    int8_t _numActiveThreads; // Number of threads working on compilations for this client
                              // This is smaller or equal to _inUse because some threads
@@ -279,7 +279,7 @@ class ClientSessionData
 // This indirection is needed so that we can cache the value of the pointer so
 // that we can access client session data without going through the hashtable.
 // Accesss to this hashtable must be protected by the compilation monitor.
-// Compilation threads may purge old entries periodically at the beginning of a 
+// Compilation threads may purge old entries periodically at the beginning of a
 // compilation. Entried with inUse > 0 must not be purged.
 class ClientSessionHT
    {
@@ -304,7 +304,6 @@ class ClientSessionHT
 
 size_t methodStringLength(J9ROMMethod *);
 std::string packROMClass(J9ROMClass *, TR_Memory *);
-bool handleServerMessage(JITServer::ClientStream *, TR_J9VM *);
 TR_MethodMetaData *remoteCompile(J9VMThread *, TR::Compilation *, TR_ResolvedMethod *,
       J9Method *, TR::IlGeneratorMethodDetails &, TR::CompilationInfoPerThreadBase *);
 TR_MethodMetaData *remoteCompilationEnd(J9VMThread * vmThread, TR::Compilation *comp, TR_ResolvedMethod * compilee, J9Method * method,
@@ -462,7 +461,7 @@ class JITaaSHelpers
       static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2);
       static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
       //purgeCache function can only be used inside the JITaaSCompilationThread.cpp file.
-      //It is a templated function, calling it outside the JITaaSCompilationThread.cpp will give linking error. 
+      //It is a templated function, calling it outside the JITaaSCompilationThread.cpp will give linking error.
       template <typename map, typename key>
       static void purgeCache (std::vector<ClassUnloadedData> *unloadedClasses, map m, key ClassUnloadedData::*k);
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -53,7 +53,7 @@ public:
 #endif
 
    static void initVersion();
-  
+
 
    static uint64_t getJITServerVersion()
       {
@@ -162,7 +162,9 @@ protected:
 #else
       if (!((FileOutputStream*)_outputStream)->Flush())
 #endif
-         throw JITServer::StreamFailure("JITServer I/O error: flushing stream");
+         {
+         throw JITServer::StreamFailure("JITServer I/O error: flushing stream: GetErrno " + std::to_string(((FileOutputStream*)_outputStream)->GetErrno()));
+         }
       }
 
    int _connfd; // connection file descriptor

--- a/runtime/compiler/net/ProtobufTypeConvert.hpp
+++ b/runtime/compiler/net/ProtobufTypeConvert.hpp
@@ -272,7 +272,7 @@ namespace JITServer
          {
          auto data = message->data(n);
          if (data.type_case() != AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase())
-            throw StreamTypeMismatch("Expected type " + std::to_string(data.type_case()) + " but got type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
+            throw StreamTypeMismatch("Recevied type " + std::to_string(data.type_case()) + " but expect type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
          return std::make_tuple(ProtobufTypeConvert<Arg>::onRecv(&data));
          }
       };
@@ -280,7 +280,7 @@ namespace JITServer
    std::tuple<Args...> getArgs(const AnyData *message)
       {
       if (sizeof...(Args) != message->data_size())
-         throw StreamArityMismatch("Expected " + std::to_string(message->data_size()) + " args to unpack but got " + std::to_string(sizeof...(Args)) + "-tuple");
+         throw StreamArityMismatch("Received " + std::to_string(message->data_size()) + " args to unpack but expect " + std::to_string(sizeof...(Args)) + "-tuple");
       return GetArgs<Args...>::getArgs(message, 0);
       }
 

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -47,14 +47,15 @@ message AnyData
 
 enum MessageType
    {
-   compilationCode = 0;
-   mirrorResolvedJ9Method = 1;
-   get_params_to_construct_TR_j9method = 2;
-   getUnloadedClassRanges = 3;
-   compilationRequest = 4; // type used when client sends remote compilation requests
-   compilationInterrupted = 5; // type used when client informs the server to abort the remote compilation
-   clientSessionTerminate = 6; // type used when client process is about to terminate
-   connectionTerminate = 7; // type used when client informs the server to close the connection
+   compilationCode = 0; // Send the compiled code back to the client
+   compilationFailure = 1;
+   mirrorResolvedJ9Method = 2;
+   get_params_to_construct_TR_j9method = 3;
+   getUnloadedClassRanges = 4;
+   compilationRequest = 5; // type used when client sends remote compilation requests
+   compilationInterrupted = 6; // type used when client informs the server to abort the remote compilation
+   clientSessionTerminate = 7; // type used when client process is about to terminate
+   connectionTerminate = 8; // type used when client informs the server to close the connection
 
    // For TR_ResolvedJ9JITaaSServerMethod methods
    ResolvedMethod_isJNINative = 100;

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -45,5 +45,5 @@ void J9CompileDispatcher::compile(JITServer::ServerStream *stream)
          }
       } // end critical section
    // If we reached this point there was a memory allocation failure
-   stream->finishCompilation(compilationLowPhysicalMemory);
+   stream->writeError(compilationLowPhysicalMemory);
    }


### PR DESCRIPTION
There are two issues with the exception
`Arity mismatch: Expected 1 args to unpack but got 9-tuple`:
1. The error message was misleading. What it should say is
`Received 1 args to unpack but expect 9-tuple`.
2. If `statusCode` is not `compilationOK`, except for the statusCode,
the server does not send any argument to the client.
The argument mismatch exception should not be thrown in this case.

== Changes include ==
- Add a new message type `compilationFailure` to handle the error path case.
- Add a new API `writeError()` to `ServerStream` to send statusCode in
  `compilationFailure` message to client. `finishCompilation()` will no longer take
  `statusCode` since this API by default means `compilationOK`.
- Make `handleServerMessage()` local to JITaaSCompilationThread.cpp.
- Removed white trailing spaces in header files.

Fixes #6729

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>