### PR TITLE
AArch64: Implement functions of TR_ARM64RelocationTarget

### DIFF
--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -533,6 +533,7 @@ uint8_t *TR::ARM64CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSi
 
    TR::RealRegister *x15reg = cg->machine()->getRealRegister(TR::RealRegister::x15);
 
+   *((int32_t *)thunk + 1) = buffer - returnValue;  // patch offset for AOT relocation
    // movz x15, low 16 bits
    *(int32_t *)buffer = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::movzx) | ((dispatcher & 0xFFFF) << 5);
    x15reg->setRegisterFieldRD((uint32_t *)buffer);
@@ -554,7 +555,6 @@ uint8_t *TR::ARM64CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argSi
    x15reg->setRegisterFieldRN((uint32_t *)buffer);
    buffer += ARM64_INSTRUCTION_LENGTH;
 
-   *((int32_t *)thunk + 1) = buffer - returnValue;  // patch offset for AOT relocation
    *(int32_t *)thunk = buffer - returnValue;        // patch size of thunk
 
 #ifdef TR_HOST_ARM64

--- a/runtime/compiler/aarch64/runtime/ARM64RelocationTarget.cpp
+++ b/runtime/compiler/aarch64/runtime/ARM64RelocationTarget.cpp
@@ -27,67 +27,90 @@ void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize);
 uint8_t *
 TR_ARM64RelocationTarget::eipBaseForCallOffset(uint8_t *reloLocation)
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   // reloLocation points at the start of the call offset
+   return reloLocation;
    }
 
 void
 TR_ARM64RelocationTarget::storeCallTarget(uintptr_t callTarget, uint8_t *reloLocation)
    {
-   TR_UNIMPLEMENTED();
+   // reloLocation points at the start of the call offset, so just store the uint8_t * at reloLocation
+   storePointer((uint8_t *)callTarget, reloLocation);;
    }
 
 uint32_t
 TR_ARM64RelocationTarget::loadCPIndex(uint8_t *reloLocation)
    {
-   TR_UNIMPLEMENTED();
-   return 0;
+   // reloLocation points at the cpAddress in snippet, need to find cpIndex location
+   reloLocation += sizeof(uintptr_t);
+   return (uint32_t)(((uintptr_t )loadPointer(reloLocation)) & 0xFFFFFFFFUL); // Mask out lower 32 bits for index
    }
 
 uintptr_t
 TR_ARM64RelocationTarget::loadThunkCPIndex(uint8_t *reloLocation)
    {
-   TR_UNIMPLEMENTED();
-   return 0;
+   // reloLocation points at the cpAddress in snippet, need to find cpIndex location
+   reloLocation += sizeof(uintptr_t);
+   return (uintptr_t )loadPointer(reloLocation);
    }
 
 void
 TR_ARM64RelocationTarget::performThunkRelocation(uint8_t *thunkBase, uintptr_t vmHelper)
    {
-   TR_UNIMPLEMENTED();
+   uintptr_t sendTarget = vmHelper;
+   int32_t *thunkRelocationData = (int32_t *)(thunkBase - sizeof(int32_t));
+
+   storeAddressSequence((uint8_t *)vmHelper, thunkBase + *thunkRelocationData, 1);
+
+   arm64CodeSync(thunkBase, *((int32_t*)(thunkBase - 2*sizeof(int32_t))));
    }
 
 uint8_t *
 TR_ARM64RelocationTarget::loadAddressSequence(uint8_t *reloLocation)
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   TR_ASSERT(0, "AOT New Relo Runtime: don't expect loadAddressSequence to be called!\n");
+   uintptr_t value = 0;
+   return (uint8_t *)value;
    }
 
 void
 TR_ARM64RelocationTarget::storeAddressSequence(uint8_t *address, uint8_t *reloLocation, uint32_t seqNumber)
    {
-   TR_UNIMPLEMENTED();
+   uintptr_t value = (uintptr_t)address;
+   uint32_t *movInstruction = (uint32_t *) reloLocation;
+   // immediate offset is at bit 20:5
+   *movInstruction = (*movInstruction & (~((uint32_t)0xFFFF << 5))) | ((value & 0x0000FFFF) << 5);
+   *(movInstruction + 1) = (*(movInstruction + 1) & (~((uint32_t)0xFFFF << 5))) | (((value >> 16) & 0x0000FFFF) << 5);
+   *(movInstruction + 2) = (*(movInstruction + 2) & (~((uint32_t)0xFFFF << 5))) | (((value >> 32) & 0x0000FFFF) << 5);
+   *(movInstruction + 3) = (*(movInstruction + 3) & (~((uint32_t)0xFFFF << 5))) | (((value >> 48) & 0x0000FFFF) << 5);
    }
 
 void
 TR_ARM64RelocationTarget::storeRelativeTarget(uintptr_t callTarget, uint8_t *reloLocation)
    {
-   TR_UNIMPLEMENTED();
+   // reloLocation points at the start of the instruction. We store imm26 offset to the instruction.
+   int32_t instruction = *((int32_t *)reloLocation);
+
+   instruction &= (int32_t)0xFC000000;
+   // labels will always be 4 aligned, CPU shifts # left by 2
+   // during execution (26 bits -> 28 bit branch reach)
+   instruction |= (callTarget >> 2) & 0x03FFFFFF;
+
+   storeSigned32b(instruction, (uint8_t *)reloLocation);
    }
 
 bool
-TR_ARM64RelocationTarget::useTrampoline(uint8_t * helperAddress, uint8_t *baseLocation)
+TR_ARM64RelocationTarget::useTrampoline(uint8_t *helperAddress, uint8_t *baseLocation)
    {
-   TR_UNIMPLEMENTED();
-   return false;
+   return
+      !TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange((intptrj_t)helperAddress, (intptrj_t)baseLocation) ||
+      TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines);
    }
 
 uint8_t *
 TR_ARM64RelocationTarget::arrayCopyHelperAddress(J9JavaVM *javaVM)
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   return reinterpret_cast<uint8_t *>(javaVM->memoryManagerFunctions->referenceArrayCopy);
    }
 
 void


### PR DESCRIPTION
This commit adds implementation of TR_ARM64RelocationTarget and
changes patch offset encoded in TR::ARM64CallSnippet::generateVIThunk.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>