### PR TITLE
Revert "Enable z15 by default" (0.16.0)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1961,6 +1961,14 @@ J9::Options::fePreProcess(void * base)
       {
       self()->setOption(TR_InlineVeryLargeCompiledMethods);
       }
+
+   static bool enableZ15 = feGetEnv("TR_EnableZ15") != NULL;
+
+   if (!enableZ15)
+      {
+      // Disable zNext support until it has been gone through several rounds of functional stress testing
+      self()->setOption(TR_DisableZ15);
+      }
 #endif
 
    // On big machines we can afford to spend more time compiling


### PR DESCRIPTION
This reverts commit 8eac3fc6d4ea01e4b13844f5bd0177d87f90eda4.

Extensible stress testing for z15 has not been completed yet and the
processor is not yet publicly available. To prevent users running an
older OpenJ9 release on the new hardware at some future point we will
disable z15 exploitation in all releases until proper stress testing
has successfully completed and the processor is publicly available.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>