### PR TITLE
Avoid object corruption in Unsafe

### DIFF
--- a/runtime/oti/UnsafeAPI.hpp
+++ b/runtime/oti/UnsafeAPI.hpp
@@ -251,14 +251,11 @@ instanceField:
 			} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 				/* Static field */
 				J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 				if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 					VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 				}
 				void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-				{
-					objectAccessBarrier->inlineStaticStoreU32(currentThread, fieldClass, (U_32*)valueAddress, (U_32)value, isVolatile);
-				}
+				objectAccessBarrier->inlineStaticStoreU32(currentThread, fieldClass, (U_32*)valueAddress, (U_32)value, isVolatile);
 			} else {
 instanceField:
 				/* Instance field */
@@ -332,14 +329,11 @@ instanceField:
 			} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 				/* Static field */
 				J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 				if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 					VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 				}
 				void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-				{
-					objectAccessBarrier->inlineStaticStoreU64(currentThread, fieldClass, (U_64*)valueAddress, (U_64)value, isVolatile);
-				}
+				objectAccessBarrier->inlineStaticStoreU64(currentThread, fieldClass, (U_64*)valueAddress, (U_64)value, isVolatile);
 			} else {
 instanceField:
 				/* Instance field */
@@ -519,50 +513,44 @@ public:
 	}
 
 	static VMINLINE void
-	putObject(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, bool isVolatile, j9object_t value)
+	putObject(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, bool isVolatile, j9object_t *value)
 	{
 		if (VM_VMHelpers::objectIsArray(currentThread, object)) {
 			UDATA index = convertOffsetToIndex(currentThread, offset, logFJ9ObjectSize(currentThread));
-			objectAccessBarrier->inlineIndexableObjectStoreObject(currentThread, object, index, value, isVolatile);
+			objectAccessBarrier->inlineIndexableObjectStoreObject(currentThread, object, index, *value, isVolatile);
 		} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 			/* Static field */
 			J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 			if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 				VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 			}
 			void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-			{
-				objectAccessBarrier->inlineStaticStoreObject(currentThread, fieldClass, (j9object_t*)valueAddress, value, isVolatile);
-			}
+			objectAccessBarrier->inlineStaticStoreObject(currentThread, fieldClass, (j9object_t*)valueAddress, *value, isVolatile);
 		} else {
 			/* Instance field */
-			objectAccessBarrier->inlineMixedObjectStoreObject(currentThread, object, offset, value, isVolatile);
+			objectAccessBarrier->inlineMixedObjectStoreObject(currentThread, object, offset, *value, isVolatile);
 		}
 	}
 
 	static VMINLINE bool
-	compareAndSwapObject(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, j9object_t compareValue, j9object_t swapValue)
+	compareAndSwapObject(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, j9object_t *compareValue, j9object_t *swapValue)
 	{
 		bool result = false;
 		
 		if (VM_VMHelpers::objectIsArray(currentThread, object)) {
 			UDATA index = convertOffsetToIndex(currentThread, offset, logFJ9ObjectSize(currentThread));
-			result = objectAccessBarrier->inlineIndexableObjectCompareAndSwapObject(currentThread, object, index, compareValue, swapValue, true);
+			result = objectAccessBarrier->inlineIndexableObjectCompareAndSwapObject(currentThread, object, index, *compareValue, *swapValue, true);
 		} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 			/* Static field */
 			J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 			if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 				VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 			}
 			void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-			{
-				result = objectAccessBarrier->inlineStaticCompareAndSwapObject(currentThread, fieldClass, (j9object_t*)valueAddress, compareValue, swapValue, true);
-			}
+			result = objectAccessBarrier->inlineStaticCompareAndSwapObject(currentThread, fieldClass, (j9object_t*)valueAddress, *compareValue, *swapValue, true);
 		} else {
 			/* Instance field */
-			result = objectAccessBarrier->inlineMixedObjectCompareAndSwapObject(currentThread, object, offset, compareValue, swapValue, true);
+			result = objectAccessBarrier->inlineMixedObjectCompareAndSwapObject(currentThread, object, offset, *compareValue, *swapValue, true);
 		}
 		return result;
 	}
@@ -588,14 +576,11 @@ public:
 			} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 				/* Static field */
 				J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 				if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 					VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 				}
 				void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-				{
-					result = objectAccessBarrier->inlineStaticCompareAndSwapU64(currentThread, fieldClass, (U_64*)valueAddress, compareValue, swapValue, true);
-				}
+				result = objectAccessBarrier->inlineStaticCompareAndSwapU64(currentThread, fieldClass, (U_64*)valueAddress, compareValue, swapValue, true);
 			} else {
 instanceField:
 				/* Instance field */
@@ -626,14 +611,11 @@ instanceField:
 			} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 				/* Static field */
 				J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 				if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 					VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 				}
 				void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-				{
-					result = objectAccessBarrier->inlineStaticCompareAndSwapU32(currentThread, fieldClass, (U_32*)valueAddress, compareValue, swapValue, true);
-				}
+				result = objectAccessBarrier->inlineStaticCompareAndSwapU32(currentThread, fieldClass, (U_32*)valueAddress, compareValue, swapValue, true);
 			} else {
 instanceField:
 				/* Instance field */
@@ -644,7 +626,7 @@ instanceField:
 	}
 
 	static VMINLINE j9object_t
-	compareAndExchangeObject(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, j9object_t compareValue, j9object_t swapValue)
+	compareAndExchangeObject(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, j9object_t *compareValue, j9object_t *swapValue)
 	{
 		Assert_VM_notNull(object);
 
@@ -652,21 +634,18 @@ instanceField:
 
 		if (VM_VMHelpers::objectIsArray(currentThread, object)) {
 			UDATA index = convertOffsetToIndex(currentThread, offset, logFJ9ObjectSize(currentThread));
-			result = objectAccessBarrier->inlineIndexableObjectCompareAndExchangeObject(currentThread, object, index, compareValue, swapValue, true);
+			result = objectAccessBarrier->inlineIndexableObjectCompareAndExchangeObject(currentThread, object, index, *compareValue, *swapValue, true);
 		} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 			/* Static field */
 			J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 			if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 				VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 			}
 			void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-			{
-				result = objectAccessBarrier->inlineStaticCompareAndExchangeObject(currentThread, fieldClass, (j9object_t*)valueAddress, compareValue, swapValue, true);
-			}
+			result = objectAccessBarrier->inlineStaticCompareAndExchangeObject(currentThread, fieldClass, (j9object_t*)valueAddress, *compareValue, *swapValue, true);
 		} else {
 			/* Instance field */
-			result = objectAccessBarrier->inlineMixedObjectCompareAndExchangeObject(currentThread, object, offset, compareValue, swapValue, true);
+			result = objectAccessBarrier->inlineMixedObjectCompareAndExchangeObject(currentThread, object, offset, *compareValue, *swapValue, true);
 		}
 		return result;
 	}
@@ -696,10 +675,9 @@ instanceField:
 				if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 					VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 				}
+
 				void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-				{
-					result = objectAccessBarrier->inlineStaticCompareAndExchangeU32(currentThread, fieldClass, (U_32*)valueAddress, compareValue, swapValue, true);
-				}
+				result = objectAccessBarrier->inlineStaticCompareAndExchangeU32(currentThread, fieldClass, (U_32*)valueAddress, compareValue, swapValue, true);
 			} else {
 instanceField:
 				/* Instance field */
@@ -730,14 +708,11 @@ instanceField:
 			} else if (offset & J9_SUN_STATIC_FIELD_OFFSET_TAG) {
 				/* Static field */
 				J9Class *fieldClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, object);
-
 				if (J9_ARE_ANY_BITS_SET(offset, J9_SUN_FINAL_FIELD_OFFSET_TAG)) {
 					VM_VMHelpers::reportFinalFieldModified(currentThread, fieldClass);
 				}
 				void *valueAddress = (void*)((UDATA)fieldClass->ramStatics + (offset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
-				{
-					result = objectAccessBarrier->inlineStaticCompareAndExchangeU64(currentThread, fieldClass, (U_64*)valueAddress, compareValue, swapValue, true);
-				}
+				result = objectAccessBarrier->inlineStaticCompareAndExchangeU64(currentThread, fieldClass, (U_64*)valueAddress, compareValue, swapValue, true);
 			} else {
 instanceField:
 				/* Instance field */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3726,7 +3726,7 @@ done:
 	inlUnsafePutObject(REGISTER_ARGS_LIST, bool isVolatile)
 	{
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
-		j9object_t value = *(j9object_t*)_sp;
+		j9object_t *value = (j9object_t*)_sp;
 		UDATA offset = (UDATA)*(I_64*)(_sp + 1);
 		j9object_t obj = *(j9object_t*)(_sp + 3);
 		
@@ -3848,8 +3848,8 @@ done:
 	inlUnsafeCompareAndSwapObject(REGISTER_ARGS_LIST)
 	{
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
-		j9object_t swapValue = *(j9object_t*)_sp;
-		j9object_t compareValue = *(j9object_t*)(_sp + 1);
+		j9object_t *swapValue = (j9object_t*)_sp;
+		j9object_t *compareValue = (j9object_t*)(_sp + 1);
 		UDATA offset = (UDATA)*(I_64*)(_sp + 2);
 		j9object_t obj = *(j9object_t*)(_sp + 4);
 

--- a/runtime/vm/OutOfLineINL_jdk_internal_misc_Unsafe.cpp
+++ b/runtime/vm/OutOfLineINL_jdk_internal_misc_Unsafe.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,8 +40,8 @@ OutOfLineINL_jdk_internal_misc_Unsafe_fullFence(J9VMThread *currentThread, J9Met
 VM_BytecodeAction
 OutOfLineINL_jdk_internal_misc_Unsafe_compareAndExchangeObjectVolatile(J9VMThread *currentThread, J9Method *method)
 {
-	j9object_t swapValue = *(j9object_t*)currentThread->sp;
-	j9object_t compareValue = *(j9object_t*)(currentThread->sp + 1);
+	j9object_t *swapValue = (j9object_t*)currentThread->sp;
+	j9object_t *compareValue = (j9object_t*)(currentThread->sp + 1);
 	UDATA offset = (UDATA)*(I_64*)(currentThread->sp + 2);
 	j9object_t obj = *(j9object_t*)(currentThread->sp + 4);
 	MM_ObjectAccessBarrierAPI _objectAccessBarrier = MM_ObjectAccessBarrierAPI(currentThread);


### PR DESCRIPTION
Wheh writing to static final fields, reporting the modification to the
JIT can release VM access, allowing the GC to move objects.

Use indirect pointers (to the java stack slots) for the object values to
avoid the possible corruption.

Fixes: #6947

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>