### PR TITLE
Eliminate ClassEnv_getROMClassRefName messages

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -515,24 +515,43 @@ J9::ClassEnv::getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int
 uint8_t *
 J9::ClassEnv::getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t cpIndex, int &classRefLen)
    {
-#if defined(JITSERVER_SUPPORT)
-   auto stream = TR::CompilationInfo::getStream();
-   if (stream && comp->isOutOfProcessCompilation())
-      {
-      stream->write(JITServer::MessageType::ClassEnv_getROMClassRefName, clazz, cpIndex);
-      auto classRefNameStr = std::get<0>(stream->read<std::string>());
-      classRefLen = classRefNameStr.length();
-      uint8_t *classRefName = (uint8_t *) comp->trMemory()->allocateHeapMemory(classRefLen);
-      memcpy(classRefName, &classRefNameStr[0], classRefLen);
-      return classRefName;
-      }
-#endif /* defined(JITSERVER_SUPPORT) */
-   J9ConstantPool *ramCP = reinterpret_cast<J9ConstantPool *>(comp->fej9()->getConstantPoolFromClass(clazz));
-   J9ROMConstantPoolItem *romCP = ramCP->romConstantPool;
+   J9ROMConstantPoolItem *romCP = getROMConstantPool(comp, clazz);
    J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&romCP[cpIndex];
+   TR_ASSERT(inROMClass(romFieldRef), "field ref must be in ROM class");
    J9ROMClassRef *romClassRef = (J9ROMClassRef *)&romCP[romFieldRef->classRefCPIndex];
+   TR_ASSERT(inROMClass(romClassRef), "class ref must be in ROM class");
+#if defined(JITSERVER_SUPPORT)
+   if (comp->isOutOfProcessCompilation())
+      {
+      TR::CompilationInfoPerThread *compInfoPT = TR::compInfoPT;
+      char *name;
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
+      auto &classMap = compInfoPT->getClientData()->getROMClassMap();
+      auto it = classMap.find(reinterpret_cast<J9Class *>(clazz));
+      auto &classInfo = it->second;
+      name = classInfo.getROMString(classRefLen, romClassRef,
+                             {
+                             offsetof(J9ROMClassRef, name)
+                             });
+      return (uint8_t *) name;
+      }
+#endif
    J9UTF8 *classRefNameUtf8 = J9ROMCLASSREF_NAME(romClassRef);
    classRefLen = J9UTF8_LENGTH(classRefNameUtf8);
    uint8_t *classRefName = J9UTF8_DATA(classRefNameUtf8);
    return classRefName;
+   }
+
+J9ROMConstantPoolItem *
+J9::ClassEnv::getROMConstantPool(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (comp->isOutOfProcessCompilation())
+      {
+      J9ROMClass *romClass = TR::compInfoPT->getAndCacheRemoteROMClass(reinterpret_cast<J9Class *>(clazz));
+      return (J9ROMConstantPoolItem *) ((UDATA) romClass + sizeof(J9ROMClass));
+      }
+#endif /* defined(JITSERVER_SUPPORT) */
+   J9ConstantPool *ramCP = reinterpret_cast<J9ConstantPool *>(comp->fej9()->getConstantPoolFromClass(clazz));
+   return ramCP->romConstantPool;
    }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -133,6 +133,7 @@ public:
     */
    intptrj_t getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset);
    uint8_t *getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t cpIndex, int &classRefLen);
+   J9ROMConstantPoolItem *getROMConstantPool(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);
    };
 
 }

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -299,6 +299,8 @@ enum MessageType
 
    Recompilation_getExistingMethodInfo = 1000;
    Recompilation_getJittedBodyInfoFromPC = 1001;
+
+   ClassInfo_getRemoteROMString = 1100;
    }
 
 message J9ServerMessage

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -385,6 +385,77 @@ ClientSessionData::notifyAndDetachFirstWaitingThread()
    return entry;
    }
 
+bool
+ClientSessionData::ClassInfo::inROMClass(void * address)
+   {
+   return address >= _romClass && address < ((uint8_t*) _romClass) + _romClass->romSize;
+   }
+
+char *
+ClientSessionData::ClassInfo::getRemoteROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
+   {
+   auto offsetFirst = *offsets.begin();
+   auto offsetSecond = (offsets.size() == 2) ? *(offsets.begin() + 1) : 0;
+
+   TR_ASSERT(offsetFirst < (1 << 16) && offsetSecond < (1 << 16), "Offsets are larger than 16 bits");
+   TR_ASSERT(offsets.size() <= 2, "Number of offsets is greater than 2"); 
+
+   // create a key for hashing into a table of strings
+   TR_RemoteROMStringKey key;
+   uint32_t offsetKey = (offsetFirst << 16) + offsetSecond;
+   key._basePtr = basePtr;
+   key._offsets = offsetKey;
+   
+   std::string *cachedStr = NULL;
+   bool isCached = false;
+   auto gotStr = _remoteROMStringsCache.find(key);
+   if (gotStr != _remoteROMStringsCache.end())
+      {
+      cachedStr = &(gotStr->second);
+      isCached = true;
+      }
+
+   // only make a query if a string hasn't been cached
+   if (!isCached)
+      {
+      size_t offsetFromROMClass = (uint8_t*) basePtr - (uint8_t*) _romClass;
+      std::string offsetsStr((char*) offsets.begin(), offsets.size() * sizeof(size_t));
+      
+      JITServer::ServerStream *stream = TR::CompilationInfo::getStream();      
+      stream->write(JITServer::MessageType::ClassInfo_getRemoteROMString, _remoteRomClass, offsetFromROMClass, offsetsStr);
+      cachedStr = &(_remoteROMStringsCache.insert({key, std::get<0>(stream->read<std::string>())}).first->second);
+      }
+
+   len = cachedStr->length();
+   return &(cachedStr->at(0));
+   }
+
+// Takes a pointer to some data which is placed statically relative to the rom class,
+// as well as a list of offsets to J9SRP fields. The first offset is applied before the first
+// SRP is followed.
+//
+// If at any point while following the chain of SRP pointers we land outside the ROM class,
+// then we fall back to getRemoteROMString which follows the same process on the client.
+//
+// This is a workaround because some data referenced in the ROM constant pool is located outside of
+// it, but we cannot easily determine if the reference is outside or not (or even if it is a reference!)
+// because the data is untyped.
+char *
+ClientSessionData::ClassInfo::getROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
+   {
+   uint8_t *ptr = (uint8_t*) basePtr;
+   for (size_t offset : offsets)
+      {
+      ptr += offset;
+      if (!inROMClass(ptr))
+         return getRemoteROMString(len, basePtr, offsets);
+      ptr = ptr + *(J9SRP*)ptr;
+      }
+   if (!inROMClass(ptr))
+      return getRemoteROMString(len, basePtr, offsets);
+   char *data = utf8Data((J9UTF8*) ptr, len);
+   return data;
+   }
 
 template <typename map, typename key>
 void ClientSessionData::purgeCache(std::vector<ClassUnloadedData> *unloadedClasses, map m, key ClassUnloadedData::*k)

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -262,6 +262,10 @@ class ClientSessionData
       uintptrj_t _classFlags;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDeclaringClassCache;
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
+
+      bool inROMClass(void *address);
+      char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
+      char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       }; // struct ClassInfo
 
 


### PR DESCRIPTION
This message is one of the most frequent messages
during AOT compilations.
The method from which it's called accesses ROM constant pool,
gets `J9ROMClassRef` from there and retrieves the name of the
reference. We already cache ROM classes and their constant pools
on the server, however, we can't simply access reference name,
because the actual class reference might be outside the ROM class,
and thus not necessarily cached. We already encountered and solved
a similar problem in resolved methods, so I just copied methods
`getROMString` and `getRemoteROMString` from there into `ClassInfo`
and used them to appropriately fetch a string from either cache or
the client.
In a follow-up commit, the resolved method versions of methods that
retrieve ROM strings should be removed and replaced with `ClassInfo`
versions.