### PR TITLE
Use correct query when adding TR_DataAddress relo records

### DIFF
--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -126,9 +126,12 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
       }
    else if (_reloType==TR_DataAddress)
       {
-      AOTcgDiag1(  comp, "TR_DataAddress cursor=%x\n", cursor);
-      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_DataAddress, cg),
+      if (cg->needRelocationsForStatics())
+         {
+         AOTcgDiag1(  comp, "TR_DataAddress cursor=%x\n", cursor);
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_DataAddress, cg),
                               file, line, node);
+         }
       }
    else if (_reloType==TR_BodyInfoAddress)
       {


### PR DESCRIPTION
Depending on the type of compilation, we may or may not need to
add relocation records for TR_DataAddress. The needRelocationsForStatics
query will provide the correct answer depending on the situation.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>