### PR TITLE
Remove reference to j9getuserid.h

### DIFF
--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -91,10 +91,6 @@
 #undef nl_langinfo
 #endif
 
-#if defined(J9ZOS390)
-#include "j9getuserid.h"
-#endif
-
 /* End copy from j9filetext.c */
 
 #ifdef AIXPPC


### PR DESCRIPTION
Header does not exist

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>