### PR TITLE
Fix memory leak in archetypeArgPlaceholderSlot

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1345,11 +1345,11 @@ J9::SymbolReferenceTable::isReturnTypeBool(TR::SymbolReference *symRef)
    return isSignatureReturnTypeBool(methodSignature, len);
    }
 
-static bool parmSlotCameFromExpandingAnArchetypeArgPlaceholder(int32_t slot, TR::ResolvedMethodSymbol *sym, TR_Memory *mem)
+static bool parmSlotCameFromExpandingAnArchetypeArgPlaceholder(int32_t slot, TR::ResolvedMethodSymbol *sym)
    {
-   TR_ResolvedMethod *meth = sym->getResolvedMethod();
+   TR_ResolvedJ9Method *meth = (TR_ResolvedJ9Method *) sym->getResolvedMethod();
    if (meth->convertToMethod()->isArchetypeSpecimen())
-      return slot >= meth->archetypeArgPlaceholderSlot(mem);
+      return slot >= meth->archetypeArgPlaceholderSlot();
    else
       return false;
    }
@@ -1370,7 +1370,7 @@ J9::SymbolReferenceTable::addParameters(TR::ResolvedMethodSymbol * methodSymbol)
       else
          symRef = createTempSymRefWithKnownObject(p, index, p->getSlot(), knownObjectIndex);
       methodSymbol->setParmSymRef(p->getSlot(), symRef);
-      if (!parmSlotCameFromExpandingAnArchetypeArgPlaceholder(p->getSlot(), methodSymbol, trMemory()))
+      if (!parmSlotCameFromExpandingAnArchetypeArgPlaceholder(p->getSlot(), methodSymbol))
          methodSymbol->getAutoSymRefs(p->getSlot()).add(symRef);
       }
    }
@@ -2171,7 +2171,7 @@ J9::SymbolReferenceTable::createParameterSymbol(
       symRef = createTempSymRefWithKnownObject(sym,  owningMethodSymbol->getResolvedMethodIndex(), slot, knownObjectIndex);
 
    owningMethodSymbol->setParmSymRef(slot, symRef);
-   if (!parmSlotCameFromExpandingAnArchetypeArgPlaceholder(slot, owningMethodSymbol, trMemory()))
+   if (!parmSlotCameFromExpandingAnArchetypeArgPlaceholder(slot, owningMethodSymbol))
       owningMethodSymbol->getAutoSymRefs(slot).add(symRef);
 
    return sym;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5227,16 +5227,30 @@ TR_ResolvedJ9Method::numberOfParameterSlots()
    }
 
 U_16
-TR_ResolvedJ9Method::archetypeArgPlaceholderSlot(TR_Memory *mem)
+TR_ResolvedJ9Method::archetypeArgPlaceholderSlot()
    {
    TR_ASSERT(isArchetypeSpecimen(), "should not be called for non-ArchetypeSpecimen methods");
-   // Note that this creates and discards a TR_ResolvedMethod, so it leaks heap memory.
-   // TODO: Need a better implementation.  Probably should just re-parse the archetype's signature.
-   // Then we won't need the TR_Memory argument anymore either.
-   //
-   TR_ResolvedMethod *archetype = fej9()->createResolvedMethod(mem, getNonPersistentIdentifier());
-   //TR_ASSERT(((TR_ResolvedMethod*)this)->numberOfParameterSlots() == archetype->numberOfParameterSlots(), "not equal %d %d", ((TR_ResolvedMethod*)this)->numberOfParameterSlots(), archetype->numberOfParameterSlots());
-   return archetype->numberOfParameterSlots() - 1; // "-1" because the placeholder is a 1-slot type (int)
+   TR_OpaqueMethodBlock * aMethod = getNonPersistentIdentifier();
+   J9ROMMethod * romMethod;
+
+      {
+      TR::VMAccessCriticalSection j9method(_fe);
+      romMethod = getOriginalROMMethod((J9Method *)aMethod);
+      }
+
+   J9ROMClass *romClass = J9_CLASS_FROM_METHOD(((J9Method *)aMethod))->romClass;
+   J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(romMethod);
+
+   U_8 tempArgTypes[256];
+   uintptr_t    paramElements;
+   uintptr_t    paramSlots;
+   jitParseSignature(signature, tempArgTypes, &paramElements, &paramSlots);
+   /*
+    * result should be : paramSlot + 1 -1 = paramSlot
+    * +1 :thunk archetype are always virtual method and has a receiver
+    * -1 :the placeholder is a 1-slot type (int)
+    */
+   return paramSlots;
    }
 
 U_16

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -314,7 +314,7 @@ public:
    virtual bool                  isSameMethod(TR_ResolvedMethod *);
 
    virtual uint16_t              numberOfParameterSlots();
-   virtual uint16_t              archetypeArgPlaceholderSlot(TR_Memory *);
+   virtual uint16_t              archetypeArgPlaceholderSlot();
    virtual uint16_t              numberOfTemps();
    virtual uint16_t              numberOfPendingPushes();
 


### PR DESCRIPTION
We shouldn't need to create a new TR_ResolvedMethod just for calculating
the place holder argument slot. Doing so results in memory leak and also
causes problem when the method being created is AOT compiled. Fix the
code to get the place holder slot index by parsing the ROM method
signature.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>