### PR TITLE
Remove object pointer from Object Scanner

### DIFF
--- a/runtime/gc_glue_java/MixedObjectScanner.hpp
+++ b/runtime/gc_glue_java/MixedObjectScanner.hpp
@@ -63,7 +63,7 @@ protected:
 	 * @param[in] flags Scanning context flags
 	 */
 	MMINLINE GC_MixedObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, uintptr_t flags)
-		: GC_ObjectScanner(env, objectPtr, env->getExtensions()->mixedObjectModel.getHeadlessObject(objectPtr), 0, flags, J9GC_J9OBJECT_CLAZZ(objectPtr, env)->instanceHotFieldDescription)
+		: GC_ObjectScanner(env, env->getExtensions()->mixedObjectModel.getHeadlessObject(objectPtr), 0, flags)
 		, _endPtr((fomrobject_t *)((uint8_t*)_scanPtr + env->getExtensions()->mixedObjectModel.getSizeInBytesWithoutHeader(objectPtr)))
 		, _mapPtr(_scanPtr)
 		, _descriptionPtr(NULL)
@@ -79,12 +79,11 @@ protected:
 	 * @param[in] env The scanning thread environment
 	 */
 	MMINLINE void
-	initialize(MM_EnvironmentBase *env)
+	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
 	{
 		GC_ObjectScanner::initialize(env);
 
 		/* Initialize the slot map from description bits */
-		J9Class *clazzPtr = J9GC_J9OBJECT_CLAZZ(_parentObjectPtr, env);
 		_scanMap = (uintptr_t)clazzPtr->instanceDescription;
 #if defined(J9VM_GC_LEAF_BITS)
 		_leafMap = (uintptr_t)clazzPtr->instanceLeafDescription;
@@ -123,7 +122,7 @@ public:
 	{
 		GC_MixedObjectScanner *objectScanner = (GC_MixedObjectScanner *)allocSpace;
 		new(objectScanner) GC_MixedObjectScanner(env, objectPtr, flags);
-		objectScanner->initialize(env);
+		objectScanner->initialize(env, J9GC_J9OBJECT_CLAZZ(objectPtr, env));
 		return objectScanner;
 	}
 	

--- a/runtime/gc_glue_java/PointerArrayObjectScanner.hpp
+++ b/runtime/gc_glue_java/PointerArrayObjectScanner.hpp
@@ -136,7 +136,7 @@ public:
 		/* If splitAmount is 0 the new scanner will return NULL on the first call to getNextSlot(). */
 		splitScanner = (GC_PointerArrayObjectScanner *)allocSpace;
 		/* Create new scanner for next chunk of array starting at the end of current chunk size splitAmount elements */
-		new(splitScanner) GC_PointerArrayObjectScanner(env, _parentObjectPtr, _basePtr, _limitPtr, _endPtr, _endPtr + splitAmount, _flags);
+		new(splitScanner) GC_PointerArrayObjectScanner(env, getArrayObject(), _basePtr, _limitPtr, _endPtr, _endPtr + splitAmount, _flags);
 		splitScanner->initialize(env);
 
 		return splitScanner;

--- a/runtime/gc_glue_java/ReferenceObjectScanner.hpp
+++ b/runtime/gc_glue_java/ReferenceObjectScanner.hpp
@@ -82,9 +82,9 @@ protected:
 	 * Subclasses must call this method to set up the instance description bits and description pointer.
 	 */
 	MMINLINE void
-	initialize(MM_EnvironmentBase *env)
+	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
 	{
-		GC_MixedObjectScanner::initialize(env);
+		GC_MixedObjectScanner::initialize(env, clazzPtr);
 
 		/* Skip over referent slot if required */
 		_scanMap = skipReferentSlot(_scanPtr, _scanMap);
@@ -106,7 +106,7 @@ public:
 	{
 		GC_ReferenceObjectScanner *objectScanner = (GC_ReferenceObjectScanner *)allocSpace;
 		new(objectScanner) GC_ReferenceObjectScanner(env, objectPtr, referentSlotAddress, flags);
-		objectScanner->initialize(env);
+		objectScanner->initialize(env, J9GC_J9OBJECT_CLAZZ(objectPtr, env));
 		return objectScanner;
 	}
 


### PR DESCRIPTION
This is second step of silo dance:
- start use new constructor of GC_ObjectScanner
- prepare removal of _hotFieldsDescriptor

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>