### PR TITLE
AArch64: Declare TR::ARM64PrivateLinkage::buildPrivateLinkageArgs()

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -193,6 +193,15 @@ void TR::ARM64PrivateLinkage::createEpilogue(TR::Instruction *cursor)
 int32_t TR::ARM64PrivateLinkage::buildArgs(TR::Node *callNode,
    TR::RegisterDependencyConditions *dependencies)
    {
+   return buildPrivateLinkageArgs(callNode, dependencies, TR_Private);
+   }
+
+int32_t TR::ARM64PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
+   TR::RegisterDependencyConditions *dependencies,
+   TR_LinkageConventions linkage)
+   {
+   TR_ASSERT(linkage == TR_Private || linkage == TR_Helper || linkage == TR_CHelper, "Unexpected linkage convention");
+
    TR_UNIMPLEMENTED();
    return 0;
    }

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -39,6 +39,17 @@ class ARM64PrivateLinkage : public TR::Linkage
 
    TR::ARM64LinkageProperties _properties;
 
+   /**
+    * @brief Builds method arguments
+    * @param[in] node : caller node
+    * @param[in] dependencies : register dependency conditions
+    * @param[in] linkage : linkage type
+    */
+   int32_t buildPrivateLinkageArgs(
+         TR::Node *callNode,
+         TR::RegisterDependencyConditions *dependencies,
+         TR_LinkageConventions linkage);
+
    public:
 
    /**


### PR DESCRIPTION
This commit declares buildPrivateLinkageArgs() in ARM64PrivateLinkage.
The functions is called by both TR::ARM64PrivateLinkage::buildArgs()
and TR::ARM64HelperLinkage::buildArgs().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>