### PR TITLE
Port JITServer changes in J9VMEnv/J9VMMethodEnv

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -478,9 +478,6 @@ JITServerHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo,
 J9ROMMethod *
 JITServerHelpers::romMethodOfRamMethod(J9Method* method)
    {
-   if (!TR::CompilationInfo::getStream()) // Not JITServer
-      return J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
-
    // JITServer
    auto clientData = TR::compInfoPT->getClientData();
    J9ROMMethod *romMethod = NULL;

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -38,6 +38,9 @@
 #include "j9cfg.h"
 #include "jilconsts.h"
 #include "vmaccess.h"
+#if defined(JITSERVER_SUPPORT)
+#include "runtime/JITClientSession.hpp"
+#endif
 
 int64_t
 J9::VMEnv::maxHeapSizeInBytes()
@@ -488,5 +491,12 @@ J9::VMEnv::isSelectiveMethodEnterExitEnabled(TR::Compilation *comp)
 size_t
 J9::VMEnv::getInterpreterVTableOffset()
    {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_interpreterVTableOffset;
+      }
+#endif
    return sizeof(J9Class);
    }

--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -29,11 +29,18 @@
 #include "j9cfg.h"
 #include "jilconsts.h"
 #include "j9protos.h"
+#if defined(JITSERVER_SUPPORT)
+#include "control/JITServerHelpers.hpp"
+#endif
 
 bool
 J9::VMMethodEnv::hasBackwardBranches(TR_OpaqueMethodBlock *method)
    {
+#if defined(JITSERVER_SUPPORT)
+   J9ROMMethod * romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method *)method);
+#else
    J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+#endif
    return (romMethod->modifiers & J9AccMethodHasBackwardBranches) != 0;
    }
 
@@ -61,7 +68,18 @@ J9::VMMethodEnv::startPC(TR_OpaqueMethodBlock *method)
 uintptr_t
 J9::VMMethodEnv::bytecodeStart(TR_OpaqueMethodBlock *method)
    {
-   J9ROMMethod *romMethod = getOriginalROMMethod((J9Method *)method);
+   J9ROMMethod *romMethod = NULL;
+#if defined(JITSERVER_SUPPORT)
+   if (TR::CompilationInfo::getStream())
+      // Don't need to call getOriginalROMMethod, because
+      // in JITServer romMethodOfRamMethod already fetches
+      // ROM method from its ROM class.
+      // Also, the return value of this function might be 
+      // dereferenced later on, so need ROM method to be on the server.
+      romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method *) method);
+   else
+#endif
+      romMethod = getOriginalROMMethod((J9Method *)method);
    return (uintptr_t)(J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
    }
 
@@ -69,7 +87,11 @@ J9::VMMethodEnv::bytecodeStart(TR_OpaqueMethodBlock *method)
 uint32_t
 J9::VMMethodEnv::bytecodeSize(TR_OpaqueMethodBlock *method)
    {
+#if defined(JITSERVER_SUPPORT)
+   J9ROMMethod *romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method*) method);
+#else
    J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+#endif
    return (uint32_t)(J9_BYTECODE_END_FROM_ROM_METHOD(romMethod) -
                      J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
    }

--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -36,11 +36,13 @@
 bool
 J9::VMMethodEnv::hasBackwardBranches(TR_OpaqueMethodBlock *method)
    {
+   J9ROMMethod *romMethod = NULL;
 #if defined(JITSERVER_SUPPORT)
-   J9ROMMethod * romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method *)method);
-#else
-   J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+   if (TR::CompilationInfo::getStream())
+      romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method *)method);
+   else
 #endif
+      romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
    return (romMethod->modifiers & J9AccMethodHasBackwardBranches) != 0;
    }
 
@@ -87,11 +89,13 @@ J9::VMMethodEnv::bytecodeStart(TR_OpaqueMethodBlock *method)
 uint32_t
 J9::VMMethodEnv::bytecodeSize(TR_OpaqueMethodBlock *method)
    {
+   J9ROMMethod *romMethod = NULL;
 #if defined(JITSERVER_SUPPORT)
-   J9ROMMethod *romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method*) method);
-#else
-   J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
+   if (TR::CompilationInfo::getStream())
+      romMethod = JITServerHelpers::romMethodOfRamMethod((J9Method*) method);
+   else
 #endif
+      romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
    return (uint32_t)(J9_BYTECODE_END_FROM_ROM_METHOD(romMethod) -
                      J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
    }


### PR DESCRIPTION
Add JITServer support for a few VM env APIs.
- J9::VMEnv::getInterpreterVTableOffset
- J9::VMMethodEnv::hasBackwardBranches
- J9::VMMethodEnv::bytecodeStart
- J9::VMMethodEnv::bytecodeSize

Signed-off-by: Harry Yu <harryyu1994@gmail.com>