### PR TITLE
AArch64: Fix alignment of embedded address in PicBuilder.spp

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -139,6 +139,8 @@ L_outOfRange:
 	ldp	x0, x30, [J9SP, #16]		// restore registers
 	add	J9SP, J9SP, #32
 	b	L_rewriteBranch
+
+	.align	3
 const_mcc_lookupHelperTrampoline_unwrapper:
 	.dword	mcc_lookupHelperTrampoline_unwrapper
 
@@ -374,8 +376,8 @@ L_SGCclinitCase:
 	ret	x2						// if not, return to static glue to call interpreter
 L_SGCclinitCase1:
 	br	x1						// in <clinit> case, dispatch method directly without patching
-const_mcc_callPointPatching_unwrapper:
 	.align	3
+const_mcc_callPointPatching_unwrapper:
 	.dword	mcc_callPointPatching_unwrapper
 
 _interpreterVoidStaticGlue:


### PR DESCRIPTION
Fix alignment of some function pointers embedded in PicBuilder.spp

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>