### PR TITLE
AArch64: Enable JIT compiler by default

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2738,11 +2738,6 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 		}
 	}
 
-#if defined(J9AARCH64)
-	// temporary change until the JIT becomes available
-	xint = TRUE;
-#endif
-
 	if (xint) {
 		JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "-Xint set\n");
 	}


### PR DESCRIPTION
This commit reverts the temporary change in #6246, and enables the
JIT compiler by default for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>