### PR TITLE
Fixes for -XX:+ClassRelationshipVerifier implementation

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -2731,8 +2731,9 @@ j9bcv_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved)
 				if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_XFUTURE)) {
 					loadInfo->fatalErrorStr = "-XX:+ClassRelationshipVerifier cannot be used if -Xfuture or if -Xverify:all is enabled";
 					returnVal = J9VMDLLMAIN_FAILED;
+				} else {
+					vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_CLASS_RELATIONSHIP_VERIFIER;
 				}
-				vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_CLASS_RELATIONSHIP_VERIFIER;
 			}
 
 			break;

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -386,11 +386,6 @@ doVerify:
 						setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_CLASS_RELATIONSHIP_INVALID, J9VMCONSTANTPOOL_JAVALANGVERIFYERROR, clazzNameLength, clazzName, resultNameLength, resultName);
 					}
 				}
-				if (VM_VMHelpers::exceptionPending(currentThread)) {
-					initializationLock = setInitStatus(currentThread, clazz, J9ClassInitUnverified, initializationLock);
-					clazz = VM_VMHelpers::currentClass(clazz);
-					goto done;
-				}
 				initializationLock = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 				clazz = VM_VMHelpers::currentClass(clazz);
 				if (VM_VMHelpers::exceptionPending(currentThread)) {


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/7140

- Remove redundant exception check causing intermittent failures

   - Intermittent test failures were occurring due to the use of `initializationLock` in the exception check. If gc occurs and the lock is not updated (pushed/popped properly), then the lock may be bogus. `setInitStatus()` would then attempt to use the bogus lock, causing a segmentation fault.
- Set class relationships runtime flag only if -Xfuture is not used

Related to #7089