### PR TITLE
Add an empty MethodHandle.customize()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1620,9 +1620,10 @@ public abstract class MethodHandle
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
-/*[IF Sidecar19-SE-OpenJ9]*/
+/*[IF Sidecar18-SE-OpenJ9]*/
 	void customize() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		// this is an empty implementation to satisfy RI specific method calls
+		// https://github.com/eclipse/openj9/issues/7080
 	}
 /*[ENDIF]*/
 	


### PR DESCRIPTION
Add an empty `MethodHandle.customize()`

Added an empty `MethodHandle.customize()` to pass compilation (`JDK 8`) and method invocation (`JDK 11`).

Verified that `JDK 8/11` with this PR passed the test from https://github.com/eclipse/openj9/issues/7080

closes: #7080 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>