### PR TITLE
Remove _registerSaveDescription field in J9Instruction.hpp

### DIFF
--- a/runtime/compiler/codegen/J9Instruction.cpp
+++ b/runtime/compiler/codegen/J9Instruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,8 +40,6 @@ J9::Instruction::Instruction(
       TR::Node *node) :
    OMR::InstructionConnector(cg, op, node)
    {
-   _registerSaveDescription = 0;
-
    if (self()->getPrev())
       {
       _liveLocals = cg->getLiveLocals();
@@ -62,8 +60,6 @@ J9::Instruction::Instruction(
       TR::Node *node) :
    OMR::InstructionConnector(cg, precedingInstruction, op, node)
    {
-   _registerSaveDescription = 0;
-
    if (precedingInstruction != 0)
       {
       _liveLocals = precedingInstruction->_liveLocals;

--- a/runtime/compiler/codegen/J9Instruction.hpp
+++ b/runtime/compiler/codegen/J9Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,14 +76,10 @@ class OMR_EXTENSIBLE Instruction : public OMR::InstructionConnector
    TR_BitVector *getLiveMonitors() { return _liveMonitors; }
    TR_BitVector *setLiveMonitors(TR_BitVector *v) { return (_liveMonitors = v); }
 
-   int32_t getRegisterSaveDescription() { return _registerSaveDescription; }
-   int32_t setRegisterSaveDescription(int32_t v) { return (_registerSaveDescription = v); }
-
    private:
 
    TR_BitVector *_liveLocals;
    TR_BitVector *_liveMonitors;
-   int32_t _registerSaveDescription;
 
    union TR_GCInfo
       {


### PR DESCRIPTION
Remove `_registerSaveDescription` field, which is no longer in use.
Remove `_registerSaveDescription` getters and setters for this field.

Upstream OMR PR [here](https://github.com/eclipse/omr/pull/4372).

Fixes #7203 