### PR TITLE
Store caches inside ClassInfo instead of pointers to them

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -197,8 +197,6 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    J9Method *methods = classInfoStruct._methodsOfClass;
    classInfoStruct._baseComponentClass = std::get<2>(classInfo);
    classInfoStruct._numDimensions = std::get<3>(classInfo);
-   classInfoStruct._remoteROMStringsCache = NULL;
-   classInfoStruct._fieldOrStaticNameCache = NULL;
    classInfoStruct._parentClass = std::get<4>(classInfo);
    auto &tmpInterfaces = std::get<5>(classInfo);
    classInfoStruct._interfaces = new (PERSISTENT_NEW) PersistentVector<TR_OpaqueClassBlock *>
@@ -215,18 +213,9 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    classInfoStruct._componentClass = std::get<14>(classInfo);
    classInfoStruct._arrayClass = std::get<15>(classInfo);
    classInfoStruct._totalInstanceSize = std::get<16>(classInfo);
-   classInfoStruct._classOfStaticCache = NULL;
-   classInfoStruct._constantClassPoolCache = NULL;
    classInfoStruct._remoteRomClass = std::get<17>(classInfo);
-   classInfoStruct._fieldAttributesCache = NULL;
-   classInfoStruct._staticAttributesCache = NULL;
-   classInfoStruct._fieldAttributesCacheAOT = NULL;
-   classInfoStruct._staticAttributesCacheAOT = NULL;
    classInfoStruct._constantPool = (J9ConstantPool *)std::get<18>(classInfo);
-   classInfoStruct._jitFieldsCache = NULL;
    classInfoStruct._classFlags = std::get<19>(classInfo);
-   classInfoStruct._fieldOrStaticDeclaringClassCache = NULL;
-   classInfoStruct._J9MethodNameCache = NULL;
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 
    uint32_t numMethods = romClass->romMethodCount;

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -413,10 +413,8 @@ TR_J9ServerVM::getCachedField(J9Class *ramClass, int32_t cpIndex, J9Class **decl
    if (it != _compInfoPT->getClientData()->getROMClassMap().end())
       {
       auto &jitFieldsCache = it->second._jitFieldsCache;
-      if (!jitFieldsCache)
-         return false;
-      auto cacheIt = jitFieldsCache->find(cpIndex);
-      if (cacheIt != jitFieldsCache->end())
+      auto cacheIt = jitFieldsCache.find(cpIndex);
+      if (cacheIt != jitFieldsCache.end())
          {
          *declaringClass = cacheIt->second.first;
          *field = cacheIt->second.second;
@@ -434,9 +432,7 @@ TR_J9ServerVM::cacheField(J9Class *ramClass, int32_t cpIndex, J9Class *declaring
    if (it != _compInfoPT->getClientData()->getROMClassMap().end())
       {
       auto &jitFieldsCache = it->second._jitFieldsCache;
-      if (!jitFieldsCache)
-         jitFieldsCache = new (PERSISTENT_NEW) TR_JitFieldsCache(TR_JitFieldsCache::allocator_type(TR::Compiler->persistentAllocator()));
-      jitFieldsCache->insert({cpIndex, std::make_pair(declaringClass, field)});
+      jitFieldsCache.insert({cpIndex, std::make_pair(declaringClass, field)});
       }
    }
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -152,25 +152,17 @@ TR_ResolvedJ9JITServerMethod::getClassFromConstantPool(TR::Compilation * comp, u
       {
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &constantClassPoolCache = getJ9ClassInfo(compInfoPT, _ramClass)._constantClassPoolCache;
-      if (!constantClassPoolCache)
-         {
-         // initialize cache, called once per ram class
-         constantClassPoolCache = new (PERSISTENT_NEW) PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>(PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>::allocator_type(TR::Compiler->persistentAllocator()));
-         }
-      else
-         {
-         auto it = constantClassPoolCache->find(cpIndex);
-         if (it != constantClassPoolCache->end())
-            return it->second;
-         }
+      auto it = constantClassPoolCache.find(cpIndex);
+      if (it != constantClassPoolCache.end())
+         return it->second;
       }
    _stream->write(JITServer::MessageType::ResolvedMethod_getClassFromConstantPool, _remoteMirror, cpIndex, returnClassForAOT);
    TR_OpaqueClassBlock *resolvedClass = std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
    if (resolvedClass)
       {
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
-      auto constantClassPoolCache = getJ9ClassInfo(compInfoPT, _ramClass)._constantClassPoolCache;
-      constantClassPoolCache->insert({cpIndex, resolvedClass});
+      auto &constantClassPoolCache = getJ9ClassInfo(compInfoPT, _ramClass)._constantClassPoolCache;
+      constantClassPoolCache.insert({cpIndex, resolvedClass});
       }
    return resolvedClass;
    }
@@ -182,25 +174,17 @@ TR_ResolvedJ9JITServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation
       {
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &cache = getJ9ClassInfo(compInfoPT, _ramClass)._fieldOrStaticDeclaringClassCache;
-      if (!cache)
-         {
-         // initialize cache, called once per ram class
-         cache = new (PERSISTENT_NEW) PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>(PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>::allocator_type(TR::Compiler->persistentAllocator()));
-         }
-      else
-         {
-         auto it = cache->find(cpIndex);
-         if (it != cache->end())
-            return it->second;
-         }
+      auto it = cache.find(cpIndex);
+      if (it != cache.end())
+         return it->second;
       }
    _stream->write(JITServer::MessageType::ResolvedMethod_getDeclaringClassFromFieldOrStatic, _remoteMirror, cpIndex);
    TR_OpaqueClassBlock *declaringClass = std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
    if (declaringClass)
       {
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
-      auto cache = getJ9ClassInfo(compInfoPT, _ramClass)._fieldOrStaticDeclaringClassCache;
-      cache->insert({cpIndex, declaringClass});
+      auto &cache = getJ9ClassInfo(compInfoPT, _ramClass)._fieldOrStaticDeclaringClassCache;
+      cache.insert({cpIndex, declaringClass});
       }
    return declaringClass;
    }
@@ -216,14 +200,8 @@ TR_ResolvedJ9JITServerMethod::classOfStatic(I_32 cpIndex, bool returnClassForAOT
       {
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
       auto &classOfStaticCache = getJ9ClassInfo(compInfoPT, _ramClass)._classOfStaticCache;
-      if (!classOfStaticCache)
-         {
-         // initialize cache, called once per ram class
-         classOfStaticCache = new (PERSISTENT_NEW) PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>(PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>::allocator_type(TR::Compiler->persistentAllocator()));
-         }
-      
-      auto it = classOfStaticCache->find(cpIndex);
-      if (it != classOfStaticCache->end())
+      auto it = classOfStaticCache.find(cpIndex);
+      if (it != classOfStaticCache.end())
          return it->second;
       }
 
@@ -239,8 +217,8 @@ TR_ResolvedJ9JITServerMethod::classOfStatic(I_32 cpIndex, bool returnClassForAOT
       // if client returned NULL, don't cache, because class might not be fully initialized,
       // so the result may change in the future
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
-      auto classOfStaticCache = getJ9ClassInfo(compInfoPT, _ramClass)._classOfStaticCache;
-      classOfStaticCache->insert({cpIndex, classOfStatic});
+      auto &classOfStaticCache = getJ9ClassInfo(compInfoPT, _ramClass)._classOfStaticCache;
+      classOfStaticCache.insert({cpIndex, classOfStatic});
       }
    else
       {
@@ -442,7 +420,7 @@ TR_ResolvedJ9JITServerMethod::staticsAreSame(int32_t cpIndex1, TR_ResolvedMethod
    return false;
    }
 
-TR_FieldAttributesCache *
+TR_FieldAttributesCache &
 TR_ResolvedJ9JITServerMethod::getAttributesCache(bool isStatic, bool unresolvedInCP)
    {
    // Return a persistent attributes cache for regular JIT compilations
@@ -450,11 +428,6 @@ TR_ResolvedJ9JITServerMethod::getAttributesCache(bool isStatic, bool unresolvedI
    auto &attributesCache = isStatic ? 
       getJ9ClassInfo(compInfoPT, _ramClass)._staticAttributesCache :
       getJ9ClassInfo(compInfoPT, _ramClass)._fieldAttributesCache;
-   if (!attributesCache)
-      {
-      // initialize cache, called once per ram class
-      attributesCache = new (PERSISTENT_NEW) TR_FieldAttributesCache(TR_FieldAttributesCache::allocator_type(TR::Compiler->persistentAllocator()));
-      }
    return attributesCache;
    }
 
@@ -465,9 +438,9 @@ TR_ResolvedJ9JITServerMethod::getCachedFieldAttributes(int32_t cpIndex, TR_J9Met
       {
       // First, search a global cache
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
-      auto attributesCache = getAttributesCache(isStatic);
-      auto it = attributesCache->find(cpIndex);
-      if (it != attributesCache->end())
+      auto &attributesCache = getAttributesCache(isStatic);
+      auto it = attributesCache.find(cpIndex);
+      if (it != attributesCache.end())
          {
          attributes = it->second;
          return true;
@@ -499,20 +472,20 @@ TR_ResolvedJ9JITServerMethod::cacheFieldAttributes(int32_t cpIndex, const TR_J9M
       {
       // field is resolved in CP, can cache globally per RAM class.
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
-      auto attributesCache = getAttributesCache(isStatic);
+      auto &attributesCache = getAttributesCache(isStatic);
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
       TR_ASSERT(canCacheFieldAttributes(cpIndex, attributes, isStatic), "new and cached field attributes are not equal");
 #endif
-      attributesCache->insert({cpIndex, attributes});
+      attributesCache.insert({cpIndex, attributes});
       }
    }
 
 bool
 TR_ResolvedJ9JITServerMethod::canCacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic)
    {
-   auto attributesCache = getAttributesCache(isStatic);
-   auto it = attributesCache->find(cpIndex);
-   if (it != attributesCache->end())
+   auto &attributesCache = getAttributesCache(isStatic);
+   auto it = attributesCache.find(cpIndex);
+   if (it != attributesCache.end())
       {
       // Attempting to cache attributes when this key is already cached.
       // This case can happen when two threads call `getCachedFieldAttributes`,
@@ -951,13 +924,8 @@ TR_ResolvedJ9JITServerMethod::getRemoteROMString(int32_t &len, void *basePtr, st
    {
       OMR::CriticalSection getRemoteROMClass(threadCompInfo->getClientData()->getROMMapMonitor()); 
       auto &stringsCache = getJ9ClassInfo(threadCompInfo, _ramClass)._remoteROMStringsCache;
-      // initialize cache if it hasn't been done yet
-      if (!stringsCache)
-         {
-         stringsCache = new (PERSISTENT_NEW) PersistentUnorderedMap<TR_RemoteROMStringKey, std::string>(PersistentUnorderedMap<TR_RemoteROMStringKey, std::string>::allocator_type(TR::Compiler->persistentAllocator()));
-         }
-      auto gotStr = stringsCache->find(key);
-      if (gotStr != stringsCache->end())
+      auto gotStr = stringsCache.find(key);
+      if (gotStr != stringsCache.end())
          {
          cachedStr = &(gotStr->second);
          isCached = true;
@@ -975,7 +943,7 @@ TR_ResolvedJ9JITServerMethod::getRemoteROMString(int32_t &len, void *basePtr, st
          // reaquire the monitor
          OMR::CriticalSection getRemoteROMClass(threadCompInfo->getClientData()->getROMMapMonitor()); 
          auto &stringsCache = getJ9ClassInfo(threadCompInfo, _ramClass)._remoteROMStringsCache;
-         cachedStr = &(stringsCache->insert({key, std::get<0>(_stream->read<std::string>())}).first->second);
+         cachedStr = &(stringsCache.insert({key, std::get<0>(_stream->read<std::string>())}).first->second);
          }
       }
 
@@ -1115,13 +1083,8 @@ TR_ResolvedJ9JITServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_
    {
       OMR::CriticalSection getRemoteROMClass(threadCompInfo->getClientData()->getROMMapMonitor()); 
       auto &stringsCache = getJ9ClassInfo(threadCompInfo, _ramClass)._fieldOrStaticNameCache;
-      // initialize cache if it hasn't been done yet
-      if (!stringsCache)
-         {
-         stringsCache = new (PERSISTENT_NEW) PersistentUnorderedMap<int32_t, std::string>(PersistentUnorderedMap<TR_RemoteROMStringKey, std::string>::allocator_type(TR::Compiler->persistentAllocator()));
-         }
-      auto gotStr = stringsCache->find(cpIndex);
-      if (gotStr != stringsCache->end())
+      auto gotStr = stringsCache.find(cpIndex);
+      if (gotStr != stringsCache.end())
          {
          cachedStr = &(gotStr->second);
          isCached = true;
@@ -1136,7 +1099,7 @@ TR_ResolvedJ9JITServerMethod::fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_
          // reaquire the monitor
          OMR::CriticalSection getRemoteROMClass(threadCompInfo->getClientData()->getROMMapMonitor()); 
          auto &stringsCache = getJ9ClassInfo(threadCompInfo, _ramClass)._fieldOrStaticNameCache;
-         cachedStr = &(stringsCache->insert({cpIndex, std::get<0>(_stream->read<std::string>())}).first->second);
+         cachedStr = &(stringsCache.insert({cpIndex, std::get<0>(_stream->read<std::string>())}).first->second);
          }
       }
 
@@ -2558,7 +2521,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::staticAttributes(TR::Compilation * comp
    return theFieldIsFromLocalClass;
    }
 
-TR_FieldAttributesCache *
+TR_FieldAttributesCache &
 TR_ResolvedRelocatableJ9JITServerMethod::getAttributesCache(bool isStatic, bool unresolvedInCP)
    {
    // Return persistent attributes cache for AOT compilations
@@ -2566,11 +2529,6 @@ TR_ResolvedRelocatableJ9JITServerMethod::getAttributesCache(bool isStatic, bool 
    auto &attributesCache = isStatic ? 
       getJ9ClassInfo(compInfoPT, _ramClass)._staticAttributesCacheAOT :
       getJ9ClassInfo(compInfoPT, _ramClass)._fieldAttributesCacheAOT;
-   if (!attributesCache)
-      {
-      // initialize cache, called once per ram class
-      attributesCache = new (PERSISTENT_NEW) TR_FieldAttributesCache(TR_FieldAttributesCache::allocator_type(TR::Compiler->persistentAllocator()));
-      }
    return attributesCache;
    }
 
@@ -2617,23 +2575,15 @@ TR_J9ServerMethod::TR_J9ServerMethod(TR_FrontEnd * fe, TR_Memory * trMemory, J9C
       // look up parameters for construction of this method in a cache first
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
       auto &cache = getJ9ClassInfo(compInfoPT, aClazz)._J9MethodNameCache;
-      if (!cache)
+      // search the cache for existing method parameters
+      auto it = cache.find(cpIndex);
+      if (it != cache.end())
          {
-         // initialize cache, called once per ram class
-         cache = new (PERSISTENT_NEW) PersistentUnorderedMap<int32_t, J9MethodNameAndSignature>(PersistentUnorderedMap<int32_t, J9MethodNameAndSignature>::allocator_type(TR::Compiler->persistentAllocator()));
-         }
-      else
-         {
-         // search the cache for existing method parameters
-         auto it = cache->find(cpIndex);
-         if (it != cache->end())
-            {
-            const J9MethodNameAndSignature &params = it->second;
-            classNameStr = params._classNameStr;
-            methodNameStr = params._methodNameStr;
-            methodSignatureStr = params._methodSignatureStr;
-            cached = true;
-            }
+         const J9MethodNameAndSignature &params = it->second;
+         classNameStr = params._classNameStr;
+         methodNameStr = params._methodNameStr;
+         methodSignatureStr = params._methodSignatureStr;
+         cached = true;
          }
       }
 
@@ -2648,8 +2598,8 @@ TR_J9ServerMethod::TR_J9ServerMethod(TR_FrontEnd * fe, TR_Memory * trMemory, J9C
       methodSignatureStr = std::get<2>(recv);
 
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
-      auto cache = getJ9ClassInfo(compInfoPT, aClazz)._J9MethodNameCache;
-      cache->insert({cpIndex, {classNameStr, methodNameStr, methodSignatureStr}});
+      auto &cache = getJ9ClassInfo(compInfoPT, aClazz)._J9MethodNameCache;
+      cache.insert({cpIndex, {classNameStr, methodNameStr, methodSignatureStr}});
       }
 
    _className = str2utf8((char*)&classNameStr[0], classNameStr.length(), trMemory, heapAlloc);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -203,7 +203,7 @@ protected:
    static void setAttributeResultFromResolvedMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, U_32 * fieldOffset, void **address, TR::DataType * type, bool * volatileP, bool * isFinal, bool * isPrivate, bool * unresolvedInCP, bool *result, bool isStatic);
    virtual bool getCachedFieldAttributes(int32_t cpIndex, TR_J9MethodFieldAttributes &attributes, bool isStatic);
    virtual void cacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic);
-   virtual TR_FieldAttributesCache *getAttributesCache(bool isStatic, bool unresolvedInCP=false);
+   virtual TR_FieldAttributesCache &getAttributesCache(bool isStatic, bool unresolvedInCP=false);
    virtual bool validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation);
    virtual bool canCacheFieldAttributes(int32_t cpIndex, const TR_J9MethodFieldAttributes &attributes, bool isStatic);
 
@@ -275,7 +275,7 @@ protected:
    virtual void                  handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual char *                fieldOrStaticNameChars(int32_t cpIndex, int32_t & len) override;
-   virtual TR_FieldAttributesCache *getAttributesCache(bool isStatic, bool unresolvedInCP=false) override;
+   virtual TR_FieldAttributesCache &getAttributesCache(bool isStatic, bool unresolvedInCP=false) override;
    virtual bool validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation) override;
    UDATA getFieldType(J9ROMConstantPoolItem * CP, int32_t cpIndex);
    };

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -277,76 +277,29 @@ ClientSessionData::printStats()
    j9tty_printf(PORTLIB, "\tTotal size of cached ROM classes + methods: %d bytes\n", total);
    }
 
+ClientSessionData::ClassInfo::ClassInfo() :
+   _fieldAttributesCache(decltype(_fieldAttributesCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _staticAttributesCache(decltype(_staticAttributesCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _fieldAttributesCacheAOT(decltype(_fieldAttributesCacheAOT)::allocator_type(TR::Compiler->persistentAllocator())),
+   _staticAttributesCacheAOT(decltype(_fieldAttributesCacheAOT)::allocator_type(TR::Compiler->persistentAllocator())),
+   _jitFieldsCache(decltype(_jitFieldsCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _fieldOrStaticNameCache(decltype(_fieldOrStaticNameCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _remoteROMStringsCache(decltype(_remoteROMStringsCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _constantClassPoolCache(decltype(_constantClassPoolCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _fieldOrStaticDeclaringClassCache(decltype(_fieldOrStaticDeclaringClassCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(TR::Compiler->persistentAllocator()))
+   {
+   }
+
 void
 ClientSessionData::ClassInfo::freeClassInfo()
    {
    TR_Memory::jitPersistentFree(_romClass);
-   // If string cache exists, free it
-   if (_remoteROMStringsCache)
-      {
-      _remoteROMStringsCache->~PersistentUnorderedMap<TR_RemoteROMStringKey, std::string>();
-      jitPersistentFree(_remoteROMStringsCache);
-      }
 
-   // if fieldOrStaticNameCache exists, free it
-   if (_fieldOrStaticNameCache)
-      {
-      _fieldOrStaticNameCache->~PersistentUnorderedMap<int32_t, std::string>();
-      jitPersistentFree(_fieldOrStaticNameCache);
-      }
    // free cached _interfaces
    _interfaces->~PersistentVector<TR_OpaqueClassBlock *>();
    jitPersistentFree(_interfaces);
-
-   // if class of static cache exists, free it
-   if (_classOfStaticCache)
-      {
-      _classOfStaticCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
-      jitPersistentFree(_classOfStaticCache);
-      }
-
-   if (_constantClassPoolCache)
-      {
-      _constantClassPoolCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
-      jitPersistentFree(_constantClassPoolCache);
-      }
-
-   if (_fieldAttributesCache)
-      {
-      _fieldAttributesCache->~TR_FieldAttributesCache();
-      jitPersistentFree(_fieldAttributesCache);
-      }
-   if (_staticAttributesCache)
-      {
-      _staticAttributesCache->~TR_FieldAttributesCache();
-      jitPersistentFree(_staticAttributesCache);
-      }
-
-   if (_fieldAttributesCacheAOT)
-      {
-      _fieldAttributesCacheAOT->~TR_FieldAttributesCache();
-      jitPersistentFree(_fieldAttributesCacheAOT);
-      }
-   if (_staticAttributesCacheAOT)
-      {
-      _staticAttributesCacheAOT->~TR_FieldAttributesCache();
-      jitPersistentFree(_staticAttributesCacheAOT);
-      }
-   if (_jitFieldsCache)
-      {
-      _jitFieldsCache->~TR_JitFieldsCache();
-      jitPersistentFree(_jitFieldsCache);
-      }
-   if (_fieldOrStaticDeclaringClassCache)
-      {
-      _fieldOrStaticDeclaringClassCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
-      jitPersistentFree(_fieldOrStaticDeclaringClassCache);
-      }
-   if (_J9MethodNameCache)
-      {
-      _J9MethodNameCache->~PersistentUnorderedMap<int32_t, J9MethodNameAndSignature>();
-      jitPersistentFree(_J9MethodNameCache);
-      }
    }
 
 ClientSessionData::VMInfo *

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -228,6 +228,7 @@ class ClientSessionData
 
    struct ClassInfo
       {
+      ClassInfo();
       void freeClassInfo(); // this method is in place of a destructor. We can't have destructor
       // because it would be called after inserting ClassInfo into the ROM map, freeing romClass
       J9ROMClass *_romClass; // romClass content exists in persistentMemory at the server
@@ -236,8 +237,8 @@ class ClientSessionData
       // Fields meaningful for arrays
       TR_OpaqueClassBlock *_baseComponentClass;
       int32_t _numDimensions;
-      PersistentUnorderedMap<TR_RemoteROMStringKey, std::string> *_remoteROMStringsCache; // cached strings from the client
-      PersistentUnorderedMap<int32_t, std::string> *_fieldOrStaticNameCache;
+      PersistentUnorderedMap<TR_RemoteROMStringKey, std::string> _remoteROMStringsCache; // cached strings from the client
+      PersistentUnorderedMap<int32_t, std::string> _fieldOrStaticNameCache;
       TR_OpaqueClassBlock *_parentClass;
       PersistentVector<TR_OpaqueClassBlock *> *_interfaces;
       bool _classHasFinalFields;
@@ -250,17 +251,17 @@ class ClientSessionData
       TR_OpaqueClassBlock * _componentClass; // caching the componentType of the J9ArrayClass
       TR_OpaqueClassBlock * _arrayClass;
       uintptrj_t _totalInstanceSize;
-      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_classOfStaticCache;
-      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_constantClassPoolCache;
-      TR_FieldAttributesCache *_fieldAttributesCache;
-      TR_FieldAttributesCache *_staticAttributesCache;
-      TR_FieldAttributesCache *_fieldAttributesCacheAOT;
-      TR_FieldAttributesCache *_staticAttributesCacheAOT;
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _constantClassPoolCache;
+      TR_FieldAttributesCache _fieldAttributesCache;
+      TR_FieldAttributesCache _staticAttributesCache;
+      TR_FieldAttributesCache _fieldAttributesCacheAOT;
+      TR_FieldAttributesCache _staticAttributesCacheAOT;
       J9ConstantPool *_constantPool;
-      TR_JitFieldsCache *_jitFieldsCache;
+      TR_JitFieldsCache _jitFieldsCache;
       uintptrj_t _classFlags;
-      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_fieldOrStaticDeclaringClassCache;
-      PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> *_J9MethodNameCache; // key is a cpIndex
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDeclaringClassCache;
+      PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
       }; // struct ClassInfo
 
 


### PR DESCRIPTION
Caches that are stored inside `ClassInfo` are global and persist
until the class is unloaded or client disconnects. Thus, most
caches will likely be populated, so it's more convinient to store the
cache outright, instead of a pointer to the cache. This removes the
need for allocating memory for the cache the first time it's used and
freeing it when class info is freed.
Even if the cache is never used, empty `std::unordered_map` takes little
space so it shouldn't have a significant effect on memory footprint.