### PR TITLE
Wrapped job creation to reduce ConcurrentModificationException

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1044,8 +1044,15 @@ def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType, id){
     params.put('DISCARDER_NUM_BUILDS', DISCARDER_NUM_BUILDS)
 
     def templatePath = 'buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy'
-
-    create = jobDsl targets: templatePath, ignoreExisting: false, additionalParameters: params
+    ret = false    
+    retry(3) {
+       if (ret) {
+          sleep time: 120,unit: 'SECONDS'
+       } else {
+          ret = true
+       }
+       jobDsl targets: templatePath, ignoreExisting: false, additionalParameters: params
+    }
 }
 
 def set_misc_variables() {


### PR DESCRIPTION
Added a retry block to reduce ConcurrentModificationException, and
deleted the create variable to save memory.

[skip ci]

Signed-off-by: Jenny Chen <Jenny.Chen@ibm.com>