### PR TITLE
Port JITServer VMJ9-related changes to master

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4566,7 +4566,7 @@ J9::CodeGenerator::generateCatchBlockBBStartPrologue(
       TR::Node *node,
       TR::Instruction *fenceInstruction)
    {
-   if (self()->comp()->getOptions()->getReportByteCodeInfoAtCatchBlock())
+   if (self()->comp()->fej9vm()->getReportByteCodeInfoAtCatchBlock())
       {
       // Note we should not use `fenceInstruction` here because it is not the first instruction in this BB. The first
       // instruction is a label that incoming branches will target. We will use this label (first instruction in the

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2917,7 +2917,6 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::Co
    // JITSERVER_TODO guards the code that relies on other JITServer unmerged files.
 #if defined(JITSERVER_TODO)
    compInfoPT->getClientData()->setRtResolve(rtResolve);
-   _reportByteCodeInfoAtCatchBlock = fe->getReportByteCodeInfoAtCatchBlock();
 #endif /* defined(JITSERVER_TODO) */
    unpackRegex(options->_traceForCodeMining);
    unpackRegex(options->_disabledOptTransformations);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -160,8 +160,7 @@ typedef struct TR_JitPrivateConfig
    TR_AOTStats *aotStats;
    } TR_JitPrivateConfig;
 
-#if defined(JITSERVER_SUPPORT)
-// JITServer: union containing all possible datatypes of static final fields
+// Union containing all possible datatypes of static final fields
 union
 TR_StaticFinalData
    {
@@ -173,7 +172,6 @@ TR_StaticFinalData
    double dataDouble;
    uintptrj_t dataAddress;
    };
-#endif /* defined(JITSERVER_SUPPORT) */
 
 #ifdef __cplusplus
 extern "C" {
@@ -285,6 +283,8 @@ public:
    virtual bool helpersNeedRelocation() { return false; }
    virtual bool needClassAndMethodPointerRelocations() { return false; }
    virtual bool needRelocationsForStatics() { return false; }
+   virtual bool needRelocationsForBodyInfoData() { return false; }
+   virtual bool needRelocationsForPersistentInfoData() { return false; }
    virtual bool nopsAlsoProcessedByRelocations() { return false; }
 
    bool supportsContextSensitiveInlining () { return true; }
@@ -309,10 +309,10 @@ public:
    static bool isBigDecimalConvertersClass(J9UTF8 * className);
 
    int32_t *getStringClassEnableCompressionFieldAddr(TR::Compilation *comp, bool isVettedForAOT);
-   bool stringEquals(TR::Compilation * comp, uintptrj_t* stringLocation1, uintptrj_t* stringLocation2, int32_t& result);
-   bool getStringHashCode(TR::Compilation * comp, uintptrj_t* stringLocation, int32_t& result);
+   virtual bool stringEquals(TR::Compilation * comp, uintptrj_t* stringLocation1, uintptrj_t* stringLocation2, int32_t& result);
+   virtual bool getStringHashCode(TR::Compilation * comp, uintptrj_t* stringLocation, int32_t& result);
 
-   bool isThunkArchetype(J9Method * method);
+   virtual bool isThunkArchetype(J9Method * method);
 
    J9VMThread * vmThread();
 
@@ -381,7 +381,7 @@ public:
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
    virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory *, TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *, char *signature, int32_t signatureLength, TR_ResolvedMethod *);
-   void * getStaticFieldAddress(TR_OpaqueClassBlock *, unsigned char *, uint32_t, unsigned char *, uint32_t);
+   virtual void * getStaticFieldAddress(TR_OpaqueClassBlock *, unsigned char *, uint32_t, unsigned char *, uint32_t);
    virtual int32_t getInterpreterVTableSlot(TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);
    virtual int32_t getVTableSlot(TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);
    virtual uint32_t           offsetOfIsOverriddenBit();
@@ -424,10 +424,10 @@ public:
 
    virtual int32_t            getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex);
    virtual bool               isJavaOffloadEnabled();
-   uint32_t                   getMethodSize(TR_OpaqueMethodBlock *method);
-   void *                     getMethods(TR_OpaqueClassBlock *classPointer);
-   uint32_t                   getNumInnerClasses(TR_OpaqueClassBlock *classPointer);
-   uint32_t                   getNumMethods(TR_OpaqueClassBlock *classPointer);
+   virtual uint32_t           getMethodSize(TR_OpaqueMethodBlock *method);
+   virtual void *             getMethods(TR_OpaqueClassBlock *classPointer);
+   virtual uint32_t           getNumInnerClasses(TR_OpaqueClassBlock *classPointer);
+   virtual uint32_t           getNumMethods(TR_OpaqueClassBlock *classPointer);
 
    uintptr_t                  getMethodIndexInClass(TR_OpaqueClassBlock *classPointer, TR_OpaqueMethodBlock *methodPointer);
 
@@ -447,6 +447,7 @@ public:
    virtual bool canRelocateDirectNativeCalls() {return true; }
 
    virtual bool storeOffsetToArgumentsInVirtualIndirectThunks() { return false; }
+
 
    virtual bool               tlhHasBeenCleared();
    virtual bool               isStaticObjectFlags();
@@ -500,7 +501,7 @@ public:
    virtual uintptrj_t         getJ9ObjectFlagsMask64();
    uintptrj_t                 getOffsetOfJ9ThreadJ9VM();
    uintptrj_t                 getOffsetOfJ9ROMArrayClassArrayShape();
-   uintptrj_t                 getOffsetOfJLThreadJ9Thread();
+   virtual uintptrj_t         getOffsetOfJLThreadJ9Thread();
    uintptrj_t                 getOffsetOfJavaVMIdentityHashData();
    uintptrj_t                 getOffsetOfJ9IdentityHashData1();
    uintptrj_t                 getOffsetOfJ9IdentityHashData2();
@@ -509,7 +510,7 @@ public:
    uintptrj_t                 getJ9IdentityHashSaltPolicyStandard();
    uintptrj_t                 getJ9IdentityHashSaltPolicyRegion();
    uintptrj_t                 getJ9IdentityHashSaltPolicyNone();
-   uintptrj_t                 getIdentityHashSaltPolicy();
+   virtual uintptrj_t         getIdentityHashSaltPolicy();
    virtual uintptrj_t         getJ9JavaClassRamShapeShift();
    virtual uintptrj_t         getObjectHeaderShapeMask();
 
@@ -534,15 +535,15 @@ public:
    virtual void                 emitNewPseudoRandomStringVerbose(char *);
    virtual void                 emitNewPseudoRandomStringVerboseLine(char *);
 
-   uint32_t                   getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock * clazz);
+   virtual uint32_t             getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock * clazz);
 
-   TR_OpaqueClassBlock *getObjectClass(uintptrj_t objectPointer);
-   uintptrj_t           getReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
-   uintptrj_t           getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
-   uintptrj_t           getReferenceFieldAtAddress(uintptrj_t fieldAddress);
-   uintptrj_t           getReferenceFieldAtAddress(void *fieldAddress){ return getReferenceFieldAtAddress((uintptrj_t)fieldAddress); }
-   uintptrj_t           getStaticReferenceFieldAtAddress(uintptrj_t fieldAddress);
-   int32_t              getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset);
+   virtual TR_OpaqueClassBlock *getObjectClass(uintptrj_t objectPointer);
+   virtual uintptrj_t           getReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
+   virtual uintptrj_t           getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
+   virtual uintptrj_t           getReferenceFieldAtAddress(uintptrj_t fieldAddress);
+   virtual uintptrj_t           getReferenceFieldAtAddress(void *fieldAddress){ return getReferenceFieldAtAddress((uintptrj_t)fieldAddress); }
+   virtual uintptrj_t           getStaticReferenceFieldAtAddress(uintptrj_t fieldAddress);
+   virtual int32_t              getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset);
 
    int32_t getInt32Field(uintptrj_t objectPointer, char *fieldName)
       {
@@ -553,20 +554,20 @@ public:
       {
       return getInt64FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "J"));
       }
-   int64_t                      getInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset);
-   void                         setInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t newValue);
+   virtual int64_t              getInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset);
+   virtual void                 setInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t newValue);
    void setInt64Field(uintptrj_t objectPointer, char *fieldName, int64_t newValue)
       {
       setInt64FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "J"), newValue);
       }
 
-   bool                         compareAndSwapInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t oldValue, int64_t newValue);
+   virtual bool                 compareAndSwapInt64FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset, int64_t oldValue, int64_t newValue);
    bool compareAndSwapInt64Field(uintptrj_t objectPointer, char *fieldName, int64_t oldValue, int64_t newValue)
       {
       return compareAndSwapInt64FieldAt(objectPointer, getInstanceFieldOffset(getObjectClass(objectPointer), fieldName, "J"), oldValue, newValue);
       }
 
-   intptrj_t                    getArrayLengthInElements(uintptrj_t objectPointer);
+   virtual intptrj_t            getArrayLengthInElements(uintptrj_t objectPointer);
    int32_t                      getInt32Element(uintptrj_t objectPointer, int32_t elementIndex);
    virtual uintptrj_t           getReferenceElement(uintptrj_t objectPointer, intptrj_t elementIndex);
 
@@ -707,7 +708,7 @@ public:
 #endif
    virtual void refineColdness (TR::Node* node, bool& isCold);
 
-   virtual TR::Node * inlineNativeCall( TR::Compilation *,  TR::TreeTop *, TR::Node *) { return 0; }
+   virtual TR::Node * inlineNativeCall(TR::Compilation *,  TR::TreeTop *, TR::Node *) { return 0; }
 
    virtual bool               inlinedAllocationsMustBeVerified() { return false; }
 
@@ -728,6 +729,7 @@ public:
    virtual char *             getClassSignature_DEPRECATED(TR_OpaqueClassBlock * clazz, int32_t & length, TR_Memory *);
    virtual char *             getClassSignature(TR_OpaqueClassBlock * clazz, TR_Memory *);
    virtual int32_t            printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method);
+   virtual int32_t            printTruncatedSignature(char *sigBuf, int32_t bufLen, J9UTF8 *className, J9UTF8 *name, J9UTF8 *signature);
 
    virtual bool               isClassFinal(TR_OpaqueClassBlock *);
    virtual bool               isClassArray(TR_OpaqueClassBlock *);
@@ -746,6 +748,7 @@ public:
    virtual char    *getJ2IThunkSignatureForDispatchVirtual(char *invokeHandleSignature, uint32_t signatureLength,  TR::Compilation *comp);
    virtual TR::Node *getEquivalentVirtualCallNodeForDispatchVirtual(TR::Node *node,  TR::Compilation *comp);
    virtual bool     needsInvokeExactJ2IThunk(TR::Node *node,  TR::Compilation *comp);
+   virtual void setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp);
 
    virtual void *findPersistentJ2IThunk(char *signatureChars);
    virtual void *findPersistentThunk(char *signatureChars, uint32_t signatureLength);
@@ -821,12 +824,12 @@ public:
    virtual int32_t *          getReferenceSlotsInClass( TR::Compilation *, TR_OpaqueClassBlock *classPointer);
    virtual void               initializeLocalObjectHeader( TR::Compilation *, TR::Node * allocationNode,  TR::TreeTop * allocationTreeTop);
    virtual void               initializeLocalArrayHeader ( TR::Compilation *, TR::Node * allocationNode,  TR::TreeTop * allocationTreeTop);
-   virtual TR::TreeTop*        initializeClazzFlagsMonitorFields(TR::Compilation*, TR::TreeTop* prevTree, TR::Node* allocationNode, TR::Node* classNode, J9Class* ramClass);
+   virtual TR::TreeTop*        initializeClazzFlagsMonitorFields(TR::Compilation*, TR::TreeTop* prevTree, TR::Node* allocationNode, TR::Node* classNode, TR_OpaqueClassBlock* ramClass);
 
    bool shouldPerformEDO(TR::Block *catchBlock,  TR::Compilation * comp);
 
    // Multiple code cache support
-   virtual TR::CodeCache *getDesignatedCodeCache( TR::Compilation *comp); // MCT
+   virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation *comp); // MCT
    virtual void setHasFailedCodeCacheAllocation(); // MCT
    void *getCCPreLoadedCodeAddress(TR::CodeCache *codeCache, TR_CCPreLoadedCode h, TR::CodeGenerator *cg);
 
@@ -881,11 +884,13 @@ public:
    virtual J9Method *convertMethodOffsetToMethodPtr(TR_OpaqueMethodBlock *methodOffset);
    virtual TR_OpaqueMethodBlock *convertMethodPtrToMethodOffset(J9Method *methodPtr);
 
+   virtual TR_OpaqueClassBlock *getHostClass(TR_OpaqueClassBlock *clazzOffset);
    virtual bool canAllocateInlineClass(TR_OpaqueClassBlock *clazz);
+   virtual bool isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz);
    virtual intptrj_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset);
 
-    TR::TreeTop * lowerAsyncCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-    TR::TreeTop * lowerAtcCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerAsyncCheck(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerAtcCheck(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodTracingEnabled(J9Method *j9method)
       {
@@ -898,13 +903,15 @@ public:
    virtual bool canMethodExitEventBeHooked();
    virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled();
 
-   TR::TreeTop * lowerMethodHook( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerArrayLength( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerContigArrayLength( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerMultiANewArray( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerToVcall( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerMethodHook(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerArrayLength(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerContigArrayLength(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerMultiANewArray(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerToVcall(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   virtual U_8 * fetchMethodExtendedFlagsPointer(J9Method *method); // wrapper method of fetchMethodExtendedFlagsPointer in util/extendedmethodblockaccess.c, for JITServer override purpose
+   virtual void * getStaticHookAddress(int32_t event);
 
-   TR::Node * initializeLocalObjectFlags( TR::Compilation *, TR::Node * allocationNode, J9Class * ramClass);
+   TR::Node * initializeLocalObjectFlags(TR::Compilation *, TR::Node * allocationNode, TR_OpaqueClassBlock * ramClass);
 
    virtual J9JITConfig *getJ9JITConfig() { return _jitConfig; }
 
@@ -917,7 +924,8 @@ public:
    virtual bool isAnonymousClass(J9ROMClass *romClass) { return (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)); }
    virtual int64_t getCpuTimeSpentInCompThread(TR::Compilation * comp); // resolution is 0.5 sec or worse. Returns -1 if unavailable
 
-   virtual void *             getClassLoader(TR_OpaqueClassBlock * classPointer);
+   virtual void * getClassLoader(TR_OpaqueClassBlock * classPointer);
+   virtual bool getReportByteCodeInfoAtCatchBlock();
 
    J9VMThread *            _vmThread;
    J9PortLibrary *         _portLibrary;
@@ -975,8 +983,11 @@ public:
    virtual bool acquireClassTableMutex();
    virtual void releaseClassTableMutex(bool);
 
+   virtual bool classInitIsFinished(TR_OpaqueClassBlock *clazz) { return (((J9Class*)clazz)->initializeStatus & J9ClassInitStatusMask) == J9ClassInitSucceeded; }
+
    virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
    virtual TR_OpaqueClassBlock * getClassFromNewArrayTypeNonNull(int32_t arrayType);
+
    // --------------------------------------------------------------------------
    // Object model
    // --------------------------------------------------------------------------
@@ -1002,7 +1013,10 @@ public:
    virtual void *getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *classPointer);
    virtual bool isMethodBreakpointed(TR_OpaqueMethodBlock *method);
 
+   virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass);
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) { return false; }
+   virtual bool isStringCompressionEnabledVM();
+   virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType);
 
 protected:
 
@@ -1023,7 +1037,8 @@ public:
 
    virtual bool               classHasBeenExtended(TR_OpaqueClassBlock *);
    virtual bool               classHasBeenReplaced(TR_OpaqueClassBlock *);
-   virtual TR::Node *          inlineNativeCall( TR::Compilation *,  TR::TreeTop *, TR::Node *);
+   virtual TR::Node *         inlineNativeCall( TR::Compilation *,  TR::TreeTop *, TR::Node *);
+   virtual bool               transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass);
    virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method);
    virtual int32_t            getObjectAlignmentInBytes();
 
@@ -1060,6 +1075,7 @@ public:
    virtual const char *       sampleSignature(TR_OpaqueMethodBlock * aMethod, char *buf, int32_t bufLen, TR_Memory *memory);
 
    virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *);
+   virtual TR_OpaqueMethodBlock * getObjectNewInstanceImplMethod();
 
    virtual intptrj_t          methodTrampolineLookup( TR::Compilation *, TR::SymbolReference *symRef, void *callSite);
    virtual TR::CodeCache*    getResolvedTrampoline( TR::Compilation *, TR::CodeCache *curCache, J9Method * method, bool inBinaryEncoding);
@@ -1075,6 +1091,10 @@ public:
    virtual uint32_t               getPrimitiveArrayOffsetInJavaVM(uint32_t arrayType);
 
    virtual bool isDecimalFormatPattern( TR::Compilation *comp, TR_ResolvedMethod *method);
+
+   virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType);
+   virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp);
+   virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod);
 
    TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 
@@ -1103,6 +1123,8 @@ public:
    virtual bool               supportsEmbeddedHeapBounds()                    { return false; }
    virtual bool               supportsFastNanoTime()                          { return false; }
    virtual bool               needRelocationsForStatics()                     { return true; }
+   virtual bool               needRelocationsForBodyInfoData()                { return true; }
+   virtual bool               needRelocationsForPersistentInfoData()          { return true; }
    virtual bool               forceUnresolvedDispatch()                       { return true; }
    virtual bool               nopsAlsoProcessedByRelocations()                { return true; }
    virtual bool               supportsGuardMerging()                          { return false; }
@@ -1112,7 +1134,7 @@ public:
    virtual bool               doStringPeepholing()                            { return false; }
    virtual bool               hardwareProfilingInstructionsNeedRelocation()   { return true; }
    virtual bool               supportsMethodEntryPadding()                    { return false; }
-   virtual bool               isBenefitInliningCheckIfFinalizeObject()          { return true; }
+   virtual bool               isBenefitInliningCheckIfFinalizeObject()        { return true; }
    virtual bool               needsContiguousCodeAndDataCacheAllocation()     { return true; }
    virtual bool               shouldDelayAotLoad();
 
@@ -1173,7 +1195,7 @@ public:
    virtual TR_OpaqueClassBlock *getProfiledClassFromProfiledInfo(TR_ExtraAddressInfo *profiledInfo);
 
    // Multiple code cache support
-   virtual TR::CodeCache *getDesignatedCodeCache( TR::Compilation *comp); // MCT
+   virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation *comp); // MCT
 
    virtual void *getJ2IThunk(char *signatureChars, uint32_t signatureLength,  TR::Compilation *comp);
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp);

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -125,7 +125,6 @@ enum MessageType
    VM_isClassLibraryMethod = 201;
    VM_getSuperClass = 202;
    VM_isInstanceOf = 203;
-   VM_getArrayLengthOfStaticAddress = 204;
    VM_isClassArray = 205;
    VM_transformJlrMethodInvoke = 206;
 //   VM_isAbstractClass = 207;

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1283,7 +1283,7 @@ createMethodMetaData(
    // Find unmergeable GC maps
    //
    GCStackMapSet nonmergeableBCI(std::less<TR_GCStackMap*>(), cg->trMemory()->heapMemoryRegion());
-   if (comp->getOptions()->getReportByteCodeInfoAtCatchBlock())
+   if (comp->fej9vm()->getReportByteCodeInfoAtCatchBlock())
       {
       for (TR::TreeTop* treetop = comp->getStartTree(); treetop; treetop = treetop->getNextTreeTop())
          {


### PR DESCRIPTION
Replace `ramClass->romClass` with `TR::Compiler->cls.romClassOf(ramClass)` to get `romClass` from `ramClass`. The reason for that is JITServer needs to obtain the `romClass` differently. JITServer gets `romClass` either from the cache or remotely.

Introduce new frontend APIs:
- `TR_J9VMBase::instanceOfOrCheckCast`
- `TR_J9VMBase::fetchMethodExtendedFlagsPointer`
- `TR_J9VMBase::getStaticHookAddress`
- `TR_J9VMBase::setInvokeExactJ2IThunk`
- `TR_J9VMBase::getHostClass`
- `TR_J9VMBase::isClassLoadedBySystemClassLoader`
- `TR_J9VMBase::getArrayLengthOfStaticAddress`
- `TR_J9VMBase::getReportByteCodeInfoAtCatchBlock`
- `TR_J9VM::transformJlrMethodInvoke`
- `TR_J9VMBase::isStringCompressionEnabledVM`
- `TR_J9VMBase::getInvokeExactThunkHelperAddress`
- `TR_J9VM::dereferenceStaticFinalAddress`
- `TR_J9VM::getClassFromCP`
- `TR_J9VM::getROMMethodFromRAMMethod`
- `TR_J9VMBase::classInitIsFinished`
- `TR_J9VM::getObjectNewInstanceImplMethod`
- `TR_J9SharedCacheVM::needRelocationsForBodyInfoData`
- `TR_J9SharedCacheVM::needRelocationsForPersistentInfoData`

Refactor APIs:
- `TR_J9VMBase::printTruncatedSignature`
- `TR_J9VMBase::isQueuedForVeryHotOrScorching`
- `TR_J9VMBase::initializeLocalObjectFlags`
- `TR_J9VMBase::initializeLocalArrayHeader`
- `TR_J9VM::getObjectNewInstanceImplMethod`
- `TR_J9VMBase::initializeLocalObjectFlags`

Signed-off-by: Harry Yu <harryyu1994@gmail.com>