### PR TITLE
(v0.17.0) Don't convert type in computeHash

### DIFF
--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -990,9 +990,6 @@ TR_JProfilingValue::computeHash(TR::Compilation *comp, TR_AbstractHashTableProfi
       hash->setAndIncChild(0, value);
       hash->setAndIncChild(1, hashAddr);
       hash->setAndIncChild(2, TR::Node::iconst(value, table->getBits()));
-
-      // Convert to the platform address width
-      hash = convertType(hash, TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32);
       }
    else if (table->getHashType() == BitShiftHash)
       {


### PR DESCRIPTION
Converting the type of the hash node in TR_JProfilingValue::computeHash is an unneeded conversion and can also lead to ill-formed trees where the hash node's data type is not consistent with its parent's (which is a *ternary node).

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>