### PR TITLE
Add TR_J9VM::isSameOrSuperClass API

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3422,10 +3422,10 @@ TR_J9VMBase::lowerAsyncCheck(TR::Compilation * comp, TR::Node * root, TR::TreeTo
    }
 
 bool
- TR_J9VMBase::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
-    {
-    return VM_VMHelpers::methodBeingTraced(_jitConfig->javaVM, (J9Method *)method);
-    }
+TR_J9VMBase::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
+   {
+   return VM_VMHelpers::methodBeingTraced(_jitConfig->javaVM, (J9Method *)method);
+   }
 
 bool
 TR_J9VMBase::isSelectiveMethodEnterExitEnabled()
@@ -6536,6 +6536,11 @@ TR_J9VM::getSuperClass(TR_OpaqueClassBlock * classPointer)
    return convertClassPtrToClassOffset(classDepth >= 0 ? clazz->superclasses[classDepth]: 0);
    }
 
+bool
+TR_J9VM::isSameOrSuperClass(J9Class * superClass, J9Class * subClass)
+   {
+   return VM_VMHelpers::isSameOrSuperclass(superClass, subClass);
+   }
 
 bool
 TR_J9VMBase::sameClassLoaders(TR_OpaqueClassBlock * class1, TR_OpaqueClassBlock * class2)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1036,6 +1036,7 @@ public:
    virtual bool               stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
 
    virtual TR_OpaqueClassBlock *             getSuperClass(TR_OpaqueClassBlock *classPointer);
+   virtual bool               isSameOrSuperClass(J9Class *superClass, J9Class *subClass);
    virtual bool               isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *);
 
    virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *);

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -33,7 +33,6 @@
 #include "runtime/SymbolValidationManager.hpp"
 
 #include "j9protos.h"
-#include "VMHelpers.hpp"
 
 #if defined (_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
@@ -106,7 +105,7 @@ TR::SymbolValidationManager::isClassWorthRemembering(TR_OpaqueClassBlock *clazz)
     * ability to optimize for them) rather than risk a load failure due to a code path that was unlikely to
     * execute.
     */
-   if (_jlthrowable &&  VM_VMHelpers::isSameOrSuperclass((J9Class *)_jlthrowable, (J9Class*)clazz))
+   if (_jlthrowable && _fej9->isSameOrSuperClass((J9Class *)_jlthrowable, (J9Class *)clazz))
       {
       if (_comp->getOption(TR_TraceRelocatableDataCG))
          traceMsg(_comp, "isClassWorthRemembering: clazz %p is or inherits from jlthrowable\n", clazz);


### PR DESCRIPTION
In compiler/runtime/SymbolValidationManager.cpp, the method TR::SymbolValidationManager::isClassWorthRemembering is using an API from oti/VMHelpers.hpp. We replaced that call with an equivalent API from TR_J9VM. This move also allows JIT-as-a-Service to override this API for JITServer.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>