### PR TITLE
Eliminate VM_isSameOrSuperClass messages

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -84,9 +84,27 @@ TR_J9ServerVM::getSuperClass(TR_OpaqueClassBlock *clazz)
 bool
 TR_J9ServerVM::isSameOrSuperClass(J9Class *superClass, J9Class *subClass)
    {
+   if (superClass == subClass) // same class
+      return true;
+
+   void *superClassLoader, *subClassLoader;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_isSameOrSuperClass, superClass, subClass);
-   return std::get<0>(stream->read<bool>());
+   JITServerHelpers::getAndCacheRAMClassInfo(superClass, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_LOADER, &superClassLoader);
+   JITServerHelpers::getAndCacheRAMClassInfo(subClass, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_LOADER, &subClassLoader);
+   if (superClassLoader != subClassLoader)
+      return false;
+
+   TR_OpaqueClassBlock *candidateSuperClassPtr = reinterpret_cast<TR_OpaqueClassBlock *>(superClass);
+   TR_OpaqueClassBlock *classPtr = reinterpret_cast<TR_OpaqueClassBlock *>(subClass);
+   // walk the hierarchy, trying to find a matching super class
+   while (classPtr)
+      {
+      // getSuperClass might invoke a remote call with a very low probability
+      classPtr = getSuperClass(classPtr); 
+      if (classPtr == candidateSuperClassPtr)
+         return true;
+      }
+   return false;
    }
 
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -65,9 +65,6 @@ public:
    virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMethod, TR_OpaqueClassBlock *classForNewInstance,
                                                                  char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod) override;
    virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed = true, bool optimizeForAOT = false) override;
-   //virtual bool isInterfaceClass(TR_OpaqueClassBlock *clazzPointer) override;
-   //virtual bool isClassFinal(TR_OpaqueClassBlock *) override;
-   //virtual bool isAbstractClass(TR_OpaqueClassBlock *clazzPointer) override;
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT = false) override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool canMethodEnterEventBeHooked() override;
@@ -86,19 +83,15 @@ public:
    virtual bool classHasBeenReplaced(TR_OpaqueClassBlock *) override;
    virtual bool classHasBeenExtended(TR_OpaqueClassBlock *) override;
    virtual bool compiledAsDLTBefore(TR_ResolvedMethod *) override;
-   //virtual char * getClassNameChars(TR_OpaqueClassBlock *ramClass, int32_t & length) override;
    virtual uintptrj_t getOverflowSafeAllocSize() override;
    virtual bool isThunkArchetype(J9Method * method) override;
    virtual int32_t printTruncatedSignature(char *sigBuf, int32_t bufLen, TR_OpaqueMethodBlock *method) override;
-   //virtual bool isPrimitiveClass(TR_OpaqueClassBlock * clazz) override;
    virtual bool isClassInitialized(TR_OpaqueClassBlock * clazz) override;
    virtual UDATA getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method) override;
    virtual int32_t getByteOffsetToLockword(TR_OpaqueClassBlock * clazz) override;
    virtual bool isString(TR_OpaqueClassBlock * clazz) override;
    virtual void * getMethods(TR_OpaqueClassBlock * clazz) override;
    virtual void getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, List<TR_ResolvedMethod> * resolvedMethodsInClass) override;
-   //virtual uint32_t getNumMethods(TR_OpaqueClassBlock * clazz) override;
-   //virtual uint32_t getNumInnerClasses(TR_OpaqueClassBlock * clazz) override;
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *clazz) override;
    virtual uint32_t getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getObjectClass(uintptrj_t objectPointer) override;

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -230,7 +230,6 @@ enum MessageType
    VM_getReferenceFieldAt = 306;
    VM_getJ2IThunk = 307;
    VM_needsInvokeExactJ2IThunk = 308;
-   VM_isSameOrSuperClass = 309;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
After a recent rebase `VM_isSameOrSuperClass` is the most frequent message in AOT mode, as described in issue #7072. Eliminate this message by using `getSuperClass` method of the VM to fetch the super class, instead of calling a VM method directly. Since we already do caching in `getSuperClass`, this will eliminate most messages associated with `isSameOrSuperClass`.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>