### PR TITLE
AArch64: Enable helper linkage call

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -217,3 +217,9 @@ TR::Register *TR::ARM64PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    TR_UNIMPLEMENTED();
    return NULL;
    }
+
+int32_t TR::ARM64HelperLinkage::buildArgs(TR::Node *callNode,
+   TR::RegisterDependencyConditions *dependencies)
+   {
+   return buildPrivateLinkageArgs(callNode, dependencies, _helperLinkage);
+   }

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -127,8 +127,25 @@ class ARM64HelperLinkage : public TR::ARM64PrivateLinkage
    /**
     * @brief Constructor
     * @param[in] cg : CodeGenerator
+    * @param[in] helperLinkage : linkage convention
     */
-   ARM64HelperLinkage(TR::CodeGenerator *cg) : TR::ARM64PrivateLinkage(cg) {}
+   ARM64HelperLinkage(TR::CodeGenerator *cg, TR_LinkageConventions helperLinkage) : _helperLinkage(helperLinkage), TR::ARM64PrivateLinkage(cg)
+      {
+      TR_ASSERT(helperLinkage == TR_Helper || helperLinkage == TR_CHelper, "Unexpected helper linkage convention");
+      }
+
+   /**
+    * @brief Builds method arguments for helper call
+    * @param[in] node : caller node
+    * @param[in] dependencies : register dependency conditions
+    * @return total size that arguments occupy on Java stack
+    */
+   virtual int32_t buildArgs(
+      TR::Node *callNode,
+      TR::RegisterDependencyConditions *dependencies);
+   protected:
+
+   TR_LinkageConventions _helperLinkage;
    };
 
 }

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -66,7 +66,7 @@ J9::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
          break;
       case TR_CHelper:
       case TR_Helper:
-         linkage = new (self()->trHeapMemory()) TR::ARM64HelperLinkage(self());
+         linkage = new (self()->trHeapMemory()) TR::ARM64HelperLinkage(self(), lc);
          break;
       case TR_J9JNILinkage:
          linkage = new (self()->trHeapMemory()) TR::ARM64JNILinkage(self());


### PR DESCRIPTION
This commit(https://github.com/eclipse/openj9/commit/6642278aba23df67b779422bebf0a590ae9c3ec4) adds `TR::ARM64HelperLinkage::buildArgs` to enable helper linkage call.
Depends on https://github.com/eclipse/openj9/pull/6664 because `TR::ARM64HelperLinkage::buildArgs` calls `TR::ARM64PrivateLinkage::buildPrivateLinkageArgs` which is added with that PR. The source branch for this PR is based on the source branch for https://github.com/eclipse/openj9/pull/6664 as the commit also changes `TR::ARM64PrivateLinkage::buildPrivateLinkageArgs` which does not exist in current master branch. I will rebase the source branch when https://github.com/eclipse/openj9/pull/6664 is merged.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>