### PR TITLE
Common up the check of `TR_OptimizeForSpace` , `TR_DisableInlin…

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -734,9 +734,15 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
 
    TR::SymbolReference *castClassSymRef = castClassNode->getSymbolReference();
 
+   if (cg->comp()->getOption(TR_OptimizeForSpace) || (cg->comp()->getOption(TR_DisableInlineCheckCast) && (instanceOfOrCheckCastNode->getOpCodeValue() == TR::checkcast || instanceOfOrCheckCastNode->getOpCodeValue() == TR::checkcastAndNULLCHK)) || (cg->comp()->getOption(TR_DisableInlineInstanceOf) && instanceOfOrCheckCastNode->getOpCodeValue() == TR::instanceof))
+      {
+      if (instanceOfOrCheckCastNode->getOpCodeValue() == TR::checkcastAndNULLCHK)
+         sequences[i++] = NullTest;
+      sequences[i++] = HelperCall;  
+      }
    // Object is known to be null, usually removed by the optimizer, but in case they're not we know the result of the cast/instanceof.
    //
-   if (objectNode->isNull())
+   else if (objectNode->isNull())
       {
       if (instanceOfOrCheckCastNode->getOpCodeValue() == TR::checkcastAndNULLCHK)
             sequences[i++] = NullTest;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -2164,53 +2164,12 @@ TR::Register *J9::Power::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::
 
 TR::Register *J9::Power::TreeEvaluator::instanceofEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Compilation * comp = cg->comp();
-   if (comp->getOption(TR_OptimizeForSpace) || comp->getOption(TR_DisableInlineInstanceOf))
-      {
-      TR::ILOpCodes opCode = node->getOpCodeValue();
-      TR::Node::recreate(node, TR::icall);
-      TR::Register *targetRegister = directCallEvaluator(node, cg);
-      TR::Node::recreate(node, opCode);
-      return targetRegister;
-      }
-   else
-      return VMinstanceOfEvaluator(node, cg);
+   return VMinstanceOfEvaluator(node, cg);
    }
 
 TR::Register *J9::Power::TreeEvaluator::checkcastEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Compilation * comp = cg->comp();
-   if (comp->getOption(TR_OptimizeForSpace) || comp->getOption(TR_DisableInlineCheckCast))
-      {
-      bool isCheckcastAndNullChk = (node->getOpCodeValue() == TR::checkcastAndNULLCHK);
-      TR::Node *objNode = node->getFirstChild();
-      bool needsNullTest = !objNode->isNonNull();
-
-      if (needsNullTest && isCheckcastAndNullChk)
-         {
-         TR::Instruction *gcPoint;
-         // get the bytecode info of the
-         // NULLCHK that was compacted
-         TR::Node *nullChkInfo = comp->findNullChkInfo(node);
-         TR::Register *objReg = cg->evaluate(objNode);
-
-         if (cg->getHasResumableTrapHandler())
-            gcPoint = generateNullTestInstructions(cg, objReg, nullChkInfo);
-         else
-            // a helper is needed
-            gcPoint = generateNullTestInstructions(cg, objReg, nullChkInfo, true);
-         gcPoint->PPCNeedsGCMap(0xFFFFFFFF);
-         }
-
-      TR::ILOpCodes opCode = node->getOpCodeValue();
-      TR::Node::recreate(node, TR::call);
-      TR::Register *targetRegister = directCallEvaluator(node, cg);
-      TR::Node::recreate(node, opCode);
-
-      return targetRegister;
-      }
-   else
-      return TR::TreeEvaluator::VMcheckcastEvaluator(node, cg);
+   return TR::TreeEvaluator::VMcheckcastEvaluator(node, cg);
    }
 
 TR::Register *J9::Power::TreeEvaluator::checkcastAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
Z and Power used to use the similar structure to check JIToptions 'TR_DisableInlineInstanceOf,' T'R_OptimizeForSpace' and 'TR_DisableInlineCheckcast' in 'instanceof' and 'checkcast’s evaluators before entering the common API 'calculateInstanceOfOrCheckCastSequences' which generate a list of tests for the nodes.

The changes move the check of JIToptions from Z and Power platform to the common API to have it generate 'HelperCall' if the node is 'instanceof' and one of the options 'TR_OptimizeForSpace' and 'TR_DisableInlineInstanceOf' is turned on. The changes also allow the common API to generate 'HelperCall' if the node is 'checkcast/checkCastAndNullCheck' and either 'TR_OptimizeForSpace' or 'TR_DisableInlineCheckcast' is enabled.

And if the node is 'checkCastAndNullCheck', beside the 'HelperCall', the common API would also generate 'NullTest'.

Closes: #6190
Signed-off-by: simonameng <simonameng97@gmail.com>