### PR TITLE
Add wrapper to swap stack for jprofiler helpers

### DIFF
--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -449,12 +449,12 @@ void J9FASTCALL _jitProfileAddress(uintptr_t value, TR_LinkedListProfilerInfo<ui
 
 extern "C" {
 
-void J9FASTCALL _jProfile32BitValue(uint32_t value, TR_HashTableProfilerInfo<uint32_t> *table)
+void J9FASTCALL jProfile32BitValue(uint32_t value, TR_HashTableProfilerInfo<uint32_t> *table)
    {
    table->addKey(value);
    }
 
-void J9FASTCALL _jProfile64BitValue(uint64_t value, TR_HashTableProfilerInfo<uint64_t> *table)
+void J9FASTCALL jProfile64BitValue(uint64_t value, TR_HashTableProfilerInfo<uint64_t> *table)
    {
    table->addKey(value);
    }
@@ -1158,7 +1158,11 @@ JIT_HELPER(_jitProfileStringValueX);
 JIT_HELPER(_jitProfileAddressX);
 JIT_HELPER(_induceRecompilation);
 
+#endif
 
+#if defined(TR_HOST_X86) && defined(TR_HOST_64BIT)
+JIT_HELPER(jProfile32BitValueWrapper);
+JIT_HELPER(jProfile64BitValueWrapper);
 #endif
 
 
@@ -1178,8 +1182,8 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValueWrap,   TR_Helper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValueWrap,       TR_Helper);
    SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_Helper);
-   SET_CONST(TR_jProfile32BitValue,             (void *)_jProfile32BitValue);
-   SET_CONST(TR_jProfile64BitValue,             (void *)_jProfile64BitValue);
+   SET_CONST(TR_jProfile32BitValue,             (void *)jProfile32BitValue);
+   SET_CONST(TR_jProfile64BitValue,             (void *)jProfile64BitValue);
 #elif defined(TR_HOST_X86)
    SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_CHelper);
    SET(TR_jitProfileAddress,                    (void *)_jitProfileAddress,               TR_CHelper);
@@ -1188,8 +1192,13 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValue,       TR_CHelper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValue,           TR_CHelper);
    SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_CHelper);
-   SET(TR_jProfile32BitValue,                   (void *)_jProfile32BitValue,              TR_CHelper);
-   SET(TR_jProfile64BitValue,                   (void *)_jProfile64BitValue,              TR_CHelper);
+#if defined(TR_HOST_64BIT)
+   SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValueWrapper,        TR_CHelper);
+   SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValueWrapper,        TR_CHelper);
+#else
+   SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValue,        TR_CHelper);
+   SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValue,        TR_CHelper);
+#endif
 #else
    SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_Helper);
    SET(TR_jitProfileAddress,                    (void *)_jitProfileAddress,               TR_Helper);
@@ -1198,8 +1207,8 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValue,       TR_Helper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValue,           TR_Helper);
    SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_Helper);
-   SET(TR_jProfile32BitValue,                   (void *)_jProfile32BitValue,              TR_Helper);
-   SET(TR_jProfile64BitValue,                   (void *)_jProfile64BitValue,              TR_Helper);
+   SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValue,              TR_Helper);
+   SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValue,              TR_Helper);
 #endif
 
 #if defined(J9ZOS390)

--- a/runtime/compiler/runtime/ValueProfiler.cpp
+++ b/runtime/compiler/runtime/ValueProfiler.cpp
@@ -262,8 +262,8 @@ JIT_HELPER(_jitProfileBigDecimalValue);
 JIT_HELPER(_jitProfileStringValue);
 JIT_HELPER(_jitProfileAddress);
 JIT_HELPER(_jitProfileWarmCompilePICAddress);
-JIT_HELPER(_jProfile32BitValue);
-JIT_HELPER(_jProfile64BitValue);
+JIT_HELPER(jProfile32BitValue);
+JIT_HELPER(jProfile64BitValue);
 
 void PPCinitializeValueProfiler()
    {
@@ -274,7 +274,7 @@ void PPCinitializeValueProfiler()
    SET(TR_jitProfileLongValue,             (void *) _jitProfileLongValue,             TR_Helper);
    SET(TR_jitProfileBigDecimalValue,       (void *) _jitProfileBigDecimalValue,       TR_Helper);
    SET(TR_jitProfileStringValue,           (void *) _jitProfileStringValue,           TR_Helper);
-   SET(TR_jProfile32BitValue,              (void *) _jProfile32BitValue,              TR_Helper);
-   SET(TR_jProfile64BitValue,              (void *) _jProfile64BitValue,              TR_Helper);
+   SET(TR_jProfile32BitValue,              (void *) jProfile32BitValue,               TR_Helper);
+   SET(TR_jProfile64BitValue,              (void *) jProfile64BitValue,               TR_Helper);
    }
 #endif


### PR DESCRIPTION
Executing c code on java stack can be dangerous. This commit introduces
two assembly wrappers to swap the stack for jprofiler helpers on X64.
The wrappers are needed to enable jprofiler.

Also remove the underscore prefix to avoid linker issues on OSX.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>