### PR TITLE
Increase timeout for JITClient to 2 seconds

### DIFF
--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -133,7 +133,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _remoteCompilationMode(JITServer::NONE),
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
-         _socketTimeoutMs(1000),
+         _socketTimeoutMs(2000),
          _clientUID(0),
 #endif /* defined(JITSERVER_SUPPORT) */
       OMR::PersistentInfoConnector(pm)


### PR DESCRIPTION
Recent experiments in various test environments have shown that the
current timeout value of 1 second is not enough. If the JITServer is rather
slow and the compilation is expensive, this timeout value could be
exceeded for legitimate reasons and the client will declare that the server
has stopped responding and close the connection. In this case the client
will perform the compilation itself, which is not a bad thing, except for
the fact that timeouts happen exactly for expensive compilations which we
want to avoid being performed at the client.

This commit increases the value of the default timeout to 2 seconds.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>