### PR TITLE
Grab TR_J9SharedCache from AOT FE in sampling hook

### DIFF
--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -217,7 +217,7 @@ TR_OptimizationPlan *TR::DefaultCompilationStrategy::processEvent(TR_MethodEvent
             plan = TR_OptimizationPlan::alloc(hotnessLevel);
             *newPlanCreated = true;
             }
-         
+
          TR_OptimizationPlan::_optimizationPlanMonitor->enter();
          attachedPlan = methodInfo->_optimizationPlan;
          if (attachedPlan)
@@ -1043,7 +1043,8 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
                         if (cmdLineOptions->getOption(TR_UpgradeBootstrapAtWarm) && fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)j9method))
                            {
 #ifndef PUBLIC_BUILD
-                           bool expensiveComp = (TR_J9SharedCache *)(((TR_J9VMBase *) fe)->sharedCache())->isHint(j9method, TR_HintLargeMemoryMethodW);
+                           TR_J9SharedCache *sc = TR_J9VMBase::get(jitConfig, event->_vmThread, TR_J9VMBase::AOT_VM)->sharedCache();
+                           bool expensiveComp = sc->isHint(j9method, TR_HintLargeMemoryMethodW);
                            if (!expensiveComp)
 #endif //!PUBLIC_BUILD
                               nextOptLevel = warm;
@@ -1596,4 +1597,3 @@ TR::ThresholdCompilationStrategy::processJittedSample(TR_MethodEvent *event)
       }
       return plan;
    }
-


### PR DESCRIPTION
The JIT FE used in some contexts does not have a TR_J9SharedCache.
In those cases we need to retrieve the AOT FE specifically to ensure
that we can get a TR_J9SharedCache.

When moving the hints APIs from the FE to TR_J9SharedCache[1] most
places in the code that accessed hints via the FE were modified to do so
via TR_J9SharedCache instead, and places where the FE might not
have a TR_J9SharedCache were modified to retrieve the AOT FE first.

The sampling hook is one such place that was previously missed.

[1] dcc7e89b34ecc5d6b94ef81a48f5115e99948b9e

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>

Fixes: #6945 