### PR TITLE
Update the build script for bootstrapMethodArgumentTest

### DIFF
--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
@@ -67,7 +67,7 @@
 			<fileset dir="./" />
 		</jar>
 		<copy todir="${DEST}">
-			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.xml,*.mk"/>
 		</copy>
 	</target>
 


### PR DESCRIPTION
The fix is to copy .mk file to the destination directory
to accommodate the latest test framework changes.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>