### PR TITLE
Back port changes in JITClientCompilationThread from master

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -827,8 +827,9 @@ public:
    void     setAotRelocationTime(uint32_t reloTime) { _statTotalAotRelocationTime = reloTime; }
    void    incrementNumMethodsFoundInSharedCache() { _numMethodsFoundInSharedCache++; }
    int32_t numMethodsFoundInSharedCache() { return _numMethodsFoundInSharedCache; }
+#if defined(JITSERVER_SUPPORT)
    bool isRomClassForMethodInSharedCache(J9Method *method);
-   TR_YesNoMaybe isMethodInSharedCache(J9Method *method);
+#endif /* defined(JITSERVER_SUPPORT) */
    int32_t getNumInvRequestsInCompQueue() const { return _numInvRequestsInCompQueue; }
    TR::CompilationInfoPerThreadBase *getCompInfoForCompOnAppThread() const { return _compInfoForCompOnAppThread; }
    J9JITConfig *getJITConfig() { return _jitConfig; }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -886,7 +886,9 @@ TR::CompilationInfoPerThreadBase::CompilationInfoPerThreadBase(TR::CompilationIn
    _compInfo(compInfo),
    _jitConfig(jitConfig),
    _sharedCacheReloRuntime(jitConfig),
+#if defined(JITSERVER_SUPPORT)
    _remoteCompileReloRuntime(jitConfig),
+#endif /* defined(JITSERVER_SUPPORT) */
    _compThreadId(id),
    _onSeparateThread(onSeparateThread),
    _vm(NULL),
@@ -1501,20 +1503,11 @@ TR::CompilationInfo::disableAOTCompilations()
 
 #if defined(JITSERVER_SUPPORT)
 #if defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-
 // Note: this method must be called only when we know that AOT mode for shared classes is enabled !!
 bool TR::CompilationInfo::isRomClassForMethodInSharedCache(J9Method *method)
    {
    J9ROMClass *romClass = J9_CLASS_FROM_METHOD(method)->romClass;
    return _sharedCacheReloRuntime.isRomClassForMethodInSharedCache(method) ? true : false;
-   }
-
-TR_YesNoMaybe TR::CompilationInfo::isMethodInSharedCache(J9Method *method)
-   {
-   if (isRomClassForMethodInSharedCache(method))
-      return TR_maybe;
-   else
-      return TR_no;
    }
 #endif
 #endif /* defined(JITSERVER_SUPPORT) */
@@ -6905,7 +6898,6 @@ TR::CompilationInfoPerThreadBase::shouldPerformLocalComp(const TR_MethodToBeComp
  */
 void
 TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
-                                                      J9JavaVM *javaVM,
                                                       TR_MethodToBeCompiled *entry,
                                                       J9Method *method,
                                                       const void **aotCachedMethod,
@@ -7588,7 +7580,7 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
       TR::Region dispatchRegion(regionSegmentProvider, rawAllocator);
       TR_Memory trMemory(*_compInfo.persistentMemory(), dispatchRegion);
 
-      preCompilationTasks(vmThread, javaVM, entry,
+      preCompilationTasks(vmThread, entry,
                           method, &aotCachedMethod, trMemory,
                           canDoRelocatableCompile, eligibleForRelocatableCompile, 
                           reloRuntime);

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -160,7 +160,6 @@ class CompilationInfoPerThreadBase
    TR_MethodMetaData *performAOTLoad(J9VMThread *context, TR::Compilation *, TR_ResolvedMethod *compilee, TR_J9VMBase *vm, J9Method *method);
 
    void preCompilationTasks(J9VMThread * vmThread,
-                            J9JavaVM *javaVM,
                             TR_MethodToBeCompiled *entry,
                             J9Method *method,
                             const void **aotCachedMethod,
@@ -259,7 +258,9 @@ class CompilationInfoPerThreadBase
    TR::CompilationInfo &        _compInfo;
    J9JITConfig * const          _jitConfig;
    TR_SharedCacheRelocationRuntime _sharedCacheReloRuntime;
+#if defined(JITSERVER_SUPPORT)
    TR_JITServerRelocationRuntime _remoteCompileReloRuntime;
+#endif /* defined(JITSERVER_SUPPORT) */
    int32_t const                _compThreadId; // unique number starting from 0; Only used for compilation on separate thread
    bool const                   _onSeparateThread;
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -21,13 +21,16 @@
  *******************************************************************************/
 
 #include "codegen/CodeGenerator.hpp"
+#include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
 #include "control/JITServerHelpers.hpp"
 #include "control/MethodToBeCompiled.hpp"
 #include "env/ClassTableCriticalSection.hpp"
+#include "env/J2IThunk.hpp"
 #include "env/j9methodServer.hpp"
 #include "env/JITServerPersistentCHTable.hpp"
 #include "env/VMAccessCriticalSection.hpp"
+#include "env/VMJ9.h"
 #include "net/ClientStream.hpp"
 #include "runtime/CodeCacheExceptions.hpp"
 #include "runtime/J9VMAccess.hpp"

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -20,15 +20,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "net/ServerStream.hpp"
 #include "j9methodServer.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
-#include "control/MethodToBeCompiled.hpp"
 #include "control/JITServerCompilationThread.hpp"
 #include "control/JITServerHelpers.hpp"
+#include "control/MethodToBeCompiled.hpp"
+#include "env/VMJ9Server.hpp"
 #include "exceptions/DataCacheError.hpp"
 #include "ilgen/J9ByteCodeIterator.hpp"
+#include "net/ServerStream.hpp"
 
 ClientSessionData::ClassInfo &
 getJ9ClassInfo(TR::CompilationInfoPerThread *threadCompInfo, J9Class *clazz)
@@ -2558,7 +2559,6 @@ TR_J9ServerMethod::TR_J9ServerMethod(TR_FrontEnd * fe, TR_Memory * trMemory, J9C
    : TR_J9Method()
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
-
    TR_J9ServerVM *fej9 = (TR_J9ServerVM *) fe;
    TR::CompilationInfoPerThread *compInfoPT = fej9->_compInfoPT;
    std::string classNameStr;

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -118,6 +118,21 @@ TR_ResolvedMethodCacheEntry
 
 using TR_ResolvedMethodInfoCache = UnorderedMap<TR_ResolvedMethodKey, TR_ResolvedMethodCacheEntry>;
 
+/**
+ * @class TR_ResolvedJ9JITServerMethod
+ * @brief Class used by JITServer for obtaining method/class information needed
+ * during compilation from JITClient
+ *
+ * This class is an extension of the TR_ResolvedJ9Method class. Most of the APIs of
+ * TR_ResolvedJ9JITServerMethod are remote calls to the JITClient to obtain
+ * compilation information about the compiling method and related classes. Upon
+ * instantiation of a TR_ResolvedJ9JITServerMethod class, a mirror TR_ResolvedJ9Method
+ * will be created on the client via TR_ResolvedJ9JITServerMethod::createResolvedMethodMirror.
+ * During compilation the JITServer will mostly be communicating with the client-side
+ * mirror instance. Certain data are cached at the JITServer to reduce the number
+ * of remote calls to JITClient.
+ */
+
 class TR_ResolvedJ9JITServerMethod : public TR_ResolvedJ9Method
    {
 public:
@@ -228,6 +243,18 @@ private:
    virtual char * fieldOrStaticName(I_32 cpIndex, int32_t & len, TR_Memory * trMemory, TR_AllocationKind kind = heapAlloc) override;
    void unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    };
+
+
+/**
+ * @class TR_ResolvedRelocatableJ9JITServerMethod
+ * @brief Class used by JITServer for obtaining method/class information needed
+ * during compilation from JITClient plus additional handling for AOT compilations
+ *
+ * This class is an extension of the above TR_ResolvedJ9JITServerMethod class that
+ * has additional handling for AOT compilations. The relationship between
+ * TR_ResolvedJ9JITServerMethod and TR_ResolvedRelocatableJ9JITServerMethod is similar
+ * to the relationship between TR_ResolvedJ9Method and TR_ResolvedRelocatableJ9Method.
+ */
 
 class TR_ResolvedRelocatableJ9JITServerMethod : public TR_ResolvedJ9JITServerMethod
    {


### PR DESCRIPTION
Include PR #7215 (`JITClientCompilationThread`) and PR #7151(`j9methodServer`) from the `master` branch.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>