### PR TITLE
Use / instead of $(D) in testEnv.mk

### DIFF
--- a/test/TestConfig/testEnv.mk
+++ b/test/TestConfig/testEnv.mk
@@ -27,10 +27,10 @@ testEnvTeardown:
 
 ifneq (,$(findstring JITAAS,$(TEST_FLAG)))
 testEnvSetup:
-	$(TEST_JDK_HOME)$(D)bin$(D)java -XX:StartAsJITServer &
+	$(TEST_JDK_HOME)/bin/java -XX:StartAsJITServer &
 
 testEnvTeardown:
-	pkill -9 -xf "$(TEST_JDK_HOME)$(D)bin$(D)java -XX:StartAsJITServer"; true
+	pkill -9 -xf "$(TEST_JDK_HOME)/bin/java -XX:StartAsJITServer"; true
 
 RESERVED_OPTIONS += -XX:+UseJITServer
 endif


### PR DESCRIPTION
When using testEnv.mk, $(D) is not defined. Using / instead of $(D)

Fixes: #6983
[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>