### PR TITLE
Copy private linkage register indices to parameter symbols

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -24,6 +24,7 @@
 #include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/MemoryReference.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
 
 TR::ARM64PrivateLinkage::ARM64PrivateLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
@@ -181,6 +182,51 @@ void TR::ARM64PrivateLinkage::initARM64RealRegisterLinkage()
    for (icount = TR::RealRegister::v0; icount <= TR::RealRegister::v31; icount++)
       machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
    }
+
+
+void
+TR::ARM64PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
+   {
+   ListIterator<TR::ParameterSymbol> paramIterator(&(method->getParameterList()));
+   TR::ParameterSymbol *paramCursor = paramIterator.getFirst();
+   int32_t numIntArgs = 0, numFloatArgs = 0;
+   const TR::ARM64LinkageProperties& properties = getProperties();
+
+   while ( (paramCursor!=NULL) &&
+           ( (numIntArgs < properties.getNumIntArgRegs()) ||
+             (numFloatArgs < properties.getNumFloatArgRegs()) ) )
+      {
+      int32_t index = -1;
+
+      switch (paramCursor->getDataType())
+         {
+         case TR::Int8:
+         case TR::Int16:
+         case TR::Int32:
+         case TR::Int64:
+         case TR::Address:
+            if (numIntArgs < properties.getNumIntArgRegs())
+               {
+               index = numIntArgs;
+               }
+            numIntArgs++;
+            break;
+
+         case TR::Float:
+         case TR::Double:
+            if (numFloatArgs < properties.getNumFloatArgRegs())
+               {
+               index = numFloatArgs;
+               }
+            numFloatArgs++;
+            break;
+         }
+
+      paramCursor->setLinkageRegisterIndex(index);
+      paramCursor = paramIterator.getNext();
+      }
+   }
+
 
 void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
    {

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -30,6 +30,7 @@
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
 namespace TR { class Register; }
+namespace TR { class ResolvedMethodSymbol; }
 
 namespace TR {
 
@@ -86,6 +87,13 @@ class ARM64PrivateLinkage : public TR::Linkage
     * @brief Initializes ARM64 RealRegister linkage
     */
    virtual void initARM64RealRegisterLinkage();
+
+   /**
+    * @brief Copy linkage register indices to parameter symbols
+    *
+    * @param[in] method : the resolved method symbol
+    */
+   void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method);
 
    /**
     * @brief Creates method prologue


### PR DESCRIPTION
Implement setParameterLinkageRegisterIndex for AArch64.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>