### PR TITLE
Rename TR_DisableInliningOfIsAssignableFrom to TR_disableInlineIsAssignableFrom

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -396,7 +396,7 @@ J9::X86::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod 
 bool
 J9::X86::CodeGenerator::supportsInliningOfIsAssignableFrom()
    {
-   static const bool disableInliningOfIsAssignableFrom = (bool)feGetEnv("TR_DisableInliningOfIsAssignableFrom");
+   static const bool disableInliningOfIsAssignableFrom = feGetEnv("TR_disableInlineIsAssignableFrom") != NULL;
    return !disableInliningOfIsAssignableFrom;
    }
 


### PR DESCRIPTION
Add consistency with other codegens by performing the environment
variable rename.

Fixes: #7194

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>