### PR TITLE
(v0.17.0) Make Unsafe constructor private to prevent instantiation

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -36,6 +36,9 @@ import jdk.internal.ref.Cleaner;
 
 public final class Unsafe {
 
+	/* Prevents this class from being instantiated. */
+	private Unsafe() {}
+	
 	/* unsafe instance */
 	private static final Unsafe theUnsafe;
 


### PR DESCRIPTION
**Make Unsafe constructor private to prevent instantiation**

Added a private constructor to prevent Unsafe from being instantiated.

Note: this only affects `OpenJ9 JDK 11+` while `JDK 8` uses `OpenJDK` version. The `Unsafe` instance is available via `public static Unsafe getUnsafe()` which is not exported hence guarded by modularity access control. Preventing instantiation is to enforce API usage and match `JDK 8` behaviours.

This is back-ported from https://github.com/eclipse/openj9/pull/7311. 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>