### PR TITLE
Disable countDigits idiom recognition for remote compilations

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2153,6 +2153,11 @@ J9::Options::setupJITServerOptions()
          // IProfiler thread is not needed at JITServer because
          // no IProfiler info is collected at the server itself
          self()->setOption(TR_DisableIProfilerThread);
+
+         // This option is used to generate SIMD instructions on Z. Currently the infrastructure
+         // to support the relocation of some of those instructions is not available. Thus we disable
+         // this option for remote compilations.
+         self()->setOption(TR_DisableSIMDArrayTranslate);
          }
 
       // In the JITServer world, expensive compilations are performed remotely so there is no risk of blowing the footprint limit on the JVM

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1047,8 +1047,10 @@ TR_CISCGraph::makePreparedCISCGraphs(TR::Compilation *c)
    bool genLDiv2Mul = c->cg()->getSupportsLoweringConstLDiv();
    // FIXME: We need getSupportsCountDecimalDigit() like interface
    // this idiom is only enabled on 390 for the moment
-   //
-   bool genDecimal = TR::Compiler->target.cpu.isZ();
+
+   // Enabling genDecimal generates the TROT instruction on Z which is currently not
+   // relocatable for remote compiles. Thus we disable this option for remote compiles for now.
+   bool genDecimal = TR::Compiler->target.cpu.isZ() && !c->isOutOfProcessCompilation();
    bool genBitOpMem = TR::Compiler->target.cpu.isZ();
    bool is64Bit = TR::Compiler->target.is64Bit();
    bool isBig = TR::Compiler->target.cpu.isBigEndian();


### PR DESCRIPTION
This idiom is recognized in a late optimization and currently
introduces some unrelocatable code. Additionally, this
pattern recognition is only enabled on Z. To achieve functional
correctness we disable this optimization for now in remote
compilations.

[skip ci]
Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>