### PR TITLE
Fix RAT hangs by avoiding double free in TR_PatchNOPedGuardSiteOnClas… (0.16.0)

### DIFF
--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -127,10 +127,13 @@ class TR_PatchNOPedGuardSiteOnClassPreInitialize : public TR::PatchNOPedGuardSit
       TR_FrontEnd *fe, TR_PersistentMemory *, char *sig, uint32_t sigLen, uint8_t *loc, uint8_t *dest, OMR::RuntimeAssumption **sentinel);
    static uintptrj_t hashCode(char *sig, uint32_t sigLen);
 
-   virtual void reclaim() { jitPersistentFree((void*)_key); }
+   /** \copydoc OMR::RuntimeAssumption::reclaim()
+    *     See base class documentation for more details.
+    */
+   virtual void reclaim();
+
    virtual bool matches(uintptrj_t key) { return false; }
    virtual bool matches(char *sig, uint32_t sigLen);
-   virtual void compensate(TR_FrontEnd *vm, bool isSMP, void *data);
    virtual uintptrj_t hashCode() { return hashCode((char*)getKey(), _sigLen); }
    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnClassPreInitialize; }
 

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -456,11 +456,11 @@ void TR_RuntimeAssumptionTable::reclaimMarkedAssumptionsFromRAT(int32_t cleanupC
  */
 void TR_RuntimeAssumptionTable::markAssumptionsAndDetach(void * md, bool reclaimPrePrologueAssumptions)
    {
+   assumptionTableMutex->enter();
    J9JITExceptionTable *metaData = (J9JITExceptionTable*) md;
    OMR::RuntimeAssumption *sentry = (OMR::RuntimeAssumption*)(metaData->runtimeAssumptionList);
    OMR::RuntimeAssumption *cursor, *next;
 
-   assumptionTableMutex->enter();
    if (sentry)
       {
       TR_ASSERT(sentry->getAssumptionKind() == RuntimeAssumptionSentinel, "First assumption must be the sentinel\n");

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -51,15 +51,6 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize::make(
    return result;
    }
 
-
-void
-TR_PatchNOPedGuardSiteOnClassPreInitialize::compensate(TR_FrontEnd *fe, bool isSMP, void *data)
-   {
-   reclaim();
-   TR::PatchNOPedGuardSite::compensate(fe, isSMP, data);
-   }
-
-
 uintptrj_t
 TR_PatchNOPedGuardSiteOnClassPreInitialize::hashCode(char *sig, uint32_t sigLen)
    {
@@ -90,20 +81,33 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize::hashCode(char *sig, uint32_t sigLen)
    return sum;
    }
 
+void
+TR_PatchNOPedGuardSiteOnClassPreInitialize::reclaim()
+   {
+   TR_ASSERT_FATAL(_key != NULL, "Attempt to reclaim an already freed _key");
+
+   jitPersistentFree((void*)_key);
+   _key = 0;
+   }
 
 bool
 TR_PatchNOPedGuardSiteOnClassPreInitialize::matches(char *sig, uint32_t sigLen)
    {
-   if (sigLen+2 != _sigLen) return false;
+   if (sigLen + 2 != _sigLen)
+      {
+      return false;
+      }
+
    char *mySig = (char*)getKey();
-   uint32_t compareIndex = sigLen-1;
-   for ( ; sigLen > 0; sigLen--)
+
+   for (uint32_t compareIndex = sigLen - 1; sigLen > 0; sigLen--)
       {
       if (mySig[compareIndex+1] != sig[compareIndex])
          return false;
 
       compareIndex--;
       }
+
    return true;
    }
 


### PR DESCRIPTION
…sPreInitialize

When a class which has runtime assumptions registered against it gets
initialized (for example `Ljava/lang/String$StringCompressionFlag;`)
the `classGotInitialized` function will be invoked which will walk the
list of assumptions looking for the particular class signature.

If such an assumption is found `compensate` will be called so that the
runtime assumption patching logic is invoked. In the particular case of
the `TR_PatchNOPedGuardSiteOnClassPreInitialize` the compensation logic
will reclaim any persistent memory allocated when the assumption was
initialized. This particular class stores the full signature of class
the assumption is to trigger on in persistent memory, thus it will free
the allocated memory when `reclaim` is invoked inside of `compensate`.

The issue with this is that once the assumption is compensated it is
marked for removal. At a later point we attempt to reclaim the
assumption (in `reclaimMarkedAssumptionsFromRAT`) at which point
`reclaim` is invoked again on the runtime assumption. This second
reclaim will again deallocate the persistent memory thus causing a
double free to happen.

The observed issue is a hang in the RAT reclamation logic because in
between the two calls to `reclaim` another runtime assumption was
allocated in the JIT persistent memory which was freed for the class
signature. When the second `reclaim` is invoked we inadvertently free
the JIT persistent memory associated with another runtime assumption
and we end up in an undefined scenario which manifests itself as a hang.

To fix this issue we ensure no double free happens by validating the
allocated pointer before freeing and painting the pointer after freeing.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>