### PR TITLE
Delete unused variable assignment

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5238,7 +5238,6 @@ TR_ResolvedJ9Method::archetypeArgPlaceholderSlot()
       romMethod = getOriginalROMMethod((J9Method *)aMethod);
       }
 
-   J9ROMClass *romClass = J9_CLASS_FROM_METHOD(((J9Method *)aMethod))->romClass;
    J9UTF8 * signature = J9ROMMETHOD_SIGNATURE(romMethod);
 
    U_8 tempArgTypes[256];


### PR DESCRIPTION
Deleted the romClass assignment as it's not used anywhere. 

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>