### PR TITLE
master: Disallow duplicate LocalVariableTypeTable entries

### DIFF
--- a/runtime/bcutil/BuildResult.hpp
+++ b/runtime/bcutil/BuildResult.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@
 enum BuildResult {
 	OK = BCT_ERR_NO_ERROR,
 	GenericError = BCT_ERR_GENERIC_ERROR,
+	GenericErrorCustomMsg = BCT_ERR_GENERIC_ERROR_CUSTOM_MSG,
 	OutOfROM = BCT_ERR_OUT_OF_ROM,
 	ClassRead = BCT_ERR_CLASS_READ,
 	BytecodeTranslationFailed = BCT_ERR_BYTECODE_TRANSLATION_FAILED,

--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -34,6 +34,7 @@
 #include "jbcmap.h"
 #include "ut_j9bcu.h"
 #include "util_api.h"
+#include "j9protos.h"
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 #define VALUE_TYPES_MAJOR_VERSION 55
@@ -964,6 +965,23 @@ ClassFileOracle::walkMethodMethodParametersAttribute(U_16 methodIndex)
 
 }
 
+void
+ClassFileOracle::throwGenericErrorWithCustomMsg(UDATA code, UDATA offset)
+{
+	_buildResult = OutOfMemory;
+	PORT_ACCESS_FROM_PORT(_context->portLibrary());
+	U_8* errorMsg = (U_8 *)j9mem_allocate_memory(sizeof(J9CfrError), J9MEM_CATEGORY_CLASSES);
+	if (NULL != errorMsg) {
+		_buildResult = GenericErrorCustomMsg;
+		buildError((J9CfrError*)errorMsg, code, GenericErrorCustomMsg, offset);
+		/* avoid leaking memory if classFileError was not previously null */
+		J9TranslationBufferSet* dlb = _context->javaVM()->dynamicLoadBuffers;
+		if (NULL != dlb->classFileError) {
+			j9mem_free_memory(dlb->classFileError);
+		}
+		dlb->classFileError = errorMsg;
+	}
+}
 
 void
 ClassFileOracle::walkMethodCodeAttributeAttributes(U_16 methodIndex)
@@ -1126,7 +1144,8 @@ ClassFileOracle::walkMethodCodeAttributeAttributes(U_16 methodIndex)
 						if (codeAttribute->maxLocals <= index) {
 							Trc_BCU_ClassFileOracle_walkMethodCodeAttributeAttributes_LocalVariableTableIndexOutOfBounds(
 									index, codeAttribute->maxLocals, (U_32)getUTF8Length(_classFile->methods[methodIndex].nameIndex), getUTF8Data(_classFile->methods[methodIndex].nameIndex));
-							_buildResult = GenericError;
+
+							throwGenericErrorWithCustomMsg(J9NLS_CFR_LVT_INDEX_OUTOFRANGE__ID, index);
 							break;
 						} else if (NULL == _methodsInfo[methodIndex].localVariablesInfo[index].localVariableTable) {
 							_methodsInfo[methodIndex].localVariablesInfo[index].localVariableTable = localVariableTable;
@@ -1158,19 +1177,32 @@ ClassFileOracle::walkMethodCodeAttributeAttributes(U_16 methodIndex)
 				J9CfrAttributeLocalVariableTypeTable *localVariableTypeTable = (J9CfrAttributeLocalVariableTypeTable *) attribute;
 				if (0 != localVariableTypeTable->localVariableTypeTableLength) {
 					for (U_16 localVariableTypeTableIndex = 0; localVariableTypeTableIndex < localVariableTypeTable->localVariableTypeTableLength; ++localVariableTypeTableIndex) {
-						U_16 index = localVariableTypeTable->localVariableTypeTable[localVariableTypeTableIndex].index;
-						if (codeAttribute->maxLocals <= index) {
+						J9CfrLocalVariableTypeTableEntry *lvttEntry = localVariableTypeTable->localVariableTypeTable + localVariableTypeTableIndex;
+						if (codeAttribute->maxLocals <= lvttEntry->index) {
 							Trc_BCU_ClassFileOracle_walkMethodCodeAttributeAttributes_LocalVariableTypeTableIndexOutOfBounds(
-									index, codeAttribute->maxLocals, (U_32)getUTF8Length(_classFile->methods[methodIndex].nameIndex), getUTF8Data(_classFile->methods[methodIndex].nameIndex));
-							_buildResult = GenericError;
+									lvttEntry->index, codeAttribute->maxLocals, (U_32)getUTF8Length(_classFile->methods[methodIndex].nameIndex), getUTF8Data(_classFile->methods[methodIndex].nameIndex));
+							throwGenericErrorWithCustomMsg(J9NLS_CFR_LVTT_INDEX_OUTOFRANGE__ID, lvttEntry->index);
 							break;
-						} else if (NULL == _methodsInfo[methodIndex].localVariablesInfo[index].localVariableTypeTable) {
-							_methodsInfo[methodIndex].localVariablesInfo[index].localVariableTypeTable = localVariableTypeTable;
-						} else if (localVariableTypeTable != _methodsInfo[methodIndex].localVariablesInfo[index].localVariableTypeTable) {
+						} else if (NULL == _methodsInfo[methodIndex].localVariablesInfo[lvttEntry->index].localVariableTypeTable) {
+							_methodsInfo[methodIndex].localVariablesInfo[lvttEntry->index].localVariableTypeTable = localVariableTypeTable;
+						} else if (localVariableTypeTable != _methodsInfo[methodIndex].localVariablesInfo[lvttEntry->index].localVariableTypeTable) {
 							Trc_BCU_ClassFileOracle_walkMethodCodeAttributeAttributes_DuplicateLocalVariableTypeTable(
-									(U_32)getUTF8Length(_classFile->methods[methodIndex].nameIndex), getUTF8Data(_classFile->methods[methodIndex].nameIndex), localVariableTypeTable, _methodsInfo[methodIndex].localVariablesInfo[index].localVariableTypeTable);
+									(U_32)getUTF8Length(_classFile->methods[methodIndex].nameIndex), getUTF8Data(_classFile->methods[methodIndex].nameIndex), localVariableTypeTable, _methodsInfo[methodIndex].localVariablesInfo[lvttEntry->index].localVariableTypeTable);
 							_buildResult = GenericError;
 							break;
+						}
+
+						/* 4.7.14: There may be no more than one LocalVariableTypeTable attribute per local variable in the attributes table of a Code attribute. 
+						 * The entry is unique with its startPC, length, and index. */
+						for (U_16 localVariableTypeTableCompareIndex = 0; localVariableTypeTableCompareIndex < localVariableTypeTableIndex; ++localVariableTypeTableCompareIndex) {
+							J9CfrLocalVariableTypeTableEntry *lvttCompareEntry = localVariableTypeTable->localVariableTypeTable + localVariableTypeTableCompareIndex;
+							if ((lvttEntry->startPC == lvttCompareEntry->startPC)
+								&& (lvttEntry->length == lvttCompareEntry->length)
+								&& (lvttEntry->index == lvttCompareEntry->index) 
+							) {
+								throwGenericErrorWithCustomMsg(J9NLS_CFR_LVTT_DUPLICATE__ID, lvttEntry->index);
+								break;
+							}
 						}
 						markConstantUTF8AsReferenced(localVariableTypeTable->localVariableTypeTable[localVariableTypeTableIndex].signatureIndex);
 					}

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1029,6 +1029,7 @@ private:
 	void walkMethodAttributes(U_16 methodIndex);
 	void walkMethodThrownExceptions(U_16 methodIndex);
 	void walkMethodCodeAttribute(U_16 methodIndex);
+	void throwGenericErrorWithCustomMsg(UDATA code, UDATA offset);
 	void walkMethodCodeAttributeAttributes(U_16 methodIndex);
 	void walkMethodCodeAttributeCaughtExceptions(U_16 methodIndex);
 	void walkMethodCodeAttributeCode(U_16 methodIndex);

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -831,7 +831,7 @@ class NameAndTypeIterator
 	FieldIterator getFieldIterator() { return FieldIterator(_fieldsInfo, _classFile); }
 	MethodIterator getMethodIterator() { return MethodIterator(_methodsInfo, _classFile); }
 
-	ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *classFile, ConstantPoolMap *constantPoolMap, U_8 * verifyExcludeAttribute, ROMClassCreationContext *context);
+	ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *classFile, ConstantPoolMap *constantPoolMap, U_8 * verifyExcludeAttribute, U_8 * romBuilderClassFileBuffer, ROMClassCreationContext *context);
 	~ClassFileOracle();
 
 	bool isOK() const { return OK == _buildResult; }
@@ -967,6 +967,7 @@ private:
 	J9CfrClassFile *_classFile;
 	ConstantPoolMap *_constantPoolMap;
 	U_8 *_verifyExcludeAttribute;
+	U_8 *_romBuilderClassFileBuffer;
 	UDATA _bctFlags;
 	ROMClassCreationContext *_context;
 

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -438,7 +438,7 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 	}
 
 	ConstantPoolMap constantPoolMap(bufferManager, context);
-	ClassFileOracle classFileOracle(bufferManager, classFileParser->getParsedClassFile(), &constantPoolMap, _verifyExcludeAttribute, context);
+	ClassFileOracle classFileOracle(bufferManager, classFileParser->getParsedClassFile(), &constantPoolMap, _verifyExcludeAttribute, _classFileBuffer, context);
 	if ( !classFileOracle.isOK() ) {
 		return classFileOracle.getBuildResult();
 	}

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -843,15 +843,6 @@ createROMClassFromClassFile(J9VMThread *currentThread, J9LoadROMClassData *loadD
 	Trc_BCU_Assert_True(NULL != vm->dynamicLoadBuffers);
 
 	switch (result) {
-		case BCT_ERR_CLASS_READ: {
-			J9CfrError * cfrError = (J9CfrError *) vm->dynamicLoadBuffers->classFileError;
-
-			errorUTF = (U_8 *) buildVerifyErrorString(vm, cfrError, className, classNameLength);
-			exceptionNumber = cfrError->errorAction;
-			/* We don't free vm->dynamicLoadBuffers->classFileError because it is also used as a classFileBuffer in ROMClassBuilder */
-			break;
-		}
-
 		case BCT_ERR_INVALID_BYTECODE:
 		case BCT_ERR_STACK_MAP_FAILED:
 		case BCT_ERR_VERIFY_ERROR_INLINING:
@@ -874,12 +865,32 @@ createROMClassFromClassFile(J9VMThread *currentThread, J9LoadROMClassData *loadD
 			exceptionNumber = J9VMCONSTANTPOOL_JAVALANGOUTOFMEMORYERROR;
 			break;
 
+		/*
+		 * Error messages are contents of vm->dynamicLoadBuffers->classFileError with class name appended.
+		 * 
+		 * We don't free vm->dynamicLoadBuffers->classFileError because it is also used as a classFileBuffer in ROMClassBuilder.
+		 */
+		case BCT_ERR_CLASS_READ:
+			exceptionNumber = ((J9CfrError *)vm->dynamicLoadBuffers->classFileError)->errorAction;
+			/* FALLTHROUGH */
+
+		case BCT_ERR_GENERIC_ERROR_CUSTOM_MSG: {
+			/* default value for exceptionNumber (J9VMCONSTANTPOOL_JAVALANGCLASSFORMATERROR) assigned before switch */		
+			errorUTF = (U_8 *)buildVerifyErrorString(vm, (J9CfrError *)vm->dynamicLoadBuffers->classFileError, className, classNameLength);
+			break;
+		}
+
+		/*
+		 * Error messages are contents of vm->dynamicLoadBuffers->classFileError if anything is assigned 
+		 * otherwise just the classname.
+		 */
 		case BCT_ERR_CLASS_NAME_MISMATCH:
 			exceptionNumber = J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR;
 			/* FALLTHROUGH */
 			
 		default:
-			/* default value for exceptionNumber (J9VMCONSTANTPOOL_JAVALANGCLASSFORMATERROR) assigned before switch */
+			/* BCT_ERR_GENERIC_ERROR: default value for exceptionNumber (J9VMCONSTANTPOOL_JAVALANGCLASSFORMATERROR) 
+			 * assigned before switch */
 			errorUTF = vm->dynamicLoadBuffers->classFileError;
 			if (NULL == errorUTF) {
 				PORT_ACCESS_FROM_JAVAVM(vm);

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1452,3 +1452,23 @@ J9NLS_CFR_ERR_PREVIEW_VERSION.system_action=The JVM will throw a verification or
 J9NLS_CFR_ERR_PREVIEW_VERSION.user_response=Run with the correct Java runtime version and use --enable-preview.
 # END NON-TRANSLATABLE
 
+J9NLS_CFR_LVT_INDEX_OUTOFRANGE=Index in LocalVariableTable is out of range
+# START NON-TRANSLATABLE
+J9NLS_CFR_LVT_INDEX_OUTOFRANGE.explanation=Please consult the Java Virtual Machine Specification for a detailed explaination.
+J9NLS_CFR_LVT_INDEX_OUTOFRANGE.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_LVT_INDEX_OUTOFRANGE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_CFR_LVTT_INDEX_OUTOFRANGE=Index in LocalVariableTypeTable is out of range
+# START NON-TRANSLATABLE
+J9NLS_CFR_LVTT_INDEX_OUTOFRANGE.explanation=Please consult the Java Virtual Machine Specification for a detailed explaination.
+J9NLS_CFR_LVTT_INDEX_OUTOFRANGE.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_LVTT_INDEX_OUTOFRANGE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_CFR_LVTT_DUPLICATE=Duplicate entries in LocalVariableTypeTable are not allowed
+# START NON-TRANSLATABLE
+J9NLS_CFR_LVTT_DUPLICATE.explanation=Please consult the Java Virtual Machine Specification for a detailed explaination.
+J9NLS_CFR_LVTT_DUPLICATE.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_LVTT_DUPLICATE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/oti/bcutil.h
+++ b/runtime/oti/bcutil.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 IBM Corp. and others
+ * Copyright (c) 2011, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,3 +36,4 @@
 #define BCT_ERR_INVALID_ANNOTATION  -13
 #define BCT_ERR_LINE_NUMBER_TABLE_DECOMPRESS_FAILED -14
 #define BCT_ERR_INVALID_BYTECODE_SIZE -15
+#define BCT_ERR_GENERIC_ERROR_CUSTOM_MSG  -16


### PR DESCRIPTION
- JVM Spec 4.7.14: There may be no more than one LocalVariableTypeTable attribute per local variable in the attributes table of a Code attribute
- Refactor ClassFormatErrors with messages in ClassFileOracle.cpp

Parts of this are from https://github.com/eclipse/openj9/pull/6289

pr to 0.17.0 release branch: https://github.com/eclipse/openj9/pull/7263

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>