### PR TITLE
(v0.17.0) Add javadoc comments to openj9 modules

### DIFF
--- a/jcl/src/openj9.cuda/share/classes/module-info.java
+++ b/jcl/src/openj9.cuda/share/classes/module-info.java
@@ -23,6 +23,11 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Provides access to CUDA-capable devices from Java.
+ * <p>
+ * A wealth of background information on CUDA is available <a href="http://www.nvidia.com/object/cuda_home.html">here</a>.
+ */
 module openj9.cuda {
   requires java.base;
   exports com.ibm.cuda;

--- a/jcl/src/openj9.dataaccess/share/classes/module-info.java
+++ b/jcl/src/openj9.dataaccess/share/classes/module-info.java
@@ -23,6 +23,11 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Packed decimal and decimal data access accelerator API. Arithmetic, copying and shifting operations
+ * for packed decimal data. Convert between decimal data types stored in byte arrays and Java binary types.
+ * Marshall Java binary types to and from byte arrays.
+ */
 module openj9.dataaccess {
   exports com.ibm.dataaccess;
 }

--- a/jcl/src/openj9.dtfjview/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfjview/share/classes/module-info.java
@@ -23,6 +23,9 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/** 
+ * Defines the jdmpview tool for reading system core and java core diagnostic files.
+ */
 module openj9.dtfjview {
   requires openj9.dtfj;
   requires java.logging;

--- a/jcl/src/openj9.gpu/share/classes/module-info.java
+++ b/jcl/src/openj9.gpu/share/classes/module-info.java
@@ -23,6 +23,10 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Defines API to perform certain operations using any connected CUDA capable GPU,
+ * such as sorting arrays of natives types.
+ */
 module openj9.gpu {
   requires java.base;
   requires openj9.cuda;

--- a/jcl/src/openj9.jvm/share/classes/module-info.java
+++ b/jcl/src/openj9.jvm/share/classes/module-info.java
@@ -23,6 +23,10 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Defines API for creating diagnostic dump files, querying and controlling OS logging,
+ * querying Java heap and OS memory stats, and controlling and logging trace file output. 
+ */
 module openj9.jvm {
   exports com.ibm.jvm;
 }

--- a/jcl/src/openj9.sharedclasses/share/classes/module-info.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/module-info.java
@@ -23,6 +23,10 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Defines the shared class cache API. Used to add shared class caching to a ClassLoader implementation.
+ * Obtain information about the current shared class cache, available shared class caches, or destroy caches.
+ */
 module openj9.sharedclasses {
   requires java.base;
   exports com.ibm.oti.shared;

--- a/jcl/src/openj9.traceformat/share/classes/module-info.java
+++ b/jcl/src/openj9.traceformat/share/classes/module-info.java
@@ -23,6 +23,9 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ *  Provides the traceformat utility for formatting binary trace files.
+ */
 module openj9.traceformat {
   exports com.ibm.jvm.trace.format.api;
 }

--- a/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
+++ b/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
@@ -23,6 +23,9 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Provides the ConditionException class for z/OS Language Environment condition handling.
+ */
 module openj9.zosconditionhandling {
   exports com.ibm.le.conditionhandling;
 }


### PR DESCRIPTION
Fixes #6951

Port of https://github.com/eclipse/openj9/pull/7310 for the 0.17 release

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>