### PR TITLE
Port the latest networking and runtime files to master

### DIFF
--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -123,8 +123,8 @@ int ClientStream::static_init(TR::PersistentInfo *info)
 
    _sslCtx = ctx;
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
 #endif
    return 0;
    }
@@ -148,7 +148,7 @@ int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs
 
    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
    if (sockfd < 0)
-      throw StreamFailure("Cannot create socket for JITaaS");
+      throw StreamFailure("Cannot create socket for JITServer");
 
    int flag = 1;
    if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void*)&flag, sizeof(flag)) < 0)
@@ -251,8 +251,8 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
       throw JITServer::StreamFailure("Failed to set BIO SSL");
       }
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
                                                       connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
    return bio;
    }

--- a/runtime/compiler/net/ClientStream.hpp
+++ b/runtime/compiler/net/ClientStream.hpp
@@ -90,7 +90,7 @@ public:
       {
       if (getVersionCheckStatus() == NOT_DONE)
          {
-         _cMsg.set_version(getJITaaSVersion());
+         _cMsg.set_version(getJITServerVersion());
          write(MessageType::compilationRequest, args...);
          _cMsg.clear_version();
          }
@@ -141,14 +141,15 @@ public:
    /**
       @brief Send an error message to the JITServer
 
-      Examples of error messages include 'compilationAbort' (e.g. when class unloading happens)
-      and `clientTerminate` (e.g. when the client is about to exit)
+      Examples of error messages include 'compilationInterrupted' (e.g. when class unloading happens),
+      'clientSessionTerminate' (e.g. when the client is about to exit), 
+      and 'connectionTerminate' (e.g. when the client is closing the connection)
    */
    template <typename ...T>
    void writeError(MessageType type, T... args)
       {
       _cMsg.set_type(type);
-      if (type == MessageType::compilationAbort)
+      if (type == MessageType::compilationInterrupted || type == MessageType::connectionTerminate)
          _cMsg.mutable_data()->clear_data();
       else
          setArgs<T...>(_cMsg.mutable_data(), args...);

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -25,6 +25,8 @@
 #include "env/CompilerEnv.hpp" // for TR::Compiler->target.is64Bit()
 #include "control/Options.hpp" // TR::Options::useCompressedPointers()
 #include "control/CompilationRuntime.hpp"
+#include "j9cfg.h" // for JAVA_SPEC_VERSION
+
 
 namespace JITServer
 {
@@ -34,8 +36,9 @@ void CommunicationStream::initVersion()
    {
    if (TR::Compiler->target.is64Bit() && TR::Options::useCompressedPointers())
       {
-      CONFIGURATION_FLAGS |= JITaaSCompressedRef;
+      CONFIGURATION_FLAGS |= JITServerCompressedRef;
       }
+   CONFIGURATION_FLAGS |= JAVA_SPEC_VERSION & JITServerJavaVersionMask;
    }
 
 #if defined(JITSERVER_ENABLE_SSL)

--- a/runtime/compiler/net/ProtobufTypeConvert.hpp
+++ b/runtime/compiler/net/ProtobufTypeConvert.hpp
@@ -272,7 +272,7 @@ namespace JITServer
          {
          auto data = message->data(n);
          if (data.type_case() != AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase())
-            throw StreamTypeMismatch("Expected type " + std::to_string(data.type_case()) + " but got type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
+            throw StreamTypeMismatch("Received type " + std::to_string(data.type_case()) + " but expect type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
          return std::make_tuple(ProtobufTypeConvert<Arg>::onRecv(&data));
          }
       };
@@ -280,7 +280,7 @@ namespace JITServer
    std::tuple<Args...> getArgs(const AnyData *message)
       {
       if (sizeof...(Args) != message->data_size())
-         throw StreamArityMismatch("Expected " + std::to_string(message->data_size()) + " args to unpack but got " + std::to_string(sizeof...(Args)) + "-tuple");
+         throw StreamArityMismatch("Received " + std::to_string(message->data_size()) + " args to unpack but expect " + std::to_string(sizeof...(Args)) + "-tuple");
       return GetArgs<Args...>::getArgs(message, 0);
       }
 

--- a/runtime/compiler/net/ServerStream.cpp
+++ b/runtime/compiler/net/ServerStream.cpp
@@ -72,7 +72,8 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
       exit(1);
       }
 
-   SSL_CTX_set_session_id_context(ctx, (const unsigned char*) "JITaaS", 6);
+   const char *sessionIDContext = "JITServer";
+   SSL_CTX_set_session_id_context(ctx, (const unsigned char*)sessionIDContext, strlen(sessionIDContext));
 
    if (SSL_CTX_set_ecdh_auto(ctx, 1) != 1)
       {
@@ -144,8 +145,8 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
    // verify server identity using standard method
    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
 
    return ctx;
    }
@@ -153,8 +154,8 @@ SSL_CTX *createSSLContext(TR::PersistentInfo *info)
 static bool
 handleOpenSSLConnectionError(int connfd, SSL *&ssl, BIO *&bio, const char *errMsg)
 {
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "%s: errno=%d", errMsg, errno);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "%s: errno=%d", errMsg, errno);
    ERR_print_errors_fp(stderr);
 
    close(connfd);
@@ -193,8 +194,8 @@ acceptOpenSSLConnection(SSL_CTX *sslCtx, int connfd, BIO *&bio)
    if (BIO_set_ssl(bio, ssl, true) != 1)
       return handleOpenSSLConnectionError(connfd, ssl, bio, "Error setting BIO SSL");
 
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
                                                      connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
    return true;
    }
@@ -259,8 +260,8 @@ ServerStream::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR
       int connfd = accept(sockfd, (struct sockaddr *)&cli_addr, &clilen);
       if (connfd < 0)
          {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Error accepting connection: errno=%d", errno);
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Error accepting connection: errno=%d", errno);
          continue;
          }
 

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -37,27 +37,43 @@ private:
    std::string _message;
    };
 
-class StreamCancel: public virtual std::exception
+class StreamInterrupted: public virtual std::exception
    {
 public:
-   StreamCancel(MessageType type, uint64_t clientId=0) : _type(type), _clientId(clientId) { }
+   StreamInterrupted() { }
    virtual const char* what() const throw()
       {
-      if (_type == MessageType::clientTerminate)
-         return "Client session terminated at client's request";
-      else
-         return "Compilation cancelled by client";
+      return "Compilation interrupted at JITClient's request";
       }
-   MessageType getType() const
+   };
+
+class StreamConnectionTerminate: public virtual std::exception
+   {
+public:
+   StreamConnectionTerminate() { }
+   virtual const char* what() const throw()
       {
-      return _type;
+      return "Connection terminated at JITClient's request";
+      }
+   };
+
+class StreamClientSessionTerminate: public virtual std::exception
+   {
+public:
+   StreamClientSessionTerminate(uint64_t clientId) : _clientId(clientId)
+      {
+      _message = "JITClient session " + std::to_string(_clientId) + " terminated at JITClient's request";
+      }
+   virtual const char* what() const throw()
+      {
+      return _message.c_str();
       }
    uint64_t getClientId() const
       {
       return _clientId;
       }
 private:
-   MessageType _type;
+   std::string _message;
    uint64_t _clientId;
    };
 
@@ -76,9 +92,10 @@ public:
 class StreamMessageTypeMismatch: public virtual std::exception
    {
 public:
+   StreamMessageTypeMismatch() : _message("JITServer/JITClient message type mismatch detected") { }
    StreamMessageTypeMismatch(MessageType serverType, MessageType clientType)
       {
-      _message = "server expected mesasge type " + std::to_string(serverType) + " received " + std::to_string(clientType);
+      _message = "JITServer expected mesasge type " + std::to_string(serverType) + " received " + std::to_string(clientType);
       }
    virtual const char* what() const throw() 
       {
@@ -91,10 +108,10 @@ private:
 class StreamVersionIncompatible: public virtual std::exception
    {
 public:
-   StreamVersionIncompatible() : _message("client/server incompatibility detected") { }
+   StreamVersionIncompatible() : _message("JITServer/JITClient incompatibility detected") { }
    StreamVersionIncompatible(uint64_t serverVersion, uint64_t clientVersion)
       {
-      _message = "server expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
+      _message = "JITServer expected version " + std::to_string(serverVersion) + " received " + std::to_string(clientVersion);
       }
    virtual const char* what() const throw()
       {
@@ -113,7 +130,7 @@ public:
 class ServerCompilationFailure: public virtual std::exception
    {
 public:
-   ServerCompilationFailure() : _message("Generic JITaaS server compilation failure") { }
+   ServerCompilationFailure() : _message("Generic JITServer compilation failure") { }
    ServerCompilationFailure(const std::string &message) : _message(message) { }
    virtual const char* what() const throw() { return _message.c_str(); }
 private:

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -47,13 +47,15 @@ message AnyData
 
 enum MessageType
    {
-   compilationCode = 0;
-   mirrorResolvedJ9Method = 1;
-   get_params_to_construct_TR_j9method = 2;
-   getUnloadedClassRanges = 3;
-   compilationRequest = 4; // type used when client sends remote compilation requests
-   compilationAbort = 5; // type used when client informs the server to abort the remote compilation
-   clientTerminate = 6; // type used when client process is about to terminate
+   compilationCode = 0; // Send the compiled code back to the client
+   compilationFailure = 1;
+   mirrorResolvedJ9Method = 2;
+   get_params_to_construct_TR_j9method = 3;
+   getUnloadedClassRanges = 4;
+   compilationRequest = 5; // type used when client sends remote compilation requests
+   compilationInterrupted = 6; // type used when client informs the server to abort the remote compilation
+   clientSessionTerminate = 7; // type used when client process is about to terminate
+   connectionTerminate = 8; // type used when client informs the server to close the connection
 
    // For TR_ResolvedJ9JITaaSServerMethod methods
    ResolvedMethod_isJNINative = 100;
@@ -227,6 +229,8 @@ enum MessageType
    VM_getClassFromCP = 304;
    VM_getROMMethodFromRAMMethod = 305;
    VM_getReferenceFieldAt = 306;
+   VM_getJ2IThunk = 307;
+   VM_needsInvokeExactJ2IThunk = 308;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -32,8 +32,8 @@ void J9CompileDispatcher::compile(JITServer::ServerStream *stream)
    TR::CompilationInfo * compInfo = getCompilationInfo(_jitConfig);
 
    TR_MethodToBeCompiled *entry = NULL;
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server received request for stream %p", stream);
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Server received request for stream %p", stream);
       {
       // Grab the compilation monitor to queue this entry and notify a compilation thread
       OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
@@ -45,5 +45,5 @@ void J9CompileDispatcher::compile(JITServer::ServerStream *stream)
          }
       } // end critical section
    // If we reached this point there was a memory allocation failure
-   stream->finishCompilation(compilationLowPhysicalMemory);
+   stream->writeError(compilationLowPhysicalMemory);
    }

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -68,8 +68,8 @@ static int32_t J9THREAD_PROC listenerThreadProc(void * entryarg)
 
    // Note: the following code will never be executed, because 
    // serveRemoteCompilationRequests() is executed "forever"
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Detaching JITaaSServer listening thread");
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Detaching JITServer listening thread");
 
    vm->internalVMFunctions->DetachCurrentThread((JavaVM *) vm);
    listener->getListenerMonitor()->enter();


### PR DESCRIPTION
This merge is to pick up the JITaaS name replacement
change from #6643. JITaaS is being removed in eclipse/omr#4209.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>