### PR TITLE
Fix client crash due to uncaught stream flush exception

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -4002,7 +4002,19 @@ TR::CompilationInfoPerThread::processEntries()
       if (client)
          {
          // Inform the server that client is closing the connection with a connectionTerminate message
-         client->writeError(JITServer::MessageType::connectionTerminate, 0 /* placeholder */);
+         if (JITaaSHelpers::isServerAvailable())
+            {
+            try
+               {
+               client->writeError(JITServer::MessageType::connectionTerminate, 0 /* placeholder */);
+               }
+            catch (const JITServer::StreamFailure &e)
+               {
+               if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer StreamFailure when sending connectionTerminate: %s", e.what());
+               }
+            }
+
          client->~ClientStream();
          TR_Memory::jitPersistentFree(client);
          setClientStream(NULL);

--- a/runtime/compiler/net/ProtobufTypeConvert.hpp
+++ b/runtime/compiler/net/ProtobufTypeConvert.hpp
@@ -272,7 +272,7 @@ namespace JITServer
          {
          auto data = message->data(n);
          if (data.type_case() != AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase())
-            throw StreamTypeMismatch("Recevied type " + std::to_string(data.type_case()) + " but expect type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
+            throw StreamTypeMismatch("Received type " + std::to_string(data.type_case()) + " but expect type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
          return std::make_tuple(ProtobufTypeConvert<Arg>::onRecv(&data));
          }
       };


### PR DESCRIPTION

The client side first experienced `I/O error: reading message size` stream failure.
The server became unavailable. The compilation was done locally.
In this scenario, at the end of processing compilation entries,
`connectionTerminate` should not be sent when the server was gone already.
Meanwhile, the `StreamFailure` exception should be handled properly.

Issue #6716

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>