### PR TITLE
Enable Ownable Synchronizers tracking for Concurrent Scavenger

### DIFF
--- a/runtime/gc_api/HeapIteratorAPI.cpp
+++ b/runtime/gc_api/HeapIteratorAPI.cpp
@@ -496,7 +496,7 @@ j9mm_iterate_all_ownable_synchronizer_objects(J9VMThread *vmThread, J9PortLibrar
 	J9JavaVM *javaVM = vmThread->javaVM;
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(javaVM->omrVM);
 	MM_ObjectAccessBarrier *barrier = extensions->accessBarrier;
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = extensions->ownableSynchronizerObjectLists;
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = extensions->getOwnableSynchronizerObjectListsExternal(vmThread);
 
 	Assert_MM_true(NULL != ownableSynchronizerObjectList);
 

--- a/runtime/gc_api/HeapRootScanner.cpp
+++ b/runtime/gc_api/HeapRootScanner.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -466,7 +466,7 @@ MM_HeapRootScanner::scanOwnableSynchronizerObjects()
 	setReachability(RootScannerEntityReachability_Weak);
 
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->ownableSynchronizerObjectLists;
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->getOwnableSynchronizerObjectLists();
 
 	while(NULL != ownableSynchronizerObjectList) {
 		J9Object *objectPtr = ownableSynchronizerObjectList->getHeadOfList();

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -36,6 +36,7 @@
 #if defined(J9VM_GC_IDLE_HEAP_MANAGER)
  #include  "IdleGCManager.hpp"
 #endif /* defined(J9VM_GC_IDLE_HEAP_MANAGER) */
+#include "MemorySpace.hpp"
 #include "MemorySubSpace.hpp"
 #include "ObjectModel.hpp"
 #include "ReferenceChainWalkerMarkMap.hpp"
@@ -266,4 +267,15 @@ MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
 #endif /* OMR_ENV_DATA64 */
 
 	memoryMax = MM_Math::roundToFloor(heapAlignment, memoryMax);
+}
+
+MM_OwnableSynchronizerObjectList *
+MM_GCExtensions::getOwnableSynchronizerObjectListsExternal(J9VMThread *vmThread)
+{
+	if (isConcurrentScavengerInProgress()) {
+		MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+		((MM_MemorySpace *)vmThread->omrVMThread->memorySpace)->localGarbageCollect(env, J9MMCONSTANT_IMPLICIT_GC_COMPLETE_CONCURRENT);
+	}
+
+	return ownableSynchronizerObjectLists;
 }

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,8 @@ class MM_IdleGCManager;
  * @ingroup GC_Base
  */
 class MM_GCExtensions : public MM_GCExtensionsBase {
+private:
+	MM_OwnableSynchronizerObjectList* ownableSynchronizerObjectLists; /**< The global linked list of ownable synchronizer object lists. */
 public:
 	MM_StringTable* stringTable; /**< top level String Table structure (internally organized as a set of hash sub-tables */
 
@@ -150,8 +152,7 @@ public:
 
 
 	MM_UnfinalizedObjectList* unfinalizedObjectLists; /**< The global linked list of unfinalized object lists. */
-	MM_OwnableSynchronizerObjectList* ownableSynchronizerObjectLists; /**< The global linked list of ownable synchronizer object lists. */
-
+	
 	UDATA objectListFragmentCount; /**< the size of Local Object Buffer(per gc thread), used by referenceObjectBuffer, UnfinalizedObjectBuffer and OwnableSynchronizerObjectBuffer */
 
 	MM_Wildcard* numaCommonThreadClassNamePatterns; /**< A linked list of thread class names which should be associated with the common context */
@@ -261,12 +262,23 @@ public:
 	static MM_GCExtensions* getExtensions(MM_EnvironmentBase* env) { return getExtensions(env->getExtensions()); }
 
 	MMINLINE J9JavaVM* getJavaVM() {return static_cast<J9JavaVM*>(_omrVM->_language_vm);}
+	
+	/**
+	 * Return ownable synchronizer object lists by first ensuring that the lists are in a consistent state (e.g., during concurrent gc).
+	 * This should be used by any external consumer (non-GC consuming the list)     
+	 * @param vmThread The current J9VMThread thread (used to invoke j9gc apis if required)
+	 * @return Linked list of ownable synchronizer objects
+	 */
+	MM_OwnableSynchronizerObjectList* getOwnableSynchronizerObjectListsExternal(J9VMThread *vmThread);
+	MMINLINE MM_OwnableSynchronizerObjectList* getOwnableSynchronizerObjectLists() { return ownableSynchronizerObjectLists; }
+	MMINLINE void setOwnableSynchronizerObjectLists(MM_OwnableSynchronizerObjectList* newOwnableSynchronizerObjectLists) { ownableSynchronizerObjectLists = newOwnableSynchronizerObjectLists; }
 
 	/**
 	 * Create a GCExtensions object
 	 */
 	MM_GCExtensions()
 		: MM_GCExtensionsBase()
+		, ownableSynchronizerObjectLists(NULL)
 		, stringTable(NULL)
 		, gcchkExtensions(NULL)
 		, tgcExtensions(NULL)
@@ -292,7 +304,6 @@ public:
 		, deadClassLoaderCacheSize(1024 * 1024) /* default is one MiB */
 #endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
 		, unfinalizedObjectLists(NULL)
-		, ownableSynchronizerObjectLists(NULL)
 		, objectListFragmentCount(0)
 		, numaCommonThreadClassNamePatterns(NULL)
 		, stringDedupPolicy(J9_JIT_STRING_DEDUP_POLICY_UNDEFINED)

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -713,7 +713,7 @@ MM_RootScanner::scanOwnableSynchronizerObjects(MM_EnvironmentBase *env)
 	reportScanningStarted(RootScannerEntity_OwnableSynchronizerObjects);
 
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->ownableSynchronizerObjectLists;
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->getOwnableSynchronizerObjectLists();
 	while(NULL != ownableSynchronizerObjectList) {
 		if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			J9Object *objectPtr = ownableSynchronizerObjectList->getHeadOfList();

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -96,7 +96,7 @@ j9gc_modron_local_collect(J9VMThread *vmThread)
 {
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
 
-	((MM_MemorySpace *)vmThread->omrVMThread->memorySpace)->localGarbageCollect(env);
+	((MM_MemorySpace *)vmThread->omrVMThread->memorySpace)->localGarbageCollect(env, J9MMCONSTANT_IMPLICIT_GC_DEFAULT);
 
 	return 0;
 }
@@ -659,6 +659,9 @@ j9gc_get_gc_cause(OMR_VMThread *omrVMthread)
 			ret = "collect due to JVM becomes idle";
 			break;
 #endif
+		case J9MMCONSTANT_IMPLICIT_GC_COMPLETE_CONCURRENT :
+			ret = "concurrent collection must be completed";
+			break;
 		case J9MMCONSTANT_IMPLICIT_GC_PERCOLATE_CRITICAL_REGIONS :
 		default :
 			ret = "unknown";

--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -104,13 +104,11 @@ GC_CheckEngine::verifyOwnableSynchronizerObjectCounts()
 {
 	bool ret = true;
 
-	if (!MM_GCExtensions::getExtensions(_javaVM)->isConcurrentScavengerEnabled()) {
-		if ((UNINITIALIZED_SIZE_FOR_OWNABLESYNCHRONIER != _ownableSynchronizerObjectCountOnList) && (UNINITIALIZED_SIZE_FOR_OWNABLESYNCHRONIER != _ownableSynchronizerObjectCountOnHeap)) {
-			if (_ownableSynchronizerObjectCountOnList != _ownableSynchronizerObjectCountOnHeap) {
-				PORT_ACCESS_FROM_PORT(_portLibrary);
-				j9tty_printf(PORTLIB, "  <gc check: found count=%zu of OwnableSynchronizerObjects on Heap doesn't match count=%zu on lists>\n", _ownableSynchronizerObjectCountOnHeap, _ownableSynchronizerObjectCountOnList);
-				ret = false;
-			}
+	if ((UNINITIALIZED_SIZE_FOR_OWNABLESYNCHRONIER != _ownableSynchronizerObjectCountOnList) && (UNINITIALIZED_SIZE_FOR_OWNABLESYNCHRONIER != _ownableSynchronizerObjectCountOnHeap)) {
+		if (_ownableSynchronizerObjectCountOnList != _ownableSynchronizerObjectCountOnHeap) {
+			PORT_ACCESS_FROM_PORT(_portLibrary);
+			j9tty_printf(PORTLIB, "  <gc check: found count=%zu of OwnableSynchronizerObjects on Heap doesn't match count=%zu on lists>\n", _ownableSynchronizerObjectCountOnHeap, _ownableSynchronizerObjectCountOnList);
+			ret = false;
 		}
 	}
 
@@ -1066,15 +1064,13 @@ GC_CheckEngine::checkObjectHeap(J9JavaVM *javaVM, J9MM_IterateObjectDescriptor *
 		result = userData.result;
 	}
 
-	if (!extensions->isConcurrentScavengerEnabled()) {
-		/* check Ownable Synchronizer Object consistency */
-		if ((OBJECT_HEADER_SHAPE_MIXED == J9GC_CLASS_SHAPE(clazz)) && (0 != (J9CLASS_FLAGS(clazz) & J9AccClassOwnableSynchronizer))) {
-			if (NULL == extensions->accessBarrier->isObjectInOwnableSynchronizerList(objectDesc->object)) {
-				PORT_ACCESS_FROM_PORT(_portLibrary);
-				j9tty_printf(PORTLIB, "  <gc check: found Ownable SynchronizerObject %p is not on the list >\n", objectDesc->object);
-			} else {
-				_ownableSynchronizerObjectCountOnHeap += 1;
-			}
+	/* check Ownable Synchronizer Object consistency */
+	if ((OBJECT_HEADER_SHAPE_MIXED == J9GC_CLASS_SHAPE(clazz)) && (0 != (J9CLASS_FLAGS(clazz) & J9AccClassOwnableSynchronizer))) {
+		if (NULL == extensions->accessBarrier->isObjectInOwnableSynchronizerList(objectDesc->object)) {
+			PORT_ACCESS_FROM_PORT(_portLibrary);
+			j9tty_printf(PORTLIB, "  <gc check: found Ownable SynchronizerObject %p is not on the list >\n", objectDesc->object);
+		} else {
+			_ownableSynchronizerObjectCountOnHeap += 1;
 		}
 	}
 

--- a/runtime/gc_check/CheckOwnableSynchronizerList.cpp
+++ b/runtime/gc_check/CheckOwnableSynchronizerList.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ void
 GC_CheckOwnableSynchronizerList::check()
 {
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->ownableSynchronizerObjectLists;
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->getOwnableSynchronizerObjectLists();
 
 	MM_HeapRegionManager* heapRegionManager = _extensions->heapRegionManager;
 	UDATA maximumOwnableSynchronizerCountOnHeap = heapRegionManager->getTotalHeapSizeInBytes()/J9_GC_MINIMUM_OBJECT_SIZE;
@@ -84,7 +84,7 @@ void
 GC_CheckOwnableSynchronizerList::print()
 {
 	MM_ObjectAccessBarrier *barrier = _extensions->accessBarrier;
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->ownableSynchronizerObjectLists;
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = _extensions->getOwnableSynchronizerObjectLists();
 
 	GC_ScanFormatter formatter(_portLibrary, "ownableSynchronizerObjectList");
 	while(NULL != ownableSynchronizerObjectList) {

--- a/runtime/gc_glue_java/ConfigurationDelegate.hpp
+++ b/runtime/gc_glue_java/ConfigurationDelegate.hpp
@@ -193,12 +193,12 @@ public:
 				extensions->unfinalizedObjectLists = &regionExtension->_unfinalizedObjectLists[list];
 
 				new(&regionExtension->_ownableSynchronizerObjectLists[list]) MM_OwnableSynchronizerObjectList();
-				regionExtension->_ownableSynchronizerObjectLists[list].setNextList(extensions->ownableSynchronizerObjectLists);
+				regionExtension->_ownableSynchronizerObjectLists[list].setNextList(extensions->getOwnableSynchronizerObjectLists());
 				regionExtension->_ownableSynchronizerObjectLists[list].setPreviousList(NULL);
-				if (NULL != extensions->ownableSynchronizerObjectLists) {
-					extensions->ownableSynchronizerObjectLists->setPreviousList(&regionExtension->_ownableSynchronizerObjectLists[list]);
+				if (NULL != extensions->getOwnableSynchronizerObjectLists()) {
+					extensions->getOwnableSynchronizerObjectLists()->setPreviousList(&regionExtension->_ownableSynchronizerObjectLists[list]);
 				}
-				extensions->ownableSynchronizerObjectLists = &regionExtension->_ownableSynchronizerObjectLists[list];
+				extensions->setOwnableSynchronizerObjectLists(&regionExtension->_ownableSynchronizerObjectLists[list]);
 
 				new(&regionExtension->_referenceObjectLists[list]) MM_ReferenceObjectList();
 			}

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -260,7 +260,7 @@ MM_MetronomeDelegate::allocateAndInitializeOwnableSynchronizerObjectLists(MM_Env
 		ownableSynchronizerObjectLists[index].setNextList(nextOwnableSynchronizerObjectList);
 		ownableSynchronizerObjectLists[index].setPreviousList(previousOwnableSynchronizerObjectList);
 	}
-	_extensions->ownableSynchronizerObjectLists = ownableSynchronizerObjectLists;
+	_extensions->setOwnableSynchronizerObjectLists(ownableSynchronizerObjectLists);
 	return true;
 }
 
@@ -277,9 +277,9 @@ MM_MetronomeDelegate::tearDown(MM_EnvironmentBase *env)
 		_extensions->unfinalizedObjectLists = NULL;
 	}
 
-	if (NULL != _extensions->ownableSynchronizerObjectLists) {
-		env->getForge()->free(_extensions->ownableSynchronizerObjectLists);
-		_extensions->ownableSynchronizerObjectLists = NULL;
+	if (NULL != _extensions->getOwnableSynchronizerObjectLists()) {
+		env->getForge()->free(_extensions->getOwnableSynchronizerObjectLists());
+		_extensions->setOwnableSynchronizerObjectLists(NULL);
 	}
 	
 	if (NULL != _extensions->accessBarrier) {
@@ -1219,7 +1219,7 @@ MM_MetronomeDelegate::scanOwnableSynchronizerObjects(MM_EnvironmentRealtime *env
 		GC_OMRVMInterface::flushNonAllocationCaches(env);
 		UDATA listIndex;
 		for (listIndex = 0; listIndex < maxIndex; ++listIndex) {
-			MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = &_extensions->ownableSynchronizerObjectLists[listIndex];
+			MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = &_extensions->getOwnableSynchronizerObjectLists()[listIndex];
 			ownableSynchronizerObjectList->startOwnableSynchronizerProcessing();
 		}
 		env->_currentTask->releaseSynchronizedGCThreads(env);
@@ -1229,7 +1229,7 @@ MM_MetronomeDelegate::scanOwnableSynchronizerObjects(MM_EnvironmentRealtime *env
 	MM_OwnableSynchronizerObjectBuffer *buffer = gcEnv->_ownableSynchronizerObjectBuffer;
 	UDATA listIndex;
 	for (listIndex = 0; listIndex < maxIndex; ++listIndex) {
-		MM_OwnableSynchronizerObjectList *list = &_extensions->ownableSynchronizerObjectLists[listIndex];
+		MM_OwnableSynchronizerObjectList *list = &_extensions->getOwnableSynchronizerObjectLists()[listIndex];
 		if (!list->wasEmpty()) {
 			if (J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 				J9Object *object = list->getPriorList();

--- a/runtime/gc_realtime/OwnableSynchronizerObjectBufferRealtime.cpp
+++ b/runtime/gc_realtime/OwnableSynchronizerObjectBufferRealtime.cpp
@@ -71,7 +71,7 @@ void
 MM_OwnableSynchronizerObjectBufferRealtime::flushImpl(MM_EnvironmentBase* env)
 {
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = &extensions->ownableSynchronizerObjectLists[_ownableSynchronizerObjectListIndex];
+	MM_OwnableSynchronizerObjectList *ownableSynchronizerObjectList = &extensions->getOwnableSynchronizerObjectLists()[_ownableSynchronizerObjectListIndex];
 	ownableSynchronizerObjectList->addAll(env, _head, _tail);
 	_ownableSynchronizerObjectListIndex += 1;
 	if (extensions->realtimeGC->getRealtimeDelegate()->getOwnableSynchronizerObjectListCount(env) == _ownableSynchronizerObjectListIndex) {

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,12 +100,12 @@ MM_HeapRegionDescriptorVLHGC::initialize(MM_EnvironmentBase *env, MM_HeapRegionM
 	extensions->unfinalizedObjectLists = &_unfinalizedObjectList;
 
 	/* add our ownable synchronizer list to the global list (no locking - assumes single threaded initialization) */
-	_ownableSynchronizerObjectList.setNextList(extensions->ownableSynchronizerObjectLists);
+	_ownableSynchronizerObjectList.setNextList(extensions->getOwnableSynchronizerObjectLists());
 	_ownableSynchronizerObjectList.setPreviousList(NULL);
-	if (NULL != extensions->ownableSynchronizerObjectLists) {
-		extensions->ownableSynchronizerObjectLists->setPreviousList(&_ownableSynchronizerObjectList);
+	if (NULL != extensions->getOwnableSynchronizerObjectLists()) {
+		extensions->getOwnableSynchronizerObjectLists()->setPreviousList(&_ownableSynchronizerObjectList);
 	}
-	extensions->ownableSynchronizerObjectLists = &_ownableSynchronizerObjectList;
+	extensions->setOwnableSynchronizerObjectLists(&_ownableSynchronizerObjectList);
 	
 	return true;
 }
@@ -128,7 +128,7 @@ MM_HeapRegionDescriptorVLHGC::tearDown(MM_EnvironmentBase *env)
 
 	_rememberedSetCardList.tearDown(extensions);
 	extensions->unfinalizedObjectLists = NULL;
-	extensions->ownableSynchronizerObjectLists = NULL;
+	extensions->setOwnableSynchronizerObjectLists(NULL);
 
 	MM_HeapRegionDescriptor::tearDown(env);
 }


### PR DESCRIPTION
Ownable sync lists used to track objects are left in an inconsistent state during concurrent phases, for this reason tracking ownable sync objects had been disabled for concurrent scavenger. Consequently, apis such as mxBean dumpAllThreads and getThreadInfo didn't return any info concerning ownable syncs.

- Make `SCAN_OWNABLESYNCHRONIZER_OBJECT` unguarded to allow objs to be added to Ownable sync list for CS
- _ownableSynchronizerObjectLists_ changed from public to private member of GCExtensions
  - _For external (non GC) consumers of the list_: introduced a getter to return the ownable synchronizer object lists by first ensuring that the **lists are in a consistent state by forcing completion of any concurrent scavenge cycles in progress before returning the list.**
- Clear language specific stats at the end of gc cycle - these stats get incorrectly merged for concurrent scavenger

Signed-off-by: Salman Rana <salman.rana@ibm.com>