### PR TITLE
Fix AOT load failures

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1432,12 +1432,6 @@ TR_ResolvedRelocatableJ9Method::setAttributeResult(bool isStaticField, bool resu
    *type = decodeType(ltype);
    }
 
-char *
-TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
-   {
-   len = 0;
-   return ""; // TODO: Implement me
-   }
 
 TR::Method *   TR_ResolvedRelocatableJ9Method::convertToMethod()              { return this; }
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -604,7 +604,6 @@ protected:
 
    bool                            unresolvedFieldAttributes (int32_t cpIndex, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate);
    bool                            unresolvedStaticAttributes(int32_t cpIndex, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate);
-   virtual char *                  fieldOrStaticNameChars(int32_t cpIndex, int32_t & len);
 
    J9ExceptionHandler *            exceptionHandler();
    };


### PR DESCRIPTION
PR #7044 made `TR_ResolvedJ9Method::fieldOrStaticNameChars()` virtual, but
the implementation of `TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars()`
returns a dummy answer. The code only works on romLiterals and there is no
reason why the relocatable version cannot return a proper answer. In fact
for similar methods (e.g. classSignatureOfFieldOrStatic,
classNameOfFieldOrStatic, classCPIndexOfFieldOrStatic,fieldOrStaticName,
fieldOrStaticSignatureChars) there is only one implementation.
This commit will remove the overidden implementation of
`TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars()`

Fixes #7241

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>