### PR TITLE
WIP: Use system linkage for jprofiler c helpers on X86

### DIFF
--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -899,8 +899,6 @@ TR_JProfilingValue::createHelperCall(TR::Compilation *comp, TR::Node *value, TR:
 
 #if defined(TR_HOST_POWER) || defined(TR_HOST_ARM) || defined(TR_HOST_S390)
    profiler->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
-#elif defined(TR_HOST_X86)
-   profiler->getSymbol()->castToMethodSymbol()->setSystemLinkageDispatch();
 #endif
 
    TR::Node *helperCall = TR::Node::createWithSymRef(value, TR::call, 2, profiler);

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -449,12 +449,20 @@ void J9FASTCALL _jitProfileAddress(uintptr_t value, TR_LinkedListProfilerInfo<ui
 
 extern "C" {
 
+#if defined(TR_HOST_X86)
+void _jProfile32BitValue(uint32_t value, TR_HashTableProfilerInfo<uint32_t> *table)
+#else
 void J9FASTCALL _jProfile32BitValue(uint32_t value, TR_HashTableProfilerInfo<uint32_t> *table)
+#endif
    {
    table->addKey(value);
    }
 
+#if defined(TR_HOST_X86)
+void _jProfile64BitValue(uint64_t value, TR_HashTableProfilerInfo<uint64_t> *table)
+#else
 void J9FASTCALL _jProfile64BitValue(uint64_t value, TR_HashTableProfilerInfo<uint64_t> *table)
+#endif
    {
    table->addKey(value);
    }
@@ -1188,8 +1196,8 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValue,       TR_CHelper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValue,           TR_CHelper);
    SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_CHelper);
-   SET(TR_jProfile32BitValue,                   (void *)_jProfile32BitValue,              TR_CHelper);
-   SET(TR_jProfile64BitValue,                   (void *)_jProfile64BitValue,              TR_CHelper);
+   SET(TR_jProfile32BitValue,                   (void *)_jProfile32BitValue,              TR_System);
+   SET(TR_jProfile64BitValue,                   (void *)_jProfile64BitValue,              TR_System);
 #else
    SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_Helper);
    SET(TR_jitProfileAddress,                    (void *)_jitProfileAddress,               TR_Helper);


### PR DESCRIPTION
Jprofiler helpers are c functions which are implemented with complex c
code, calling them on java stack can be very dangerous. One known issue
is that java stack is not 16-byte aligned on X86-32, this will cause
crashes if there's SSE instruction in the c code. Use system linkage to
switch to c stack before the call.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>