### PR TITLE
Remove TR::imulover IL opcode

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -815,7 +815,6 @@ static const char * nvvmOpCodeNames[] =
 
 
 
-   NULL,          // TR::imulover
 
    NULL,          // TR::dfloor
    NULL,          // TR::ffloor


### PR DESCRIPTION
Remove IL Opcode TR::imulover from OpenJ9.

Issue: eclipse/omr#4351
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>