### PR TITLE
AArch64: Remove unused symbols in arm64helpers.m4

### DIFF
--- a/runtime/oti/arm64helpers.m4
+++ b/runtime/oti/arm64helpers.m4
@@ -27,9 +27,6 @@ define({ALen},{8})
 
 define({J9VMTHREAD},{x19})
 define({J9SP},{x20})
-define({J9PC},{x21})
-define({J9LITERALS},{x22})
-define({J9A0},{x23})
 
 define({FUNC_LABEL},{$1})
 


### PR DESCRIPTION
This commit removes three symbols that are not used, J9PC,
J9LITERALS, and J9A0, from arm64helpers.m4.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>