### PR TITLE
Fix APIs that overwrite data in the shared cache.

### DIFF
--- a/runtime/shared_common/ByteDataManagerImpl.cpp
+++ b/runtime/shared_common/ByteDataManagerImpl.cpp
@@ -218,6 +218,8 @@ SH_ByteDataManagerImpl::findSingleEntry(J9VMThread* currentThread, const char* k
 	Trc_SHR_BDMI_findSingleEntry_Entry(currentThread, keylen, key, dataType, jvmID);
 
 	if ((found = (BdLinkedListImpl*)hllTableLookup(currentThread, key, (U_16)keylen, true))) {
+		/* set found to found->_next, so that we see the last added item first, which means we will always find the item in the higher layer cache first */
+		found = (BdLinkedListImpl*)found->_next;
 		walk = found;
 		do {
 			const ShcItem* item = walk->_item;
@@ -262,7 +264,8 @@ SH_ByteDataManagerImpl::markAllStaleForKey(J9VMThread* currentThread, const char
 
 	if ((found = (BdLinkedListImpl*)hllTableLookup(currentThread, key, (U_16)keylen, true))) {
 		U_16 jvmID = _cache->getCompositeCacheAPI()->getJVMID();
-		
+		/* set found to found->_next, so that we see the last added item first, which means we will always find the item in the higher layer cache first */
+		found = (BdLinkedListImpl*)found->_next;
 		walk = found;
 		do {
 			const ShcItem* item = walk->_item;
@@ -326,6 +329,8 @@ SH_ByteDataManagerImpl::find(J9VMThread* currentThread, const char* key, UDATA k
 	Trc_SHR_BDMI_find_Entry(currentThread, keylen, key, limitDataType, includePrivateData, firstItem, descriptorPool);
 
 	if ((found = (BdLinkedListImpl*)hllTableLookup(currentThread, key, (U_16)keylen, true))) {
+		/* set found to found->_next, so that we see the last added item first, which means we will always find the item in the higher layer cache first */
+		found = (BdLinkedListImpl*)found->_next;
 		walk = found;
 		do {
 			const ShcItem* item = walk->_item;

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2962,3 +2962,5 @@ TraceExit-Exception=Trc_SHR_CM_startup_Exit12 Overhead=1 Level=1 Template="CM st
 TraceExit-Exception=Trc_SHR_CM_startup_Exit13 Overhead=1 Level=1 Template="CM startup: Failed to read the cache. Cache is corrupted"
 TraceExit-Exception=Trc_SHR_CM_updateROMClassResource_Exit7 Overhead=1 Level=1 Template="CM updateROMClassResource: The address to be updated %p (length %zu) is not in top layer cache."
 TraceException=Trc_SHR_CM_storeSharedData_OverwriteExisting_NotInTopLayer Overhead=1 Level=2 Template="CM storeSharedData: Existing data in the shared cache (data->address %p, foundDatalen %zu) is not in top layer cache."
+TraceEvent=Trc_SHR_RRM_storeNew_existingEntryRemoved Overhead=1 Level=6 Template="RRM storeNew: removed existing item 0x%p from the hashTable"
+TraceExit-Exception=Trc_SHR_CM_updateROMClassResource_Exit8 Overhead=1 Level=1 Template="CM updateROMClassResource: Failed to allocate memory for ROMClass resource"


### PR DESCRIPTION
Store a new item in the top layer cache if JIT/GC wants to overwrite
an existing data in a lower layer cache.

issue #5480

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>