### PR TITLE
Prepare JITServer j9method-related changes

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4942,14 +4942,12 @@ J9::CodeGenerator::allocateCodeMemoryInner(
    bool hadClassUnloadMonitor;
    bool hadVMAccess = self()->fej9()->releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(comp, &hadClassUnloadMonitor);
 
-   bool useContiguousAllocation = self()->fej9()->needsContiguousAllocation();                                                                                                                                      
-
    uint8_t *warmCode = TR::CodeCacheManager::instance()->allocateCodeMemory(
          warmCodeSizeInBytes,
          coldCodeSizeInBytes,
          &codeCache,
          coldCode,
-         useContiguousAllocation,
+         self()->fej9()->needsContiguousCodeAndDataCacheAllocation(),
          isMethodHeaderNeeded);
 
    self()->fej9()->acquireClassUnloadMonitorAndReleaseVMAccessIfNeeded(comp, hadVMAccess, hadClassUnloadMonitor);

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -42,6 +42,7 @@
 #include "runtime/RelocationRuntime.hpp"
 #if defined(JITSERVER_SUPPORT)
 #include "env/PersistentCollections.hpp"
+#include "net/ServerStream.hpp"
 #endif /* defined(JITSERVER_SUPPORT) */
 
 extern "C" {
@@ -76,8 +77,6 @@ template <typename T> class TR_PersistentArray;
 typedef J9JITExceptionTable TR_MethodMetaData;
 #if defined(JITSERVER_SUPPORT)
 class ClientSessionHT;
-
-namespace JITServer { class ServerStream; }
 #endif /* defined(JITSERVER_SUPPORT) */
 
 struct TR_SignatureCountPair

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2086,7 +2086,7 @@ TR_J9VMBase::allocateRelocationData(TR::Compilation * comp, uint32_t numBytes)
    uint8_t * relocationData = NULL;
    uint32_t size = 0;
    bool shouldRetryAllocation;
-   relocationData = allocateDataCacheRecord(numBytes, comp, needsContiguousAllocation(), &shouldRetryAllocation,
+   relocationData = allocateDataCacheRecord(numBytes, comp, needsContiguousCodeAndDataCacheAllocation(), &shouldRetryAllocation,
                                             J9_JIT_DCE_RELOCATION_DATA, &size);
    if (!relocationData)
       {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -246,7 +246,7 @@ public:
    virtual ~TR_J9VMBase() {}
 
    virtual bool isAOT_DEPRECATED_DO_NOT_USE() { return false; }
-   virtual bool needsContiguousAllocation() { return false; }
+   virtual bool needsContiguousCodeAndDataCacheAllocation() { return false; }
    virtual bool supportsMethodEntryPadding() { return true; }
    virtual bool canUseSymbolValidationManager() { return false; }
 
@@ -1137,7 +1137,7 @@ public:
    virtual bool               hardwareProfilingInstructionsNeedRelocation()   { return true; }
    virtual bool               supportsMethodEntryPadding()                    { return false; }
    virtual bool               isBenefitInliningCheckIfFinalizeObject()        { return true; }
-   virtual bool               needsContiguousAllocation()                     { return true; }
+   virtual bool               needsContiguousCodeAndDataCacheAllocation()     { return true; }
    virtual bool               shouldDelayAotLoad();
 
    virtual bool               isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -33,7 +33,7 @@ public:
       {}
 
    virtual bool storeOffsetToArgumentsInVirtualIndirectThunks() override { return true; }
-   virtual bool needsContiguousAllocation() override                     { return true; }
+   virtual bool needsContiguousCodeAndDataCacheAllocation() override     { return true; }
    virtual bool supportsEmbeddedHeapBounds() override                    { return false; }
    virtual bool supportsFastNanoTime() override                          { return false; }
    virtual bool helpersNeedRelocation() override                         { return true; }
@@ -193,33 +193,33 @@ public:
       {}
 
    // in process of removing this query in favour of more meaningful queries below
-   virtual bool       isAOT_DEPRECATED_DO_NOT_USE()  override                 { return true; }
+   virtual bool       isAOT_DEPRECATED_DO_NOT_USE()  override                  { return true; }
 
    // replacing calls to isAOT
-   virtual bool       canUseSymbolValidationManager() override                { return true; }
-   virtual bool       supportsCodeCacheSnippets() override                    { return false; }
-   virtual bool       canRelocateDirectNativeCalls() override                 { return false; }
-   virtual bool       needClassAndMethodPointerRelocations() override         { return true; }
-   virtual bool       inlinedAllocationsMustBeVerified() override             { return true; }
-   virtual bool       helpersNeedRelocation() override                        { return true; }
-   virtual bool       supportsEmbeddedHeapBounds() override                   { return false; }
-   virtual bool       supportsFastNanoTime() override                         { return false; }
-   virtual bool       needRelocationsForStatics() override                    { return true; }
-   virtual bool       needRelocationsForBodyInfoData() override               { return true; }
-   virtual bool       needRelocationsForPersistentInfoData() override         { return true; }
-   virtual bool       forceUnresolvedDispatch() override                      { return true; }
-   virtual bool       nopsAlsoProcessedByRelocations() override               { return true; }
-   virtual bool       supportsGuardMerging() override                         { return false; }
-   virtual bool       canDevirtualizeDispatch() override                      { return false; }
+   virtual bool       canUseSymbolValidationManager() override                 { return true; }
+   virtual bool       supportsCodeCacheSnippets() override                     { return false; }
+   virtual bool       canRelocateDirectNativeCalls() override                  { return false; }
+   virtual bool       needClassAndMethodPointerRelocations() override          { return true; }
+   virtual bool       inlinedAllocationsMustBeVerified() override              { return true; }
+   virtual bool       helpersNeedRelocation() override                         { return true; }
+   virtual bool       supportsEmbeddedHeapBounds() override                    { return false; }
+   virtual bool       supportsFastNanoTime() override                          { return false; }
+   virtual bool       needRelocationsForStatics() override                     { return true; }
+   virtual bool       needRelocationsForBodyInfoData() override                { return true; }
+   virtual bool       needRelocationsForPersistentInfoData() override          { return true; }
+   virtual bool       forceUnresolvedDispatch() override                       { return true; }
+   virtual bool       nopsAlsoProcessedByRelocations() override                { return true; }
+   virtual bool       supportsGuardMerging() override                          { return false; }
+   virtual bool       canDevirtualizeDispatch() override                       { return false; }
    virtual bool       storeOffsetToArgumentsInVirtualIndirectThunks() override { return true; }
-   virtual bool       callTargetsNeedRelocations() override                   { return true; }
-   virtual bool       doStringPeepholing() override                           { return false; }
-   virtual bool       hardwareProfilingInstructionsNeedRelocation() override  { return true; }
-   virtual bool       supportsMethodEntryPadding() override                   { return false; }
-   virtual bool       isBenefitInliningCheckIfFinalizeObject() override       { return true; }
-   virtual bool       needsContiguousAllocation() override                    { return true; }
+   virtual bool       callTargetsNeedRelocations() override                    { return true; }
+   virtual bool       doStringPeepholing() override                            { return false; }
+   virtual bool       hardwareProfilingInstructionsNeedRelocation() override   { return true; }
+   virtual bool       supportsMethodEntryPadding() override                    { return false; }
+   virtual bool       isBenefitInliningCheckIfFinalizeObject() override        { return true; }
+   virtual bool       needsContiguousCodeAndDataCacheAllocation() override     { return true; }
 
-   virtual bool shouldDelayAotLoad() override                                 { return true; }
+   virtual bool shouldDelayAotLoad() override                                  { return true; }
    virtual bool isClassVisible(TR_OpaqueClassBlock * sourceClass, TR_OpaqueClassBlock * destClass) override;
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -23,7 +23,6 @@
 #ifndef j9method_h
 #define j9method_h
 
-#include "net/ServerStream.hpp"
 #include "codegen/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
@@ -65,14 +64,6 @@ extern "C" J9UTF8 * getClassNameFromTR_VMMethod(TR_OpaqueMethodBlock *vmMethod);
 extern "C" J9Class * getRAMClassFromTR_ResolvedVMMethod(TR_OpaqueMethodBlock *vmMethod);
 #endif
 
-static bool supportsFastJNI(TR_FrontEnd *fe)
-   {
-#if defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER)
-   return true;
-#else
-   return false;
-#endif
-   }
 
 UDATA getFieldType(J9ROMConstantPoolItem * cp, I_32 cpIndex);
 inline char *nextSignatureArgument(char *currentArgument)
@@ -271,9 +262,6 @@ class TR_ResolvedJ9Method : public TR_J9Method, public TR_ResolvedJ9MethodBase
 public:
    TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd *, TR_Memory *, TR_ResolvedMethod * owningMethod = 0, uint32_t vTableSlot = 0);
 
-   // JITServer: make virtual
-   //
-   // JITServer TODO: make protected, returning Opaque versions
    J9ROMMethod *           romMethod() { return _romMethod; }
    virtual J9ROMClass *            romClassPtr();
    virtual J9ConstantPool *      cp();
@@ -500,10 +488,11 @@ public:
    virtual bool shouldFailSetRecognizedMethodInfoBecauseOfHCR();
    virtual void setRecognizedMethodInfo(TR::RecognizedMethod rm);
 
-   virtual bool                  owningMethodDoesntMatter();
+   virtual bool owningMethodDoesntMatter();
    virtual bool isMethodInValidLibrary();
-
+#if defined(JITSERVER_SUPPORT)
    virtual TR_PersistentJittedBodyInfo *getExistingJittedBodyInfo();
+#endif
 
    static bool isInvokePrivateVTableOffset(UDATA vTableOffset);
 
@@ -519,11 +508,7 @@ protected:
    virtual TR_J9MethodBase *asJ9Method(){ return this; }
    TR_ResolvedJ9Method(TR_FrontEnd *, TR_ResolvedMethod * owningMethod = 0);
    virtual void construct();
-
-// JITServer TODO
-//private:
    virtual TR_ResolvedMethod *createResolvedMethodFromJ9Method( TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats);
-
    virtual void                  handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP);
    virtual void                  handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP);
    virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2090,7 +2090,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::allocateException(uint32_t numBytes, TR
    J9JITExceptionTable *eTbl = NULL;
    uint32_t size = 0;
    bool shouldRetryAllocation;
-   eTbl = (J9JITExceptionTable *)_fe->allocateDataCacheRecord(numBytes, comp, _fe->needsContiguousAllocation(), &shouldRetryAllocation,
+   eTbl = (J9JITExceptionTable *)_fe->allocateDataCacheRecord(numBytes, comp, _fe->needsContiguousCodeAndDataCacheAllocation(), &shouldRetryAllocation,
                                                               J9_JIT_DCE_EXCEPTION_INFO, &size);
    if (!eTbl)
       {

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -88,7 +88,7 @@ static uint8_t * allocateGCData(TR_J9VMBase * vm, uint32_t numBytes, TR::Compila
    uint8_t *gcData = NULL;
    uint32_t size = 0;
    bool shouldRetryAllocation;
-   gcData = vm->allocateDataCacheRecord(numBytes, comp, vm->needsContiguousAllocation(), &shouldRetryAllocation,
+   gcData = vm->allocateDataCacheRecord(numBytes, comp, vm->needsContiguousCodeAndDataCacheAllocation(), &shouldRetryAllocation,
                                         J9_JIT_DCE_STACK_ATLAS, &size);
    if (!gcData)
       {
@@ -1089,7 +1089,7 @@ populateBodyInfo(
          uint8_t *persistentInfo = vm->allocateDataCacheRecord(
             bytesRequested,
             comp,
-            vm->needsContiguousAllocation(),
+            vm->needsContiguousCodeAndDataCacheAllocation(),
             &retryCompilation,
             J9_JIT_DCE_AOT_PERSISTENT_INFO,
             &bytesAllocated


### PR DESCRIPTION
Clean up j9method.h/cpp for merge to master which will be needed by j9methodServer.hpp/cpp files.

Involved changes:
- guard JITServer specific code with JITSERVER_SUPPORT
- move "#include "net/ServerStream.hpp"" out of j9method.hpp as it does not depend on it
- replace `if (auto stream = TR::CompilationInfo::getStream())` with `if (comp()->isOutOfProcessCompilation())`
- rebase j9method.h/cpp to latest master. 
(API name change: https://github.com/eclipse/openj9/pull/6838 `needsContiguousAllocation()` changed to `needsContiguousCodeAndDataCacheAllocation()` in master branch.)

Signed-off-by: Harry Yu <harryyu1994@gmail.com>