### PR TITLE
Initial implementation of a J9 InstructionDelegate hierarchy

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/aarch64/codegen/J9InstructionDelegate.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_ARM64_INSTRUCTIONDELEGATE_INCL
+#define J9_ARM64_INSTRUCTIONDELEGATE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_INSTRUCTIONDELEGATE_CONNECTOR
+#define J9_INSTRUCTIONDELEGATE_CONNECTOR
+namespace J9 { namespace ARM64 { class InstructionDelegate; } }
+namespace J9 { typedef J9::ARM64::InstructionDelegate InstructionDelegateConnector; }
+#else
+#error J9::ARM64::InstructionDelegate expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9InstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace J9
+{
+
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public J9::InstructionDelegate
+   {
+protected:
+
+   InstructionDelegate() {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/arm/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/arm/codegen/J9InstructionDelegate.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_ARM_INSTRUCTIONDELEGATE_INCL
+#define J9_ARM_INSTRUCTIONDELEGATE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_INSTRUCTIONDELEGATE_CONNECTOR
+#define J9_INSTRUCTIONDELEGATE_CONNECTOR
+namespace J9 { namespace ARM { class InstructionDelegate; } }
+namespace J9 { typedef J9::ARM::InstructionDelegate InstructionDelegateConnector; }
+#else
+#error J9::ARM::InstructionDelegate expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9InstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace J9
+{
+
+namespace ARM
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public J9::InstructionDelegate
+   {
+protected:
+
+   InstructionDelegate() {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/codegen/InstructionDelegate.hpp
+++ b/runtime/compiler/codegen/InstructionDelegate.hpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_INSTRUCTIONDELEGATE_INCL
+#define TR_INSTRUCTIONDELEGATE_INCL
+
+#include "codegen/J9InstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public J9::InstructionDelegateConnector
+   {
+   // InstructionDelegate cannot be instantiated.  It can only
+   // contain static members.
+   //
+private:
+
+   InstructionDelegate() : J9::InstructionDelegateConnector() {}
+
+   };
+
+}
+
+#endif

--- a/runtime/compiler/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/codegen/J9InstructionDelegate.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_INSTRUCTIONDELEGATE_INCL
+#define J9_INSTRUCTIONDELEGATE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_INSTRUCTIONDELEGATE_CONNECTOR
+#define J9_INSTRUCTIONDELEGATE_CONNECTOR
+
+namespace J9 { class InstructionDelegate; }
+namespace J9 { typedef J9::InstructionDelegate InstructionDelegateConnector; }
+#endif
+
+#include "codegen/OMRInstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace J9
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public OMR::InstructionDelegateConnector
+   {
+protected:
+
+   InstructionDelegate() : OMR::InstructionDelegateConnector() {}
+
+   };
+
+}
+
+#endif

--- a/runtime/compiler/p/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/p/codegen/J9InstructionDelegate.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_POWER_INSTRUCTIONDELEGATE_INCL
+#define J9_POWER_INSTRUCTIONDELEGATE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_INSTRUCTIONDELEGATE_CONNECTOR
+#define J9_INSTRUCTIONDELEGATE_CONNECTOR
+namespace J9 { namespace Power { class InstructionDelegate; } }
+namespace J9 { typedef J9::Power::InstructionDelegate InstructionDelegateConnector; }
+#else
+#error J9::Power::InstructionDelegate expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9InstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace J9
+{
+
+namespace Power
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public J9::InstructionDelegate
+   {
+protected:
+
+   InstructionDelegate() {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/x/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/x/codegen/J9InstructionDelegate.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_X86_INSTRUCTIONDELEGATE_INCL
+#define J9_X86_INSTRUCTIONDELEGATE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_INSTRUCTIONDELEGATE_CONNECTOR
+#define J9_INSTRUCTIONDELEGATE_CONNECTOR
+namespace J9 { namespace X86 { class InstructionDelegate; } }
+namespace J9 { typedef J9::X86::InstructionDelegate InstructionDelegateConnector; }
+#else
+#error J9::X86::InstructionDelegate expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9InstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace J9
+{
+
+namespace X86
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public J9::InstructionDelegate
+   {
+protected:
+
+   InstructionDelegate() {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/runtime/compiler/z/codegen/J9InstructionDelegate.hpp
+++ b/runtime/compiler/z/codegen/J9InstructionDelegate.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_Z_INSTRUCTIONDELEGATE_INCL
+#define J9_Z_INSTRUCTIONDELEGATE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_INSTRUCTIONDELEGATE_CONNECTOR
+#define J9_INSTRUCTIONDELEGATE_CONNECTOR
+namespace J9 { namespace Z { class InstructionDelegate; } }
+namespace J9 { typedef J9::Z::InstructionDelegate InstructionDelegateConnector; }
+#else
+#error J9::Z::InstructionDelegate expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "compiler/codegen/J9InstructionDelegate.hpp"
+#include "infra/Annotations.hpp"
+
+namespace J9
+{
+
+namespace Z
+{
+
+class OMR_EXTENSIBLE InstructionDelegate : public J9::InstructionDelegate
+   {
+protected:
+
+   InstructionDelegate() {}
+
+   };
+
+}
+
+}
+
+#endif


### PR DESCRIPTION
This is a skeleton implementation of the J9 specializations for
an InstructionDelegate hierarchy and contains no static member
functions yet.

OMR Issue eclipse/omr#3778

Signed-off-by: Daryl Maier <maier@ca.ibm.com>