### PR TITLE
Print help text instead of error when no command specified

### DIFF
--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jcmd.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jcmd.java
@@ -86,19 +86,24 @@ public class Jcmd {
 		} else if ((args.length == 1) && (null != firstArgument) && Arrays.stream(HELP_OPTIONS).anyMatch(firstArgument::equals)) {	
 			System.out.printf(HELPTEXT);
 		} else {
-			String vmid = firstArgument;
-			AttacherDiagnosticsProvider diagProvider = new AttacherDiagnosticsProvider();
 			command = DiagnosticUtils.makeJcmdCommand(args, 1);
-			try {
-				diagProvider.attach(vmid);
-				try {
-					Util.runCommandAndPrintResult(diagProvider, command, command); // $NON-NLS-1$
-				} finally {
-					diagProvider.detach();
-				}
-			} catch (IOException e) {
-				Util.handleCommandException(vmid, e);
+			if (command.isEmpty()) {
+				System.err.printf("There is no jcmd command.%n"); //$NON-NLS-1$
 				System.out.printf(HELPTEXT);
+			} else {
+				String vmid = firstArgument;
+				AttacherDiagnosticsProvider diagProvider = new AttacherDiagnosticsProvider();
+				try {
+					diagProvider.attach(vmid);
+					try {
+						Util.runCommandAndPrintResult(diagProvider, command, command); // $NON-NLS-1$
+					} finally {
+						diagProvider.detach();
+					}
+				} catch (IOException e) {
+					Util.handleCommandException(vmid, e);
+					System.out.printf(HELPTEXT);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Print help text instead of error when no command specified ####

Don't send an empty command to the target and get an error back, print an error message and help text instead.

Related: #6780 

Reviewer: @pshipton 
FYI: @pdbain-ibm 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>