### PR TITLE
WIP: Disable DDR in AArch64 pipeline builds

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -435,7 +435,7 @@ aarch64_linux_xl:
   freemarker: '/home/jenkins/freemarker.jar'
   openjdk_reference_repo: '/home/jenkins/openjdk_cache'
   extra_configure_options:
-    11: '--with-noncompressedrefs'
+    11: '--with-noncompressedrefs --disable-ddr'
   node_labels:
     build:
       11: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
@@ -449,6 +449,8 @@ aarch64_linux:
     11: 'linux-aarch64-normal-server-release'
   freemarker: '/home/jenkins/freemarker.jar'
   openjdk_reference_repo: '/home/jenkins/openjdk_cache'
+  extra_configure_options:
+    11: '--disable-ddr'
   node_labels:
     build:
       11: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'


### PR DESCRIPTION
DDR is not yet supported on AArch64.

Fixes #6979

Signed-off-by: Daryl Maier <maier@ca.ibm.com>