### PR TITLE
Fix non-OpenJ9 builds by using Sidecar18-SE preprocessor tag

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -440,7 +440,7 @@ private void readObject(ObjectInputStream s)
 	if (suppressedExceptions != null) {
 		List<Throwable> newList = Collections.EMPTY_LIST;;
 		try {
-/*[IF Sidecar18-SE-OpenJ9&!Sidecar19-SE-OpenJ9]*/
+/*[IF Sidecar18-SE&!Sidecar19-SE-OpenJ9]*/
 			ClassLoader listClassLoader = suppressedExceptions.getClass().getClassLoader();
 			/* null ClassLoader from getClassLoader() call represents the bootstrap ClassLoader */
 			if (listClassLoader == null) {


### PR DESCRIPTION
#6557 should have used Sidecar18 instead of Sidecar18-SE-OpenJ9

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>