### PR TITLE
(v0.17.0) Fix handleStartupError() to return the result of deleting the cache and DDR shrc command

### DIFF
--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -506,7 +506,7 @@ private:
 
 	IDATA getPrereqCache(J9VMThread* currentThread, const char* cacheDir, SH_CompositeCacheImpl* ccToUse, bool startupForStats, const char** prereqCacheID, UDATA* idLen);
 
-	void handleStartupError(J9VMThread* currentThread, SH_CompositeCacheImpl* ccToUse, IDATA errorCode, U_64 runtimeFlags, UDATA verboseFlags, bool *doRetry);
+	void handleStartupError(J9VMThread* currentThread, SH_CompositeCacheImpl* ccToUse, IDATA errorCode, U_64 runtimeFlags, UDATA verboseFlags, bool *doRetry, IDATA *deleteRC);
 	
 	void setCacheAddressRangeArray(void);
 	


### PR DESCRIPTION
Fix handleStartupError() to return the result of deleting the cache and fix DDR shrc command

1. We are checking if we failed to delete the existing cache with a
different buildID before unsetting
J9SHR_RUNTIMEFLAG_AUTOKILL_DIFF_BUILDID, so handleStartupError() should
return deleteRC

2. Unset J9SHR_RUNTIMEFLAG_AUTOKILL_DIFF_BUILDID for lower layer
readonly caches.

3. Fix DDR shrc commands

Port of #7316 and #7325 

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>
