### PR TITLE
Fix missing X11 header errors when building JDK11 on s390x

### DIFF
--- a/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
     libx11-dev \
     libxext-dev \
     libxrender-dev \
+	libxrandr-dev \
     libxt-dev \
     libxtst-dev \
     make \


### PR DESCRIPTION
Fix the following build error:

```
checking for X11/extensions/shape.h... yes
checking for X11/extensions/Xrender.h... yes
checking for X11/extensions/XTest.h... yes
checking for X11/Intrinsic.h... yes
checking for X11/extensions/Xrandr.h... no
configure: error: Could not find all X11 headers (shape.h Xrender.h
Xrandr.h XTest.h Intrinsic.h). You might be able to fix this by running
'sudo apt-get install libx11-dev libxext-dev libxrender-dev
libxrandr-dev libxtst-dev libxt-dev'.
configure exiting with result code 1
```

Fixes: #6995

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>