### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -1362,7 +1362,7 @@ readdWide:
 		case JBsyncReturn0: /* Fall-through */
 		case JBsyncReturn1: /* Fall-through */
 		case JBsyncReturn2: {
-			J9UTF8 * signature = J9ROMMETHOD_GET_SIGNATURE(_romClass, method);
+			J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(method);
 			U_8 * sigData = J9UTF8_DATA(signature);
 			U_16 sigLength = J9UTF8_LENGTH(signature);
 

--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -220,10 +220,10 @@ buildBranchMap (J9BytecodeVerificationData * verifyData)
 			Trc_BCV_buildBranchMap_UnknownInstruction(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 					bc, verifyData->errorPC, verifyData->errorPC);
 			return BCV_ERR_INTERNAL_ERROR;
 		}
@@ -314,10 +314,10 @@ buildBranchMap (J9BytecodeVerificationData * verifyData)
 	Trc_BCV_buildBranchMap_branchCount(verifyData->vmStruct,
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 			J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 			count);
 
 	return count;
@@ -399,10 +399,10 @@ decompressStackMaps (J9BytecodeVerificationData * verifyData, IDATA localsCount,
 			Trc_BCV_decompressStackMaps_LocalsArrayOverFlowUnderFlow(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 					i, mapPC);
 			rc = BCV_FAIL;
 			break;
@@ -421,10 +421,10 @@ decompressStackMaps (J9BytecodeVerificationData * verifyData, IDATA localsCount,
 			Trc_BCV_decompressStackMaps_StackArrayOverFlow(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 					i, mapPC);
 			rc = BCV_FAIL;
 			break;
@@ -436,10 +436,10 @@ decompressStackMaps (J9BytecodeVerificationData * verifyData, IDATA localsCount,
 			Trc_BCV_decompressStackMaps_MapOutOfRange(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 					i, mapPC, length);
 			rc = BCV_FAIL;
 			break;
@@ -529,10 +529,10 @@ _underflow:
 	Trc_BCV_parseLocals_LocalsArrayUnderFlow(verifyData->vmStruct,
 		(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 		J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
 	return BCV_ERR_INTERNAL_ERROR;
 
 _overflow:
@@ -546,10 +546,10 @@ _overflow:
 	Trc_BCV_parseLocals_LocalsArrayOverFlow(verifyData->vmStruct,
 		(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 		J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
 	return BCV_ERR_INTERNAL_ERROR;
 }
 
@@ -695,20 +695,20 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 			Trc_BCV_mergeObjectTypes_UnableToLoadClass(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				sourceType, targetType);
 			return (IDATA) BCV_FAIL;
 		} else if (BCV_ERR_INSUFFICIENT_MEMORY == reasonCode) {
 			Trc_BCV_mergeObjectTypes_MergeClasses_OutOfMemoryException(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
 			return BCV_ERR_INSUFFICIENT_MEMORY;
 		}
 	}
@@ -720,10 +720,10 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 		Trc_BCV_mergeObjectTypes_NullTargetOverwritten(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				sourceType);
 		*targetTypePointer = sourceType;
 		/* cause a re-walk */
@@ -736,10 +736,10 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 		Trc_BCV_mergeObjectTypes_DecaySourceArray(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				sourceType);
 		sourceType = (sourceType & BCV_ARITY_MASK) | ((U_32)BCV_JAVA_LANG_OBJECT_INDEX << BCV_CLASS_INDEX_SHIFT);
 	}
@@ -748,10 +748,10 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 		Trc_BCV_mergeObjectTypes_DecayTargetArray(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				targetType);
 		targetType = (targetType & BCV_ARITY_MASK) | ((U_32)BCV_JAVA_LANG_OBJECT_INDEX << BCV_CLASS_INDEX_SHIFT);
 	}
@@ -792,19 +792,19 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
  				Trc_BCV_mergeObjectTypes_MergeClasses_OutOfMemoryException(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
  				return BCV_ERR_INSUFFICIENT_MEMORY;
  			} else {
  				Trc_BCV_mergeObjectTypes_MergeClassesFail(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 					sourceLength, sourceName, targetLength, targetName);
  				*targetTypePointer = sourceType;
  				/* cause a re-walk */
@@ -816,10 +816,10 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 		Trc_BCV_mergeObjectTypes_MergeClassesSucceed(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				sourceLength, sourceName, targetLength, targetName, J9UTF8_LENGTH(name), J9UTF8_DATA(name), classIndex);
 
 	} else {
@@ -830,10 +830,10 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 		Trc_BCV_mergeObjectTypes_MergeClassesMinimumArity(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				classArity, targetArity);
 		/* Find minimum common arity of arrays */ 
 		if( targetArity < classArity ) {
@@ -846,10 +846,10 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 	Trc_BCV_mergeObjectTypes_MergedClass(verifyData->vmStruct,
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 			J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 			*targetTypePointer);
 	/* cause a re-walk */
 	return (IDATA) BCV_FAIL;
@@ -881,10 +881,10 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 	Trc_BCV_mergeStacks_Entry(verifyData->vmStruct,
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 			J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 			target, target);
 
 	if (targetStack->stackBaseIndex == -1) {
@@ -897,10 +897,10 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 		Trc_BCV_mergeStacks_CopyStack(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				stackIndex, target, target);
 		goto _finished;
 
@@ -914,10 +914,10 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 			Trc_BCV_mergeStacks_DepthMismatch(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 					stackIndex, target, target,
 					liveStack->stackTopIndex, targetStack->stackTopIndex);
 			goto _finished;
@@ -935,10 +935,10 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 		Trc_BCV_mergeStacks_MergeStacks(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				stackIndex, target, target);
 
 		while (sourceStackPtr != sourceStackTop) {
@@ -1003,20 +1003,20 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 										Trc_BCV_mergeStacks_OptMergeRequired(verifyData->vmStruct,
 												(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 												J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-												J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-												J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+												J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+												J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 												origSource, origTarget, *targetStackPtr);
 
 									} else {
 										Trc_BCV_mergeStacks_OptMergeNotRequired(verifyData->vmStruct,
 												(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 												J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-												J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-												J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+												J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+												J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 												*sourceStackPtr, *targetStackPtr);
 										/* Tag undefined - local variable is dead */
 										*targetStackPtr = (UDATA) (BCV_BASE_TYPE_TOP);
@@ -1062,10 +1062,10 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 			Trc_BCV_mergeStacks_QueueForRewalk(verifyData->vmStruct,
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 					target, target);
 			verifyData->rewalkQueue[verifyData->rewalkQueueTail++] = target;
 			verifyData->rewalkQueueTail %= (verifyData->rootQueueSize / sizeof(UDATA));
@@ -1079,10 +1079,10 @@ _finished:
 	Trc_BCV_mergeStacks_Exit(verifyData->vmStruct,
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 			J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 			rc);
 
 	return rc;
@@ -1117,7 +1117,7 @@ printMethod (J9BytecodeVerificationData * verifyData)
 	}
   
 	/* Return type. */
-	string = J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, method));
+	string = J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(method));
 	i = 0;
 	while(string[i++] != ')');
 	arity = 0;
@@ -1172,7 +1172,7 @@ printMethod (J9BytecodeVerificationData * verifyData)
 	for(i = 0; i < arity; i++)
 		printf( "[]");
 
-	printf( " %.*s(", J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, method)), J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, method)));
+	printf( " %.*s(", J9UTF8_LENGTH(J9ROMMETHOD_NAME(method)), J9UTF8_DATA(J9ROMMETHOD_NAME(method)));
 
 	for(i = 1; string[i] != ')'; i++)
 	{
@@ -1981,10 +1981,10 @@ _checkFinished:
 			Trc_BCV_simulateStack_NewWalkFrom(verifyData->vmStruct, 
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 					start, start, pc, pc);
 		} else if (verifyData->rewalkQueueHead != verifyData->rewalkQueueTail) {
 			pc = verifyData->rewalkQueue[verifyData->rewalkQueueHead++];
@@ -2002,10 +2002,10 @@ _checkFinished:
 			Trc_BCV_simulateStack_RewalkFrom(verifyData->vmStruct, 
 					(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 					J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-					J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+					(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+					J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 					start, start, pc, pc);
 		} else {
 			Trc_BCV_simulateStack_Exit(verifyData->vmStruct);
@@ -2028,10 +2028,10 @@ _verifyError:
 	Trc_BCV_simulateStack_verifyErrorBytecode(verifyData->vmStruct,
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 			J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 			verifyData->errorCode, verifyData->errorPC, verifyData->errorPC, bc);
 	Trc_BCV_simulateStack_Exit(verifyData->vmStruct);
 
@@ -2046,10 +2046,10 @@ _outOfMemoryError:
 	Trc_BCV_simulateStack_verifyErrorBytecode_OutOfMemoryException(verifyData->vmStruct,
 		(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 		J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 		verifyData->errorCode, verifyData->errorPC, verifyData->errorPC, bc);
 	Trc_BCV_simulateStack_Exit(verifyData->vmStruct);
 
@@ -2420,10 +2420,10 @@ j9bcv_verifyBytecodes (J9PortLibrary * portLib, J9Class * clazz, J9ROMClass * ro
 		Trc_BCV_j9bcv_verifyBytecodes_VerifyMethod(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH((J9ROMCLASS_CLASSNAME(romClass))),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)),
-				(UDATA) J9UTF8_LENGTH((J9ROMMETHOD_GET_NAME(romClass, romMethod))),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-				(UDATA) J9UTF8_LENGTH((J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod))),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
+				(UDATA) J9UTF8_LENGTH((J9ROMMETHOD_NAME(romMethod))),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+				(UDATA) J9UTF8_LENGTH((J9ROMMETHOD_SIGNATURE(romMethod))),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 				romMethod->modifiers);
 
 		/* If native or abstract method, do nothing */
@@ -2585,10 +2585,10 @@ _fallBack:
 					Trc_BCV_j9bcv_verifyBytecodes_ReverifyMethod(verifyData->vmStruct,
 							(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)),
 							J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 
 					/* retry with ignoreStackMaps enabled */
 					verifyData->ignoreStackMaps = TRUE;
@@ -2612,10 +2612,10 @@ _done:
 		Trc_BCV_j9bcv_verifyBytecodes_OutOfMemory(verifyData->vmStruct, 
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, romMethod)));
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 	}
 
 	if (verboseVerification) {

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -240,10 +240,10 @@ findAndMatchStack (J9BytecodeVerificationData *verifyData, IDATA targetPC, IDATA
 		Trc_RTV_findAndMatchStack_StackNotFound(verifyData->vmStruct, 
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				targetPC);
 		rc = BCV_FAIL;
 		verifyData->errorDetailCode = BCV_ERR_EXPECT_STACKMAP_FRAME;
@@ -286,10 +286,10 @@ matchStack(J9BytecodeVerificationData * verifyData, J9BranchTargetStack *liveSta
 		Trc_RTV_matchStack_DepthMismatchException(verifyData->vmStruct,
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				size, targetStack->stackTopIndex);
 		rc = BCV_FAIL; /* fail - stack depth mismatch */
 		verifyData->errorDetailCode = BCV_ERR_STACK_SIZE_MISMATCH;
@@ -329,20 +329,20 @@ matchStack(J9BytecodeVerificationData * verifyData, J9BranchTargetStack *liveSta
 						Trc_RTV_matchStack_OutOfMemoryException(verifyData->vmStruct,
 							(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 							J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
 						rc = BCV_ERR_INSUFFICIENT_MEMORY;
 						goto _finished;
 					} else {
 						Trc_RTV_matchStack_IncompatibleClassException(verifyData->vmStruct,
 								(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 								J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-								J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-								J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+								J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+								J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 								(livePtr - liveStack->stackElements), *livePtr, *targetPtr);
 						rc = BCV_FAIL; /* fail - object type mismatch*/
 						goto _incompatibleType;
@@ -352,10 +352,10 @@ matchStack(J9BytecodeVerificationData * verifyData, J9BranchTargetStack *liveSta
 				Trc_RTV_matchStack_PrimitiveMismatchException(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 						(livePtr - liveStack->stackElements), *livePtr, *targetPtr);
 				rc = BCV_FAIL; /* fail - primitive or special mismatch */
 				goto _incompatibleType;
@@ -469,10 +469,10 @@ verifyBytecodes (J9BytecodeVerificationData * verifyData)
 	BOOLEAN isNextStack = FALSE;
 
 	Trc_RTV_verifyBytecodes_Entry(verifyData->vmStruct, 
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 
 	pc = 0;
 
@@ -1152,7 +1152,7 @@ _inconsistentStack2:
 			break;
 
 		case RTV_RETURN:
-			utf8string = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+			utf8string = J9ROMMETHOD_SIGNATURE(romMethod);
 			temp = &J9UTF8_DATA(utf8string)[J9UTF8_LENGTH(utf8string) - 2];
 			returnChar = (UDATA) temp[1];
 			if (temp[0] != ')') {
@@ -1221,10 +1221,10 @@ _illegalPrimitiveReturn:
 							Trc_RTV_j9rtv_verifyBytecodes_Unreachable(verifyData->vmStruct,
 								(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 								J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-								J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-								J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+								J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+								(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+								J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 								__LINE__);
 							break;
 						}
@@ -2402,19 +2402,19 @@ _verifyError:
 
 	Trc_RTV_verifyBytecodes_VerifyError(verifyData->vmStruct,
 		errorType, 
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 		start);
 
 	Trc_RTV_verifyBytecodes_VerifyErrorBytecode(verifyData->vmStruct, 
 		(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 		J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 		errorType, start, start, *(code + start));
 	BUILD_VERIFY_ERROR(errorModule, errorType);
 
@@ -2429,10 +2429,10 @@ _outOfMemoryError:
 	errorType = J9NLS_BCV_ERR_VERIFY_OUT_OF_MEMORY__ID;
 	Trc_RTV_verifyBytecodes_OutOfMemoryException(verifyData->vmStruct,
 		errorType,
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+		(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 		start);
 	BUILD_VERIFY_ERROR(errorModule, errorType);
 	return BCV_ERR_INSUFFICIENT_MEMORY;
@@ -2458,10 +2458,10 @@ verifyExceptions (J9BytecodeVerificationData *verifyData)
 	IDATA reasonCode = 0;
 
 	Trc_RTV_verifyExceptions_Entry(verifyData->vmStruct, 
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 	
 	/* Verify catch types are throwable */
 	exceptionInfo = J9_EXCEPTION_DATA_FROM_ROM_METHOD(romMethod);
@@ -2480,20 +2480,20 @@ verifyExceptions (J9BytecodeVerificationData *verifyData)
 					Trc_RTV_verifyExceptions_OutOfMemoryException(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 					rc = BCV_ERR_INSUFFICIENT_MEMORY;
 					break;
 				} else {
 					Trc_RTV_verifyExceptions_VerifyError(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 						i, J9UTF8_LENGTH(catchName), J9UTF8_DATA(catchName));
 					rc = BCV_FAIL;
 					break;
@@ -2584,10 +2584,10 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 					Trc_RTV_j9rtv_verifyArguments_Unreachable(verifyData->vmStruct, 
 							(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 							J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 							__LINE__);
 					mrc = BCV_FAIL;
 					break;
@@ -2601,10 +2601,10 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 					Trc_RTV_j9rtv_verifyArguments_Unreachable(verifyData->vmStruct, 
 							(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 							J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 							__LINE__);
 					mrc = BCV_FAIL;
 					break;
@@ -2623,30 +2623,30 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 					Trc_RTV_j9rtv_verifyArguments_OutOfMemoryException(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
 					mrc = BCV_ERR_INSUFFICIENT_MEMORY;
 					break;
 				} else if (BCV_ERR_INACCESSIBLE_CLASS == reasonCode) {
 					Trc_RTV_j9rtv_verifyArguments_InaccessibleClass(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)));
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)));
 					mrc = BCV_ERR_INACCESSIBLE_CLASS;
 					break;
 				} else {
 					Trc_RTV_j9rtv_verifyArguments_ObjectMismatch(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 						index, J9UTF8_LENGTH(utf8string), J9UTF8_DATA(utf8string), stackTop[index]);
 					mrc = BCV_FAIL;
 					verifyData->errorDetailCode = BCV_ERR_INCOMPATIBLE_TYPE; /* failure - object type mismatch */
@@ -2663,10 +2663,10 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 				Trc_RTV_j9rtv_verifyArguments_Unreachable(verifyData->vmStruct,
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 						__LINE__);
 				mrc = BCV_FAIL;
 				break;
@@ -2689,10 +2689,10 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 				Trc_RTV_j9rtv_verifyArguments_Unreachable(verifyData->vmStruct, 
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 						__LINE__);
 				mrc = BCV_FAIL;
 				break;
@@ -2702,10 +2702,10 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 				Trc_RTV_j9rtv_verifyArguments_PrimitiveMismatch(verifyData->vmStruct, 
 						(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-						J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 						index, J9UTF8_LENGTH(utf8string), J9UTF8_DATA(utf8string), stackTop[index]);
 				mrc = BCV_FAIL;
 				verifyData->errorDetailCode = BCV_ERR_INCOMPATIBLE_TYPE; /* failure - primitive mismatch */
@@ -2719,10 +2719,10 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 					Trc_RTV_j9rtv_verifyArguments_WidePrimitiveMismatch(verifyData->vmStruct, 
 							(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 							J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-							J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+							J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 							index, J9UTF8_LENGTH(utf8string), J9UTF8_DATA(utf8string));
 					mrc = BCV_FAIL;
 					verifyData->errorDetailCode = BCV_ERR_INCOMPATIBLE_TYPE; /* failure - wide primitive mismatch */
@@ -2770,10 +2770,10 @@ nextStack (J9BytecodeVerificationData *verifyData, UDATA *nextMapIndex, IDATA *n
 	Trc_RTV_nextStack_Result(verifyData->vmStruct, 
 			(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 			J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+			(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 			verifyData->stackMapsCount, *nextMapIndex, *nextStackPC, 
 			J9_BYTECODE_SIZE_FROM_ROM_METHOD(verifyData->romMethod));
 	return returnStack;
@@ -2802,10 +2802,10 @@ nextExceptionStart (J9BytecodeVerificationData *verifyData, J9ROMMethod *romMeth
 		Trc_RTV_nextExceptionStart_Result(verifyData->vmStruct, 
 				(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
 				J9UTF8_DATA(J9ROMCLASS_CLASSNAME(verifyData->romClass)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_NAME(verifyData->romClass, verifyData->romMethod)),
-				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
-				J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(verifyData->romClass, verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_NAME(verifyData->romMethod)),
+				(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
+				J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(verifyData->romMethod)),
 				exceptionInfo->catchCount, lastPC, nextPC, 
 				J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod));
 	}

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -247,7 +247,7 @@ buildStackFromMethodSignature( J9BytecodeVerificationData *verifyData, UDATA **s
 
 	if ((!(romMethod->modifiers & J9AccStatic)) && (argMax > 0)) {	
 		/* this is a virtual method, an object compatible with this class is on the stack */
-		J9UTF8* utf8string  = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+		J9UTF8* utf8string  = J9ROMMETHOD_NAME(romMethod);
 		J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 
 		classIndex = findClassName(verifyData, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
@@ -265,7 +265,7 @@ buildStackFromMethodSignature( J9BytecodeVerificationData *verifyData, UDATA **s
 
 	/* Walk the signature of the method to determine the arg shape */
 
-	args = J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod));
+	args = J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod));
  
 	for (i = 1; args[i] != ')'; i++) {
 		(*argCount)++;
@@ -796,8 +796,8 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
 	stringLength = strlen(errorString);
 
 	stringLength += J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(error->romClass));
-	stringLength += J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(error->romClass, error->romMethod));
-	stringLength += J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(error->romClass, error->romMethod));
+	stringLength += J9UTF8_LENGTH(J9ROMMETHOD_NAME(error->romMethod));
+	stringLength += J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(error->romMethod));
 	stringLength += 10; /* for the PC */
 	if (NULL != error->errorSignatureString) {
 		stringLength += 10;  /* for the argument index */
@@ -812,8 +812,8 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
 	if (NULL != verifyError) {
 		UDATA errStrLength = 0;
 		J9UTF8 * romClassName = J9ROMCLASS_CLASSNAME(error->romClass);
-		J9UTF8 * romMethodName = J9ROMMETHOD_GET_NAME(error->romClass, error->romMethod);
-		J9UTF8 * romMethodSignatureString = J9ROMMETHOD_GET_SIGNATURE(error->romClass, error->romMethod);
+		J9UTF8 * romMethodName = J9ROMMETHOD_NAME(error->romMethod);
+		J9UTF8 * romMethodSignatureString = J9ROMMETHOD_SIGNATURE(error->romMethod);
 
 		if (NULL == error->errorSignatureString) {
 			errStrLength = j9str_printf(PORTLIB, (char*) verifyError, stringLength, formatString, errorString,

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -5379,15 +5379,15 @@ static void j9_formatMethod(J9ROMClass* romClass, J9ROMMethod* method, char *for
 
 					case 'n':
 						/* method name */
-						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, method));
-						string = ((U_8*) J9ROMMETHOD_GET_NAME(romClass, method)) + 2;
+						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_NAME(method));
+						string = ((U_8*) J9ROMMETHOD_NAME(method)) + 2;
 						for(j = 0; j < utfLength; j++) j9tty_output_char(string[j]);
 						break;
 
 					case 's':
 						/* type signature */
-						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, method));
-						string = ((U_8*) J9ROMMETHOD_GET_SIGNATURE(romClass, method)) + 2;
+						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(method));
+						string = ((U_8*) J9ROMMETHOD_SIGNATURE(method)) + 2;
 						for(j = 0; j < utfLength; j++)
 						{
 							ch2 = string[j];
@@ -5398,8 +5398,8 @@ static void j9_formatMethod(J9ROMClass* romClass, J9ROMMethod* method, char *for
 
 					case 'r':
 						/* qualified return type name */
-						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, method));
-						string = ((U_8*) J9ROMMETHOD_GET_SIGNATURE(romClass, method)) + 2;
+						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(method));
+						string = ((U_8*) J9ROMMETHOD_SIGNATURE(method)) + 2;
 						j = 0;
 						arity = 0;
 						while(string[j++] != ')');
@@ -5463,8 +5463,8 @@ static void j9_formatMethod(J9ROMClass* romClass, J9ROMMethod* method, char *for
 
 					case 'p':
 						/* qualified parameter type names */
-						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, method));
-						string = ((U_8*) J9ROMMETHOD_GET_SIGNATURE(romClass, method)) + 2;
+						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(method));
+						string = ((U_8*) J9ROMMETHOD_SIGNATURE(method)) + 2;
 						j = 1;
 						while(string[j] != ')')
 						{
@@ -5718,15 +5718,15 @@ static void j9_formatBytecode(J9ROMClass* romClass, J9ROMMethod* method, U_8* bc
 
 					case 'n':
 						/* method name */
-						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, method));
-						string = ((U_8*) J9ROMMETHOD_GET_NAME(romClass, method)) + 2;
+						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_NAME(method));
+						string = ((U_8*) J9ROMMETHOD_NAME(method)) + 2;
 						for(j = 0; j < utfLength; j++) j9tty_output_char(string[j]);
 						break;
 
 					case 's':
 						/* type signature */
-						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, method));
-						string = ((U_8*) J9ROMMETHOD_GET_SIGNATURE(romClass, method)) + 2;
+						utfLength = J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(method));
+						string = ((U_8*) J9ROMMETHOD_SIGNATURE(method)) + 2;
 						for(j = 0; j < utfLength; j++)
 						{
 							ch2 = string[j];

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -235,8 +235,8 @@ decompPrintMethod(J9VMThread * currentThread, J9Method * method)
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9UTF8 * className = J9ROMCLASS_CLASSNAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass);
 	J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	J9UTF8 * name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
-	J9UTF8 * sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+	J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+	J9UTF8 * sig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 	Trc_Decomp_printMethod(currentThread, method, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(sig), J9UTF8_DATA(sig));
 }
@@ -908,7 +908,7 @@ decompileOuterFrame(J9VMThread * currentThread, J9JITDecompileState * decompileS
 		j2iFrame->previousJ2iFrame = currentJ2iFrame;
 		currentJ2iFrame = (UDATA *) &(j2iFrame->taggedReturnSP);
 
-		returnChar = (char *) J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, romMethod));
+		returnChar = (char *) J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod));
 		while (*returnChar++ != ')') ;
 		switch(*returnChar) {
 			case 'V':

--- a/runtime/codert_vm/jswalk.c
+++ b/runtime/codert_vm/jswalk.c
@@ -525,8 +525,8 @@ static void jitWalkFrame(J9StackWalkState *walkState, UDATA walkLocals, void *st
 			PORT_ACCESS_FROM_WALKSTATE(walkState);
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState->method);
 			J9UTF8 * className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(walkState->method)->romClass);
-			J9UTF8 * name = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(walkState->method)->romClass, romMethod);
-			J9UTF8 * sig = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(walkState->method)->romClass, romMethod);
+			J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+			J9UTF8 * sig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 			j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_BEGIN_MULTI_LINE, J9NLS_CODERT_UNABLE_TO_LOCATE_JIT_STACKMAP);
 			j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_MULTI_LINE, J9NLS_CODERT_UNABLE_TO_LOCATE_JIT_STACKMAP_METHOD, (U_32) J9UTF8_LENGTH(className), J9UTF8_DATA(className), (U_32) J9UTF8_LENGTH(name), J9UTF8_DATA(name), (U_32) J9UTF8_LENGTH(sig), J9UTF8_DATA(sig), walkState->method);
@@ -976,7 +976,7 @@ static void jitWalkResolveMethodFrame(J9StackWalkState *walkState)
 		J9Method * method = (J9Method *) JIT_RESOLVE_PARM(1);
 		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 
-		signature = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass,romMethod);
+		signature = J9ROMMETHOD_SIGNATURE(romMethod);
 		pendingSendSlots = J9_ARG_COUNT_FROM_ROM_METHOD(romMethod); /* receiver is already included in this arg count */
 		walkStackedReceiver = ((romMethod->modifiers & J9AccStatic) == 0);
 #ifdef J9SW_ARGUMENT_REGISTER_COUNT
@@ -1016,7 +1016,7 @@ static void jitWalkResolveMethodFrame(J9StackWalkState *walkState)
 			}
 		}
 		romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-		signature = J9ROMMETHOD_GET_SIGNATURE(interfaceClass->romClass, romMethod);
+		signature = J9ROMMETHOD_SIGNATURE(romMethod);
 		pendingSendSlots = J9_ARG_COUNT_FROM_ROM_METHOD(romMethod); /* receiver is already included in this arg count */
 		walkStackedReceiver = TRUE;
 #ifdef J9SW_ARGUMENT_REGISTER_COUNT

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2712,9 +2712,9 @@ void printAllCounts(J9JavaVM *javaVM)
                J9UTF8 *utf8;
                utf8 = J9ROMCLASS_CLASSNAME(clazz->romClass);
                fprintf(stderr, "%.*s", J9UTF8_LENGTH(utf8), (char *) J9UTF8_DATA(utf8));
-               utf8 = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+               utf8 = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
                fprintf(stderr, ".%.*s", J9UTF8_LENGTH(utf8), (char *) J9UTF8_DATA(utf8));
-               utf8 = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+               utf8 = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
                fprintf(stderr, "%.*s", J9UTF8_LENGTH(utf8), (char *) J9UTF8_DATA(utf8));
                   */
                intptrj_t count = (intptrj_t) TR::CompilationInfo::getInvocationCount(method);
@@ -5378,7 +5378,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
             if (J9UTF8_LENGTH(className) == 36 &&
                 0==memcmp(utf8Data(className), "com/ibm/rmi/io/FastPathForCollocated", 36))
                {
-               J9UTF8 *utf8 = J9ROMMETHOD_GET_NAME(declaringClazz, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+               J9UTF8 *utf8 = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
                if (J9UTF8_LENGTH(utf8)==21 &&
                    0==memcmp(J9UTF8_DATA(utf8), "isVMDeepCopySupported", 21))
                   isORB = true;
@@ -6582,7 +6582,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
             0 == memcmp(utf8Data(className), "com/ibm/rmi/io/FastPathForCollocated", 36)
             )
             {
-            J9UTF8 *utf8 = J9ROMMETHOD_GET_NAME(declaringClazz, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+            J9UTF8 *utf8 = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
             if (
                J9UTF8_LENGTH(utf8)==21 &&
                0 == memcmp(J9UTF8_DATA(utf8), "isVMDeepCopySupported", 21)

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -444,7 +444,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       if (J9UTF8_LENGTH(className) == 36
           && J9UTF8_LENGTH(name) == 21
           && 0==memcmp(utf8Data(className), "com/ibm/rmi/io/FastPathForCollocated", 36)
-          && 0==memcmp(utf8Data(J9ROMMETHOD_GET_NAME(declaringClazz, romMethod)), "isVMDeepCopySupported", 21)
+          && 0==memcmp(utf8Data(J9ROMMETHOD_NAME(romMethod)), "isVMDeepCopySupported", 21)
          )
          {
          count = 0;
@@ -452,7 +452,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       else if (J9UTF8_LENGTH(className) == 39
           && J9UTF8_LENGTH(name) == 9
           && 0 == memcmp(utf8Data(className), "java/util/concurrent/ThreadPoolExecutor", 39)
-          && 0 == memcmp(utf8Data(J9ROMMETHOD_GET_NAME(declaringClazz, romMethod)), "runWorker", 9)
+          && 0 == memcmp(utf8Data(J9ROMMETHOD_NAME(romMethod)), "runWorker", 9)
           )
          {
          count = 0;
@@ -3189,14 +3189,14 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
             {
          char *classNameChars = (char *)J9UTF8_DATA(J9ROMCLASS_CLASSNAME(ROMCl));
          int32_t classNameLen = (int32_t)J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(ROMCl));
-         char *superSignature = (char*)J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(superMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
-         int32_t superSigLen = (int32_t)J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(superMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
-         char *superName = (char*)J9UTF8_DATA(J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(superMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
-         int32_t superNameLen = (int32_t) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(superMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
-         char *subSignature = (char*)J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(subMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
-         int32_t subSigLen = (int32_t)J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(subMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
-         char *subName = (char*)J9UTF8_DATA(J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(subMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
-         int32_t subNameLen = (int32_t)J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(subMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
+         char *superSignature = (char*)J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
+         int32_t superSigLen = (int32_t)J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
+         char *superName = (char*)J9UTF8_DATA(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
+         int32_t superNameLen = (int32_t) J9UTF8_LENGTH(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(superMethod)));
+         char *subSignature = (char*)J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
+         int32_t subSigLen = (int32_t)J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
+         char *subName = (char*)J9UTF8_DATA(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
+         int32_t subNameLen = (int32_t)J9UTF8_LENGTH(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(subMethod)));
 
          printf("class = %.*s superSignature = %.*s, superName = %.*s, supermodifers = %x , subSignature = %.*s, subName = %.*s, submodifiers = %x subMethod = %p methodModifiersAreSafe = %d\n"
                ,classNameLen,classNameChars,superSigLen,superSignature,superNameLen,superName,(int)superROM->modifiers,subSigLen,subSignature,subNameLen,subName,(int)subROM->modifiers,subMethod,methodModifiersAreSafe );
@@ -3368,8 +3368,8 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
                callSignature = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature);
                callName = J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature);
 
-               J9UTF8 *superSignature = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(superMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(superMethod));
-               J9UTF8 *superName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(superMethod)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(superMethod));
+               J9UTF8 *superSignature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(superMethod));
+               J9UTF8 *superName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(superMethod));
 
                if(   J9UTF8_LENGTH(superSignature) != J9UTF8_LENGTH(callSignature)
                    || J9UTF8_LENGTH(superName) != J9UTF8_LENGTH(callName)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6413,8 +6413,8 @@ TR_J9VMBase::getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock * classPo
    // Iterate over all romMethods until the desired one is found
    for (uint32_t i = 0; i < numMethods; i++)
       {
-      J9UTF8 *mName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-      J9UTF8 *mSig = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+      J9UTF8 *mName = J9ROMMETHOD_NAME(romMethod);
+      J9UTF8 *mSig = J9ROMMETHOD_SIGNATURE(romMethod);
       if (J9UTF8_LENGTH(mName) == nameLength &&
          J9UTF8_LENGTH(mSig) == sigLength &&
          memcmp(utf8Data(mName), methodName, nameLength) == 0 &&

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -124,8 +124,8 @@ void releaseVMaccessIfNeeded(J9VMThread *vmThread, bool haveAcquiredVMAccess);
 inline void getClassNameSignatureFromMethod(J9Method *method, J9UTF8 *& methodClazz, J9UTF8 *& methodName, J9UTF8 *& methodSignature)
    {
    methodClazz = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
-   methodName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
-   methodSignature = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+   methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
+   methodSignature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
    }
 
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -704,7 +704,7 @@ bool
 TR_J9MethodBase::isBigDecimalMethod(J9ROMMethod * romMethod, J9ROMClass * romClass)
    {
    return TR_J9VMBase::isBigDecimalClass(J9ROMCLASS_CLASSNAME(romClass)) &&
-          isBigDecimalNameAndSignature(J9ROMMETHOD_GET_NAME(romClass, romMethod), J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod));
+          isBigDecimalNameAndSignature(J9ROMMETHOD_NAME(romMethod), J9ROMMETHOD_SIGNATURE(romMethod));
    }
 
 bool
@@ -766,7 +766,7 @@ bool
 TR_J9MethodBase::isBigDecimalConvertersMethod(J9ROMMethod * romMethod, J9ROMClass * romClass)
    {
    return TR_J9VMBase::isBigDecimalConvertersClass(J9ROMCLASS_CLASSNAME(romClass)) &&
-          isBigDecimalConvertersNameAndSignature(J9ROMMETHOD_GET_NAME(romClass, romMethod), J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod));
+          isBigDecimalConvertersNameAndSignature(J9ROMMETHOD_NAME(romMethod), J9ROMMETHOD_SIGNATURE(romMethod));
    }
 
 bool
@@ -2309,8 +2309,8 @@ TR_J9Method::TR_J9Method(TR_FrontEnd * fe, TR_Memory * trMemory, TR_OpaqueMethod
 
    J9ROMClass *romClass = J9_CLASS_FROM_METHOD(((J9Method *)aMethod))->romClass;
    _className = J9ROMCLASS_CLASSNAME(romClass);
-   _name = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-   _signature = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+   _name = J9ROMMETHOD_NAME(romMethod);
+   _signature = J9ROMMETHOD_SIGNATURE(romMethod);
 
    parseSignature(trMemory);
    _fullSignature = NULL;
@@ -5188,7 +5188,7 @@ bool TR_ResolvedJ9Method::isSubjectToPhaseChange(TR::Compilation *comp)
          for (int i = 0; i < numMethods; ++i)
             {
             J9Method *method = &(methods[i]);
-            J9UTF8 *name = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+            J9UTF8 *name = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 
             if (J9UTF8_LENGTH(name) == 13)
                {
@@ -5875,8 +5875,8 @@ TR_ResolvedJ9Method::allocateException(uint32_t numBytes, TR::Compilation *comp)
 
    #if defined(J9VM_RAS_EYECATCHERS)
    eTbl->className       = J9ROMCLASS_CLASSNAME(romClassPtr());
-   eTbl->methodName      = J9ROMMETHOD_GET_NAME(romClassPtr(), romMethod());// J9ROMMETHOD_NAME(romMethod());
-   eTbl->methodSignature = J9ROMMETHOD_GET_SIGNATURE(romClassPtr(), romMethod());   //J9ROMMETHOD_SIGNATURE(romMethod());
+   eTbl->methodName      = J9ROMMETHOD_NAME(romMethod());
+   eTbl->methodSignature = J9ROMMETHOD_SIGNATURE(romMethod());
    #endif
 
    J9ConstantPool *cpool;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -681,7 +681,7 @@ TR_RelocationRuntime::relocateMethodMetaData(UDATA codeRelocationAmount, UDATA d
       fprintf(stdout, "-> %p", _exceptionTable->ramMethod);
       if (classReloAmount())
          {
-         name = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(((J9ROMMethod *)_exceptionTable->ramMethod))->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(((J9ROMMethod *)_exceptionTable->ramMethod)));
+         name = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(((J9ROMMethod *)_exceptionTable->ramMethod)));
          fprintf(stdout, " (%.*s)", name->length, name->data);
          }
       fprintf(stdout, "\n");

--- a/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
+++ b/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,10 +139,10 @@ TR_RelocationRuntimeLogger::method(bool newLine)
 
    U_8 * className = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_CP(reloRuntime()->ramCP())->romClass));
    int classNameLen = J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_CP(reloRuntime()->ramCP())->romClass));
-   U_8 *methodName = J9UTF8_DATA(J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(reloRuntime()->method())->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
-   int methodNameLen = J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(reloRuntime()->method())->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
-   U_8 *signature = J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(reloRuntime()->method())->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
-   int signatureLen= J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(reloRuntime()->method())->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
+   U_8 *methodName = J9UTF8_DATA(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
+   int methodNameLen = J9UTF8_LENGTH(J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
+   U_8 *signature = J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
+   int signatureLen= J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(reloRuntime()->method())));
 
    bool wasLocked = lockLog();
    JITRT_PRINTF(jitConfig())(jitConfig(), patternString, classNameLen, className,

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -848,7 +848,7 @@ JVM_GetClassDeclaredConstructors(JNIEnv* env, jclass clazz, jboolean unknown)
 
 		while (romMethodCount-- != 0) {
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method++);
-			J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+			J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
 
 			if (J9UTF8_DATA_EQUALS(J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), eyecatcher, 6)) {
 				size++;
@@ -876,10 +876,10 @@ JVM_GetClassDeclaredConstructors(JNIEnv* env, jclass clazz, jboolean unknown)
 
 		while (romMethodCount-- != 0) {
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method++);
-			J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+			J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
 
 			if (J9UTF8_DATA_EQUALS(J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), eyecatcher, 6)) {
-				J9UTF8 * signatureUTF = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+				J9UTF8 * signatureUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 				char* name = utf8_to_cstring(env, nameUTF);
 				char* signature = utf8_to_cstring(env, signatureUTF);
 				jmethodID methodID = (*env)->GetMethodID(env, clazz, name, signature);
@@ -1003,7 +1003,7 @@ JVM_GetClassDeclaredMethods(JNIEnv* env, jobject clazz, jboolean unknown)
 
 		while (romMethodCount-- != 0) {
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method++);
-			J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+			J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
 
 			if (!J9UTF8_DATA_EQUALS(J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), eyecatcher, 6)) {
 				size++;
@@ -1031,10 +1031,10 @@ JVM_GetClassDeclaredMethods(JNIEnv* env, jobject clazz, jboolean unknown)
 
 		while (romMethodCount-- != 0) {
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method++);
-			J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+			J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
 
 			if (!J9UTF8_DATA_EQUALS(J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), eyecatcher, 6)) {
-				J9UTF8 * signatureUTF = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+				J9UTF8 * signatureUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 				char* name = utf8_to_cstring(env, nameUTF);
 				char* signature = utf8_to_cstring(env, signatureUTF);
 				U_32 modifiers = romMethod->modifiers;
@@ -1468,7 +1468,7 @@ JVM_GetStackTraceElement(JNIEnv* env, jobject throwable, jint index)
 
 	/* Convert to Java format */
 	declaringClass = utf8_to_java_lang_String(env, J9ROMCLASS_CLASSNAME(userData.romClass));
-	methodName = utf8_to_java_lang_String(env, J9ROMMETHOD_GET_NAME(userData.romClass, userData.romMethod));
+	methodName = utf8_to_java_lang_String(env, J9ROMMETHOD_NAME(userData.romMethod));
 	fileName = utf8_to_java_lang_String(env, userData.fileName);
 	lineNumber = (jint)userData.lineNumber;
 

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -52,7 +52,7 @@ stackFrameFilter(J9VMThread * currentThread, J9StackWalkState * walkState)
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState->method);
 		J9ROMClass *romClass = J9_CLASS_FROM_METHOD(walkState->method)->romClass;
 
-		J9UTF8 *utf = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+		J9UTF8 *utf = J9ROMMETHOD_NAME(romMethod);
 		const char  *stackWalkerMethod = (const char  *) walkState->userData2;
 		result = J9_STACKWALK_KEEP_ITERATING;
 
@@ -211,13 +211,13 @@ Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 			}
 			J9VMJAVALANGSTACKWALKERSTACKFRAMEIMPL_SET_CLASSNAME(vmThread, PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0), stringObject);
 
-			stringObject = utfToStringObject(env, J9ROMMETHOD_GET_NAME(romClass, romMethod), J9_STR_INTERN);
+			stringObject = utfToStringObject(env, J9ROMMETHOD_NAME(romMethod), J9_STR_INTERN);
 			if (VM_VMHelpers::exceptionPending(vmThread)) {
 				goto _pop_frame;
 			}
 			J9VMJAVALANGSTACKWALKERSTACKFRAMEIMPL_SET_METHODNAME(vmThread, PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0), stringObject);
 
-			stringObject = utfToStringObject(env, J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod), J9_STR_INTERN);
+			stringObject = utfToStringObject(env, J9ROMMETHOD_SIGNATURE(romMethod), J9_STR_INTERN);
 			if (VM_VMHelpers::exceptionPending(vmThread)) {
 				goto _pop_frame;
 			}

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -175,7 +175,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 
 			/* Fill in method name */
 
-			utf = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+			utf = J9ROMMETHOD_NAME(romMethod);
 			string = vm->memoryManagerFunctions->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_XLAT);
 			if (string == NULL) {
 				rc = FALSE;

--- a/runtime/jcl/common/jclvm.c
+++ b/runtime/jcl/common/jclvm.c
@@ -457,7 +457,7 @@ hasConstructor(J9VMThread *vmThread, J9StackWalkState *state)
 	} else {
 		J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-		J9UTF8 *methodName = J9ROMMETHOD_GET_NAME(methodClass->romClass, romMethod);
+		J9UTF8 *methodName = J9ROMMETHOD_NAME(romMethod);
 	
 		/* if the method is a constructor in the class we're looking for then quit looking for more
 		 * a constructor is a non-static (to filter clinit) method which starts with '<'. 

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -68,7 +68,7 @@ static UDATA
 isConstructor(J9Method *ramMethod)
 {
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	return (0 == (romMethod->modifiers & J9AccStatic)) && ('<' == J9UTF8_DATA(J9ROMMETHOD_GET_NAME(methodClass->romClass, romMethod))[0]);
+	return (0 == (romMethod->modifiers & J9AccStatic)) && ('<' == J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod))[0]);
 }
 
 /*
@@ -310,7 +310,6 @@ getMethodParametersAsArray(JNIEnv *env, jobject jlrExecutable)
 		char buffer[256];
 		J9MethodParameter * parameters = NULL;
 		BOOLEAN parameterListOkay = TRUE;
-		U_8 methodParametersLimit = computeArgCount(romMethod);
 		U_32 extMods = getExtendedModifiersDataFromROMMethod(romMethod);
 
 		if (NULL == parametersData) {
@@ -331,12 +330,12 @@ getMethodParametersAsArray(JNIEnv *env, jobject jlrExecutable)
 			goto finished;
 		}
 		Trc_JCL_getMethodParametersAsArray_Event5(env, parametersArray);
-		if ((NULL != parametersData) && (methodParametersLimit != parametersData->parameterCount)) {
+		if ((NULL != parametersData) && (numberOfParameters != parametersData->parameterCount)) {
 			/* PR 97987 force an error if mismatch between parameters attribute and actual argument count */
 			Trc_JCL_getMethodParametersAsArray_WrongParameterCount(env, parametersData->parameterCount);
 			parameterListOkay = FALSE;
 		}
-		for (index = 0; index < methodParametersLimit; index++) {
+		for (index = 0; index < numberOfParameters; index++) {
 		
 			U_16 flags = (NULL != parameters) ? parameters[index].flags : 0;
 			jstring nameStr = NULL;
@@ -537,7 +536,7 @@ static j9object_t
 parameterTypesForMethod(struct J9VMThread *vmThread, struct J9Method *ramMethod, struct J9Class **returnType)
 {
 	j9object_t params = NULL;
-	J9UTF8 *sigUTF = J9ROMMETHOD_GET_SIGNATURE(methodClass->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod));
+	J9UTF8 *sigUTF = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod));
 	J9ClassLoader* classLoader = J9_CLASS_FROM_METHOD(ramMethod)->classLoader;
 	U_8 *sigData = J9UTF8_DATA(sigUTF);
 	U_32 argCount = getArgCountFromSignature(sigUTF);
@@ -673,7 +672,7 @@ fillInReflectMethod(j9object_t methodObject, struct J9Class *declaringClass, jme
 	J9VMJAVALANGREFLECTMETHOD_SET_PARAMETERTYPES(vmThread, methodObject, parameterTypes);
 	J9VMJAVALANGREFLECTMETHOD_SET_RETURNTYPE(vmThread, methodObject, J9VM_J9CLASS_TO_HEAPCLASS(returnType));
 
-	nameUTF = J9ROMMETHOD_GET_NAME(methodClass->romClass, romMethod);
+	nameUTF = J9ROMMETHOD_NAME(romMethod);
 	nameString = gcFunctions->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(nameUTF), (U_32) J9UTF8_LENGTH(nameUTF), J9_STR_INTERN);
 	if (NULL == nameString) {
 		DROP_OBJECT_IN_SPECIAL_FRAME(vmThread); /* methodObject */

--- a/runtime/jnichk/jnicbuf.c
+++ b/runtime/jnichk/jnicbuf.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,7 +97,7 @@ computeArgsCRC(const jvalue *args, jmethodID methodID)
 	ramMethod = ((J9JNIMethodID*)methodID)->method;
 	methodClass = J9_CLASS_FROM_METHOD(ramMethod);
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	sig = J9ROMMETHOD_GET_SIGNATURE(methodClass->romClass, romMethod);
+	sig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 	/* count the args */
 	length = 0;

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -403,7 +403,7 @@ jniCheckCallV(const char* function, JNIEnv* env, jobject receiver, UDATA methodT
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9Method *ramMethod = ((J9JNIMethodID*)method)->method;
 	J9ROMMethod* romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	J9UTF8* sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(ramMethod)->ramClass->romClass, romMethod);
+	J9UTF8* sig = J9ROMMETHOD_SIGNATURE(romMethod);
 	char* sigArgs;
 	va_list args;
 	UDATA argNum;
@@ -464,7 +464,7 @@ jniCheckCallA(const char* function, JNIEnv* env, jobject receiver, UDATA methodT
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9Method *ramMethod = ((J9JNIMethodID*)method)->method;
 	J9ROMMethod* romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	J9UTF8* sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(ramMethod)->ramClass->romClass, romMethod);
+	J9UTF8* sig = J9ROMMETHOD_SIGNATURE(romMethod);
 	char* sigArgs;
 	UDATA argNum;
 	UDATA trace = vm->checkJNIData.options & JNICHK_TRACE;
@@ -1005,8 +1005,8 @@ jniCheckPrintMethod(JNIEnv* env, U_32 level)
 	if (method != NULL) {
 		J9UTF8 * className = J9ROMCLASS_CLASSNAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass);
 		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-		J9UTF8 * name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
-		J9UTF8 * sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+		J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+		J9UTF8 * sig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 		/* special case for JNI_OnLoad */
 		if (isLoadLibraryWithPath(className, name)) {
@@ -1178,8 +1178,8 @@ static void jniIsLocalRefOSlotWalkFunction(J9VMThread* aThread, J9StackWalkState
 	if (method != NULL) {
 		J9UTF8 * className = J9ROMCLASS_CLASSNAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass);
 		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-		J9UTF8 * name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
-		J9UTF8 * sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+		J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+		J9UTF8 * sig = J9ROMMETHOD_SIGNATURE(romMethod);
 		printf("Found in frame %d in %.*s.%.*s%.*s\n", walkState->framesWalked + 1, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(sig), J9UTF8_DATA(sig));
 	}
 }
@@ -1388,8 +1388,8 @@ static void jniTraceMethodID(JNIEnv* env, jmethodID mid) {
 
 	J9Method* method = ((J9JNIMethodID*)mid)->method;
 	J9ROMMethod* romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	J9UTF8* name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
-	J9UTF8* sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+	J9UTF8* name = J9ROMMETHOD_NAME(romMethod);
+	J9UTF8* sig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 	j9tty_printf(PORTLIB, "%.*s%.*s", J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(sig), J9UTF8_DATA(sig));
 
@@ -1672,8 +1672,8 @@ methodEnterHook(J9HookInterface** hook, UDATA eventNum, void* eventData, void* u
 	if (trace) {
 		PORT_ACCESS_FROM_VMC(vmThread);
 		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-		J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
-		J9UTF8 * sigUTF = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+		J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
+		J9UTF8 * sigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 		J9UTF8 * classNameUTF = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
 		char argBuffer[2048 + 3];
 		UDATA remainingSize = sizeof(argBuffer) - 3;
@@ -1725,7 +1725,7 @@ methodExitHook(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 	UDATA* returnValues = event->returnValuePtr;
 	jobject returnRef = event->poppedByException ? (jobject)NULL : event->returnRef;
 	J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	J9UTF8 * sigUTF = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+	J9UTF8 * sigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 	U_8 * sigData = J9UTF8_DATA(sigUTF) + 1;
     UDATA sigChar;
 
@@ -2064,7 +2064,7 @@ inBootstrapClass(JNIEnv* env)
 				if (cpEntry.flags & CPE_FLAG_BOOTSTRAP) {
 					J9UTF8 * className = J9ROMCLASS_CLASSNAME(clazz->romClass);
 					J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-					J9UTF8 * name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+					J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
 
 					/* special case for JNI_OnLoad */
 					if (isLoadLibraryWithPath(className, name)) {
@@ -2240,7 +2240,7 @@ jniCheckCall(const char* function, JNIEnv* env, jobject receiver, UDATA methodTy
 	J9Class *declaringClass = J9_CLASS_FROM_METHOD(ramMethod);
 	jclass declaringClassRef;
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	J9UTF8 *sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(ramMethod)->ramClass->romClass,romMethod);
+	J9UTF8 *sig = J9ROMMETHOD_SIGNATURE(romMethod);
 	char *returnSig;
 	UDATA novalist = vm->checkJNIData.options & JNICHK_NOVALIST;
 
@@ -2249,7 +2249,7 @@ jniCheckCall(const char* function, JNIEnv* env, jobject receiver, UDATA methodTy
 	jniCallIn((J9VMThread *) env);
 
 	if (methodType == METHOD_CONSTRUCTOR) {
-		J9UTF8* name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(ramMethod)->ramClass->romClass,romMethod);
+		J9UTF8* name = J9ROMMETHOD_NAME(romMethod);
 		if ( (J9UTF8_DATA(name)[0] != '<') || (J9UTF8_LENGTH(name) != sizeof("<init>") - 1) ) {
 			jniCheckFatalErrorNLS(env, J9NLS_JNICHK_METHOD_IS_NOT_CONSTRUCTOR, function);
 		}

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -1025,10 +1025,10 @@ createBreakpointedMethod(J9VMThread * currentThread, J9Method * ramMethod)
 #ifdef J9VM_ENV_DATA64
 	/* Account for the space taken by the name and signature UTF8s */
 
-	methodName = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(ramMethod)->ramClass->romClass, originalROMMethod);
+	methodName = J9ROMMETHOD_NAME(originalROMMethod);
 	/* allocSize guaranteed to be 4-aligned at this point, so no need to align for UTF */
 	allocSize += ((sizeof(U_16) + J9UTF8_LENGTH(methodName) + 1) & ~1);
-	methodSignature = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(ramMethod)->ramClass->romClass, originalROMMethod);
+	methodSignature = J9ROMMETHOD_SIGNATURE(originalROMMethod);
 	allocSize += ((sizeof(U_16) + J9UTF8_LENGTH(methodSignature) + 1) & ~1);
 	genericSignature = J9_GENERIC_SIGNATURE_FROM_ROM_METHOD(originalROMMethod);
 	if (genericSignature != NULL) {

--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -57,7 +57,7 @@ jvmtiGetMethodName(jvmtiEnv* env,
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
 
 	if (name_ptr != NULL) {
-		J9UTF8 * utf = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(((J9JNIMethodID *) method)->method)->ramClass->romClass, romMethod);
+		J9UTF8 * utf = J9ROMMETHOD_NAME(romMethod);
 		UDATA length = J9UTF8_LENGTH(utf);
 
 		name = j9mem_allocate_memory(length + 1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
@@ -71,7 +71,7 @@ jvmtiGetMethodName(jvmtiEnv* env,
 	}
 
 	if (signature_ptr != NULL) {
-		J9UTF8 * utf = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(((J9JNIMethodID *) method)->method)->ramClass->romClass, romMethod);
+		J9UTF8 * utf = J9ROMMETHOD_SIGNATURE(romMethod);
 		UDATA length = J9UTF8_LENGTH(utf);
 
 		signature = j9mem_allocate_memory(length + 1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
@@ -692,7 +692,7 @@ readdWide:
 				case JBsyncReturn0:
 				case JBsyncReturn1:
 				case JBsyncReturn2: {
-					J9UTF8 * signature = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(((J9JNIMethodID *) method)->method)->ramClass->romClass, romMethod);
+					J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(romMethod);
 					U_8 * sigData = J9UTF8_DATA(signature);
 					U_16 sigLength = J9UTF8_LENGTH(signature);
 

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -210,9 +210,6 @@ typedef struct J9ClassLoaderWalkState {
 /* Important: We check both valueOffset and flagsAndClass because we do not set them atomically on resolve. */
 #define J9RAMSTATICFIELDREF_IS_RESOLVED(base) ((-1 != (base)->valueOffset) && ((base)->flagsAndClass) > 0)
 
-#define J9ROMMETHOD_GET_NAME(romClass, rommethod) J9ROMMETHOD_NAME(rommethod)
-#define J9ROMMETHOD_GET_SIGNATURE(romClass, rommethod) J9ROMMETHOD_SIGNATURE(rommethod)
-
 /* From tracehelp.c - prototyped here because the macro is here */
 
 /**

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5462,6 +5462,7 @@ typedef struct J9JavaVM {
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
 	UDATA valueFlatteningThreshold;
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+	UDATA dCacheLineSize;
 } J9JavaVM;
 
 #define J9VM_PHASE_NOT_STARTUP  2

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -390,7 +390,7 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 		if (throwSite.romClass && throwSite.romMethod) {
 			J9UTF8 *exceptionClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(vmThread, exception)->romClass);
 			J9UTF8 *throwClassName  = J9ROMCLASS_CLASSNAME(throwSite.romClass);
-			J9UTF8 *throwMethodName = J9ROMMETHOD_GET_NAME(throwSite.romClass, throwSite.romMethod);
+			J9UTF8 *throwMethodName = J9ROMMETHOD_NAME(throwSite.romMethod);
 			
 			if (throwClassName && throwMethodName) {
 				if (stackOffsetFilter) {

--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,7 +81,7 @@ matchMethod(RasMethodTable * methodTable, J9Method *method)
 		 * Specific method, any class
 		 */
 
-		methodName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+		methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 		return wildcardMatch(
 			methodTable->methodMatchFlag,
 			(const char *)J9UTF8_DATA(methodTable->methodName), J9UTF8_LENGTH(methodTable->methodName),
@@ -91,7 +91,7 @@ matchMethod(RasMethodTable * methodTable, J9Method *method)
 		 *  Specific method(s), specific class(es)
 		 */
 
-		methodName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+		methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 		if (wildcardMatch(
 			methodTable->methodMatchFlag,
 			(const char *)J9UTF8_DATA(methodTable->methodName), J9UTF8_LENGTH(methodTable->methodName),
@@ -169,8 +169,8 @@ static void
 traceMethodEnter(J9VMThread *thr, J9Method *method, void *receiverAddress, UDATA isCompiled, UDATA doParameters)
 {
 	J9UTF8* className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
-	J9UTF8* methodName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
-	J9UTF8* methodSignature = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+	J9UTF8* methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
+	J9UTF8* methodSignature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 	UDATA modifiers = J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers;
 
 	if (isCompiled) {
@@ -228,8 +228,8 @@ static void
 traceMethodExit(J9VMThread *thr, J9Method *method, UDATA isCompiled, void* returnValuePtr, UDATA doParameters)
 {
 	J9UTF8* className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
-	J9UTF8* methodName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
-	J9UTF8* methodSignature = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+	J9UTF8* methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
+	J9UTF8* methodSignature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 	UDATA modifiers = J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers;
 
 	if (isCompiled) {
@@ -277,8 +277,8 @@ static void
 traceMethodExitX(J9VMThread *thr, J9Method *method, UDATA isCompiled, void* exceptionPtr,UDATA doParameters)
 {
 	J9UTF8* className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
-	J9UTF8* methodName = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
-	J9UTF8* methodSignature = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method));
+	J9UTF8* methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
+	J9UTF8* methodSignature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 	UDATA modifiers = J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers;
 
 	if (isCompiled) {

--- a/runtime/rastrace/method_trigger.c
+++ b/runtime/rastrace/method_trigger.c
@@ -136,10 +136,10 @@ rasTriggerMethod(J9VMThread *thr, J9Method *method, I_32 entry, const TriggerPha
 					entry ? "entry" : "return",
 					J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass)->length,
 					J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass)->data,
-					J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method))->length,
-					J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method))->data,
-					J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method))->length,
-					J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method))->data);
+					J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method))->length,
+					J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method))->data,
+					J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method))->length,
+					J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method))->data);
 
 	/*
 	 * Go through each of the rules seeing if this method is one of theirs
@@ -948,7 +948,7 @@ traceFrameCallBack(J9VMThread *vmThread, J9StackWalkState *state)
 	methodClass = J9_CLASS_FROM_METHOD(method);
 	className = J9ROMCLASS_CLASSNAME(methodClass->romClass);
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	methodName = J9ROMMETHOD_GET_NAME(methodClass->romClass, romMethod);
+	methodName = J9ROMMETHOD_NAME(romMethod);
 
 	if (romMethod->modifiers & J9AccNative) {
 		frameType = NATIVE_METHOD;

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -3182,8 +3182,8 @@ SH_CacheMap::storeAttachedData(J9VMThread* currentThread, const void* addressInC
 			J9ClassLoader* loader;
 			J9InternalVMFunctions *vmFunctions = currentThread->javaVM->internalVMFunctions;
 			J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)addressInCache, &loader);
-			J9UTF8* methodName = J9ROMMETHOD_GET_NAME(romClass, (J9ROMMethod *)addressInCache);
-			J9UTF8* methodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, (J9ROMMethod *)addressInCache);
+			J9UTF8* methodName = J9ROMMETHOD_NAME((J9ROMMethod *)addressInCache);
+			J9UTF8* methodSig = J9ROMMETHOD_SIGNATURE((J9ROMMethod *)addressInCache);
  			J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
 
 			if ( 0 == result ) {
@@ -3258,8 +3258,8 @@ SH_CacheMap::updateAttachedData(J9VMThread* currentThread, const void* addressIn
 			J9ClassLoader* loader;
 			J9InternalVMFunctions *vmFunctions = currentThread->javaVM->internalVMFunctions;
 			J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)addressInCache, &loader);
-			J9UTF8* methodName = J9ROMMETHOD_GET_NAME(romClass, (J9ROMMethod *)addressInCache);
-			J9UTF8* methodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, (J9ROMMethod *)addressInCache);
+			J9UTF8* methodName = J9ROMMETHOD_NAME((J9ROMMethod *)addressInCache);
+			J9UTF8* methodSig = J9ROMMETHOD_SIGNATURE((J9ROMMethod *)addressInCache);
 			J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
 
 			if (0 == result) {
@@ -3336,8 +3336,8 @@ SH_CacheMap::updateAttachedUDATA(J9VMThread* currentThread, const void* addressI
 			J9ClassLoader* loader;
 			J9InternalVMFunctions *vmFunctions = currentThread->javaVM->internalVMFunctions;
 			J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)addressInCache, &loader);
-			J9UTF8* methodName = J9ROMMETHOD_GET_NAME(romClass, (J9ROMMethod *)addressInCache);
-			J9UTF8* methodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, (J9ROMMethod *)addressInCache);
+			J9UTF8* methodName = J9ROMMETHOD_NAME((J9ROMMethod *)addressInCache);
+			J9UTF8* methodSig = J9ROMMETHOD_SIGNATURE((J9ROMMethod *)addressInCache);
 			J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
 
 			if (0 == result) {
@@ -3401,8 +3401,8 @@ SH_CacheMap::findAttachedDataAPI(J9VMThread* currentThread, const void* addressI
 			J9ClassLoader* loader;
 			J9InternalVMFunctions *vmFunctions = currentThread->javaVM->internalVMFunctions;
 			J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)addressInCache, &loader);
-			J9UTF8* methodName = J9ROMMETHOD_GET_NAME(romClass, (J9ROMMethod *)addressInCache);
-			J9UTF8* methodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, (J9ROMMethod *)addressInCache);
+			J9UTF8* methodName = J9ROMMETHOD_NAME((J9ROMMethod *)addressInCache);
+			J9UTF8* methodSig = J9ROMMETHOD_SIGNATURE((J9ROMMethod *)addressInCache);
 			J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
 
 			if (( NULL == result) || (J9SHR_RESOURCE_MAX_ERROR_VALUE >= (UDATA)result)) {
@@ -4660,8 +4660,8 @@ SH_CacheMap::printAllCacheStats(J9VMThread* currentThread, UDATA showFlags, SH_C
 								break;
 							}
 						
-							romMethodName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-							romMethodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+							romMethodName = J9ROMMETHOD_NAME(romMethod);
+							romMethodSig = J9ROMMETHOD_SIGNATURE(romMethod);
 							if (romMethodName && romMethodSig) {
 								CACHEMAP_PRINT5(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_ROMMETHOD_DISPLAY,
 										J9UTF8_LENGTH(romMethodName), J9UTF8_DATA(romMethodName), J9UTF8_LENGTH(romMethodSig), J9UTF8_DATA(romMethodSig), romMethod);
@@ -4712,8 +4712,8 @@ SH_CacheMap::printAllCacheStats(J9VMThread* currentThread, UDATA showFlags, SH_C
 					J9ClassLoader* loader;
 					J9UTF8* romClassName = NULL;
 					J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)romMethod, &loader);
- 					J9UTF8* romMethodName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-					J9UTF8* romMethodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+ 					J9UTF8* romMethodName = J9ROMMETHOD_NAME(romMethod);
+					J9UTF8* romMethodSig = J9ROMMETHOD_SIGNATURE(romMethod);
 					
  					if (romClass) {
 						romClassName = J9ROMCLASS_CLASSNAME(romClass);
@@ -4757,8 +4757,8 @@ SH_CacheMap::printAllCacheStats(J9VMThread* currentThread, UDATA showFlags, SH_C
 						J9ClassLoader* loader;
 						J9UTF8* romClassName = NULL;
 						J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)romMethod, &loader);
-						J9UTF8* romMethodName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-						J9UTF8* romMethodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+						J9UTF8* romMethodName = J9ROMMETHOD_NAME(romMethod);
+						J9UTF8* romMethodSig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 						if (romClass) {
 							romClassName = J9ROMCLASS_CLASSNAME(romClass);
@@ -6881,8 +6881,8 @@ SH_CacheMap::aotMethodOperationHelper(J9VMThread* currentThread, MethodSpecTable
 			J9UTF8* romClassName = NULL;
 			J9ClassLoader* loader = NULL;
 			J9ROMClass* romClass = vmFunctions->findROMClassFromPC(currentThread, (UDATA)romMethod, &loader);
-	 		J9UTF8* romMethodName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-			J9UTF8* romMethodSig = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+	 		J9UTF8* romMethodName = J9ROMMETHOD_NAME(romMethod);
+			J9UTF8* romMethodSig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 			if (NULL != romClass) {
 				romClassName = J9ROMCLASS_CLASSNAME(romClass);

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -4367,7 +4367,7 @@ addTestJitHint(J9HookInterface** hookInterface, UDATA eventNum, void* voidData, 
 	J9UTF8* romclassName = J9ROMCLASS_CLASSNAME(romclass);
 	J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romclass);
 	if (NULL != romMethod) {
-		J9UTF8 *methodName = J9ROMMETHOD_GET_NAME(romclass, romMethod);
+		J9UTF8 *methodName = J9ROMMETHOD_NAME(romMethod);
 
 		j9file_printf(PORTLIB, J9PORT_TTY_OUT, "addTestJitHint adding hint to %.*s.%.*s\n",
 				J9UTF8_LENGTH(romclassName), J9UTF8_DATA(romclassName), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName));

--- a/runtime/stackmap/debuglocalmap.c
+++ b/runtime/stackmap/debuglocalmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,7 +169,7 @@ debugMapAllLocals(DebugLocalMap * mapData)
 	/* Start with the arguments configured from the signature */
 	/* A side effect is zeroing out the result array */
 	argBitsFromSignature(
-			J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(mapData->romClass, romMethod)),
+			J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 			mapData->resultArrayBase,
 			(remainingLocals + 31) >> 5,
 			(romMethod->modifiers & J9AccStatic) != 0);
@@ -552,8 +552,8 @@ j9localmap_DebugLocalBitsForPC(J9PortLibrary * portLib, J9ROMClass * romClass, J
 
 	Trc_Map_j9localmap_DebugLocalBitsForPC_Method(J9_TEMP_COUNT_FROM_ROM_METHOD(romMethod) + J9_ARG_COUNT_FROM_ROM_METHOD(romMethod), pc, 
 													(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)),
-													(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-													(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+													(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)), J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+													(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)), J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 	
 	memset(&mapData, 0, sizeof(DebugLocalMap));
 	mapData.romMethod = romMethod;

--- a/runtime/stackmap/fixreturns.c
+++ b/runtime/stackmap/fixreturns.c
@@ -96,7 +96,7 @@ fixReturnBytecodes(J9PortLibrary * portLib, struct J9ROMClass* romClass)
 		if ((romMethod->modifiers & (CFR_ACC_NATIVE | CFR_ACC_ABSTRACT)) == 0) {
 			if (isJavaLangObject) {
 				/* Avoid rewriting genericReturn for Object.<init>() */
-				U_8 * nameData = J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod));
+				U_8 * nameData = J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod));
 				if (('<' == nameData[0]) && ('i' == nameData[1]) && (1 == romMethod->argCount)) {
 					continue;
 				}
@@ -123,8 +123,8 @@ getReturnBytecode(J9ROMClass * romClass, J9ROMMethod * romMethod, UDATA * return
 
 	U_8 sigChar, returnBytecode;
 
-	J9UTF8 * name = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-	J9UTF8 * signature = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+	J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+	J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(romMethod);
 
 	U_8 * sigData = J9UTF8_DATA(signature);
 	UDATA sigLength = J9UTF8_LENGTH(signature);

--- a/runtime/stackmap/localmap.c
+++ b/runtime/stackmap/localmap.c
@@ -449,7 +449,7 @@ void
 j9localmap_ArgBitsForPC0 (J9ROMClass * romClass, J9ROMMethod * romMethod, U_32 * resultArrayBase) 
 {
 	argBitsFromSignature(
-		J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)),
+		J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 		resultArrayBase,
 		(J9_ARG_COUNT_FROM_ROM_METHOD(romMethod) + 31) >> 5,
 		(romMethod->modifiers & J9AccStatic) != 0);
@@ -477,8 +477,8 @@ j9localmap_LocalBitsForPC(J9PortLibrary * portLib, J9ROMClass * romClass, J9ROMM
 
 	Trc_Map_j9localmap_LocalBitsForPC_Method(J9_TEMP_COUNT_FROM_ROM_METHOD(romMethod) + J9_ARG_COUNT_FROM_ROM_METHOD(romMethod), pc, 
 												(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)), J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)), J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 	
 	/* clear the result map as we may not write all of it */
 	memset ((U_8 *)resultArrayBase, 0, mapWords * sizeof (U_32));

--- a/runtime/stackmap/maxmap.c
+++ b/runtime/stackmap/maxmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,8 +76,8 @@ j9maxmap_setMapMemoryBuffer(J9JavaVM * vm, J9ROMClass * romClass)
 					maxSize = tempMaxSize;
 					Trc_Map_j9maxmap_setMapMemoryBuffer_Larger_Method(tempMaxSize, 
 							(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_NAME(NULL,romMethod)),
-							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(NULL,romMethod)));
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)), J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+							(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)), J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 #if 0
 					printf("[][][] maxStack = %d, maxBranchCount = %d, length = %d\n", maxStack, romClass->maxBranchCount, length);
 					printf("[][][] new unrounded maxSize = %d from stk = %d, lcl = %d, dbg = %d\n", tempMaxSize, stackmapSize + 8192, localmapSize + 8192, debuglocalmapSize + 8192);

--- a/runtime/stackmap/stackmap.c
+++ b/runtime/stackmap/stackmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,8 +123,8 @@ j9stackmap_StackBitsForPC(J9PortLibrary * portLib, UDATA pc, J9ROMClass * romCla
 
 	Trc_Map_j9stackmap_StackBitsForPC_Method(J9_MAX_STACK_FROM_ROM_METHOD(romMethod), pc, 
 												(UDATA) J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_NAME(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod)),
-												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)), J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_NAME(romMethod)), J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod)),
+												(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)), J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)));
 	
 	/* Add 2 for the J9MappingStack size */
 	stackStructSize = J9_MAX_STACK_FROM_ROM_METHOD(romMethod) + 2;

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -682,11 +682,11 @@ dumpAnnotationInfo( J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 			U_32 *codeTypeAnnotationData = getCodeTypeAnnotationsDataFromROMMethod(romMethod);
 			if ((NULL != methodAnnotationData) || (NULL != parametersAnnotationData) || (NULL != defaultAnnotationData)) {
 				j9tty_printf(PORTLIB, "      Name: ");
-				dumpUTF( (J9UTF8 *) J9ROMMETHOD_GET_NAME(romClass, romMethod), portLib, flags );
+				dumpUTF( (J9UTF8 *) J9ROMMETHOD_NAME(romMethod), portLib, flags );
 				j9tty_printf( PORTLIB, "\n");
 
 				j9tty_printf(PORTLIB, "      Signature: ");
-				dumpUTF( (J9UTF8 *) J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod), portLib, flags );
+				dumpUTF( (J9UTF8 *) J9ROMMETHOD_SIGNATURE(romMethod), portLib, flags );
 				j9tty_printf(PORTLIB, "\n");
 			}
 			if (NULL != methodAnnotationData) {
@@ -878,11 +878,11 @@ I_32 j9bcutil_dumpRomMethod( J9ROMMethod *romMethod, J9ROMClass *romClass, J9Por
 	PORT_ACCESS_FROM_PORT( portLib );
 
 	j9tty_printf( PORTLIB,  "  Name: ");
-	dumpUTF( (J9UTF8 *) J9ROMMETHOD_GET_NAME(romClass, romMethod), portLib, flags );
+	dumpUTF( (J9UTF8 *) J9ROMMETHOD_NAME(romMethod), portLib, flags );
 	j9tty_printf( PORTLIB,  "\n");
 
 	j9tty_printf( PORTLIB,  "  Signature: ");
-	dumpUTF( (J9UTF8 *) J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod), portLib, flags );
+	dumpUTF( (J9UTF8 *) J9ROMMETHOD_SIGNATURE(romMethod), portLib, flags );
 	j9tty_printf( PORTLIB,  "\n");
 
 	j9tty_printf( PORTLIB, "  Access Flags (%X): ", romMethod->modifiers);

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -164,12 +164,12 @@ constructRtvMethodContextInfo(MethodContextInfo* methodInfo, J9BytecodeVerificat
 	methodInfo->className.length = J9UTF8_LENGTH((J9ROMCLASS_CLASSNAME(romClass)));
 
 	/* Method */
-	methodInfo->methodName.bytes = J9UTF8_DATA(J9ROMMETHOD_GET_NAME(romClass, romMethod));
-	methodInfo->methodName.length = J9UTF8_LENGTH((J9ROMMETHOD_GET_NAME(romClass, romMethod)));
+	methodInfo->methodName.bytes = J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod));
+	methodInfo->methodName.length = J9UTF8_LENGTH((J9ROMMETHOD_NAME(romMethod)));
 
 	/* Signature */
-	methodInfo->signature.bytes = J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod));
-	methodInfo->signature.length = J9UTF8_LENGTH((J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod)));
+	methodInfo->signature.bytes = J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod));
+	methodInfo->signature.length = J9UTF8_LENGTH((J9ROMMETHOD_SIGNATURE(romMethod)));
 
 	/* Exception handler table */
 	methodInfo->exceptionTable = NULL;

--- a/runtime/vm/ObjectFieldInfo.hpp
+++ b/runtime/vm/ObjectFieldInfo.hpp
@@ -129,18 +129,10 @@ public:
 		_subclassBackfillOffset(NO_BACKFILL_AVAILABLE)
 	{
 		if (J9ROMCLASS_IS_CONTENDED(romClass)) {
-			PORT_ACCESS_FROM_VMC(vm);
-			J9CacheInfoQuery cQuery;
-			memset(&cQuery, 0, sizeof(cQuery));
-			cQuery.cmd = J9PORT_CACHEINFO_QUERY_LINESIZE;
-			cQuery.level = 1;
-			cQuery.cacheType = J9PORT_CACHEINFO_DCACHE;
-			IDATA queryResult = j9sysinfo_get_cache_info(&cQuery);
-			if (queryResult > 0) {
-				_cacheLineSize = (U_32) queryResult;
+			UDATA dCacheLineSize = vm->dCacheLineSize;
+			if (dCacheLineSize > 0) {
+				_cacheLineSize = (U_32) dCacheLineSize;
 				_useContendedClassLayout = true;
-			} else {
-				Trc_VM_contendedLinesizeFailed(queryResult);
 			}
 		}
 	}

--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -364,10 +364,10 @@ buildNativeFunctionNames(J9JavaVM * javaVM, J9Method* ramMethod, J9Class* ramCla
 	classNameData = J9UTF8_DATA(className);
 	classNameLength = J9UTF8_LENGTH(className);
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-	methodName = J9ROMMETHOD_GET_NAME(ramClass->romClass, romMethod);
+	methodName = J9ROMMETHOD_NAME(romMethod);
 	methodNameData = J9UTF8_DATA(methodName) + nameOffset;
 	methodNameLength = J9UTF8_LENGTH(methodName) - (U_16) nameOffset;
-	methodSig = J9ROMMETHOD_GET_SIGNATURE(ramClass->romClass, romMethod);
+	methodSig = J9ROMMETHOD_SIGNATURE(romMethod);
 	methodSigData = J9UTF8_DATA(methodSig);
 	methodSigLength = J9UTF8_LENGTH(methodSig);
 
@@ -566,7 +566,7 @@ nativeSignature(J9Method* nativeMethod, char *resultBuffer)
 	BOOLEAN parsingReturnType = FALSE, processingBracket = FALSE;
 	char nextType = '\0';
 
-	methodSig = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(nativeMethod)->romClass,J9_ROM_METHOD_FROM_RAM_METHOD(nativeMethod));
+	methodSig = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(nativeMethod));
 
 	i = 0;
 	arg = 3; /* skip the return type slot and JNI standard slots, they will be filled in later. */

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -113,7 +113,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *rom
 		j9tty_err_printf(PORTLIB, (char*)format);
 	} else {
 		J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
-		J9UTF8* methodName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
+		J9UTF8* methodName = J9ROMMETHOD_NAME(romMethod);
 		char *sourceFileName = NULL;
 		UDATA sourceFileNameLen = 0;
 		char *moduleNameUTF = NULL;

--- a/runtime/vm/gphandle.c
+++ b/runtime/vm/gphandle.c
@@ -1045,8 +1045,8 @@ writeJITInfo(J9VMThread* vmThread, char* s, UDATA length, void* gpInfo)
 			J9Method *ramMethod = vmThread->jitMethodToBeCompiled;
 			J9Class *clazz = J9_CLASS_FROM_METHOD(ramMethod);
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
-			J9UTF8 *methName = J9ROMMETHOD_GET_NAME(clazz->romClass, romMethod);
-			J9UTF8 *methSig = J9ROMMETHOD_GET_SIGNATURE(clazz->romClass, romMethod);
+			J9UTF8 *methName = J9ROMMETHOD_NAME(romMethod);
+			J9UTF8 *methSig = J9ROMMETHOD_SIGNATURE(romMethod);
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(clazz->romClass);
 
 			n = j9str_printf(PORTLIB, s, length, "\nMethod_being_compiled=%.*s.%.*s%.*s\n",
@@ -1077,8 +1077,8 @@ writeJITInfo(J9VMThread* vmThread, char* s, UDATA length, void* gpInfo)
 			J9Class *clazz = J9_CLASS_FROM_METHOD(ramMethod);
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
 			J9ROMClass *romClass = clazz->romClass;
-			J9UTF8 *methName = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-			J9UTF8 *methSig = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+			J9UTF8 *methName = J9ROMMETHOD_NAME(romMethod);
+			J9UTF8 *methSig = J9ROMMETHOD_SIGNATURE(romMethod);
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 
 			n = j9str_printf(PORTLIB, s, length, "\nCompiled_method=%.*s.%.*s%.*s\n",

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -458,7 +458,7 @@ UDATA JNICALL   pushArguments(J9VMThread *vmThread, J9Method* method, void *args
 #define ARG(type, sig) (jvalues ? (jvalues++->sig) : va_arg(*(va_list*)args, type))
 
 	/* process the arguments */
-	sigChar = &J9UTF8_DATA(J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, J9_ROM_METHOD_FROM_RAM_METHOD(method)))[1];	/* skip the opening '(' */
+	sigChar = &J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method)))[1];	/* skip the opening '(' */
 
 	sp = vmThread->sp;
 
@@ -2115,8 +2115,8 @@ findJNIMethod(J9VMThread* currentThread, J9Class* clazz, char* name, char* signa
 		J9UTF8 * methodName = NULL;
 
 		romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-		methodSignature = J9ROMMETHOD_GET_SIGNATURE(clazz->romClass, romMethod);
-		methodName = J9ROMMETHOD_GET_NAME(clazz->romClass, romMethod);
+		methodSignature = J9ROMMETHOD_SIGNATURE(romMethod);
+		methodName = J9ROMMETHOD_NAME(romMethod);
 		if ((J9UTF8_LENGTH(methodSignature) == signatureLength)
 		&& (J9UTF8_LENGTH(methodName) == nameLength)
 		&& (memcmp(J9UTF8_DATA(methodSignature), signature, signatureLength) == 0)

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5631,6 +5631,18 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 #endif
 
 	PORT_ACCESS_FROM_PORT(portLibrary);
+	IDATA queryResult = 0;
+	J9CacheInfoQuery cQuery = {0};
+	cQuery.cmd = J9PORT_CACHEINFO_QUERY_LINESIZE;
+	cQuery.level = 1;
+	cQuery.cacheType = J9PORT_CACHEINFO_DCACHE;
+	queryResult = j9sysinfo_get_cache_info(&cQuery);
+	if (queryResult > 0) {
+		vm->dCacheLineSize = (UDATA)queryResult;
+	} else {
+		Trc_VM_contendedLinesizeFailed(queryResult);
+	}
+
 	/* check for -Xipt flag and run the iconv_global_init accordingly.
 	 * If this function fails, bail out of VM init instead of hitting some random
 	 * weird undebuggable crash later on

--- a/runtime/vm/linearswalk.c
+++ b/runtime/vm/linearswalk.c
@@ -526,8 +526,8 @@ lswPrintFrames(J9VMThread * vmThread, J9StackWalkState * walkState)
 
 		if (method) {
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-			J9UTF8 * name = J9ROMMETHOD_GET_NAME(J9_CLASS_FROM_METHOD(method)->romClass,romMethod);
-			J9UTF8 * sig = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, romMethod);
+			J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+			J9UTF8 * sig = J9ROMMETHOD_SIGNATURE(romMethod);
 			J9UTF8 * className = J9ROMCLASS_CLASSNAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass);
 
 			lswPrintf(privatePortLibrary, "[%s%-20s%s] j9method 0x%x  %s%.*s.%.*s%.*s%s\n", 

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -113,8 +113,8 @@ searchClassForMethodCommon(J9Class * clazz, U_8 * name, UDATA nameLength, U_8 * 
 
 			do {
 				J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(&(methods[midIndex]));
-				J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-				J9UTF8 * sigUTF = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+				J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
+				J9UTF8 * sigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 				IDATA result = partialMatch ?
 						compareMethodNameAndPartialSignature(name, (U_16) nameLength, sig, (U_16) sigLength, J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(sigUTF))
 						: compareMethodNameAndSignature(name, (U_16) nameLength, sig, (U_16) sigLength, J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(sigUTF));
@@ -135,8 +135,8 @@ searchClassForMethodCommon(J9Class * clazz, U_8 * name, UDATA nameLength, U_8 * 
 
 			do {
 				J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methods);
-				J9UTF8 * nameUTF = J9ROMMETHOD_GET_NAME(romClass, romMethod);
-				J9UTF8 * sigUTF = J9ROMMETHOD_GET_SIGNATURE(romClass, romMethod);
+				J9UTF8 * nameUTF = J9ROMMETHOD_NAME(romMethod);
+				J9UTF8 * sigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 				IDATA result = partialMatch ?
 						compareMethodNameAndPartialSignature(name, (U_16) nameLength, sig, (U_16) sigLength, J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(sigUTF))
 						: compareMethodNameAndSignature(name, (U_16) nameLength, sig, (U_16) sigLength, J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(sigUTF), J9UTF8_LENGTH(sigUTF));
@@ -235,7 +235,7 @@ processMethod(J9VMThread * currentThread, UDATA lookupOptions, J9Method * method
 
 			if (cl1 != cl2) {
 				J9UTF8 * lookupSig;
-				J9UTF8 * methodSig = J9ROMMETHOD_GET_SIGNATURE(J9_CLASS_FROM_METHOD(method)->romClass, romMethod);
+				J9UTF8 * methodSig = J9ROMMETHOD_SIGNATURE(romMethod);
 				if (lookupOptions & J9_LOOK_DIRECT_NAS) {
 					J9NameAndSignature * nas = (J9NameAndSignature *) nameAndSig;
 					lookupSig = nas->signature;

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -421,7 +421,7 @@ UDATA walkFrame(J9StackWalkState * walkState)
 			J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState->method);
 
 			if (!(romMethod->modifiers & J9AccStatic)) {
-				if (J9UTF8_DATA(J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(walkState->method)->ramClass->romClass, romMethod))[0] == '<') {
+				if (J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod))[0] == '<') {
 					if (*walkState->arg0EA == (UDATA) walkState->restartException) {
 						return J9_STACKWALK_KEEP_ITERATING;
 					}
@@ -1103,8 +1103,8 @@ void swPrintMethod(J9StackWalkState * walkState) {
 		PORT_ACCESS_FROM_WALKSTATE(walkState);
 		J9UTF8 * className = J9ROMCLASS_CLASSNAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass);
 		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-		J9UTF8 * name = J9ROMMETHOD_GET_NAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
-		J9UTF8 * sig = J9ROMMETHOD_GET_SIGNATURE(UNTAGGED_METHOD_CP(method)->ramClass->romClass, romMethod);
+		J9UTF8 * name = J9ROMMETHOD_NAME(romMethod);
+		J9UTF8 * sig = J9ROMMETHOD_SIGNATURE(romMethod);
 
 		swPrintf(walkState, 2, "\tMethod: %.*s.%.*s%.*s "
 			"(%p)"

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1466,8 +1466,8 @@ static UDATA printMethodInfo(J9VMThread *currentThread , J9StackWalkState *state
 	J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
 	J9UTF8 *className = J9ROMCLASS_CLASSNAME(methodClass->romClass);
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	J9UTF8* methodName = J9ROMMETHOD_GET_NAME(methodClass->romClass, romMethod);
-	J9UTF8* sig = J9ROMMETHOD_GET_SIGNATURE(methodClass->romClass, romMethod);
+	J9UTF8* methodName = J9ROMMETHOD_NAME(romMethod);
+	J9UTF8* sig = J9ROMMETHOD_SIGNATURE(romMethod);
 	IDATA tracefd = (IDATA) state->userData1;
 	char buf[1024] = "";
 	char *cursor = buf;


### PR DESCRIPTION
- remove J9ROMMETHOD_GET_NAME/SIGNATURE macros
- findDeadlockedThreads missing an exception set
- optimize methodExists UTF comparison
- getMethodParametersAsArray computing arg count twice
- ObjectFieldInfo querying cache line size every construction

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>