### PR TITLE
AArch64: Implement initializeAOTRelocationHeader

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -22,6 +22,10 @@
 
 #include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "runtime/RelocationRuntime.hpp"
+#include "runtime/RelocationRecord.hpp"
 
 J9::ARM64::AheadOfTimeCompile::AheadOfTimeCompile(TR::CodeGenerator *cg) :
          J9::AheadOfTimeCompile(_relocationTargetTypeToHeaderSizeMap, cg->comp()),
@@ -36,8 +40,1035 @@ void J9::ARM64::AheadOfTimeCompile::processRelocations()
 
 uint8_t *J9::ARM64::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   TR::Compilation* comp = TR::comp();
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
+   TR_SharedCache *sharedCache = fej9->sharedCache();
+   TR::SymbolValidationManager *symValManager = comp->getSymbolValidationManager();
+
+   TR_VirtualGuard *guard;
+   uint8_t flags = 0;
+   TR_ResolvedMethod *resolvedMethod;
+
+   uint8_t *cursor = relocation->getRelocationData();
+
+   TR_RelocationRuntime *reloRuntime = comp->reloRuntime();
+   TR_RelocationTarget *reloTarget = reloRuntime->reloTarget();
+
+   uint8_t * aotMethodCodeStart = (uint8_t *) comp->getRelocatableMethodCodeStart();
+   // size of relocation goes first in all types
+   *(uint16_t *) cursor = relocation->getSizeOfRelocationData();
+
+   cursor += 2;
+
+   uint8_t modifier = 0;
+   uint8_t *relativeBitCursor = cursor;
+   TR::LabelSymbol *table;
+   uint8_t *codeLocation;
+
+   if (relocation->needsWideOffsets())
+      modifier |= RELOCATION_TYPE_WIDE_OFFSET;
+
+   uint8_t targetKind = relocation->getTargetKind();
+   *cursor++ = targetKind;
+   uint8_t *flagsCursor = cursor++;
+   *flagsCursor = modifier;
+   uint32_t *wordAfterHeader = (uint32_t*)cursor;
+#if defined(TR_HOST_64BIT)
+   cursor += 4; // padding
+#endif
+
+   // This has to be created after the kind has been written into the header
+   TR_RelocationRecord storage;
+   TR_RelocationRecord *reloRecord = TR_RelocationRecord::create(&storage, reloRuntime, reloTarget, reinterpret_cast<TR_RelocationRecordBinaryTemplate *>(relocation->getRelocationData()));
+
+   switch (targetKind)
+      {
+      case TR_MethodObject:
+         {
+         TR::SymbolReference *tempSR = (TR::SymbolReference *) relocation->getTargetAddress();
+
+         // next word is the index in the above stored constant pool
+         // that indicates the particular relocation target
+         *(uint64_t *) cursor = (uint64_t) relocation->getTargetAddress2();
+         cursor += SIZEPOINTER;
+
+         // final word is the address of the constant pool to
+         // which the index refers
+         *(uint64_t *) cursor = (uint64_t) (uintptrj_t) tempSR->getOwningMethod(comp)->constantPool();
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_JNISpecialTargetAddress:
+      case TR_VirtualRamMethodConst:
+         {
+         TR::SymbolReference *tempSR = (TR::SymbolReference *)relocation->getTargetAddress();
+         uintptr_t inlinedSiteIndex = (uintptr_t)relocation->getTargetAddress2();
+
+         inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(tempSR->getOwningMethod(comp)->constantPool(), inlinedSiteIndex);
+
+         *(uintptrj_t *)cursor = inlinedSiteIndex;  // inlinedSiteIndex
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)tempSR->getOwningMethod(comp)->constantPool(); // constantPool
+         cursor += SIZEPOINTER;
+
+         uintptrj_t cpIndex=(uintptrj_t)tempSR->getCPIndex();
+         *(uintptrj_t *)cursor =cpIndex;// cpIndex
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_ClassAddress:
+         {
+         TR::SymbolReference *tempSR = (TR::SymbolReference *) relocation->getTargetAddress();
+
+         *(uint64_t *) cursor = (uint64_t) self()->findCorrectInlinedSiteIndex(tempSR->getOwningMethod(comp)->constantPool(), (uintptr_t)relocation->getTargetAddress2()); //inlineSiteIndex
+         cursor += SIZEPOINTER;
+
+         *(uint64_t *) cursor = (uint64_t) (uintptrj_t) tempSR->getOwningMethod(comp)->constantPool();
+         cursor += SIZEPOINTER;
+
+         *(uint64_t *) cursor = tempSR->getCPIndex(); // cpIndex
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_DataAddress:
+         {
+         TR::SymbolReference *tempSR = (TR::SymbolReference *) relocation->getTargetAddress();
+         uintptr_t inlinedSiteIndex = (uintptr_t) relocation->getTargetAddress2();
+
+         // next word is the address of the constant pool to which the index refers
+         inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(tempSR->getOwningMethod(comp)->constantPool(), inlinedSiteIndex);
+
+         // relocation target
+         *(uintptrj_t *) cursor = inlinedSiteIndex; // inlinedSiteIndex
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *) cursor = (uintptrj_t) tempSR->getOwningMethod(comp)->constantPool(); // constantPool
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *) cursor = tempSR->getCPIndex(); // cpIndex
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *) cursor = tempSR->getOffset(); // offset
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_FixedSequenceAddress2:
+         {
+         TR_ASSERT(relocation->getTargetAddress(), "target address is NULL");
+         *(uint64_t *) cursor = relocation->getTargetAddress() ?
+            (uint64_t)((uint8_t *) relocation->getTargetAddress() - aotMethodCodeStart) : 0x0;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_ConstantPoolOrderedPair:
+         {
+         *(uintptrj_t *)cursor = (uintptrj_t)relocation->getTargetAddress2(); // inlined site index
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)relocation->getTargetAddress(); // constantPool
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_ResolvedTrampolines:
+         {
+         uint8_t *symbol = relocation->getTargetAddress();
+         uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+         TR_ASSERT_FATAL(symbolID, "symbolID should exist!\n");
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordResolvedTrampolinesBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordResolvedTrampolinesBinaryTemplate *>(cursor);
+
+         binaryTemplate->_symbolID = symbolID;
+
+         cursor += sizeof(TR_RelocationRecordResolvedTrampolinesBinaryTemplate);
+         }
+         break;
+
+      case TR_J2IVirtualThunkPointer:
+         {
+         auto info = (TR_RelocationRecordInformation*)relocation->getTargetAddress();
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data2; // inlined site index
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data1; // constantPool
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data3; // offset to J2I virtual thunk pointer
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_CheckMethodExit:
+         {
+         *(uint64_t *) cursor = (uint64_t) (uintptrj_t) relocation->getTargetAddress();
+         cursor += SIZEPOINTER;
+         }
+         break;
+     case TR_J2IThunks:
+         {
+         TR::Node *node = (TR::Node*)relocation->getTargetAddress();
+         TR::SymbolReference *symRef = node->getSymbolReference();
+
+         *(uintptrj_t *)cursor = (uintptrj_t)node->getInlinedSiteIndex();
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)symRef->getOwningMethod(comp)->constantPool(); // cp address
+         cursor += SIZEPOINTER;
+
+
+         *(uintptrj_t *)cursor = (uintptrj_t)symRef->getCPIndex(); // cp index
+         cursor += SIZEPOINTER;
+
+         break;
+         }
+      case TR_RamMethodSequence:
+      case TR_RamMethodSequenceReg:
+         {
+         *(uint64_t *) cursor = relocation->getTargetAddress() ?
+            (uint64_t)((uint8_t *) relocation->getTargetAddress() - aotMethodCodeStart) : 0x0;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_MethodPointer:
+         {
+         TR::Node *aconstNode = (TR::Node *) relocation->getTargetAddress();
+         uintptrj_t inlinedSiteIndex = (uintptrj_t)aconstNode->getInlinedSiteIndex();
+         *(uintptrj_t *)cursor = inlinedSiteIndex;
+         cursor += SIZEPOINTER;
+
+         TR_OpaqueMethodBlock *j9method = (TR_OpaqueMethodBlock *) aconstNode->getAddress();
+         TR_OpaqueClassBlock *j9class = fej9->getClassFromMethodBlock(j9method);
+
+         uintptrj_t classChainOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         cursor = self()->emitClassChainOffset(cursor, j9class);
+
+         uintptrj_t vTableOffset = (uintptrj_t) fej9->getInterpreterVTableSlot(j9method, j9class);
+         *(uintptrj_t *)cursor = vTableOffset;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_ClassPointer:
+         {
+         TR::Node *aconstNode = (TR::Node *) relocation->getTargetAddress();
+         uintptrj_t inlinedSiteIndex = (uintptrj_t)aconstNode->getInlinedSiteIndex();
+         *(uintptrj_t *)cursor = inlinedSiteIndex;
+         cursor += SIZEPOINTER;
+
+         TR_OpaqueClassBlock *j9class = (TR_OpaqueClassBlock *) aconstNode->getAddress();
+
+         uintptrj_t classChainOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         cursor = self()->emitClassChainOffset(cursor, j9class);
+         }
+         break;
+
+      case TR_ArbitraryClassAddress:
+         {
+         // ExternalRelocation data is as expected for TR_ClassAddress
+         auto symRef = (TR::SymbolReference *)relocation->getTargetAddress();
+         auto sym = symRef->getSymbol()->castToStaticSymbol();
+         auto j9class = (TR_OpaqueClassBlock *)sym->getStaticAddress();
+         uintptr_t inlinedSiteIndex = self()->findCorrectInlinedSiteIndex(symRef->getOwningMethod(comp)->constantPool(), (uintptr_t)relocation->getTargetAddress2());
+
+         // Data identifying the class is as though for TR_ClassPointer
+         // (TR_RelocationRecordPointerBinaryTemplate)
+         *(uintptrj_t *)cursor = inlinedSiteIndex;
+         cursor += SIZEPOINTER;
+
+         uintptrj_t classChainOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(j9class);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         cursor = self()->emitClassChainOffset(cursor, j9class);
+         }
+         break;
+
+      case TR_InlinedAbstractMethodWithNopGuard:
+      case TR_InlinedVirtualMethod:
+      case TR_InlinedInterfaceMethod:
+         {
+         guard = (TR_VirtualGuard *) relocation->getTargetAddress2();
+
+         // Setup flags field with type of method that needs to be validated at relocation time
+         if (guard->getSymbolReference()->getSymbol()->getMethodSymbol()->isStatic())
+            flags = inlinedMethodIsStatic;
+         if (guard->getSymbolReference()->getSymbol()->getMethodSymbol()->isSpecial())
+            flags = inlinedMethodIsSpecial;
+         if (guard->getSymbolReference()->getSymbol()->getMethodSymbol()->isVirtual())
+            flags = inlinedMethodIsVirtual;
+
+         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
+         *flagsCursor |= (flags & RELOCATION_RELOC_FLAGS_MASK);
+
+         int32_t inlinedSiteIndex = guard->getCurrentInlinedSiteIndex();
+         *(uintptrj_t *) cursor = (uintptrj_t) inlinedSiteIndex;
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *) cursor = (uintptrj_t) guard->getSymbolReference()->getOwningMethod(comp)->constantPool(); // record constant pool
+         cursor += SIZEPOINTER;
+
+         if (relocation->getTargetKind() == TR_InlinedInterfaceMethodWithNopGuard ||
+             relocation->getTargetKind() == TR_InlinedInterfaceMethod ||
+             relocation->getTargetKind() == TR_InlinedAbstractMethodWithNopGuard)
+            {
+            TR_InlinedCallSite *inlinedCallSite = &comp->getInlinedCallSite(inlinedSiteIndex);
+            TR_AOTMethodInfo *aotMethodInfo = (TR_AOTMethodInfo *) inlinedCallSite->_methodInfo;
+            resolvedMethod = aotMethodInfo->resolvedMethod;
+            }
+         else
+            {
+            resolvedMethod = guard->getSymbolReference()->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod();
+            }
+
+         if (comp->getOption(TR_UseSymbolValidationManager))
+            {
+            TR_OpaqueMethodBlock *method = resolvedMethod->getPersistentIdentifier();
+            TR_OpaqueClassBlock *thisClass = guard->getThisClass();
+            uint16_t methodID = symValManager->getIDFromSymbol(static_cast<void *>(method));
+            uint16_t receiverClassID = symValManager->getIDFromSymbol(static_cast<void *>(thisClass));
+
+            uintptrj_t data = 0;
+            data = (((uintptrj_t)receiverClassID << 16) | (uintptrj_t)methodID);
+            *(uintptrj_t*)cursor = data;
+            }
+         else
+            {
+            *(uintptrj_t*)cursor = (uintptrj_t)guard->getSymbolReference()->getCPIndex(); // record cpIndex
+            }
+         cursor += SIZEPOINTER;
+
+         TR_OpaqueClassBlock *inlinedMethodClass = resolvedMethod->containingClass();
+         void *romClass = (void *) fej9->getPersistentClassPointerFromClassPointer(inlinedMethodClass);
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romClass);
+
+         *(uintptrj_t *) cursor = romClassOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         if (relocation->getTargetKind() != TR_InlinedInterfaceMethod &&
+             relocation->getTargetKind() != TR_InlinedVirtualMethod)
+            {
+            *(uintptrj_t *) cursor = (uintptrj_t) relocation->getTargetAddress(); // record Patch Destination Address
+            cursor += SIZEPOINTER;
+            }
+         }
+         break;
+
+      case TR_ProfiledInlinedMethodRelocation:
+      case TR_ProfiledClassGuardRelocation:
+      case TR_ProfiledMethodGuardRelocation:
+         {
+         guard = (TR_VirtualGuard *) relocation->getTargetAddress2();
+
+         int32_t inlinedSiteIndex = guard->getCurrentInlinedSiteIndex();
+         *(uintptrj_t *) cursor = (uintptrj_t) inlinedSiteIndex;
+         cursor += SIZEPOINTER;
+
+         TR::SymbolReference *callSymRef = guard->getSymbolReference();
+         TR_ResolvedMethod *owningMethod = callSymRef->getOwningMethod(comp);
+
+         TR_InlinedCallSite & ics = comp->getInlinedCallSite(inlinedSiteIndex);
+         TR_ResolvedMethod *inlinedMethod = ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod;
+         TR_OpaqueClassBlock *inlinedCodeClass = reinterpret_cast<TR_OpaqueClassBlock *>(inlinedMethod->classOfMethod());
+
+         *(uintptrj_t *) cursor = (uintptrj_t) owningMethod->constantPool(); // record constant pool
+         cursor += SIZEPOINTER;
+
+         if (comp->getOption(TR_UseSymbolValidationManager))
+            {
+            uint16_t inlinedCodeClassID = symValManager->getIDFromSymbol(static_cast<void *>(inlinedCodeClass));
+            uintptrj_t data = (uintptrj_t)inlinedCodeClassID;
+            *(uintptrj_t*)cursor = data;
+            }
+         else
+            {
+            *(uintptrj_t*)cursor = (uintptrj_t)callSymRef->getCPIndex(); // record cpIndex
+            }
+         cursor += SIZEPOINTER;
+
+         void *romClass = (void *) fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass);
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romClass);
+         traceMsg(comp, "class is %p, romclass is %p, offset is %p\n", inlinedCodeClass, romClass, romClassOffsetInSharedCache);
+         *(uintptrj_t *) cursor = romClassOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         uintptrj_t classChainOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(inlinedCodeClass);
+         *(uintptrj_t *) cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         cursor = self()->emitClassChainOffset(cursor, inlinedCodeClass);
+
+         uintptrj_t methodIndex = fej9->getMethodIndexInClass(inlinedCodeClass, inlinedMethod->getNonPersistentIdentifier());
+         *(uintptrj_t *)cursor = methodIndex;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_GlobalValue:
+         {
+         *(uintptrj_t*)cursor = (uintptr_t) relocation->getTargetAddress();
+         cursor += SIZEPOINTER;
+         break;
+         }
+
+      case TR_ValidateClassByName:
+         {
+         TR::ClassByNameRecord *record = reinterpret_cast<TR::ClassByNameRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateClassByNameBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateClassByNameBinaryTemplate *>(cursor);
+
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, record->_classChain);
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(record->_class);
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(record->_beholder);
+         binaryTemplate->_classChainOffsetInSCC = classChainOffsetInSharedCache;
+
+         cursor += sizeof(TR_RelocationRecordValidateClassByNameBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateProfiledClass:
+         {
+         TR::ProfiledClassRecord *record = reinterpret_cast<TR::ProfiledClassRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateProfiledClassBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateProfiledClassBinaryTemplate *>(cursor);
+
+         TR_OpaqueClassBlock *classToValidate = record->_class;
+         void *classChainForClassToValidate = record->_classChain;
+
+         //store the classchain's offset for the classloader for the class
+         uintptrj_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(classToValidate);
+
+         //store the classchain's offset for the class that needs to be validated in the second run
+         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(classToValidate));
+         binaryTemplate->_classChainOffsetInSCC = classChainOffsetInSharedCache;
+         binaryTemplate->_classChainOffsetForCLInScc = classChainOffsetInSharedCacheForCL;
+
+         cursor += sizeof(TR_RelocationRecordValidateProfiledClassBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateClassFromCP:
+         {
+         TR::ClassFromCPRecord *record = reinterpret_cast<TR::ClassFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateClassFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateClassFromCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = record->_cpIndex;
+
+         cursor += sizeof(TR_RelocationRecordValidateClassFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateDefiningClassFromCP:
+         {
+         TR::DefiningClassFromCPRecord *record = reinterpret_cast<TR::DefiningClassFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_isStatic = record->_isStatic;
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = record->_cpIndex;
+
+         cursor += sizeof(TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateStaticClassFromCP:
+         {
+         TR::StaticClassFromCPRecord *record = reinterpret_cast<TR::StaticClassFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = record->_cpIndex;
+
+         cursor += sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateArrayClassFromComponentClass:
+         {
+         TR::ArrayClassFromComponentClassRecord *record = reinterpret_cast<TR::ArrayClassFromComponentClassRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateArrayFromCompBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateArrayFromCompBinaryTemplate *>(cursor);
+
+         binaryTemplate->_arrayClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_arrayClass));
+         binaryTemplate->_componentClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_componentClass));
+
+         cursor += sizeof(TR_RelocationRecordValidateArrayFromCompBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateSuperClassFromClass:
+         {
+         TR::SuperClassFromClassRecord *record = reinterpret_cast<TR::SuperClassFromClassRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *>(cursor);
+
+         binaryTemplate->_superClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_superClass));
+         binaryTemplate->_childClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_childClass));
+
+         cursor += sizeof(TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateClassInstanceOfClass:
+         {
+         TR::ClassInstanceOfClassRecord *record = reinterpret_cast<TR::ClassInstanceOfClassRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *>(cursor);
+
+         binaryTemplate->_objectTypeIsFixed = record->_objectTypeIsFixed;
+         binaryTemplate->_castTypeIsFixed = record->_castTypeIsFixed;
+         binaryTemplate->_isInstanceOf = record->_isInstanceOf;
+         binaryTemplate->_classOneID = symValManager->getIDFromSymbol(static_cast<void *>(record->_classOne));
+         binaryTemplate->_classTwoID = symValManager->getIDFromSymbol(static_cast<void *>(record->_classTwo));
+
+         cursor += sizeof(TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateSystemClassByName:
+         {
+         TR::SystemClassByNameRecord *record = reinterpret_cast<TR::SystemClassByNameRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *>(cursor);
+
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, record->_classChain);
+         binaryTemplate->_systemClassID = symValManager->getIDFromSymbol(record->_class);
+         binaryTemplate->_classChainOffsetInSCC = classChainOffsetInSharedCache;
+
+         cursor += sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateClassFromITableIndexCP:
+         {
+         TR::ClassFromITableIndexCPRecord *record = reinterpret_cast<TR::ClassFromITableIndexCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = record->_cpIndex;
+
+         cursor += sizeof(TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateDeclaringClassFromFieldOrStatic:
+         {
+         TR::DeclaringClassFromFieldOrStaticRecord *record = reinterpret_cast<TR::DeclaringClassFromFieldOrStaticRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *>(cursor);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = record->_cpIndex;
+
+         cursor += sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateConcreteSubClassFromClass:
+         {
+         TR::ConcreteSubClassFromClassRecord *record = reinterpret_cast<TR::ConcreteSubClassFromClassRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *>(cursor);
+
+         binaryTemplate->_childClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_childClass));
+         binaryTemplate->_superClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_superClass));
+
+         cursor += sizeof(TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateClassChain:
+         {
+         TR::ClassChainRecord *record = reinterpret_cast<TR::ClassChainRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateClassChainBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateClassChainBinaryTemplate *>(cursor);
+
+         void *classToValidate = static_cast<void *>(record->_class);
+         void *classChainForClassToValidate = record->_classChain;
+         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(classToValidate);
+         binaryTemplate->_classChainOffsetInSCC = classChainOffsetInSharedCache;
+
+         cursor += sizeof(TR_RelocationRecordValidateClassChainBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateMethodFromClass:
+         {
+         TR::MethodFromClassRecord *record = reinterpret_cast<TR::MethodFromClassRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateMethodFromClassBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateMethodFromClassBinaryTemplate *>(cursor);
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_index = static_cast<uintptrj_t>(record->_index);
+
+         cursor += sizeof(TR_RelocationRecordValidateMethodFromClassBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateStaticMethodFromCP:
+         {
+         TR::StaticMethodFromCPRecord *record = reinterpret_cast<TR::StaticMethodFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *>(cursor);
+
+         TR_ASSERT_FATAL(
+            (record->_cpIndex & J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG) == 0,
+            "static method cpIndex has special split table flag set");
+
+         if ((record->_cpIndex & J9_STATIC_SPLIT_TABLE_INDEX_FLAG) != 0)
+            *flagsCursor |= TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT;
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex & J9_SPLIT_TABLE_INDEX_MASK);
+
+         cursor += sizeof(TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateSpecialMethodFromCP:
+         {
+         TR::SpecialMethodFromCPRecord *record = reinterpret_cast<TR::SpecialMethodFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *>(cursor);
+
+         TR_ASSERT_FATAL(
+            (record->_cpIndex & J9_STATIC_SPLIT_TABLE_INDEX_FLAG) == 0,
+            "special method cpIndex has static split table flag set");
+
+         if ((record->_cpIndex & J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG) != 0)
+            *flagsCursor |= TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT;
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex & J9_SPLIT_TABLE_INDEX_MASK);
+
+         cursor += sizeof(TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateVirtualMethodFromCP:
+         {
+         TR::VirtualMethodFromCPRecord *record = reinterpret_cast<TR::VirtualMethodFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex);
+
+         cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateVirtualMethodFromOffset:
+         {
+         TR::VirtualMethodFromOffsetRecord *record = reinterpret_cast<TR::VirtualMethodFromOffsetRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *>(cursor);
+
+         TR_ASSERT_FATAL((record->_virtualCallOffset & 1) == 0, "virtualCallOffset must be even");
+         TR_ASSERT_FATAL(
+            record->_virtualCallOffset == (int32_t)(int16_t)record->_virtualCallOffset,
+            "virtualCallOffset must fit in a 16-bit signed integer");
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_virtualCallOffsetAndIgnoreRtResolve = (uint16_t)(record->_virtualCallOffset | (int)record->_ignoreRtResolve);
+
+         cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateInterfaceMethodFromCP:
+         {
+         TR::InterfaceMethodFromCPRecord *record = reinterpret_cast<TR::InterfaceMethodFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_lookupID = symValManager->getIDFromSymbol(static_cast<void *>(record->_lookup));
+         binaryTemplate->_cpIndex = static_cast<uintptrj_t>(record->_cpIndex);
+
+         cursor += sizeof(TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateImproperInterfaceMethodFromCP:
+         {
+         TR::ImproperInterfaceMethodFromCPRecord *record = reinterpret_cast<TR::ImproperInterfaceMethodFromCPRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *>(cursor);
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex);
+
+         cursor += sizeof(TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateMethodFromClassAndSig:
+         {
+         TR::MethodFromClassAndSigRecord *record = reinterpret_cast<TR::MethodFromClassAndSigRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *>(cursor);
+
+         // Store rom method to get name of method
+         J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
+         J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
+         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_lookupClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_lookupClass));
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
+         binaryTemplate->_romMethodOffsetInSCC = romMethodOffsetInSharedCache;
+
+         cursor += sizeof(TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateMethodFromSingleImplementer:
+         {
+         TR::MethodFromSingleImplementer *record = reinterpret_cast<TR::MethodFromSingleImplementer *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *>(cursor);
+
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_thisClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_thisClass));
+         binaryTemplate->_cpIndexOrVftSlot = record->_cpIndexOrVftSlot;
+         binaryTemplate->_callerMethodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_callerMethod));
+         binaryTemplate->_useGetResolvedInterfaceMethod = (uint16_t)record->_useGetResolvedInterfaceMethod;
+
+         cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateMethodFromSingleInterfaceImplementer:
+         {
+         TR::MethodFromSingleInterfaceImplementer *record = reinterpret_cast<TR::MethodFromSingleInterfaceImplementer *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *>(cursor);
+
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_thisClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_thisClass));
+         binaryTemplate->_callerMethodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_callerMethod));
+         binaryTemplate->_cpIndex = (uint16_t)record->_cpIndex;
+
+         cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateMethodFromSingleAbstractImplementer:
+         {
+         TR::MethodFromSingleAbstractImplementer *record = reinterpret_cast<TR::MethodFromSingleAbstractImplementer *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *>(cursor);
+
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_thisClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_thisClass));
+         binaryTemplate->_vftSlot = record->_vftSlot;
+         binaryTemplate->_callerMethodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_callerMethod));
+
+         cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateStackWalkerMaySkipFramesRecord:
+         {
+         TR::StackWalkerMaySkipFramesRecord *record = reinterpret_cast<TR::StackWalkerMaySkipFramesRecord *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *>(cursor);
+
+         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_methodClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_methodClass));
+         binaryTemplate->_skipFrames = record->_skipFrames;
+
+         cursor += sizeof(TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateClassInfoIsInitialized:
+         {
+         TR::ClassInfoIsInitialized *record = reinterpret_cast<TR::ClassInfoIsInitialized *>(relocation->getTargetAddress());
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *>(cursor);
+
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
+         binaryTemplate->_isInitialized = record->_isInitialized;
+
+         cursor += sizeof(TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate);
+         }
+         break;
+
+      case TR_SymbolFromManager:
+         {
+         uint8_t *symbol = relocation->getTargetAddress();
+         uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+
+         uint16_t symbolType = (uint16_t)(uintptrj_t)relocation->getTargetAddress2();
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordSymbolFromManagerBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordSymbolFromManagerBinaryTemplate *>(cursor);
+
+         binaryTemplate->_symbolID = symbolID;
+         binaryTemplate->_symbolType = symbolType;
+
+         cursor += sizeof(TR_RelocationRecordSymbolFromManagerBinaryTemplate);
+         }
+         break;
+
+      case TR_DiscontiguousSymbolFromManager:
+         {
+         uint8_t *symbol = (uint8_t *)relocation->getTargetAddress();
+         uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
+
+         uint16_t symbolType = (uint16_t)(uintptrj_t)relocation->getTargetAddress2();
+
+         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+
+         TR_RelocationRecordSymbolFromManagerBinaryTemplate *binaryTemplate =
+               reinterpret_cast<TR_RelocationRecordSymbolFromManagerBinaryTemplate *>(cursor);
+
+         binaryTemplate->_symbolID = symbolID;
+         binaryTemplate->_symbolType = symbolType;
+
+         cursor += sizeof(TR_RelocationRecordSymbolFromManagerBinaryTemplate);
+         }
+         break;
+
+      case TR_ValidateClass:
+         {
+         *(uintptrj_t*)cursor = (uintptrj_t)relocation->getTargetAddress(); // Inlined site index
+         cursor += SIZEPOINTER;
+
+         TR::AOTClassInfo *aotCI = (TR::AOTClassInfo*)relocation->getTargetAddress2();
+         *(uintptrj_t*)cursor = (uintptrj_t) aotCI->_constantPool;
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t*)cursor = (uintptrj_t) aotCI->_cpIndex;
+         cursor += SIZEPOINTER;
+
+         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, aotCI->_classChain);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_ValidateStaticField:
+         {
+         *(uintptrj_t*)cursor = (uintptrj_t)relocation->getTargetAddress(); // Inlined site index
+         cursor += SIZEPOINTER;
+
+         TR::AOTClassInfo *aotCI = (TR::AOTClassInfo*)relocation->getTargetAddress2();
+         *(uintptrj_t*)cursor = (uintptrj_t) aotCI->_constantPool;
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t*)cursor = (uintptrj_t) aotCI->_cpIndex;
+         cursor += SIZEPOINTER;
+
+         void *romClass = (void *)fej9->getPersistentClassPointerFromClassPointer(aotCI->_clazz);
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romClass);
+         *(uintptrj_t *)cursor = romClassOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_ValidateArbitraryClass:
+         {
+         TR::AOTClassInfo *aotCI = (TR::AOTClassInfo*) relocation->getTargetAddress2();
+         TR_OpaqueClassBlock *classToValidate = aotCI->_clazz;
+
+         //store the classchain's offset for the classloader for the class
+         uintptrj_t classChainOffsetInSharedCacheForCL = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(classToValidate);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCacheForCL;
+         cursor += SIZEPOINTER;
+
+         //store the classchain's offset for the class that needs to be validated in the second run
+         void *romClass = (void *)fej9->getPersistentClassPointerFromClassPointer(classToValidate);
+         uintptrj_t *classChainForClassToValidate = (uintptrj_t *) aotCI->_classChain;
+         uintptr_t classChainOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, classChainForClassToValidate);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_HCR:
+         {
+         flags = 0;
+         if (((TR_HCRAssumptionFlags)((uintptrj_t)(relocation->getTargetAddress2()))) == needsFullSizeRuntimeAssumption)
+            flags = needsFullSizeRuntimeAssumption;
+         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
+         *flagsCursor |= (flags & RELOCATION_RELOC_FLAGS_MASK);
+
+         *(uintptrj_t*) cursor = (uintptrj_t) relocation->getTargetAddress();
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      case TR_DebugCounter:
+         {
+         TR::DebugCounterBase *counter = (TR::DebugCounterBase *) relocation->getTargetAddress();
+         if (!counter || !counter->getReloData() || !counter->getName())
+            comp->failCompilation<TR::CompilationException>("Failed to generate debug counter relo data");
+
+         TR::DebugCounterReloData *counterReloData = counter->getReloData();
+
+         uintptrj_t offset = (uintptrj_t)fej9->sharedCache()->rememberDebugCounterName(counter->getName());
+
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_callerIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_bytecodeIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = offset;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_delta;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_fidelity;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_staticDelta;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
+      default:
+         // initializeCommonAOTRelocationHeader is currently in the process
+         // of becoming the canonical place to initialize the platform agnostic
+         // relocation headers; new relocation records' header should be
+         // initialized here.
+         cursor = self()->initializeCommonAOTRelocationHeader(relocation, reloRecord);
+
+      }
+   return cursor;
    }
 
 uint32_t J9::ARM64::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds] =

--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.hpp
@@ -63,7 +63,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
     */
    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
-   static bool classAddressUsesReloRecordInfo() { return true; }
+   static bool classAddressUsesReloRecordInfo() { return false; }
 
    private:
    TR::CodeGenerator *_cg;


### PR DESCRIPTION
Add implementation of `J9::ARM64::initializeAOTRelocationHeader`.
This implementation assumes that `TR_RelocationRecordInformation` is not used for `TR_ClassAddress`, `TR_DataAddress`, etc.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>