### PR TITLE
WIP: Add findOr{Create,Fabricate}ShadowSymbol function

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1710,7 +1710,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
 
    if (!definingClass)
       {
-      definingClass = (J9Class *) reloRuntime->getClassFromCP(fej9->vmThread(), constantPool, cpIndex, isStatic);
+      definingClass = (J9Class *) TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, isStatic);
       traceMsg(comp, "\tdefiningClass recomputed from cp as %p\n", definingClass);
       }
 
@@ -1834,7 +1834,7 @@ TR_ResolvedRelocatableJ9Method::fieldAttributes(TR::Compilation * comp, int32_t 
                else
                   reloRuntime = compInfo->getCompInfoForThread(fej9->vmThread())->reloRuntime();
 
-               TR_OpaqueClassBlock *clazz = reloRuntime->getClassFromCP(fej9->vmThread(), constantPool, cpIndex, false);
+               TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, false);
 
                fieldInfoCanBeUsed = comp->getSymbolValidationManager()->addDefiningClassFromCPRecord(clazz, constantPool, cpIndex);
                }
@@ -1959,7 +1959,7 @@ TR_ResolvedRelocatableJ9Method::staticAttributes(TR::Compilation * comp,
          else
             reloRuntime = compInfo->getCompInfoForThread(fej9->vmThread())->reloRuntime();
 
-         TR_OpaqueClassBlock *clazz = reloRuntime->getClassFromCP(fej9->vmThread(), constantPool, cpIndex, true);
+         TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, true);
 
          fieldInfoCanBeUsed = comp->getSymbolValidationManager()->addDefiningClassFromCPRecord(clazz, constantPool, cpIndex, true);
          }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2017,6 +2017,15 @@ TR_ResolvedRelocatableJ9Method::staticAttributes(TR::Compilation * comp,
    return theFieldIsFromLocalClass;
    }
 
+TR_OpaqueClassBlock *
+TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef(
+   TR::Compilation *comp,
+   I_32 cpIndex,
+   bool isStatic)
+   {
+   return TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+   }
+
 char *
 TR_ResolvedRelocatableJ9Method::fieldSignatureChars(int32_t cpIndex, int32_t & len)
    {
@@ -7069,6 +7078,58 @@ TR_ResolvedJ9Method::staticAttributes(TR::Compilation * comp, I_32 cpIndex, void
    return resolved;
    }
 
+TR_OpaqueClassBlock *
+TR_ResolvedJ9Method::definingClassFromCPFieldRef(
+   TR::Compilation *comp,
+   J9ConstantPool *constantPool,
+   I_32 cpIndex,
+   bool isStatic)
+   {
+   J9VMThread *vmThread = comp->j9VMThread();
+   J9JavaVM *javaVM = vmThread->javaVM;
+   J9JITConfig *jitConfig = javaVM->jitConfig;
+   TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, vmThread);
+   TR::VMAccessCriticalSection definingClassFromCPFieldRef(fe);
+
+   /* Get the class.  Stop immediately if an exception occurs. */
+   J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&constantPool->romConstantPool[cpIndex];
+
+   // TODO: J9_RESOLVE_FLAG_JIT_COMPILE_TIME vs. J9_RESOLVE_FLAG_AOT_LOAD_TIME
+   J9Class *resolvedClass = javaVM->internalVMFunctions->resolveClassRef(vmThread, constantPool, romFieldRef->classRefCPIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
+
+   if (resolvedClass == NULL)
+      return NULL;
+
+   J9Class *classFromCP = J9_CLASS_FROM_CP(constantPool);
+   J9ROMFieldShape *field;
+   J9Class *definingClass;
+   J9ROMNameAndSignature *nameAndSig;
+   J9UTF8 *name;
+   J9UTF8 *signature;
+
+   nameAndSig = J9ROMFIELDREF_NAMEANDSIGNATURE(romFieldRef);
+   name = J9ROMNAMEANDSIGNATURE_NAME(nameAndSig);
+   signature = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
+   if (isStatic)
+      {
+      void *staticAddress = javaVM->internalVMFunctions->staticFieldAddress(vmThread, resolvedClass, J9UTF8_DATA(name), J9UTF8_LENGTH(name), J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), &definingClass, (UDATA *)&field, J9_LOOK_NO_JAVA, classFromCP);
+      }
+   else
+      {
+      IDATA fieldOffset = javaVM->internalVMFunctions->instanceFieldOffset(vmThread, resolvedClass, J9UTF8_DATA(name), J9UTF8_LENGTH(name), J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), &definingClass, (UDATA *)&field, J9_LOOK_NO_JAVA);
+      }
+
+   return (TR_OpaqueClassBlock *)definingClass;
+   }
+
+TR_OpaqueClassBlock *
+TR_ResolvedJ9Method::definingClassFromCPFieldRef(
+   TR::Compilation *comp,
+   I_32 cpIndex,
+   bool isStatic)
+   {
+   return definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+   }
 
 bool
 TR_ResolvedJ9Method::fieldIsFromLocalClass(int32_t cpIndex)

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -423,6 +423,9 @@ public:
 
 
    virtual bool                    staticAttributes( TR::Compilation *, int32_t cpIndex, void * *, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOValidation);
+   
+   static TR_OpaqueClassBlock  * definingClassFromCPFieldRef(TR::Compilation *comp, J9ConstantPool *constantPool, int32_t cpIndex, bool isStatic);
+   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
    virtual char *                  fieldNameChars(int32_t cpIndex, int32_t & len);
    virtual char *                  staticNameChars(int32_t cpIndex, int32_t & len);
@@ -569,6 +572,8 @@ public:
    virtual bool                    fieldAttributes ( TR::Compilation *, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
 
    virtual bool                    staticAttributes( TR::Compilation *, int32_t cpIndex, void * *, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
+
+   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
    virtual int32_t                 virtualCallSelector(uint32_t cpIndex);
    virtual char *                  fieldSignatureChars(int32_t cpIndex, int32_t & len);

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -158,6 +158,7 @@ private:
    // GenLoadStore
    //
    void         loadInstance(int32_t);
+   void         loadInstance(TR::SymbolReference *, int32_t);
    void         loadStatic(int32_t);
    void         loadAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);
    TR::Node     *loadSymbol(TR::ILOpCodes, TR::SymbolReference *);
@@ -179,6 +180,7 @@ private:
    void         loadMonitorArg();
 
    void         storeInstance(int32_t);
+   void         storeInstance(TR::SymbolReference *symRef);
    void         storeStatic(int32_t);
    void         storeAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);
    void         storeArrayElement(TR::DataType dt){ storeArrayElement(dt, comp()->il.opCodeForIndirectArrayStore(dt)); }
@@ -221,6 +223,9 @@ private:
    int32_t      genAThrow();
    void         genMonitorEnter();
    void         genMonitorExit(bool);
+   TR_OpaqueClassBlock *loadValueClass(int32_t classCpIndex);
+   void         genDefaultValue(uint16_t classCpIndex);
+   void         genWithField(uint16_t fieldCpIndex);
    void         genFlush(int32_t nargs);
    void         genFullFence(TR::Node *node);
    void         handlePendingPushSaveSideEffects(TR::Node *, int32_t stackSize = -1);

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -602,6 +602,10 @@ const uint8_t TR_J9ByteCodeIterator::_byteCodeFlags[] =
                              0x01, // J9BCmonitorenter
                              0x01, // J9BCmonitorexit
                              0x00, // J9BCwide
+                             0x01, // J9BCasyncCheck --- TODO: Is this the right size?
+                             0x03, // J9BCdefaultvalue
+                             0x03, // J9BCwithfield
+                             0x01, // J9BCbreakpoint --- TODO: Is this the right size?
                              0x01, // BCunknown
    };
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3164,8 +3164,7 @@ TR_RelocationRecordValidateInstanceField::getClassFromCP(TR_RelocationRuntime *r
    TR_OpaqueClassBlock *definingClass = NULL;
    if (void_cp)
       {
-      J9JavaVM *javaVM = reloRuntime->javaVM();
-      definingClass = reloRuntime->getClassFromCP(javaVM->internalVMFunctions->currentVMThread(javaVM), (J9ConstantPool *) void_cp, cpIndex(reloTarget), false);
+      definingClass = TR_ResolvedJ9Method::definingClassFromCPFieldRef(reloRuntime->comp(), (J9ConstantPool *) void_cp, cpIndex(reloTarget), false);
       }
 
    return definingClass;
@@ -3217,8 +3216,7 @@ TR_RelocationRecordValidateStaticField::getClass(TR_RelocationRuntime *reloRunti
    TR_OpaqueClassBlock *definingClass = NULL;
    if (void_cp)
       {
-      J9JavaVM *javaVM = reloRuntime->javaVM();
-      definingClass = reloRuntime->getClassFromCP(javaVM->internalVMFunctions->currentVMThread(javaVM), (J9ConstantPool *) void_cp, cpIndex(reloTarget), true);
+      definingClass = TR_ResolvedJ9Method::definingClassFromCPFieldRef(reloRuntime->comp(), (J9ConstantPool *) void_cp, cpIndex(reloTarget), true); 
       }
 
    return definingClass;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -725,13 +725,6 @@ TR_RelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)
    return false;
    }
 
-TR_OpaqueClassBlock *
-TR_RelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)
-   {
-   TR_ASSERT(0, "Error: getClassFromCP not supported in this relocation runtime");
-   return NULL;
-   }
-
 bool TR_RelocationRuntime::_globalValuesInitialized=false;
 
 uintptr_t TR_RelocationRuntime::_globalValueList[TR_NumGlobalValueItems] =
@@ -1125,41 +1118,6 @@ TR_SharedCacheRelocationRuntime::storeAOTHeader(TR_FrontEnd *fe, J9VMThread *cur
       TR_J9SharedCache::setStoreSharedDataFailedLength(aotHeaderLen);
       return false;
       }
-   }
-
-TR_OpaqueClassBlock *
-TR_SharedCacheRelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)
-   {
-   J9JITConfig *jitConfig = vmThread->javaVM->jitConfig;
-   TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, vmThread);
-   TR::VMAccessCriticalSection getClassFromCP(fe);
-   /* Get the class.  Stop immediately if an exception occurs. */
-   J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&constantPool->romConstantPool[cpIndex];
-
-   J9Class *resolvedClass = javaVM()->internalVMFunctions->resolveClassRef(vmThread, constantPool, romFieldRef->classRefCPIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
-
-   if (resolvedClass == NULL)
-      return NULL;
-
-   J9Class *classFromCP = J9_CLASS_FROM_CP(constantPool);
-   J9ROMFieldShape *field;
-   J9Class *definingClass;
-   J9ROMNameAndSignature *nameAndSig;
-   J9UTF8 *name;
-   J9UTF8 *signature;
-
-   nameAndSig = J9ROMFIELDREF_NAMEANDSIGNATURE(romFieldRef);
-   name = J9ROMNAMEANDSIGNATURE_NAME(nameAndSig);
-   signature = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
-   if (isStatic)
-      {
-      void *staticAddress = javaVM()->internalVMFunctions->staticFieldAddress(vmThread, resolvedClass, J9UTF8_DATA(name), J9UTF8_LENGTH(name), J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), &definingClass, (UDATA *)&field, J9_LOOK_NO_JAVA, classFromCP);
-      }
-   else
-      {
-      IDATA fieldOffset = javaVM()->internalVMFunctions->instanceFieldOffset(vmThread, resolvedClass, J9UTF8_DATA(name), J9UTF8_LENGTH(name), J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), &definingClass, (UDATA *)&field, J9_LOOK_NO_JAVA);
-      }
-   return (TR_OpaqueClassBlock *)definingClass;
    }
 
 uintptr_t

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -184,8 +184,6 @@ class TR_RelocationRuntime {
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
 
-      virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
-
       static uintptr_t    getGlobalValue(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
@@ -349,8 +347,6 @@ public:
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-
-      virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
 
 private:
       uint32_t getCurrentLockwordOptionHashValue(J9JavaVM *vm) const;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1052,7 +1052,7 @@ TR::SymbolValidationManager::validateDefiningClassFromCPRecord(uint16_t classID,
 
    J9Class *beholder = getJ9ClassFromID(beholderID);
    J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
-   return validateSymbol(classID, reloRuntime->getClassFromCP(_vmThread, beholderCP, cpIndex, isStatic));
+   return validateSymbol(classID, TR_ResolvedJ9Method::definingClassFromCPFieldRef(_comp, beholderCP, cpIndex, isStatic));
    }
 
 bool


### PR DESCRIPTION
Added findOrCreateShadowSymbol function and findOrFabricateShadowSymbol
to accept a TR_OpaqueClassBlock. These will be needed for supporting
value types. Replaced function calls to
TR_SharedCacheRelocationRuntime::getClassFromCP
with calls to TR_ResolvedJ9Method::definingClassFromCPFieldRef,
because the latter is more general. After replacing calls,
TR_SharedCacheRelocationRuntime::getClassFromCP was deleted.

Signed-off-by: Yiling Han <Yiling.Han@ibm.com>