### PR TITLE
Cache which fields are unresolved in TR_J9ServerVM::jitFieldsAreSame

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -113,7 +113,8 @@ TR::CompilationInfoPerThreadRemote::CompilationInfoPerThreadRemote(TR::Compilati
    _classOfStaticMap(NULL),
    _fieldAttributesCache(NULL),
    _staticAttributesCache(NULL),
-   _isUnresolvedStrCache(NULL)
+   _isUnresolvedStrCache(NULL),
+   _unresolvedFieldCache(NULL)
    {}
 
 // waitForMyTurn needs to be executed with sequencingMonitor in hand
@@ -913,6 +914,20 @@ TR::CompilationInfoPerThreadRemote::getCachedIsUnresolvedStr(TR_OpaqueClassBlock
    }
 
 void
+TR::CompilationInfoPerThreadRemote::cacheUnresolvedField(J9Class *ramClass, int32_t cpIndex)
+   {
+   J9Class *nullClazz = NULL;
+   cacheToPerCompilationMap(_unresolvedFieldCache, std::make_pair(ramClass, cpIndex), nullClazz);
+   }
+
+bool
+TR::CompilationInfoPerThreadRemote::getCachedUnresolvedField(J9Class *ramClass, int32_t cpIndex)
+   {
+   J9Class *nullClazz;
+   return getCachedValueFromPerCompilationMap(_unresolvedFieldCache, std::make_pair(ramClass, cpIndex), nullClazz);
+   }
+
+void
 TR::CompilationInfoPerThreadRemote::clearPerCompilationCaches()
    {
    clearPerCompilationCache(_methodIPDataPerComp);
@@ -922,6 +937,7 @@ TR::CompilationInfoPerThreadRemote::clearPerCompilationCaches()
    clearPerCompilationCache(_fieldAttributesCache);
    clearPerCompilationCache(_staticAttributesCache);
    clearPerCompilationCache(_isUnresolvedStrCache);
+   clearPerCompilationCache(_unresolvedFieldCache);
    }
 
 void

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -74,6 +74,9 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    void cacheIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_IsUnresolvedString &stringAttrs);
    bool getCachedIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_IsUnresolvedString &stringAttrs);
 
+   void cacheUnresolvedField(J9Class *ramClass, int32_t cpIndex);
+   bool getCachedUnresolvedField(J9Class *ramClass, int32_t cpIndex);
+
    void clearPerCompilationCaches();
    void deleteClientSessionData(uint64_t clientId, TR::CompilationInfo* compInfo, J9VMThread* compThread);
 
@@ -142,6 +145,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    FieldOrStaticAttrTable_t *_fieldAttributesCache;
    FieldOrStaticAttrTable_t *_staticAttributesCache;
    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_IsUnresolvedString> *_isUnresolvedStrCache;
+   UnorderedMap<std::pair<J9Class *, int32_t>, J9Class *> *_unresolvedFieldCache;
    }; // class CompilationInfoPerThreadRemote
 } // namespace TR
 


### PR DESCRIPTION
`VM_jitFieldsAreSame` is the most frequent message in all
of the benchmarks we use.
We already perform global caching of resolved fields, but we cannot do
that for unresolved fields because they might become resolved later on.
A workaround that this commit implements is to cache which fields are
unresolved
for the duration of a single compilation. This way, even if a field
becomes resolved during the compilation, incorrect result will be used
only for a short period of time, not affecting performance.