### PR TITLE
Skip package signer check for trusted system code

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -542,8 +542,16 @@ final Class<?> defineClassInternal(
 	if (className != null) {
 		/*[PR 95417]*/
 		String packageName = checkClassName(className);
-		/*[PR 93858]*/
-		checkPackageSigners(packageName, className, certs);
+		if ((protectionDomain == null) && allowNullProtectionDomain) {
+			/*
+			 * Skip checkPackageSigners(), in this condition, the caller of this method is 
+			 * java.lang.Access.defineClass() and invoked by trusted system code hence 
+			 * there is no need to check its ProtectionDomain and associated code source certificates.
+			 */
+		} else {
+			/*[PR 93858]*/
+			checkPackageSigners(packageName, className, certs);
+		}
 	}
 
 	/*[PR 123387] bogus parameters to defineClass() should produce ArrayIndexOutOfBoundsException */


### PR DESCRIPTION
#### Skip package signer check for trusted system code ####

Skip `checkPackageSigners()` if `((protectionDomain == null) && allowNullProtectionDomain)`;
In such condition, the caller of this method is `java.lang.Access.defineClass()` and invoked by trusted system code hence there is no need to check its `ProtectionDomain` and associated code certificates.

closes: #6855 

There are two such references [1] & [2] which are going to skip the `checkPackageSigners()`.
[1] https://github.com/ibmruntimes/openj9-openjdk-jdk12/blob/1521c967faf405e5aff5c07198e577899aefd9e3/src/java.base/share/classes/java/lang/reflect/Proxy.java#L537-L538
[2] https://github.com/ibmruntimes/openj9-openjdk-jdk12/blob/1521c967faf405e5aff5c07198e577899aefd9e3/src/java.base/share/classes/jdk/internal/reflect/ClassDefiner.java#L65

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>