### PR TITLE
AArch64: Implement L_outOfRange in PicBuilder.spp

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -117,6 +117,7 @@ L_refreshHelper:
 	bne	L_outOfRange			// distance is out of +/-128MB range
 
 L_rewriteBranch:
+	sub	x3, x1, x0			// distance = (target - callSite)
 	ldr	w2, [x0]			// fetch branch instruction
 	ubfx	x1, x3, #2, #26			// distance >> 2, masking out sign bits
 	and	w2, w2, #0xFC000000		// mask out branch distance
@@ -127,8 +128,19 @@ L_rewriteBranch:
 
 // Get a new (reachable) target address for calling the helper via trampoline
 L_outOfRange:
-	hlt	#0	// Not implemented yet -- Use mcc_lookupHelperTrampoline_unwrapper
+	sub	J9SP, J9SP, #32
+	stp	x0, x30, [J9SP, #16]		// save registers
+	stp	x0, x2, [J9SP]			// push call site addr (x0) and helper index (x2)
+	ldr	x0, const_mcc_lookupHelperTrampoline_unwrapper
+	mov	x1, J9SP			// addr of the first arg for mcc_lookupHelperTrampoline_unwrapper
+	mov	x2, J9SP			// addr of the return value from mcc_lookupHelperTrampoline_unwrapper
+	bl	jitCallCFunction
+	ldr	x1, [J9SP]
+	ldp	x0, x30, [J9SP, #16]		// restore registers
+	add	J9SP, J9SP, #32
 	b	L_rewriteBranch
+const_mcc_lookupHelperTrampoline_unwrapper:
+	.dword	mcc_lookupHelperTrampoline_unwrapper
 
 // Static glue target table is laid out as:
 //


### PR DESCRIPTION
This commit implements L_outOfRange in PicBuilder.spp for AArch64,
which looks up a Trampoline for Helper call.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>