### PR TITLE
Move all steps running on master to workers

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -285,7 +285,7 @@ def build_with_slack(DOWNSTREAM_JOB_NAME, ghprbGhRepository, ghprbActualCommit, 
     GITHUB_REPO = "https://${GITHUB_SERVER}/${ghprbGhRepository}"
     // Set Github Commit Status
     if (ghprbActualCommit) {
-        node('master') {
+        node(SETUP_LABEL) {
             set_build_status(GITHUB_REPO, DOWNSTREAM_JOB_NAME, ghprbActualCommit, BUILD_URL, 'PENDING', "Build Started")
         }
     }
@@ -315,7 +315,7 @@ def build_with_slack(DOWNSTREAM_JOB_NAME, ghprbGhRepository, ghprbActualCommit, 
             }
             // Set Github Commit Status
             if (ghprbActualCommit) {
-                node('master') {
+                node(SETUP_LABEL) {
                     set_build_status(GITHUB_REPO, DOWNSTREAM_JOB_NAME, ghprbActualCommit, DOWNSTREAM_JOB_URL, 'FAILURE', "Build ${JOB.result}")
                 }
             }
@@ -325,7 +325,7 @@ def build_with_slack(DOWNSTREAM_JOB_NAME, ghprbGhRepository, ghprbActualCommit, 
             }
             // Set Github Commit Status
             if (ghprbActualCommit) {
-                node('master') {
+                node(SETUP_LABEL) {
                     set_build_status(GITHUB_REPO, DOWNSTREAM_JOB_NAME, ghprbActualCommit, DOWNSTREAM_JOB_URL, 'FAILURE', "Build FAILED")
                 }
             }
@@ -340,7 +340,7 @@ def build_with_slack(DOWNSTREAM_JOB_NAME, ghprbGhRepository, ghprbActualCommit, 
         echo "Downstream job ${DOWNSTREAM_JOB_NAME} PASSED after ${DOWNSTREAM_JOB_TIME}"
         // Set Github Commit Status
         if (ghprbActualCommit) {
-            node('master') {
+            node(SETUP_LABEL) {
                 set_build_status(GITHUB_REPO, DOWNSTREAM_JOB_NAME, ghprbActualCommit, DOWNSTREAM_JOB_URL, 'SUCCESS', "Build PASSED")
             }
         }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -252,7 +252,7 @@ try {
 
                                 builds["${job_name}"] = {
                                     if (AUTOMATIC_GENERATION != 'false') {
-                                        node('master') {
+                                        node(SETUP_LABEL) {
                                             unstash 'DSL'
                                             variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline', 'Pipeline')
                                         }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
@@ -76,7 +76,7 @@ timestamps {
 
     try {
         if (params.AUTOMATIC_GENERATION != 'false'){
-            node('master') {
+            node(SETUP_LABEL) {
                 unstash 'DSL'
                 variableFile.create_job(BUILD_NAME, SDK_VERSION, SPEC, 'build', buildFile.convert_build_identifier(BUILD_IDENTIFIER))
             }


### PR DESCRIPTION
- New Eclipse Jenkins does not allow executors on master
- As per https://bugs.eclipse.org/bugs/show_bug.cgi?id=549790#c10
- Two types of steps are Job DSL and GH commit status updater

Related #6276
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>