### PR TITLE
Replace all JITaaS prefix with JITServer under runtime folder

### DIFF
--- a/doc/compiler/jitserver/Caching.md
+++ b/doc/compiler/jitserver/Caching.md
@@ -51,6 +51,6 @@ It is possible for this cache to contain outdated profiling data, because IProfi
 - Persistent cache: stores data for already compiled methods, because their interpreter profiling data will definitely not change.
 Uses a slightly different hash table type `IPTable_t`, because it's located inside entries of `J9MethodInfo`, so it only takes
 bytecode index as a key.
-## `TR_ResolvedJ9JITaaSServerMethod`
+## `TR_ResolvedJ9JITServerMethod`
 Some per-compilation caches are stored inside resolved methods, they store results of some resolved method query. These caches do not need to be explicitly cleared, since resolved methods only exist for the duration of one compilation. I am not sure if it is a good thing to have local caches spread out across 2 files, maybe it would be a good idea to move all caches from resolved method to `CompilationInfoPerThreadRemote`.
 

--- a/doc/compiler/jitserver/OptionsDev.md
+++ b/doc/compiler/jitserver/OptionsDev.md
@@ -20,7 +20,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-Options parsing happens mostly in `control/J9Options.cpp`. Parsing of the -XX:JITServer options happens mostly in `fePostProcess` and a few helper functions. If you want to add a suboption that should probably go in `JITaaSParseOptionsCommon`. The values of most options are stored in the `PersistentInfo` after they are parsed.
+Options parsing happens mostly in `control/J9Options.cpp`. Parsing of the -XX:JITServer options happens mostly in `fePostProcess` and a few helper functions. If you want to add a suboption that should probably go in `JITServerParseCommonOptions`. The values of most options are stored in the `PersistentInfo` after they are parsed.
 
 Two functions `packOptions` and `unpackOptions` are used for sending options specified at the client to the server, so that it is not necessary to specify the same options on both the client and server. However, at the moment there is still some code that checks for command line options directly instead of going through the options for the current compilation. So for those options you must specify them at both the client and the server. You usually don't need to worry about this, but if some option doesn't seem to be working you may want to try adding it to the server as well. There are also a few options which are not sent because they are uncommon and difficult to serialize. Such options are set to `NULL` within `packOptions`.
 

--- a/doc/compiler/jitserver/ResolvedMethod.md
+++ b/doc/compiler/jitserver/ResolvedMethod.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2018 IBM Corp. and others
+Copyright (c) 2018, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 ResolvedMethod is a wrapper around a Java method which exists for the duration of a single compilation. It collects and manages information about a method and related classes. We need to extend it 
 
-On the server, we extend `TR_ResolvedJ9JITaaSServerMethod` from `TR_ResolvedJ9Method`. Upon instantiation, a mirror instance is created on the client. Instantiation happens either directly via the `createResolvedMethod` family, or indirectly using one of multiple `getResolvedXXXMethod` methods, which perform operations to locate a method of interest and then create the corresponding `ResolvedMethod`.
+On the server, we extend `TR_ResolvedJ9JITServerMethod` from `TR_ResolvedJ9Method`. Upon instantiation, a mirror instance is created on the client. Instantiation happens either directly via the `createResolvedMethod` family, or indirectly using one of multiple `getResolvedXXXMethod` methods, which perform operations to locate a method of interest and then create the corresponding `ResolvedMethod`.
 
 Many method calls which require VM access are relayed to the client-side mirror. However, some values are cached at the server to avoid sending remote messages. Since all resolved methods are destroyed at the end of the compilation, this is a good choice as a cache for data which may be invalidated by class unloading/redefinition.

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1085,7 +1085,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
          if (!allowedToReserve)
             {
             persistentClassInfo->setReservable(false);
-            // This is currently the only place where this flag gets cleared. For JITaaS, we should propagate it to the client,
+            // This is currently the only place where this flag gets cleared. For JITServer, we should propagate it to the client,
             // to avoid having to call scanForNativeMethodsUntilMonitorNode again.
             if (auto stream = TR::CompilationInfo::getStream())
                {
@@ -2627,11 +2627,11 @@ J9::CodeGenerator::processRelocations()
    //Project neutral non-AOT processRelocation
    OMR::CodeGenerator::processRelocations();
 
-   bool isJITaaSMode = comp()->isOutOfProcessCompilation();
+   bool isJITServerMode = comp()->isOutOfProcessCompilation();
 
    int32_t missedSite = -1;
 
-   if (self()->comp()->compileRelocatableCode() || isJITaaSMode)
+   if (self()->comp()->compileRelocatableCode() || isJITServerMode)
       {
       if (self()->comp()->compileRelocatableCode())
          {

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -65,7 +65,7 @@
  */
 bool firstCompileStarted = false;
 
-// TODO disabled to allow for JITaaS
+// TODO disabled to allow for JITServer
 /*
 void *operator new(size_t size)
    {
@@ -89,7 +89,7 @@ void *operator new(size_t size)
  * can't be used by JIT code, so we inject an assertion here.
  */
 
-// TODO disabled to allow for JITaaS
+// TODO disabled to allow for JITServer
 /*
 void operator delete(void *)
    {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -313,7 +313,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool incompleteOptimizerSupportForReadWriteBarriers();
 
-   // JITaaS
+   // JITServer
    bool isOutOfProcessCompilation() const { return _outOfProcessCompilation; } // server side
    void setOutOfProcessCompilation() { _outOfProcessCompilation = true; }
    bool isRemoteCompilation() const { return _remoteCompilation; } // client side
@@ -409,10 +409,10 @@ private:
    TR_RelocationRuntime *_reloRuntime;
 
    // The following flag is set when this compilation is performed in a
-   // VM that does not have the runtime part (server side in JITaaS)
+   // VM that does not have the runtime part (server side in JITServer)
    bool _outOfProcessCompilation; 
    // The following flag is set when a request to complete this compilation
-   // has been sent to a remote VM (client side in JITaaS)
+   // has been sent to a remote VM (client side in JITServer)
    bool _remoteCompilation; 
 
    TR::SymbolValidationManager *_symbolValidationManager;

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1429,7 +1429,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
       symRef->setReallySharesSymbol();
 
    TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
-   // check for KnownObjectTable first, in JITaaS mode, this will return NULL,
+   // check for KnownObjectTable first, in JITServer mode, this will return NULL,
    // so we never enter the critical section
    TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
    if (knot

--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -263,10 +263,10 @@ TR_OptimizationPlan *TR::DefaultCompilationStrategy::processEvent(TR_MethodEvent
          }
          break;
       case TR_MethodEvent::RemoteCompilationRequest:
-         //compInfo->_stats._methodsCompiledOnCount++; // JITaaS TODO: add a new statistic
+         //compInfo->_stats._methodsCompiledOnCount++; // JITServer TODO: add a new statistic
 
-         hotnessLevel = event->_JITaaSClientOptLevel;
-         // JITaaS TODO: allow the creation of a profiling body
+         hotnessLevel = event->_JITClientOptLevel;
+         // JITServer TODO: allow the creation of a profiling body
          plan = TR_OptimizationPlan::alloc(hotnessLevel);
          *newPlanCreated = true;
          break;

--- a/runtime/compiler/control/CompilationController.hpp
+++ b/runtime/compiler/control/CompilationController.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ class TR_MethodEvent
    J9VMThread * _vmThread;
    J9Class *    _classNeedingThunk; // for newInstanceImpl
    TR_Hotness   _nextOptLevel; // Used for HWP-based recompilation
-   TR_Hotness   _JITaaSClientOptLevel; // Used for JITaaS compilation
+   TR_Hotness   _JITClientOptLevel; // Used for JITServer compilation
    };
 
 

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -74,7 +74,7 @@ struct TR_JitPrivateConfig;
 struct TR_MethodToBeCompiled;
 template <typename T> class TR_PersistentArray;
 typedef J9JITExceptionTable TR_MethodMetaData;
-class ClientSessionHT; // JITaaS TODO: maybe move all JITServer specific stuff in an extension for CompInfo
+class ClientSessionHT; // JITServer TODO: maybe move all JITServer specific stuff in an extension for CompInfo
 
 #if defined(JITSERVER_SUPPORT)
 namespace JITServer { class ServerStream; }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3319,7 +3319,7 @@ void TR::CompilationInfo::stopCompilationThreads()
          }
       }
 
-   if (feGetEnv("TR_PrintJITaaSConnStats"))
+   if (feGetEnv("TR_PrintJITServerConnStats"))
       {
       if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
@@ -4001,8 +4001,8 @@ TR::CompilationInfoPerThread::processEntries()
          }
       }
 
-   static bool enableJITaaSPerCompConn = feGetEnv("TR_EnableJITaaSPerCompConn") ? true : false;
-   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT && !enableJITaaSPerCompConn)
+   static bool enableJITServerPerCompConn = feGetEnv("TR_EnableJITServerPerCompConn") ? true : false;
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT && !enableJITServerPerCompConn)
       {
       JITServer::ClientStream *client = getClientStream();
       if (client)
@@ -5336,7 +5336,7 @@ void TR::CompilationInfo::recycleCompilationEntry(TR_MethodToBeCompiled *entry)
    entry->_freeTag |= ENTRY_IN_POOL_NOT_FREE;
    if (entry->_numThreadsWaiting == 0)
       entry->_freeTag |= ENTRY_IN_POOL_FREE;
-   entry->cleanupJITaaS();
+   entry->cleanupJITServer();
 
    entry->_next = _methodPool;
    _methodPool = entry;
@@ -7147,7 +7147,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
                doLocalCompilation = true;
                entry->_optimizationPlan->setOptLevel(cold);
                entry->_optimizationPlan->setOptLevelDowngraded(true);
-               // JITaaS TODO: queue a remote upgrade right away, but at a lower priority
+               // JITServer TODO: queue a remote upgrade right away, but at a lower priority
                // If so, disable GCR trees for those cold compilations.
                }
             }
@@ -7850,7 +7850,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   (vm->isAOT_DEPRECATED_DO_NOT_USE() || that->_methodBeingCompiled->isAotLoad()),
                   that->getCompThreadId());
 
-            // JITaaS TODO determine if we care to support annotations
+            // JITServer TODO determine if we care to support annotations
             if (that->_methodBeingCompiled->isRemoteCompReq())
                options->setOption(TR_EnableAnnotations,false);
 
@@ -8269,7 +8269,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                p->_optimizationPlan,
                reloRuntime);
 
-         // JITaaS TODO: put info in optPlan so that compilation constructor can do this
+         // JITServer TODO: put info in optPlan so that compilation constructor can do this
          if (that->_methodBeingCompiled->isRemoteCompReq())
             compiler->setRemoteCompilation();
          else if (that->_methodBeingCompiled->isOutOfProcessCompReq())
@@ -8756,7 +8756,7 @@ TR::CompilationInfoPerThreadBase::compile(
          }
 
       // If we want to compile without VM access, now it's the time to release it
-      // For the JITaaS client we must not enter this path. The class unload monitor 
+      // For the JITClient we must not enter this path. The class unload monitor
       // will not be acquired/released and we'll only release VMaccess when 
       // waiting for a reply from the server
       if (!compiler->getOption(TR_DisableNoVMAccess) &&
@@ -12776,7 +12776,7 @@ TR::CompilationInfo::requeueOutOfProcessEntry(TR_MethodToBeCompiled *entry)
 
    recycleCompilationEntry(entry);
    // we do not requeue outOfProcessEntry for the Per-Compilation-Connection Mode
-   if (feGetEnv("TR_EnableJITaaSPerCompConn"))
+   if (feGetEnv("TR_EnableJITServerPerCompConn"))
       return;
 
    if (entry->_stream && addOutOfProcessMethodToBeCompiled(entry->_stream))

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -244,7 +244,7 @@ class CompilationInfoPerThreadBase
    static TR::FILE *getPerfFile() { return _perfFile; } // used on Linux for perl tool support
    static void setPerfFile(TR::FILE *f) { _perfFile = f; }
 
-   // JITaaS
+   // JITServer
    void                   setClientData(ClientSessionData *data) { _cachedClientDataPtr = data; }
    ClientSessionData     *getClientData() { return _cachedClientDataPtr; }
 
@@ -256,7 +256,7 @@ class CompilationInfoPerThreadBase
    TR::CompilationInfo &        _compInfo;
    J9JITConfig * const          _jitConfig;
    TR_SharedCacheRelocationRuntime _sharedCacheReloRuntime;
-   TR_JITaaSRelocationRuntime      _remoteCompileReloRuntime;
+   TR_JITServerRelocationRuntime _remoteCompileReloRuntime;
    int32_t const                _compThreadId; // unique number starting from 0; Only used for compilation on separate thread
    bool const                   _onSeparateThread;
 
@@ -277,7 +277,7 @@ class CompilationInfoPerThreadBase
 
    static TR::FILE *_perfFile; // used on Linux for perl tool support
 
-   // JITaaS
+   // JITServer
    ClientSessionData * _cachedClientDataPtr;
    JITServer::ClientStream * _clientStream;
 
@@ -373,7 +373,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    bool                   isDiagnosticThread() const { return _isDiagnosticThread; }
    CpuSelfThreadUtilization& getCompThreadCPU() { return _compThreadCPU; }
 
-   // JITaaS
+   // JITServer
    TR_J9ServerVM         *getServerVM() { return _serverVM; }
    void                   setServerVM(TR_J9ServerVM *vm) { _serverVM = vm; }
    TR_J9SharedCacheServerVM *getSharedCacheServerVM() { return _sharedCacheServerVM; }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1968,9 +1968,9 @@ IDATA dumpJitInfo(J9VMThread *crashedThread, char *logFileLabel, J9RASdumpContex
       TR::CompilationInfo *compInfo = TR::CompilationInfo::get(context->javaVM->jitConfig);
       if (compInfo)
          {
-         static char * isPrintJITaaSMsgStats = feGetEnv("TR_PrintJITaaSMsgStats");
-         if (isPrintJITaaSMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-            printJITaaSMsgStats(jitConfig);
+         static char * isPrintJITServerMsgStats = feGetEnv("TR_PrintJITServerMsgStats");
+         if (isPrintJITServerMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+            printJITServerMsgStats(jitConfig);
 
          if (feGetEnv("TR_PrintJITServerCHTableStats"))
             printJITServerCHTableStats(jitConfig, compInfo);
@@ -2765,7 +2765,7 @@ static void jitHookClassUnload(J9HookInterface * * hookInterface, UDATA eventNum
    if (table)
       table->classGotUnloaded(fej9, clazz);
 
-   // Add to JITaaS unload list
+   // Add to JITServer unload list
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       compInfo->getUnloadedClassesTempList()->push_back(clazz);
 
@@ -3002,7 +3002,7 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
    classPair = classList;
    for (i = 0; i < classCount; i++)
       {
-      // Add to JITaaS unload list
+      // Add to JITServer unload list
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
          compInfo->getUnloadedClassesTempList()->push_back((TR_OpaqueClassBlock *) classPair->oldClass);
 
@@ -4759,9 +4759,9 @@ void JitShutdown(J9JITConfig * jitConfig)
       j9tty_printf(PORTLIB, "\tNo prof. info because timestamp expired: %10d\n", TR_IProfiler::_STATS_timestampHasExpired);
       }
 
-   static char * isPrintJITaaSMsgStats = feGetEnv("TR_PrintJITaaSMsgStats");
-   if (isPrintJITaaSMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-      printJITaaSMsgStats(jitConfig);
+   static char * isPrintJITServerMsgStats = feGetEnv("TR_PrintJITServerMsgStats");
+   if (isPrintJITServerMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+      printJITServerMsgStats(jitConfig);
 
    static char * isPrintJITServerCHTableStats = feGetEnv("TR_PrintJITServerCHTableStats");
    if (isPrintJITServerCHTableStats)

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2083,7 +2083,7 @@ J9::Options::fePreProcess(void * base)
          compInfo->getPersistentInfo()->setClientUID(dist(rng));
          }
       }
-   // _safeReservePhysicalMemoryValue is set as 0 for the JITServer client because compilations
+   // _safeReservePhysicalMemoryValue is set as 0 for the JITClient because compilations
    // are done remotely. The user can still override it with a command line option
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
       {

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -732,7 +732,7 @@ TR_PersistentMethodInfo::setForSharedInfo(TR_PersistentProfileInfo** ptr, TR_Per
       TR_PersistentProfileInfo::decRefCount((TR_PersistentProfileInfo*)oldPtr);
    }
 
-// used for JITaaS
+// used for JITServer
 TR_PersistentJittedBodyInfo *
 J9::Recompilation::persistentJittedBodyInfoFromString(const std::string &bodyInfoStr, const std::string &methodInfoStr, TR_Memory *trMemory)
    {

--- a/runtime/compiler/control/J9Recompilation.hpp
+++ b/runtime/compiler/control/J9Recompilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,7 +132,7 @@ public:
    static int32_t jitGlobalSampleCount;
    static int32_t jitRecompilationsInduced;
 
-   // used for JITaaS
+   // used for JITServer
    static TR_PersistentJittedBodyInfo * persistentJittedBodyInfoFromString(const std::string &bodyInfoStr, const std::string &methodInfoStr, TR_Memory * trMemory);
 
 protected:

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -20,8 +20,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef JITaaS_COMPILATION_THREAD_H
-#define JITaaS_COMPILATION_THREAD_H
+#ifndef JITSERVER_COMPILATION_THREAD_H
+#define JITSERVER_COMPILATION_THREAD_H
 
 #include <unordered_map>
 #include "control/CompilationThread.hpp"
@@ -35,13 +35,11 @@ class TR_PersistentClassInfo;
 class TR_IPBytecodeHashTableEntry;
 struct TR_RemoteROMStringKey;
 
-
 using IPTableHeapEntry = UnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
 using IPTableHeap_t = UnorderedMap<J9Method *, IPTableHeapEntry *>;
 using ResolvedMirrorMethodsPersistIP_t = Vector<TR_ResolvedJ9Method *>;
 using ClassOfStatic_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_OpaqueClassBlock *>;
 using FieldOrStaticAttrTable_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_J9MethodFieldAttributes>;
-
 
 size_t methodStringLength(J9ROMMethod *);
 std::string packROMClass(J9ROMClass *, TR_Memory *);
@@ -50,13 +48,13 @@ TR_MethodMetaData *remoteCompile(J9VMThread *, TR::Compilation *, TR_ResolvedMet
 TR_MethodMetaData *remoteCompilationEnd(J9VMThread * vmThread, TR::Compilation *comp, TR_ResolvedMethod * compilee, J9Method * method,
    TR::CompilationInfoPerThreadBase *compInfoPT, const std::string& codeCacheStr, const std::string& dataCacheStr);
 void outOfProcessCompilationEnd(TR_MethodToBeCompiled *entry, TR::Compilation *comp);
-void printJITaaSMsgStats(J9JITConfig *);
+void printJITServerMsgStats(J9JITConfig *);
 void printJITServerCHTableStats(J9JITConfig *, TR::CompilationInfo *);
-void printJITaaSCacheStats(J9JITConfig *, TR::CompilationInfo *);
+void printJITServerCacheStats(J9JITConfig *, TR::CompilationInfo *);
 
 namespace TR
 {
-// Objects of this type are instantiated at JITaaS server
+// Objects of this type are instantiated at JITServer
 class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    {
    public:
@@ -73,8 +71,8 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
 
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
-   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo);
-   bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedJ9JITaaSServerMethod *owningMethod, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
+   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedJ9JITServerMethodInfo &methodInfo);
+   bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedJ9JITServerMethod *owningMethod, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
    TR_ResolvedMethodKey getResolvedMethodKey(TR_ResolvedMethodType type, TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_OpaqueClassBlock *classObject = NULL);
 
    void cacheResolvedMirrorMethodsPersistIPInfo(TR_ResolvedJ9Method *resolvedMethod);
@@ -233,4 +231,4 @@ class JITServerHelpers
    static TR::Monitor * _clientStreamMonitor;
    }; // class JITServerHelpers
 
-#endif // defined(JITaaS_COMPILATION_THREAD_H)
+#endif // defined(JITSERVER_COMPILATION_THREAD_H)

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -96,7 +96,7 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
 void
 TR_MethodToBeCompiled::shutdown()
    {
-   cleanupJITaaS();
+   cleanupJITServer();
    TR::MonitorTable *table = TR::MonitorTable::get();
    if (!table) return;
    table->removeAndDestroy(_monitor);
@@ -146,9 +146,9 @@ TR_MethodToBeCompiled::getClientUID() const
    }
 
 void
-TR_MethodToBeCompiled::cleanupJITaaS()
+TR_MethodToBeCompiled::cleanupJITServer()
    {
-   // JITaaS: clean up c-style string client options which was allocated using persistent allocator
+   // JITServer: clean up c-style string client options which was allocated using persistent allocator
    if (_clientOptions)
       {
       _compInfoPT->getCompilationInfo()->persistentMemory()->freePersistentMemory((void *)_clientOptions);

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -67,7 +67,7 @@ struct TR_MethodToBeCompiled
    void unsetRemoteCompReq() { _remoteCompReq = false; }
    bool isOutOfProcessCompReq() const { return _stream != NULL; } // at the server
    uint64_t getClientUID() const;
-   void cleanupJITaaS();
+   void cleanupJITServer();
    bool hasChangedToLocalSyncComp() const { return _origOptLevel != unknownHotness; }
 
    TR_MethodToBeCompiled *_next;
@@ -123,7 +123,7 @@ struct TR_MethodToBeCompiled
    uint8_t                _weight; // Up to 256 levels of weight
    bool                   _hasIncrementedNumCompThreadsCompilingHotterMethods;
    uint8_t                _jitStateWhenQueued;
-   bool                   _remoteCompReq; // comp request should be sent remotely to JITaaS server
+   bool                   _remoteCompReq; // comp request should be sent remotely to JITServer
    JITServer::ServerStream  *_stream; // a non-NULL field denotes an out-of-process compilation request
    char                  *_clientOptions;
    size_t                _clientOptionsSize;

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -325,7 +325,7 @@ class TR_PersistentJittedBodyInfo
    friend class TR_DebugExt;
 
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
-   friend void fixPersistentMethodInfo(void *table, bool isJITaaS);
+   friend void fixPersistentMethodInfo(void *table, bool isJITServer);
 #endif
 
    public:

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -782,14 +782,14 @@ TR_J9SharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataD
          descriptor);
    }
 
-TR_J9JITaaSServerSharedCache::TR_J9JITaaSServerSharedCache(TR_J9VMBase *fe)
+TR_J9JITServerSharedCache::TR_J9JITServerSharedCache(TR_J9VMBase *fe)
    : TR_J9SharedCache(fe)
    {
    _stream = NULL;
    }
 
 void *
-TR_J9JITaaSServerSharedCache::pointerFromOffsetInSharedCache(void *offset)
+TR_J9JITServerSharedCache::pointerFromOffsetInSharedCache(void *offset)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    // compute pointer from client's cache start address
@@ -798,7 +798,7 @@ TR_J9JITaaSServerSharedCache::pointerFromOffsetInSharedCache(void *offset)
    }
 
 void *
-TR_J9JITaaSServerSharedCache::offsetInSharedCacheFromPointer(void *ptr)
+TR_J9JITServerSharedCache::offsetInSharedCacheFromPointer(void *ptr)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    // return offset from client's cache start address
@@ -807,7 +807,7 @@ TR_J9JITaaSServerSharedCache::offsetInSharedCacheFromPointer(void *ptr)
    }
 
 UDATA *
-TR_J9JITaaSServerSharedCache::rememberClass(J9Class *clazz, bool create)
+TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    auto clientData = TR::compInfoPT->getClientData();
@@ -841,7 +841,7 @@ TR_J9JITaaSServerSharedCache::rememberClass(J9Class *clazz, bool create)
    }
 
 UDATA
-TR_J9JITaaSServerSharedCache::getCacheStartAddress()
+TR_J9JITServerSharedCache::getCacheStartAddress()
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
@@ -849,7 +849,7 @@ TR_J9JITaaSServerSharedCache::getCacheStartAddress()
    }
 
 uintptrj_t
-TR_J9JITaaSServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz)
+TR_J9JITServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    _stream->write(JITServer::MessageType::SharedCache_getClassChainOffsetInSharedCache, clazz);
@@ -857,7 +857,7 @@ TR_J9JITaaSServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSh
    }
 
 void
-TR_J9JITaaSServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
+TR_J9JITServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
@@ -869,7 +869,7 @@ TR_J9JITaaSServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theH
    }
 
 const void *
-TR_J9JITaaSServerSharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    std::string dataStr((char *) descriptor->address, descriptor->length);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -162,12 +162,12 @@ private:
    static UDATA                          _storeSharedDataFailedLength;
    };
 
-class TR_J9JITaaSServerSharedCache : public TR_J9SharedCache
+class TR_J9JITServerSharedCache : public TR_J9SharedCache
    {
 public:
    TR_ALLOC(TR_Memory::SharedCache)
 
-   TR_J9JITaaSServerSharedCache(TR_J9VMBase *fe);
+   TR_J9JITServerSharedCache(TR_J9VMBase *fe);
 
    virtual bool isHint(TR_ResolvedMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT(false, "called"); return false;}
    virtual bool isHint(J9Method *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT(false, "called"); return false;}

--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -67,7 +67,7 @@ J9::VMMethodEnv::bytecodeStart(TR_OpaqueMethodBlock *method)
    auto stream = TR::CompilationInfo::getStream();
    if (stream)
       // Don't need to call getOriginalROMMethod, because
-      // in JITaaS romMethodOfRamMethod already fetches
+      // in JITServer romMethodOfRamMethod already fetches
       // ROM method from its ROM class.
       // Also, the return value of this function might be 
       // dereferenced later on, so need ROM method to be on the server.

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -151,7 +151,7 @@ JITServerPersistentCHTable::commitModifications(const std::string &rawData)
          auto classInfo = findClassInfo(flat->_subClasses[i]);
 
          // For some reason the subclass info is still null sometimes. This may be indicative of a larger problem or it could be harmless.
-         // JITaaS TODO: figure out why this is happening
+         // JITServer TODO: figure out why this is happening
          //TR_ASSERT(classInfo, "subclass info cannot be null: ensure subclasses are loaded before superclass");
          if (classInfo)
             persist->addSubClass(classInfo);
@@ -451,7 +451,7 @@ JITClientPersistentCHTable::classGotLoaded(
       TR_OpaqueClassBlock *classId)
    {
    TR_ASSERT(!findClassInfo(classId), "Should not add duplicates to hash table\n");
-   TR_PersistentClassInfo *clazz = new (PERSISTENT_NEW) TR_JITaaSPersistentClassInfo(classId, this);
+   TR_PersistentClassInfo *clazz = new (PERSISTENT_NEW) TR_JITServerPersistentClassInfo(classId, this);
    if (clazz)
       {
       auto classes = getClasses();
@@ -497,131 +497,131 @@ JITClientPersistentCHTable::markDirty(TR_OpaqueClassBlock *clazz)
    }
 
 
-// TR_JITaaSPersistentClassInfo
-JITClientPersistentCHTable *TR_JITaaSPersistentClassInfo::_chTable = NULL;
+// TR_JITServerPersistentClassInfo
+JITClientPersistentCHTable *TR_JITServerPersistentClassInfo::_chTable = NULL;
 
-TR_JITaaSPersistentClassInfo::TR_JITaaSPersistentClassInfo(TR_OpaqueClassBlock *id, JITClientPersistentCHTable *chTable) : 
+TR_JITServerPersistentClassInfo::TR_JITServerPersistentClassInfo(TR_OpaqueClassBlock *id, JITClientPersistentCHTable *chTable) :
    TR_PersistentClassInfo(id)
    {
    // assign pointer to the CH table, if it's the first class info created
-   if (!TR_JITaaSPersistentClassInfo::_chTable)
-      TR_JITaaSPersistentClassInfo::_chTable = chTable;
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(id);
+   if (!TR_JITServerPersistentClassInfo::_chTable)
+      TR_JITServerPersistentClassInfo::_chTable = chTable;
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(id);
    }
 
 void
-TR_JITaaSPersistentClassInfo::setInitialized(TR_PersistentMemory *persistentMemory)
+TR_JITServerPersistentClassInfo::setInitialized(TR_PersistentMemory *persistentMemory)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setInitialized(persistentMemory);
    }
 
 void
-TR_JITaaSPersistentClassInfo::setClassId(TR_OpaqueClassBlock *newClass)
+TR_JITServerPersistentClassInfo::setClassId(TR_OpaqueClassBlock *newClass)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setClassId(newClass);
    }
 
-void TR_JITaaSPersistentClassInfo::setFirstSubClass(TR_SubClass *sc)
+void TR_JITServerPersistentClassInfo::setFirstSubClass(TR_SubClass *sc)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setFirstSubClass(sc);
    }
 
-void TR_JITaaSPersistentClassInfo::setFieldInfo(TR_PersistentClassInfoForFields *i)
+void TR_JITServerPersistentClassInfo::setFieldInfo(TR_PersistentClassInfoForFields *i)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setFieldInfo(i);
    }
 
-TR_SubClass *TR_JITaaSPersistentClassInfo::addSubClass(TR_PersistentClassInfo *subClass)
+TR_SubClass *TR_JITServerPersistentClassInfo::addSubClass(TR_PersistentClassInfo *subClass)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    return TR_PersistentClassInfo::addSubClass(subClass);
    }
 
-void TR_JITaaSPersistentClassInfo::removeSubClasses()
+void TR_JITServerPersistentClassInfo::removeSubClasses()
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::removeSubClasses();
    }
 
-void TR_JITaaSPersistentClassInfo::removeASubClass(TR_PersistentClassInfo *subClass)
+void TR_JITServerPersistentClassInfo::removeASubClass(TR_PersistentClassInfo *subClass)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::removeASubClass(subClass);
    }
 
-void TR_JITaaSPersistentClassInfo::removeUnloadedSubClasses()
+void TR_JITServerPersistentClassInfo::removeUnloadedSubClasses()
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::removeUnloadedSubClasses();
    }
 
-void TR_JITaaSPersistentClassInfo::setUnloaded()
+void TR_JITServerPersistentClassInfo::setUnloaded()
    {
    // The only method that marks for removal
-   TR_JITaaSPersistentClassInfo::_chTable->markForRemoval(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markForRemoval(getClassId());
    TR_PersistentClassInfo::setUnloaded();
    }
 
-void TR_JITaaSPersistentClassInfo::incNumPrexAssumptions()
+void TR_JITServerPersistentClassInfo::incNumPrexAssumptions()
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::incNumPrexAssumptions();
    }
    
-void TR_JITaaSPersistentClassInfo::setReservable(bool v)
+void TR_JITServerPersistentClassInfo::setReservable(bool v)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setReservable(v);
    }
 
-void TR_JITaaSPersistentClassInfo::setShouldNotBeNewlyExtended(int32_t ID)
+void TR_JITServerPersistentClassInfo::setShouldNotBeNewlyExtended(int32_t ID)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setShouldNotBeNewlyExtended(ID);
    }
 
-void TR_JITaaSPersistentClassInfo::resetShouldNotBeNewlyExtended(int32_t ID)
+void TR_JITServerPersistentClassInfo::resetShouldNotBeNewlyExtended(int32_t ID)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::resetShouldNotBeNewlyExtended(ID);
    }
 
-void TR_JITaaSPersistentClassInfo::clearShouldNotBeNewlyExtended()
+void TR_JITServerPersistentClassInfo::clearShouldNotBeNewlyExtended()
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::clearShouldNotBeNewlyExtended();
    }
 
-void TR_JITaaSPersistentClassInfo::setHasRecognizedAnnotations(bool v)
+void TR_JITServerPersistentClassInfo::setHasRecognizedAnnotations(bool v)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setHasRecognizedAnnotations(v);
    }
 
-void TR_JITaaSPersistentClassInfo::setAlreadyCheckedForAnnotations(bool v)
+void TR_JITServerPersistentClassInfo::setAlreadyCheckedForAnnotations(bool v)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setAlreadyCheckedForAnnotations(v);
    }
 
-void TR_JITaaSPersistentClassInfo::setCannotTrustStaticFinal(bool v)
+void TR_JITServerPersistentClassInfo::setCannotTrustStaticFinal(bool v)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setCannotTrustStaticFinal(v);
    }
 
-void TR_JITaaSPersistentClassInfo::setClassHasBeenRedefined(bool v)
+void TR_JITServerPersistentClassInfo::setClassHasBeenRedefined(bool v)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setClassHasBeenRedefined(v);
    }
 
-void TR_JITaaSPersistentClassInfo::setNameLength(int32_t length)
+void TR_JITServerPersistentClassInfo::setNameLength(int32_t length)
    {
-   TR_JITaaSPersistentClassInfo::_chTable->markDirty(getClassId());
+   TR_JITServerPersistentClassInfo::_chTable->markDirty(getClassId());
    TR_PersistentClassInfo::setNameLength(length);
    }

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -136,11 +136,11 @@ public:
    TR_OpaqueClassBlock                *_subClasses[0];
    };
 
-class TR_JITaaSPersistentClassInfo : public TR_PersistentClassInfo
+class TR_JITServerPersistentClassInfo : public TR_PersistentClassInfo
    {
 public:
    TR_PERSISTENT_ALLOC(TR_Memory::PersistentInfo);
-   TR_JITaaSPersistentClassInfo(TR_OpaqueClassBlock *id, JITClientPersistentCHTable *chTable);
+   TR_JITServerPersistentClassInfo(TR_OpaqueClassBlock *id, JITClientPersistentCHTable *chTable);
 
    // All of these methods mark the classInfo as dirty/removed and call a parent method
    virtual void setInitialized(TR_PersistentMemory *) override;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -739,10 +739,10 @@ TR_J9VMBase::TR_J9VMBase(
    _sharedCache = NULL;
    if (TR::Options::sharedClassCache() ||
        (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER))
-      // shared classes and AOT must be enabled, or we should be on the JITaaS server with remote AOT enabled
+      // shared classes and AOT must be enabled, or we should be on the JITServer with remote AOT enabled
       {
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-         _sharedCache = new (PERSISTENT_NEW) TR_J9JITaaSServerSharedCache(this);
+         _sharedCache = new (PERSISTENT_NEW) TR_J9JITServerSharedCache(this);
       else
          _sharedCache = new (PERSISTENT_NEW) TR_J9SharedCache(this);
       if (!_sharedCache)
@@ -3826,7 +3826,7 @@ TR_J9VMBase::tryToAcquireAccess(TR::Compilation * comp, bool *haveAcquiredVMAcce
    bool hasVMAccess;
    *haveAcquiredVMAccess = false;
 
-   // JITaaS TODO: For now, we always take the "safe path" on the server
+   // JITServer TODO: For now, we always take the "safe path" on the server
    if (TR::CompilationInfo::getStream())
       return false;
 
@@ -7364,7 +7364,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
 
          TR::SymbolReference *helperSymRef = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
          sym->setMethodAddress(helperSymRef->getMethodAddress());
-         // JITaaS: store the helper reference number in the node for use in creating TR_HelperAddress relocation
+         // JITServer: store the helper reference number in the node for use in creating TR_HelperAddress relocation
          callNode->getSymbolReference()->setReferenceNumber(helperSymRef->getReferenceNumber());
          return callNode;
          }

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -162,7 +162,7 @@ typedef struct TR_JitPrivateConfig
    } TR_JitPrivateConfig;
 
 
-// JITaaS: union containing all possible datatypes of static final fields
+// JITServer: union containing all possible datatypes of static final fields
 union
 TR_StaticFinalData
    {
@@ -238,8 +238,8 @@ public:
       DEFAULT_VM = 0
       , J9_VM
       , AOT_VM
-      , J9_SERVER_VM // for JITaaS
-      , J9_SHARED_CACHE_SERVER_VM // for Remote AOT JITaaS
+      , J9_SERVER_VM // for JITServer
+      , J9_SHARED_CACHE_SERVER_VM // for Remote AOT JITServer
       };
 
    TR_J9VMBase(J9JITConfig * jitConfig, TR::CompilationInfo * compInfo, J9VMThread * vmContext);
@@ -911,7 +911,7 @@ public:
    TR::TreeTop * lowerContigArrayLength( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    TR::TreeTop * lowerMultiANewArray( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    TR::TreeTop * lowerToVcall( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   virtual U_8 * fetchMethodExtendedFlagsPointer(J9Method *method); // wrapper method of fetchMethodExtendedFlagsPointer in util/extendedmethodblockaccess.c, for JITaaS override purpose
+   virtual U_8 * fetchMethodExtendedFlagsPointer(J9Method *method); // wrapper method of fetchMethodExtendedFlagsPointer in util/extendedmethodblockaccess.c, for JITServer override purpose
    virtual void * getStaticHookAddress(int32_t event);
 
    TR::Node * initializeLocalObjectFlags( TR::Compilation *, TR::Node * allocationNode, TR_OpaqueClassBlock * ramClass);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1364,8 +1364,8 @@ TR_ResolvedRelocatableJ9Method::TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBl
             SVM_ASSERT_ALREADY_VALIDATED(svm, aMethod);
             SVM_ASSERT_ALREADY_VALIDATED(svm, containingClass());
             }
-         else if (owner) // JITaaS: in baseline, if owner doesn't exist then comp doesn't exist, so thi case is not possible
-            // but in JITaaS client comp is initialized before creating resolved method for compilee, so need this guard.
+         else if (owner) // JITServer: in baseline, if owner doesn't exist then comp doesn't exist, so thi case is not possible
+            // but in JITClient comp is initialized before creating resolved method for compilee, so need this guard.
             {
             ((TR_ResolvedRelocatableJ9Method *) owner)->validateArbitraryClass(comp, (J9Class*)containingClass());
             }
@@ -2366,7 +2366,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
    construct();
    }
 
-// protected constructor to be used by JITaaS
+// protected constructor to be used by JITServer
 // had to reorder arguments to prevent ambiguity with above constructor (because the way constructors work in C++ is awful)
 TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_FrontEnd * fe, TR_ResolvedMethod * owner)
    : TR_J9Method(), TR_ResolvedJ9MethodBase(fe, owner), _pendingPushSlots(-1)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -204,7 +204,7 @@ public:
    TR_J9Method(TR_FrontEnd *trvm, TR_Memory *, TR_OpaqueMethodBlock * aMethod);
 
 protected:
-   // To be used by JITaaS.
+   // To be used by JITServer.
    // Warning: some initialization must be done manually after calling this constructor
    TR_J9Method();
    };
@@ -271,9 +271,9 @@ class TR_ResolvedJ9Method : public TR_J9Method, public TR_ResolvedJ9MethodBase
 public:
    TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
 
-   // JITaaS: make virtual
+   // JITServer: make virtual
    //
-   // JITaaS TODO: make protected, returning Opaque versions
+   // JITServer TODO: make protected, returning Opaque versions
    J9ROMMethod *           romMethod() { return _romMethod; }
    virtual J9ROMClass *            romClassPtr();
    virtual J9ConstantPool *      cp();
@@ -520,7 +520,7 @@ protected:
    TR_ResolvedJ9Method(TR_FrontEnd *, TR_ResolvedMethod * owningMethod = 0);
    virtual void construct();
 
-// JITaaS TODO
+// JITServer TODO
 //private:
    virtual TR_ResolvedMethod *createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats);
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -49,7 +49,7 @@ romMethodAtClassIndex(J9ROMClass *romClass, uint64_t methodIndex)
    return romMethod;
    }
 
-TR_ResolvedJ9JITaaSServerMethod::TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, TR_ResolvedMethod * owningMethod, uint32_t vTableSlot)
+TR_ResolvedJ9JITServerMethod::TR_ResolvedJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, TR_ResolvedMethod * owningMethod, uint32_t vTableSlot)
    : TR_ResolvedJ9Method(fe, owningMethod)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
@@ -58,17 +58,17 @@ TR_ResolvedJ9JITaaSServerMethod::TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethod
    _stream = threadCompInfo->getMethodBeingCompiled()->_stream;
 
    // Create client side mirror of this object to use for calls involving RAM data
-   TR_ResolvedJ9Method* owningMethodMirror = owningMethod ? ((TR_ResolvedJ9JITaaSServerMethod*) owningMethod)->_remoteMirror : NULL;
+   TR_ResolvedJ9Method* owningMethodMirror = owningMethod ? ((TR_ResolvedJ9JITServerMethod*) owningMethod)->_remoteMirror : NULL;
 
    // If in AOT mode, will actually create relocatable version of resolved method on the client
    _stream->write(JITServer::MessageType::mirrorResolvedJ9Method, aMethod, owningMethodMirror, vTableSlot, fej9->isAOT_DEPRECATED_DO_NOT_USE());
-   auto recv = _stream->read<TR_ResolvedJ9JITaaSServerMethodInfo>();
+   auto recv = _stream->read<TR_ResolvedJ9JITServerMethodInfo>();
    auto &methodInfo = std::get<0>(recv);
 
    unpackMethodInfo(aMethod, fe, trMemory, vTableSlot, threadCompInfo, methodInfo);
    }
 
-TR_ResolvedJ9JITaaSServerMethod::TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_ResolvedMethod * owningMethod, uint32_t vTableSlot)
+TR_ResolvedJ9JITServerMethod::TR_ResolvedJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedMethod * owningMethod, uint32_t vTableSlot)
    : TR_ResolvedJ9Method(fe, owningMethod)
    {
    // Mirror has already been created, its parameters are passed in methodInfo
@@ -80,31 +80,31 @@ TR_ResolvedJ9JITaaSServerMethod::TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethod
    }
 
 J9ROMClass *
-TR_ResolvedJ9JITaaSServerMethod::romClassPtr()
+TR_ResolvedJ9JITServerMethod::romClassPtr()
    {
    return _romClass;
    }
 
 J9RAMConstantPoolItem *
-TR_ResolvedJ9JITaaSServerMethod::literals()
+TR_ResolvedJ9JITServerMethod::literals()
    {
    return _literals;
    }
 
 J9Class *
-TR_ResolvedJ9JITaaSServerMethod::constantPoolHdr()
+TR_ResolvedJ9JITServerMethod::constantPoolHdr()
    {
    return _ramClass;
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isJNINative()
+TR_ResolvedJ9JITServerMethod::isJNINative()
    {
    return _isJNINative;
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::setRecognizedMethodInfo(TR::RecognizedMethod rm)
+TR_ResolvedJ9JITServerMethod::setRecognizedMethodInfo(TR::RecognizedMethod rm)
    {
    TR_ResolvedJ9Method::setRecognizedMethodInfo(rm);
    _stream->write(JITServer::MessageType::ResolvedMethod_setRecognizedMethodInfo, _remoteMirror, rm);
@@ -112,13 +112,13 @@ TR_ResolvedJ9JITaaSServerMethod::setRecognizedMethodInfo(TR::RecognizedMethod rm
    }
 
 J9ClassLoader *
-TR_ResolvedJ9JITaaSServerMethod::getClassLoader()
+TR_ResolvedJ9JITServerMethod::getClassLoader()
    {
    return _classLoader; // cached version
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::staticAttributes(TR::Compilation * comp, I_32 cpIndex, void * * address, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
+TR_ResolvedJ9JITServerMethod::staticAttributes(TR::Compilation * comp, I_32 cpIndex, void * * address, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
    {
    bool isStatic = true;
    TR_J9MethodFieldAttributes attributes;
@@ -143,7 +143,7 @@ TR_ResolvedJ9JITaaSServerMethod::staticAttributes(TR::Compilation * comp, I_32 c
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp, uint32_t cpIndex, bool returnClassForAOT)
+TR_ResolvedJ9JITServerMethod::getClassFromConstantPool(TR::Compilation * comp, uint32_t cpIndex, bool returnClassForAOT)
    {
    if (cpIndex == -1)
       return NULL;
@@ -176,7 +176,7 @@ TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedJ9JITaaSServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)
+TR_ResolvedJ9JITServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)
    {
    TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
       {
@@ -206,7 +206,7 @@ TR_ResolvedJ9JITaaSServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilat
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedJ9JITaaSServerMethod::classOfStatic(I_32 cpIndex, bool returnClassForAOT)
+TR_ResolvedJ9JITServerMethod::classOfStatic(I_32 cpIndex, bool returnClassForAOT)
    {
    // if method is unresolved, return right away
    if (cpIndex < 0)
@@ -252,7 +252,7 @@ TR_ResolvedJ9JITaaSServerMethod::classOfStatic(I_32 cpIndex, bool returnClassFor
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isConstantDynamic(I_32 cpIndex)
+TR_ResolvedJ9JITServerMethod::isConstantDynamic(I_32 cpIndex)
    {
    TR_ASSERT_FATAL(cpIndex != -1, "ConstantDynamic cpIndex shouldn't be -1");
    UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(_romClass), cpIndex);
@@ -260,7 +260,7 @@ TR_ResolvedJ9JITaaSServerMethod::isConstantDynamic(I_32 cpIndex)
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Compilation * comp, I_32 cpIndex, bool ignoreRtResolve, bool * unresolvedInCP)
+TR_ResolvedJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Compilation * comp, I_32 cpIndex, bool ignoreRtResolve, bool * unresolvedInCP)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 #if TURN_OFF_INLINING
@@ -280,7 +280,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
          performTransformation(comp, "Setting as unresolved virtual call cpIndex=%d\n",cpIndex) ) || ignoreRtResolve)
       {
       _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedPossiblyPrivateVirtualMethodAndMirror, (TR_ResolvedMethod *) _remoteMirror, literals(), cpIndex);
-      auto recv = _stream->read<J9Method *, UDATA, bool, TR_ResolvedJ9JITaaSServerMethodInfo>();
+      auto recv = _stream->read<J9Method *, UDATA, bool, TR_ResolvedJ9JITServerMethodInfo>();
       J9Method *ramMethod = std::get<0>(recv);
       UDATA vTableIndex = std::get<1>(recv);
 
@@ -301,7 +301,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
          if (comp->getOption(TR_EnableAOTStats))
             aotStats = & (((TR_JitPrivateConfig *)_fe->_jitConfig->privateConfig)->aotStats->virtualMethods);
 
-         TR_ResolvedJ9JITaaSServerMethodInfo methodInfo = std::get<3>(recv);
+         TR_ResolvedJ9JITServerMethodInfo methodInfo = std::get<3>(recv);
          
          // call constructor without making a new query
          if (createResolvedMethod)
@@ -341,7 +341,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Com
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(
+TR_ResolvedJ9JITServerMethod::getResolvedVirtualMethod(
    TR::Compilation *comp,
    I_32 cpIndex,
    bool ignoreRtResolve,
@@ -357,13 +357,13 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::fieldsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame)
+TR_ResolvedJ9JITServerMethod::fieldsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame)
    {
    if (TR::comp()->compileRelocatableCode())
       // in AOT, this should always return false, because mainline compares class loaders
       // with fe->sameClassLoaders, which always returns false for AOT compiles
       return false;
-   TR_ResolvedJ9JITaaSServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(m2);
+   TR_ResolvedJ9JITServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITServerMethod*>(m2);
    if (getClassLoader() != serverMethod2->getClassLoader())
       return false;
 
@@ -399,13 +399,13 @@ TR_ResolvedJ9JITaaSServerMethod::fieldsAreSame(int32_t cpIndex1, TR_ResolvedMeth
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::staticsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame)
+TR_ResolvedJ9JITServerMethod::staticsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame)
    {
    if (TR::comp()->compileRelocatableCode())
       // in AOT, this should always return false, because mainline compares class loaders
       // with fe->sameClassLoaders, which always returns false for AOT compiles
       return false;
-   TR_ResolvedJ9JITaaSServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(m2);
+   TR_ResolvedJ9JITServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITServerMethod*>(m2);
    if (getClassLoader() != serverMethod2->getClassLoader())
       return false;
 
@@ -443,7 +443,7 @@ TR_ResolvedJ9JITaaSServerMethod::staticsAreSame(int32_t cpIndex1, TR_ResolvedMet
    }
 
 TR_FieldAttributesCache *
-TR_ResolvedJ9JITaaSServerMethod::getAttributesCache(bool isStatic, bool unresolvedInCP)
+TR_ResolvedJ9JITServerMethod::getAttributesCache(bool isStatic, bool unresolvedInCP)
    {
    // Return a persistent attributes cache for regular JIT compilations
    TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
@@ -459,7 +459,7 @@ TR_ResolvedJ9JITaaSServerMethod::getAttributesCache(bool isStatic, bool unresolv
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::getCachedFieldAttributes(int32_t cpIndex, TR_J9MethodFieldAttributes &attributes, bool isStatic)
+TR_ResolvedJ9JITServerMethod::getCachedFieldAttributes(int32_t cpIndex, TR_J9MethodFieldAttributes &attributes, bool isStatic)
    {
    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
       {
@@ -481,7 +481,7 @@ TR_ResolvedJ9JITaaSServerMethod::getCachedFieldAttributes(int32_t cpIndex, TR_J9
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::cacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic)
+TR_ResolvedJ9JITServerMethod::cacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic)
    {
    // When caching field or static attributes, there are 2 caches where they can go:
    // 1. Persistent cache - stores attributes of all resolved fields. Since the field is resolved,
@@ -508,7 +508,7 @@ TR_ResolvedJ9JITaaSServerMethod::cacheFieldAttributes(int32_t cpIndex, const TR_
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::canCacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic)
+TR_ResolvedJ9JITServerMethod::canCacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic)
    {
    auto attributesCache = getAttributesCache(isStatic);
    auto it = attributesCache->find(cpIndex);
@@ -526,7 +526,7 @@ TR_ResolvedJ9JITaaSServerMethod::canCacheFieldAttributes(int32_t cpIndex, const 
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::fieldAttributes(TR::Compilation * comp, I_32 cpIndex, U_32 * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
+TR_ResolvedJ9JITServerMethod::fieldAttributes(TR::Compilation * comp, I_32 cpIndex, U_32 * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
    {
    bool isStatic = false;
    TR_J9MethodFieldAttributes attributes;
@@ -580,9 +580,9 @@ static bool doResolveAtRuntime(J9Method *method, I_32 cpIndex, TR::Compilation *
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedStaticMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP)
+TR_ResolvedJ9JITServerMethod::getResolvedStaticMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP)
    {
-   // JITaaS TODO: Decide whether the counters should be updated on the server or the client
+   // JITServer TODO: Decide whether the counters should be updated on the server or the client
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 
    auto compInfoPT = (TR::CompilationInfoPerThreadRemote *) _fe->_compInfoPT;
@@ -591,7 +591,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedStaticMethod(TR::Compilation * comp,
       return resolvedMethod;
 
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedStaticMethodAndMirror, _remoteMirror, cpIndex);
-   auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo, bool>();
+   auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITServerMethodInfo, bool>();
    J9Method * ramMethod = std::get<0>(recv); 
    if (unresolvedInCP)
       *unresolvedInCP = std::get<2>(recv);
@@ -643,9 +643,9 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedStaticMethod(TR::Compilation * comp,
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP)
+TR_ResolvedJ9JITServerMethod::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP)
    {
-   // JITaaS TODO: Decide whether the counters should be updated on the server or the client
+   // JITServer TODO: Decide whether the counters should be updated on the server or the client
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    
    auto compInfoPT = (TR::CompilationInfoPerThreadRemote *) _fe->_compInfoPT;
@@ -658,7 +658,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedSpecialMethod(TR::Compilation * comp
       *unresolvedInCP = true;
 
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror, _remoteMirror, cpIndex);
-   auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo>();
+   auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITServerMethodInfo>();
    J9Method * ramMethod = std::get<0>(recv);
    auto methodInfo = std::get<1>(recv);
 
@@ -693,26 +693,26 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedSpecialMethod(TR::Compilation * comp
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats)
+TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats)
    {
-   return new (comp->trHeapMemory()) TR_ResolvedJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) j9Method, _fe, comp->trMemory(), this, vTableSlot);
+   return new (comp->trHeapMemory()) TR_ResolvedJ9JITServerMethod((TR_OpaqueMethodBlock *) j9Method, _fe, comp->trMemory(), this, vTableSlot);
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo)
+TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITServerMethodInfo &methodInfo)
    {
-   return new (comp->trHeapMemory()) TR_ResolvedJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) j9Method, _fe, comp->trMemory(), methodInfo, this, vTableSlot);
+   return new (comp->trHeapMemory()) TR_ResolvedJ9JITServerMethod((TR_OpaqueMethodBlock *) j9Method, _fe, comp->trMemory(), methodInfo, this, vTableSlot);
    }
 
 uint32_t
-TR_ResolvedJ9JITaaSServerMethod::classCPIndexOfMethod(uint32_t methodCPIndex)
+TR_ResolvedJ9JITServerMethod::classCPIndexOfMethod(uint32_t methodCPIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_classCPIndexOfMethod, _remoteMirror, methodCPIndex);
    return std::get<0>(_stream->read<uint32_t>());
    }
 
 void *
-TR_ResolvedJ9JITaaSServerMethod::startAddressForJittedMethod()
+TR_ResolvedJ9JITServerMethod::startAddressForJittedMethod()
    {
    // return the cached value if we have any
    if (_startAddressForJittedMethod)
@@ -727,7 +727,7 @@ TR_ResolvedJ9JITaaSServerMethod::startAddressForJittedMethod()
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::localName(U_32 slotNumber, U_32 bcIndex, I_32 &len, TR_Memory *trMemory)
+TR_ResolvedJ9JITServerMethod::localName(U_32 slotNumber, U_32 bcIndex, I_32 &len, TR_Memory *trMemory)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_localName, _remoteMirror, slotNumber, bcIndex);
    const std::string nameString = std::get<0>(_stream->read<std::string>());
@@ -738,7 +738,7 @@ TR_ResolvedJ9JITaaSServerMethod::localName(U_32 slotNumber, U_32 bcIndex, I_32 &
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(I_32 cpIndex, UDATA *pITableIndex)
+TR_ResolvedJ9JITServerMethod::getResolvedInterfaceMethod(I_32 cpIndex, UDATA *pITableIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedInterfaceMethod_2, _remoteMirror, cpIndex);
    auto recv = _stream->read<TR_OpaqueClassBlock *, UDATA>();
@@ -755,7 +755,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(I_32 cpIndex, UDATA 
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(TR::Compilation * comp, TR_OpaqueClassBlock * classObject, I_32 cpIndex)
+TR_ResolvedJ9JITServerMethod::getResolvedInterfaceMethod(TR::Compilation * comp, TR_OpaqueClassBlock * classObject, I_32 cpIndex)
    {
    TR_ResolvedMethod *resolvedMethod = NULL;
    auto compInfoPT = (TR::CompilationInfoPerThreadRemote *) _fe->_compInfoPT;
@@ -764,7 +764,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(TR::Compilation * co
       return resolvedMethod;
    
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedInterfaceMethodAndMirror_3, getPersistentIdentifier(), classObject, cpIndex, _remoteMirror);
-   auto recv = _stream->read<bool, J9Method*, TR_ResolvedJ9JITaaSServerMethodInfo>();
+   auto recv = _stream->read<bool, J9Method*, TR_ResolvedJ9JITServerMethodInfo>();
    bool resolved = std::get<0>(recv);
    J9Method *ramMethod = std::get<1>(recv);
    auto &methodInfo = std::get<2>(recv);
@@ -816,7 +816,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethod(TR::Compilation * co
    }
 
 U_32
-TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * classObject, I_32 cpIndex)
+TR_ResolvedJ9JITServerMethod::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * classObject, I_32 cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedInterfaceMethodOffset, _remoteMirror, classObject, cpIndex);
    auto recv = _stream->read<U_32>();
@@ -830,7 +830,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedInterfaceMethodOffset(TR_OpaqueClass
  * - a non-final method of Object, using virtual dispatch.
  */
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(TR::Compilation * comp, I_32 cpIndex)
+TR_ResolvedJ9JITServerMethod::getResolvedImproperInterfaceMethod(TR::Compilation * comp, I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 #if TURN_OFF_INLINING
@@ -846,7 +846,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(TR::Compilat
 
       // query for resolved method and create its mirror at the same time
       _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror, _remoteMirror, cpIndex);
-      auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITaaSServerMethodInfo>();
+      auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITServerMethodInfo>();
       auto j9method = std::get<0>(recv);
       auto methodInfo = std::get<1>(recv);
 
@@ -868,7 +868,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(TR::Compilat
    }
 
 void *
-TR_ResolvedJ9JITaaSServerMethod::startAddressForJNIMethod(TR::Compilation *comp)
+TR_ResolvedJ9JITServerMethod::startAddressForJNIMethod(TR::Compilation *comp)
    {
    // For fastJNI methods, we have the address cached
    if (_jniProperties)
@@ -878,14 +878,14 @@ TR_ResolvedJ9JITaaSServerMethod::startAddressForJNIMethod(TR::Compilation *comp)
    }
 
 void *
-TR_ResolvedJ9JITaaSServerMethod::startAddressForInterpreterOfJittedMethod()
+TR_ResolvedJ9JITServerMethod::startAddressForInterpreterOfJittedMethod()
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_startAddressForInterpreterOfJittedMethod, _remoteMirror);
    return std::get<0>(_stream->read<void *>());
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp, TR_OpaqueClassBlock * classObject, I_32 virtualCallOffset, bool ignoreRtResolve)
+TR_ResolvedJ9JITServerMethod::getResolvedVirtualMethod(TR::Compilation * comp, TR_OpaqueClassBlock * classObject, I_32 virtualCallOffset, bool ignoreRtResolve)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
    if (_fe->_compInfoPT->getClientData()->getRtResolve() && !ignoreRtResolve)
@@ -900,7 +900,7 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp
 
    // Remote call finds RAM method at offset and creates a resolved method at the client
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedVirtualMethod, classObject, virtualCallOffset, ignoreRtResolve, (TR_ResolvedJ9Method *) getRemoteMirror());
-   auto recv = _stream->read<TR_OpaqueMethodBlock *, TR_ResolvedJ9JITaaSServerMethodInfo>();
+   auto recv = _stream->read<TR_OpaqueMethodBlock *, TR_ResolvedJ9JITServerMethodInfo>();
    auto ramMethod = std::get<0>(recv);
    auto &methodInfo = std::get<1>(recv);
 
@@ -913,11 +913,11 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp
          if (!comp->getSymbolValidationManager()->addVirtualMethodFromOffsetRecord(ramMethod, classObject, virtualCallOffset, ignoreRtResolve))
             return NULL;
          }
-      resolvedMethod = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), methodInfo, this) : 0;
+      resolvedMethod = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), methodInfo, this) : 0;
       }
    else
       {
-      resolvedMethod = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), methodInfo, this) : 0;
+      resolvedMethod = ramMethod ? new (comp->trHeapMemory()) TR_ResolvedJ9JITServerMethod((TR_OpaqueMethodBlock *) ramMethod, _fe, comp->trMemory(), methodInfo, this) : 0;
       }
    if (resolvedMethod)
       compInfoPT->cacheResolvedMethod(compInfoPT->getResolvedMethodKey(TR_ResolvedMethodType::VirtualFromOffset, clazz, virtualCallOffset, classObject), ramMethod, 0, methodInfo);
@@ -925,13 +925,13 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedVirtualMethod(TR::Compilation * comp
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::inROMClass(void * address)
+TR_ResolvedJ9JITServerMethod::inROMClass(void * address)
    {
    return address >= romClassPtr() && address < ((uint8_t*)romClassPtr()) + romClassPtr()->romSize;
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::getRemoteROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
+TR_ResolvedJ9JITServerMethod::getRemoteROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
    {
    auto offsetFirst = *offsets.begin();
    auto offsetSecond = (offsets.size() == 2) ? *(offsets.begin() + 1) : 0;
@@ -994,7 +994,7 @@ TR_ResolvedJ9JITaaSServerMethod::getRemoteROMString(int32_t &len, void *basePtr,
 // it, but we cannot easily determine if the reference is outside or not (or even if it is a reference!)
 // because the data is untyped.
 char *
-TR_ResolvedJ9JITaaSServerMethod::getROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
+TR_ResolvedJ9JITServerMethod::getROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
    {
    uint8_t *ptr = (uint8_t*) basePtr;
    for (size_t offset : offsets)
@@ -1011,7 +1011,7 @@ TR_ResolvedJ9JITaaSServerMethod::getROMString(int32_t &len, void *basePtr, std::
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticSignatureChars(I_32 cpIndex, int32_t & len)
+TR_ResolvedJ9JITServerMethod::fieldOrStaticSignatureChars(I_32 cpIndex, int32_t & len)
    {
    if (cpIndex < 0)
       return 0;
@@ -1025,7 +1025,7 @@ TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticSignatureChars(I_32 cpIndex, int32
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length)
+TR_ResolvedJ9JITServerMethod::getClassNameFromConstantPool(uint32_t cpIndex, uint32_t &length)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 
@@ -1039,7 +1039,7 @@ TR_ResolvedJ9JITaaSServerMethod::getClassNameFromConstantPool(uint32_t cpIndex, 
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::classNameOfFieldOrStatic(I_32 cpIndex, int32_t & len)
+TR_ResolvedJ9JITServerMethod::classNameOfFieldOrStatic(I_32 cpIndex, int32_t & len)
    {
    if (cpIndex == -1)
       return 0;
@@ -1054,7 +1054,7 @@ TR_ResolvedJ9JITaaSServerMethod::classNameOfFieldOrStatic(I_32 cpIndex, int32_t 
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::classSignatureOfFieldOrStatic(I_32 cpIndex, int32_t & len)
+TR_ResolvedJ9JITServerMethod::classSignatureOfFieldOrStatic(I_32 cpIndex, int32_t & len)
    {
    if (cpIndex == -1)
       return 0;
@@ -1068,7 +1068,7 @@ TR_ResolvedJ9JITaaSServerMethod::classSignatureOfFieldOrStatic(I_32 cpIndex, int
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
+TR_ResolvedJ9JITServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
    {
    if (cpIndex < 0)
       return 0;
@@ -1082,7 +1082,7 @@ TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & 
    }
 
 char *
-TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind)
+TR_ResolvedJ9JITServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind)
    {
    if (cpIndex == -1)
       return "<internal name>";
@@ -1145,7 +1145,7 @@ TR_ResolvedJ9JITaaSServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, 
    }
 
 void *
-TR_ResolvedJ9JITaaSServerMethod::stringConstant(I_32 cpIndex)
+TR_ResolvedJ9JITServerMethod::stringConstant(I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
@@ -1157,7 +1157,7 @@ TR_ResolvedJ9JITaaSServerMethod::stringConstant(I_32 cpIndex)
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
+TR_ResolvedJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
    {
    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
    TR_IsUnresolvedString stringAttrs;
@@ -1173,7 +1173,7 @@ TR_ResolvedJ9JITaaSServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeF
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isSubjectToPhaseChange(TR::Compilation *comp)
+TR_ResolvedJ9JITServerMethod::isSubjectToPhaseChange(TR::Compilation *comp)
    {
    bool candidate = comp->getOptLevel() <= warm &&
         // comp->getPersistentInfo()->getJitState() == STARTUP_STATE // This needs to be asked at the server
@@ -1193,13 +1193,13 @@ TR_ResolvedJ9JITaaSServerMethod::isSubjectToPhaseChange(TR::Compilation *comp)
       {
       _stream->write(JITServer::MessageType::ResolvedMethod_isSubjectToPhaseChange, _remoteMirror);
       return std::get<0>(_stream->read<bool>());
-      // JITaaS TODO: cache the JitState when we create  TR_ResolvedJ9JITaaSServerMethod
-      // This may not behave exactly like the non-JITaaS due to timing differences
+      // JITServer TODO: cache the JitState when we create  TR_ResolvedJ9JITServerMethod
+      // This may not behave exactly like the non-JITServer due to timing differences
       }
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP)
+TR_ResolvedJ9JITServerMethod::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 #if TURN_OFF_INLINING
@@ -1219,14 +1219,14 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedHandleMethod(TR::Compilation * comp,
 
 #if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
 void *
-TR_ResolvedJ9JITaaSServerMethod::methodTypeTableEntryAddress(int32_t cpIndex)
+TR_ResolvedJ9JITServerMethod::methodTypeTableEntryAddress(int32_t cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_methodTypeTableEntryAddress, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<void*>());
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
+TR_ResolvedJ9JITServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedMethodTypeTableEntry, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<bool>());
@@ -1234,35 +1234,35 @@ TR_ResolvedJ9JITaaSServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpInde
 #endif
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)
+TR_ResolvedJ9JITServerMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedCallSiteTableEntry, _remoteMirror, callSiteIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
 void *
-TR_ResolvedJ9JITaaSServerMethod::callSiteTableEntryAddress(int32_t callSiteIndex)
+TR_ResolvedJ9JITServerMethod::callSiteTableEntryAddress(int32_t callSiteIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_callSiteTableEntryAddress, _remoteMirror, callSiteIndex);
    return std::get<0>(_stream->read<void*>());
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
+TR_ResolvedJ9JITServerMethod::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
 void *
-TR_ResolvedJ9JITaaSServerMethod::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
+TR_ResolvedJ9JITServerMethod::varHandleMethodTypeTableEntryAddress(int32_t cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_varHandleMethodTypeTableEntryAddress, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<void*>());
    }
 
 TR_ResolvedMethod *
-TR_ResolvedJ9JITaaSServerMethod::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callSiteIndex, bool * unresolvedInCP)
+TR_ResolvedJ9JITServerMethod::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callSiteIndex, bool * unresolvedInCP)
    {
    TR_ASSERT(callSiteIndex != -1, "callSiteIndex shouldn't be -1");
 
@@ -1285,19 +1285,19 @@ TR_ResolvedJ9JITaaSServerMethod::getResolvedDynamicMethod(TR::Compilation * comp
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::shouldFailSetRecognizedMethodInfoBecauseOfHCR()
+TR_ResolvedJ9JITServerMethod::shouldFailSetRecognizedMethodInfoBecauseOfHCR()
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_shouldFailSetRecognizedMethodInfoBecauseOfHCR, _remoteMirror);
    return std::get<0>(_stream->read<bool>());
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isSameMethod(TR_ResolvedMethod * m2)
+TR_ResolvedJ9JITServerMethod::isSameMethod(TR_ResolvedMethod * m2)
    {
    if (isNative())
       return false; // A jitted JNI method doesn't call itself
 
-   auto other = static_cast<TR_ResolvedJ9JITaaSServerMethod*>(m2);
+   auto other = static_cast<TR_ResolvedJ9JITServerMethod*>(m2);
 
    bool sameRamMethod = ramMethod() == other->ramMethod();
    if (!sameRamMethod)
@@ -1344,7 +1344,7 @@ TR_ResolvedJ9JITaaSServerMethod::isSameMethod(TR_ResolvedMethod * m2)
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::isInlineable(TR::Compilation *comp)
+TR_ResolvedJ9JITServerMethod::isInlineable(TR::Compilation *comp)
    {
    // Reduce number of remote queries by testing the options first
    // This assumes knowledge of how the original is implemented
@@ -1360,7 +1360,7 @@ TR_ResolvedJ9JITaaSServerMethod::isInlineable(TR::Compilation *comp)
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *comp)
+TR_ResolvedJ9JITServerMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *comp)
    {
    // set the variable in the server IProfiler
    TR_ResolvedJ9Method::setWarmCallGraphTooBig(bcIndex, comp);
@@ -1370,20 +1370,20 @@ TR_ResolvedJ9JITaaSServerMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Co
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::setVirtualMethodIsOverridden()
+TR_ResolvedJ9JITServerMethod::setVirtualMethodIsOverridden()
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_setVirtualMethodIsOverridden, _remoteMirror);
    _stream->read<JITServer::Void>();
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::methodIsNotzAAPEligible()
+TR_ResolvedJ9JITServerMethod::methodIsNotzAAPEligible()
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_methodIsNotzAAPEligible, _remoteMirror);
    return std::get<0>(_stream->read<bool>());
    }
 void
-TR_ResolvedJ9JITaaSServerMethod::setClassForNewInstance(J9Class *c)
+TR_ResolvedJ9JITServerMethod::setClassForNewInstance(J9Class *c)
    {
    _j9classForNewInstance = c;
    _stream->write(JITServer::MessageType::ResolvedMethod_setClassForNewInstance, _remoteMirror, c);
@@ -1391,7 +1391,7 @@ TR_ResolvedJ9JITaaSServerMethod::setClassForNewInstance(J9Class *c)
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedJ9JITaaSServerMethod::classOfMethod()
+TR_ResolvedJ9JITServerMethod::classOfMethod()
       {
       if (isNewInstanceImplThunk())
          {
@@ -1403,13 +1403,13 @@ TR_ResolvedJ9JITaaSServerMethod::classOfMethod()
       }
 
 TR_PersistentJittedBodyInfo *
-TR_ResolvedJ9JITaaSServerMethod::getExistingJittedBodyInfo()
+TR_ResolvedJ9JITServerMethod::getExistingJittedBodyInfo()
    {
    return _bodyInfo; // return cached value
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::getFaninInfo(uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight)
+TR_ResolvedJ9JITServerMethod::getFaninInfo(uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight)
    {
    uint32_t i = 0;
    uint32_t w = 0;
@@ -1434,7 +1434,7 @@ TR_ResolvedJ9JITaaSServerMethod::getFaninInfo(uint32_t *count, uint32_t *weight,
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::getCallerWeight(TR_ResolvedJ9Method *caller, uint32_t *weight, uint32_t pcIndex)
+TR_ResolvedJ9JITServerMethod::getCallerWeight(TR_ResolvedJ9Method *caller, uint32_t *weight, uint32_t pcIndex)
    {
    TR_OpaqueMethodBlock *callerMethod = caller->getPersistentIdentifier();
    bool useTuples = (pcIndex != ~0);
@@ -1469,7 +1469,7 @@ TR_ResolvedJ9JITaaSServerMethod::getCallerWeight(TR_ResolvedJ9Method *caller, ui
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory)
+TR_ResolvedJ9JITServerMethod::createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory)
    {
    // Create resolved method mirror on the client.
    // Should be called to mirror a call to resolved method constructor,
@@ -1486,7 +1486,7 @@ TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodMirror(TR_ResolvedJ9JITaaSS
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory)
+TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory)
    {
    // Create resolved method mirror on the client.
    // Should be called to mirror a call to TR_Resolved(Relocatable)MethodFromJ9Method::createResolvedMethodFromJ9Method.
@@ -1554,7 +1554,7 @@ TR_ResolvedJ9JITaaSServerMethod::createResolvedMethodFromJ9MethodMirror(TR_Resol
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::packMethodInfo(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_ResolvedJ9Method *resolvedMethod, TR_FrontEnd *fe)
+TR_ResolvedJ9JITServerMethod::packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedJ9Method *resolvedMethod, TR_FrontEnd *fe)
    {
    auto &methodInfoStruct = std::get<0>(methodInfo);
    if (!resolvedMethod)
@@ -1612,7 +1612,7 @@ TR_ResolvedJ9JITaaSServerMethod::packMethodInfo(TR_ResolvedJ9JITaaSServerMethodI
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo)
+TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo)
    {
    auto methodInfoStruct = std::get<0>(methodInfo);
    
@@ -1669,7 +1669,7 @@ TR_ResolvedJ9JITaaSServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method)
+TR_ResolvedJ9JITServerMethod::addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method)
    {
    // This method should be called whenever this resolved method is fetched from
    // cache during AOT compilation, because
@@ -1711,7 +1711,7 @@ TR_ResolvedJ9JITaaSServerMethod::addValidationRecordForCachedResolvedMethod(cons
    }
 
 void
-TR_ResolvedJ9JITaaSServerMethod::cacheResolvedMethodsCallees()
+TR_ResolvedJ9JITServerMethod::cacheResolvedMethodsCallees()
    {
    // 1. Iterate through bytecodes and look for method invokes.
    // If resolved method corresponding to an invoke is not cached, add it
@@ -1780,7 +1780,7 @@ TR_ResolvedJ9JITaaSServerMethod::cacheResolvedMethodsCallees()
 
    // 2. Send a remote query to mirror all uncached resolved methods
    _stream->write(JITServer::MessageType::ResolvedMethod_getMultipleResolvedMethods, (TR_ResolvedJ9Method *) _remoteMirror, methodTypes, cpIndices);
-   auto recv = _stream->read<std::vector<J9Method *>, std::vector<uint32_t>, std::vector<TR_ResolvedJ9JITaaSServerMethodInfo>>();
+   auto recv = _stream->read<std::vector<J9Method *>, std::vector<uint32_t>, std::vector<TR_ResolvedJ9JITServerMethodInfo>>();
 
    // 3. Cache all received resolved methods
    auto ramMethods = std::get<0>(recv);
@@ -1808,7 +1808,7 @@ TR_ResolvedJ9JITaaSServerMethod::cacheResolvedMethodsCallees()
    }
 
 bool
-TR_ResolvedJ9JITaaSServerMethod::validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation)
+TR_ResolvedJ9JITServerMethod::validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation)
    {
    // Validation should not be done against attributes cached per-resolved method,
    // because unresolved attribute might have become resolved during the current compilation
@@ -1827,7 +1827,7 @@ TR_ResolvedJ9JITaaSServerMethod::validateMethodFieldAttributes(const TR_J9Method
    }
 
 U_16
-TR_ResolvedJ9JITaaSServerMethod::archetypeArgPlaceholderSlot()
+TR_ResolvedJ9JITServerMethod::archetypeArgPlaceholderSlot()
    {
    TR_ASSERT(isArchetypeSpecimen(), "should not be called for non-ArchetypeSpecimen methods");
    TR_OpaqueMethodBlock * aMethod = getNonPersistentIdentifier();
@@ -1846,8 +1846,8 @@ TR_ResolvedJ9JITaaSServerMethod::archetypeArgPlaceholderSlot()
    return paramSlots;
    }
 
-TR_ResolvedRelocatableJ9JITaaSServerMethod::TR_ResolvedRelocatableJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, TR_ResolvedMethod * owner, uint32_t vTableSlot)
-   : TR_ResolvedJ9JITaaSServerMethod(aMethod, fe, trMemory, owner, vTableSlot)
+TR_ResolvedRelocatableJ9JITServerMethod::TR_ResolvedRelocatableJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, TR_ResolvedMethod * owner, uint32_t vTableSlot)
+   : TR_ResolvedJ9JITServerMethod(aMethod, fe, trMemory, owner, vTableSlot)
    {
    // NOTE: avoid using this constructor as much as possible.
    // Using may result in multiple remote messages (up to 3?) sent to the client
@@ -1865,14 +1865,14 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::TR_ResolvedRelocatableJ9JITaaSServer
             }
          else
             {
-            ((TR_ResolvedRelocatableJ9JITaaSServerMethod *) owner)->validateArbitraryClass(comp, (J9Class*)containingClass());
+            ((TR_ResolvedRelocatableJ9JITServerMethod *) owner)->validateArbitraryClass(comp, (J9Class*)containingClass());
             }
          }
       }
    }
 
-TR_ResolvedRelocatableJ9JITaaSServerMethod::TR_ResolvedRelocatableJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_ResolvedMethod * owner, uint32_t vTableSlot)
-   : TR_ResolvedJ9JITaaSServerMethod(aMethod, fe, trMemory, methodInfo, owner, vTableSlot)
+TR_ResolvedRelocatableJ9JITServerMethod::TR_ResolvedRelocatableJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedMethod * owner, uint32_t vTableSlot)
+   : TR_ResolvedJ9JITServerMethod(aMethod, fe, trMemory, methodInfo, owner, vTableSlot)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
    TR::Compilation *comp = fej9->_compInfoPT->getCompilation();
@@ -1893,19 +1893,19 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::TR_ResolvedRelocatableJ9JITaaSServer
          {
          // TODO: this will require more remote messages.
          // For simplicity, leave it like this for now, once testing can be done, optimize it
-         ((TR_ResolvedRelocatableJ9JITaaSServerMethod *) owner)->validateArbitraryClass(comp, (J9Class*)containingClass());
+         ((TR_ResolvedRelocatableJ9JITServerMethod *) owner)->validateArbitraryClass(comp, (J9Class*)containingClass());
          }
       }
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::constantPool()
+TR_ResolvedRelocatableJ9JITServerMethod::constantPool()
    {
    return romLiterals();
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::isInterpreted()
+TR_ResolvedRelocatableJ9JITServerMethod::isInterpreted()
    {
    bool alwaysTreatAsInterpreted = true;
 #if defined(TR_TARGET_S390)
@@ -1935,29 +1935,29 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::isInterpreted()
    if (alwaysTreatAsInterpreted)
       return true;
 
-   return TR_ResolvedJ9JITaaSServerMethod::isInterpreted();
+   return TR_ResolvedJ9JITServerMethod::isInterpreted();
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::isInterpretedForHeuristics()
+TR_ResolvedRelocatableJ9JITServerMethod::isInterpretedForHeuristics()
    {
-   return TR_ResolvedJ9JITaaSServerMethod::isInterpreted();
+   return TR_ResolvedJ9JITServerMethod::isInterpreted();
    }
 
 TR_OpaqueMethodBlock *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getNonPersistentIdentifier()
+TR_ResolvedRelocatableJ9JITServerMethod::getNonPersistentIdentifier()
    {
    return (TR_OpaqueMethodBlock *)ramMethod();
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::validateArbitraryClass(TR::Compilation *comp, J9Class *clazz)
+TR_ResolvedRelocatableJ9JITServerMethod::validateArbitraryClass(TR::Compilation *comp, J9Class *clazz)
    {
    return storeValidationRecordIfNecessary(comp, cp(), 0, TR_ValidateArbitraryClass, ramMethod(), clazz);
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::storeValidationRecordIfNecessary(TR::Compilation * comp, J9ConstantPool *constantPool, int32_t cpIndex, TR_ExternalRelocationTargetKind reloKind, J9Method *ramMethod, J9Class *definingClass)
+TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Compilation * comp, J9ConstantPool *constantPool, int32_t cpIndex, TR_ExternalRelocationTargetKind reloKind, J9Method *ramMethod, J9Class *definingClass)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *) comp->fe();
    bool storeClassInfo = true;
@@ -2085,7 +2085,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::storeValidationRecordIfNecessary(TR:
    }
 
 U_8 *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::allocateException(uint32_t numBytes, TR::Compilation *comp)
+TR_ResolvedRelocatableJ9JITServerMethod::allocateException(uint32_t numBytes, TR::Compilation *comp)
    {
    J9JITExceptionTable *eTbl = NULL;
    uint32_t size = 0;
@@ -2111,7 +2111,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::allocateException(uint32_t numBytes,
    }
 
 TR_ResolvedMethod *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::createResolvedMethodFromJ9Method(TR::Compilation *comp, I_32 cpIndex, uint32_t vTableSlot, J9Method *j9method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats) {
+TR_ResolvedRelocatableJ9JITServerMethod::createResolvedMethodFromJ9Method(TR::Compilation *comp, I_32 cpIndex, uint32_t vTableSlot, J9Method *j9method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats) {
    // This method is called when a remote mirror hasn't been created yet, so it needs to be created from here.
    TR_ResolvedMethod *resolvedMethod = NULL;
 
@@ -2124,7 +2124,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::createResolvedMethodFromJ9Method(TR:
    // This message will create a remote mirror.
    // Calling constructor would be simpler, but we would have to make another message to update stats
    _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, getRemoteMirror(), j9method, cpIndex, vTableSlot);
-   auto recv = _stream->read<TR_ResolvedJ9JITaaSServerMethodInfo, bool, bool, bool>();
+   auto recv = _stream->read<TR_ResolvedJ9JITServerMethodInfo, bool, bool, bool>();
    auto methodInfo = std::get<0>(recv);
    // These parameters are only needed to update AOT stats. 
    // Maybe we shouldn't even track them, because another version of this method doesn't.
@@ -2135,7 +2135,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::createResolvedMethodFromJ9Method(TR:
    if (std::get<0>(methodInfo).remoteMirror)
       {
       // Remote mirror created successfully
-      resolvedMethod = new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) j9method, _fe, comp->trMemory(), methodInfo, this, vTableSlot);
+      resolvedMethod = new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod((TR_OpaqueMethodBlock *) j9method, _fe, comp->trMemory(), methodInfo, this, vTableSlot);
       if (aotStats)
          {
          aotStats->numMethodResolvedAtCompile++;
@@ -2160,25 +2160,25 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::createResolvedMethodFromJ9Method(TR:
    }
 
 TR_ResolvedMethod *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo)
+TR_ResolvedRelocatableJ9JITServerMethod::createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITServerMethodInfo &methodInfo)
    {
    // If this method is called, remote mirror has either already been created or creation failed.
    // In either case, methodInfo contains all parameters required to construct a resolved method or check that it's NULL.
    // The only problem is that we can't update AOT stats from this method.
    TR_ResolvedMethod *resolvedMethod = NULL;
    if (std::get<0>(methodInfo).remoteMirror)
-      resolvedMethod = new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITaaSServerMethod((TR_OpaqueMethodBlock *) j9method, _fe, comp->trMemory(), methodInfo, this, vTableSlot);
+      resolvedMethod = new (comp->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod((TR_OpaqueMethodBlock *) j9method, _fe, comp->trMemory(), methodInfo, this, vTableSlot);
 
    return resolvedMethod;
    }
 
 TR_ResolvedMethod *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(
+TR_ResolvedRelocatableJ9JITServerMethod::getResolvedImproperInterfaceMethod(
    TR::Compilation * comp,
    I_32 cpIndex)
    {
    if (comp->getOption(TR_UseSymbolValidationManager))
-      return TR_ResolvedJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(comp, cpIndex);
+      return TR_ResolvedJ9JITServerMethod::getResolvedImproperInterfaceMethod(comp, cpIndex);
 
    // For now leave private and Object invokeinterface unresolved in AOT. If we
    // resolve it, we may forceUnresolvedDispatch in codegen, in which case the
@@ -2188,39 +2188,39 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getResolvedImproperInterfaceMethod(
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::startAddressForJittedMethod()
+TR_ResolvedRelocatableJ9JITServerMethod::startAddressForJittedMethod()
    {
    return NULL;
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::startAddressForJNIMethod(TR::Compilation * comp)
+TR_ResolvedRelocatableJ9JITServerMethod::startAddressForJNIMethod(TR::Compilation * comp)
    {
 #if defined(TR_TARGET_S390)  || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER)
-   return TR_ResolvedJ9JITaaSServerMethod::startAddressForJNIMethod(comp);
+   return TR_ResolvedJ9JITServerMethod::startAddressForJNIMethod(comp);
 #else
    return NULL;
 #endif
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::startAddressForJITInternalNativeMethod()
+TR_ResolvedRelocatableJ9JITServerMethod::startAddressForJITInternalNativeMethod()
    {
    return NULL;
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::startAddressForInterpreterOfJittedMethod()
+TR_ResolvedRelocatableJ9JITServerMethod::startAddressForInterpreterOfJittedMethod()
    {
    return ((J9Method *)getNonPersistentIdentifier())->extra;
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation *comp, uint32_t cpIndex, bool returnClassForAOT)
+TR_ResolvedRelocatableJ9JITServerMethod::getClassFromConstantPool(TR::Compilation *comp, uint32_t cpIndex, bool returnClassForAOT)
    {
    if (returnClassForAOT || comp->getOption(TR_UseSymbolValidationManager))
       {
-      TR_OpaqueClassBlock * resolvedClass = TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(comp, cpIndex, returnClassForAOT);
+      TR_OpaqueClassBlock * resolvedClass = TR_ResolvedJ9JITServerMethod::getClassFromConstantPool(comp, cpIndex, returnClassForAOT);
       if (resolvedClass &&
          validateClassFromConstantPool(comp, (J9Class *)resolvedClass, cpIndex))
          {
@@ -2231,7 +2231,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compila
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::validateClassFromConstantPool(TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex,  TR_ExternalRelocationTargetKind reloKind)
+TR_ResolvedRelocatableJ9JITServerMethod::validateClassFromConstantPool(TR::Compilation *comp, J9Class *clazz, uint32_t cpIndex,  TR_ExternalRelocationTargetKind reloKind)
    {
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
@@ -2244,54 +2244,54 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::validateClassFromConstantPool(TR::Co
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 
    if (optimizeForAOT)
-      return TR_ResolvedJ9JITaaSServerMethod::isUnresolvedString(cpIndex);
+      return TR_ResolvedJ9JITServerMethod::isUnresolvedString(cpIndex);
    return true;
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::methodTypeConstant(I_32 cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::methodTypeConstant(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
    return NULL;
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::isUnresolvedMethodType(I_32 cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedMethodType(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
    return true;
    }
 
 void *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::methodHandleConstant(I_32 cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::methodHandleConstant(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
    return NULL;
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::isUnresolvedMethodHandle(I_32 cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedMethodHandle(I_32 cpIndex)
    {
    TR_ASSERT(false, "should be unreachable");
    return true;
    }
 
 char *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
+TR_ResolvedRelocatableJ9JITServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
    {
    len = 0;
    return "";
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)
    {
-   TR_OpaqueClassBlock *definingClass = TR_ResolvedJ9JITaaSServerMethod::getDeclaringClassFromFieldOrStatic(comp, cpIndex);
+   TR_OpaqueClassBlock *definingClass = TR_ResolvedJ9JITServerMethod::getDeclaringClassFromFieldOrStatic(comp, cpIndex);
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (!comp->getSymbolValidationManager()->addDeclaringClassFromFieldOrStaticRecord(definingClass, cp(), cpIndex))
@@ -2301,9 +2301,9 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getDeclaringClassFromFieldOrStatic(T
    }
 
 TR_OpaqueClassBlock *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::classOfStatic(int32_t cpIndex, bool returnClassForAOT)
+TR_ResolvedRelocatableJ9JITServerMethod::classOfStatic(int32_t cpIndex, bool returnClassForAOT)
    {
-   TR_OpaqueClassBlock * clazz = TR_ResolvedJ9JITaaSServerMethod::classOfStatic(cpIndex, returnClassForAOT);
+   TR_OpaqueClassBlock * clazz = TR_ResolvedJ9JITServerMethod::classOfStatic(cpIndex, returnClassForAOT);
 
    TR::Compilation *comp = TR::comp();
    bool validated = false;
@@ -2324,14 +2324,14 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::classOfStatic(int32_t cpIndex, bool 
    }
 
 TR_ResolvedMethod *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(
+TR_ResolvedRelocatableJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod(
    TR::Compilation *comp,
    int32_t cpIndex,
    bool ignoreRtResolve,
    bool * unresolvedInCP)
    {
    TR_ResolvedMethod *method =
-      TR_ResolvedJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMethod(
+      TR_ResolvedJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod(
          comp,
          cpIndex,
          ignoreRtResolve,
@@ -2347,7 +2347,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getResolvedPossiblyPrivateVirtualMet
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedFieldInCP(I_32 cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::getUnresolvedFieldInCP(I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM))
@@ -2359,45 +2359,45 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedFieldInCP(I_32 cpIndex)
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedStaticMethodInCP(int32_t cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::getUnresolvedStaticMethodInCP(int32_t cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_getUnresolvedStaticMethodInCP, getRemoteMirror(), cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedSpecialMethodInCP(I_32 cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::getUnresolvedSpecialMethodInCP(I_32 cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedMethod_getUnresolvedSpecialMethodInCP, getRemoteMirror(), cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
 
 void
-TR_ResolvedRelocatableJ9JITaaSServerMethod::handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP)
+TR_ResolvedRelocatableJ9JITServerMethod::handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP)
    {
    *unresolvedInCP = getUnresolvedStaticMethodInCP(cpIndex);
    }
 
 void
-TR_ResolvedRelocatableJ9JITaaSServerMethod::handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP)
+TR_ResolvedRelocatableJ9JITServerMethod::handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP)
    {
    *unresolvedInCP = getUnresolvedSpecialMethodInCP(cpIndex);
    }
 
 void
-TR_ResolvedRelocatableJ9JITaaSServerMethod::handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP)
+TR_ResolvedRelocatableJ9JITServerMethod::handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP)
    {
    *unresolvedInCP = getUnresolvedVirtualMethodInCP(cpIndex);
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getUnresolvedVirtualMethodInCP(int32_t cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::getUnresolvedVirtualMethodInCP(int32_t cpIndex)
    {
    return false;
    }
 
 UDATA
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getFieldType(J9ROMConstantPoolItem * CP, int32_t cpIndex)
+TR_ResolvedRelocatableJ9JITServerMethod::getFieldType(J9ROMConstantPoolItem * CP, int32_t cpIndex)
    {
    _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_getFieldType, cpIndex, getRemoteMirror());
    auto recv = _stream->read<UDATA>();
@@ -2405,7 +2405,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getFieldType(J9ROMConstantPoolItem *
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::fieldAttributes(TR::Compilation * comp, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
+TR_ResolvedRelocatableJ9JITServerMethod::fieldAttributes(TR::Compilation * comp, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool isStore, bool * unresolvedInCP, bool needAOTValidation)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    
@@ -2478,7 +2478,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::fieldAttributes(TR::Compilation * co
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::staticAttributes(TR::Compilation * comp,
+TR_ResolvedRelocatableJ9JITServerMethod::staticAttributes(TR::Compilation * comp,
                                                  int32_t cpIndex,
                                                  void * * address,
                                                  TR::DataType * type,
@@ -2559,7 +2559,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::staticAttributes(TR::Compilation * c
    }
 
 TR_FieldAttributesCache *
-TR_ResolvedRelocatableJ9JITaaSServerMethod::getAttributesCache(bool isStatic, bool unresolvedInCP)
+TR_ResolvedRelocatableJ9JITServerMethod::getAttributesCache(bool isStatic, bool unresolvedInCP)
    {
    // Return persistent attributes cache for AOT compilations
    TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
@@ -2575,7 +2575,7 @@ TR_ResolvedRelocatableJ9JITaaSServerMethod::getAttributesCache(bool isStatic, bo
    }
 
 bool
-TR_ResolvedRelocatableJ9JITaaSServerMethod::validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation)
+TR_ResolvedRelocatableJ9JITServerMethod::validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation)
    {
    // Validation should not be done against attributes cached per-resolved method,
    // because unresolved attribute might have become resolved during the current compilation

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -29,7 +29,7 @@
 #include "runtime/JITClientSession.hpp"
 
 struct
-TR_ResolvedJ9JITaaSServerMethodInfoStruct
+TR_ResolvedJ9JITServerMethodInfoStruct
    {
    TR_ResolvedJ9Method *remoteMirror;
    J9RAMConstantPoolItem *literals;
@@ -50,7 +50,7 @@ TR_ResolvedJ9JITaaSServerMethodInfoStruct
 
 
 // The last 3 strings are serialized versions of jittedBodyInfo, persistentMethodInfo and TR_ContiguousIPMethodHashTableInfo
-using TR_ResolvedJ9JITaaSServerMethodInfo = std::tuple<TR_ResolvedJ9JITaaSServerMethodInfoStruct, std::string, std::string, std::string>;
+using TR_ResolvedJ9JITServerMethodInfo = std::tuple<TR_ResolvedJ9JITServerMethodInfoStruct, std::string, std::string, std::string>;
 
 // key used to identify a resolved method in resolved methods cache.
 // Since one cache contains different types of resolved methods, need to uniquely identify
@@ -113,16 +113,16 @@ TR_ResolvedMethodCacheEntry
    {
    TR_OpaqueMethodBlock *method;
    uint32_t vTableSlot;
-   TR_ResolvedJ9JITaaSServerMethodInfo methodInfo;
+   TR_ResolvedJ9JITServerMethodInfo methodInfo;
    };
 
 using TR_ResolvedMethodInfoCache = UnorderedMap<TR_ResolvedMethodKey, TR_ResolvedMethodCacheEntry>;
 
-class TR_ResolvedJ9JITaaSServerMethod : public TR_ResolvedJ9Method
+class TR_ResolvedJ9JITServerMethod : public TR_ResolvedJ9Method
    {
 public:
-   TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
-   TR_ResolvedJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
+   TR_ResolvedJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
+   TR_ResolvedJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
 
    virtual J9ROMClass *romClassPtr() override;
    virtual J9RAMConstantPoolItem *literals() override;
@@ -144,7 +144,7 @@ public:
    virtual TR_ResolvedMethod * getResolvedStaticMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP) override;
    virtual TR_ResolvedMethod * getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpIndex, bool * unresolvedInCP) override;
    virtual TR_ResolvedMethod * createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats) override;
-   virtual TR_ResolvedMethod * createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo);
+   virtual TR_ResolvedMethod * createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    virtual uint32_t classCPIndexOfMethod(uint32_t methodCPIndex) override;
    virtual bool fieldsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame) override;
    virtual bool staticsAreSame(int32_t cpIndex1, TR_ResolvedMethod *m2, int32_t cpIndex2, bool &sigSame) override;
@@ -191,15 +191,15 @@ public:
 
    TR_ResolvedJ9Method *getRemoteMirror() const { return _remoteMirror; }
    bool inROMClass(void *address);
-   static void createResolvedMethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
-   static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
+   static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
+   static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method);
    void cacheResolvedMethodsCallees();
 
 protected:
    JITServer::ServerStream *_stream;
    J9Class *_ramClass; // client pointer to RAM class
-   static void packMethodInfo(TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_ResolvedJ9Method *resolvedMethod, TR_FrontEnd *fe);
+   static void packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedJ9Method *resolvedMethod, TR_FrontEnd *fe);
    static void setAttributeResultFromResolvedMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, U_32 * fieldOffset, void **address, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool * unresolvedInCP, bool *result, bool isStatic);
    virtual bool getCachedFieldAttributes(int32_t cpIndex, TR_J9MethodFieldAttributes &attributes, bool isStatic);
    virtual void cacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic);
@@ -226,14 +226,14 @@ private:
    char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
    virtual char * fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind = heapAlloc) override;
-   void unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo);
+   void unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    };
 
-class TR_ResolvedRelocatableJ9JITaaSServerMethod : public TR_ResolvedJ9JITaaSServerMethod
+class TR_ResolvedRelocatableJ9JITServerMethod : public TR_ResolvedJ9JITServerMethod
    {
    public:
-   TR_ResolvedRelocatableJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
-   TR_ResolvedRelocatableJ9JITaaSServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
+   TR_ResolvedRelocatableJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
+   TR_ResolvedRelocatableJ9JITServerMethod(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
 
    virtual void *                constantPool() override;
    virtual bool                  isInterpreted() override;
@@ -270,7 +270,7 @@ class TR_ResolvedRelocatableJ9JITaaSServerMethod : public TR_ResolvedJ9JITaaSSer
 
 protected:
    virtual TR_ResolvedMethod *   createResolvedMethodFromJ9Method(TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats) override;
-   virtual TR_ResolvedMethod * createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITaaSServerMethodInfo &methodInfo) override;
+   virtual TR_ResolvedMethod * createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats, const TR_ResolvedJ9JITServerMethodInfo &methodInfo) override;
    virtual void                  handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual void                  handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -57,7 +57,7 @@ enum MessageType
    clientSessionTerminate = 7; // type used when client process is about to terminate
    connectionTerminate = 8; // type used when client informs the server to close the connection
 
-   // For TR_ResolvedJ9JITaaSServerMethod methods
+   // For TR_ResolvedJ9JITServerMethod methods
    ResolvedMethod_isJNINative = 100;
    ResolvedMethod_isInterpreted = 101;
    ResolvedMethod_setRecognizedMethodInfo = 102;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -597,10 +597,10 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
    if (comp()->isOutOfProcessCompilation())
       {
-      // JITaaS optimization: 
+      // JITServer optimization:
       // request this resolved method to create all of its callee resolved methods
       // in a single query.
-      auto calleeMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(calltarget->_calleeMethod);
+      auto calleeMethod = static_cast<TR_ResolvedJ9JITServerMethod *>(calltarget->_calleeMethod);
       calleeMethod->cacheResolvedMethodsCallees();
       }
 

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -210,7 +210,7 @@ public:
    // returns the number of bytes the equivalent storage structure needs
    virtual uint32_t                   getBytesFootprint() = 0; 
 
-   // Serialization used for JITaaS
+   // Serialization used for JITServer
    // not sufficient for persisting to the shared cache
    virtual uint32_t canBeSerialized(TR::PersistentInfo *info) { return IPBC_ENTRY_CAN_PERSIST; }
    virtual void serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info) = 0;
@@ -518,7 +518,7 @@ public:
    /* 
    leave the TR_ResolvedMethodSymbol argument for debugging purpose when called from Ilgen
    */
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp); // JITaaS: mark virtual
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp); // JITServer: mark virtual
    bool elgibleForPersistIprofileInfo(TR::Compilation *comp) const;
 
    void checkMethodHashTable();
@@ -574,7 +574,7 @@ public:
    bool postIprofilingBufferToWorkingQueue(J9VMThread * vmThread, const U_8* dataStart, UDATA size);
    // this is wrapper of registered version, for the helper function, from JitRunTime
 
-   // Data accessors, overridden for JITaaS
+   // Data accessors, overridden for JITServer
    //
 
    // This method is used to search only the hash table

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -91,7 +91,7 @@ inline uint32_t getJitEntryOffset(TR_LinkageInfo *linkageInfo)
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
 uint32_t *getLinkageInfo(void * startPC);
 uint32_t isRecompMethBody(void *li);
-void fixPersistentMethodInfo(void *table, bool isJITaaS);
+void fixPersistentMethodInfo(void *table, bool isJITServer);
 void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo);
 #endif
 

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -46,15 +46,15 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _javaLangClassPtr = NULL;
    _inUse = 1;
    _numActiveThreads = 0;
-   _romMapMonitor = TR::Monitor::create("JIT-JITaaSROMMapMonitor");
-   _classMapMonitor = TR::Monitor::create("JIT-JITaaSClassMapMonitor");
-   _classChainDataMapMonitor = TR::Monitor::create("JIT-JITaaSClassChainDataMapMonitor");
-   _sequencingMonitor = TR::Monitor::create("JIT-JITaaSSequencingMonitor");
-   _constantPoolMapMonitor = TR::Monitor::create("JIT-JITaaSConstantPoolMonitor");
+   _romMapMonitor = TR::Monitor::create("JIT-JITServerROMMapMonitor");
+   _classMapMonitor = TR::Monitor::create("JIT-JITServerClassMapMonitor");
+   _classChainDataMapMonitor = TR::Monitor::create("JIT-JITServerClassChainDataMapMonitor");
+   _sequencingMonitor = TR::Monitor::create("JIT-JITServerSequencingMonitor");
+   _constantPoolMapMonitor = TR::Monitor::create("JIT-JITServerConstantPoolMonitor");
    _vmInfo = NULL;
-   _staticMapMonitor = TR::Monitor::create("JIT-JITaaSStaticMapMonitor");
+   _staticMapMonitor = TR::Monitor::create("JIT-JITServerStaticMapMonitor");
    _markedForDeletion = false;
-   _thunkSetMonitor = TR::Monitor::create("JIT-JITaaSThunkSetMonitor");
+   _thunkSetMonitor = TR::Monitor::create("JIT-JITServerThunkSetMonitor");
    }
 
 ClientSessionData::~ClientSessionData()
@@ -601,7 +601,7 @@ ClientSessionHT::purgeOldDataIfNeeded()
    }
 
 // to print these stats,
-// set the env var `TR_PrintJITaaSCacheStats=1`
+// set the env var `TR_PrintJITServerCacheStats=1`
 // run the server with `-Xdump:jit:events=user`
 // then `kill -3` it when you want to print them 
 void

--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -47,7 +47,7 @@ JITServerIProfiler::JITServerIProfiler(J9JITConfig *jitConfig)
 TR_IPMethodHashTableEntry *
 JITServerIProfiler::deserializeMethodEntry(TR_ContiguousIPMethodHashTableEntry *serialEntry, TR_Memory *trMemory)
    {
-   // caching is done inside TR_ResolvedJ9JITaaSServerMethod so we need to use heap memory.
+   // caching is done inside TR_ResolvedJ9JITServerMethod so we need to use heap memory.
    TR_IPMethodHashTableEntry *entry = (TR_IPMethodHashTableEntry *) trMemory->allocateHeapMemory(sizeof(TR_IPMethodHashTableEntry));
    if (entry)
       {
@@ -794,7 +794,7 @@ JITServerIProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, 
 
    if (clientSessionData->getOrCacheVMInfo(stream)->_elgibleForPersistIprofileInfo)
       {
-      auto serverMethod = static_cast<TR_ResolvedJ9JITaaSServerMethod *>(method);
+      auto serverMethod = static_cast<TR_ResolvedJ9JITServerMethod *>(method);
       compInfoPT->cacheResolvedMirrorMethodsPersistIPInfo(serverMethod->getRemoteMirror());
       }
    }

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1330,14 +1330,14 @@ uint32_t isRecompMethBody(void *li)
 
 // This method MUST be used only for methods that were AOTed and then relocated
 // It marks the BodyInfo that this is an aoted method.
-void fixPersistentMethodInfo(void *table, bool isJITaaS)
+void fixPersistentMethodInfo(void *table, bool isJITServer)
    {
    J9JITExceptionTable *exceptionTable = (J9JITExceptionTable *)table;
    TR_PersistentJittedBodyInfo *bodyInfo = (TR_PersistentJittedBodyInfo *)exceptionTable->bodyInfo;
    void *vmMethodInfo = (void *)exceptionTable->ramMethod;
    TR_PersistentMethodInfo *methodInfo;
 
-   if (!isJITaaS)
+   if (!isJITServer)
       {
       methodInfo = (TR_PersistentMethodInfo *)((char *)bodyInfo + sizeof(TR_PersistentJittedBodyInfo));
       bodyInfo->setMethodInfo(methodInfo);
@@ -1358,7 +1358,7 @@ void fixPersistentMethodInfo(void *table, bool isJITaaS)
    bodyInfo->setSampleIntervalCount(0);
    bodyInfo->setProfileInfo(NULL);
 
-   if (!isJITaaS)
+   if (!isJITServer)
       {
       bodyInfo->setIsAotedBody(true);
       }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -273,7 +273,7 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
       else
          {
          _newExceptionTableStart = allocateSpaceInDataCache(_exceptionTableCacheEntry->size, _exceptionTableCacheEntry->type);
-         // JITaaS: code should always be non-NULL, should point to the code cache
+         // JITServer: code should always be non-NULL, should point to the code cache
          // received from the server.
          if (existingCode)
             tempCodeStart = existingCode;
@@ -1364,14 +1364,14 @@ void TR_RelocationRuntime::addClazzRecord(uint8_t *ia, uint32_t bcIndex, TR_Opaq
 #endif
 
 void
-TR_JITaaSRelocationRuntime::initializeCacheDeltas()
+TR_JITServerRelocationRuntime::initializeCacheDeltas()
    {
    _dataCacheDelta = 0;
    _codeCacheDelta = 0;
    }
 
 U_8 *
-TR_JITaaSRelocationRuntime::allocateSpaceInCodeCache(UDATA codeSize)
+TR_JITServerRelocationRuntime::allocateSpaceInCodeCache(UDATA codeSize)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)_fe;
    TR::CodeCacheManager *manager = TR::CodeCacheManager::instance();
@@ -1418,7 +1418,7 @@ TR_JITaaSRelocationRuntime::allocateSpaceInCodeCache(UDATA codeSize)
    }
 
 uint8_t *
-TR_JITaaSRelocationRuntime::allocateSpaceInDataCache(uintptr_t metaDataSize,
+TR_JITServerRelocationRuntime::allocateSpaceInDataCache(uintptr_t metaDataSize,
                                                    uintptr_t type)
    {
    _metaDataAllocSize = TR_DataCacheManager::alignToMachineWord(metaDataSize);
@@ -1429,7 +1429,7 @@ TR_JITaaSRelocationRuntime::allocateSpaceInDataCache(uintptr_t metaDataSize,
    }
 
 uint8_t *
-TR_JITaaSRelocationRuntime::copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe)
+TR_JITServerRelocationRuntime::copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe)
    {
    TR::CompilationInfoPerThreadBase *compInfoPT = fe->_compInfoPT;
    int32_t numReserved;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -388,11 +388,11 @@ private:
       static const UDATA aotHeaderKeyLength;
 };
 
-class TR_JITaaSRelocationRuntime : public TR_RelocationRuntime {
+class TR_JITServerRelocationRuntime : public TR_RelocationRuntime {
 public:
       TR_ALLOC(TR_Memory::Relocation)
       void * operator new(size_t, J9JITConfig *);
-      TR_JITaaSRelocationRuntime(J9JITConfig *jitCfg) : TR_RelocationRuntime(jitCfg) {}
+      TR_JITServerRelocationRuntime(J9JITConfig *jitCfg) : TR_RelocationRuntime(jitCfg) {}
 // The following public APIs should not be used with this class
       virtual bool storeAOTHeader(J9JavaVM *javaVM, TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
       virtual TR_AOTHeader *createAOTHeader(J9JavaVM *javaVM, TR_FrontEnd *fe)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -72,8 +72,8 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
    if (stream && _fej9->sharedCache())
       // because a different VM is used here, a new Shared Cache object was created, so
       // need to update stream
-      // JITaaS TODO: we update stream in multiple places, better to change it to only one
-      ((TR_J9JITaaSServerSharedCache *) _fej9->sharedCache())->setStream(stream);
+      // JITServer TODO: we update stream in multiple places, better to change it to only one
+      ((TR_J9JITServerSharedCache *) _fej9->sharedCache())->setStream(stream);
 
    defineGuaranteedID(NULL, TR::SymbolType::typeOpaque);
    defineGuaranteedID(_rootClass, TR::SymbolType::typeClass);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -757,7 +757,7 @@ public:
 
    static bool assertionsAreFatal();
 
-   std::string serializeSymbolToIDMap(); // JITaaS
+   std::string serializeSymbolToIDMap(); // JITServer
    void deserializeSymbolToIDMap(const std::string &symbolToIdStr);
 
 private:

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -946,7 +946,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       //the desired invoke bytecode.
       if (!isJitInduceOSRCall)
          {
-         // XXX: Ugly, not sure how this was supposed to work but for AOT (and now JITaaS) we do direct calls
+         // XXX: Ugly, not sure how this was supposed to work but for AOT (and now JITServer) we do direct calls
 	 // through snippets, except the method we're calling might already be compiled, in which case getMethodAddress()
 	 // returns the compiled code entrypoint instead of the RAM method... how did AOT not hit this?
          intptrj_t ramMethod = comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER && !methodSymbol->isInterpreted() ?

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1901,7 +1901,7 @@ void TR::X86PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef, T
    if (TR::Compiler->target.is64Bit() && methodSymRef->getReferenceNumber()>=TR_AMD64numRuntimeHelpers)
       fej9->reserveTrampolineIfNecessary(comp(), methodSymRef, false);
 
-   // JITaaS Workaround: Further transmute dispatchJ9Method symbols to appear as a runtime helper, this will cause OMR to
+   // JITServer Workaround: Further transmute dispatchJ9Method symbols to appear as a runtime helper, this will cause OMR to
    // generate a TR_HelperAddress relocation instead of a TR_RelativeMethodAddress Relocation.
    if (!comp()->getOption(TR_DisableInliningOfNatives) &&
        methodSymbol->getMandatoryRecognizedMethod() == TR::java_lang_invoke_ComputedCalls_dispatchJ9Method)


### PR DESCRIPTION
As decided by eclipse/openj9#6203, replace all `JITaaS` prefix with `JITServer` under `runtime`  folder.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>