### PR TITLE
Merge PR 4032 from JITServer to master

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -100,17 +100,6 @@ struct TR_SignatureCountPair
    int32_t count;
 };
 
-// Must be less than 8 because in some parts of the code (CHTable) we keep flags on a byte variable
-// Also, if this increases past 10, we need to expand the _activeThreadName and _suspendedThreadName
-// fields in TR::CompilationInfoPerThread as currently they have 1 char available for the thread number.
-//
-#define MAX_USABLE_COMP_THREADS 7
-#define MAX_DIAGNOSTIC_COMP_THREADS 1
-#define MAX_TOTAL_COMP_THREADS (MAX_USABLE_COMP_THREADS + MAX_DIAGNOSTIC_COMP_THREADS)
-#if (MAX_TOTAL_COMP_THREADS > 8)
-#error "MAX_TOTAL_COMP_THREADS should be less than 8"
-#endif
-
 #ifndef J9_INVOCATION_COUNT_MASK
 #define J9_INVOCATION_COUNT_MASK                   0x00000000FFFFFFFF
 #endif
@@ -694,6 +683,15 @@ public:
    bool                   isQueuedForCompilation(J9Method *, void *oldStartPC);
    void *                 startPCIfAlreadyCompiled(J9VMThread *, TR::IlGeneratorMethodDetails & details, void *oldStartPC);
 
+   static int32_t getCompThreadSuspensionThreshold(int32_t threadID) { return _compThreadSuspensionThresholds[threadID]; }
+
+   // updateNumUsableCompThreads() is called before startCompilationThread() to update TR::Options::_numUsableCompilationThreads.
+   // It makes sure the number of usable compilation threads is within allowed bounds.
+   // If not, set it to the upper bound based on the mode: JITClient/non-JITServer or JITServer.
+   void updateNumUsableCompThreads(int32_t &numUsableCompThreads);
+   bool allocateCompilationThreads(int32_t numUsableCompThreads);
+   void freeAllCompilationThreads();
+
    uintptr_t startCompilationThread(int32_t priority, int32_t id, bool isDiagnosticThread);
    bool initializeCompilationOnApplicationThread();
    bool  asynchronousCompilation();
@@ -838,8 +836,8 @@ public:
    TR::CompilationInfoPerThreadBase *getCompInfoForCompOnAppThread() const { return _compInfoForCompOnAppThread; }
    J9JITConfig *getJITConfig() { return _jitConfig; }
    TR::CompilationInfoPerThread *getCompInfoForThread(J9VMThread *vmThread);
-   int32_t getNumUsableCompilationThreads() const { return _compThreadIndex; }
-   int32_t getNumTotalCompilationThreads() const { return _compThreadIndex + _numDiagnosticThreads; }
+   int32_t getNumUsableCompilationThreads() const { return _numCompThreads; }
+   int32_t getNumTotalCompilationThreads() const { return _numCompThreads + _numDiagnosticThreads; }
    TR::CompilationInfoPerThreadBase *getCompInfoWithID(int32_t ID);
    TR::Compilation *getCompilationWithID(int32_t ID);
    TR::CompilationInfoPerThread *getFirstSuspendedCompilationThread();
@@ -1047,6 +1045,12 @@ public:
    struct CompilationStatsPerInterval _intervalStats;
    TR_PersistentArray<TR_SignatureCountPair *> *_persistedMethods;
 
+   // Must be less than 8 at the JITClient or non-JITServer mode.
+   // Because in some parts of the code (CHTable) we keep flags on a byte variable.
+   static const uint32_t MAX_CLIENT_USABLE_COMP_THREADS = 7;  // For JITClient and non-JITServer mode
+   static const uint32_t MAX_SERVER_USABLE_COMP_THREADS = 63; // JITServer
+   static const uint32_t MAX_DIAGNOSTIC_COMP_THREADS = 1;
+
 private:
 
    enum
@@ -1078,7 +1082,11 @@ private:
 
    static TR::CompilationInfo * _compilationRuntime;
 
-   TR::CompilationInfoPerThread *_arrayOfCompilationInfoPerThread[MAX_TOTAL_COMP_THREADS]; // first NULL entry means end of the array
+   static int32_t *_compThreadActivationThresholds;
+   static int32_t *_compThreadSuspensionThresholds;
+   static int32_t *_compThreadActivationThresholdsonStarvation;
+
+   TR::CompilationInfoPerThread **_arrayOfCompilationInfoPerThread; // First NULL entry means end of the array
    TR::CompilationInfoPerThread *_compInfoForDiagnosticCompilationThread; // compinfo for dump compilation thread
    TR::CompilationInfoPerThreadBase *_compInfoForCompOnAppThread; // This is NULL for separate compilation thread
    TR_MethodToBeCompiled *_methodQueue;
@@ -1180,7 +1188,7 @@ private:
 #ifdef DEBUG
    bool                   _traceCompiling;
 #endif
-   int32_t                _compThreadIndex;
+   int32_t                _numCompThreads; // Number of usable compilation threads that does not include the diagnostic thread
    int32_t                _numDiagnosticThreads;
    int32_t                _iprofilerMaxCount;
    int32_t                _numGCRQueued; // how many GCR requests are in the queue

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -93,6 +93,7 @@
 #include "env/SystemSegmentProvider.hpp"
 #include "env/DebugSegmentProvider.hpp"
 #if defined(JITSERVER_SUPPORT)
+#include "control/JITServerCompilationThread.hpp"
 #include "control/JITServerHelpers.hpp"
 #include "runtime/JITClientSession.hpp"
 #endif /* defined(JITSERVER_SUPPORT) */
@@ -489,14 +490,6 @@ int32_t TR::CompilationInfo::computeDynamicDumbInlinerBytecodeSizeCutoff(TR::Opt
    return cutoff;
    }
 
-// How to read it: the queueWeight has to be over 100 to activate second comp thread
-//                 the queueWeight has to be below 10 to suspend second comp thread
-int32_t compThreadActivationThresholds[MAX_TOTAL_COMP_THREADS+1] =       {-1, 100, 200, 300, 400, 500, 600, 700, 800};
-int32_t compThreadSuspensionThresholds[MAX_TOTAL_COMP_THREADS+1] = {-1,  -1,  10,  110, 210, 310, 410, 510, 610};
-
-
-int32_t compThreadActivationThresholdsonStarvation[MAX_TOTAL_COMP_THREADS + 1] = {-1, 800, 1600, 3200, 6400, 12800, 19200, 25600, 32000};
-
 // Examine if we need to activate a new thread
 // Must have compilation queue monitor in hand when calling this routine
 TR_YesNoMaybe TR::CompilationInfo::shouldActivateNewCompThread()
@@ -548,19 +541,19 @@ TR_YesNoMaybe TR::CompilationInfo::shouldActivateNewCompThread()
       {
       if (getNumCompThreadsActive() < getNumTargetCPUs() - 1)
          {
-         if (_queueWeight > compThreadActivationThresholds[getNumCompThreadsActive()])
+         if (_queueWeight > _compThreadActivationThresholds[getNumCompThreadsActive()])
             return TR_yes;
          }
       else if (_starvationDetected)
          {
          // comp thread starvation; may activate threads beyond numCpu-1
-         if (_queueWeight > compThreadActivationThresholdsonStarvation[getNumCompThreadsActive()])
+         if (_queueWeight > _compThreadActivationThresholdsonStarvation[getNumCompThreadsActive()])
             return TR_yes;
          }
       }
    else // number of compilation threads indicated by the user
       {
-      if (_queueWeight > compThreadActivationThresholds[getNumCompThreadsActive()])
+      if (_queueWeight > _compThreadActivationThresholds[getNumCompThreadsActive()])
          return TR_yes;
       }
 
@@ -760,6 +753,9 @@ void TR::CompilationInfo::freeCompilationInfo(J9JITConfig *jitConfig)
    TR_ASSERT(_compilationRuntime, "The global compilation info has already been freed.");
    TR::CompilationInfo * compilationRuntime = _compilationRuntime;
    _compilationRuntime = NULL;
+
+   compilationRuntime->freeAllCompilationThreads();
+
    TR::RawAllocator rawAllocator(jitConfig->javaVM);
    compilationRuntime->~CompilationInfo();
    rawAllocator.deallocate(compilationRuntime);
@@ -893,7 +889,10 @@ TR::CompilationInfoPerThreadBase::CompilationInfoPerThreadBase(TR::CompilationIn
 #endif /* defined(JITSERVER_SUPPORT) */
    _addToJProfilingQueue(false)
    {
-   TR_ASSERT(_compThreadId < MAX_TOTAL_COMP_THREADS, "Cannot have a compId greater than MAX_TOTAL_COMP_THREADS");
+   // At this point, compilation threads have not been fully started yet. getNumTotalCompilationThreads()
+   // would not return a correct value. Need to use TR::Options::_numUsableCompilationThreads
+   TR_ASSERT_FATAL(_compThreadId < (TR::Options::_numUsableCompilationThreads + TR::CompilationInfo::MAX_DIAGNOSTIC_COMP_THREADS),
+             "Cannot have a compId %d greater than %u", _compThreadId, (TR::Options::_numUsableCompilationThreads + TR::CompilationInfo::MAX_DIAGNOSTIC_COMP_THREADS));
    }
 
 TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread)
@@ -911,14 +910,14 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
    // name the thread
    //
    // NOTE:
-   //      increasing MAX_TOTAL_COMP_THREADS past 9 requires an
+   //      increasing MAX_*_COMP_THREADS over three digits requires an
    //      increase in the length of _activeThreadName and _suspendedThreadName
 
    // constant thread name formats
-   static const char activeDiagnosticThreadName[]    = "JIT Diagnostic Compilation Thread-%d";
-   static const char suspendedDiagnosticThreadName[] = "JIT Diagnostic Compilation Thread-%d Suspended";
-   static const char activeThreadName[]              = "JIT Compilation Thread-%d";
-   static const char suspendedThreadName[]           = "JIT Compilation Thread-%d Suspended";
+   static const char activeDiagnosticThreadName[]    = "JIT Diagnostic Compilation Thread-%03d";
+   static const char suspendedDiagnosticThreadName[] = "JIT Diagnostic Compilation Thread-%03d Suspended";
+   static const char activeThreadName[]              = "JIT Compilation Thread-%03d";
+   static const char suspendedThreadName[]           = "JIT Compilation Thread-%03d Suspended";
 
    const char * selectedActiveThreadName;
    const char * selectedSuspendedThreadName;
@@ -928,7 +927,7 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
    // determine the correct name to use, and its length
    //
    // NOTE:
-   //       using sizeof(...) - 1 because the characters "%d" will be replaced by one digit;
+   //       using sizeof(...) - 1 because the characters "%3d" will be replaced by three digits;
    //       the null character however *is* counted by sizeof
    if (isDiagnosticThread)
       {
@@ -987,7 +986,10 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
 #endif /* defined(JITSERVER_SUPPORT) */
    _persistentMemory(pointer_cast<TR_PersistentMemory *>(jitConfig->scratchSegment)),
    _sharedCacheReloRuntime(jitConfig),
-   _samplingThreadWaitTimeInDeepIdleToNotifyVM(-1)
+   _samplingThreadWaitTimeInDeepIdleToNotifyVM(-1),
+   _numDiagnosticThreads(0),
+   _numCompThreads(0),
+   _arrayOfCompilationInfoPerThread(NULL)
    {
    // The object is zero-initialized before this method is called
    //
@@ -1094,7 +1096,7 @@ bool TR::CompilationInfo::initializeCompilationOnApplicationThread()
       {
       PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
 
-      // NOTE: _compThreadIndex is 0 now because it's not incremented in TR::CompilationInfoPerThreadBase constructor
+      // NOTE: _numCompThreads is 0 now because it's not incremented in TR::CompilationInfoPerThreadBase constructor
       _compInfoForCompOnAppThread = new (PERSISTENT_NEW) TR::CompilationInfoPerThreadBase(*this, _jitConfig, 0, false);
 
       if (!_compInfoForCompOnAppThread)
@@ -1219,7 +1221,7 @@ TR_YesNoMaybe TR::CompilationInfo::detectCompThreadStarvation()
    int32_t numActive = 0;
    TR_YesNoMaybe answer = TR_maybe;
    bool compCpuFunctional = true;
-   for (int32_t compId = 0; compId < _compThreadIndex; compId++)
+   for (int32_t compId = 0; compId < _numCompThreads; compId++)
       {
       // We must look at all active threads because we want to avoid the
       // case where they compete with each other (4 comp threads on a single processor)
@@ -2550,6 +2552,146 @@ TR::CompilationInfoPerThread* TR::CompilationInfo::getCompInfoForThread(J9VMThre
    return NULL;
    }
 
+int32_t *TR::CompilationInfo::_compThreadActivationThresholds = NULL;
+int32_t *TR::CompilationInfo::_compThreadSuspensionThresholds = NULL;
+int32_t *TR::CompilationInfo::_compThreadActivationThresholdsonStarvation = NULL;
+
+void TR::CompilationInfo::updateNumUsableCompThreads(int32_t &numUsableCompThreads)
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      numUsableCompThreads = ((numUsableCompThreads < 0) ||
+                              (numUsableCompThreads > MAX_SERVER_USABLE_COMP_THREADS)) ?
+                               MAX_SERVER_USABLE_COMP_THREADS : numUsableCompThreads;
+      }
+   else
+#endif /* defined(JITSERVER_SUPPORT) */
+      {
+      numUsableCompThreads = ((numUsableCompThreads < 0) ||
+                              (numUsableCompThreads > MAX_CLIENT_USABLE_COMP_THREADS)) ?
+                               MAX_CLIENT_USABLE_COMP_THREADS : numUsableCompThreads;
+      }
+   }
+
+bool
+TR::CompilationInfo::allocateCompilationThreads(int32_t numUsableCompThreads)
+   {
+   if (_compThreadActivationThresholds ||
+       _compThreadSuspensionThresholds ||
+       _compThreadActivationThresholdsonStarvation ||
+       _arrayOfCompilationInfoPerThread)
+      {
+      TR_ASSERT_FATAL(false, "Compilation threads have been allocated\n");
+      return false;
+      }
+
+   TR_ASSERT((numUsableCompThreads == TR::Options::_numUsableCompilationThreads),
+             "numUsableCompThreads %d is not equal to the Option value %d", numUsableCompThreads, TR::Options::_numUsableCompilationThreads);
+
+#if defined(JITSERVER_SUPPORT)
+   if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      TR_ASSERT((0 < numUsableCompThreads) && (numUsableCompThreads <= MAX_SERVER_USABLE_COMP_THREADS),
+               "numUsableCompThreads %d is greater than supported %d", numUsableCompThreads, MAX_SERVER_USABLE_COMP_THREADS);
+      }
+   else
+#endif /* defined(JITSERVER_SUPPORT) */
+      {
+      TR_ASSERT((0 < numUsableCompThreads) && (numUsableCompThreads <= MAX_CLIENT_USABLE_COMP_THREADS),
+               "numUsableCompThreads %d is greater than supported %d", numUsableCompThreads, MAX_CLIENT_USABLE_COMP_THREADS);
+      }
+
+   uint32_t numTotalCompThreads = numUsableCompThreads + MAX_DIAGNOSTIC_COMP_THREADS;
+
+   TR::MonitorTable *table = TR::MonitorTable::get();
+   if ((!table) ||
+       (!table->allocInitClassUnloadMonitorHolders(numTotalCompThreads)))
+      {
+      return false;
+      }
+
+   _compThreadActivationThresholds = static_cast<int32_t *>(jitPersistentAlloc((numTotalCompThreads + 1) * sizeof(int32_t)));
+   _compThreadSuspensionThresholds = static_cast<int32_t *>(jitPersistentAlloc((numTotalCompThreads + 1) * sizeof(int32_t)));
+   _compThreadActivationThresholdsonStarvation = static_cast<int32_t *>(jitPersistentAlloc((numTotalCompThreads + 1) * sizeof(int32_t)));
+
+   _arrayOfCompilationInfoPerThread = static_cast<TR::CompilationInfoPerThread **>(jitPersistentAlloc(numTotalCompThreads * sizeof(TR::CompilationInfoPerThread *)));
+
+   if (_compThreadActivationThresholds &&
+       _compThreadSuspensionThresholds &&
+       _compThreadActivationThresholdsonStarvation &&
+       _arrayOfCompilationInfoPerThread)
+      {
+      // How to read it: the queueWeight has to be over 100 to activate second comp thread
+      //                 the queueWeight has to be below 10 to suspend second comp thread
+      // For example:
+      // compThreadActivationThresholds[MAX_TOTAL_COMP_THREADS+1] = {-1, 100, 200, 300, 400, 500, 600, 700, 800};
+      // compThreadSuspensionThresholds[MAX_TOTAL_COMP_THREADS+1] = {-1,  -1,  10, 110, 210, 310, 410, 510, 610};
+      // compThreadActivationThresholdsonStarvation[MAX_TOTAL_COMP_THREADS+1] = {-1, 800, 1600, 3200, 6400, 12800, 19200, 25600, 32000};
+      _compThreadActivationThresholds[0] = -1;
+      _compThreadActivationThresholds[1] = 100;
+      _compThreadActivationThresholds[2] = 200;
+
+      _compThreadSuspensionThresholds[0] = -1;
+      _compThreadSuspensionThresholds[1] = -1;
+      _compThreadSuspensionThresholds[2] = 10;
+
+      for (int32_t i=3; i<(numTotalCompThreads+1); ++i)
+         {
+         _compThreadActivationThresholds[i] = _compThreadActivationThresholds[i-1] + 100;
+         _compThreadSuspensionThresholds[i] = _compThreadSuspensionThresholds[i-1] + 100;
+         }
+
+      _compThreadActivationThresholdsonStarvation[0] = -1;
+      _compThreadActivationThresholdsonStarvation[1] = 800;
+
+      for (int32_t i=2; i<(numTotalCompThreads+1); ++i)
+         {
+         if (_compThreadActivationThresholdsonStarvation[i-1] < 12800)
+            {
+            _compThreadActivationThresholdsonStarvation[i] = _compThreadActivationThresholdsonStarvation[i-1] * 2;
+            }
+         else
+            {
+            _compThreadActivationThresholdsonStarvation[i] = _compThreadActivationThresholdsonStarvation[i-1] + 6400;
+            }
+         }
+
+      for (int32_t i=0; i<numTotalCompThreads; ++i)
+         {
+         _arrayOfCompilationInfoPerThread[i] = NULL;
+         }
+      return true;
+      }
+   return false;
+   }
+
+void
+TR::CompilationInfo::freeAllCompilationThreads()
+   {
+   if (_compThreadActivationThresholds)
+      {
+      jitPersistentFree(_compThreadActivationThresholds);
+      }
+
+   if (_compThreadSuspensionThresholds)
+      {
+      jitPersistentFree(_compThreadSuspensionThresholds);
+      }
+
+   if (_compThreadActivationThresholdsonStarvation)
+      {
+      jitPersistentFree(_compThreadActivationThresholdsonStarvation);
+      }
+
+   if (_arrayOfCompilationInfoPerThread)
+      {
+      // TODO: Need to properly free all dynamically allocated objects from
+      // CompilationInfoPerThread and CompilationInfoPerThreadRemote first
+      jitPersistentFree(_arrayOfCompilationInfoPerThread);
+      }
+   }
+
 //-------------------------- startCompilationThread --------------------------
 // Start ONE compilation thread and initialize the associated
 // TR::CompilationInfoPerThread structure
@@ -2567,11 +2709,14 @@ TR::CompilationInfo::startCompilationThread(int32_t priority, int32_t threadId, 
 
    if (!isDiagnosticThread)
       {
-      if (getNumUsableCompilationThreads() >= MAX_USABLE_COMP_THREADS)
+      if (_numCompThreads >= TR::Options::_numUsableCompilationThreads)
          return 1;
       }
    else
       {
+      if (_numDiagnosticThreads >= MAX_DIAGNOSTIC_COMP_THREADS)
+         return 1;
+
       // _compInfoForDiagnosticCompilationThread should be NULL before creation
       if (_compInfoForDiagnosticCompilationThread)
          return 1;
@@ -2583,7 +2728,14 @@ TR::CompilationInfo::startCompilationThread(int32_t priority, int32_t threadId, 
    setCompBudget(TR::Options::_compilationBudget); // might do it several time, but it does not hurt
 
    // Create a compInfo for this thread
+#if defined(JITSERVER_SUPPORT)
+   TR::CompilationInfoPerThread  *compInfoPT = getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER ?
+      new (persistentMemory()) TR::CompilationInfoPerThreadRemote(*this, _jitConfig, threadId, isDiagnosticThread) :
+      new (persistentMemory()) TR::CompilationInfoPerThread(*this, _jitConfig, threadId, isDiagnosticThread);
+#else
    TR::CompilationInfoPerThread  *compInfoPT = new (persistentMemory()) TR::CompilationInfoPerThread(*this, _jitConfig, threadId, isDiagnosticThread);
+#endif /* defined(JITSERVER_SUPPORT) */
+
    if (!compInfoPT || !compInfoPT->initializationSucceeded() || !compInfoPT->getCompThreadMonitor())
       return 1; // TODO must deallocate some things in compInfoPT as well as the memory for it
 
@@ -2621,7 +2773,7 @@ TR::CompilationInfo::startCompilationThread(int32_t priority, int32_t threadId, 
    else
       {
       getCompilationMonitor()->enter();
-      _compThreadIndex++;
+      _numCompThreads++;
       getCompilationMonitor()->exit();
       }
 
@@ -4017,7 +4169,8 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
          || (
             !tryCompilingAgain
             /*&& compInfoPT->getCompThreadId() != 0*/
-            && TR::Options::getCmdLineOptions()->getOption(TR_SuspendEarly) && compInfo->getQueueWeight() < compThreadSuspensionThresholds[compInfo->getNumCompThreadsActive()]
+            && TR::Options::getCmdLineOptions()->getOption(TR_SuspendEarly)
+            && compInfo->getQueueWeight() < TR::CompilationInfo::getCompThreadSuspensionThreshold(compInfo->getNumCompThreadsActive())
             )
          )
       )
@@ -4449,7 +4602,7 @@ TR::CompilationInfo::addMethodToBeCompiled(TR::IlGeneratorMethodDetails & detail
             // remains active until the blocking request gets compiled
             //
             TR_MethodToBeCompiled *lowPriCompReq = lowPriCompThread->getMethodBeingCompiled();
-            uint8_t targetWeight = compThreadSuspensionThresholds[2] <= 0xff ? compThreadSuspensionThresholds[2] : 0xff;
+            uint8_t targetWeight = _compThreadSuspensionThresholds[2] <= 0xff ? _compThreadSuspensionThresholds[2] : 0xff;
             if (lowPriCompReq->_weight < targetWeight)
                {
                uint8_t diffWeight = targetWeight - lowPriCompReq->_weight;

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5488,49 +5488,70 @@ bool CPUThrottleEnabled(TR::CompilationInfo *compInfo, uint64_t crtTime)
 
 /// Sums up CPU utilization of all compilation thread and write this
 /// value in the compilation info (or -1 in case of error)
+static void DoCalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, uint64_t crtTime, J9VMThread *currentThread, int32_t *cpuUtilizationValues)
+   {
+   // Sum up the CPU utilization of all the compilation threads
+   int32_t totalCompCPUUtilization = 0;
+   //TODO: Is getArrayOfCompilationInfoPerThread() called after setupCompilationThreads()
+   TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
+
+   for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
+      {
+      const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
+      if (cpuUtil.isFunctional())
+         {
+         // If the last interval ended more than 1.5 second ago, do not include it
+         // in the calculations.
+         int32_t cpuUtilValue = cpuUtil.computeThreadCpuUtilOverLastNns(1500000000);
+         cpuUtilizationValues[i] = cpuUtilValue; // memorize for later
+         if (cpuUtilValue >= 0) // if first interval is not done, we read -1
+            totalCompCPUUtilization += cpuUtilValue;
+         }
+      else
+         {
+         totalCompCPUUtilization = -1; // error
+         break;
+         }
+      }
+   compInfo->setOverallCompCpuUtilization(totalCompCPUUtilization);
+   // Issue tracepoint indicating CPU usage percent (-1 on error)
+   Trc_JIT_OverallCompCPU(currentThread, totalCompCPUUtilization);
+   // Print the overall comp CPU utilization if the right verbose option is specified
+   if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompilationThreads, TR_VerboseCompilationThreadsDetails))
+      {
+      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::writeLine(TR_Vlog_INFO, "t=%6u TotalCompCpuUtil=%3d%%.", (uint32_t)crtTime, totalCompCPUUtilization);
+      TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
+      for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
+         {
+         const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
+         TR_VerboseLog::write(" compThr%d:%3d%% (%2d%%, %2d%%) ", i, cpuUtilizationValues[i], cpuUtil.getThreadLastCpuUtil(), cpuUtil.getThreadPrevCpuUtil());
+         if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompilationThreadsDetails))
+            TR_VerboseLog::write("(%dms, %dms, lastCheckpoint=%u) ", (int32_t)cpuUtil.getLastMeasurementInterval() / 1000000, (int32_t)cpuUtil.getSecondLastMeasurementInterval() / 1000000, cpuUtil.getLowResolutionClockAtLastUpdate());
+         }
+      TR_VerboseLog::vlogRelease();
+      }
+   }
+
 void CalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, uint64_t crtTime, J9VMThread *currentThread)
    {
    if (compInfo->getOverallCompCpuUtilization() >= 0) // No error so far
       {
-      // Sum up the CPU utilization of all the compilation threads
-      int32_t totalCompCPUUtilization = 0;
-      TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
-      int32_t cpuUtilizationValues[MAX_USABLE_COMP_THREADS];
-      for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
+      if (compInfo->getNumUsableCompilationThreads() < 8)
          {
-         const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
-         if (cpuUtil.isFunctional())
-            {
-            // If the last interval ended more than 1.5 second ago, do not include it
-            // in the calculations.
-            int32_t cpuUtilValue = cpuUtil.computeThreadCpuUtilOverLastNns(1500000000);
-            cpuUtilizationValues[i] = cpuUtilValue; // memorize for later
-            if (cpuUtilValue >= 0) // if first interval is not done, we read -1
-               totalCompCPUUtilization += cpuUtilValue;
-            }
-         else
-            {
-            totalCompCPUUtilization = -1; // error
-            break;
-            }
+         int32_t cpuUtilizationValues[7];
+         DoCalculateOverallCompCPUUtilization(compInfo, crtTime, currentThread, cpuUtilizationValues);
          }
-      compInfo->setOverallCompCpuUtilization(totalCompCPUUtilization);
-      // Issue tracepoint indicating CPU usage percent (-1 on error)
-      Trc_JIT_OverallCompCPU(currentThread, totalCompCPUUtilization);
-      // Print the overall comp CPU utilization if the right verbose option is specified
-      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompilationThreads, TR_VerboseCompilationThreadsDetails))
+      else
          {
-         TR_VerboseLog::vlogAcquire();
-         TR_VerboseLog::writeLine(TR_Vlog_INFO, "t=%6u TotalCompCpuUtil=%3d%%.", (uint32_t)crtTime, totalCompCPUUtilization);
-         TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
-         for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
+         PORT_ACCESS_FROM_JAVAVM(currentThread->javaVM);
+
+         int32_t *cpuUtilizationValues = static_cast<int32_t *>(j9mem_allocate_memory(compInfo->getNumUsableCompilationThreads() * sizeof(int32_t), J9MEM_CATEGORY_JIT));
+         if (cpuUtilizationValues)
             {
-            const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
-            TR_VerboseLog::write(" compThr%d:%3d%% (%2d%%, %2d%%) ", i, cpuUtilizationValues[i], cpuUtil.getThreadLastCpuUtil(), cpuUtil.getThreadPrevCpuUtil());
-            if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompilationThreadsDetails))
-               TR_VerboseLog::write("(%dms, %dms, lastCheckpoint=%u) ", (int32_t)cpuUtil.getLastMeasurementInterval() / 1000000, (int32_t)cpuUtil.getSecondLastMeasurementInterval() / 1000000, cpuUtil.getLowResolutionClockAtLastUpdate());
+            DoCalculateOverallCompCPUUtilization(compInfo, crtTime, currentThread, cpuUtilizationValues);
+            j9mem_free_memory(cpuUtilizationValues);
             }
-         TR_VerboseLog::vlogRelease();
          }
       }
    }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1473,9 +1473,11 @@ onLoadInternal(
       if (TR::Options::_numUsableCompilationThreads > maxNumberOfCodeCaches)
          TR::Options::_numUsableCompilationThreads =  maxNumberOfCodeCaches;
 
-      if (TR::Options::_numUsableCompilationThreads > MAX_USABLE_COMP_THREADS)
+      compInfo->updateNumUsableCompThreads(TR::Options::_numUsableCompilationThreads);
+
+      if (!compInfo->allocateCompilationThreads(TR::Options::_numUsableCompilationThreads))
          {
-         fprintf(stderr, "Too many compilation threads. Only up to %d supported\n", MAX_USABLE_COMP_THREADS);
+         fprintf(stderr, "onLoadInternal: Failed to set up %d compilation threads\n", TR::Options::_numUsableCompilationThreads);
          return -1;
          }
 
@@ -1491,6 +1493,7 @@ onLoadInternal(
             }
          }
 
+      // If more than one diagnostic compilation thread is created, MAX_DIAGNOSTIC_COMP_THREADS needs to be updated
       // create diagnostic compilation thread
       if (compInfo->startCompilationThread(-1, highestThreadID, /* isDiagnosticThread */ true) != 0)
          {

--- a/runtime/compiler/infra/J9MonitorTable.hpp
+++ b/runtime/compiler/infra/J9MonitorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,7 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    int32_t readReleaseClassUnloadMonitor(int32_t compThreadIndex);
    int32_t getClassUnloadMonitorHoldCount(int32_t i) const { return _classUnloadMonitorHolders[i]; }
 
+   bool allocInitClassUnloadMonitorHolders(uint32_t allowedTotalCompThreads);
 
    private:
 
@@ -94,6 +95,7 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    // the classUnloadmonitor. Normally it should not be more than 1
    //
    int32_t *_classUnloadMonitorHolders;
+   uint32_t _numCompThreads;
    };
 
 }

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -301,10 +301,10 @@ TR_DebugExt::compInfosPerThreadAvailable()
    {
    if (_localCompInfosPT == NULL)
       {
-      _localCompInfosPT = (TR::CompilationInfoPerThread **) dxMalloc(sizeof(TR::CompilationInfoPerThread *) * MAX_TOTAL_COMP_THREADS, NULL);
+      _localCompInfosPT = (TR::CompilationInfoPerThread **) dxMalloc(sizeof(TR::CompilationInfoPerThread *) * _localCompInfo->getNumTotalCompilationThreads(), NULL);
       if (_localCompInfosPT)
          {
-         for (size_t i = 0; i < MAX_TOTAL_COMP_THREADS; ++i)
+         for (size_t i = 0; i < _localCompInfo->getNumTotalCompilationThreads(); ++i)
             {
             _localCompInfosPT[i] = _localCompInfo->_arrayOfCompilationInfoPerThread[i] != NULL ?
                (TR::CompilationInfoPerThread *) dxMallocAndRead(sizeof(TR::CompilationInfoPerThread), _localCompInfo->_arrayOfCompilationInfoPerThread[i], true) :
@@ -321,10 +321,10 @@ TR_DebugExt::activeMethodsToBeCompiledAvailable()
    if (!compInfosPerThreadAvailable()) return false;
    if (_localActiveMethodsToBeCompiled == NULL)
       {
-      _localActiveMethodsToBeCompiled = (TR_MethodToBeCompiled **) dxMalloc(sizeof(TR_MethodToBeCompiled *) * MAX_TOTAL_COMP_THREADS, NULL);
+      _localActiveMethodsToBeCompiled = (TR_MethodToBeCompiled **) dxMalloc(sizeof(TR_MethodToBeCompiled *) * _localCompInfo->getNumTotalCompilationThreads(), NULL);
       if (_localActiveMethodsToBeCompiled)
          {
-         for (size_t i = 0; i < MAX_TOTAL_COMP_THREADS; ++i)
+         for (size_t i = 0; i < _localCompInfo->getNumTotalCompilationThreads(); ++i)
             {
             _localActiveMethodsToBeCompiled[i] = _localCompInfosPT[i] && _localCompInfosPT[i]->_methodBeingCompiled ?
                (TR_MethodToBeCompiled *) dxMallocAndRead(sizeof(TR_MethodToBeCompiled), _localCompInfosPT[i]->_methodBeingCompiled, true) :
@@ -341,7 +341,7 @@ TR_DebugExt::isAOTCompileRequested(TR::Compilation * remoteCompilation)
    if (!compInfosPerThreadAvailable()) return false;
    if (!activeMethodsToBeCompiledAvailable()) return false;
 
-   for (size_t i = 0; i < MAX_TOTAL_COMP_THREADS; ++i)
+   for (size_t i = 0; i < _localCompInfo->getNumTotalCompilationThreads(); ++i)
       {
       if (
          _localCompInfosPT[i]
@@ -1266,7 +1266,7 @@ TR_DebugExt::dxTrPrint(const char* name1, void* addr2, uintptrj_t argCount, cons
    else if (stricmp_ignore_locale(className, "arrayofcompilationinfoperthread") == 0)
       {
       TR::CompilationInfoPerThread ** arrayOfCompInfoPT = NULL;
-      uint8_t numThreads = MAX_TOTAL_COMP_THREADS;
+      uint8_t numThreads = _localCompInfo->getNumTotalCompilationThreads();
       bool allocated = false;
 
       if (argCount == 2 && addr != 0)
@@ -2174,7 +2174,7 @@ TR_DebugExt::dxPrintMethodsBeingCompiled(TR::CompilationInfo *remoteCompInfo)
       }
 
    TR::CompilationInfoPerThread ** arrayOfCompInfoPT = NULL;
-   uint8_t numThreads = MAX_TOTAL_COMP_THREADS;
+   uint8_t numThreads = remoteCompInfo->getNumTotalCompilationThreads();
 
    arrayOfCompInfoPT = dxMallocAndGetArrayOfCompilationInfoPerThread(numThreads, remoteCompInfo->_arrayOfCompilationInfoPerThread);
 
@@ -2266,7 +2266,7 @@ void TR_DebugExt::dxPrintCompilationInfo(TR::CompilationInfo *remoteCompInfo)
       _dbgPrintf("int32_t                               _samplingThreadLifetimeState     = %d\n", localCompInfo->_samplingThreadLifetimeState);
       _dbgPrintf("int32_t                               _numMethodsFoundInSharedCache    = %d\n", localCompInfo->_numMethodsFoundInSharedCache);
       _dbgPrintf("int32_t                               _numInvRequestsInCompQueue       = %d\n", localCompInfo->_numInvRequestsInCompQueue);
-      _dbgPrintf("int32_t                               _compThreadIndex                 = %d\n", localCompInfo->_compThreadIndex);
+      _dbgPrintf("int32_t                               _numCompThreads                  = %d\n", localCompInfo->_numCompThreads);
       _dbgPrintf("int32_t                               _numDiagnosticThreads            = %d\n", localCompInfo->_numDiagnosticThreads);
       _dbgPrintf("int32_t                               _numSeriousFailures              = %d\n", localCompInfo->_numSeriousFailures);
       _dbgPrintf("int32_t[numHotnessLevels]             _statsOptLevels                  = 0x%p\n", localCompInfo->_statsOptLevels);


### PR DESCRIPTION
- This change merges PR #4032 that increases the number of compilation threads at the server
to 64 and it affects the implementation of the non-JITServer mode as well.
- The maximum of 8 compilation threads limitation is due to
the size of uint8_t `TR_PersistentClassInfo::_shouldNotBeNewlyExtended`.
The JITaaS server uses a different mechanism to track newly extended
classes and it does not set the bit in `_shouldNotBeNewlyExtended`.
- For the JITClient and the non-JITServer mode, the max number
of compilation threads remains as 8.

The mirrored `jitaas` branch update is in PR #7307.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>