### PR TITLE
Skip Pre- and PostEscapeAnalysis if EA is not enabled

### DIFF
--- a/runtime/compiler/optimizer/PostEscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/PostEscapeAnalysis.cpp
@@ -31,6 +31,15 @@
 
 int32_t TR_PostEscapeAnalysis::perform()
    {
+   if (!optimizer()->isEnabled(OMR::escapeAnalysis))
+      {
+      if (comp()->trace(OMR::escapeAnalysis))
+         {
+         traceMsg(comp(), "EscapeAnalysis is disabled - skipping Post-EscapeAnalysis\n");
+         }
+      return 0;
+      }
+
    if (comp()->getOSRMode() != TR::voluntaryOSR)
       {
       if (comp()->trace(OMR::escapeAnalysis))

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
@@ -32,6 +32,15 @@
 
 int32_t TR_PreEscapeAnalysis::perform()
    {
+   if (!optimizer()->isEnabled(OMR::escapeAnalysis))
+      {
+      if (comp()->trace(OMR::escapeAnalysis))
+         {
+         traceMsg(comp(), "EscapeAnalysis is disabled - skipping Pre-EscapeAnalysis\n");
+         }
+      return 0;
+      }
+
    if (comp()->getOSRMode() != TR::voluntaryOSR)
       {
       if (comp()->trace(OMR::escapeAnalysis))


### PR DESCRIPTION
The `PreEscapeAnalysis` and `PostEscapeAnalysis` optimization passes are designed so that `PreEscapeAnalysis` inserts extra information into the trees for the use of EscapeAnalysis (EA), and then `PostEscapeAnalysis` undoes the modifications of PreEscapeAnalysis.  If EA does not run, the effect of running `PreEscapeAnalysis` and `PostEscapeAnalysis` is a no-op.

This change skips performing `PreEscapeAnalysis` and `PostEscapeAnalysis` if EA itself is not enabled.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>