### PR TITLE
Set custom SecurityManager constructor accessible flag

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -281,7 +281,9 @@ public abstract class ClassLoader {
 				System.setSecurityManager(new SecurityManager());
 			} else {
 				try {
-					System.setSecurityManager((SecurityManager)Class.forName(javaSecurityManager, true, applicationClassLoader).getDeclaredConstructor().newInstance());
+					Constructor<?> constructor = Class.forName(javaSecurityManager, true, applicationClassLoader).getConstructor();
+					constructor.setAccessible(true);
+					System.setSecurityManager((SecurityManager)constructor.newInstance());
 				} catch (Throwable e) {
 					/*[MSG "K0631", "JVM can't set custom SecurityManager due to {0}"]*/
 					throw new Error(com.ibm.oti.util.Msg.getString("K0631", e.toString()), e); //$NON-NLS-1$

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_System.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_System.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -374,6 +374,36 @@ public class Test_System {
 		}
 	}
 
+	/**
+	 * @tests java.lang.System#setSecurityManager(java.lang.SecurityManager)
+	 */
+	@Test
+	public void test_setSecurityManager3() {
+		/* https://github.com/eclipse/openj9/issues/6661 */
+		try {
+			String helperName = "org.openj9.test.java.lang.Test_System$TestSecurityManagerNonPublicConstructor";
+			String output = Support_Exec.execJava(new String[] { "-Djava.security.manager=" + helperName, helperName },
+					null, true,
+					"java.lang.NoSuchMethodException: org.openj9.test.java.lang.Test_System$TestSecurityManagerNonPublicConstructor.<init>()");
+			// if the expected error string was not found, Assert.fail() will be invoked
+			// within Support_Exec.execJava() above.
+		} catch (Exception e) {
+			Assert.fail("Unexpected: " + e);
+		}
+	}
+
+	/**
+	 * @tests java.lang.System#setSecurityManager(java.lang.SecurityManager)
+	 */
+	public static class TestSecurityManagerNonPublicConstructor extends SecurityManager {
+		TestSecurityManagerNonPublicConstructor() {
+		}
+
+		public static void main(String[] args) {
+			System.out.println(System.getSecurityManager().getClass().getName());
+		}
+	}
+	
 	/**
 	 * Sets up the fixture, for example, open a network connection. This method
 	 * is called before a test is executed.


### PR DESCRIPTION
**Set custom SecurityManager constructor accessible flag**

The constructor for custom `SecurityManager` must set its accessible flag to `true` to suppress access checking, otherwise an `IllegalAccessException` is thrown when invoking `constructor.newInstance()`.
Changed `getConstructor()` to `getDeclaredConstructor()` to only allow instantiation of custom `SecurityManger` with a `public constructor` just like `RI`.
Added a test to ensure that `NoSuchMethodException` is thrown at `getConstructor()` when loading a custom `SecurityManger` with a `non-public constructor`.

Verified that this PR passes the test at https://github.com/eclipse/openj9/issues/6661

closes: #6661 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>