### PR TITLE
AArch64: Fix BRANCH_VIA_VMTHREAD macro

### DIFF
--- a/runtime/oti/arm64helpers.m4
+++ b/runtime/oti/arm64helpers.m4
@@ -182,8 +182,8 @@ define({RESTORE_PRESERVED_REGS},{
 })
 
 define({BRANCH_VIA_VMTHREAD},{
-	ldr x0,[J9VMTHREAD,{#}$1]
-	br x0
+	ldr x8,[J9VMTHREAD,{#}$1]
+	br x8
 })
 
 define({SWITCH_TO_JAVA_STACK},{ldr J9SP,[J9VMTHREAD,{#}J9TR_VMThread_sp]})


### PR DESCRIPTION
This commit fixes the BRANCH_VIA_VMTHREAD macro in arm64helpers.m4.
Using the register x0 in it destroys integer return values in
jitExitInterpreter1 in arm64nathelp.m4, for example.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>