### PR TITLE
Updated error handling for MethodHandle invocation

### DIFF
--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -1090,7 +1090,11 @@ VM_MHInterpreter::spreadForAsSpreader(j9object_t methodHandle)
 		if (0 != spreadCount) {
 			/* Build a frame so we can throw an exception */
 			buildMethodTypeFrame(_currentThread, currentType);
+#if JAVA_SPEC_VERSION >= 10
+			setCurrentException(_currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
+#else
 			setCurrentException(_currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
+#endif /* JAVA_SPEC_VERSION >= 10 */
 			goto exitSpreadForAsSpreader;
 		}
 	} else {

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -1100,11 +1100,11 @@ VM_MHInterpreter::spreadForAsSpreader(j9object_t methodHandle)
 		if (0 != spreadCount) {
 			/* Build a frame so we can throw an exception */
 			buildMethodTypeFrame(_currentThread, currentType);
-#if JAVA_SPEC_VERSION >= 10
+#if JAVA_SPEC_VERSION >= 11
 			setCurrentException(_currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 #else
 			setCurrentException(_currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
-#endif /* JAVA_SPEC_VERSION >= 10 */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 			goto exitSpreadForAsSpreader;
 		}
 	} else {

--- a/runtime/vm/MHInterpreter.hpp
+++ b/runtime/vm/MHInterpreter.hpp
@@ -489,6 +489,7 @@ foundITable:
 	* Perform an invoke generic for InvokeGenericHandle
 	* @param methodHandle
 	* @return j9object_t The target MethodHandle (the one to execute next)
+	* 			or null if target MethodHandle is null
 	*/
 	j9object_t
 	doInvokeGeneric(j9object_t methodHandle);


### PR DESCRIPTION
- For Java 10 and up, throw a NullPointerException in stead of
IlleagalArgumentException when SpreadHandle expect non-zero
length array argument and received null

- Validate receiver MethodHandle during invocation

Closes: #6943 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>