### PR TITLE
Consolidate JIT-to-JIT entry point alignment on all codegens

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4543,9 +4543,9 @@ J9::CodeGenerator::wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedCla
    }
 
 bool
-J9::CodeGenerator::supportsMethodEntryPadding()
+J9::CodeGenerator::supportsJitMethodEntryAlignment()
    {
-   return self()->fej9()->supportsMethodEntryPadding();
+   return self()->fej9()->supportsJitMethodEntryAlignment();
    }
 
 bool

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -392,7 +392,7 @@ public:
    bool hasFixedFrameC_CallingConvention() {return _j9Flags.testAny(HasFixedFrameC_CallingConvention);}
    void setHasFixedFrameC_CallingConvention() {_j9Flags.set(HasFixedFrameC_CallingConvention);}
 
-   bool supportsMethodEntryPadding();
+   bool supportsJitMethodEntryAlignment();
 
    /** \brief
     *     Determines whether the code generator supports inlining of java/lang/Class.isAssignableFrom

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -245,7 +245,7 @@ public:
 
    virtual bool isAOT_DEPRECATED_DO_NOT_USE() { return false; }
    virtual bool needsContiguousCodeAndDataCacheAllocation() { return false; }
-   virtual bool supportsMethodEntryPadding() { return true; }
+   virtual bool supportsJitMethodEntryAlignment() { return true; }
    virtual bool canUseSymbolValidationManager() { return false; }
 
 #if defined(TR_TARGET_S390)
@@ -1133,7 +1133,7 @@ public:
    virtual bool               callTargetsNeedRelocations()                    { return true; }
    virtual bool               doStringPeepholing()                            { return false; }
    virtual bool               hardwareProfilingInstructionsNeedRelocation()   { return true; }
-   virtual bool               supportsMethodEntryPadding()                    { return false; }
+   virtual bool               supportsJitMethodEntryAlignment()               { return false; }
    virtual bool               isBenefitInliningCheckIfFinalizeObject()        { return true; }
    virtual bool               needsContiguousCodeAndDataCacheAllocation()     { return true; }
    virtual bool               shouldDelayAotLoad();

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -221,10 +221,9 @@ J9::Power::CodeGenerator::generateBinaryEncodingPrologue(
       data->cursorInstruction = data->cursorInstruction->getNext();
       }
 
-   int32_t boundary = comp->getOptions()->getJitMethodEntryAlignmentBoundary(self());
+   int32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
    if (boundary && (boundary > 4) && ((boundary & (boundary - 1)) == 0))
       {
-      comp->getOptions()->setJitMethodEntryAlignmentBoundary(boundary);
       self()->setPreJitMethodEntrySize(data->estimate);
       data->estimate += (boundary - 4);
       }

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -221,11 +221,10 @@ J9::Power::CodeGenerator::generateBinaryEncodingPrologue(
       data->cursorInstruction = data->cursorInstruction->getNext();
       }
 
-   int32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
-   if (boundary > 4)
+   if (self()->supportsJitMethodEntryAlignment())
       {
       self()->setPreJitMethodEntrySize(data->estimate);
-      data->estimate += (boundary - 4);
+      data->estimate += (self()->getJitMethodEntryAlignmentBoundary() - 1);
       }
 
    tempInstruction = data->cursorInstruction;

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -222,7 +222,7 @@ J9::Power::CodeGenerator::generateBinaryEncodingPrologue(
       }
 
    int32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
-   if (boundary && (boundary > 4) && ((boundary & (boundary - 1)) == 0))
+   if (boundary > 4)
       {
       self()->setPreJitMethodEntrySize(data->estimate);
       data->estimate += (boundary - 4);

--- a/runtime/compiler/z/codegen/S390Recompilation.cpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.cpp
@@ -290,7 +290,7 @@ TR_S390Recompilation::generatePrePrologue()
       }
 
    // Save the preprologue size to the JIT entry point for use of JIT entry point alignment
-   cg->setPreprologueOffset(preprologueSize);
+   cg->setPreJitMethodEntrySize(preprologueSize);
 
    return cursor;
    }


### PR DESCRIPTION
This series of commits consolidates the JIT-to-JIT entry point alignment on all codegens so we all use the same API, namely `alignBinaryBufferCursor`, to perform the alignment. As part of this change we introduce several new APIs and rename some existing ones so as to stay more consistent. We also take this opportunity to document all the APIs.

This cleanup is a step towards commoning up the Binary Encoding phase across codegens and will hopefully help the adaptation of new code generators, such as ARM, AArch64, and RISC-V.