### PR TITLE
SIGKILL support added for Jython

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -435,6 +435,9 @@ static const J9SignalMapping signalMap[] = {
 #if defined(SIGRECONFIG)
 	J9_SIGNAL_MAP_ENTRY("RECONFIG", SIGRECONFIG),
 #endif /* defined(SIGRECONFIG) */
+#if defined(SIGKILL)
+	J9_SIGNAL_MAP_ENTRY("KILL", SIGKILL),
+#endif /* defined(SIGKILL) */
 	{NULL, J9_SIG_ERR}
 };
 


### PR DESCRIPTION
Java does not support `SIGKILL`. But, Jython needs `SIGKILL` support for
`os.kill(<PID>, SIGKILL)`. `os.kill` depends on `JVM_RaiseSignal`. Adding
`SIGKILL` in `J9SignalMapping` allows `JVM_RaiseSignal` to support `SIGKILL`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>