### PR TITLE
Remove redundant z13 processor checks on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1149,8 +1149,7 @@ J9::Z::TreeEvaluator::genLoadForObjectHeadersMasked(TR::CodeGenerator *cg, TR::N
    TR::Instruction *loadInstr;
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z13) &&
-         !(comp->getOption(TR_DisableZ13) || comp->getOption(TR_DisableZ13LoadAndMask)))
+   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z13))
       {
       iCursor = generateRXInstruction(cg, TR::InstOpCode::LLZRGF, node, reg, tempMR, iCursor);
       loadInstr = iCursor;


### PR DESCRIPTION
Similarly to all other processors, since the migration of CPU checks to
the CPU class we no longer need to explicitly check for specific
"disableZ13*" options when also checking for processor support since
these checks are already performed for us.

We simplify the implementation here to stay consistent with all the
other checks for the various CPU processors.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>