### PR TITLE
Update the default format strings for NLS message

### DIFF
--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -761,7 +761,7 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
 
 	if ((IDATA) error->errorPC == -1) {
 		/* J9NLS_BCV_ERROR_TEMPLATE_NO_PC=%1$s; class=%3$.*2$s, method=%5$.*4$s%7$.*6$s */
-		formatString = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_BCV_ERROR_TEMPLATE_NO_PC, "%s;%.*s,%.*s%.*s");
+		formatString = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_BCV_ERROR_TEMPLATE_NO_PC, "%s; class=%.*s, method=%.*s%.*s");
 	} else {
 		/* Jazz 82615: Generate the error message framework by default.
 		 * The error message framework is not required when the -XX:-VerifyErrorDetails option is specified.
@@ -784,10 +784,11 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
 		/*Jazz 82615: fetch the corresponding NLS message when type mismatch error is detected */
 		if (NULL == error->errorSignatureString) {
 			/* J9NLS_BCV_ERROR_TEMPLATE_WITH_PC=%1$s; class=%3$.*2$s, method=%5$.*4$s%7$.*6$s, pc=%8$u */
-			formatString = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_BCV_ERROR_TEMPLATE_WITH_PC, "%s;%.*s,%.*s%.*s,%u");
+			formatString = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_BCV_ERROR_TEMPLATE_WITH_PC, "%s; class=%.*s, method=%.*s%.*s, pc=%u");
 		} else {
-			/*Jazz 82615: J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH=%1$s; class=%3$.*2$s, method=%5$.*4$s%7$.*6$s, pc=%8$u; Mismatch, argument %9$d in signature %11$.*10$s.%13$.*12$s:%15$.*14$s does not match */
-			formatString = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH, "%s;%.*s,%.*s%.*s,%u;,%d%.*s.%.*s:%.*s");
+			/*Jazz 82615: J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH=%1$s; class=%3$.*2$s, method=%5$.*4$s%7$.*6$s, pc=%8$u; Type Mismatch, argument %9$d in signature %11$.*10$s.%13$.*12$s:%15$.*14$s does not match */
+			formatString = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_BCV_ERROR_TEMPLATE_TYPE_MISMATCH,
+					"%s; class=%.*s, method=%.*s%.*s, pc=%u; Type Mismatch, argument %d in signature %.*s.%.*s:%.*s does not match");
 		}
 	}
 

--- a/runtime/verutil/cfrerr.c
+++ b/runtime/verutil/cfrerr.c
@@ -46,7 +46,7 @@ getJ9CfrErrorNormalMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8*
 	errorDescription = getJ9CfrErrorDescription(PORTLIB, error);
 
 	/* J9NLS_CFR_ERROR_TEMPLATE_NO_METHOD=%1$s; class=%3$.*2$s, offset=%4$u */
-	template = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERROR_TEMPLATE_NO_METHOD, "%s;%.*s,%u");
+	template = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERROR_TEMPLATE_NO_METHOD, "%s; class=%.*s, offset=%u");
 
 	allocSize = strlen(template) + strlen(errorDescription) + classNameLength + MAX_INT_SIZE;
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
@@ -65,7 +65,8 @@ getJ9CfrErrorBsmMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8* cl
 	char *errorString = NULL;
 
 	/* J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY=BootstrapMethod (%1$d) arguments contain invalid constantpool entry at index (#%2$u) of type (%3$u); class=%5$.*4$s, offset=%6$u */
-	const char *template = j9nls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY, NULL);
+	const char *template = j9nls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY,
+			"BootstrapMethod (%d) arguments contain invalid constantpool entry at index (#%u) of type (%u); class=%.*s, offset=%u");
 
 	allocSize = strlen(template) + classNameLength + (MAX_INT_SIZE * 4);
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
@@ -106,7 +107,7 @@ getJ9CfrErrorDetailMessageForMethod(J9PortLibrary* portLib, J9CfrError* error, c
 	errorDescription = getJ9CfrErrorDescription(PORTLIB, error);
 
 	/* J9NLS_CFR_ERROR_TEMPLATE_METHOD=%1$s; class=%3$.*2$s, method=%5$.*4$s%7$.*6$s, pc=%8$u */
-	template = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERROR_TEMPLATE_METHOD, "%s;%.*s,%.*s%.*s,%u");
+	template = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERROR_TEMPLATE_METHOD, "%s; class=%.*s, method=%.*s%.*s, pc=%u");
 
 	allocSize = strlen(template) + strlen(errorDescription) + MAX_INT_SIZE + classNameLength + methodNameLength + methodSignatureLength + detailedExceptionLength;
 


### PR DESCRIPTION
The changes are to avoid the NLS lookup in English locale
and return the correct format string for NLS message generation.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>