### PR TITLE
Update JITServer's IProfiler serialize API

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11071,7 +11071,7 @@ TR::CompilationInfo::storeAOTInSharedCache(
       // If validation has been performed, then a header already existed
       // or one was already been created in this JVM
       TR_J9SharedCacheVM *fe = (TR_J9SharedCacheVM *) TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM);
-      safeToStore = entry->_compInfoPT->reloRuntime()->storeAOTHeader(jitConfig->javaVM, fe, vmThread);
+      safeToStore = entry->_compInfoPT->reloRuntime()->storeAOTHeader(fe, vmThread);
       }
    else
       {

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2604,6 +2604,24 @@ TR_IPBCDataFourBytes::operator new (size_t size) throw()
    return TR_IPBytecodeHashTableEntry::alignedPersistentAlloc(size);
    }
 
+#if defined(JITSERVER_SUPPORT)
+void
+TR_IPBCDataFourBytes::serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info)
+   {
+   TR_IPBCDataFourBytesStorage * store = (TR_IPBCDataFourBytesStorage *) storage;
+   storage->pc = _pc - methodStartAddress;
+   storage->left = 0;
+   storage->right = 0;
+   storage->ID = TR_IPBCD_FOUR_BYTES;
+   store->data = data;
+   }
+void
+TR_IPBCDataFourBytes::deserialize(TR_IPBCDataStorageHeader *storage)
+   {
+   loadFromPersistentCopy(storage, NULL);
+   }
+#endif
+
 void
 TR_IPBCDataFourBytes::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info)
    {
@@ -2685,7 +2703,24 @@ TR_IPBCDataEightWords::copyFromEntry(TR_IPBytecodeHashTableEntry * originalEntry
       data[i] = entry->data[i];
    }
 
-
+#if defined(JITSERVER_SUPPORT)
+void
+TR_IPBCDataEightWords::serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info)
+   {
+   TR_IPBCDataEightWordsStorage * store = (TR_IPBCDataEightWordsStorage *) storage;
+   storage->pc = _pc - methodStartAddress;
+   storage->ID = TR_IPBCD_EIGHT_WORDS;
+   storage->left = 0;
+   storage->right = 0;
+   for (int i = 0; i < SWITCH_DATA_COUNT; i++)
+      store->data[i] = data[i];
+   }
+void
+TR_IPBCDataEightWords::deserialize(TR_IPBCDataStorageHeader *storage)
+   {
+   loadFromPersistentCopy(storage, NULL);
+   }
+#endif
 
 int32_t
 TR_IPBCDataCallGraph::setData(uintptrj_t v, uint32_t freq)

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -318,8 +318,8 @@ public:
    virtual TR_IPBCDataFourBytes  *asIPBCDataFourBytes() { return this; }
    virtual uint32_t getBytesFootprint() {return sizeof (TR_IPBCDataFourBytesStorage);}
 #if defined(JITSERVER_SUPPORT)
-   virtual void serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info) { createPersistentCopy(methodStartAddress, 0, storage, info); } // use cacheSize=0 because createPersistentCopy doesn't use it
-   virtual void deserialize(TR_IPBCDataStorageHeader *storage) { loadFromPersistentCopy(storage, NULL, 0); }
+   virtual void serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info);
+   virtual void deserialize(TR_IPBCDataStorageHeader *storage);
 #endif
    virtual void createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info);
    virtual void loadFromPersistentCopy(TR_IPBCDataStorageHeader *storage, TR::Compilation *comp);
@@ -376,8 +376,8 @@ public:
    virtual TR_IPBCDataEightWords  *asIPBCDataEightWords() { return this; }
    virtual uint32_t getBytesFootprint() {return sizeof(TR_IPBCDataEightWordsStorage);}
 #if defined(JITSERVER_SUPPORT)
-   virtual void serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info) { createPersistentCopy(methodStartAddress, 0, storage, info); } // use cacheSize=0 because createPersistentCopy doesn't use it
-   virtual void deserialize(TR_IPBCDataStorageHeader *storage) { loadFromPersistentCopy(storage, NULL, 0); }
+   virtual void serialize(uintptrj_t methodStartAddress, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info);
+   virtual void deserialize(TR_IPBCDataStorageHeader *storage);
 #endif
    virtual void createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info);
    virtual void loadFromPersistentCopy(TR_IPBCDataStorageHeader *storage, TR::Compilation *comp);


### PR DESCRIPTION
The old version API `createPersistentCopy` used by `TR_IPBCDataFourBytes::serialize` and `TR_IPBCDataEightWords::serialize` no longer exists but it's still needed by JITServer's `serialize`. Restore the API inside `serialize`.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>