### PR TITLE
Backport JITServer VMJ9-related changes from master

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4751,7 +4751,7 @@ J9::CodeGenerator::generateCatchBlockBBStartPrologue(
       TR::Node *node,
       TR::Instruction *fenceInstruction)
    {
-   if (self()->comp()->getOptions()->getReportByteCodeInfoAtCatchBlock())
+   if (self()->comp()->fej9vm()->getReportByteCodeInfoAtCatchBlock())
       {
       // Note we should not use `fenceInstruction` here because it is not the first instruction in this BB. The first
       // instruction is a label that incoming branches will target. We will use this label (first instruction in the

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2919,8 +2919,6 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::Co
    // On JITServer, we store this value for each client in ClientSessionData
    bool rtResolve = (bool) *((uint8_t *) options + clientOptionsSize - sizeof(bool));
    compInfoPT->getClientData()->setRtResolve(rtResolve);
-   _reportByteCodeInfoAtCatchBlock = fe->getReportByteCodeInfoAtCatchBlock();
-
    unpackRegex(options->_traceForCodeMining);
    unpackRegex(options->_disabledOptTransformations);
    unpackRegex(options->_disabledInlineSites);

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1052,15 +1052,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getVFTEntry(std::get<0>(recv), std::get<1>(recv)));
          }
          break;
-      case MessageType::VM_getArrayLengthOfStaticAddress:
-         {
-         auto recv = client->getRecvData<void*>();
-         void *ptr = std::get<0>(recv);
-         int32_t length;
-         bool ok = fe->getArrayLengthOfStaticAddress(ptr, length);
-         client->write(response, ok, length);
-         }
-         break;
       case MessageType::VM_isClassArray:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock*>();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -22,7 +22,9 @@
 
 #define J9_EXTERNAL_TO_VM
 
+#if defined(JITSERVER_SUPPORT)
 #include "env/VMJ9Server.hpp"
+#endif
 
 #if defined (_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf
@@ -593,6 +595,7 @@ TR_J9VMBase::get(J9JITConfig * jitConfig, J9VMThread * vmThread, VM_TYPE vmType)
       // Check if this thread has cached the frontend inside
 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
+#if defined(JITSERVER_SUPPORT)
       if (vmType==J9_SERVER_VM || vmType==J9_SHARED_CACHE_SERVER_VM)
          {
          TR_ASSERT(vmWithoutThreadInfo->_compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER, "J9_SERVER_VM and J9_SHARED_CACHE_SERVER_VM should only be instantiated in JITServer::SERVER mode");
@@ -651,6 +654,7 @@ TR_J9VMBase::get(J9JITConfig * jitConfig, J9VMThread * vmThread, VM_TYPE vmType)
             return sharedCacheServerVM;
             }
          }
+#endif
       if (vmType==AOT_VM)
          {
          TR_J9VMBase * aotVMWithThreadInfo = static_cast<TR_J9VMBase *>(vmThread->aotVMwithThreadInfo);
@@ -737,14 +741,23 @@ TR_J9VMBase::TR_J9VMBase(
          }
 
    _sharedCache = NULL;
-   if (TR::Options::sharedClassCache() ||
-       (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER))
+   if (TR::Options::sharedClassCache()
+#if defined(JITSERVER_SUPPORT)
+      || (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+#endif
+      )
       // shared classes and AOT must be enabled, or we should be on the JITServer with remote AOT enabled
       {
+#if defined(JITSERVER_SUPPORT)
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+         {
          _sharedCache = new (PERSISTENT_NEW) TR_J9JITServerSharedCache(this);
+         }
       else
+#endif   
+         {
          _sharedCache = new (PERSISTENT_NEW) TR_J9SharedCache(this);
+         }
       if (!_sharedCache)
          {
          TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
@@ -766,7 +779,9 @@ TR_J9VMBase::freeSharedCache()
    {
    if (_sharedCache)        // shared classes and AOT must be enabled
       {
+#if defined(JITSERVER_SUPPORT)
       if (_compInfo && (_compInfo->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER))
+#endif
          {
          TR_ASSERT(TR::Options::sharedClassCache(), "Found shared cache with option disabled");
          }
@@ -3504,7 +3519,7 @@ TR_J9VMBase::lowerMethodHook(TR::Compilation * comp, TR::Node * root, TR::TreeTo
 U_8 *
 TR_J9VMBase::fetchMethodExtendedFlagsPointer(J9Method *method)
    {
-   return fetchMethodExtendedFlagsPointer(method);
+   return ::fetchMethodExtendedFlagsPointer(method);
    }
 
 void *
@@ -3831,9 +3846,11 @@ TR_J9VMBase::tryToAcquireAccess(TR::Compilation * comp, bool *haveAcquiredVMAcce
    bool hasVMAccess;
    *haveAcquiredVMAccess = false;
 
+#if defined(JITSERVER_SUPPORT)
    // JITServer TODO: For now, we always take the "safe path" on the server
-   if (TR::CompilationInfo::getStream())
+   if (comp->isOutOfProcessCompilation())
       return false;
+#endif
 
    if (!comp->getOption(TR_DisableNoVMAccess))
       {
@@ -6022,23 +6039,6 @@ TR_J9VMBase::isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz)
    return getSystemClassLoader() == getClassLoader(clazz);
    }
 
-bool
-TR_J9VMBase::getArrayLengthOfStaticAddress(void *ptr, int32_t &length)
-   {
-   TR::VMAccessCriticalSection getArrayLengthOfStaticAddress(this);
-   if ((*(void **)ptr != 0))
-      {
-      length = *((int32_t *) (((uintptrj_t) *(void ***)ptr) + (uintptrj_t) getOffsetOfContiguousArraySizeField()));
-
-      if (length == 0 && TR::Compiler->om.useHybridArraylets())
-         {
-         length = *((int32_t *) (((uintptrj_t) *(void ***)ptr) + (uintptrj_t) getOffsetOfDiscontiguousArraySizeField()));
-         }
-      return true;
-      }
-   return false;
-   }
-
 intptrj_t
 TR_J9VMBase::getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset)
    {
@@ -7368,8 +7368,10 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
 
          TR::SymbolReference *helperSymRef = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
          sym->setMethodAddress(helperSymRef->getMethodAddress());
+#if defined(JITSERVER_SUPPORT)
          // JITServer: store the helper reference number in the node for use in creating TR_HelperAddress relocation
          callNode->getSymbolReference()->setReferenceNumber(helperSymRef->getReferenceNumber());
+#endif
          return callNode;
          }
       case TR::java_lang_invoke_MethodHandle_invokeWithArgumentsHelper:
@@ -8350,7 +8352,6 @@ TR_J9VM::getPrimitiveArrayAllocationClass(J9Class *clazz)
    {
    return (TR_OpaqueClassBlock *) clazz;
    }
-
 
 TR_StaticFinalData
 TR_J9VM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -161,8 +161,7 @@ typedef struct TR_JitPrivateConfig
    TR_AOTStats *aotStats;
    } TR_JitPrivateConfig;
 
-
-// JITServer: union containing all possible datatypes of static final fields
+// Union containing all possible datatypes of static final fields
 union
 TR_StaticFinalData
    {
@@ -174,7 +173,6 @@ TR_StaticFinalData
    double dataDouble;
    uintptrj_t dataAddress;
    };
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -712,7 +710,7 @@ public:
 #endif
    virtual void refineColdness (TR::Node* node, bool& isCold);
 
-   virtual TR::Node * inlineNativeCall( TR::Compilation *,  TR::TreeTop *, TR::Node *) { return 0; }
+   virtual TR::Node * inlineNativeCall(TR::Compilation *,  TR::TreeTop *, TR::Node *) { return 0; }
 
    virtual bool               inlinedAllocationsMustBeVerified() { return false; }
 
@@ -891,11 +889,10 @@ public:
    virtual TR_OpaqueClassBlock *getHostClass(TR_OpaqueClassBlock *clazzOffset);
    virtual bool canAllocateInlineClass(TR_OpaqueClassBlock *clazz);
    virtual bool isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz);
-   virtual bool getArrayLengthOfStaticAddress(void *ptr, int32_t &length);
    virtual intptrj_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset);
 
-    TR::TreeTop * lowerAsyncCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-    TR::TreeTop * lowerAtcCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerAsyncCheck(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerAtcCheck(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodTracingEnabled(J9Method *j9method)
       {
@@ -908,15 +905,15 @@ public:
    virtual bool canMethodExitEventBeHooked();
    virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled();
 
-   TR::TreeTop * lowerMethodHook( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerArrayLength( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerContigArrayLength( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerMultiANewArray( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   TR::TreeTop * lowerToVcall( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerMethodHook(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerArrayLength(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerContigArrayLength(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerMultiANewArray(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   TR::TreeTop * lowerToVcall(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    virtual U_8 * fetchMethodExtendedFlagsPointer(J9Method *method); // wrapper method of fetchMethodExtendedFlagsPointer in util/extendedmethodblockaccess.c, for JITServer override purpose
    virtual void * getStaticHookAddress(int32_t event);
 
-   TR::Node * initializeLocalObjectFlags( TR::Compilation *, TR::Node * allocationNode, TR_OpaqueClassBlock * ramClass);
+   TR::Node * initializeLocalObjectFlags(TR::Compilation *, TR::Node * allocationNode, TR_OpaqueClassBlock * ramClass);
 
    virtual J9JITConfig *getJ9JITConfig() { return _jitConfig; }
 
@@ -929,7 +926,7 @@ public:
    virtual bool isAnonymousClass(J9ROMClass *romClass) { return (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)); }
    virtual int64_t getCpuTimeSpentInCompThread(TR::Compilation * comp); // resolution is 0.5 sec or worse. Returns -1 if unavailable
 
-   virtual void *             getClassLoader(TR_OpaqueClassBlock * classPointer);
+   virtual void * getClassLoader(TR_OpaqueClassBlock * classPointer);
    virtual bool getReportByteCodeInfoAtCatchBlock();
 
    J9VMThread *            _vmThread;

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,14 +115,14 @@ TR_J9ServerVM::createMethod(TR_Memory * trMemory, TR_OpaqueClassBlock * clazz, i
 
 TR_ResolvedMethod *
 TR_J9ServerVM::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod,
-                                  TR_ResolvedMethod * owningMethod, TR_OpaqueClassBlock *classForNewInstance)
+                                    TR_ResolvedMethod * owningMethod, TR_OpaqueClassBlock *classForNewInstance)
    {
    return createResolvedMethodWithSignature(trMemory, aMethod, classForNewInstance, NULL, -1, owningMethod);
    }
 
 TR_ResolvedMethod *
 TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
-                          char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod)
+                                                 char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod)
    {
    TR_ResolvedJ9Method *result = NULL;
    if (isAOT_DEPRECATED_DO_NOT_USE())
@@ -171,31 +171,7 @@ TR_J9ServerVM::isInstanceOf(TR_OpaqueClassBlock *a, TR_OpaqueClassBlock *b, bool
       return TR_no;
    return TR_maybe;
    }
-/*
-bool
-TR_J9ServerVM::isInterfaceClass(TR_OpaqueClassBlock *clazzPointer)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isInterfaceClass, clazzPointer);
-   return std::get<0>(stream->read<bool>());
-   }
 
-bool
-TR_J9ServerVM::isClassFinal(TR_OpaqueClassBlock *clazzPointer)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isClassFinal, clazzPointer);
-   return std::get<0>(stream->read<bool>());
-   }
-
-bool
-TR_J9ServerVM::isAbstractClass(TR_OpaqueClassBlock *clazzPointer)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isAbstractClass, clazzPointer);
-   return std::get<0>(stream->read<bool>());
-   }
-*/
 TR_OpaqueClassBlock *
 TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT)
    {
@@ -218,7 +194,6 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
       {
       OMR::CriticalSection getSystemClassCS(_compInfoPT->getClientData()->getClassMapMonitor());
       classByNameMap[key] = clazz;
-
       }
    else
       {
@@ -336,8 +311,6 @@ TR_J9ServerVM::getClassFromSignature(const char *sig, int32_t length, TR_Resolve
       // In theory we could consider this a special case and watch the CHTable updates
       // for a class load event for Ljava/lang/String$StringCompressionFlag, but it may not
       // be worth the trouble.
-      //static unsigned long errorsSystem = 0;
-      //printf("ErrorSystem %lu for cl=%p\tclassName=%.*s\n", ++errorsSystem, cl, length, sig);
       }
    return clazz;
    }
@@ -375,7 +348,9 @@ TR_J9ServerVM::jitFieldsAreSame(TR_ResolvedMethod * method1, I_32 cpIndex1, TR_R
 
    bool sigSame = true;
    if (serverMethod1->fieldsAreSame(cpIndex1, serverMethod2, cpIndex2, sigSame))
+      {
       result = true;
+      }
    else
       {
       if (sigSame)
@@ -469,7 +444,9 @@ TR_J9ServerVM::jitStaticsAreSame(TR_ResolvedMethod *method1, I_32 cpIndex1, TR_R
 
    bool sigSame = true;
    if (serverMethod1->staticsAreSame(cpIndex1, serverMethod2, cpIndex2, sigSame))
+      {
       result = true;
+      }
    else
       {
       if (sigSame)
@@ -542,21 +519,6 @@ TR_J9ServerVM::compiledAsDLTBefore(TR_ResolvedMethod *method)
 #endif
    }
 
-
-/*
-char *
-TR_J9ServerVM::getClassNameChars(TR_OpaqueClassBlock * ramClass, int32_t & length)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getClassNameChars, ramClass);
-   const std::string className = std::get<0>(stream->read<std::string>());
-   char * classNameChars = (char*) _compInfoPT->getCompilation()->trMemory()->allocateMemory(className.length(), heapAlloc);
-   memcpy(classNameChars, &className[0], className.length());
-   length = className.length();
-   return classNameChars;
-   }
-*/
-
 uintptrj_t
 TR_J9ServerVM::getOverflowSafeAllocSize()
    {
@@ -596,15 +558,7 @@ TR_J9ServerVM::printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMe
    J9UTF8 * signature = str2utf8((char*)&signatureStr[0], signatureStr.length(), trMemory, heapAlloc);
    return TR_J9VMBase::printTruncatedSignature(sigBuf, bufLen, className, name, signature);
    }
-/*
-bool
-TR_J9ServerVM::isPrimitiveClass(TR_OpaqueClassBlock * clazz)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isPrimitiveClass, clazz);
-   return std::get<0>(stream->read<bool>());
-   }
-*/
+
 bool
 TR_J9ServerVM::isClassInitialized(TR_OpaqueClassBlock * clazz)
    {
@@ -683,22 +637,6 @@ TR_J9ServerVM::getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * cl
    getResolvedMethodsAndMethods(trMemory, classPointer, resolvedMethodsInClass, NULL, NULL);
    }
 
-
-/*uint32_t
-TR_J9ServerVM::getNumMethods(TR_OpaqueClassBlock * clazz)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getNumMethods, clazz);
-   return std::get<0>(stream->read<uint32_t>());
-   }
-
-uint32_t
-TR_J9ServerVM::getNumInnerClasses(TR_OpaqueClassBlock * clazz)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getNumInnerClasses, clazz);
-   return std::get<0>(stream->read<uint32_t>());
-   }*/
 bool
 TR_J9ServerVM::isPrimitiveArray(TR_OpaqueClassBlock *clazz)
    {
@@ -801,14 +739,7 @@ TR_J9ServerVM::getStringUTF8Length(uintptrj_t objectPointer)
    stream->write(JITServer::MessageType::VM_getStringUTF8Length, objectPointer);
    return std::get<0>(stream->read<intptrj_t>());
    }
-/*
-uintptrj_t
-TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock *clazz)
-   {
-   J9Class *j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
-   return reinterpret_cast<uintptrj_t>(TR::compInfoPT->getAndCacheRemoteROMClass(j9clazz));
-   }
-*/
+
 bool
 TR_J9ServerVM::classInitIsFinished(TR_OpaqueClassBlock *clazz)
    {
@@ -1499,16 +1430,6 @@ TR_J9ServerVM::createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptrj
    return result;
    }
 
-bool
-TR_J9ServerVM::getArrayLengthOfStaticAddress(void *ptr, int32_t &length)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getArrayLengthOfStaticAddress, ptr);
-   auto recv = stream->read<bool, int32_t>();
-   length = std::get<1>(recv);
-   return std::get<0>(recv);
-   }
-
 intptrj_t
 TR_J9ServerVM::getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset)
    {
@@ -1680,17 +1601,17 @@ TR_J9ServerVM::getClassFromCP(J9ConstantPool *cp)
    }
 
 void
-TR_J9ServerVM::reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding)
-{
-    // Not necessary in JITServer server mode
-}
+TR_J9ServerVM::reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding)
+   {
+   // Not necessary in JITServer server mode
+   }
 
 intptrj_t
 TR_J9ServerVM::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference * symRef, void * callSite)
-{
-    // Not necessary in JITServer server mode, return the call's PC so that the call will not appear to require a trampoline
-    return (intptrj_t)callSite;
-}
+   {
+   // Not necessary in JITServer server mode, return the call's PC so that the call will not appear to require a trampoline
+   return (intptrj_t)callSite;
+   }
 
 uintptrj_t
 TR_J9ServerVM::getPersistentClassPointerFromClassPointer(TR_OpaqueClassBlock * clazz)
@@ -1822,11 +1743,7 @@ TR_J9SharedCacheServerVM::isPublicClass(TR_OpaqueClassBlock * classPointer)
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return publicClass;
-   else
-      return true;
+   return validated ? publicClass : true;
    }
 
 TR_OpaqueClassBlock *
@@ -1850,11 +1767,7 @@ TR_J9SharedCacheServerVM::getProfiledClassFromProfiledInfo(TR_ExtraAddressInfo *
       if (((TR_ResolvedRelocatableJ9JITServerMethod*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)classPointer))
          validated = true;
       }
-
-   if (validated)
-      return classPointer;
-   else
-      return NULL;
+   return validated ? classPointer : NULL;
    }
 
 TR_YesNoMaybe
@@ -1873,11 +1786,7 @@ TR_J9SharedCacheServerVM::isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBl
       {
       validated = optimizeForAOT;
       }
-
-   if (validated)
-      return isAnInstanceOf;
-   else
-      return TR_maybe;
+   return validated ? isAnInstanceOf : TR_maybe;
    }
 
 TR_OpaqueClassBlock *
@@ -1899,11 +1808,7 @@ TR_J9SharedCacheServerVM::getSystemClassFromClassName(const char * name, int32_t
             validated = true;
          }
       }
-
-   if (validated)
-      return classPointer;
-   else
-      return NULL;
+   return validated ? classPointer : NULL;
    }
 
 bool
@@ -2025,11 +1930,7 @@ TR_J9SharedCacheServerVM::hasFinalizer(TR_OpaqueClassBlock * classPointer)
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return classHasFinalizer;
-   else
-      return true;
+   return validated ? classHasFinalizer : true;
    }
 
 bool
@@ -2051,11 +1952,7 @@ TR_J9SharedCacheServerVM::isPrimitiveClass(TR_OpaqueClassBlock * classPointer)
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return isPrimClass;
-   else
-      return false;
+   return validated ? isPrimClass : false;
    }
 
 bool
@@ -2232,11 +2129,7 @@ TR_J9SharedCacheServerVM::getResolvedMethodForNameAndSignature(TR_Memory * trMem
       {
       validated = ((TR_ResolvedRelocatableJ9JITServerMethod *)comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *)classPointer);
       }
-
-   if (validated)
-      return resolvedMethod;
-   else
-      return NULL;
+   return validated ? resolvedMethod : NULL;
    }
 
 bool
@@ -2258,11 +2151,7 @@ TR_J9SharedCacheServerVM::isPrimitiveArray(TR_OpaqueClassBlock *classPointer)
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return isPrimArray;
-   else
-      return false;
+   return validated ? isPrimArray : false;
    }
 
 bool
@@ -2284,11 +2173,7 @@ TR_J9SharedCacheServerVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return isRefArray;
-   else
-      return false;
+   return validated ? isRefArray : false;
    }
 
 TR_OpaqueMethodBlock *
@@ -2316,11 +2201,7 @@ TR_J9SharedCacheServerVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * class
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return classDepthFlags;
-   else
-      return 0;
+   return validated ? classDepthFlags : 0;
    }
 
 uintptrj_t
@@ -2337,11 +2218,7 @@ TR_J9SharedCacheServerVM::getClassFlagsValue(TR_OpaqueClassBlock * classPointer)
       SVM_ASSERT_ALREADY_VALIDATED(comp->getSymbolValidationManager(), classPointer);
       validated = true;
       }
-
-   if (validated)
-      return classFlags;
-   else
-      return 0;
+   return validated ? classFlags : 0;
    }
 
 bool
@@ -2456,11 +2333,7 @@ TR_J9SharedCacheServerVM::getComponentClassFromArrayClass(TR_OpaqueClassBlock * 
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) arrayClass))
          validated = true;
       }
-
-   if (validated)
-      return componentClass;
-   else
-      return NULL;
+   return validated ? componentClass : NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -2481,11 +2354,7 @@ TR_J9SharedCacheServerVM::getArrayClassFromComponentClass(TR_OpaqueClassBlock * 
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) componentClass))
          validated = true;
       }
-
-   if (validated)
-      return arrayClass;
-   else
-      return NULL;
+   return validated ? arrayClass : NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -2507,11 +2376,7 @@ TR_J9SharedCacheServerVM::getLeafComponentClassFromArrayClass(TR_OpaqueClassBloc
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) arrayClass))
          validated = true;
       }
-
-   if (validated)
-      return leafComponent;
-   else
-      return NULL;
+   return validated ? leafComponent : NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -2533,11 +2398,7 @@ TR_J9SharedCacheServerVM::getBaseComponentClass(TR_OpaqueClassBlock * classPoint
       if (((TR_ResolvedRelocatableJ9JITServerMethod *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
          validated = true;
       }
-
-   if (validated)
-      return baseComponent;
-   else
-      return classPointer;  // not sure about this return value, but it's what we used to return before we got "smart"
+   return validated ? baseComponent : classPointer;  // not sure about this return value, but it's what we used to return before we got "smart"
    }
 
 TR_OpaqueClassBlock *

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -25,6 +25,19 @@
 
 #include "env/VMJ9.h"
 
+/**
+ * @class TR_J9ServerVM
+ * @brief Class used by JITServer for querying client-side VM information 
+ *
+ * This class is an extension of the TR_J9VM class which overrides a number 
+ * of TR_J9VM's APIs. TR_J9ServerVM is used by JITServer and the overridden 
+ * APIs mostly send remote messages to JITClient to query information from 
+ * the TR_J9VM on the client. The information is needed for JITServer to 
+ * compile code that is compatible with the client-side VM. To minimize the 
+ * number of remote messages as a way to optimize JITServer performance, a 
+ * lot of client-side TR_J9VM information are cached on JITServer.
+ */
+
 class TR_J9ServerVM: public TR_J9VM
    {
 public:
@@ -40,10 +53,7 @@ public:
    virtual bool canDevirtualizeDispatch() override                       { return true; }
    virtual bool needRelocationsForBodyInfoData() override                { return true; }
    virtual bool needRelocationsForPersistentInfoData() override          { return true; }
-
-   virtual void markHotField(TR::Compilation *, TR::SymbolReference *, TR_OpaqueClassBlock *, bool) override
-      { return; }
-
+   virtual void markHotField(TR::Compilation *, TR::SymbolReference *, TR_OpaqueClassBlock *, bool) override { return; }
    virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT) override;
    virtual bool isClassLibraryClass(TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getSuperClass(TR_OpaqueClassBlock *classPointer) override;
@@ -53,9 +63,6 @@ public:
    virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
                                                                  char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod) override;
    virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed = true, bool optimizeForAOT = false) override;
-//   virtual bool isInterfaceClass(TR_OpaqueClassBlock *clazzPointer) override;
-//   virtual bool isClassFinal(TR_OpaqueClassBlock *) override;
-//   virtual bool isAbstractClass(TR_OpaqueClassBlock *clazzPointer) override;
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT = false) override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool canMethodEnterEventBeHooked() override;
@@ -74,19 +81,15 @@ public:
    virtual bool classHasBeenReplaced(TR_OpaqueClassBlock *) override;
    virtual bool classHasBeenExtended(TR_OpaqueClassBlock *) override;
    virtual bool compiledAsDLTBefore(TR_ResolvedMethod *) override;
-//   virtual char * getClassNameChars(TR_OpaqueClassBlock *ramClass, int32_t & length) override;
    virtual uintptrj_t getOverflowSafeAllocSize() override;
    virtual bool isThunkArchetype(J9Method * method) override;
    virtual int32_t printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method) override;
-//   virtual bool isPrimitiveClass(TR_OpaqueClassBlock * clazz) override;
    virtual bool isClassInitialized(TR_OpaqueClassBlock * clazz) override;
    virtual UDATA getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method) override;
    virtual int32_t getByteOffsetToLockword(TR_OpaqueClassBlock * clazz) override;
    virtual bool isString(TR_OpaqueClassBlock * clazz) override;
    virtual void * getMethods(TR_OpaqueClassBlock * clazz) override;
    virtual void getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, List<TR_ResolvedMethod> * resolvedMethodsInClass) override;
-   //virtual uint32_t getNumMethods(TR_OpaqueClassBlock * clazz) override;
-   //virtual uint32_t getNumInnerClasses(TR_OpaqueClassBlock * clazz) override;
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *clazz) override;
    virtual uint32_t getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getObjectClass(uintptrj_t objectPointer) override;
@@ -159,7 +162,6 @@ public:
    virtual void setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp) override;
    virtual bool needsInvokeExactJ2IThunk(TR::Node *node,  TR::Compilation *comp) override;
    virtual TR_ResolvedMethod *createMethodHandleArchetypeSpecimen(TR_Memory *, uintptrj_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0) override;
-   virtual bool getArrayLengthOfStaticAddress(void *ptr, int32_t &length) override;
    virtual intptrj_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset) override;
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptrj_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
@@ -184,6 +186,16 @@ protected:
    bool getCachedField(J9Class *ramClass, int32_t cpIndex, J9Class **declaringClass, UDATA *field);
    void cacheField(J9Class *ramClass, int32_t cpIndex, J9Class *declaringClass, UDATA field);
    };
+
+/**
+ * @class TR_J9SharedCacheServerVM
+ * @brief Class used by JITServer for querying client-side VM information with
+ * additional handling for AOT compilation
+ *
+ * This class is an extension of the TR_J9ServerVM class. This class conceptually
+ * does very similar things compared to TR_J9ServerVM except it's used for AOT 
+ * compilation.
+ */
 
 class TR_J9SharedCacheServerVM: public TR_J9ServerVM
    {

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -125,7 +125,6 @@ enum MessageType
    VM_isClassLibraryMethod = 201;
    VM_getSuperClass = 202;
    VM_isInstanceOf = 203;
-   VM_getArrayLengthOfStaticAddress = 204;
    VM_isClassArray = 205;
    VM_transformJlrMethodInvoke = 206;
 //   VM_isAbstractClass = 207;

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1283,7 +1283,7 @@ createMethodMetaData(
    // Find unmergeable GC maps
    //
    GCStackMapSet nonmergeableBCI(std::less<TR_GCStackMap*>(), cg->trMemory()->heapMemoryRegion());
-   if (comp->getOptions()->getReportByteCodeInfoAtCatchBlock())
+   if (comp->fej9vm()->getReportByteCodeInfoAtCatchBlock())
       {
       for (TR::TreeTop* treetop = comp->getStartTree(); treetop; treetop = treetop->getNextTreeTop())
          {


### PR DESCRIPTION
Remove unused TR_J9VMBase::getArrayLengthOfStaticAddress
Fix getReportByteCodeInfoAtCatchBlock bug, instead of querying the Options API, we switch it to the frontend API which has additional handling for JITServer.

[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>