### PR TITLE
Restore J9_JAVA_XXX constants in j9consts.h

### DIFF
--- a/runtime/ddr/vmddr.cpp
+++ b/runtime/ddr/vmddr.cpp
@@ -67,18 +67,3 @@ VM_DdrDebugLink(J9VMPopFramesInterruptEvent)
  * @ddr_namespace: map_to_type=DDRAlgorithmVersions
  */
 #define J9DDR_GENERATE_VERSION 1
-
-/* Declare these for compatibility with old DTFJ plugins, see https://github.com/eclipse/openj9/issues/6316. */
-/* @ddr_namespace: map_to_type=J9Consts */
-
-#define J9_JAVA_CLASS_ARRAY J9AccClassArray
-#define J9_JAVA_CLASS_DEPTH_MASK J9AccClassDepthMask
-#define J9_JAVA_CLASS_DYING J9AccClassDying
-#define J9_JAVA_CLASS_GC_SPECIAL J9AccClassGCSpecial
-#define J9_JAVA_CLASS_HOT_SWAPPED_OUT J9AccClassHotSwappedOut
-#define J9_JAVA_CLASS_RAM_ARRAY J9AccClassRAMArray
-#define J9_JAVA_CLASS_RAM_SHAPE_SHIFT J9AccClassRAMShapeShift
-#define J9_JAVA_CLASS_REFERENCE_MASK J9AccClassReferenceMask
-#define J9_JAVA_INTERFACE J9AccInterface
-#define J9_JAVA_NATIVE J9AccNative
-#define J9_JAVA_STATIC J9AccStatic

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -825,6 +825,24 @@ extern "C" {
 #define J9_ITABLE_OFFSET_VIRTUAL 2
 #define J9_ITABLE_OFFSET_TAG_BITS (J9_ITABLE_OFFSET_DIRECT | J9_ITABLE_OFFSET_VIRTUAL)
 
+/*
+ * These constants are declared only so that they are available in core files to retain
+ * compatibility with old DTFJ plugins, see https://github.com/eclipse/openj9/issues/6316.
+ *
+ * They should not be used for any other purpose.
+ */
+#define J9_JAVA_CLASS_ARRAY 0x10000
+#define J9_JAVA_CLASS_DEPTH_MASK 0xFFFF
+#define J9_JAVA_CLASS_DYING 0x8000000
+#define J9_JAVA_CLASS_GC_SPECIAL 0x800000
+#define J9_JAVA_CLASS_HOT_SWAPPED_OUT 0x4000000
+#define J9_JAVA_CLASS_RAM_ARRAY 0x10000
+#define J9_JAVA_CLASS_RAM_SHAPE_SHIFT 0x10
+#define J9_JAVA_CLASS_REFERENCE_MASK 0x30000000
+#define J9_JAVA_INTERFACE 0x200
+#define J9_JAVA_NATIVE 0x100
+#define J9_JAVA_STATIC 0x8
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This will make those constants available in IBM builds, not just OpenJ9 builds.