### PR TITLE
Include object javanextvmi for Java 11

### DIFF
--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -99,7 +99,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				-->
 			</object>
 			<object name="javanextvmi">
-				<include-if condition="spec.java12"/>
+				<include-if condition="spec.java11"/>
 			</object>
 		</objects>
 


### PR DESCRIPTION
Fixes link error seen on Windows with #6751.