### PR TITLE
Update uses of getExistingJittedBodyInfo()

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -42,6 +42,7 @@
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/jittypes.h"
+#include "env/j9method.h"
 #include "il/Block.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -1197,8 +1198,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
                methodSymbol->getResolvedMethodSymbol() &&
                methodSymbol->getResolvedMethodSymbol()->getResolvedMethod())
             {
-            void * methodAddress = methodSymbol->getResolvedMethodSymbol()->getResolvedMethod()->startAddressForInterpreterOfJittedMethod();
-            TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(methodAddress);
+            TR_PersistentJittedBodyInfo * bodyInfo = ((TR_ResolvedJ9Method*) methodSymbol->getResolvedMethodSymbol()->getResolvedMethod())->getExistingJittedBodyInfo();
             //printf("Pushing node %p\n", node);
             //fflush(stdout);
             if (bodyInfo &&

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7271,19 +7271,8 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
         sc->addHint(that->_methodBeingCompiled->getMethodDetails().getMethod(), TR_HintDLT);
       }
 
-   if (that->_methodBeingCompiled->_optimizationPlan->isUpgradeRecompilation())
-      {
-      TR_ASSERT(that->_methodBeingCompiled->_oldStartPC, "upgrade recompilations must have some oldstartpc");
-      TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(that->_methodBeingCompiled->_oldStartPC);
-      if (bodyInfo->getIsAotedBody() || bodyInfo->getHotness() <= cold)
-         {
-         TR_J9SharedCache *sc = (TR_J9SharedCache *) (vm->sharedCache());
-         if (sc)
-            sc->addHint(that->_methodBeingCompiled->getMethodDetails().getMethod(), TR_HintUpgrade);
-         }
-      }
-
    that->setMetadata(NULL);
+
    try
       {
       InterruptibleOperation generatingCompilationObject(*that);
@@ -7304,6 +7293,19 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
       else
          {
          compilee = vm->createResolvedMethod(p->trMemory(), method);
+         }
+
+      if (that->_methodBeingCompiled->_optimizationPlan->isUpgradeRecompilation())
+         {
+         // TR_ASSERT(that->_methodBeingCompiled->_oldStartPC, "upgrade recompilations must have some oldstartpc");
+         // In JITServer mode, it doesn't have to.
+         TR_PersistentJittedBodyInfo *bodyInfo = ((TR_ResolvedJ9Method*)compilee)->getExistingJittedBodyInfo();
+         if (bodyInfo->getIsAotedBody() || bodyInfo->getHotness() <= cold)
+            {
+            TR_J9SharedCache *sc = (TR_J9SharedCache *) (vm->sharedCache());
+            if (sc)
+               sc->addHint(that->_methodBeingCompiled->getMethodDetails().getMethod(), TR_HintUpgrade);
+            }
          }
 
       // See if this method can be compiled and check it against the method

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -608,8 +608,7 @@ TR_PersistentMethodInfo::get(TR_ResolvedMethod * feMethod)
    if (feMethod->isInterpreted() || feMethod->isJITInternalNative())
       return 0;
 
-   void *startPC = (void *)feMethod->startAddressForInterpreterOfJittedMethod();
-   TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(startPC);
+   TR_PersistentJittedBodyInfo *bodyInfo = ((TR_ResolvedJ9Method*) feMethod)->getExistingJittedBodyInfo();
    return bodyInfo ? bodyInfo->getMethodInfo() : 0;
    }
 

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -37,6 +37,7 @@
 #include "env/PersistentCHTable.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/jittypes.h"
+#include "env/j9method.h"
 #include "env/ClassTableCriticalSection.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
@@ -819,8 +820,7 @@ bool CollectCompiledImplementors::visitSubclass(TR_PersistentClassInfo *cl)
             }
          else
             {
-            void *methodAddress = (_implArray[_count - 1])->startAddressForInterpreterOfJittedMethod();
-            TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(methodAddress);
+            TR_PersistentJittedBodyInfo * bodyInfo = ((TR_ResolvedJ9Method*) _implArray[_count - 1])->getExistingJittedBodyInfo();
             if (!bodyInfo || bodyInfo->getHotness() < _hotness)
                {
                _count -= 1;

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -3037,8 +3037,7 @@ TR_MultipleCallTargetInliner::walkCallSites(TR::ResolvedMethodSymbol * callerSym
                         {
                         if (TR::Compiler->mtd.isCompiledMethod(callsite->getTarget(i)->_calleeSymbol->getResolvedMethod()->getPersistentIdentifier()))
                            {
-                           void * methodAddress = callsite->getTarget(i)->_calleeSymbol->getResolvedMethodSymbol()->getResolvedMethod()->startAddressForInterpreterOfJittedMethod();
-                           TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(methodAddress);
+                           TR_PersistentJittedBodyInfo * bodyInfo = ((TR_ResolvedJ9Method*) callsite->getTarget(i)->_calleeSymbol->getResolvedMethodSymbol()->getResolvedMethod())->getExistingJittedBodyInfo();
                            if (bodyInfo &&
                                bodyInfo->getHotness() < warm &&
                                !bodyInfo->getIsProfilingBody())
@@ -4118,8 +4117,7 @@ bool TR_MultipleCallTargetInliner::isLargeCompiledMethod(TR_ResolvedMethod *call
    TR_OpaqueMethodBlock* methodCallee = calleeResolvedMethod->getPersistentIdentifier();
    if (!calleeResolvedMethod->isInterpreted())
       {
-      void * methodAddress = calleeResolvedMethod->startAddressForInterpreterOfJittedMethod();
-      TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(methodAddress);
+      TR_PersistentJittedBodyInfo * bodyInfo = ((TR_ResolvedJ9Method*) calleeResolvedMethod)->getExistingJittedBodyInfo();
       if ((comp()->getMethodHotness() <= warm))
          {
          if (bodyInfo &&
@@ -4202,8 +4200,7 @@ TR_MultipleCallTargetInliner::exceedsSizeThreshold(TR_CallSite *callSite, int by
       TR_PersistentJittedBodyInfo *bodyInfo = NULL;
       if (!calleeResolvedMethod->isInterpretedForHeuristics() && !calleeResolvedMethod->isJITInternalNative())
          {
-         void *startPC = (void *)calleeResolvedMethod->startAddressForInterpreterOfJittedMethod();
-         bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(startPC);
+         bodyInfo = ((TR_ResolvedJ9Method*) calleeResolvedMethod)->getExistingJittedBodyInfo();
          }
       if (((!bodyInfo && !calleeResolvedMethod->isInterpretedForHeuristics() && !calleeResolvedMethod->isJITInternalNative()) //jitted method without bodyInfo must be scorching
          || (bodyInfo && bodyInfo->getHotness() == scorching)

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -31,6 +31,7 @@
 #include "compile/ResolvedMethod.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
+#include "env/j9method.h"
 #include "env/VMJ9.h"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -71,9 +72,8 @@ TR_PersistentMethodInfo *TR_X86Recompilation::getExistingMethodInfo(TR_ResolvedM
    // start PC address. The mechanism is different depending on whether the
    // method was compiled for sampling or counting.
    //
-   void *startPC = method->startAddressForInterpreterOfJittedMethod();
-   TR_PersistentMethodInfo *info = getMethodInfoFromPC(startPC);
-   return info;
+   TR_PersistentJittedBodyInfo *bodyInfo = ((TR_ResolvedJ9Method*) method)->getExistingJittedBodyInfo();
+   return bodyInfo ? bodyInfo->getMethodInfo() : NULL;
    }
 
 TR::Instruction *TR_X86Recompilation::generatePrePrologue()

--- a/runtime/compiler/z/codegen/S390Recompilation.cpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.cpp
@@ -30,6 +30,7 @@
 #include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
+#include "env/j9method.h"
 #include "env/VMJ9.h"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -59,19 +60,8 @@ TR_S390Recompilation::getExistingMethodInfo(TR_ResolvedMethod * method)
    // start PC address. The mechanism is different depending on whether the
    // method was compiled for sampling or counting.
    //
-   char * startPC = (char *) method->startAddressForInterpreterOfJittedMethod();
-   if (NULL == startPC)
-      {
-      return NULL;
-      }
-   // need to pass in StartPC, which is the entry point of the interpreter ie includes the loads
-   TR_PersistentMethodInfo *info = getMethodInfoFromPC(startPC);
-   if (debug("traceRecompilation"))
-      {
-      //diagnostic("RC>>Recompiling %s at level %d\n", signature(_compilation->getCurrentMethod()), info->getHotness());
-      }
-
-   return info;
+   TR_PersistentJittedBodyInfo *bodyInfo = ((TR_ResolvedJ9Method*) method)->getExistingJittedBodyInfo();
+   return bodyInfo ? bodyInfo->getMethodInfo() : NULL;
    }
 
 TR_S390Recompilation::TR_S390Recompilation(TR::Compilation * comp)


### PR DESCRIPTION
- a follow-up PR to #7044 
- #7044 introduced `getExistingJittedBodyInfo()` and this PR updates all the uses of it.
- essentially some minor refactoring

Signed-off-by: Harry Yu <harryyu1994@gmail.com>