### PR TITLE
Backport JITServerIProfiler changes from master to jitaas

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -99,10 +99,15 @@
 #include "env/ClassLoaderTable.hpp"
 #include "runtime/ArtifactManager.hpp"
 #include "runtime/CodeCacheMemorySegment.hpp"
+#if defined(JITSERVER_SUPPORT)
 #include "env/j9methodServer.hpp"
 #include "control/JITServerCompilationThread.hpp"
 #include "env/JITServerPersistentCHTable.hpp"
 #include "runtime/JITServerIProfiler.hpp"
+#include "net/ClientStream.hpp"
+#include "net/ServerStream.hpp"
+#include "control/JITServerHelpers.hpp"
+#endif
 
 #ifdef COMPRESS_AOT_DATA
 #ifdef J9ZOS390

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -24,10 +24,8 @@
 #define JITSERVER_COMPILATION_THREAD_H
 
 #include "control/CompilationThread.hpp"
-#include "control/JITServerHelpers.hpp"
-#include "env/j9methodServer.hpp"
-#include "net/ClientStream.hpp"
 #include "runtime/JITClientSession.hpp"
+#include "env/j9methodServer.hpp"
 
 class TR_IPBytecodeHashTableEntry;
 

--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -26,7 +26,10 @@
 #include "env/VMMethodEnv.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
+#if defined(JITSERVER_SUPPORT)
 #include "control/JITServerCompilationThread.hpp"
+#include "control/JITServerHelpers.hpp"
+#endif
 #include "j9.h"
 #include "j9cfg.h"
 #include "jilconsts.h"

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -30,6 +30,7 @@
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/CodeCacheExceptions.hpp"
 #include "control/JITServerCompilationThread.hpp"
+#include "control/JITServerHelpers.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "exceptions/AOTFailure.hpp"
 #include "codegen/CodeGenerator.hpp"

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -26,6 +26,7 @@
 #include "control/CompilationThread.hpp"
 #include "control/MethodToBeCompiled.hpp"
 #include "control/JITServerCompilationThread.hpp"
+#include "control/JITServerHelpers.hpp"
 #include "exceptions/DataCacheError.hpp"
 #include "ilgen/J9ByteCodeIterator.hpp"
 

--- a/runtime/compiler/runtime/ExternalProfiler.hpp
+++ b/runtime/compiler/runtime/ExternalProfiler.hpp
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 class TR_ValueProfileInfo;
+class TR_ExternalValueProfileInfo;
 namespace TR { class CFG; }
 namespace TR { class Compilation; }
 namespace TR { class Node; }

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -65,6 +65,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "env/jittypes.h"
+#include "il/Node.hpp"
 #include "infra/Link.hpp"
 #include "runtime/ExternalProfiler.hpp"
 
@@ -86,6 +87,11 @@ namespace TR { class PersistentInfo; }
 namespace TR { class Monitor; }
 struct J9Class;
 struct J9PortLibrary;
+namespace TR { class ResolvedMethodSymbol; }
+class TR_ResolvedMethod;
+class TR_AbstractInfo;
+class TR_BitVector;
+class TR_J9VMBase;
 
 #if defined (_MSC_VER)
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();


### PR DESCRIPTION
Backporting JITServerIProfiler.cpp/hpp changes and some other minor refactoring.
Since JITServerCompilationThread.hpp does not depend on JITServerHelpers.hpp, I removed it.
And this lead to a few source files needing `JITServerHelpers.hpp`.
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>