### PR TITLE
Eliminate VM_isSameOrSuperClass messages

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -228,12 +228,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getSuperClass(clazz));
          }
          break;
-      case MessageType::VM_isSameOrSuperClass:
-         {
-         auto tup = client->getRecvData<J9Class*, J9Class*>();
-         client->write(response, fe->isSameOrSuperClass(std::get<0>(tup), std::get<1>(tup)));
-         }
-         break;
       case MessageType::VM_isInstanceOf:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, bool, bool, bool>();

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -83,9 +83,27 @@ TR_J9ServerVM::getSuperClass(TR_OpaqueClassBlock *clazz)
 bool
 TR_J9ServerVM::isSameOrSuperClass(J9Class *superClass, J9Class *subClass)
    {
+   if (superClass == subClass) // same class
+      return true;
+
+   void *superClassLoader, *subClassLoader;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isSameOrSuperClass, superClass, subClass);
-   return std::get<0>(stream->read<bool>());
+   JITServerHelpers::getAndCacheRAMClassInfo(superClass, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_LOADER, &superClassLoader);
+   JITServerHelpers::getAndCacheRAMClassInfo(subClass, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_LOADER, &subClassLoader);
+   if (superClassLoader != subClassLoader)
+      return false;
+
+   TR_OpaqueClassBlock *candidateSuperClassPtr = reinterpret_cast<TR_OpaqueClassBlock *>(superClass);
+   TR_OpaqueClassBlock *classPtr = reinterpret_cast<TR_OpaqueClassBlock *>(subClass);
+   // walk the hierarchy, trying to find a matching super class
+   while (classPtr)
+      {
+      // getSuperClass might invoke a remote call with a very low probability
+      classPtr = getSuperClass(classPtr); 
+      if (classPtr == candidateSuperClassPtr)
+         return true;
+      }
+   return false;
    }
 
 

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -231,7 +231,6 @@ enum MessageType
    VM_getReferenceFieldAt = 306;
    VM_getJ2IThunk = 307;
    VM_needsInvokeExactJ2IThunk = 308;
-   VM_isSameOrSuperClass = 309;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
After a recent rebase `VM_isSameOrSuperClass` is the most
frequent message in AOT mode, as described in issue #7072.
Eliminate this message by using `getSuperClass` method of
the VM to fetch the super class, instead of calling a VM
method directly. Since we already do caching in `getSuperClass`,
this will eliminate most messages associated with
`isSameOrSuperClass`.