### PR TITLE
Unsafe writebackMemory for Java 14

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -186,26 +186,6 @@ public final class Unsafe {
 	/* Mask byte offset of an int. */
 	private static final long BYTE_OFFSET_MASK = 0b11L;
 
-/*[IF Java14]*/
-	/* 
-	 * Platform feature needed for the writebackMemory method. Takes the value of the
-	 * feature constant in j9port.h (for example J9PORT_X86_FEATURE_CLFSH or 19) or 0
-	 * if cache writeback is not supported. A value of -1 means that this field has not
-	 * been set yet.
-	 * 
-	 * For x86, valid values are J9PORT_X86_FEATURE_CLFSH (19),
-	 * J9PORT_X86_FEATURE_CLFLUSHOPT (96+23), and J9PORT_X86_FEATURE_CLWB (96+24)
-	 */
-	private static int CACHE_WRITEBACK_FEATURE = -1;
-
-	/* 
-	 * Size of a cache line on the current platform in bytes. A value of -1 means this
-	 * field has not been set yet
-	 */
-	private static long CACHE_LINE_SIZE = -1;
-/*[ENDIF] Java14 */
-
-	
 	static {
 		registerNatives();
 
@@ -1064,28 +1044,23 @@ public final class Unsafe {
 
 /*[IF Java14]*/
 	/**
-	 * Writes modified memory in an address range from cache to main memory.
-	 * Uses memory barriers before and after writeback to ensure ordering.
+	 * Make sure that the virtual memory at address "addr" for length "len" has
+	 * been written back from the cache to physical memory.
+	 * Throw RuntimeException if cache flushing is not enabled on the runtime OS.
 	 * 
-	 * @param addr address of block to write back to memory
-	 * @param len length of block being written
-	 * @param writebackMethod the feature we use to do the writeback
-	 * @param cacheLineSize length of a cache line on the current platform
+	 * @param addr address to the start of the block of virtual memory to be flushed
+	 * @param len length of the block of virtual memory to be flushed
+	 * @throws RuntimeException if cache flushing not enabled
 	 */
-	private native void writebackMemory0(long addr, long len, int writebackMethod, long cacheLineSize);
-
+	public native void writebackMemory(long addr, long len);
 
 	/**
-	 * Checks if the platform supports writeback from cache to memory. This
-	 * function checks for a feature that is supported on the current platform
-	 * which allows cache writeback then writes a constant in j9port.h which
-	 * corresponds to that feature (for example J9PORT_X86_FEATURE_CLFSH)
-	 * in the CACHE_WRITEBACK_FEATURE class field. A value of 0 is written if
-	 * cache writeback is not supported.
+	 * Check if cache writeback is possible on the runtime platform by checking
+	 * if there is OS and/or CPU support.
 	 * 
-	 * The size of a cache line is also written to the CACHE_LINE_SIZE field.
+	 * @return true if cache writeback is possible, else false
 	 */
-	private static native void cpuWritebackFeatures0();
+	public static native boolean isWritebackEnabled();
 /*[ENDIF] Java14 */
 	
 	/**
@@ -5912,36 +5887,6 @@ public final class Unsafe {
 		}
 	}
 /*[ENDIF] Java12 */
-
-/*[IF Java14]*/
-	/**
-	 * Make sure that the virtual memory at address "addr" for length "len" has been flushed to physical memory.
-	 * Throw RuntimeException if cache flushing not enabled on the runtime OS.
-	 * 
-	 * @param addr address to the start of the block of virtual memory to be flushed
-	 * @param len length of the block of virtual memory to be flushed
-	 * @throws RuntimeException if cache flushing not enabled
-	 */
-	public void writebackMemory(long addr, long len) {
-		if (isWritebackEnabled()) {
-			writebackMemory0(addr, len, CACHE_WRITEBACK_FEATURE, CACHE_LINE_SIZE);
-		} else {
-			throw new RuntimeException("writebackMemory not enabled");
-		}
-	}
-
-	/**
-	 * Check if cache writeback is possible on the runtime OS
-	 * 
-	 * @return true if cache writeback is possible, else false
-	 */
-	public static boolean isWritebackEnabled() {
-		if (CACHE_WRITEBACK_FEATURE == -1) {
-			cpuWritebackFeatures0();
-		}
-		return (CACHE_WRITEBACK_FEATURE > 0) && (CACHE_LINE_SIZE > 0);
-	}
-/*[ENDIF] Java14 */
 
 	/* 
 	 * Private methods 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5114,6 +5114,11 @@ typedef struct J9JavaVM {
 	UDATA valueFlatteningThreshold;
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	UDATA dCacheLineSize;
+	/* Indicates processor support for committing cache lines to memory. On X86,
+	 * examples would be CLFLUSH or CLWB instructions. This field takes the value
+	 * of the feature constants listed in j9port.h
+	 */
+	U_32 cpuCacheWritebackCapabilities;
 } J9JavaVM;
 
 #define J9VM_PHASE_NOT_STARTUP  2

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -643,6 +643,43 @@ typedef struct J9ProcessorDesc {
 #define J9PORT_X86_FEATURE_AVX          32 + 28 /* Processor supports the AVX instruction extensions. */
 #define J9PORT_X86_FEATURE_F16C         32 + 29 /* 16-bit floating-point conversion instructions. */
 #define J9PORT_X86_FEATURE_RDRAND       32 + 30 /* Processor supports RDRAND instruction. */
+
+
+/* INTEL INSTRUCTION SET REFERENCE, A-L May 2019
+ * Vol. 2 3-197 Table 3-8. Structured Feature Information Returned in the EBX Register by CPUID instruction
+ */
+#define J9PORT_X86_FEATURE_FSGSBASE 		96 + 0	/* fsgsbase instructions support */
+#define J9PORT_X86_FEATURE_IA32_TSC_ADJUST	96 + 1	/* IA32_TSC_ADJUST MSR support */
+#define J9PORT_X86_FEATURE_SGX				96 + 2	/* Intel Software Guard Extensions */
+#define J9PORT_X86_FEATURE_BMI1				96 + 3	/* Bit Manipulation Instructions 1 */
+#define J9PORT_X86_FEATURE_HLE				96 + 4	/* Hardware Lock Elison */
+#define J9PORT_X86_FEATURE_AVX2				96 + 5	/* AVX2 support */
+#define J9PORT_X86_FEATURE_FDP_EXCPTN_ONLY	96 + 6	/* x87 FPU data pointer updated only on exceptions */
+#define J9PORT_X86_FEATURE_SMEP				96 + 7	/* Supervsior-Mode Execution Prevention */
+#define J9PORT_X86_FEATURE_BMI2				96 + 8	/* Bit Manipulation Instructions 2 */
+#define J9PORT_X86_FEATURE_ERMSB			96 + 9	/* Enhanced REP MOVSB/STOSB */
+#define J9PORT_X86_FEATURE_INVPCID			96 + 10	/* Invalidate Process-Context Identifier instruction */
+#define J9PORT_X86_FEATURE_RTM				96 + 11	/* Restricted Transactional Memory */
+#define J9PORT_X86_FEATURE_RDT_M			96 + 12	/* Intel RDT Monitoring */
+#define J9PORT_X86_FEATURE_DEPRECATE_FPUCS	96 + 13	/* Deprecates FPU CS and FPU DS when set */
+#define J9PORT_X86_FEATURE_MPX				96 + 14	/* Intel Memory Protextion Extensions */
+#define J9PORT_X86_FEATURE_RDT_A			96 + 15	/* Intel RDT Allocation */
+#define J9PORT_X86_FEATURE_AVX512F			96 + 16	/* AVX512 Foundation */
+#define J9PORT_X86_FEATURE_AVX512DQ			96 + 17	/* AVX512 Doubleword & Quadword */
+#define J9PORT_X86_FEATURE_RDSEED			96 + 18	/* RDSEED instruction support */
+#define J9PORT_X86_FEATURE_ADX				96 + 19	/* Intel ADX (multi-precision arithmetic) */
+#define J9PORT_X86_FEATURE_SMAP				96 + 20	/* Supervisor-Mode Access Prevention */
+#define J9PORT_X86_FEATURE_AVX512_IFMA		96 + 21	/* AVX512 Integer Fused Multiply Add */
+#define J9PORT_X86_FEATURE_22				96 + 22	/* reserved */
+#define J9PORT_X86_FEATURE_CLFLUSHOPT		96 + 23	/* cache flush optimized */
+#define J9PORT_X86_FEATURE_CLWB				96 + 24	/* cache line write back */
+#define J9PORT_X86_FEATURE_IPT				96 + 25	/* Intel Processor Trace */
+#define J9PORT_X86_FEATURE_AVX512PF			96 + 26	/* AVX512 Prefetch */
+#define J9PORT_X86_FEATURE_AVX512ER			96 + 27	/* AVX512 Exponential and Reciprocal */
+#define J9PORT_X86_FEATURE_AVX512CD			96 + 28	/* AVX512 Conflict Detection */
+#define J9PORT_X86_FEATURE_SHA				96 + 29	/* Intel SHA Extensions */
+#define J9PORT_X86_FEATURE_AVX512BW			96 + 30	/* AVX512 Byte and Word */
+#define J9PORT_X86_FEATURE_AVX512VL			96 + 31	/* AVX512 Vector Length */
 
 /* cache types */
 #define J9PORT_CACHEINFO_ICACHE 0x01

--- a/runtime/port/common/j9sysinfo_helpers.c
+++ b/runtime/port/common/j9sysinfo_helpers.c
@@ -242,7 +242,7 @@ getX86CPUIDext(uint32_t leaf, uint32_t subleaf, uint32_t *cpuInfo)
 /* Implemented for x86 & x86_64 bit platforms */
 #if defined(WIN32)
 	/* Specific CPUID instruction available in Windows */
-	__cpuidex(CPUInfo, cpuInfo[0], cpuInfo[2]);
+	__cpuidex(cpuInfo, cpuInfo[0], cpuInfo[2]);
 
 #elif defined(LINUX) || defined(OSX)
 #if defined(J9X86)

--- a/runtime/port/common/j9sysinfo_helpers.c
+++ b/runtime/port/common/j9sysinfo_helpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,8 +39,9 @@
 #endif /* defined(WIN32) */
 
 /* defines for the CPUID instruction */
-#define CPUID_VENDOR_INFO	0
-#define CPUID_FAMILY_INFO	1
+#define CPUID_VENDOR_INFO						0
+#define CPUID_FAMILY_INFO						1
+#define CPUID_STRUCTURED_EXTENDED_FEATURE_INFO	7
 
 #define CPUID_VENDOR_INTEL		"GenuineIntel"
 #define CPUID_VENDOR_AMD		"AuthenticAMD"
@@ -150,9 +151,15 @@ getX86Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	desc->physicalProcessor = desc->processor;
 
 	/* features */
-	desc->features[0] = CPUInfo[3];
-	desc->features[1] = CPUInfo[2];
-	desc->features[2] = 0; /* reserved for future expansion */
+	desc->features[0] = CPUInfo[3]; /* Feature info flags in EDX */
+	desc->features[1] = CPUInfo[2];	/* Feature info flags in ECX */
+	desc->features[2] = CPUInfo[1]; /* EBX register, cache line size info in bits 8-15 */
+
+	/* extended features */
+	getX86CPUIDext(CPUID_STRUCTURED_EXTENDED_FEATURE_INFO, 0, CPUInfo); /* 0x0 is the only valid subleaf value for this leaf */
+	desc->features[3] = CPUInfo[1]; /* Structured Extended Feature Flags in EBX */
+
+	desc->features[4] = 0; /* reserved for future expansion */
 
 	return 0;
 }
@@ -164,10 +171,12 @@ getX86Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
  * Name based on the same instruction. The leaf value specifies what information
  * to return.
  *
- * @param[in] 	leaf The leaf value to the CPUID instruction.
+ * @param[in] 	leaf		The leaf value to the CPUID instruction and the value
+ * 							in EAX when CPUID is called. A value of 0x1 returns basic
+ * 							information including feature support.
  * @param[out]	cpuInfo 	Reference to the an integer array which holds the data
  * 							of EAX,EBX,ECX and EDX registers.
- *              cpuInfo[0] To hold the EAX register data, value in this register at
+ *              cpuInfo[0]	To hold the EAX register data, value in this register at
  *							the time of CPUID tells what information to return
  *							EAX=0x1,returns the processor Info and feature bits
  *							in EBX,ECX,EDX registers.
@@ -206,6 +215,49 @@ getX86CPUID(uint32_t leaf, uint32_t *cpuInfo)
   __asm volatile(
      "cpuid;"
      :"+a" (cpuInfo[0]), "=b" (cpuInfo[1]), "=c" (cpuInfo[2]), "=d" (cpuInfo[3])
+        );
+#endif
+#endif
+}
+
+/**
+ * Similar to getX86CPUID() above, but with a second subleaf parameter for the
+ * leaves returned by the 'cpuid' instruction which are further divided into
+ * subleaves.
+ * 
+ * @param[in]	leaf		Value in EAX when cpuid is called to determine what info
+ * 							is returned.
+ * 				subleaf		Value in ECX when cpuid is called which is needed by some
+ * 							leafs returned in order to further specify what is returned
+ * @param[out]	cpuInfo		Reference to the an integer array which holds the data
+ * 							of EAX,EBX,ECX and EDX registers returned by cpuid.
+ * 							cpuInfo[0] holds EAX and cpuInfo[4] holds EDX.
+ */
+void
+getX86CPUIDext(uint32_t leaf, uint32_t subleaf, uint32_t *cpuInfo)
+{
+	cpuInfo[0] = leaf;
+	cpuInfo[2] = subleaf;
+
+/* Implemented for x86 & x86_64 bit platforms */
+#if defined(WIN32)
+	/* Specific CPUID instruction available in Windows */
+	__cpuidex(CPUInfo, cpuInfo[0], cpuInfo[2]);
+
+#elif defined(LINUX) || defined(OSX)
+#if defined(J9X86)
+	__asm volatile
+	("mov %%ebx, %%edi;"
+			"cpuid;"
+			"mov %%ebx, %%esi;"
+			"mov %%edi, %%ebx;"
+			:"+a" (cpuInfo[0]), "=S" (cpuInfo[1]), "+c" (cpuInfo[2]), "=d" (cpuInfo[3])
+			 : :"edi");
+
+#elif defined(J9HAMMER)
+  __asm volatile(
+     "cpuid;"
+     :"+a" (cpuInfo[0]), "=b" (cpuInfo[1]), "+c" (cpuInfo[2]), "=d" (cpuInfo[3])
         );
 #endif
 #endif

--- a/runtime/port/common/j9sysinfo_helpers.h
+++ b/runtime/port/common/j9sysinfo_helpers.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2013 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,9 @@
 
 extern void
 getX86CPUID(uint32_t leaf, uint32_t *cpuInfo);
+
+extern void
+getX86CPUIDext(uint32_t leaf, uint32_t subleaf, uint32_t *cpuInfo);
 
 extern intptr_t
 getX86Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc);


### PR DESCRIPTION
Implements the `writebackMemory` and `isWritebackEnabled` methods from https://github.com/eclipse/openj9/issues/6831, JEP 352.

Also get more feature info for x86 processors, which is needed since we need the cache line size for writeback and want to check for the `CLWB` instruction support.

This PR only supports Linux x86 since that is what JEP 352 targets, though we should be able to extend it to Windows and Mac OSX. 

I'm also unsure of how this would be tested, since I'm not sure how we can verify the cache lines are actually written to memory. 

Can you take a look at this @DanHeidinga 