### PR TITLE
Remove assert in Monitor Table Read Barrier

### DIFF
--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -755,22 +755,16 @@ MM_StandardAccessBarrier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object
 		omrobjectptr_t forwardPtr = forwardHeader.getForwardedObject();
 
 		if (NULL != forwardPtr) {
-			/* Object has been copied - ensure the object is fully copied before exposing it, update the slot and return.
+			/* Object has been or is being copied - ensure the object is fully copied before exposing it, update the slot and return.
 			 *  Slot update needs to be atomic, only if there is a mutator thread racing with a write operation to this same slot.
-			 *  ATM, this barrier is only used to update Monitor table entries, which should not be ever reinitialized by any mutator.
+			 *  The barrier is typically used to update Monitor table entries, which should not be ever reinitialized by any mutator.
 			 *  Updated can occur, but only by GC threads during STW clearing phase, thus no race with this barrier. */
 			forwardHeader.copyOrWait(forwardPtr);
 			*srcAddress = forwardPtr;
-		} else {
-			Assert_GC_true_with_message2(env, forwardHeader.isSelfForwardedPointer(),
-				"Monitor object, not forwarded, in Evacuate: slot %llx object %llx\n", srcAddress, object);
-			/* A typical usage of this barrier is to update monitor table slot for blocking object (blockingEnterObject).
-			 * Such object is a hard root, hence copied during initial roots scanning. We should never need to copy it via this barrier.
-			 * If this assert eventually triggers it means the barrier is used for some other objects that are not hard roots
-			 * (for example, iterating monitor table to dump info about all monitors). If so, try using the other API (that's using VM rather
-			 * than Thread argument) instead (since that API expects accessing even dead objects and does not impose the assert).
-			 */
 		}
+		/* Do nothing if the object is not copied already, since it might be dead.
+		 * This object is found without real reference to it,
+		 * for example by iterating monitor table to dump info about all monitors */
 	}
 
 	return true;
@@ -788,7 +782,7 @@ MM_StandardAccessBarrier::preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcA
 		omrobjectptr_t forwardPtr = forwardHeader.getForwardedObject();
 
 		if (NULL != forwardPtr) {
-			/* Object has been copied - ensure the object is fully copied before exposing it, update the slot and return */
+			/* Object has been or is being copied - ensure the object is fully copied before exposing it, update the slot and return */
 			forwardHeader.copyOrWait(forwardPtr);
 			*srcAddress = forwardPtr;
 		}


### PR DESCRIPTION
The assert served its purpose - after months of usage, it 'proved' that
copy is indeed not required in weak root access barrier.

But the assert may occasionally trigger and introduce confusion, if it
is invoked at spots where object liveness is unknown (but still, we it's
safe to access the object without coping it, since noone is racing to
mutate the object). An example is JLM iterating over monitor table
entries, under exclusive VM access, to dump info for all monitors. To
avoid confusion and false asserts, we are removing it.

See also:
https://github.com/eclipse/openj9/pull/5232

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>