### PR TITLE
WIP: Add FMA ILopcodes support in OpenJ9

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -208,6 +208,16 @@ static const char * nvvmOpCodeNames[] =
    "xor",         // TR::lxor
    "xor",         // TR::bxor
    "xor",         // TR::sxor
+
+   NULL,          // TR::fmuladd
+   NULL,          // TR::fmulsub
+   NULL,          // TR::fnegmuladd
+   NULL,          // TR::fnegmulsub
+   NULL,          // TR::dmuladd
+   NULL,          // TR::dmulsub
+   NULL,          // TR::dnegmuladd
+   NULL,          // TR::dnegmulsub
+
    "sext",        // TR::i2l
    "sitofp",      // TR::i2f
    "sitofp",      // TR::i2d


### PR DESCRIPTION
In addition to eclipse/omr#4204 (Add FMA IL opcode to OMR). Need to add FMA Opcode support from OpenJ9. Add `NULL` to the `nvvmOpCodeNames` list in `CodeGenGPU.cpp` for the 8 FMA opcodes : `fmuladd`, `fmulsub`, `fnegmuladd`, `fnegmulsub`, `dmuladd`, `dmulsub`, `dnegmuladd`, `dnegmulsub`.

Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>