### PR TITLE
Rename meta data totalFrameSize field

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -68,173 +68,173 @@ import com.ibm.j9ddr.vm29.types.UDATA;
 
 /**
  * Java-equivalent of MethodMetaData.c.
- * 
+ *
  * Encapsulates the JIT-specific information required for stack walking.
- * 
+ *
  * Note that in the C, there's typedef J9JITExceptionTablePointer J9TR_MethodMetaData. That alias isn't
  * represented in the Java.
- * 
+ *
  * @author andhall
  *
  */
 public class MethodMetaData
 {
 	public static final long REGISTER_MAP_VALUE_FOR_GAP = 0xFADECAFE;
-	
+
 	public static final long BYTE_CODE_INFO_VALUE_FOR_GAP = 0x0;
-	
+
 	public static I16 getJitTotalFrameSize(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
 		return getImpl().getJitTotalFrameSize(md);
 	}
-	
+
 	public static VoidPointer getJitInlinedCallInfo(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
 		return getImpl().getJitInlinedCallInfo(md);
 	}
-	
+
 	public static void jitAddSpilledRegistersForDataResolve(WalkState walkState) throws CorruptDataException
 	{
 		getImpl().jitAddSpilledRegistersForDataResolve(walkState);
 	}
-	
+
 	public static UDATA getJitDataResolvePushes() throws CorruptDataException
 	{
 		return getImpl().getJitDataResolvePushes();
 	}
-	
+
 	public static VoidPointer getStackMapFromJitPC(J9JavaVMPointer javaVM, J9JITExceptionTablePointer methodMetaData, UDATA jitPC) throws CorruptDataException
 	{
 		return getImpl().getStackMapFromJitPC(javaVM,methodMetaData,jitPC);
 	}
-	
+
 	public static J9JITStackAtlasPointer getJitGCStackAtlas(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
 		return getImpl().getJitGCStackAtlas(md);
 	}
-	
+
 	public static VoidPointer getFirstInlinedCallSite(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 	{
 		return getImpl().getFirstInlinedCallSite(methodMetaData,stackMap);
 	}
-	
+
 	public static UDATA getJitInlineDepthFromCallSite(J9JITExceptionTablePointer methodMetaData, VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().getJitInlineDepthFromCallSite(methodMetaData,inlinedCallSite);
 	}
-	
+
 	public static boolean hasMoreInlinedMethods(VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().hasMoreInlinedMethods(inlinedCallSite);
 	}
-	
+
 	public static VoidPointer getInlinedMethod(VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().getInlinedMethod(inlinedCallSite);
 	}
-	
+
 	public static UDATA getCurrentByteCodeIndexAndIsSameReceiver(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap, VoidPointer currentInlinedCallSite, boolean[] isSameReceiver) throws CorruptDataException
 	{
 		return getImpl().getCurrentByteCodeIndexAndIsSameReceiver(methodMetaData, stackMap, currentInlinedCallSite, isSameReceiver);
 	}
-	
+
 	public static void jitAddSpilledRegisters(WalkState walkState) throws CorruptDataException
 	{
 		getImpl().jitAddSpilledRegisters(walkState);
 	}
-	
+
 	public static void jitAddSpilledRegisters(WalkState walkState, VoidPointer stackMap) throws CorruptDataException
 	{
 		getImpl().jitAddSpilledRegisters(walkState, stackMap);
 	}
-	
+
 	public static UDATAPointer getObjectArgScanCursor(WalkState walkState) throws CorruptDataException
 	{
 		return getImpl().getObjectArgScanCursor(walkState);
 	}
-	
+
 	public static U8Pointer getJitDescriptionCursor(VoidPointer stackMap, WalkState walkState) throws CorruptDataException
 	{
 		return getImpl().getJitDescriptionCursor(stackMap, walkState);
 	}
-	
+
 	public static U16 getJitNumberOfMapBytes(J9JITStackAtlasPointer sa) throws CorruptDataException
 	{
 		return getImpl().getJitNumberOfMapBytes(sa);
 	}
-	
+
 	public static U32 getJitRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 	{
 		return getImpl().getJitRegisterMap(methodMetaData,stackMap);
 	}
-	
+
 	public static U8Pointer getNextDescriptionCursor(J9JITExceptionTablePointer metadata, VoidPointer stackMap, U8Pointer jitDescriptionCursor) throws CorruptDataException
 	{
 		return getImpl().getNextDescriptionCursor(metadata,stackMap,jitDescriptionCursor);
 	}
-	
+
 	public static U16 getJitNumberOfParmSlots(J9JITStackAtlasPointer sa) throws CorruptDataException
 	{
 		return getImpl().getJitNumberOfParmSlots(sa);
 	}
-	
+
 	public static U8Pointer getJitInternalPointerMap(J9JITStackAtlasPointer sa) throws CorruptDataException
 	{
 		return getImpl().getJitInternalPointerMap(sa);
 	}
-	
+
 	public static void walkJITFrameSlotsForInternalPointers(WalkState walkState,  U8Pointer jitDescriptionCursor, UDATAPointer scanCursor, VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException
 	{
 		getImpl().walkJITFrameSlotsForInternalPointers(walkState,jitDescriptionCursor,scanCursor,stackMap,gcStackAtlas);
 	}
-	
+
 	public static VoidPointer getNextInlinedCallSite(
 			J9JITExceptionTablePointer methodMetaData,
 			VoidPointer inlinedCallSite) throws CorruptDataException
 	{
 		return getImpl().getNextInlinedCallSite(methodMetaData,inlinedCallSite);
 	}
-	
+
 	public static U8 getNextDescriptionBit(U8Pointer jitDescriptionCursor) throws CorruptDataException
 	{
 		return getImpl().getNextDescriptionBit(jitDescriptionCursor);
 	}
-	
+
 	public static UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException
 	{
 		return getImpl().getObjectTempScanCursor(walkState);
 	}
-	
+
 	public static int getJitRecompilationResolvePushes()
 	{
 		return getImpl().getJitRecompilationResolvePushes();
 	}
-	
+
 	public static int getJitVirtualMethodResolvePushes()
 	{
 		return getImpl().getJitVirtualMethodResolvePushes();
 	}
-	
+
 	public static int getJitStaticMethodResolvePushes()
 	{
 		return getImpl().getJitStaticMethodResolvePushes();
 	}
-	
+
 	public static VoidPointer getStackAllocMapFromJitPC(J9JavaVMPointer javaVM, J9JITExceptionTablePointer methodMetaData, UDATA jitPC, VoidPointer curStackMap) throws CorruptDataException
 	{
 		return getImpl().getStackAllocMapFromJitPC(javaVM, methodMetaData, jitPC, curStackMap);
 	}
-	
+
 	public static U8Pointer getJitStackSlots(J9JITExceptionTablePointer metaData,  VoidPointer stackMap) throws CorruptDataException
 	{
 		return getImpl().getJitStackSlots(metaData, stackMap);
 	}
-	
+
 	public static void markClassesInInlineRanges(J9JITExceptionTablePointer metaData, WalkState walkState) throws CorruptDataException
 	{
 		getImpl().markClassesInInlineRanges(metaData, walkState);
 	}
-	
+
 	/**
 	 * Class used to pass maps by reference to jitGetMapsFromPC.
 	 *
@@ -244,16 +244,16 @@ public class MethodMetaData
 		public PointerPointer stackMap = PointerPointer.NULL;
 		public PointerPointer inlineMap = PointerPointer.NULL;
 	}
-	
+
 	public static void jitGetMapsFromPC(J9JavaVMPointer javaVM,
 			J9JITExceptionTablePointer methodMetaData, UDATA jitPC, JITMaps maps) throws CorruptDataException
 	{
 		getImpl().jitGetMapsFromPC(javaVM, methodMetaData, jitPC, maps);
 	}
 
-	
+
 	private static MethodMetaDataImpl impl;
-	
+
 	private static final AlgorithmPicker<MethodMetaDataImpl> picker = new AlgorithmPicker<MethodMetaDataImpl>(AlgorithmVersion.METHOD_META_DATA_VERSION){
 
 		@Override
@@ -263,7 +263,7 @@ public class MethodMetaData
 			toReturn.add(new MethodMetaData_29_V0());
 			return toReturn;
 		}};
-	
+
 	private static MethodMetaDataImpl getImpl()
 	{
 		if (impl == null) {
@@ -271,12 +271,12 @@ public class MethodMetaData
 		}
 		return impl;
 	}
-	
+
 	/* In Java 8 builds, the (interim) compiler gets confused if IAlgorithm is not fully qualified. */
 	private static interface MethodMetaDataImpl extends com.ibm.j9ddr.vm29.j9.IAlgorithm
 	{
 		public UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException;
-		
+
 		public int getJitStaticMethodResolvePushes();
 
 		public int getJitVirtualMethodResolvePushes();
@@ -284,7 +284,7 @@ public class MethodMetaData
 		public int getJitRecompilationResolvePushes();
 
 		public U8Pointer getJitDescriptionCursor(VoidPointer stackMap, WalkState walkState) throws CorruptDataException;
-		
+
 		public void walkJITFrameSlotsForInternalPointers(WalkState walkState,U8Pointer jitDescriptionCursor, UDATAPointer scanCursor,VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException;
 
 		public U8Pointer getJitInternalPointerMap(J9JITStackAtlasPointer sa) throws CorruptDataException;
@@ -307,7 +307,7 @@ public class MethodMetaData
 				boolean[] isSameReceiver) throws CorruptDataException;
 
 		public boolean hasMoreInlinedMethods(VoidPointer inlinedCallSite) throws CorruptDataException;
-		
+
 		public VoidPointer getInlinedMethod(VoidPointer inlinedCallSite) throws CorruptDataException;
 
 		public UDATA getJitInlineDepthFromCallSite(
@@ -316,7 +316,7 @@ public class MethodMetaData
 
 		public VoidPointer getFirstInlinedCallSite(
 				J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException;
-		
+
 		public VoidPointer getNextInlinedCallSite(J9JITExceptionTablePointer methodMetaData,VoidPointer inlinedCallSite) throws CorruptDataException;
 
 		public J9JITStackAtlasPointer getJitGCStackAtlas(
@@ -330,20 +330,20 @@ public class MethodMetaData
 		public void jitAddSpilledRegistersForDataResolve(WalkState walkState) throws CorruptDataException;
 
 		public VoidPointer getJitInlinedCallInfo(J9JITExceptionTablePointer md) throws CorruptDataException;
-		
+
 		public void jitGetMapsFromPC(J9JavaVMPointer javaVM,
 				J9JITExceptionTablePointer methodMetaData, UDATA jitPC, JITMaps maps) throws CorruptDataException;
-		
+
 		public void jitAddSpilledRegisters(WalkState walkState) throws CorruptDataException;
-		
+
 		public void jitAddSpilledRegisters(WalkState walkState, VoidPointer stackMap) throws CorruptDataException;
-		
+
 		public U8 getNextDescriptionBit(U8Pointer jitDescriptionCursor) throws CorruptDataException;
-		
+
 		public VoidPointer getStackAllocMapFromJitPC(J9JavaVMPointer javaVM, J9JITExceptionTablePointer methodMetaData, UDATA jitPC, VoidPointer curStackMap) throws CorruptDataException;
-		
+
 		public U8Pointer getJitStackSlots(J9JITExceptionTablePointer metaData,  VoidPointer stackMap) throws CorruptDataException;
-		
+
 		public void markClassesInInlineRanges(J9JITExceptionTablePointer metaData, WalkState walkState) throws CorruptDataException;
 	}
 
@@ -356,13 +356,13 @@ public class MethodMetaData
 		protected MethodMetaData_29_V0() {
 			super(90,0);
 		}
-		
+
 		public I16 getJitTotalFrameSize(J9JITExceptionTablePointer md)
 				throws CorruptDataException
 		{
-			return new I16(md.totalFrameSize());
+			return new I16(md.totalFrameSizeInSlots());
 		}
-		
+
 		public VoidPointer getJitInlinedCallInfo(J9JITExceptionTablePointer md)
 				throws CorruptDataException
 		{
@@ -374,8 +374,8 @@ public class MethodMetaData
 		{
 			UDATAPointer slotCursor = walkState.unwindSP.add(getJitSlotsBeforeSavesInDataResolve());
 			int mapCursor = 0;
-			
-			for (int i = 0; i < J9SW_POTENTIAL_SAVED_REGISTERS; ++i) 
+
+			for (int i = 0; i < J9SW_POTENTIAL_SAVED_REGISTERS; ++i)
 			{
 				walkState.registerEAs[mapCursor++] = slotCursor;
 				slotCursor = slotCursor.add(1);
@@ -384,9 +384,9 @@ public class MethodMetaData
 			swPrintf(walkState, 2, "\t{0} slots skipped before scalar registers", getJitSlotsBeforeSavesInDataResolve());
 			jitPrintRegisterMapArray(walkState, "DataResolve");
 		}
-		
+
 		/* Number of slots of data pushed after the integer registers during data resolves */
-		
+
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
 			if (J9ConfigFlags.arch_x86) {
@@ -420,7 +420,7 @@ public class MethodMetaData
 		{
 			throw new UnsupportedOperationException("Not implemented at 2.6");
 		}
-		
+
 		public void jitAddSpilledRegisters(WalkState walkState, VoidPointer stackMap) throws CorruptDataException
 		{
 			UDATA savedGPRs = new UDATA(0), saveOffset = new UDATA(0), lowestRegister = new UDATA(0);
@@ -432,7 +432,7 @@ public class MethodMetaData
 
 			if (J9ConfigFlags.arch_x86) {
 				UDATA prologuePushes = new UDATA(getJitProloguePushes(walkState.jitInfo));
-				U8 i = new U8(1); 
+				U8 i = new U8(1);
 
 				if (! prologuePushes.eq(0)) {
 					saveCursor = walkState.bp.sub(  new UDATA(getJitScalarTempSlots(walkState.jitInfo)).add(new UDATA(getJitObjectTempSlots(walkState.jitInfo)).add(prologuePushes)) );
@@ -454,9 +454,9 @@ public class MethodMetaData
 			} else if (J9ConfigFlags.arch_power || TRBuildFlags.host_MIPS) {
 				if (J9ConfigFlags.arch_power) {
 					/*
-					 * see PPCLinkage for a description of the RSD 
-					 * the save offset is located from bits 18-32 
-					 * so first mask it off to get the bit vector 
+					 * see PPCLinkage for a description of the RSD
+					 * the save offset is located from bits 18-32
+					 * so first mask it off to get the bit vector
 					 * corresponding to the saved GPRS
 					 */
 					savedGPRs = registerSaveDescription.bitAnd(new UDATA(0x1FFFFL));
@@ -473,7 +473,7 @@ public class MethodMetaData
 				if (J9ConfigFlags.arch_power) {
 					mapCursor += lowestRegister.intValue(); /* access gpr15 in the vm register state */
 					U8 i = new U8(lowestRegister.add(1));
-					do 
+					do
 					{
 						if (savedGPRs.anyBitsIn(1)) {
 							walkState.registerEAs[mapCursor] = saveCursor;
@@ -520,7 +520,7 @@ public class MethodMetaData
 
 			jitPrintRegisterMapArray(walkState, "Frame");
 		}
-		
+
 		private U8Pointer GET_REGISTER_SAVE_DESCRIPTION_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
 			return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF);
@@ -528,19 +528,19 @@ public class MethodMetaData
 
 		public U16 getJitProloguePushes(J9JITExceptionTablePointer md) throws CorruptDataException
 		{
-			return md.prologuePushes(); 
+			return md.prologuePushes();
 		}
-		
+
 		public I16 getJitScalarTempSlots(J9JITExceptionTablePointer md) throws CorruptDataException
 		{
-			return md.scalarTempSlots(); 
+			return md.scalarTempSlots();
 		}
 
 		public I16 getJitObjectTempSlots(J9JITExceptionTablePointer md) throws CorruptDataException
-		{ 
-			return md.objectTempSlots(); 
+		{
+			return md.objectTempSlots();
 		}
-		
+
 		public UDATA getJitDataResolvePushes() throws CorruptDataException {
 			if (J9ConfigFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
@@ -591,7 +591,7 @@ public class MethodMetaData
 				return new UDATA(32);
 			} else if (TRBuildFlags.host_SH4) {
 				/* SH4 data resolve shape
-				   16 integer registers 
+				   16 integer registers
 				*/
 				return new UDATA(16);
 			} else {
@@ -603,7 +603,7 @@ public class MethodMetaData
 				J9JITExceptionTablePointer methodMetaData, UDATA jitPC) throws CorruptDataException
 		{
 			JITMaps maps = new JITMaps();
-			
+
 			jitGetMapsFromPC(javaVM, methodMetaData, jitPC, maps);
 			return VoidPointer.cast(maps.stackMap);
 		}
@@ -612,30 +612,30 @@ public class MethodMetaData
 		{
 			return J9JITStackAtlasPointer.cast(md.gcStackAtlas());
 		}
-		
+
 		public void jitGetMapsFromPC(J9JavaVMPointer javaVM,
 				J9JITExceptionTablePointer methodMetaData, UDATA jitPC,
 				JITMaps maps) throws CorruptDataException
 		{
 			MapIterator i = new MapIterator();
-			
+
 			/* We subtract one from the jitPC as jitPCs that come in are always pointing at the beginning of the next instruction
 			 * (ie: the return address from the child call).  In the case of trap handlers, the GP handler has already bumped the PC
 			 * forward by one, expecting this -1 to happen.
 			 */
 			UDATA offsetPC = jitPC.sub(methodMetaData.startPC()).sub(1);
-			
-			boolean fourByteOffsets = HAS_FOUR_BYTE_OFFSET(methodMetaData); 
-			
+
+			boolean fourByteOffsets = HAS_FOUR_BYTE_OFFSET(methodMetaData);
+
 			maps.stackMap = PointerPointer.NULL;
 			maps.inlineMap = PointerPointer.NULL;
-			
-			if (methodMetaData.gcStackAtlas().isNull()) { 
+
+			if (methodMetaData.gcStackAtlas().isNull()) {
 				return;
 			}
 
 			initializeIterator(i, methodMetaData);
-			
+
 			findMapsAtPC(i, offsetPC, maps, fourByteOffsets);
 		}
 
@@ -689,7 +689,7 @@ public class MethodMetaData
 
 			return i._currentMap;
 		}
-		
+
 		private static UDATA GET_LOW_PC_OFFSET_VALUE(boolean fourByteOffset, U8Pointer stackMap) throws CorruptDataException
 		{
 			Scalar returnValue = null;
@@ -698,31 +698,31 @@ public class MethodMetaData
 			} else {
 				returnValue = U16Pointer.cast(ADDRESS_OF_LOW_PC_OFFSET_IN_STACK_MAP(fourByteOffset,stackMap)).at(0);
 			}
-			
+
 			return new UDATA(returnValue);
 		}
-		
+
 		private static U32 GET_SIZEOF_BYTECODEINFO_MAP(boolean fourByteOffset)
 		{
 			return new U32(U32.SIZEOF).add(SIZEOF_MAP_OFFSET(fourByteOffset));
 		}
-		
+
 		private static U8Pointer ADDRESS_OF_BYTECODEINFO_IN_STACK_MAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset));
 		}
-		
+
 		private static U8Pointer ADDRESS_OF_LOW_PC_OFFSET_IN_STACK_MAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap;
 		}
-		
+
 		@SuppressWarnings("unused")
 		private static U8Pointer ADDRESS_OF_REGISTERMAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(2 * U32.SIZEOF);
 		}
-		
+
 		private static boolean RANGE_NEEDS_FOUR_BYTE_OFFSET(Scalar s)
 		{
 			//#define RANGE_NEEDS_FOUR_BYTE_OFFSET(r)   (((r) >= (USHRT_MAX   )) ? 1 : 0)
@@ -733,33 +733,33 @@ public class MethodMetaData
 		{
 			if (AlgorithmVersion.getVersionOf(AlgorithmVersion.FOUR_BYTE_OFFSETS_VERSION).getAlgorithmVersion() > 0) {
 				if (md.flags().anyBitsIn(JIT_METADATA_FLAGS_USED_FOR_SIZE)) {
-					return (md.flags().anyBitsIn(JIT_METADATA_GC_MAP_32_BIT_OFFSETS));	
+					return (md.flags().anyBitsIn(JIT_METADATA_GC_MAP_32_BIT_OFFSETS));
 				}
 			}
 			return RANGE_NEEDS_FOUR_BYTE_OFFSET(md.endPC().sub(md.startPC()));
 		}
-		
+
 		private static U32 SIZEOF_MAP_OFFSET(boolean fourByteOffset)
 		{
 			return (alignStackMaps || fourByteOffset) ? new U32(4) : new U32(2);
 		}
-		
-		private static boolean IS_BYTECODEINFO_MAP(boolean fourByteOffset, U8Pointer stackMap) throws CorruptDataException 
+
+		private static boolean IS_BYTECODEINFO_MAP(boolean fourByteOffset, U8Pointer stackMap) throws CorruptDataException
 		{
 			return ! TR_ByteCodeInfoPointer.cast(ADDRESS_OF_BYTECODEINFO_IN_STACK_MAP(fourByteOffset, stackMap))._doNotProfile().eq(0);
 		}
-		
+
 		//#define GET_REGISTER_MAP_CURSOR(fourByteOffset, stackMap) ((U_8 *)stackMap + SIZEOF_MAP_OFFSET(fourByteOffset) + 2*sizeof(U_32))
 		private static U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, U8Pointer stackMap)
 		{
 			return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(2 * U32.SIZEOF));
 		}
-		
+
 		/* Note: this differs from the native version in that nextStackMap is returned - not passed by reference */
 		private static U8Pointer GET_NEXT_STACK_MAP(boolean fourByteOffset, U8Pointer stackMap, J9JITStackAtlasPointer atlas) throws CorruptDataException
 		{
 			U8Pointer nextStackMap = stackMap;
-			
+
 			if (IS_BYTECODEINFO_MAP(fourByteOffset, stackMap)) {
 				nextStackMap = nextStackMap.add(GET_SIZEOF_BYTECODEINFO_MAP(fourByteOffset));
 			} else {
@@ -773,10 +773,10 @@ public class MethodMetaData
 				}
 				nextStackMap = nextStackMap.add(1);
 			}
-			
+
 			return nextStackMap;
 		}
-		
+
 		private void initializeIterator(MapIterator i,
 				J9JITExceptionTablePointer methodMetaData) throws CorruptDataException
 		{
@@ -805,7 +805,7 @@ public class MethodMetaData
 		{
 			return VoidPointer.cast(U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)));
 		}
-		
+
 		private VoidPointer getFirstInlinedCallSiteWithByteCodeInfo(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap, VoidPointer byteCodeInfo) throws CorruptDataException
 		{
 			if (byteCodeInfo.isNull()) {
@@ -818,13 +818,13 @@ public class MethodMetaData
 
 			return getNotUnloadedInlinedCallSiteArrayElement(methodMetaData, cix);
 		}
-		
+
 
 		private U32 sizeOfInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData) throws CorruptDataException
 		{
 			return new U32(TR_InlinedCallSite.SIZEOF).add(J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlas()).numberOfMapBytes());
 		}
-		
+
 		private U8Pointer getInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData, I32 cix) throws CorruptDataException
 		{
 			U8Pointer inlinedCallSiteArray = U8Pointer.cast(getJitInlinedCallInfo(methodMetaData));
@@ -839,7 +839,7 @@ public class MethodMetaData
 		{
 			return UDATA.cast(method).bitNot().eq(0); /* d142150: check for method==-1 in a way that works on ZOS */
 		}
-		
+
 		private  VoidPointer getNotUnloadedInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData, I32 cix) throws CorruptDataException
 		{
 			VoidPointer inlinedCallSite = VoidPointer.cast(getInlinedCallSiteArrayElement(methodMetaData, cix));
@@ -871,29 +871,29 @@ public class MethodMetaData
 			if (hasMoreInlinedMethods(inlinedCallSite)) {
 				return getNotUnloadedInlinedCallSiteArrayElement(methodMetaData, new I32(getByteCodeInfo(inlinedCallSite)._callerIndex()));
 			}
-			return VoidPointer.NULL; 
+			return VoidPointer.NULL;
 		}
-		
+
 		public boolean hasMoreInlinedMethods(VoidPointer inlinedCallSite) throws CorruptDataException
 		{
 			TR_ByteCodeInfoPointer byteCodeInfo = getByteCodeInfo(inlinedCallSite);
 			return ! byteCodeInfo._callerIndex().lt(new I32(0));
 		}
-		
+
 		private static TR_ByteCodeInfoPointer getByteCodeInfo(VoidPointer inlinedCallSite) throws CorruptDataException
 		{
 			return TR_ByteCodeInfoPointer.cast(TR_InlinedCallSitePointer.cast(inlinedCallSite)._byteCodeInfoEA());
 		}
-		
+
 		public VoidPointer getInlinedMethod(VoidPointer inlinedCallSite) throws CorruptDataException
 		{
 			return TR_InlinedCallSitePointer.cast(inlinedCallSite)._methodInfo();
 		}
-		
+
 		public UDATA getCurrentByteCodeIndexAndIsSameReceiver(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap, VoidPointer currentInlinedCallSite, boolean[] isSameReceiver) throws CorruptDataException
 		{
 			TR_ByteCodeInfoPointer byteCodeInfo = TR_ByteCodeInfoPointer.cast(getByteCodeInfoFromStackMap(methodMetaData, stackMap));
-			
+
 			if (currentInlinedCallSite.notNull()) {
 				VoidPointer inlinedCallSite = getFirstInlinedCallSiteWithByteCodeInfo(methodMetaData, stackMap, VoidPointer.cast(byteCodeInfo));
 				if (! inlinedCallSite.eq(currentInlinedCallSite))
@@ -920,7 +920,7 @@ public class MethodMetaData
 
 			if (isSameReceiver != null) {
 				isSameReceiver[0] = ! byteCodeInfo._isSameReceiver().eq(0);
-			}	
+			}
 			return new UDATA(byteCodeInfo._byteCodeIndex());
 		}
 
@@ -929,14 +929,14 @@ public class MethodMetaData
 		{
 			return VoidPointer.cast(ADDRESS_OF_BYTECODEINFO_IN_STACK_MAP(HAS_FOUR_BYTE_OFFSET(methodMetaData), U8Pointer.cast(stackMap)));
 		}
-		
+
 		public UDATAPointer getObjectArgScanCursor(WalkState walkState) throws CorruptDataException
 		{
 			return UDATAPointer.cast(U8Pointer.cast(walkState.bp).addOffset(J9JITStackAtlasPointer.cast(walkState.jitInfo.gcStackAtlas()).parmBaseOffset()));
 		}
-		
+
 		public U8Pointer getJitDescriptionCursor(VoidPointer stackMap, WalkState walkState) throws CorruptDataException
-		{ 
+		{
 			/* deprecated */
 			return U8Pointer.NULL;
 		}
@@ -949,8 +949,8 @@ public class MethodMetaData
 		public U32 getJitRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 		{
 			return U32Pointer.cast(GET_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(methodMetaData), stackMap)).at(0);
-		}		
-		
+		}
+
 		public U8Pointer getNextDescriptionCursor(J9JITExceptionTablePointer metadata, VoidPointer stackMap, U8Pointer jitDescriptionCursor) throws CorruptDataException
 		{
 			throw new UnsupportedOperationException("Not implemented at 2.6");
@@ -960,24 +960,24 @@ public class MethodMetaData
 		{
 			return sa.internalPointerMap();
 		}
-		
+
 		public U16 getJitNumberOfParmSlots(J9JITStackAtlasPointer sa) throws CorruptDataException
 		{
 			return sa.numberOfParmSlots();
 		}
-		
+
 		/* Note - unlike the native version of this function, we don't mutate the jitDescriptionCursor */
 		public U8 getNextDescriptionBit(U8Pointer jitDescriptionCursor) throws CorruptDataException
 		{
 			return jitDescriptionCursor.at(0);
 		}
-		
+
 		public UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException
 		{
 			//return (UDATA *) (((U_8 *) walkState->bp) + ((J9JITStackAtlas *)walkState->jitInfo->gcStackAtlas)->localBaseOffset);
 			return walkState.bp.addOffset( J9JITStackAtlasPointer.cast(walkState.jitInfo.gcStackAtlas()).localBaseOffset() );
 		}
-		
+
 		/** Number of slots pushed between the unwindSP of the JIT frame and the pushed register arguments for recompilation resolves.
 
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
@@ -1015,7 +1015,7 @@ public class MethodMetaData
 				1:		r2 (arg register)
 				2:		r1 (arg register)
 				3:		??							<== unwindSP points here
-				4:		??											
+				4:		??
 				5:		??
 				6:		64 bytes FP register saves
 				7:		temp1
@@ -1044,7 +1044,7 @@ public class MethodMetaData
 				return 0;
 			}
 		}
-		
+
 		/** Number of slots pushed between the unwindSP of the JIT frame and the pushed register arguments for virtual/interface method resolves.
 
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
@@ -1086,7 +1086,7 @@ public class MethodMetaData
 				1: saved r6
 				2: saved r5
 				3: saved r4
-				4: return address                <== unwindSP points here    
+				4: return address                <== unwindSP points here
 				5: saved resolved data
 				6: <last argument to method>     <== unwindSP should point here
 				*/
@@ -1095,7 +1095,7 @@ public class MethodMetaData
 				return 0;
 			}
 		}
-		
+
 		/** Number of slots pushed between the unwindSP of the JIT frame and the pushed resolve arguments for static/special method resolves.
 
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
@@ -1169,7 +1169,7 @@ public class MethodMetaData
 			indexOfFirstInternalPtr = new I16(U16Pointer.cast(tempJitDescriptionCursor).at(0));
 
 			swPrintf(walkState, 6, "Address {0}", tempJitDescriptionCursor.getHexAddress());
-			
+
 			tempJitDescriptionCursor = tempJitDescriptionCursor.add(2);
 
 			swPrintf(walkState, 6,"Index of first internal ptr {0}", indexOfFirstInternalPtr);
@@ -1207,20 +1207,20 @@ public class MethodMetaData
 				IDATA displacement = new IDATA(0);
 
 
-				swPrintf(walkState, 6, "Before object slot walk &address : {0} address : {1} bp {2} offset of first internal ptr {3}", 
-						currPinningArrayCursor.getHexAddress(), 
-						oldPinningArrayAddress.getHexAddress(), 
-						walkState.bp.getHexAddress(), 
+				swPrintf(walkState, 6, "Before object slot walk &address : {0} address : {1} bp {2} offset of first internal ptr {3}",
+						currPinningArrayCursor.getHexAddress(),
+						oldPinningArrayAddress.getHexAddress(),
+						walkState.bp.getHexAddress(),
 						offsetOfFirstInternalPtr);
 				walkState.callBacks.objectSlotWalkFunction(walkState.walkThread, walkState, currPinningArrayCursor, VoidPointer.cast(currPinningArrayCursor));
 				newPinningArrayAddress = J9ObjectPointer.cast( currPinningArrayCursor.at(0) );
 				displacement = new IDATA( UDATA.cast(newPinningArrayAddress).sub(UDATA.cast(oldPinningArrayAddress)));
 				walkState.slotIndex++;
 
-				swPrintf(walkState, 6, "After object slot walk for pinning array with &address : {0} old address {1} new address {2} displacement {3}", 
-						currPinningArrayCursor.getHexAddress(), 
-						oldPinningArrayAddress.getHexAddress(), 
-						newPinningArrayAddress.getHexAddress(), 
+				swPrintf(walkState, 6, "After object slot walk for pinning array with &address : {0} old address {1} new address {2} displacement {3}",
+						currPinningArrayCursor.getHexAddress(),
+						oldPinningArrayAddress.getHexAddress(),
+						newPinningArrayAddress.getHexAddress(),
 						displacement);
 
 
@@ -1237,13 +1237,13 @@ public class MethodMetaData
 					{
 						U8 internalPtrAuto = tempJitDescriptionCursor.at(0);
 						tempJitDescriptionCursor = tempJitDescriptionCursor.add(1);
-						
+
 						PointerPointer currInternalPtrCursor = PointerPointer.cast(walkState.bp.addOffset(offsetOfFirstInternalPtr.add( internalPtrAuto.intValue() * UDATA.SIZEOF )));
 
-						swPrintf(walkState, 6, "For pinning array {0} internal pointer auto {1} old address {2} displacement {3}", 
-								currPinningArrayIndex, 
-								internalPtrAuto, 
-								currInternalPtrCursor.at(0).getHexAddress(), 
+						swPrintf(walkState, 6, "For pinning array {0} internal pointer auto {1} old address {2} displacement {3}",
+								currPinningArrayIndex,
+								internalPtrAuto,
+								currInternalPtrCursor.at(0).getHexAddress(),
 								displacement);
 
 						/*
@@ -1270,11 +1270,11 @@ public class MethodMetaData
 						U8 k;
 
 						registerMap = registerMap.bitAnd(J9SW_REGISTER_MAP_MASK);
-						
+
 
 						swPrintf(walkState, 6, "\tJIT-RegisterMap = {0}", registerMap);
 						tempJitDescriptionCursorForRegs = U8Pointer.cast(stackMap);
-					
+
 						/* Skip the register map and register save description word */
 						tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(8);
 
@@ -1302,7 +1302,7 @@ public class MethodMetaData
 							if (currPinningArrayIndexForRegister.eq(currPinningArrayIndex))
 							{
 								int mapCursor;
-								
+
 								if (J9SW_REGISTER_MAP_WALK_REGISTERS_LOW_TO_HIGH) {
 									mapCursor = 0;
 								} else {
@@ -1360,31 +1360,31 @@ public class MethodMetaData
 		{
 			VoidPointer stackMap;
 			PointerPointer stackAllocMap;
-			
+
 			if (methodMetaData.gcStackAtlas().isNull()) {
 				return VoidPointer.NULL;
 			}
-			
+
 			if (curStackMap.notNull()) {
 				stackMap = curStackMap;
 			} else {
 				stackMap = getStackMapFromJitPC(javaVM, methodMetaData, jitPC);
 			}
-			
+
 			stackAllocMap = PointerPointer.cast(J9JITStackAtlasPointer.cast(methodMetaData.gcStackAtlas()).stackAllocMap());
-			
+
 			if (stackAllocMap.notNull()) {
 				UDATA returnValue;
-				
+
 				if (UDATAPointer.cast(stackAllocMap.at(0)).eq(stackMap)) {
 					return VoidPointer.NULL;
 				}
-				
+
 				returnValue = UDATA.cast(stackAllocMap).add(UDATA.SIZEOF);
-				
+
 				return VoidPointer.cast(returnValue);
 			}
-			
+
 			return VoidPointer.NULL;
 		}
 
@@ -1392,17 +1392,17 @@ public class MethodMetaData
 				VoidPointer stackMap) throws CorruptDataException
 		{
 			U8Pointer cursor = GET_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(metaData), stackMap);
-			
+
 			if ( U32Pointer.cast(cursor).at(0).anyBitsIn(INTERNAL_PTR_REG_MASK) && getJitInternalPointerMap(getJitGCStackAtlas(metaData)).notNull() ) {
 				cursor = cursor.add( cursor.add(4).at(0).add(1));
 			}
-			
+
 			cursor = cursor.add(4);
-			
+
 			return cursor;
 		}
-		
-		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap) 
+
+		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
 			return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 2));
 		}
@@ -1419,7 +1419,7 @@ public class MethodMetaData
 			}
 			return numInlinedCallSites;
 		}
-		
+
 		private U8Pointer getInlinedCallSiteArrayElement(J9JITExceptionTablePointer methodMetaData, int cix) throws CorruptDataException
 		{
 			U8Pointer inlinedCallSiteArray = U8Pointer.cast(getJitInlinedCallInfo(methodMetaData));
@@ -1429,7 +1429,7 @@ public class MethodMetaData
 
 			return U8Pointer.NULL;
 		}
-		
+
 		private boolean isPatchedValue(J9MethodPointer m)
 		{
 			if ((J9ConfigFlags.arch_power && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
@@ -1439,21 +1439,21 @@ public class MethodMetaData
 			return false;
 		}
 
-		
+
 		public void markClassesInInlineRanges(J9JITExceptionTablePointer methodMetaData, WalkState walkState)
 				throws CorruptDataException
 		{
 			J9MethodPointer savedMethod = walkState.method;
 			J9ConstantPoolPointer savedCP = walkState.constantPool;
-			
+
 			U32 numCallSites = getNumInlinedCallSites(methodMetaData);
-			
+
 			int i = 0;
 			for (i=0; i<numCallSites.intValue(); i++)
 			{
 				U8Pointer inlinedCallSite = getInlinedCallSiteArrayElement(methodMetaData, i);
 				J9MethodPointer inlinedMethod = J9MethodPointer.cast(getInlinedMethod(VoidPointer.cast(inlinedCallSite)));
-				
+
 				if (!isPatchedValue(inlinedMethod))
 				{
 					walkState.method = inlinedMethod;
@@ -1466,7 +1466,7 @@ public class MethodMetaData
 			walkState.constantPool = savedCP;
 
 		}
-		
+
 	}
 
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/JitMetadataFromPcCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/JitMetadataFromPcCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,14 +37,14 @@ import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class JitMetadataFromPcCommand extends Command 
+public class JitMetadataFromPcCommand extends Command
 {
 	public JitMetadataFromPcCommand()
 	{
 		addCommand("jitmetadatafrompc", "<pc>", "Show jit method metadata for PC");
 	}
-	
-	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException
 	{
 		try {
 			UDATA searchValue = new UDATA(Long.decode(args[0]));
@@ -60,7 +60,7 @@ public class JitMetadataFromPcCommand extends Command
 
 	}
 
-	void dbgext_j9jitexceptiontable(PrintStream out, J9JITExceptionTablePointer parm) throws CorruptDataException 
+	void dbgext_j9jitexceptiontable(PrintStream out, J9JITExceptionTablePointer parm) throws CorruptDataException
 	{
 		/* print individual fields */
 		CommandUtils.dbgPrint(out, "J9JITExceptionTable at %s {\n", parm.getHexAddress());
@@ -73,7 +73,7 @@ public class JitMetadataFromPcCommand extends Command
 		CommandUtils.dbgPrint(out, "    UDATA parm.endWarmPC = %s;\n", parm.endWarmPC().getHexValue());
 		CommandUtils.dbgPrint(out, "    UDATA parm.startColdPC = %s;\n", parm.startColdPC().getHexValue());
 		CommandUtils.dbgPrint(out, "    UDATA parm.endPC = %s;\n", parm.endPC().getHexValue());
-		CommandUtils.dbgPrint(out, "    UDATA parm.totalFrameSize = %s;\n", parm.totalFrameSize().getHexValue());
+		CommandUtils.dbgPrint(out, "    UDATA parm.totalFrameSizeInSlots = %s;\n", parm.totalFrameSizeInSlots().getHexValue());
 		CommandUtils.dbgPrint(out, "    I_16 parm.slots = %s;\n", parm.slots().getHexValue());
 		CommandUtils.dbgPrint(out, "    I_16 parm.scalarTempSlots = %s;\n", parm.scalarTempSlots().getHexValue());
 		CommandUtils.dbgPrint(out, "    I_16 parm.objectTempSlots = %s;\n", parm.objectTempSlots().getHexValue());

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -231,7 +231,7 @@ dumpStack(J9VMThread *currentThread, char const *msg)
 
 
 static void
-decompPrintMethod(J9VMThread * currentThread, J9Method * method) 
+decompPrintMethod(J9VMThread * currentThread, J9Method * method)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9UTF8 * className = J9ROMCLASS_CLASSNAME(UNTAGGED_METHOD_CP(method)->ramClass->romClass);
@@ -346,7 +346,7 @@ jitCleanUpDecompilationStack(J9VMThread * currentThread, J9StackWalkState * walk
 #endif /* J9VM_INTERP_HOT_CODE_REPLACEMENT (autogen) */
 
 
-void  
+void
 jitCodeBreakpointAdded(J9VMThread * currentThread, J9Method * method)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
@@ -354,7 +354,7 @@ jitCodeBreakpointAdded(J9VMThread * currentThread, J9Method * method)
 	J9JITBreakpointedMethod * breakpointedMethod;
 	J9JITBreakpointedMethod * breakpointedMethods = jitConfig->breakpointedMethods;
 	J9VMThread * loopThread;
-	
+
 	/* Called under exclusive access, so no mutex required */
 
 	Trc_Decomp_jitCodeBreakpointAdded_Entry(currentThread, method);
@@ -397,13 +397,13 @@ jitCodeBreakpointAdded(J9VMThread * currentThread, J9Method * method)
 		walkState.frameWalkFunction = codeBreakpointAddedFrameIterator;
 		walkState.walkThread = loopThread;
 		currentThread->javaVM->walkStackFrames(currentThread, &walkState);
-	} while ((loopThread = loopThread->linkNext) != currentThread);	
+	} while ((loopThread = loopThread->linkNext) != currentThread);
 
 	Trc_Decomp_jitCodeBreakpointAdded_Exit(currentThread);
 }
 
 
-void  
+void
 jitCodeBreakpointRemoved(J9VMThread * currentThread, J9Method * method)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
@@ -454,7 +454,7 @@ codeBreakpointAddedFrameIterator(J9VMThread * currentThread, J9StackWalkState * 
 
 #if (defined(J9VM_INTERP_HOT_CODE_REPLACEMENT)) /* priv. proto (autogen) */
 
-void  
+void
 jitHotswapOccurred(J9VMThread * currentThread)
 {
 	/* We have exclusive */
@@ -483,7 +483,7 @@ jitHotswapOccurred(J9VMThread * currentThread)
 #endif /* J9VM_INTERP_HOT_CODE_REPLACEMENT (autogen) */
 
 
-void  
+void
 jitDecompileMethod(J9VMThread * currentThread, J9JITDecompilationInfo * decompRecord)
 {
 	J9JITDecompileState decompileState;
@@ -1190,7 +1190,7 @@ addDecompilation(J9VMThread * currentThread, J9StackWalkState * walkState, UDATA
 	return info;
 }
 
-void  
+void
 c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 {
 	/* Fetch the exception from the JIT */
@@ -1273,7 +1273,7 @@ c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 
 #if (defined(J9VM_INTERP_HOT_CODE_REPLACEMENT)) /* priv. proto (autogen) */
 
-void  
+void
 jitDecompileMethodForFramePop(J9VMThread * currentThread, UDATA skipCount)
 {
 	J9JITDecompileState decompileState;
@@ -1349,7 +1349,7 @@ freeDecompilationRecord(J9VMThread * decompileThread, J9JITDecompilationInfo * i
 }
 
 
-void  
+void
 jitDataBreakpointAdded(J9VMThread * currentThread)
 {
 	J9JavaVM *vm = currentThread->javaVM;
@@ -1380,7 +1380,7 @@ jitDataBreakpointAdded(J9VMThread * currentThread)
 			/* Make all future compilations inline the field watch code */
 			jitConfig->inlineFieldWatches = TRUE;
 		} else {
-			jitConfig->jitClassesRedefined(currentThread, 0, NULL);			
+			jitConfig->jitClassesRedefined(currentThread, 0, NULL);
 		}
 
 		/* Find every method which has been translated and mark it for retranslation */
@@ -1400,7 +1400,7 @@ jitDataBreakpointAdded(J9VMThread * currentThread)
 }
 
 
-void  
+void
 jitDataBreakpointRemoved(J9VMThread * currentThread)
 {
 	J9JavaVM *vm = currentThread->javaVM;
@@ -1492,13 +1492,13 @@ deleteAllDecompilations(J9VMThread * currentThread, UDATA reason, J9Method * met
 				previous = &(current->next);
 			}
 		}
-	} while ((loopThread = loopThread->linkNext) != currentThread);	
+	} while ((loopThread = loopThread->linkNext) != currentThread);
 
 	Trc_Decomp_deleteAllDecompilations_Exit(currentThread);
 }
 
 
-void  
+void
 jitExceptionCaught(J9VMThread * currentThread)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
@@ -1611,7 +1611,7 @@ reinstallAllBreakpoints(J9VMThread * currentThread)
 }
 
 
-void  
+void
 jitSingleStepAdded(J9VMThread * currentThread)
 {
 	/* We have exclusive */
@@ -1629,7 +1629,7 @@ jitSingleStepAdded(J9VMThread * currentThread)
 }
 
 
-void  
+void
 jitSingleStepRemoved(J9VMThread * currentThread)
 {
 	/* We have exclusive */
@@ -1691,7 +1691,7 @@ findOSRFrameAtInlineDepth(J9OSRBuffer *osrBuffer, UDATA inlineDepth)
 
 #if (defined(J9VM_OPT_JVMTI)) /* priv. proto (autogen) */
 
-static void  
+static void
 jitFramePopNotificationAdded(J9VMThread * currentThread, J9StackWalkState * walkState, UDATA inlineDepth)
 {
 	J9JITDecompilationInfo *decompilationInfo = NULL;
@@ -1731,7 +1731,7 @@ jitStackLocalsModified(J9VMThread * currentThread, J9StackWalkState * walkState)
 }
 
 
-void  
+void
 jitBreakpointedMethodCompiled(J9VMThread * currentThread, J9Method * method, void * startAddress)
 {
 	J9JITConfig * jitConfig = currentThread->javaVM->jitConfig;
@@ -1872,9 +1872,9 @@ performOSR(J9VMThread *currentThread, J9StackWalkState *walkState, J9OSRBuffer *
 
 	/* Copy the stack frame after the scratch buffer (assume it's been allocated correctly).
 	 * Assert the number of bytes provided matches the expected frame size from the metadata
-	 * (arguments + return address + totalFrameSize slots).
+	 * (arguments + return address + totalFrameSizeInSlots slots).
 	 */
-	Assert_CodertVM_true(jitStackFrameSize == ((J9_ARG_COUNT_FROM_ROM_METHOD(J9_ROM_METHOD_FROM_RAM_METHOD(metaData->ramMethod)) + 1 + metaData->totalFrameSize) * sizeof(UDATA)));
+	Assert_CodertVM_true(jitStackFrameSize == ((J9_ARG_COUNT_FROM_ROM_METHOD(J9_ROM_METHOD_FROM_RAM_METHOD(metaData->ramMethod)) + 1 + metaData->totalFrameSizeInSlots) * sizeof(UDATA)));
 	memcpy(osrJittedFrameCopy, walkState->unwindSP, jitStackFrameSize);
 
 	/* Perform the OSR */
@@ -2206,7 +2206,7 @@ done:
  * @param[in] *currentThread current thread
  * @param[in] *jitPC compiled PC at which to OSR
  */
-void 
+void
 induceOSROnCurrentThread(J9VMThread * currentThread)
 {
 	J9JavaVM * vm = currentThread->javaVM;

--- a/runtime/codert_vm/dlt.c
+++ b/runtime/codert_vm/dlt.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,7 @@ retry:
 	/* Check for stack overflow */
 
 	metaData = jitGetExceptionTableFromPC(currentThread, (UDATA) dltEntry);
-	checkSP = walkState->sp - (metaData->totalFrameSize + J9SW_JIT_STACK_SLOTS_USED_BY_CALL);
+	checkSP = walkState->sp - (metaData->totalFrameSizeInSlots + J9SW_JIT_STACK_SLOTS_USED_BY_CALL);
 	if (checkSP < currentThread->stackOverflowMark2) {
 #if defined(J9VM_INTERP_GROWABLE_STACKS)
 		/* If we are already handling an overflow, abandon the DLT */
@@ -104,7 +104,7 @@ retry:
 				if (bytesRequired > maxSize) {
 					bytesRequired = maxSize;
 				}
-				
+
 				/* If the grow succeeds, restart the stack walk since all the stack pointers have moved */
 
 				if (vm->internalVMFunctions->growJavaStack(currentThread, bytesRequired) == 0) {

--- a/runtime/compiler/ras/kca_offsets_generator.cpp
+++ b/runtime/compiler/ras/kca_offsets_generator.cpp
@@ -103,7 +103,7 @@ J9::Options::kcaOffsets(char *option, void *, TR::OptionTable *entry)
       fprintf( file, "#define METADATA_ENDWARMPC         (%d)\n", offsetof(J9JITExceptionTable,endWarmPC) );
       fprintf( file, "#define METADATA_COLDSTART         (%d)\n", offsetof(J9JITExceptionTable,startColdPC) );
       fprintf( file, "#define METADATA_COLDEND           (%d)\n", offsetof(J9JITExceptionTable,endPC) );
-      fprintf( file, "#define METADATA_FRAMESIZE         (%d)\n", offsetof(J9JITExceptionTable,totalFrameSize) );
+      fprintf( file, "#define METADATA_FRAMESIZE         (%d)\n", offsetof(J9JITExceptionTable,totalFrameSizeInSlots) );
       fprintf( file, "#define METADATA_NUM_EXC_RANGES    (%d)\n", offsetof(J9JITExceptionTable,numExcptionRanges) );
       fprintf( file, "#define METADATA_INLINEDCALLS      (%d)\n", offsetof(J9JITExceptionTable,inlinedCalls) );
       fprintf( file, "#define METADATA_BODYINFO          (%d)\n", offsetof(J9JITExceptionTable,bodyInfo) );

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1449,7 +1449,7 @@ createMethodMetaData(
       data->flags |= JIT_METADATA_GC_MAP_32_BIT_OFFSETS;
 
    data->hotness = comp->getMethodHotness();
-   data->totalFrameSize = comp->cg()->getFrameSizeInBytes()/TR::Compiler->om.sizeofReferenceAddress();
+   data->totalFrameSizeInSlots = comp->cg()->getFrameSizeInBytes()/TR::Compiler->om.sizeofReferenceAddress();
    data->slots = vmMethod->numberOfParameterSlots();
    data->scalarTempSlots = methodSymbol->getScalarTempSlots();
    data->objectTempSlots = methodSymbol->getObjectTempSlots();

--- a/runtime/compiler/runtime/MetaDataDebug.cpp
+++ b/runtime/compiler/runtime/MetaDataDebug.cpp
@@ -63,7 +63,7 @@ TR_Debug::printJ9JITExceptionTableDetails(J9JITExceptionTable *data, J9JITExcept
    trfprintf(_file, "scalarTempSlots=%d, objectTempSlots=%d\n", data->scalarTempSlots, data->objectTempSlots);
    trfprintf(_file, "prologuePushes=%d, tempOffset=%d\n", data->prologuePushes, data->tempOffset);
    trfprintf(_file, "registerSaveDescription=[%p]\n", data->registerSaveDescription);
-   trfprintf(_file, "totalFrameSize=%d { Real Frame Size: %d }\n", data->totalFrameSize, (data->totalFrameSize + 1) * TR::Compiler->om.sizeofReferenceAddress());
+   trfprintf(_file, "totalFrameSizeInSlots=%d { Real Frame Size: %d }\n", data->totalFrameSizeInSlots, (data->totalFrameSizeInSlots + 1) * TR::Compiler->om.sizeofReferenceAddress());
    trfprintf(_file, "bodyInfo= [%p]\n", data->bodyInfo);
    }
 
@@ -78,7 +78,7 @@ TR_Debug::print(J9JITExceptionTable * data, TR_ResolvedMethod * feMethod, bool f
    int32_t sizeOfStackAtlas = 0;
    int32_t * offsetInfo = 0;
    if (sa)
-      offsetInfo = printStackAtlas(startPC, sa->getAtlasBits(), sa->getNumberOfSlotsMapped(), fourByteOffsets, &sizeOfStackAtlas, data->totalFrameSize);
+      offsetInfo = printStackAtlas(startPC, sa->getAtlasBits(), sa->getNumberOfSlotsMapped(), fourByteOffsets, &sizeOfStackAtlas, data->totalFrameSizeInSlots);
 
    TR_ASSERT( sizeOfStackAtlas, "size of stack atlas cannot be 0\n");
 

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -286,7 +286,7 @@ static void printMetaData(J9TR_MethodMetaData * methodMetaData)
       printf("Stub Metadata 0x%p, nothing to dump\n", methodMetaData);
       return;
       }
-   
+
    printf("Metadata dump:\n");
    initializeIterator(&iter, methodMetaData);
    for (index = 0; index < iter._stackAtlas->numberOfMaps; ++index)
@@ -376,7 +376,7 @@ void jitGetMapsFromPC(J9JavaVM * javaVM, J9TR_MethodMetaData * methodMetaData, U
 
    if (methodMetaData->flags & JIT_METADATA_IS_STUB)
       return;
-   
+
    if (!stackAtlas)
       return;
 
@@ -1212,7 +1212,7 @@ void aotMethodMetaDataFixEndian(J9JITExceptionTable * methodMetaData)
    J9_AOT_FIX_ENDIAN(methodMetaData->startColdPC)
 
    J9_AOT_FIX_ENDIAN(methodMetaData->hotness)
-   J9_AOT_FIX_ENDIAN(methodMetaData->totalFrameSize)
+   J9_AOT_FIX_ENDIAN(methodMetaData->totalFrameSizeInSlots)
    J9_AOT_FIX_ENDIAN_HALF(methodMetaData->slots)
    J9_AOT_FIX_ENDIAN_HALF(methodMetaData->scalarTempSlots)
    J9_AOT_FIX_ENDIAN_HALF(methodMetaData->objectTempSlots)
@@ -1367,7 +1367,7 @@ void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** 
 
        /* If base array was moved by a non zero displacement
        */
-#if defined(J9VM_INTERP_STACKWALK_TRACING) 
+#if defined(J9VM_INTERP_STACKWALK_TRACING)
       if ((displacement != 0) || (walkState->walkThread->javaVM->runtimeFlags & J9_RUNTIME_SNIFF_AND_WHACK))
 #else
       if (displacement != 0)
@@ -1767,7 +1767,7 @@ JITINLINE UDATA getJittedMethodEndPC(J9TR_MethodMetaData * md)
 
 I_16 getJitTotalFrameSize(J9TR_MethodMetaData * md)
    {
-   return (I_16) md->totalFrameSize;
+   return (I_16) md->totalFrameSizeInSlots;
    }
 
 I_16 getJitSlots(J9TR_MethodMetaData * md)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
- *
  * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
@@ -503,7 +503,7 @@ typedef struct J9JITExceptionTable {
 	UDATA endWarmPC;
 	UDATA startColdPC;
 	UDATA endPC;
-	UDATA totalFrameSize;
+	UDATA totalFrameSizeInSlots;
 	I_16 slots;
 	I_16 scalarTempSlots;
 	I_16 objectTempSlots;
@@ -1725,19 +1725,19 @@ typedef struct J9ModuleExtraInfo {
 /*             Structure of Flattened Class Cache              */
 /*                                                             *
  *    Default Value   |   Number of Entries   |                *
- *____________________|_______________________|________________* 
+ *____________________|_______________________|________________*
  *                    |                       |                *
  *      clazz 0       |   Name & Signature 0  |     offset 0   *
- *____________________|_______________________|________________* 
+ *____________________|_______________________|________________*
  *                    |                       |                *
  *      clazz 1       |   Name & Signature 1  |     offset 1   *
- *____________________|_______________________|________________* 
+ *____________________|_______________________|________________*
  *         .          |           .           |        .       *
  *         .          |           .           |        .       *
  *         .          |           .           |        .       *
- *____________________|_______________________|________________* 
+ *____________________|_______________________|________________*
  *                    |                       |                *
- *      clazz N       |   Name & Signature N  |     offset N   * 
+ *      clazz N       |   Name & Signature N  |     offset N   *
  ***************************************************************/
 typedef struct J9FlattenedClassCacheEntry {
 	struct J9Class* clazz;


### PR DESCRIPTION
The `totalFrameSize` metadata field is actually represented in slots rather than
bytes.  Rename the field to `totalFrameSizeInSlots` to make this less ambiguous
for the casual developer.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>