### PR TITLE
Fix PR 4032 to be merged into master

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5509,7 +5509,7 @@ bool CPUThrottleEnabled(TR::CompilationInfo *compInfo, uint64_t crtTime)
 
 /// Sums up CPU utilization of all compilation thread and write this
 /// value in the compilation info (or -1 in case of error)
-void DoCalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, uint64_t crtTime, J9VMThread *currentThread, int32_t *cpuUtilizationValues)
+static void DoCalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, uint64_t crtTime, J9VMThread *currentThread, int32_t *cpuUtilizationValues)
    {
    // Sum up the CPU utilization of all the compilation threads
    int32_t totalCompCPUUtilization = 0;

--- a/runtime/compiler/infra/J9MonitorTable.cpp
+++ b/runtime/compiler/infra/J9MonitorTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,8 @@ J9::MonitorTable::init(
    table->_monitors.setFirst(0);
 
    table->_numCompThreads = 0;
+   // Memory for classUnloadMonitorHolders will be allocated later in allocInitClassUnloadMonitorHolders()
+   // just before the compilation threads are started
    table->_classUnloadMonitorHolders = NULL;
 
    // Initialize the Monitors


### PR DESCRIPTION
- Removed `JITSERVER_SUPPORT` that has guarded PR #4032 change.
- Fixed the initialization of `_compThreadActivationThresholds`.

The mirrored `master` branch change is in PR #7291.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>