### PR TITLE
Implement Unsafe_compareAndSwapInt_jlObjectJII_Z support for AArch64

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -75,6 +75,9 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     * @return Endoded BL instruction
     */
    uint32_t encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node);
+   
+   bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
+   
    };
 
 }


### PR DESCRIPTION
Code that implements support for the sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z
recognized method for AArch64.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>