### PR TITLE
Reject jcmd/jmap invalid command arguments

### DIFF
--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jmap.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jmap.java
@@ -120,21 +120,37 @@ public class Jmap {
 		int optionsSelected = 0;
 		String errorMessage = null;
 		vmids = new ArrayList<>();
-		for (String a : args) {
-			if (!a.startsWith("-")) {
-				vmids.add(a);
-			} else if (a.startsWith("-histo")) {
-				histo = true;
-				optionsSelected += 1;
-				if (a.endsWith(":live")) {
-					live = true;
-				}
+		for (String arg : args) {
+			if (!arg.startsWith("-")) {
+				vmids.add(arg);
 			} else {
-				errorMessage = "unrecognized option " + a;
-				break;
+				boolean invalidArg = false;
+				String[] parts = arg.split(":");
+				if (parts.length > 2) {
+					invalidArg = true;
+				} else if ("-histo".equalsIgnoreCase(parts[0])) {
+					if (parts.length == 2) {
+						if ("live".equalsIgnoreCase(parts[1])) {
+							live = true;
+						} else {
+							invalidArg = true;
+						}
+					}
+					if (!invalidArg) {
+						histo = true;
+						optionsSelected += 1;
+					}
+				} else {
+					invalidArg = true;
+				}
+				
+				if (invalidArg) {
+					errorMessage = "unrecognized option " + arg;
+					break;
+				}
 			}
 		}
-		if (1 != optionsSelected) {
+		if ((errorMessage == null) && (optionsSelected != 1)) {
 			errorMessage = "exactly one option must be selected";
 		}
 		if (null != errorMessage) {

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -82,7 +82,7 @@ public class TestJcmd extends AttachApiTest {
 		for (String helpOption : HELP_OPTIONS) {
 			List<String> jcmdOutput = runCommandAndLogOutput(Collections.singletonList(helpOption));
 			/* Sample of the text from Jcmd.HELPTEXT */
-			String expectedString = "run diagnostic command"; //$NON-NLS-1$
+			String expectedString = "list JVM processes on the local machine."; //$NON-NLS-1$
 			Optional<String> searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
 			assertTrue(searchResult.isPresent(), "Help text corrupt: " + jcmdOutput); //$NON-NLS-1$
 		}
@@ -165,7 +165,7 @@ public class TestJcmd extends AttachApiTest {
 		List<String> args = new ArrayList<>();
 		args.add(getVmId());
 		args.add(GC_CLASS_HISTOGRAM);
-		args.add("-all"); //$NON-NLS-1$
+		args.add("all"); //$NON-NLS-1$
 		List<String> jcmdOutput = runCommandAndLogOutput(args);
 		String expectedString = commandExpectedOutputs.getOrDefault(GC_CLASS_HISTOGRAM, "Test error: expected output not defined"); //$NON-NLS-1$
 		log("Expected string: " + expectedString); //$NON-NLS-1$


### PR DESCRIPTION
#### Reject jcmd/jmap invalid command arguments ####

`jcmd` exits when `jcmd <vmid> GC.class_histogram` followed by invalid arguments those are not `live` or `all`;
`jmap` accepts `-histo[:live]` and exits when invalid arguments are specified.

closes: #6781 
Fixes #6816

Reviewer: @pshipton 
FYI: @pdbain-ibm @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>