### PR TITLE
Put the reminder of removal on top of the package name

### DIFF
--- a/buildenv/docker/test/Dockerfile
+++ b/buildenv/docker/test/Dockerfile
@@ -62,7 +62,8 @@ RUN apt-get update \
     build-essential \
     perl \
     vim \
-    libexpat1-dev \ # should be removed once the switch to TestKitGen java is complete and the builds are stabilized.
+    # 'libexpat1-dev' package should be removed once switching to TestKitGen java is complete and the builds are stabilized.
+    libexpat1-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Docker module to run test framework


### PR DESCRIPTION
Put the reminder of removal on top of the package name instead of on the side, to fix the error of 'unknown instruction: &&'.

Signed-off-by: simonameng <simonameng97@gmail.com>