### PR TITLE
Valhalla: value type cast to null changes to checkcast

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7608,12 +7608,12 @@ done:
 	{
 retry:
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
+		U_16 index = *(U_16*)(_pc + 1);
+		J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);
+		J9RAMClassRef *ramCPEntry = ((J9RAMClassRef*)ramConstantPool) + index;
+		J9Class* volatile castClass = ramCPEntry->value;
 		j9object_t obj = *(j9object_t*)_sp;
 		if (NULL != obj) {
-			U_16 index = *(U_16*)(_pc + 1);
-			J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);
-			J9RAMClassRef *ramCPEntry = ((J9RAMClassRef*)ramConstantPool) + index;
-			J9Class* volatile castClass = ramCPEntry->value;
 			if (NULL != castClass) {
 				J9Class *instanceClass = J9OBJECT_CLAZZ(_currentThread, obj);
 				profileCast(REGISTER_ARGS, instanceClass);
@@ -7626,6 +7626,7 @@ retry:
 					goto done;
 				}
 			} else {
+resolve:
 				/* Unresolved */
 				buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 				updateVMStruct(REGISTER_ARGS);
@@ -7642,6 +7643,17 @@ retry:
 				goto retry;
 			}
 		}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		else {
+			if (NULL == castClass) {
+				/* Resolve the class and then check again whether it is a value type */
+				goto resolve;
+			} else if (J9_IS_J9CLASS_VALUETYPE(castClass)) {
+				rc = THROW_NPE;
+				goto done;
+			}
+		}
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 		_pc += 3;
 done:
 		return rc;

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -101,9 +101,12 @@ public class ValueTypeGenerator extends ClassLoader {
 			testMonitorEnterOnObject(cw, className, fields);
 			testMonitorExitOnObject(cw, className, fields);
 			testMonitorEnterAndExitWithRefType(cw, className, fields);
+			testCheckCastRefClassOnNull(cw, className, fields);
 		} else {
 			makeValue(cw, className, makeValueSig, fields, makeMaxLocal);
 			makeValueTypeDefaultValue(cw, className, makeValueSig, fields, makeMaxLocal);
+			testCheckCastValueTypeOnNull(cw, className, fields);
+			testCheckCastValueTypeOnNonNullType(cw, className, fields);
 			if (!isVerifiable) {
 				makeGeneric(cw, className, "makeValueGeneric", "makeValue", makeValueSig, makeValueGenericSig, fields, makeMaxLocal);
 			}
@@ -290,6 +293,36 @@ public class ValueTypeGenerator extends ClassLoader {
 		mv.visitTypeInsn(DEFAULTVALUE, valueName);
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 0);
+		mv.visitEnd();
+	}
+
+	private static void testCheckCastValueTypeOnNonNullType(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "testCheckCastValueTypeOnNonNullType", "()Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitTypeInsn(DEFAULTVALUE, className);
+		mv.visitTypeInsn(CHECKCAST, className);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 2);
+		mv.visitEnd();
+	}
+
+	private static void testCheckCastValueTypeOnNull(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastValueTypeOnNull", "()Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitInsn(ACONST_NULL);
+		mv.visitTypeInsn(CHECKCAST, className);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 2);
+		mv.visitEnd();
+	}
+
+	private static void testCheckCastRefClassOnNull(ClassWriter cw, String className, String[] fields) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastRefClassOnNull", "()Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitTypeInsn(NEW, className);
+		mv.visitTypeInsn(CHECKCAST, className);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 2);
 		mv.visitEnd();
 	}
 

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1491,6 +1491,39 @@ public class ValueTypeTests {
 		}
 	}
 
+	/*
+	 * Ensure that casting null to a value type class will throw a null pointer exception 
+	 */
+	@Test(priority=1, expectedExceptions=NullPointerException.class)
+	static public void testCheckCastValueTypeOnNull() throws Throwable {
+		String fields[] = {"longField:J"};
+		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastValueTypeOnNull", fields);
+		MethodHandle checkCastValueTypeOnNull = lookup.findStatic(valueClass, "testCheckCastValueTypeOnNull", MethodType.methodType(Object.class));
+		checkCastValueTypeOnNull.invoke();
+	}
+
+	/*
+	 * Ensure that casting a non null value type to a valid value type will pass
+	 */
+	@Test(priority=1)
+	static public void testCheckCastValueTypeOnNonNullType() throws Throwable {
+		String fields[] = {"longField:J"};
+		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastValueTypeOnNonNullType", fields);
+		MethodHandle checkCastValueTypeOnNonNullType = lookup.findStatic(valueClass, "testCheckCastValueTypeOnNonNullType", MethodType.methodType(Object.class));
+		checkCastValueTypeOnNonNullType.invoke();
+	}
+
+	/*
+	 * Ensure that casting null to a reference type class will pass
+	 */
+	@Test(priority=1)
+	static public void testCheckCastRefClassOnNull() throws Throwable {
+		String fields[] = {"longField:J"};
+		Class refClass = ValueTypeGenerator.generateRefClass("TestCheckCastRefClassOnNull", fields);
+		MethodHandle checkCastRefClassOnNull = lookup.findStatic(refClass, "testCheckCastRefClassOnNull", MethodType.methodType(Object.class));
+		checkCastRefClassOnNull.invoke();
+	}
+
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {
 		try {
 			return lookup.findVirtual(clazz, "get"+fieldName, MethodType.methodType(fieldType));


### PR DESCRIPTION
These changes introduce functionality that throws a null pointer exception if a checkcast detects that a null reference is being casted to a value type. Tests for this are also included here.