### PR TITLE
master: Indy error checking for null resolution Java 11+

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -464,6 +464,7 @@ K0900="Create a new Reference, since a Reference cannot be cloned."
 #java.lang.invoke.MethodHandle
 K0A00="Failed to resolve Constant Dynamic entry with j9class: {0}, name: {1}, descriptor: {2}, bsmData: {3}"
 K0A01="Constant_Dynamic references bootstrap method '{0}' does not have java.lang.invoke.MethodHandles.Lookup as first parameter."
+K0A02="Bootstrap method returned null."
 
 #java.lang.System
 K0B00="`-Djava.security.manager=disallow` has been specified."

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1259,7 +1259,14 @@ public abstract class MethodHandle
 					throw WrongMethodTypeException.newWrongMethodTypeException(type, callsiteType);
 				}
 				result = cs.dynamicInvoker();
+			} 
+			/*[IF Java11]*/
+			else {
+				/* The result of the resolution of a dynamically-computed call site must not be null. */
+				/*[MSG "K0A02", "Bootstrap method returned null."]*/
+				throw new ClassCastException(Msg.getString("K0A02")); //$NON-NLS-1$
 			}
+			/*[ENDIF]*/
 		} catch(Throwable e) {
 
 			/*[IF Sidecar19-SE]*/

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/BootstrapMethods.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/BootstrapMethods.java
@@ -45,6 +45,17 @@ import java.util.List;
 import differentpackage.CrossPackageHelper;
 
 public class BootstrapMethods {
+
+	// Bootstrap method throws null the first time, else a valid CallSite
+	private static int bootstrap_test_CallSiteNullErrorRethrown_counter = 0;
+	public static CallSite bootstrap_test_CallSiteNullErrorRethrown( Lookup lookup, String name, MethodType type ) throws Throwable {
+		if (0 == bootstrap_test_CallSiteNullErrorRethrown_counter) {
+			bootstrap_test_CallSiteNullErrorRethrown_counter++;
+			return null;
+		}
+		MethodHandle handle = lookup.findStatic( Helper.class, "voidMethod", methodType( void.class ) );
+		return new ConstantCallSite(handle);
+	}
 	
 	//Bootstrap method for constant MH test
 	public static CallSite bootstrap_constant_string( Lookup lookup, String name, MethodType type, String s1, String s2 ) {

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/Helper.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/Helper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,8 @@ public class Helper {
 	public int publicInt = 1; 
 	
 	public static int publicStaticInt = 100;
+
+	public static void voidMethod() { }
 	
 	public static void addStaticPublic(int a, String b){ }
 	

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/SimpleIndyGenerator.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/indyn/SimpleIndyGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,24 @@ public class SimpleIndyGenerator {
 		cw.visit( V1_7, ACC_PUBLIC | ACC_SUPER, "com/ibm/j9/jsr292/indyn/GenIndyn", null, "java/lang/Object", null );
 
 		MethodVisitor mv;
+		{
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "test_CallSiteNullErrorRethrown", "()V", null, null );
+			mv.visitCode();
+			mv.visitInvokeDynamicInsn( "test_CallSiteNullErrorRethrown", "()V",
+					new Handle(
+							H_INVOKESTATIC, 
+							"com/ibm/j9/jsr292/indyn/BootstrapMethods", 
+							"bootstrap_test_CallSiteNullErrorRethrown",
+							Type.getType(
+									"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"
+									).getDescriptor() 
+					)
+			);
+			mv.visitInsn( RETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+		}
+		
 		{
 			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "indy_return_string", "()Ljava/lang/String;", null, null );
 			mv.visitCode();


### PR DESCRIPTION
For Java 11+ if the result of a resolved bootstrap method is null it should fail with a BootstrapMethodError.

jvms 5.4.3.6:
• If R is a symbolic reference to a dynamically-computed call site, then o is the
result of resolution if it has all of the following properties:
– o is not null
...
If o does not have these properties, resolution fails with a
BootstrapMethodError.

port to v0.17.0: https://github.com/eclipse/openj9/pull/7335

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>