### PR TITLE
Fix AOT load failures

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1435,12 +1435,6 @@ TR_ResolvedRelocatableJ9Method::setAttributeResult(bool isStaticField, bool resu
    *type = decodeType(ltype);
    }
 
-char *
-TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
-   {
-   len = 0;
-   return ""; // TODO: Implement me
-   }
 
 TR::Method *   TR_ResolvedRelocatableJ9Method::convertToMethod()              { return this; }
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -602,7 +602,6 @@ protected:
 
    bool                          unresolvedFieldAttributes (int32_t cpIndex, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate);
    bool                          unresolvedStaticAttributes(int32_t cpIndex, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate);
-   virtual char *                fieldOrStaticNameChars(int32_t cpIndex, int32_t & len);
 
    J9ExceptionHandler * exceptionHandler();
    };

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -2245,13 +2245,6 @@ TR_ResolvedRelocatableJ9JITServerMethod::isUnresolvedMethodHandle(I_32 cpIndex)
    return true;
    }
 
-char *
-TR_ResolvedRelocatableJ9JITServerMethod::fieldOrStaticNameChars(I_32 cpIndex, int32_t & len)
-   {
-   len = 0;
-   return "";
-   }
-
 TR_OpaqueClassBlock *
 TR_ResolvedRelocatableJ9JITServerMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)
    {

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -274,7 +274,6 @@ protected:
    virtual void                  handleUnresolvedStaticMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual void                  handleUnresolvedSpecialMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
    virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP) override;
-   virtual char *                fieldOrStaticNameChars(int32_t cpIndex, int32_t & len) override;
    virtual TR_FieldAttributesCache &getAttributesCache(bool isStatic, bool unresolvedInCP=false) override;
    virtual bool validateMethodFieldAttributes(const TR_J9MethodFieldAttributes &attributes, bool isStatic, int32_t cpIndex, bool isStore, bool needAOTValidation) override;
    UDATA getFieldType(J9ROMConstantPoolItem * CP, int32_t cpIndex);


### PR DESCRIPTION
`TR_ResolvedJ9Method::fieldOrStaticNameChars()` is marked virtual, but
the implementation of `TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars()`
returns a dummy answer which makes many AOT fail when the symbol validation
manager is used.
The code only works on romLiterals and there is no reason why the relocatable
version cannot return a proper answer. In fact for similar methods
(e.g. classSignatureOfFieldOrStatic, classNameOfFieldOrStatic,
classCPIndexOfFieldOrStatic,fieldOrStaticName,
fieldOrStaticSignatureChars) there is only one implementation.
This commit will remove the overidden implementation of
`TR_ResolvedRelocatableJ9Method::fieldOrStaticNameChars()`

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>