### PR TITLE
Specify cfgRegion in realEstimateCodeSize

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,7 +77,7 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
 
    protected:
       bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true);
-      bool realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallStack *prevCallStack, bool recurseDown);
+      bool realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallStack *prevCallStack, bool recurseDown, TR::Region &cfgRegion);
 
       bool reduceDAAWrapperCodeSize(TR_CallTarget* target);
 


### PR DESCRIPTION
The function realEstimateCodeSize constructs a CFG. This CFG has an
automatic scope. By specifying a memory region to hold the CFG,
the CFG created in realEstimateCodeSize can now be accessed from
outside realEstimateCodeSize. Besides the CFG being allocated on the
region, blocks are also allocated in the region.
Please note that while the function Node::createOnStack is
semantically equivalent to Node::create however one contains
assertions. Function calls to Node::createOnStack have been changed
to Node::create when no assertions are triggered.

Signed-off-by: Erick Ochoa <eochoa@ualberta.ca>