### PR TITLE
Use with-boot-jdk variable instead of hardcode

### DIFF
--- a/debugtools/DDR_VM/compile_ddr.xml
+++ b/debugtools/DDR_VM/compile_ddr.xml
@@ -305,33 +305,7 @@
 		<mkdir dir="${findbugs.results.dir}"/>
 		<mkdir dir="${findbugs.unpack.dir}"/>
 
-		<if>
-			<os family="unix"/>
-			<then>
- 				<if>
- 					<equals arg1="${product}" arg2="java8" />
- 					<then>
- 						<property name="build.compiler.java" value="/bluebird/bin/platform/linux386/ibm-jdk-1.8.0/bin/javac" />
- 					</then>
- 					<else>
- 						<property name="build.compiler.java" value="/bluebird/bin/platform/linux386/ibm-jdk-1.9.0-b136/bin/javac" />
- 					</else>
- 				</if>
-			</then>
-			<else>
-				<echo>dev tools: ${env.DEV_TOOLS}</echo>
- 				<fail unless="env.DEV_TOOLS" message="You must have the DEV_TOOLS environment defined." />
- 				<if>
- 					<equals arg1="${product}" arg2="java8" />
- 					<then>
- 						<property name="build.compiler.java" value="${env.DEV_TOOLS}/ibm-jdk-1.8.0/bin/javac.exe" />
- 					</then>
- 					<else>
- 						<property name="build.compiler.java" value="${env.DEV_TOOLS}/ibm-jdk-1.9.0/bin/javac.exe" />
- 					</else>
- 				</if>
-			</else>
-		</if>
+		<property name="build.compiler.java" value="${with-boot-jdk}/bin/javac" />
 	</target>
 
 	<target name="findbugs">

--- a/debugtools/DDR_VM/generate.xml
+++ b/debugtools/DDR_VM/generate.xml
@@ -27,6 +27,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<!-- To be used via AXXON only -->
 	<fail unless="BUILD_ID" message="Missing BUILD_ID." />
 	<fail unless="JOB_ID" message="Missing JOB_ID." />
+	<fail unless="with-boot-jdk" message="Missing with-boot-jdk." />
 	<property name="TMP_DIR" location="${java.io.tmpdir}${file.separator}bld_${BUILD_ID}${file.separator}job_${JOB_ID}" />
 	<mkdir dir="${TMP_DIR}" />
 
@@ -66,7 +67,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<property name="STUBS_NAME" value=".structure" />
 	<property name="POINTERS_NAME" value=".pointer.generated" />
 
-	<property name="with-boot-jdk" value="/bluebird/bin/platform/linux386/ibm-jdk-1.8.0" />
 	<property name="spec.level" value="1.6" />
 
 	<import file="${DDR_VM}/compile_ddr.xml" />


### PR DESCRIPTION
- Remove hardcoded reference to a network SDK.
  Switch to using the passed in with-boot-jdk
  variable.
- Remove java9 cases since we don't run that
  build anymore.
- Remove Windows case since we only run this job
  on an xlinux machine.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>