### PR TITLE
Exclude special.system testing on Windows due to timeout

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -463,6 +463,8 @@ x86-64_windows:
       13: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
       next: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
   excluded_tests:
+    8:
+      ? special.system
     11:
       ? special.system
     12:


### PR DESCRIPTION
MauveMultiThreadLoadTest_special_28 (Mode610-OSRG) and 29
(Mode612-OSRG_28) timeout.

LT  06:38:41.603 - Completed 79.9%. Number of tests started=2267923
(+12482)
STF 06:38:53.042 - Heartbeat: Process LT  is still running
STF 06:38:54.073 - **FAILED** Process LT  has timed out

We don't have the machine capacity to get through these tests on Windows, although there may also be a problem that these individual tests are timing out too early.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>