### PR TITLE
Make use of `align` utility

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -36,11 +36,12 @@
 #include "jitregmap.h"
 #include "pcstack.h"
 #include "VMHelpers.hpp"
+#include "OMR/Bytes.hpp"
 
 extern "C" {
 
 /* Generic rounding macro - result is a UDATA */
-#define ROUND_TO(granularity, number) (((UDATA)(number) + (granularity) - 1) & ~((UDATA)(granularity) - 1))
+#define ROUND_TO(granularity, number) OMR::align((UDATA)(number), granularity)
 
 typedef struct {
 	J9JITExceptionTable * metaData;

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -52,6 +52,7 @@
 #include "optimizer/TransformUtil.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "runtime/J9Profiler.hpp"
+#include "OMR/Bytes.hpp"
 
 #include "j9.h"
 #include "j9cfg.h"
@@ -720,7 +721,7 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
 
    if (node->getOpCodeValue() == TR::newarray || self()->useCompressedPointers())
       {
-      size = (int32_t)((size+(TR::Compiler->om.sizeofReferenceAddress()-1)) & ~(TR::Compiler->om.sizeofReferenceAddress()-1));
+      size = (int32_t)OMR::align(size, TR::Compiler->om.sizeofReferenceAddress());
       }
 
    if (isRealTimeGC &&

--- a/runtime/compiler/env/J9SegmentAllocator.cpp
+++ b/runtime/compiler/env/J9SegmentAllocator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/env/J9SegmentAllocator.cpp
+++ b/runtime/compiler/env/J9SegmentAllocator.cpp
@@ -26,6 +26,7 @@
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "control/CompilationRuntime.hpp"
+#include "OMR/Bytes.hpp"
 #include "j9.h"
 #undef min
 #undef max
@@ -134,7 +135,7 @@ size_t
 SegmentAllocator::pageAlign(const size_t requestedSize) throw()
    {
    size_t const pageSize = this->pageSize();
-   size_t alignedSize = (requestedSize + pageSize - 1) & ~(pageSize - 1);
+   size_t alignedSize = OMR::align(requestedSize, pageSize);
    return alignedSize;
    }
 

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -77,7 +77,7 @@ extern "C" {
 #include "OSCacheFile.hpp"
 #include "SCImplementedAPI.hpp"
 #include "UnitTest.hpp"
-
+#include "OMR/Bytes.hpp"
 
 #define SHRINIT_NAMEBUF_SIZE 256
 #define SHRINIT_LOW_FREE_DISK_SIZE ((U_64)6 * 1024 * 1024 * 1024)
@@ -4367,7 +4367,7 @@ j9shr_parseMemSize(char * str, UDATA & value) {
 	switch (*str) {
 		case '\0':
 				oldValue = value;
-				value = (value +  sizeof(UDATA) - 1) & ~(sizeof(UDATA) - 1);		/* round to nearest pointer value */
+				value = OMR::align(value, sizeof(UDATA));		/* round to nearest pointer value */
 				if (value < oldValue) {
 					/*OVERFLOW*/
 					return FALSE;

--- a/runtime/vm/J9OMRHelpers.cpp
+++ b/runtime/vm/J9OMRHelpers.cpp
@@ -27,11 +27,12 @@
 #include "OMR_VM.hpp"
 #include "OMR_VMConfiguration.hpp"
 #include "OMR_VMThread.hpp"
+#include "OMR/Bytes.hpp"
 
 extern "C" {
 
 /* Generic rounding macro - result is a UDATA */
-#define ROUND_TO(granularity, number) (((UDATA)(number) + (granularity) - 1) & ~((UDATA)(granularity) - 1))
+#define ROUND_TO(granularity, number) OMR::align((UDATA)(number), granularity)
 
 jint
 initOMRVMThread(J9JavaVM *vm, J9VMThread *vmThread)

--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -31,6 +31,7 @@
 #include "OutOfLineINL.hpp"
 #include "VMHelpers.hpp"
 #include "AtomicSupport.hpp"
+#include "OMR/Bytes.hpp"
 
 extern "C" {
 
@@ -680,7 +681,7 @@ alignJNIAddress(J9JavaVM * vm, void * address, J9ClassLoader * classLoader)
 		}
 		block->next = classLoader->jniRedirectionBlocks;
 		block->vmemID = identifier;
-		block->alloc = (U_8 *) ((((UDATA) (block + 1)) + (J9JNIREDIRECT_SEQUENCE_ALIGNMENT - 1)) & ~(J9JNIREDIRECT_SEQUENCE_ALIGNMENT - 1));
+		block->alloc = (U_8 *)OMR::align((UDATA)(block + 1), J9JNIREDIRECT_SEQUENCE_ALIGNMENT);
 		block->end = ((U_8 *) block) + J9JNIREDIRECT_BLOCK_SIZE;
 		classLoader->jniRedirectionBlocks = block;
 		TRIGGER_J9HOOK_VM_DYNAMIC_CODE_LOAD(vm->hookInterface, currentVMThread(vm), NULL, block, J9JNIREDIRECT_BLOCK_SIZE, "JNI trampoline area", NULL);


### PR DESCRIPTION
Replace the use cases whose calculation format is `(a+b-1) & ~(b-1)` with `align utility.`

Closes: #3973
Signed-off-by: simonameng <simonameng97@gmail.com>