### PR TITLE
jstack: print properties in human-readable form

### DIFF
--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstack.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstack.java
@@ -37,7 +37,7 @@ import openj9.tools.attach.diagnostics.base.DiagnosticProperties;
 import openj9.tools.attach.diagnostics.base.DiagnosticUtils;
 
 /**
- * JStack 
+ * JStack
  * A tool for listing thread information about another Java process
  *
  */
@@ -78,9 +78,11 @@ public class Jstack {
 
 				if (printProperties) {
 					out.println("System properties:"); //$NON-NLS-1$
-					out.println(diagProvider.getSystemProperties());
+					Util.printProperties(out, diagProvider.getSystemProperties());
+					out.println();
 					out.println("Agent properties:"); //$NON-NLS-1$
-					out.println(diagProvider.getAgentProperties());
+					Util.printProperties(out, diagProvider.getAgentProperties());
+					out.println();
 				}
 			} catch (Exception e) {
 				Util.handleCommandException(vmid, e);

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Util.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Util.java
@@ -28,8 +28,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -136,6 +138,18 @@ public class Util {
 			}
 		} catch (AttachNotSupportedException | IOException e) {
 			outputBuffer.append(" <no information available>"); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * Print the Properties object in key-value format.
+	 * This differs from Properties.list() in that it does not truncate long values.
+	 * @param out
+	 * @param props
+	 */
+	static void printProperties(PrintStream out, Properties props) {
+		for ( Entry<Object, Object> theEntry : props.entrySet()) {
+			out.printf("%s=%s%n", theEntry.getKey(), theEntry.getValue()); //$NON-NLS-1$
 		}
 	}
 


### PR DESCRIPTION
With the '-p' option, print the system and agent properting in formatted form.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>