### PR TITLE
Disable SymbolValidationManager for non-AOT compilations

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7317,6 +7317,11 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             options->setOption(TR_UseSymbolValidationManager);
             options->setOption(TR_DisableKnownObjectTable);
             }
+         else if (!vm->canUseSymbolValidationManager())
+            {
+            // disable SVM in case it was enabled explicitly with -Xjit:useSymbolValidationManager
+            options->setOption(TR_UseSymbolValidationManager, false);
+            }
 
          // Set jitDump specific options
          TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);


### PR DESCRIPTION
Without this change, specifying `-Xjit:useSymbolValidationManager`
sets `TR_UseSymbolValidationManager` option to true even for non-AOT
compilations, so it results in unnecessary relocations being added and
sometimes crashes.
