### PR TITLE
Work around compiler bug when reading SCC hints

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -260,7 +260,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
 
       const uint32_t scHintDataLength = sizeof(scHintData);
 
-      if (*hintFlags == 0) // If no prior hints exist, we can perform a "storeAttachedData" operation
+      if (scHintData == 0) // If no prior hints exist, we can perform a "storeAttachedData" operation
          {
          uint32_t bytesToPersist = 0;
 


### PR DESCRIPTION
XL C++ 13.1.3 on AIX generates incorrect code for the line in question.

The stack location containing the hint we fetch from the SCC is read and
tested for ==0 before it is written to, so we intermittently take the wrong
path and try to update a non-existent hint, which fails.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>

Building OpenJ9 with this patch and disassembling the JIT shows that the compiler now generates the correct sequence of instructions.

Fixes: #7045