### PR TITLE
Separate JITServerHelpers from JITServerCompilationThread

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -384,6 +384,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
 ifneq ($(JITSERVER_SUPPORT),)
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/JITServerCompilationThread.cpp \
+    compiler/control/JITServerHelpers.cpp \
     compiler/env/j9methodServer.cpp \
     compiler/env/JITServerCHTable.cpp \
     compiler/env/JITServerPersistentCHTable.cpp \

--- a/runtime/compiler/control/CMakeLists.txt
+++ b/runtime/compiler/control/CMakeLists.txt
@@ -34,5 +34,6 @@ j9jit_files(
 if(JITSERVER_SUPPORT)
 	j9jit_files(
 		control/JITServerCompilationThread.cpp
+		control/JITServerHelpers.cpp
 	)
 endif()

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -74,7 +74,7 @@ struct TR_JitPrivateConfig;
 struct TR_MethodToBeCompiled;
 template <typename T> class TR_PersistentArray;
 typedef J9JITExceptionTable TR_MethodMetaData;
-class ClientSessionHT; // JITServer TODO: maybe move all JITServer specific stuff in an extension for CompInfo
+class ClientSessionHT;
 
 #if defined(JITSERVER_SUPPORT)
 namespace JITServer { class ServerStream; }
@@ -955,7 +955,7 @@ public:
    void setSuspendThreadDueToLowPhysicalMemory(bool b) { _suspendThreadDueToLowPhysicalMemory = b; }
 
    // for JITServer
-   ClientSessionHT *getClientSessionHT() { return _clientSessionHT; }
+   ClientSessionHT *getClientSessionHT() const { return _clientSessionHT; }
    void setClientSessionHT(ClientSessionHT *ht) { _clientSessionHT = ht; }
    PersistentVector<TR_OpaqueClassBlock*> *getUnloadedClassesTempList() { return _unloadedClassesTempList; }
    void setUnloadedClassesTempList(PersistentVector<TR_OpaqueClassBlock*> *it) { _unloadedClassesTempList = it; }

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -43,6 +43,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "control/CompilationController.hpp"
+#include "control/JITServerHelpers.hpp"
 #include "env/ClassLoaderTable.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
@@ -1970,10 +1971,10 @@ IDATA dumpJitInfo(J9VMThread *crashedThread, char *logFileLabel, J9RASdumpContex
          {
          static char * isPrintJITServerMsgStats = feGetEnv("TR_PrintJITServerMsgStats");
          if (isPrintJITServerMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-            printJITServerMsgStats(jitConfig);
+            JITServerHelpers::printJITServerMsgStats(jitConfig);
 
          if (feGetEnv("TR_PrintJITServerCHTableStats"))
-            printJITServerCHTableStats(jitConfig, compInfo);
+            JITServerHelpers::printJITServerCHTableStats(jitConfig, compInfo);
 
          if (feGetEnv("TR_PrintJITServerIPMsgStats"))
             {
@@ -4761,11 +4762,11 @@ void JitShutdown(J9JITConfig * jitConfig)
 
    static char * isPrintJITServerMsgStats = feGetEnv("TR_PrintJITServerMsgStats");
    if (isPrintJITServerMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-      printJITServerMsgStats(jitConfig);
+      JITServerHelpers::printJITServerMsgStats(jitConfig);
 
    static char * isPrintJITServerCHTableStats = feGetEnv("TR_PrintJITServerCHTableStats");
    if (isPrintJITServerCHTableStats)
-      printJITServerCHTableStats(jitConfig, compInfo);
+      JITServerHelpers::printJITServerCHTableStats(jitConfig, compInfo);
 
    TRC_JIT_ShutDownEnd(vmThread, "end of JitShutdown function");
    }

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -23,17 +23,13 @@
 #ifndef JITSERVER_COMPILATION_THREAD_H
 #define JITSERVER_COMPILATION_THREAD_H
 
-#include <unordered_map>
 #include "control/CompilationThread.hpp"
-#include "net/ClientStream.hpp"
-#include "env/PersistentCollections.hpp"
+#include "control/JITServerHelpers.hpp"
 #include "env/j9methodServer.hpp"
-#include "env/J9CPU.hpp"
+#include "net/ClientStream.hpp"
 #include "runtime/JITClientSession.hpp"
 
-class TR_PersistentClassInfo;
 class TR_IPBytecodeHashTableEntry;
-struct TR_RemoteROMStringKey;
 
 using IPTableHeapEntry = UnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
 using IPTableHeap_t = UnorderedMap<J9Method *, IPTableHeapEntry *>;
@@ -41,16 +37,11 @@ using ResolvedMirrorMethodsPersistIP_t = Vector<TR_ResolvedJ9Method *>;
 using ClassOfStatic_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_OpaqueClassBlock *>;
 using FieldOrStaticAttrTable_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_J9MethodFieldAttributes>;
 
-size_t methodStringLength(J9ROMMethod *);
-std::string packROMClass(J9ROMClass *, TR_Memory *);
 TR_MethodMetaData *remoteCompile(J9VMThread *, TR::Compilation *, TR_ResolvedMethod *,
    J9Method *, TR::IlGeneratorMethodDetails &, TR::CompilationInfoPerThreadBase *);
 TR_MethodMetaData *remoteCompilationEnd(J9VMThread * vmThread, TR::Compilation *comp, TR_ResolvedMethod * compilee, J9Method * method,
    TR::CompilationInfoPerThreadBase *compInfoPT, const std::string& codeCacheStr, const std::string& dataCacheStr);
 void outOfProcessCompilationEnd(TR_MethodToBeCompiled *entry, TR::Compilation *comp);
-void printJITServerMsgStats(J9JITConfig *);
-void printJITServerCHTableStats(J9JITConfig *, TR::CompilationInfo *);
-void printJITServerCacheStats(J9JITConfig *, TR::CompilationInfo *);
 
 namespace TR
 {
@@ -157,78 +148,5 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_IsUnresolvedString> *_isUnresolvedStrCache;
    }; // class CompilationInfoPerThreadRemote
 } // namespace TR
-
-class JITServerHelpers
-   {
-   public:
-   enum ClassInfoDataType
-      {
-      CLASSINFO_ROMCLASS_MODIFIERS,
-      CLASSINFO_ROMCLASS_EXTRAMODIFIERS,
-      CLASSINFO_BASE_COMPONENT_CLASS,
-      CLASSINFO_NUMBER_DIMENSIONS,
-      CLASSINFO_PARENT_CLASS,
-      CLASSINFO_INTERFACE_CLASS,
-      CLASSINFO_CLASS_HAS_FINAL_FIELDS,
-      CLASSINFO_CLASS_DEPTH_AND_FLAGS,
-      CLASSINFO_CLASS_INITIALIZED,
-      CLASSINFO_BYTE_OFFSET_TO_LOCKWORD,
-      CLASSINFO_LEAF_COMPONENT_CLASS,
-      CLASSINFO_CLASS_LOADER,
-      CLASSINFO_HOST_CLASS,
-      CLASSINFO_COMPONENT_CLASS,
-      CLASSINFO_ARRAY_CLASS,
-      CLASSINFO_TOTAL_INSTANCE_SIZE,
-      CLASSINFO_CLASS_OF_STATIC_CACHE,
-      CLASSINFO_REMOTE_ROM_CLASS,
-      CLASSINFO_CLASS_FLAGS,
-      CLASSINFO_METHODS_OF_CLASS,
-      };
-   // NOTE: when adding new elements to this tuple, add them to the end,
-   // to not mess with the established order.
-   using ClassInfoTuple = std::tuple
-      <
-      std::string, J9Method *,                                       // 0: string                   1: _methodsOfClass
-      TR_OpaqueClassBlock *, int32_t,                                // 2: _baseComponentClass      3: _numDimensions
-      TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>,     // 4: _parentClass             5: _tmpInterfaces
-      std::vector<uint8_t>, bool,                                    // 6: _methodTracingInfo       7: _classHasFinalFields
-      uintptrj_t, bool,                                              // 8: _classDepthAndFlags      9: _classInitialized
-      uint32_t, TR_OpaqueClassBlock *,                               // 10: _byteOffsetToLockword   11: _leafComponentClass
-      void *, TR_OpaqueClassBlock *,                                 // 12: _classLoader            13: _hostClass
-      TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: _componentClass         15: _arrayClass
-      uintptrj_t, J9ROMClass *,                                      // 16: _totalInstanceSize      17: _remoteRomClass
-      uintptrj_t, uintptrj_t                                         // 18: _constantPool           19: _classFlags
-      >;
-   static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory);
-   static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
-   static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
-   static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
-   static J9ROMClass *getRemoteROMClass(J9Class *, JITServer::ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
-   static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory);
-   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType, void *data);
-   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2);
-   static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
-   static J9ROMMethod *romMethodOfRamMethod(J9Method* method);
-
-   // functions used for allowing the client to compile locally when server is unavailable
-   // should be only used on the client side
-   static void postStreamFailure(OMRPortLibrary *portLibrary);
-   static bool shouldRetryConnection(OMRPortLibrary *portLibrary);
-   static void postStreamConnectionSuccess();
-   static bool isServerAvailable() { return _serverAvailable; }
-   static TR::Monitor * getClientStreamMonitor()
-      {
-      if (!_clientStreamMonitor)
-         _clientStreamMonitor = TR::Monitor::create("clientStreamMonitor");
-      return _clientStreamMonitor;
-      }
-   static void insertIntoOOSequenceEntryList(ClientSessionData *clientData, TR_MethodToBeCompiled *entry);
-
-   private:
-   static uint64_t _waitTime;
-   static uint64_t _nextConnectionRetryTime;
-   static bool _serverAvailable;
-   static TR::Monitor * _clientStreamMonitor;
-   }; // class JITServerHelpers
 
 #endif // defined(JITSERVER_COMPILATION_THREAD_H)

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -1,0 +1,555 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "control/JITServerHelpers.hpp"
+
+#include "control/CompilationRuntime.hpp"
+#include "control/JITServerCompilationThread.hpp"
+#include "control/MethodToBeCompiled.hpp"
+#include "env/JITServerPersistentCHTable.hpp"
+#include "infra/CriticalSection.hpp"
+
+uint32_t     JITServerHelpers::serverMsgTypeCount[] = {};
+uint64_t     JITServerHelpers::_waitTimeMs = 1000;
+bool         JITServerHelpers::_serverAvailable = true;
+uint64_t     JITServerHelpers::_nextConnectionRetryTime = 0;
+TR::Monitor *JITServerHelpers::_clientStreamMonitor = NULL;
+
+static size_t
+methodStringsLength(J9ROMMethod *method)
+   {
+   J9UTF8 *name = J9ROMMETHOD_NAME(method);
+   J9UTF8 *sig = J9ROMMETHOD_SIGNATURE(method);
+   return (name->length + sig->length + (2 * sizeof(U_16)));
+   }
+
+// Packs a ROMClass into a std::string to be transferred to the server.
+// The name and signature of all methods are appended to the end of the cloned class body and the
+// self referential pointers to them are updated to deal with possible interning. The method names
+// and signature are needed on the server but may be interned globally on the client.
+static std::string
+packROMClass(J9ROMClass *origRomClass, TR_Memory *trMemory)
+   {
+   J9UTF8 *className = J9ROMCLASS_CLASSNAME(origRomClass);
+   size_t classNameSize = className->length + sizeof(U_16);
+
+   J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(origRomClass);
+   size_t totalSize = origRomClass->romSize + classNameSize;
+   for (size_t i = 0; i < origRomClass->romMethodCount; ++i)
+      {
+      totalSize += methodStringsLength(romMethod);
+      romMethod = nextROMMethod(romMethod);
+      }
+
+   J9ROMClass *romClass = (J9ROMClass *)trMemory->allocateHeapMemory(totalSize);
+   if (!romClass)
+      throw std::bad_alloc();
+   memcpy(romClass, origRomClass, origRomClass->romSize);
+
+   uint8_t *curPos = ((uint8_t *)romClass) + romClass->romSize;
+
+   memcpy(curPos, className, classNameSize);
+   NNSRP_SET(romClass->className, curPos);
+   curPos += classNameSize;
+
+   romMethod = J9ROMCLASS_ROMMETHODS(romClass);
+   J9ROMMethod *origRomMethod = J9ROMCLASS_ROMMETHODS(origRomClass);
+   for (size_t i = 0; i < romClass->romMethodCount; ++i)
+      {
+      J9UTF8 *field = J9ROMMETHOD_NAME(origRomMethod);
+      size_t fieldLen = field->length + sizeof(U_16);
+      memcpy(curPos, field, fieldLen);
+      NNSRP_SET(romMethod->nameAndSignature.name, curPos);
+      curPos += fieldLen;
+
+      field = J9ROMMETHOD_SIGNATURE(origRomMethod);
+      fieldLen = field->length + sizeof(U_16);
+      memcpy(curPos, field, fieldLen);
+      NNSRP_SET(romMethod->nameAndSignature.signature, curPos);
+      curPos += fieldLen;
+
+      romMethod = nextROMMethod(romMethod);
+      origRomMethod = nextROMMethod(origRomMethod);
+      }
+
+   std::string romClassStr((char *) romClass, totalSize);
+   trMemory->freeMemory(romClass, heapAlloc);
+   return romClassStr;
+   }
+
+// insertIntoOOSequenceEntryList needs to be executed with sequencingMonitor in hand.
+// This method belongs to ClientSessionData, but is temporarily moved here to be able
+// to push the ClientSessionData related code as a standalone piece.
+void 
+JITServerHelpers::insertIntoOOSequenceEntryList(ClientSessionData *clientData, TR_MethodToBeCompiled *entry)
+   {
+   uint32_t seqNo = ((TR::CompilationInfoPerThreadRemote*)(entry->_compInfoPT))->getSeqNo();
+   TR_MethodToBeCompiled *crtEntry = clientData->getOOSequenceEntryList();
+   TR_MethodToBeCompiled *prevEntry = NULL;
+   while (crtEntry && (seqNo > ((TR::CompilationInfoPerThreadRemote*)(crtEntry->_compInfoPT))->getSeqNo()))
+      {
+      prevEntry = crtEntry;
+      crtEntry = crtEntry->_next;
+      }
+   entry->_next = crtEntry;
+   if (prevEntry)
+      prevEntry->_next = entry;
+   else
+      clientData->setOOSequenceEntryList(entry);
+   }
+
+void
+JITServerHelpers::printJITServerMsgStats(J9JITConfig *jitConfig)
+   {
+   PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+   j9tty_printf(PORTLIB, "JITServer Message Type Statistics:\n");
+   j9tty_printf(PORTLIB, "Type# #called TypeName\n");
+   const ::google::protobuf::EnumDescriptor *descriptor = JITServer::MessageType_descriptor();
+   for (int i = 0; i < JITServer::MessageType_ARRAYSIZE; ++i)
+      {
+      if (JITServerHelpers::serverMsgTypeCount[i] > 0)
+         j9tty_printf(PORTLIB, "#%04d %7u %s\n", i, JITServerHelpers::serverMsgTypeCount[i], descriptor->FindValueByNumber(i)->name().c_str());
+      }
+   }
+
+void
+JITServerHelpers::printJITServerCHTableStats(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo)
+   {
+#ifdef COLLECT_CHTABLE_STATS
+   PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+   j9tty_printf(PORTLIB, "JITServer CHTable Statistics:\n");
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+      {
+      JITClientPersistentCHTable *table = (JITClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+      j9tty_printf(PORTLIB, "Num updates sent: %d (1 per compilation)\n", table->_numUpdates);
+      if (table->_numUpdates)
+         {
+         j9tty_printf(PORTLIB, "Num commit failures: %d. Average per compilation: %f\n", table->_numCommitFailures, table->_numCommitFailures / float(table->_numUpdates));
+         j9tty_printf(PORTLIB, "Num classes updated: %d. Average per compilation: %f\n", table->_numClassesUpdated, table->_numClassesUpdated / float(table->_numUpdates));
+         j9tty_printf(PORTLIB, "Num classes removed: %d. Average per compilation: %f\n", table->_numClassesRemoved, table->_numClassesRemoved / float(table->_numUpdates));
+         j9tty_printf(PORTLIB, "Total update bytes: %d. Compilation max: %d. Average per compilation: %f\n", table->_updateBytes, table->_maxUpdateBytes, table->_updateBytes / float(table->_numUpdates));
+         }
+      }
+   else if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      JITServerPersistentCHTable *table = (JITServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+      j9tty_printf(PORTLIB, "Num updates received: %d (1 per compilation)\n", table->_numUpdates);
+      if (table->_numUpdates)
+         {
+         j9tty_printf(PORTLIB, "Num classes updated: %d. Average per compilation: %f\n", table->_numClassesUpdated, table->_numClassesUpdated / float(table->_numUpdates));
+         j9tty_printf(PORTLIB, "Num classes removed: %d. Average per compilation: %f\n", table->_numClassesRemoved, table->_numClassesRemoved / float(table->_numUpdates));
+         j9tty_printf(PORTLIB, "Num class info queries: %d. Average per compilation: %f\n", table->_numQueries, table->_numQueries / float(table->_numUpdates));
+         j9tty_printf(PORTLIB, "Total update bytes: %d. Compilation max: %d. Average per compilation: %f\n", table->_updateBytes, table->_maxUpdateBytes, table->_updateBytes / float(table->_numUpdates));
+         }
+      }
+#endif
+   }
+
+void
+JITServerHelpers::printJITServerCacheStats(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo)
+   {
+   PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      auto clientSessionHT = compInfo->getClientSessionHT();
+      clientSessionHT->printStats();
+      }
+   }
+
+void 
+JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple)
+   {
+   ClientSessionData::ClassInfo classInfo;
+   OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+   if (it == clientSessionData->getROMClassMap().end())
+      {
+      JITServerHelpers::cacheRemoteROMClass(clientSessionData, clazz, romClass, classInfoTuple, classInfo);
+      }
+   }
+
+void
+JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfoStruct)
+   {
+   ClassInfoTuple &classInfo = *classInfoTuple;
+
+   classInfoStruct._romClass = romClass;
+   classInfoStruct._methodsOfClass = std::get<1>(classInfo);
+   J9Method *methods = classInfoStruct._methodsOfClass;
+   classInfoStruct._baseComponentClass = std::get<2>(classInfo);
+   classInfoStruct._numDimensions = std::get<3>(classInfo);
+   classInfoStruct._remoteROMStringsCache = NULL;
+   classInfoStruct._fieldOrStaticNameCache = NULL;
+   classInfoStruct._parentClass = std::get<4>(classInfo);
+   auto &tmpInterfaces = std::get<5>(classInfo);
+   classInfoStruct._interfaces = new (PERSISTENT_NEW) PersistentVector<TR_OpaqueClassBlock *>
+      (tmpInterfaces.begin(), tmpInterfaces.end(),
+       PersistentVector<TR_OpaqueClassBlock *>::allocator_type(TR::Compiler->persistentAllocator()));
+   auto &methodTracingInfo = std::get<6>(classInfo);
+   classInfoStruct._classHasFinalFields = std::get<7>(classInfo);
+   classInfoStruct._classDepthAndFlags = std::get<8>(classInfo);
+   classInfoStruct._classInitialized = std::get<9>(classInfo);
+   classInfoStruct._byteOffsetToLockword = std::get<10>(classInfo);
+   classInfoStruct._leafComponentClass = std::get<11>(classInfo);
+   classInfoStruct._classLoader = std::get<12>(classInfo);
+   classInfoStruct._hostClass = std::get<13>(classInfo);
+   classInfoStruct._componentClass = std::get<14>(classInfo);
+   classInfoStruct._arrayClass = std::get<15>(classInfo);
+   classInfoStruct._totalInstanceSize = std::get<16>(classInfo);
+   classInfoStruct._classOfStaticCache = NULL;
+   classInfoStruct._constantClassPoolCache = NULL;
+   classInfoStruct._remoteRomClass = std::get<17>(classInfo);
+   classInfoStruct._fieldAttributesCache = NULL;
+   classInfoStruct._staticAttributesCache = NULL;
+   classInfoStruct._fieldAttributesCacheAOT = NULL;
+   classInfoStruct._staticAttributesCacheAOT = NULL;
+   classInfoStruct._constantPool = (J9ConstantPool *)std::get<18>(classInfo);
+   classInfoStruct._jitFieldsCache = NULL;
+   classInfoStruct._classFlags = std::get<19>(classInfo);
+   classInfoStruct._fieldOrStaticDeclaringClassCache = NULL;
+   classInfoStruct._J9MethodNameCache = NULL;
+   clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
+
+   uint32_t numMethods = romClass->romMethodCount;
+   J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
+   for (uint32_t i = 0; i < numMethods; i++)
+      {
+      clientSessionData->getJ9MethodMap().insert({&methods[i],
+            {romMethod, NULL, static_cast<bool>(methodTracingInfo[i]), (TR_OpaqueClassBlock *)clazz, false}});
+      romMethod = nextROMMethod(romMethod);
+      }
+   }
+
+J9ROMClass *
+JITServerHelpers::getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz)
+   {
+   OMR::CriticalSection getRemoteROMClassIfCached(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find(clazz);
+   return (it == clientSessionData->getROMClassMap().end()) ? NULL : it->second._romClass;
+   }
+
+JITServerHelpers::ClassInfoTuple
+JITServerHelpers::packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory)
+   {
+   // Always use the base VM here.
+   // If this method is called inside AOT compilation, TR_J9SharedCacheVM will
+   // attempt validation and return NULL for many methods invoked here.
+   // We do not want that, because these values will be cached and later used in non-AOT
+   // compilations, where we always need a non-NULL result.
+   TR_J9VM *fe = (TR_J9VM *) TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+   J9Method *methodsOfClass = (J9Method*) fe->getMethods((TR_OpaqueClassBlock*) clazz);
+   int32_t numDims = 0;
+   TR_OpaqueClassBlock *baseClass = fe->getBaseComponentClass((TR_OpaqueClassBlock *) clazz, numDims);
+   TR_OpaqueClassBlock *parentClass = fe->getSuperClass((TR_OpaqueClassBlock *) clazz);
+
+   uint32_t numMethods = clazz->romClass->romMethodCount;
+   std::vector<uint8_t> methodTracingInfo;
+   methodTracingInfo.reserve(numMethods);
+   for(uint32_t i = 0; i < numMethods; ++i)
+      {
+      methodTracingInfo.push_back(static_cast<uint8_t>(fe->isMethodTracingEnabled((TR_OpaqueMethodBlock *) &methodsOfClass[i])));
+      }
+
+   bool classHasFinalFields = fe->hasFinalFieldsInClass((TR_OpaqueClassBlock *)clazz);
+   uintptrj_t classDepthAndFlags = fe->getClassDepthAndFlagsValue((TR_OpaqueClassBlock *)clazz);
+   bool classInitialized =  fe->isClassInitialized((TR_OpaqueClassBlock *)clazz);
+   uint32_t byteOffsetToLockword = fe->getByteOffsetToLockword((TR_OpaqueClassBlock *)clazz);
+   TR_OpaqueClassBlock * leafComponentClass = fe->getLeafComponentClassFromArrayClass((TR_OpaqueClassBlock *)clazz);
+   void * classLoader = fe->getClassLoader((TR_OpaqueClassBlock *)clazz);
+   TR_OpaqueClassBlock * hostClass = fe->convertClassPtrToClassOffset(clazz->hostClass);
+   TR_OpaqueClassBlock * componentClass = fe->getComponentClassFromArrayClass((TR_OpaqueClassBlock *)clazz);
+   TR_OpaqueClassBlock * arrayClass = fe->getArrayClassFromComponentClass((TR_OpaqueClassBlock *)clazz);
+   uintptrj_t totalInstanceSize = clazz->totalInstanceSize;
+   uintptrj_t cp = fe->getConstantPoolFromClass((TR_OpaqueClassBlock *)clazz);
+   uintptrj_t classFlags = fe->getClassFlagsValue((TR_OpaqueClassBlock *)clazz);
+
+   return std::make_tuple(packROMClass(clazz->romClass, trMemory), methodsOfClass, baseClass, numDims, parentClass, TR::Compiler->cls.getITable((TR_OpaqueClassBlock *) clazz), methodTracingInfo, classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass, classLoader, hostClass, componentClass, arrayClass, totalInstanceSize, clazz->romClass, cp, classFlags);
+   }
+
+J9ROMClass *
+JITServerHelpers::romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory)
+   {
+   auto romClass = (J9ROMClass *)(trMemory->allocatePersistentMemory(romClassStr.size(), TR_Memory::ROMClass));
+   if (!romClass)
+      throw std::bad_alloc();
+   memcpy(romClass, &romClassStr[0], romClassStr.size());
+   return romClass;
+   }
+
+J9ROMClass *
+JITServerHelpers::getRemoteROMClass(J9Class *clazz, JITServer::ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple)
+   {
+   stream->write(JITServer::MessageType::ResolvedMethod_getRemoteROMClassAndMethods, clazz);
+   const auto &recv = stream->read<ClassInfoTuple>();
+   *classInfoTuple = std::get<0>(recv);
+   return romClassFromString(std::get<0>(*classInfoTuple), trMemory->trPersistentMemory());
+   }
+
+// Return true if able to get data from cache, return false otherwise.
+bool
+JITServerHelpers::getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType, void *data)
+   {
+   JITServerHelpers::ClassInfoTuple classInfoTuple;
+   ClientSessionData::ClassInfo classInfo;
+   if (!clazz)
+      {
+      return false;
+      }
+      {
+      OMR::CriticalSection getRemoteROMClass(clientSessionData->getROMMapMonitor());
+      auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+      if (it != clientSessionData->getROMClassMap().end())
+         {
+         JITServerHelpers::getROMClassData(it->second, dataType, data);
+         return true;
+         }
+      }
+
+   stream->write(JITServer::MessageType::ResolvedMethod_getRemoteROMClassAndMethods, clazz);
+   const auto &recv = stream->read<ClassInfoTuple>();
+   classInfoTuple = std::get<0>(recv);
+
+   OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find(clazz);
+   if (it == clientSessionData->getROMClassMap().end())
+      {
+      auto romClass = romClassFromString(std::get<0>(classInfoTuple), TR::comp()->trMemory()->trPersistentMemory());
+      JITServerHelpers::cacheRemoteROMClass(clientSessionData, clazz, romClass, &classInfoTuple, classInfo);
+      JITServerHelpers::getROMClassData(classInfo, dataType, data);
+      }
+   else
+      {
+      JITServerHelpers::getROMClassData(it->second, dataType, data);
+      }
+   return false;
+   }
+
+// Return true if able to get data from cache, return false otherwise.
+bool
+JITServerHelpers::getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2)
+   {
+   JITServerHelpers::ClassInfoTuple classInfoTuple;
+   ClientSessionData::ClassInfo classInfo;
+   if (!clazz)
+      {
+      return false;
+      }
+      {
+      OMR::CriticalSection getRemoteROMClass(clientSessionData->getROMMapMonitor());
+      auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+      if (it != clientSessionData->getROMClassMap().end())
+         {
+         JITServerHelpers::getROMClassData(it->second, dataType1, data1);
+         JITServerHelpers::getROMClassData(it->second, dataType2, data2);
+         return true;
+         }
+      }
+   stream->write(JITServer::MessageType::ResolvedMethod_getRemoteROMClassAndMethods, clazz);
+   const auto &recv = stream->read<ClassInfoTuple>();
+   classInfoTuple = std::get<0>(recv);
+
+   OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find(clazz);
+   if (it == clientSessionData->getROMClassMap().end())
+      {
+      auto romClass = romClassFromString(std::get<0>(classInfoTuple), TR::comp()->trMemory()->trPersistentMemory());
+      JITServerHelpers::cacheRemoteROMClass(clientSessionData, clazz, romClass, &classInfoTuple, classInfo);
+      JITServerHelpers::getROMClassData(classInfo, dataType1, data1);
+      JITServerHelpers::getROMClassData(classInfo, dataType2, data2);
+      }
+   else
+      {
+      JITServerHelpers::getROMClassData(it->second, dataType1, data1);
+      JITServerHelpers::getROMClassData(it->second, dataType2, data2);
+      }
+   return false;
+   }
+
+void
+JITServerHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data)
+   {
+   switch (dataType)
+      {
+      case CLASSINFO_ROMCLASS_MODIFIERS :
+         {
+         *(uint32_t *)data = classInfo._romClass->modifiers;
+         }
+         break;
+      case CLASSINFO_ROMCLASS_EXTRAMODIFIERS :
+         {
+         *(uint32_t *)data = classInfo._romClass->extraModifiers;
+         }
+         break;
+      case CLASSINFO_BASE_COMPONENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo._baseComponentClass;
+         }
+         break;
+      case CLASSINFO_NUMBER_DIMENSIONS :
+         {
+         *(int32_t *)data = classInfo._numDimensions;
+         }
+         break;
+      case CLASSINFO_PARENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo._parentClass;
+         }
+         break;
+      case CLASSINFO_CLASS_HAS_FINAL_FIELDS :
+         {
+         *(bool *)data = classInfo._classHasFinalFields;
+         }
+         break;
+      case CLASSINFO_CLASS_DEPTH_AND_FLAGS :
+         {
+         *(uintptrj_t *)data = classInfo._classDepthAndFlags;
+         }
+         break;
+      case CLASSINFO_CLASS_INITIALIZED :
+         {
+         *(bool *)data = classInfo._classInitialized;
+         }
+         break;
+      case CLASSINFO_BYTE_OFFSET_TO_LOCKWORD :
+         {
+         *(uint32_t *)data = classInfo._byteOffsetToLockword;
+         }
+         break;
+      case CLASSINFO_LEAF_COMPONENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo._leafComponentClass;
+         }
+         break;
+      case CLASSINFO_CLASS_LOADER :
+         {
+         *(void **)data = classInfo._classLoader;
+         }
+         break;
+      case CLASSINFO_HOST_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo._hostClass;
+         }
+         break;
+      case CLASSINFO_COMPONENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo._componentClass;
+         }
+         break;
+      case CLASSINFO_ARRAY_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo._arrayClass;
+         }
+         break;
+      case CLASSINFO_TOTAL_INSTANCE_SIZE :
+         {
+         *(uintptrj_t *)data = classInfo._totalInstanceSize;
+         }
+         break;
+      case CLASSINFO_REMOTE_ROM_CLASS :
+         {
+         *(J9ROMClass **)data = classInfo._remoteRomClass;
+         }
+         break;
+      case CLASSINFO_CLASS_FLAGS :
+         {
+         *(uintptrj_t *)data = classInfo._classFlags;
+         }
+         break;
+      case CLASSINFO_METHODS_OF_CLASS :
+         {
+         *(J9Method **)data = classInfo._methodsOfClass;
+         }
+         break;
+      default :
+         {
+         TR_ASSERT(0, "Class Info not supported %u \n", dataType);
+         }
+         break;
+      }
+   }
+
+J9ROMMethod *
+JITServerHelpers::romMethodOfRamMethod(J9Method* method)
+   {
+   if (!TR::CompilationInfo::getStream()) // Not JITServer
+      return J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+
+   // JITServer
+   auto clientData = TR::compInfoPT->getClientData();
+   J9ROMMethod *romMethod = NULL;
+
+   // Check if the method is already cached.
+      {
+      OMR::CriticalSection romCache(clientData->getROMMapMonitor());
+      auto &map = clientData->getJ9MethodMap();
+      auto it = map.find((J9Method*) method);
+      if (it != map.end())
+         romMethod = it->second._romMethod;
+      }
+
+   // If not, cache the associated ROM class and get the ROM method from it.
+   if (!romMethod)
+      {
+      auto stream = TR::CompilationInfo::getStream();
+      stream->write(JITServer::MessageType::VM_getClassOfMethod, (TR_OpaqueMethodBlock*) method);
+      J9Class *clazz = (J9Class*) std::get<0>(stream->read<TR_OpaqueClassBlock *>());
+      TR::compInfoPT->getAndCacheRemoteROMClass(clazz);
+         {
+         OMR::CriticalSection romCache(clientData->getROMMapMonitor());
+         auto &map = clientData->getJ9MethodMap();
+         auto it = map.find((J9Method *) method);
+         if (it != map.end())
+            romMethod = it->second._romMethod;
+         }
+      }
+   TR_ASSERT(romMethod, "Should have acquired romMethod");
+   return romMethod;
+   }
+
+void
+JITServerHelpers::postStreamFailure(OMRPortLibrary *portLibrary)
+   {
+   OMR::CriticalSection postStreamFailure(getClientStreamMonitor());
+
+   OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+   uint64_t current_time = omrtime_current_time_millis();
+   if (current_time >= _nextConnectionRetryTime)
+      {
+      _waitTimeMs *= 2; // Exponential backoff
+      }
+   _nextConnectionRetryTime = current_time + _waitTimeMs;
+   _serverAvailable = false;
+   }
+
+void
+JITServerHelpers::postStreamConnectionSuccess()
+   {
+   _serverAvailable = true;
+   _waitTimeMs = 1000;
+   }
+
+bool
+JITServerHelpers::shouldRetryConnection(OMRPortLibrary *portLibrary)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+   return omrtime_current_time_millis() > _nextConnectionRetryTime;
+   }

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JITSERVER_HELPERS_H
+#define JITSERVER_HELPERS_H
+
+#include "net/gen/compile.pb.h"
+#include "runtime/JITClientSession.hpp"
+
+class JITServerHelpers
+   {
+   public:
+   enum ClassInfoDataType
+      {
+      CLASSINFO_ROMCLASS_MODIFIERS,
+      CLASSINFO_ROMCLASS_EXTRAMODIFIERS,
+      CLASSINFO_BASE_COMPONENT_CLASS,
+      CLASSINFO_NUMBER_DIMENSIONS,
+      CLASSINFO_PARENT_CLASS,
+      CLASSINFO_INTERFACE_CLASS,
+      CLASSINFO_CLASS_HAS_FINAL_FIELDS,
+      CLASSINFO_CLASS_DEPTH_AND_FLAGS,
+      CLASSINFO_CLASS_INITIALIZED,
+      CLASSINFO_BYTE_OFFSET_TO_LOCKWORD,
+      CLASSINFO_LEAF_COMPONENT_CLASS,
+      CLASSINFO_CLASS_LOADER,
+      CLASSINFO_HOST_CLASS,
+      CLASSINFO_COMPONENT_CLASS,
+      CLASSINFO_ARRAY_CLASS,
+      CLASSINFO_TOTAL_INSTANCE_SIZE,
+      CLASSINFO_CLASS_OF_STATIC_CACHE,
+      CLASSINFO_REMOTE_ROM_CLASS,
+      CLASSINFO_CLASS_FLAGS,
+      CLASSINFO_METHODS_OF_CLASS,
+      };
+   // NOTE: when adding new elements to this tuple, add them to the end,
+   // to not mess with the established order.
+   using ClassInfoTuple = std::tuple
+      <
+      std::string, J9Method *,                                       // 0:  string                  1:  _methodsOfClass
+      TR_OpaqueClassBlock *, int32_t,                                // 2:  _baseComponentClass     3:  _numDimensions
+      TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>,     // 4:  _parentClass            5:  _tmpInterfaces
+      std::vector<uint8_t>, bool,                                    // 6:  _methodTracingInfo      7:  _classHasFinalFields
+      uintptrj_t, bool,                                              // 8:  _classDepthAndFlags     9:  _classInitialized
+      uint32_t, TR_OpaqueClassBlock *,                               // 10: _byteOffsetToLockword   11: _leafComponentClass
+      void *, TR_OpaqueClassBlock *,                                 // 12: _classLoader            13: _hostClass
+      TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: _componentClass         15: _arrayClass
+      uintptrj_t, J9ROMClass *,                                      // 16: _totalInstanceSize      17: _remoteRomClass
+      uintptrj_t, uintptrj_t                                         // 18: _constantPool           19: _classFlags
+      >;
+
+   static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory);
+   static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
+   static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
+   static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
+   static J9ROMClass *getRemoteROMClass(J9Class *, JITServer::ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
+   static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType, void *data);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1,
+                                       ClassInfoDataType dataType2, void *data2);
+   static J9ROMMethod *romMethodOfRamMethod(J9Method* method);
+
+   static void insertIntoOOSequenceEntryList(ClientSessionData *clientData, TR_MethodToBeCompiled *entry);
+
+   // Functions used for allowing the client to compile locally when server is unavailable.
+   // Should be used only on the client side.
+   static void postStreamFailure(OMRPortLibrary *portLibrary);
+   static bool shouldRetryConnection(OMRPortLibrary *portLibrary);
+   static void postStreamConnectionSuccess();
+   static bool isServerAvailable() { return _serverAvailable; }
+
+   static void printJITServerMsgStats(J9JITConfig *);
+   static void printJITServerCHTableStats(J9JITConfig *, TR::CompilationInfo *);
+   static void printJITServerCacheStats(J9JITConfig *, TR::CompilationInfo *);
+
+   static uint32_t serverMsgTypeCount[JITServer::MessageType_ARRAYSIZE];
+
+   private:
+   static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
+   static TR::Monitor *getClientStreamMonitor()
+      {
+      if (!_clientStreamMonitor)
+         _clientStreamMonitor = TR::Monitor::create("clientStreamMonitor");
+      return _clientStreamMonitor;
+      }
+
+   static uint64_t _waitTimeMs;
+   static uint64_t _nextConnectionRetryTime;
+   static bool _serverAvailable;
+   static TR::Monitor * _clientStreamMonitor;
+   }; // class JITServerHelpers
+
+#endif // defined(JITSERVER_HELPERS_H)


### PR DESCRIPTION
Extract `JITServer` helper and utility functions out of
`JITServerCompilationThread`.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>