### PR TITLE
Stackmap updates to the withfield and defaultvalue instructions 

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/PCStack.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/PCStack.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1017,8 +1017,8 @@ public class PCStack
 		0x00 /* JBgotow = 200  -- pops: 0 pushes: 0*/ ,
 		0x00 /* JBunimplemented = 201  -- pops: 0 pushes: 0*/ ,
 		0x00 /* JBbreakpoint = 202  -- pops: 0 pushes: 0*/ ,
-		0x01 /* JBdefaultvalue = 203 -- pops: 0 pushes: 1*/ ,
-		0x80 /* JBwithfield = 204  -- pops: 0 pushes: 0*/ ,
+		0x50 /* JBdefaultvalue = 203 -- pops: 0 pushes: 1*/ ,
+		0x80 /* JBwithfield = 204  -- pops: 2 pushes: 1*/ ,
 		0x00 /* JBunimplemented = 205  -- pops: 0 pushes: 0*/ ,
 		0x00 /* JBunimplemented = 206  -- pops: 0 pushes: 0*/ ,
 		0x00 /* JBunimplemented = 207  -- pops: 0 pushes: 0*/ ,
@@ -1539,8 +1539,6 @@ public class PCStack
 		0x0 /* JBbreakpoint (16rCA) */,
 		0x0 /* JBdefaultvalue (16rCB) */ ,
 		0x0 /* JBwithfield (16rCC) */ ,
-		0x0 /* JBunimplemented (16rCB) */,
-		0x0 /* JBunimplemented (16rCC) */,
 		0x0 /* JBunimplemented (16rCD) */,
 		0x0 /* JBunimplemented (16rCE) */,
 		0x0 /* JBunimplemented (16rCF) */,

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/StackMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/StackMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -523,7 +523,7 @@ public class StackMap
 								PUSH(INT);
 							}
 						}
-					} else if (bc == JBputfield) {
+					} else if ((bc == JBputfield)  || (bc == JBwithfield)) {
 						POP();
 						index = PARAM_16(bcIndex, 1).intValue();
 						utf8Signature = J9ROMFieldRefPointer.cast(pool.add(index)).nameAndSignature().signature();
@@ -532,7 +532,10 @@ public class StackMap
 						if ((signature == 'D') || (signature == 'J')) {
 							POP();
 						}
-					} else if ((bc == JBputstatic) || (bc == JBwithfield)) {
+						if (bc == JBwithfield) {
+							PUSH(OBJ);
+						}
+					} else if (bc == JBputstatic) {
 						index = PARAM_16(bcIndex, 1).intValue();
 						utf8Signature = J9ROMFieldRefPointer.cast(pool.add(index)).nameAndSignature().signature();
 						signature = J9UTF8Helper.stringValue(utf8Signature).charAt(0);

--- a/runtime/stackmap/stackmap.c
+++ b/runtime/stackmap/stackmap.c
@@ -436,7 +436,7 @@ mapStack(UDATA *scratch, UDATA totalStack, U_8 * map, J9ROMClass * romClass, J9R
 					J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMFIELDREF_NAMEANDSIGNATURE
 													((J9ROMFieldRef *) (&(pool[index]))));
 				signature = (U_8) J9UTF8_DATA(utf8Signature)[0];
-				if ((signature == 'L') || (signature == '[')) {
+				if ((signature == 'L') || (signature == 'Q') || (signature == '[')) {
 					PUSH(OBJ);
 				} else {
 					PUSH(INT);
@@ -447,6 +447,7 @@ mapStack(UDATA *scratch, UDATA totalStack, U_8 * map, J9ROMClass * romClass, J9R
 				
 				break;
 
+			case JBwithfield:
 			case JBputfield:
 				POP();			/* fall through case !!! */
 
@@ -457,6 +458,10 @@ mapStack(UDATA *scratch, UDATA totalStack, U_8 * map, J9ROMClass * romClass, J9R
 													((J9ROMFieldRef *) (&(pool[index]))));
 				signature = (U_8) J9UTF8_DATA(utf8Signature)[0];
 				stackTop -= (UDATA) argCountCharConversion[signature - 'A'];
+				if (JBwithfield == bc) {
+					PUSH(OBJ);
+				}
+
 				break;
 
 			case JBinvokeinterface2:

--- a/runtime/util/argcount.c
+++ b/runtime/util/argcount.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,19 +20,38 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-
-
 #include "j9.h"
 
-/* include '[' for arrays (character after 'Z') */
+/* These represent argcounts for java field descriptors, characters without descriptions are currently unused */
 const U_8 argCountCharConversion[] = {
-0,	1,	1,	2,
-0,	1,	0,	0,
-1,	2,	0,	1,
-0,	0,	0,	0,
-0,	0,	1,	0, 
-0,	0,	0,	0,
-0,	1,	1,	0}; 
+    0, /* A */
+    1, /* B -> byte */
+    1, /* C -> char */
+    2, /* D -> double */
+    0, /* E */
+    1, /* F -> float */
+    0, /* G */
+    0, /* H */
+    1, /* I -> int */
+    2, /* J -> long */
+    0, /* K */
+    1, /* L -> nullable named class or interface type */
+    0, /* M */
+    0, /* N */
+    0, /* O */
+    0, /* P */
+    1, /* Q -> null-free named inline class type (also known as value type) */
+    0, /* R */
+    1, /* S -> short */
+    0, /* T */
+    0, /* U */
+    0, /* V -> void */
+    0, /* W */
+    0, /* X */
+    0, /* Y */
+    1, /* Z -> boolean */
+    1  /* [ -> 1-D array reference */
+}; 
 
 
 

--- a/runtime/util/pcstack.c
+++ b/runtime/util/pcstack.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -226,8 +226,8 @@ const unsigned char J9JavaInstructionSizeAndBranchActionTable[] = {
 0x25 /* JBgotow = 200 */,
 0x00 /* JBunimplemented = 201 */,
 0x71 /* JBbreakpoint = 202 */,
-0x01 /* JBdefaultvalue = 203 */ ,
-0x03 /* JBwithfield = 204 */ ,
+0x03 /* JBdefaultvalue = 203 */,
+0x03 /* JBwithfield = 204 */,
 0x00 /* JBunimplemented = 205 */,
 0x00 /* JBunimplemented = 206 */,
 0x00 /* JBunimplemented = 207 */,
@@ -491,8 +491,8 @@ const unsigned char JavaStackActionTable[] = {
 0x00 /* JBgotow = 200  -- pops: 0 pushes: 0*/ ,
 0x00 /* JBunimplemented = 201  -- pops: 0 pushes: 0*/ ,
 0x00 /* JBbreakpoint = 202  -- pops: 0 pushes: 0*/ ,
-0x01 /* JBdefaultvalue = 203 -- pops: 0 pushes: 1*/ ,
-0x80 /* JBwithfield = 204  -- pops: 0 pushes: 0*/ ,
+0x50 /* JBdefaultvalue = 203 -- pops: 0 pushes: 1*/ ,
+0x80 /* JBwithfield = 204  -- pops: 2 pushes: 1*/ ,
 0x00 /* JBunimplemented = 205  -- pops: 0 pushes: 0*/ ,
 0x00 /* JBunimplemented = 206  -- pops: 0 pushes: 0*/ ,
 0x00 /* JBunimplemented = 207  -- pops: 0 pushes: 0*/ ,
@@ -759,8 +759,8 @@ const unsigned char J9BytecodeSlotUseTable[] = {
 	0x0 /* JBgotow (16rC8) */,
 	0x0 /* JBunimplemented (16rC9) */,
 	0x0 /* JBbreakpoint (16rCA) */,
-	0x0 /* JBdefaultvalue (16rCB) */ ,
-	0x0 /* JBwithfield (16rCC) */ ,
+	0x0 /* JBdefaultvalue (16rCB) */,
+	0x0 /* JBwithfield (16rCC) */,
 	0x0 /* JBunimplemented (16rCD) */,
 	0x0 /* JBunimplemented (16rCE) */,
 	0x0 /* JBunimplemented (16rCF) */,
@@ -811,4 +811,5 @@ const unsigned char J9BytecodeSlotUseTable[] = {
 	0x0 /* JBunimplemented (16rFC) */,
 	0x0 /* JBunimplemented (16rFD) */,
 	0x0 /* JBimpdep1 (16rFE) */,
-	0x0 /* JBimpdep2 (16rFF) */};
+	0x0 /* JBimpdep2 (16rFF) */
+};


### PR DESCRIPTION
This commit does the following:
- updates the erroraneous values associated with the defaultvalue bytecode instruction
- adds the missing withfield switchcase in stackmap.c
- fixes some bugs regarding the withfield instruction in StackMap.java

Signed-off-by: Adithya Venkatarao <adi_101@live.com>