### PR TITLE
Don't override OpenJ9 SHA with PR ref

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -399,10 +399,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
         echo "Using VENDOR_TEST_REPOS = ${VENDOR_TEST_REPOS}, VENDOR_TEST_BRANCHES = ${VENDOR_TEST_BRANCHES}, VENDOR_TEST_SHAS = ${VENDOR_TEST_SHAS}, VENDOR_TEST_DIRS = ${VENDOR_TEST_DIRS}"
 
-        // For PullRequest Builds, overwrite the OpenJ9 sha for test jobs so they checkout the PR (OpenJ9 PRs only)
-        if (params.ghprbPullId && params.ghprbGhRepository == GHPRB_REPO_OPENJ9) {
-            SHAS['OPENJ9'] = "origin/pr/${params.ghprbPullId}/merge"
-        }
+        echo "Passing test OPenJ9 SHA:${SHAS['OPENJ9']}"
         for (name in TARGET_NAMES) {
             // Checking to see if the test should be excluded
             if (EXCLUDED_TESTS.contains(get_target_name(name))){


### PR DESCRIPTION
- When calling test pipelines, the OpenJ9 SHA should
  be used rather than the merge ref. Since the merge
  ref is a moving target, the SHA could change between
  the compile and the test. We need to ensure we are
  testing with the same level of OpenJ9 as we compile
  against.

Fixes #7287
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>