### PR TITLE
AArch64: Set LRKilled flag in asynccheckEvaluator()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -359,6 +359,9 @@ J9::ARM64::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::CodeGenerator 
 
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
 
+   // ARM64HelperCallSnippet generates "bl" instruction
+   cg->machine()->setLinkRegisterKilled(true);
+
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
    cg->decReferenceCount(testNode);


### PR DESCRIPTION
This commit adds a call to setLinkRegisterKilled() in
asynccheckEvaluator() for AArch64.
There was a case where LR was not restored at the method epilogue
without this fix.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>