### PR TITLE
Add JVM_InitializeFromArchive for JDK11

### DIFF
--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -333,9 +333,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_GetNestMembers"/>
 		<export name="JVM_AreNestMates"/>
 		<export name="JVM_InitClassName"/>
-	</exports>
-
-	<exports group="jdk12">
 		<export name="JVM_InitializeFromArchive"/>
 	</exports>
 

--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 #include "j9cfg.h"
 #include <jni.h>
 
-#if JAVA_SPEC_VERSION >= 12
+#if JAVA_SPEC_VERSION >= 11
 JNIEXPORT void JNICALL
 JVM_InitializeFromArchive(JNIEnv *env, jclass clz)
 {
 	/* A no-op implementation is ok. */
 }
-#endif /* JAVA_SPEC_VERSION >= 12 */
+#endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -58,9 +58,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk11">
 				<include-if condition="spec.java11"/>
 			</group>
-			<group name="jdk12">
-				<include-if condition="spec.java12"/>
-			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -311,5 +311,5 @@ _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_GetNestMembers,JNICALL,false,jobjectArray,JNIEnv *env,jclass clz)])
 _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_AreNestMates,JNICALL,false,jboolean,JNIEnv *env,jclass clzOne, jclass clzTwo)])
-_IF([JAVA_SPEC_VERSION >= 12],
+_IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_InitializeFromArchive, JNICALL, false, void, JNIEnv *env, jclass clz)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -59,9 +59,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk11">
 				<include-if condition="spec.java11"/>
 			</group>
-			<group name="jdk12">
-				<include-if condition="spec.java12"/>
-			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
#### Add JVM_InitializeFromArchive for JDK11 ####

JVM_InitializeFromArchive was added for `JDK12+`, now it is required for `JDK11` as well.
Removed empty group `jdk12`.

closes: #6748

Reviewer: @DanHeidinga 
FYI: @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>