### PR TITLE
Re-add "-fno-rounding-math" and "-fno-signaling-nans" options in JIT

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -201,6 +201,8 @@ endif
 
 ifeq ($(C_COMPILER),clang)
     CX_FLAGS+=-Wno-parentheses -Werror=header-guard
+else
+    CX_FLAGS+=-fno-rounding-math -fno-signaling-nans
 endif
 
 ifeq ($(BUILD_CONFIG),debug)


### PR DESCRIPTION
The above compiler options were removed in
https://github.com/eclipse/openj9/pull/4156.

Removing the above compiler options causes a performance regression.
Symptoms of the performance regression: bursts of high throughput mixed
with periods of lower throughput. These symptoms cause a 5-7% throughput
regression.

Reintroducing the above compiler options fixes the throughput
regression.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>