### PR TITLE
(v0.17.0) Preserve FPRs before calling JIT helper on Power

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -174,6 +174,28 @@
 
 #endif
 
+#define SaveFPRArgs                                       \
+	addi	J9SP, J9SP, -64;                             \
+	stfd	fp0, 0(J9SP);                               \
+	stfd	fp1, 8(J9SP);                               \
+	stfd	fp2, 16(J9SP);                               \
+	stfd	fp3, 24(J9SP);                               \
+	stfd	fp4, 32(J9SP);                               \
+	stfd	fp5, 40(J9SP);                               \
+	stfd	fp6, 48(J9SP);                               \
+	stfd	fp7, 56(J9SP);
+
+#define restoreFPRArgs									\
+	lfd  	fp0, 0(J9SP);                               \
+	lfd  	fp1, 8(J9SP);                               \
+	lfd  	fp2, 16(J9SP);                               \
+	lfd  	fp3, 24(J9SP);                               \
+	lfd  	fp4, 32(J9SP);                               \
+	lfd  	fp5, 40(J9SP);                               \
+	lfd  	fp6, 48(J9SP);                               \                      
+	lfd  	fp7, 56(J9SP);                               \
+	addi	J9SP, J9SP, 64;
+
 #ifdef AIXPPC
 	.lglobl   .__common_lock_check
 	.lglobl   .__common_lock_update
@@ -3104,6 +3126,8 @@ __picRegistration:
 .__picRegistration:
 #endif
 	startproc.__picRegistration:
+	! Preserve Argument FPR0-FPR7 GPRs GPR3-GPR10 were previously preserved in the caller routine
+    SaveFPRArgs
 	mfspr	r5, LR					! Save return address and allocate space for frame
 	staddru	SP, -24*ALen(SP)
 	staddr	r5, 19*ALen(SP)
@@ -3132,6 +3156,7 @@ __picRegistration:
 	laddr	r3, 16*ALen(SP)
 	laddr	r11, 17*ALen(SP)
 	addi	SP, SP, 24*ALen
+	restoreFPRArgs
 	blr
 	endproc.__picRegistration:
 


### PR DESCRIPTION
Within PicBuilder if a call to JIT C-Helpers are made the floating point registers that could contain arguments (FPR0-FPR7) could be overwritten.
To ensure the method arguments are perserved, these registers are stored onto the Java stack before branching to the C-Helper.
The floating point registers are restored coming back from the helper.

Port of https://github.com/eclipse/openj9/pull/7290 for 0.17

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>