### PR TITLE
Remove redundant recognized methods inlining code from the Power codegen

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -376,7 +376,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Math_abs_L:
       case TR::java_lang_Math_abs_F:
       case TR::java_lang_Math_abs_D:
-         return TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isZ();
+         return TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isZ() || TR::Compiler->target.cpu.isPower();
       case TR::java_lang_Math_max_I:
       case TR::java_lang_Math_min_I:
       case TR::java_lang_Math_max_L:

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -367,8 +367,10 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Class_isAssignableFrom:
          return cg()->supportsInliningOfIsAssignableFrom();
       case TR::java_lang_Integer_rotateLeft:
+      case TR::java_lang_Integer_rotateRight:
          return TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isZ() || TR::Compiler->target.cpu.isPower();
       case TR::java_lang_Long_rotateLeft:
+      case TR::java_lang_Long_rotateRight:
          return TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isZ() || (TR::Compiler->target.cpu.isPower() && TR::Compiler->target.is64Bit());
       case TR::java_lang_Math_abs_I:
       case TR::java_lang_Math_abs_L:
@@ -409,9 +411,31 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
       case TR::java_lang_Integer_rotateLeft:
          processIntrinsicFunction(treetop, node, TR::irol);
          break;
+      case TR::java_lang_Integer_rotateRight:
+         {
+         // rotateRight(x, distance) = rotateLeft(x, -distance)
+         TR::Node *distance = TR::Node::create(node, TR::ineg, 1);
+         distance->setChild(0, node->getSecondChild());
+         node->setAndIncChild(1, distance);
+
+         processIntrinsicFunction(treetop, node, TR::irol);
+
+         break;
+         }
       case TR::java_lang_Long_rotateLeft:
          processIntrinsicFunction(treetop, node, TR::lrol);
          break;
+      case TR::java_lang_Long_rotateRight:
+         {
+         // rotateRight(x, distance) = rotateLeft(x, -distance)
+         TR::Node *distance = TR::Node::create(node, TR::ineg, 1);
+         distance->setChild(0, node->getSecondChild());
+         node->setAndIncChild(1, distance);
+
+         processIntrinsicFunction(treetop, node, TR::lrol);
+
+         break;
+         }
       case TR::java_lang_Math_abs_I:
          processIntrinsicFunction(treetop, node, TR::iabs);
          break;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -367,7 +367,9 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Class_isAssignableFrom:
          return cg()->supportsInliningOfIsAssignableFrom();
       case TR::java_lang_Integer_rotateLeft:
+         return TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isZ() || TR::Compiler->target.cpu.isPower();
       case TR::java_lang_Long_rotateLeft:
+         return TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isZ() || (TR::Compiler->target.cpu.isPower() && TR::Compiler->target.is64Bit());
       case TR::java_lang_Math_abs_I:
       case TR::java_lang_Math_abs_L:
       case TR::java_lang_Math_abs_F:

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -335,11 +335,7 @@ bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::Recognized
       return true;
       }
 
-   if (method == TR::java_lang_Math_abs_F ||
-       method == TR::java_lang_Math_abs_D ||
-       method == TR::java_lang_Math_abs_I ||
-       method == TR::java_lang_Math_abs_L ||
-       method == TR::java_lang_Integer_highestOneBit ||
+   if (method == TR::java_lang_Integer_highestOneBit ||
        method == TR::java_lang_Integer_numberOfLeadingZeros ||
        method == TR::java_lang_Integer_numberOfTrailingZeros ||
        method == TR::java_lang_Long_highestOneBit ||

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -342,7 +342,6 @@ bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::Recognized
        method == TR::java_lang_Integer_highestOneBit ||
        method == TR::java_lang_Integer_numberOfLeadingZeros ||
        method == TR::java_lang_Integer_numberOfTrailingZeros ||
-       method == TR::java_lang_Integer_rotateLeft ||
        method == TR::java_lang_Integer_rotateRight ||
        method == TR::java_lang_Long_highestOneBit ||
        method == TR::java_lang_Long_numberOfLeadingZeros ||
@@ -351,8 +350,7 @@ bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::Recognized
        method == TR::java_lang_Integer_reverseBytes ||
        method == TR::java_lang_Long_reverseBytes ||
        (TR::Compiler->target.is64Bit() &&
-        (method == TR::java_lang_Long_rotateLeft ||
-        method == TR::java_lang_Long_rotateRight)))
+        method == TR::java_lang_Long_rotateRight))
       {
       return true;
       }

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -335,13 +335,7 @@ bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::Recognized
       return true;
       }
 
-   if (method == TR::java_lang_Integer_highestOneBit ||
-       method == TR::java_lang_Integer_numberOfLeadingZeros ||
-       method == TR::java_lang_Integer_numberOfTrailingZeros ||
-       method == TR::java_lang_Long_highestOneBit ||
-       method == TR::java_lang_Long_numberOfLeadingZeros ||
-       method == TR::java_lang_Long_numberOfTrailingZeros ||
-       method == TR::java_lang_Short_reverseBytes ||
+   if (method == TR::java_lang_Short_reverseBytes ||
        method == TR::java_lang_Integer_reverseBytes ||
        method == TR::java_lang_Long_reverseBytes)
       {

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -342,15 +342,12 @@ bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::Recognized
        method == TR::java_lang_Integer_highestOneBit ||
        method == TR::java_lang_Integer_numberOfLeadingZeros ||
        method == TR::java_lang_Integer_numberOfTrailingZeros ||
-       method == TR::java_lang_Integer_rotateRight ||
        method == TR::java_lang_Long_highestOneBit ||
        method == TR::java_lang_Long_numberOfLeadingZeros ||
        method == TR::java_lang_Long_numberOfTrailingZeros ||
        method == TR::java_lang_Short_reverseBytes ||
        method == TR::java_lang_Integer_reverseBytes ||
-       method == TR::java_lang_Long_reverseBytes ||
-       (TR::Compiler->target.is64Bit() &&
-        method == TR::java_lang_Long_rotateRight))
+       method == TR::java_lang_Long_reverseBytes)
       {
       return true;
       }

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -13135,8 +13135,6 @@ static void inlineVSXArrayCopy(TR::Node *node, TR::Register *srcAddrReg, TR::Reg
    generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
    }
 
-extern TR::Register *inlineLongRotateLeft(TR::Node *node, TR::CodeGenerator *cg);
-extern TR::Register *inlineIntegerRotateLeft(TR::Node *node, TR::CodeGenerator *cg);
 extern TR::Register *inlineBigDecimalConstructor(TR::Node *node, TR::CodeGenerator *cg, bool isLong, bool exp);
 extern TR::Register *inlineBigDecimalBinaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, bool scaled);
 extern TR::Register *inlineBigDecimalDivide(TR::Node * node, TR::CodeGenerator *cg);
@@ -13394,18 +13392,6 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       case TR::java_lang_Long_highestOneBit:
          resultReg = inlineLongHighestOneBit(node, cg);
          return true;
-
-      case TR::java_lang_Integer_rotateLeft:
-         resultReg = inlineIntegerRotateLeft(node, cg);
-         return true;
-
-      case TR::java_lang_Long_rotateLeft:
-         if (TR::Compiler->target.is64Bit())
-            {
-            resultReg = inlineLongRotateLeft(node, cg);
-            return true;
-            }
-         break;
 
       case TR::java_lang_Integer_rotateRight:
          resultReg = inlineIntegerRotateRight(node, cg);


### PR DESCRIPTION
Previously, the Power codegen had code to handle inlining of the following recognized methods that can be handled during optimization/ilgen:

- `Math.abs`
- `{Integer,Long}.rotateLeft`
- `{Integer,Long}.rotateRight`
- `{Integer,Long}.highestOneBit`
- `{Integer,Long}.numberOfLeadingZeros`
- `{Integer,Long}.numberOfTrailingZeros`

For all but `rotateRight`, there was existing code that could perform the necessary transformations on the IL which has been enabled on Power if necessary. For `rotateRight`, a new transformation was added to `J9RecognizedCallTransformer` that implements this function in terms of `irol`/`lrol` as we do not have an opcode for rotating to the right.

As a result of this, the code for handling these recognized methods in the Power codegen is now dead and has been removed.