### PR TITLE
Restrict fixing simple name to JDK8

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -3430,7 +3430,10 @@ public String getSimpleName() {
 				simpleName = fullName;
 			}
 		}
-	} else if (!fullName.endsWith(simpleName)) {
+	}
+	/*[IF !Sidecar19-SE]*/
+	/* In Java 8, the simple name needs to match the full name*/
+	else if (!fullName.endsWith(simpleName)) {
 		Class<?> parent = baseType.getEnclosingObjectClass();
 		int index = fullName.lastIndexOf('.') + 1;
 		if (parent == null) {
@@ -3454,6 +3457,7 @@ public String getSimpleName() {
 			simpleName = fullName.substring(index);
 		}
 	}
+	/*[ENDIF] !Sidecar19-SE*/
 	if (arrayCount > 0) {
 		StringBuilder result = new StringBuilder(simpleName);
 		for (int i=0; i<arrayCount; i++) {


### PR DESCRIPTION
In commit 5844a1d4 "Ensure class simple name is a suffix of full name"
getSimpleName was changed to ensure the simple name matched the full name.
This is only relevant in JDK8, as in later versions, the reference
implementation does not ensure the simple name and full name match anymore.

Fixes https://github.com/eclipse/openj9/issues/6857

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Can you review please @DanHeidinga 