### PR TITLE
Added reading base exclude file as backup

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_base.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_base.txt
@@ -1,0 +1,25 @@
+##############################################################################
+#  Copyright (c) 2019, 2019 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+##############################################################################
+
+# Exclude tests temporarily
+
+org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all


### PR DESCRIPTION
- when the exclude file of corresponding jdk version does not exist, the base exclude file will be read instead.
[ci skip]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>