### PR TITLE
Build DDR test only if j9ddr.jar is present in JDK

### DIFF
--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -43,7 +43,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<property name="j9ddr" location="${TEST_JDK_HOME}/lib/ddr/j9ddr.jar" />
 		</else>
 	</if>
-	
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -97,24 +96,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<delete dir="${build}" />
 	</target>
 
-	<!-- Temporarily disable compilation on zos until ddr is supported; github.com/eclipse/openj9/issues/1511 -->
 	<target name="build" >
 		<echo>os.name: ${os.name}</echo>
 		<if>
-			<or>
-				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
-				<equals arg1="${JDK_IMPL}" arg2="openj9" />
-			</or>
+			<available file="${j9ddr}" />
 			<then>
-				 <if>
-					<not>
-						<equals arg1="${os.name}" arg2="z/OS" />
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
+				<antcall target="clean" inheritall="true" />
 			</then>
+			<else>
+				<echo>File '${j9ddr}' not found; assuming JDK '${TEST_JDK_HOME}' does not support DDR.</echo>
+			</else>
 		</if>
 	</target>
 </project>


### PR DESCRIPTION
This should address #6979.