### PR TITLE
Fix testSCCMLTests1_0 to work for also 32 bit machines

### DIFF
--- a/runtime/bcutil/j9bcu.tdf
+++ b/runtime/bcutil/j9bcu.tdf
@@ -373,4 +373,4 @@ TraceException=Trc_BCU_j9bcutil_readClassFileBytes_MaxCPCount NoEnv Overhead=1 L
 
 TraceException=Trc_BCU_internalDefineClass_orphanNotFound Overhead=1 Level=1 Template="orphan ROM class %p not found in table, table entry was %p"
 
-TraceEvent=Trc_BCU_compareROMClassForEquality_event NoEnv Overhead=1 Level=7 Template="compareROMClassForEquality returns %d for class name %.*s"
+TraceEvent=Trc_BCU_compareROMClassForEquality_event NoEnv Overhead=1 Level=7 Template="compareROMClassForEquality returns %d for class name '%.*s'"

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -1052,10 +1052,10 @@
 	</test>
 	
 	<test id="Test 57-a: Make sure that lambda classes work and get stored in the shared class cache" timeout="600" runPath=".">
-    	<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
-    	<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-   		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
     
    		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
    		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -1063,40 +1063,40 @@
 	</test>
 
 	<test id="Test 57-b: Make sure that lambda classes are stored in the cache as orphans" timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
-	    <output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000 at</output>
-	    <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000 at</output>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) at</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) at</output>
 	    
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 57-c: Make sure that when the program runs again lambda classes are used from the cache and not stored again " timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
-	    <output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
 	    
-	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	
 	<test id="Test 58: Make sure that when the program runs again without the first lambda class, the second lambda class is still used from the cache and not stored again " timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 1</command>
-	    <output type="success" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 1</command>
+		<output type="success" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
 	    
-	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 58 clean-up" timeout="600" runPath=".">
@@ -1114,28 +1114,28 @@
 	</test>
 	
 	<test id="Test 59-a: Run and store 10 lambda classes in the cache " timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 2</command>
-	    <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 2</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
 	    
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 59-b: Do not run the first lambda class to check if a class with 1 digit index number gets matched to the one stored in the cache but with 2 digits index number (10th class in the previous run will be matched to 9th in this run)" timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 3</command>
-	    <output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>	    
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 3</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
 	    
-	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 59 clean-up" timeout="600" runPath=".">
@@ -1153,31 +1153,31 @@
 	</test>
 	
 	<test id="Test 60-a: Make sure that lambda classes work and get stored in the cache when another function with lambda classes in another file is being called from the current file " timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 4</command>
-	    <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} $CP_HANOI$ $PROGRAM_LAMBDA$ 4</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
 	    
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 60-b: Make sure that the classes are used from the cache when the the program is being run again" timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 4</command>
-	    <output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>    
-	    <output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
-	    <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/0000000000000000</output>  
-	    <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259,j9bcu.270} $CP_HANOI$ $PROGRAM_LAMBDA$ 4</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">compareROMClassForEquality returns 1 for class name 'org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000)'</output>
 	    
-	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test2..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 60 clean-up" timeout="600" runPath=".">
@@ -1195,25 +1195,25 @@
 	</test>
 	
 	<test id="Test 61-a: Make sure that when shared lambdas are disabled, no lambda classes are stored in the cache " timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} -XX:-ShareAnonymousClasses $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
-	    <output type="success" caseSensitive="yes" regex="no">Lambda test done!</output>
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2259} -XX:-ShareAnonymousClasses $CP_HANOI$ $PROGRAM_LAMBDA$ 0</command>
+		<output type="success" caseSensitive="yes" regex="no">Lambda test done!</output>
 
-	    <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000</output>
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9shr[\.]2259     > API j9shr_classStoreTransaction_createSharedClass : enter [\(]classname=org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) </output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<test id="Test 61-b: Make sure that no lambda classes are in the cache" timeout="600" runPath=".">
-	    <command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
-	    <output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1 at</output>
-	   
-	    <output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/0000000000000000 at</output> 
-	    <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	    <output type="failure" caseSensitive="no" regex="no">corrupt</output>
-	    <output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<command>$JAVA_EXE$ $currentMode$,printstats=orphan</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1 at</output>
+
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">ORPHAN: org/openj9/test/lambdatests/Test1..Lambda.([\d]+)/(00000000|0000000000000000) at</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
 	<test id="At end destroy cache for cleanup" timeout="600" runPath=".">

--- a/test/functional/cmdLineTests/utils/src/org/openj9/test/lambdatests/Test1.java
+++ b/test/functional/cmdLineTests/utils/src/org/openj9/test/lambdatests/Test1.java
@@ -39,22 +39,22 @@ public class Test1 {
     
     public static void main(String[] args) {
         
-		int input = 0;
-		boolean inputError = false;
+        int input = 0;
+        boolean inputError = false;
 
-		if (args.length > 0) {
-			try {
-				input = Integer.parseInt(args[0]);
-			} catch (NumberFormatException localNumberFormatException) {
-				inputError = true;
-			}
-		}
-		if ((inputError | input < 0 | input > 4)) {
-			System.out.println("Invalid argument");
-			input = 0;
-		}
-		
-    	if (input < 2) {
+        if (args.length > 0) {
+            try {
+                input = Integer.parseInt(args[0]);
+            } catch (NumberFormatException localNumberFormatException) {
+                inputError = true;
+            }
+        }
+        if ((inputError | input < 0 | input > 4)) {
+            System.out.println("Invalid argument");
+            input = 0;
+        }
+
+        if (input < 2) {
             if (0 == input) {
                 Comparator<String> stringComparatorLambda = (String o1, String o2) -> {
                     return o1.compareTo(o2) + o2.compareTo(o1) + 15 + (int)Math.sqrt(122324);
@@ -63,11 +63,11 @@ public class Test1 {
                 System.out.println(lambdaComparison);
             }
     		
-    		Comparator<String> stringComparatorLambda2 = (String o1, String o2) -> {
-    			return o1.compareTo(o2) + 42 + (int)Math.toRadians(95402.134);
-    		};
-    		int lambdaComparison2 = stringComparatorLambda2.compare("qqqsdasfds", "dsfkopvwqp");
-    		System.out.println(lambdaComparison2);
+            Comparator<String> stringComparatorLambda2 = (String o1, String o2) -> {
+                return o1.compareTo(o2) + 42 + (int)Math.toRadians(95402.134);
+            };
+            int lambdaComparison2 = stringComparatorLambda2.compare("qqqsdasfds", "dsfkopvwqp");
+            System.out.println(lambdaComparison2);
     	} else if (input < 4) {
             
             int x = 99;
@@ -136,23 +136,22 @@ public class Test1 {
             System.out.println(lambdaComparison10);
     	} else {
             int x = 99;
-    		Comparator<String> stringComparatorLambda = (String o1, String o2) -> {
-    			return str1.compareTo(o1) + o1.compareTo(o2) + o2.compareTo(o1) + 15 + x;
-    		};
-    		int lambdaComparison = stringComparatorLambda.compare("world", "hello");
-    		System.out.println(lambdaComparison);
-    		
-    		Test2 tobj = new Test2();
+            Comparator<String> stringComparatorLambda = (String o1, String o2) -> {
+                return str1.compareTo(o1) + o1.compareTo(o2) + o2.compareTo(o1) + 15 + x;
+            };
+            int lambdaComparison = stringComparatorLambda.compare("world", "hello");
+            System.out.println(lambdaComparison);
+
+            Test2 tobj = new Test2();
             tobj.func();
             
-    		Comparator<String> stringComparatorLambda2 = (String o1, String o2) -> {
-    			return str1.compareTo(o1) + o1.compareTo(o2) + o2.compareTo(o1) + 42 + x;
-    		};
-    		int lambdaComparison2 = stringComparatorLambda2.compare("qqqsdasfds", "dsfkopvwqp");
-    		System.out.println(lambdaComparison2);
-    	}
+            Comparator<String> stringComparatorLambda2 = (String o1, String o2) -> {
+                return str1.compareTo(o1) + o1.compareTo(o2) + o2.compareTo(o1) + 42 + x;
+            };
+            int lambdaComparison2 = stringComparatorLambda2.compare("qqqsdasfds", "dsfkopvwqp");
+            System.out.println(lambdaComparison2);
+        }
         
         System.out.println("Lambda test done!");
     }
 }
-


### PR DESCRIPTION
Fix the test to check for either 8 zeros or 16 zeros at the end of lambda class name because it depends if the machine is 32 bits or 64 bits and fix indentations

Fixes #6801

Signed-off-by: sogutbera <sogutbera@ibm.com>