### PR TITLE
Don't try to inline AtomicLong methods if classBlock is null

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3220,6 +3220,11 @@ bool
 J9::Z::CodeGenerator::checkFieldAlignmentForAtomicLong()
    {
    TR_OpaqueClassBlock * classBlock = self()->comp()->fej9()->getSystemClassFromClassName("java/util/concurrent/atomic/AtomicLong", 38, true);
+
+   // TR_J9SharedCacheVM::getSystemClassFromClassName can return 0 when it's impossible to relocate a J9Class later for AOT loads.
+   if (!classBlock)
+      return false;
+
    char* fieldName = "value";
    int32_t fieldNameLen = 5;
    char * fieldSig = "J";


### PR DESCRIPTION
TR_J9SharedCacheVM::getSystemClassFromClassName can return 0 when
it's impossible to relocate a J9Class later during an AOT load. One
such scenario where this can happen is for AtomicLong methods. When such
a situation occurs, z codegen queries must not allow the codegen to inline
the call.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>