### PR TITLE
AArch64: Update package URLs for cross-compilation.

### DIFF
--- a/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk11/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -87,16 +87,16 @@ RUN cd /root \
 ADD \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2_1.1.3-5_arm64.deb                \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5_arm64.deb            \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8%2bdeb9u3_arm64.deb         \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8%2bdeb9u3_arm64.deb    \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8%2bdeb9u4_arm64.deb         \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8%2bdeb9u4_arm64.deb    \
     http://ftp.us.debian.org/debian/pool/main/d/dwarfutils/libdwarf-dev_20161124-1+deb9u1_arm64.deb  \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.6.3-3.2_arm64.deb            \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6-dev_2.6.3-3.2_arm64.deb        \
     http://ftp.us.debian.org/debian/pool/main/f/fontconfig/libfontconfig1_2.13.1-2_arm64.deb         \
     http://ftp.us.debian.org/debian/pool/main/f/fontconfig/libfontconfig1-dev_2.13.1-2_arm64.deb     \
     http://ftp.us.debian.org/debian/pool/main/libi/libice/libice-dev_1.0.9-2_arm64.deb               \
-    http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng16-16_1.6.28-1_arm64.deb          \
-    http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng-dev_1.6.28-1_arm64.deb           \
+    http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng16-16_1.6.28-1+deb9u1_arm64.deb   \
+    http://ftp.us.debian.org/debian/pool/main/libp/libpng1.6/libpng-dev_1.6.28-1+deb9u1_arm64.deb    \
     http://ftp.us.debian.org/debian/pool/main/libs/libsm/libsm-dev_1.2.2-1+b3_arm64.deb              \
     http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1c-1_arm64.deb                 \
     http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl-dev_1.1.1c-1_arm64.deb                \


### PR DESCRIPTION
Update URLs of libcups and libpng.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>