### PR TITLE
v0.16.0: Add local variable size check with StackMapTable

### DIFF
--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1545,12 +1545,6 @@ checkMethodStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile, UDATA
 		}
 	}
 
-	result = checkBytecodeStructure (classfile, methodIndex, length, map, error, flags, hasRET);
-
-	if (result) {
-		goto _leaveProc;
-	}
-
 	if ((flags & J9_VERIFY_IGNORE_STACK_MAPS) == 0) {
 		StackmapExceptionDetails exceptionDetails;
 		memset(&exceptionDetails, 0, sizeof(exceptionDetails));
@@ -1578,6 +1572,12 @@ checkMethodStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile, UDATA
 				goto _formatError;
 			}
 		}
+	}
+
+	result = checkBytecodeStructure (classfile, methodIndex, length, map, error, flags, hasRET);
+
+	if (result) {
+		goto _leaveProc;
 	}
 
 	/* Should check thrown exceptions.  */

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1249,13 +1249,7 @@ checkStackMap (J9CfrClassFile* classfile, J9CfrMethod * method, J9CfrAttributeCo
 			U_8* end = entries + length;
 			UDATA j = 0;
 			UDATA offset = (UDATA) -1;
-			IDATA localSlots;
 			J9CfrConstantPoolInfo* info = &classfile->constantPool[method->descriptorIndex];
-
-			localSlots = j9bcv_checkMethodSignature(info, TRUE);
-			if ((method->accessFlags & CFR_ACC_STATIC) == 0) {
-				localSlots++;
-			}
 
 			for (j = 0; j < stackMap->numberOfEntries; j++) {
 				U_8 frameType;
@@ -1322,7 +1316,6 @@ checkStackMap (J9CfrClassFile* classfile, J9CfrMethod * method, J9CfrAttributeCo
 					}
 					if (frameType >= CFR_STACKMAP_CHOP_3) {
 						slotCount = (IDATA) frameType - CFR_STACKMAP_APPEND_BASE;
-						localSlots += slotCount;
 						if (slotCount < 0) {
 							slotCount = 0;
 						}
@@ -1332,7 +1325,6 @@ checkStackMap (J9CfrClassFile* classfile, J9CfrMethod * method, J9CfrAttributeCo
 					/* full frame */
 					/* Executed with StackMap or StackMapTable */
 					NEXT_U16(slotCount, entries);
-					localSlots = slotCount;
 					errorCode = checkStackMapEntries (classfile, code, map, &entries, slotCount, end);
 					if (0 != errorCode) {
 						goto _failedCheck;


### PR DESCRIPTION
JVM spec 4.7.4: It is an error if, for any index i, locals[i] represents a local variable whose index is greater than the maximum number of local variables for the method.

master pr: https://github.com/eclipse/openj9/pull/6542

Signed-off-by: Theresa Mammarella Theresa.T.Mammarella@ibm.com