### PR TITLE
Port cmdLineTester_lockWordAlignment_Object_* tests

### DIFF
--- a/test/functional/cmdLineTests/lockWordAlignment/alignment.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/alignment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2015, 2018 IBM Corp. and others
+  Copyright (c) 2015, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,13 +26,17 @@
 
 <suite id="J9 Field Alignment Command-Line Option Tests" timeout="300">
  <variable name="TESTSBOOTCLASSPATH" value="-Xbootclasspath/a:$TESTSJARPATH$" />
- <variable name="OBJECTTESTSBOOTCLASSPATH" value="-Xbootclasspath/p:$OBJECTJARPATH$" />
+ <variable name="OBJECTTESTSBOOTCLASSPATH" value="--patch-module java.base=$OBJECTJARPATH$" />
  <variable name="JAVAPBOOTCLASSPATH" value="-bootclasspath $OBJECTJARPATH$" />
+ 
 
  <variable name="PRIV_FIELD1" value=".*" />
  <variable name="PRIV_FIELD2" value=".*" />
  <variable name="PRIV_FIELD3" value=".*" />
  
+
+ <if testVariable="JDK_VERSION" testValue="8" resultVariable="OBJECTTESTSBOOTCLASSPATH" resultValue="-Xbootclasspath/p:$OBJECTJARPATH$"/>
+
  <if testVariable="OLWMODE" testValue="standard" resultVariable="OBJECTTESTSBOOTCLASSPATH" resultValue=" "/>
  <if testVariable="OLWMODE" testValue="standard" resultVariable="JAVAPBOOTCLASSPATH" resultValue=" "/>
 

--- a/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
+++ b/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
@@ -1,0 +1,30 @@
+##############################################################################
+#  Copyright (c) 2019, 2019 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
+
+ADD_EXPORTS=
+ASM_JAR=$(LIB_DIR)$(D)asm-all.jar
+# ADD_EXPORTS needs to set for JDK9 and up
+# if JDK_VERSION is not 8
+ifeq ($(filter 8, $(JDK_VERSION)),)
+ ADD_EXPORTS=--add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED
+ ASM_JAR=$(LIB_DIR)$(D)asm-7.0.jar
+endif

--- a/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
@@ -23,12 +23,17 @@
 -->
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
+	<include>alignmentSettings.mk</include>
 	<test>
-		<testCaseName>cmdLineTester_lockWordAlignment_Object_Standard_SE80</testCaseName>
+		<testCaseName>cmdLineTester_lockWordAlignment_Object_Standard</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) -DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		-DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DJDK_VERSION=$(JDK_VERSION) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
+		-DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) \
+		-DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>
@@ -37,20 +42,23 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_lockWordAlignment_Object_Standard</testCaseName>
+		<testCaseName>cmdLineTester_lockWordAlignment_Object_i</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) --add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED$(SQ) -DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=standard -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) -DOBJECTJARPATH= -jar $(CMDLINETESTER_JAR) -DRESDIR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(TEST_RESROOT)$(D) i; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		-DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=i -DJDK_VERSION=$(JDK_VERSION) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
+		-DOBJECTJARPATH=$(TEST_RESROOT)$(D)object_i.jar \
+		-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>
@@ -59,9 +67,81 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>9+</subset>
-		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_lockWordAlignment_Object_ii</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(TEST_RESROOT)$(D) ii; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		-DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=ii -DJDK_VERSION=$(JDK_VERSION) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
+		-DOBJECTJARPATH=$(TEST_RESROOT)$(D)object_ii.jar \
+		-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_lockWordAlignment_Object_iii</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(TEST_RESROOT)$(D) iii; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		-DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=iii -DJDK_VERSION=$(JDK_VERSION) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
+		-DOBJECTJARPATH=$(TEST_RESROOT)$(D)object_iii.jar \
+		-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_lockWordAlignment_Object_d</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(ASM_JAR)$(P)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(TEST_RESROOT)$(D) d; \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS)$(SQ) \
+		-DEXEP=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)javap$(Q) -DOLWMODE=d -DJDK_VERSION=$(JDK_VERSION) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
+		-DOBJECTJARPATH=$(TEST_RESROOT)$(D)object_d.jar \
+		-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)alignment.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
- port cmdLineTester_lockWordAlignment_Object_* tests (NonStandard)
- create `ADD_EXPORTS` and `ASM_JAR` macro so that we can merge tests for JDK8 and
JDK9+ into one

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>