### PR TITLE
Adding `libexpat1-dev` package to dependency list

### DIFF
--- a/buildenv/docker/test/Dockerfile
+++ b/buildenv/docker/test/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update \
     build-essential \
     perl \
     vim \
-    libexpat1-dev \
+    libexpat1-dev \ # should be removed once the switch to TestKitGen java is complete and the builds are stabilized.
   && rm -rf /var/lib/apt/lists/*
 
 # Install Docker module to run test framework

--- a/buildenv/docker/test/Dockerfile
+++ b/buildenv/docker/test/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update \
     build-essential \
     perl \
     vim \
+    libexpat1-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Docker module to run test framework


### PR DESCRIPTION
Adding `libexpat1-dev` package to dependency list to fix the error that the docker build will fail in ```RUN echo yes | cpan install JSON Text::CSV XML::Parser``` for being unable to find `expat.h` file when the base Docker image is using Ubuntu16 Dockerfile.

Signed-off-by: simonameng <simonameng97@gmail.com>