### PR TITLE
AArch64: Stop using x27 and x28 in PicBuilder.spp

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -168,17 +168,17 @@ __staticGlueTable:
 //
 // in:     x3  = address of resolve helper function
 //         x30 = snippet
-// out:
-// trash:	x8, x27, x28
+//
+// trash:	x10, x11, x12
 
 L_mergedUnresolvedSpecialStaticGlue:
-	mov	x27, x30					// save snippet address
-	ldr	x0, [x27, #J9TR_SCSnippet_codeCacheReturnAddress]	// Fetch code cache EIP
-	ldr	x1, [x27, #J9TR_USCSnippet_CP]			// get CP
-	ldr	x28, [x27, #J9TR_USCSnippet_CPIndex]		// get CP index & flags
-	and	x2, x28, #~(J9TR_USCSnippet_HelperOffset)	// remove helper offset from CP index
+	mov	x10, x30					// save snippet address
+	ldr	x0, [x10, #J9TR_SCSnippet_codeCacheReturnAddress]	// Fetch code cache EIP
+	ldr	x1, [x10, #J9TR_USCSnippet_CP]			// get CP
+	ldr	x11, [x10, #J9TR_USCSnippet_CPIndex]		// get CP index & flags
+	and	x2, x11, #~(J9TR_USCSnippet_HelperOffset)	// remove helper offset from CP index
 	blr	x3						// call resolve helper
-	str	x0, [x27, #J9TR_SCSnippet_method]		// update snippet with resolved method
+	str	x0, [x10, #J9TR_SCSnippet_method]		// update snippet with resolved method
 	and	x0, x0, #(~clinit_bit)				// clear the clinit bit in the returned address
 	mov	x2, x0						// save method (x0 trashed by following call)
 	bl	jitMethodIsNative				// is the method native?
@@ -188,10 +188,10 @@ L_mergedUnresolvedSpecialStaticGlue:
 	b	L_gotHelper					// and skip to writing the address into the instruction
 L_notNative:
 	ldr	x3, const_staticGlueTable			// get helper table address
-	lsr	x1, x28, #J9TR_USCSnippet_HelperOffsetShift	// get helper offset
+	lsr	x1, x11, #J9TR_USCSnippet_HelperOffsetShift	// get helper offset
 	mov	x0, x2						// recover method
 	bl	jitMethodIsSync					// is method synchronized?
-	lsr	x2, x28, #(J9TR_USCSnippet_HelperOffsetShift+2)	// save helper offset for refreshHelper
+	lsr	x2, x11, #(J9TR_USCSnippet_HelperOffsetShift+2)	// save helper offset for refreshHelper
 	cbz	x0, L_notSync
 	add	x1, x1, #J9TR_staticGlueTableSyncOffset		// if so, adjust helper offset
 	add	x2, x2, #1
@@ -199,15 +199,15 @@ L_notSync:
 	add	x2, x2, #TR_ARM64interpreterVoidStaticGlue
 	ldr	x1, [x3, x1]					// fetch static glue helper from table
 L_gotHelper:
-	ldr	x0, [x27, #J9TR_SCSnippet_codeCacheReturnAddress]	// Fetch code cache EIP
-	ldr	x3, [x27, #J9TR_SCSnippet_method]
+	ldr	x0, [x10, #J9TR_SCSnippet_codeCacheReturnAddress]	// Fetch code cache EIP
+	ldr	x3, [x10, #J9TR_SCSnippet_method]
 	tbnz	x3, #clinit_bit_number, L_USSGclinitCase	// branch if the LSB (the "clinit" bit) was set in the resolved address
-	ldr	x28, [x27, #J9TR_USCSnippet_CP]			// get CP
-	ldr	x8, [x27, #J9TR_USCSnippet_CPIndex]		// get CP index & flags
-	and	x8, x8, #(~J9TR_USCSnippet_HelperOffset)	// remove helper offset from CP index
+	ldr	x11, [x10, #J9TR_USCSnippet_CP]			// get CP
+	ldr	x12, [x10, #J9TR_USCSnippet_CPIndex]		// get CP index & flags
+	and	x12, x12, #(~J9TR_USCSnippet_HelperOffset)	// remove helper offset from CP index
 	stp	x1, x2, [J9SP, #-16]!				// save regs
-	str	x8, [J9SP, #-8]!				// push:	CP index
-	str	x28, [J9SP, #-8]!				// 		CP
+	str	x12, [J9SP, #-8]!				// push:	CP index
+	str	x11, [J9SP, #-8]!				// 		CP
 	str	x3, [J9SP, #-8]!				// 		method
 	str	x0, [J9SP, #-8]!				//
 								// prepare args for jitCallCFunction:
@@ -217,11 +217,11 @@ L_gotHelper:
 	bl	jitCallCFunction
 	add	J9SP, J9SP, #32					// restore J9SP
 	ldp	x1, x2, [J9SP], #16				// restore regs
-	add	x0, x27, #J9TR_Snippet_CallInstruction		// get address of BL instruction in snippet
+	add	x0, x10, #J9TR_Snippet_CallInstruction		// get address of BL instruction in snippet
 	mov	x30, x0						// execute the BL after rewriting it
 	b	L_refreshHelper					// update branch instruction to new target
 L_USSGclinitCase:
-	mov	x30, x27					// send helpers expect link register to contain snippet return address
+	mov	x30, x10					// send helpers expect link register to contain snippet return address
 	br	x1						// in <clinit> case, dispatch method directly without patching
 
 	.align	3
@@ -274,6 +274,12 @@ _interpreterUnresolvedInstanceDataStoreGlue:
 _virtualUnresolvedHelper:
 	hlt	#0	// Not implemented yet
 
+// Handles calls to interface call snippets
+//
+// in:     x30 = snippet
+//
+// trash:	x10, x11
+//
 _interfaceCallHelper:
 	stp	x0, x1, [J9SP, #-64]!
 	stp	x2, x3, [J9SP, #16]
@@ -282,7 +288,7 @@ _interfaceCallHelper:
 	mov	x7, x30						// preserve LR
 	add	x0, x30, #J9TR_UICSnippet_CP			// get CP/index pair pointer
 	ldr	x1, [x30, #J9TR_ICSnippet_codeCacheReturnAddress]	// get code cache RA
-	mov	x28, x1						// protect RA in x28 (in L_commonLookupException, it is expected)
+	mov	x10, x1						// protect RA in x10 (in L_commonLookupException, it is expected)
 	bl	jitResolveInterfaceMethod			// call the helper
 	cbz	x0, L_commonLookupException			// if resolve failed, throw the exception
 	add	x0, x7, #J9TR_Snippet_CallInstruction		// get address of BL instruction in snippet
@@ -306,31 +312,31 @@ L_continueInterfaceSend:
 	and	x0, x0, #~(J9TR_RequiredClassAlignment-1)	// mask VFT bits
 	add	x1, x30, #J9TR_ICSnippet_InterfaceClass		// get InterfaceClass/MethodIndex pair pointer
 	ldr	x2, [x30, #J9TR_ICSnippet_codeCacheReturnAddress]	// get code cache RA
-	mov	x28, x2						// protect LR in x28 (in L_commonLookupException, it is expected)
+	mov	x10, x2						// protect LR in x10 (in L_commonLookupException, it is expected)
 	bl	jitLookupInterfaceMethod			// call the helper
 	cbz	x0, L_commonLookupException			// if resolve failed, throw the exception
 	mov	x9, #J9TR_InterpVTableOffset
 	sub	x9, x9, x0					// convert interp vTableIndex to jit index (must be in x9 for patch virtual)
-	mov	x30, x28						// set LR = code cache RA
+	mov	x30, x10						// set LR = code cache RA
 	ldr	x0, [J9SP, #0]					// refetch 'this'
 #ifdef J9VM_GC_COMPRESSED_POINTERS
-	ldr	w14, [x0, #J9TR_ObjectHeader_class]		// load class offset of receiver
+	ldr	w11, [x0, #J9TR_ObjectHeader_class]		// load class offset of receiver
 #else
-	ldr	x14, [x0, #J9TR_ObjectHeader_class]		// load class of receiver
+	ldr	x11, [x0, #J9TR_ObjectHeader_class]		// load class of receiver
 #endif
-	and	x14, x14, #~(J9TR_RequiredClassAlignment-1)	// mask VFT bits
+	and	x11, x11, #~(J9TR_RequiredClassAlignment-1)	// mask VFT bits
 	ldr	x1, [J9SP, #8]					// restore other parameter regs
 	ldp	x2, x3, [J9SP, #16]
 	ldp	x4, x5, [J9SP, #32]
 	ldp	x6, x7, [J9SP, #48]
 	add	J9SP, J9SP, #64
-	ldr	x14, [x14, x9]					// jump thru vtable
-	br	x14
+	ldr	x11, [x11, x9]					// jump thru vtable
+	br	x11
 
 L_commonLookupException:
 	add	J9SP, J9SP, #64					// clean up stack but do not restore register values
 	ldr	x0, [J9VMTHREAD, #J9TR_VMThreadCurrentException]	// load pending exception from vmStruct
-	mov	x30, x28					// move correct LR in to get exception throw.
+	mov	x30, x10					// move correct LR in to get exception throw.
 	b	jitThrowException				// throw it
 
 	.align	3
@@ -345,7 +351,7 @@ const_interfaceDispatch:
 // out:   x0  = method
 //        x30 = code cache return address
 //
-// trash: x1, x2
+// trash: x10, x11
 //
 L_StaticGlueCallFixer:
 	ldr	x0, [x1, #J9TR_SCSnippet_method]		// get method
@@ -357,10 +363,10 @@ L_StaticGlueCallFixer:
 	beq	L_StaticGlueCallFixer1				// is method now compiled?
 	ret	x2						// if not, return to static glue to call interpreter
 L_StaticGlueCallFixer1:
-	ldr	x28, [x0, #J9TR_MethodPCStartOffset]		// get I->J start address
-	sub	x27, x30, #4					// get address of BL instruction (code cache RA points to instruction following BL)
-	str	x28, [J9SP, #-8]!				// push:	addr of the callee (MethodPCStartOffset)
-	str	x27, [J9SP, #-8]!				// 		addr of BL instr
+	ldr	x10, [x0, #J9TR_MethodPCStartOffset]		// get I->J start address
+	sub	x11, x30, #4					// get address of BL instruction (code cache RA points to instruction following BL)
+	str	x10, [J9SP, #-8]!				// push:	addr of the callee (MethodPCStartOffset)
+	str	x11, [J9SP, #-8]!				// 		addr of BL instr
 	str	x0, [J9SP, #-8]!				// 		method
 								// prepare args for jitCallCFunction:
 	ldr	x0, const_mcc_callPointPatching_unwrapper	// addr of mcc_callPointPatching_unwrapper
@@ -368,8 +374,8 @@ L_StaticGlueCallFixer1:
 	mov	x2, J9SP					// where to put the return value
 	bl	jitCallCFunction
 	add	J9SP, J9SP, #24					// restore J9SP
-	add	x30, x27, #4					// set LR to code cache RA
-	br	x28						// jump to the I->J start address
+	add	x30, x11, #4					// set LR to code cache RA
+	br	x10						// jump to the I->J start address
 L_SGCclinitCase:
 	and	x0, x0, #(~clinit_bit)				// clear the "clinit" bit
 	ldr	x1, [x0, #J9TR_MethodPCStartOffset]		// get I->J start address


### PR DESCRIPTION
This commit changes the registers used in PicBuilder.spp for AArch64.
It used to use x27 and x28 for temporary purpose.  They are preserved
registers in the PrivateLinkage, however, and they potentially hold
values that are alive across method calls.  PicBuilder routines must
not destroy them.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>