### PR TITLE
AArch64: Fix branch conditions for static method call

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -339,7 +339,7 @@ L_StaticGlueCallFixer:
 	tst	x0, #clinit_bit					// branch if the LSB (the "clinit" bit) was set in the resolved address
 	bne	L_SGCclinitCase
 	ldr	x1, [x0, #J9TR_MethodPCStartOffset]		// get I->J start address
-	tbz	x1, #J9TR_MethodNotCompiledBit, L_StaticGlueCallFixer1	// is method now compiled?
+	tbnz	x1, #J9TR_MethodNotCompiledBit, L_StaticGlueCallFixer1	// is method now compiled?
 	ret	x2						// if not, return to static glue to call interpreter
 L_StaticGlueCallFixer1:
 	ldr	x28, [x0, #J9TR_MethodPCStartOffset]		// get I->J start address
@@ -358,7 +358,7 @@ L_StaticGlueCallFixer1:
 L_SGCclinitCase:
 	and	x0, x0, #(~clinit_bit)				// clear the "clinit" bit
 	ldr	x1, [x0, #J9TR_MethodPCStartOffset]		// get I->J start address
-	tbz	x1, #J9TR_MethodNotCompiledBit, L_SGCclinitCase1	// is method now compiled?
+	tbnz	x1, #J9TR_MethodNotCompiledBit, L_SGCclinitCase1	// is method now compiled?
 	ret	x2						// if not, return to static glue to call interpreter
 L_SGCclinitCase1:
 	br	x1						// in <clinit> case, dispatch method directly without patching


### PR DESCRIPTION
This commit fixes branch conditions for static method call for AArch64.
When the J9TR_MethodNotCompiledBit is set, it should return from
L_StaticGlueCallFixer to its caller.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>