### PR TITLE
Fix incorrect JITSERVER_SUPPORT guard

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5447,14 +5447,12 @@ TR_ResolvedJ9Method::startAddressForJITInternalNativeMethod()
    return startAddressForJittedMethod();
    }
 
-#if defined(JITSERVER_SUPPORT)
 TR_PersistentJittedBodyInfo *
 TR_ResolvedJ9Method::getExistingJittedBodyInfo()
    {
    void *methodAddress = startAddressForInterpreterOfJittedMethod();
    return TR::Recompilation::getJittedBodyInfoFromPC(methodAddress);
    }
-#endif
 
 int32_t
 TR_ResolvedJ9Method::virtualCallSelector(U_32 cpIndex)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -490,9 +490,7 @@ public:
 
    virtual bool owningMethodDoesntMatter();
    virtual bool isMethodInValidLibrary();
-#if defined(JITSERVER_SUPPORT)
    virtual TR_PersistentJittedBodyInfo *getExistingJittedBodyInfo();
-#endif
 
    static bool isInvokePrivateVTableOffset(UDATA vTableOffset);
 


### PR DESCRIPTION
`getExistingJittedBodyInfo()` should not be guarded with JITSERVER_SUPPORT as it is also used by mainline code.
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>