### PR TITLE
AArch64: Temporarily disable UnresolvedDataSnippet

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
@@ -20,18 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"
+#include "compile/Compilation.hpp"
 
 uint8_t *
 J9::ARM64::UnresolvedDataSnippet::emitSnippetBody()
    {
-   TR_UNIMPLEMENTED();
+   // Implement this in OpenJ9 PR #5985
+   cg()->comp()->failCompilation<TR::AssertionFailure>("UnresolvedDataSnippet");
    return NULL;
    }
 
 uint32_t
 J9::ARM64::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   TR_UNIMPLEMENTED();
+   // Implement this in OpenJ9 PR #5985
+   cg()->comp()->failCompilation<TR::AssertionFailure>("UnresolvedDataSnippet");
    return 0;
    }


### PR DESCRIPTION
This commit adds failCompilation() to UnresolvedDataSnippet for AArch64
temporarily, until the class is implemented and merged.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>