### PR TITLE
Support signals needed by Jython

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -438,6 +438,18 @@ static const J9SignalMapping signalMap[] = {
 #if defined(SIGKILL)
 	J9_SIGNAL_MAP_ENTRY("KILL", SIGKILL),
 #endif /* defined(SIGKILL) */
+#if defined(SIGSTOP)
+	J9_SIGNAL_MAP_ENTRY("STOP", SIGSTOP),
+#endif /* defined(SIGSTOP) */
+#if defined(SIGINFO)
+	J9_SIGNAL_MAP_ENTRY("INFO", SIGINFO),
+#endif /* defined(SIGINFO) */
+#if defined(SIGIOT)
+	J9_SIGNAL_MAP_ENTRY("IOT", SIGIOT),
+#endif /* defined(SIGIOT) */
+#if defined(SIGPOLL)
+	J9_SIGNAL_MAP_ENTRY("POLL", SIGPOLL),
+#endif /* defined(SIGPOLL) */
 	{NULL, J9_SIG_ERR}
 };
 


### PR DESCRIPTION
Comparing the [signals needed by Jython](https://github.com/jythontools/jython/blob/b9ff520f4f65231209d5200c22724516a72e75f2/Lib/signal.py#L56-L87) and signals supported by OpenJ9, OpenJ9 needs to support the following signals:

```
1) SIGSTOP
2) SIGINFO
3) SIGIOT
4) SIGPOLL
```

Related: https://github.com/eclipse/openj9/pull/6876.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>