### PR TITLE
Reduce VM_getClassNameSignatureFromMethod messages

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -704,16 +704,35 @@ TR_J9ServerVM::sampleSignature(TR_OpaqueMethodBlock * aMethod, char *buf, int32_
    // the passed in TR_Memory is possibly null.
    // in the superclass it would be null if it was not needed, but here we always need it.
    // so we just get it out of the compilation.
+   bool cached = false;
+   J9UTF8 *className, *name, *signature;
    TR_Memory *trMemory = _compInfoPT->getCompilation()->trMemory();
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getClassNameSignatureFromMethod, (J9Method*) aMethod);
-   auto recv = stream->read<std::string, std::string, std::string>();
-   const std::string str_className = std::get<0>(recv);
-   const std::string str_name = std::get<1>(recv);
-   const std::string str_signature = std::get<2>(recv);
-   J9UTF8 * className = str2utf8((char*)&str_className[0], str_className.length(), trMemory, heapAlloc);
-   J9UTF8 * name = str2utf8((char*)&str_name[0], str_name.length(), trMemory, heapAlloc);
-   J9UTF8 * signature = str2utf8((char*)&str_signature[0], str_signature.length(), trMemory, heapAlloc);
+      {
+      OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
+      auto it = _compInfoPT->getClientData()->getJ9MethodMap().find((J9Method*) aMethod);
+      if (it != _compInfoPT->getClientData()->getJ9MethodMap().end())
+         {
+         cached = true;
+         TR_OpaqueClassBlock *owningClass = it->second._owningClass;
+         J9ROMMethod *romMethod = it->second._romMethod;
+         className = J9ROMCLASS_CLASSNAME(TR::Compiler->cls.romClassOf(owningClass));
+         name = J9ROMMETHOD_NAME(romMethod);
+         signature = J9ROMMETHOD_SIGNATURE(romMethod);
+         }
+      }
+   if (!cached)
+      {
+      JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      stream->write(JITServer::MessageType::VM_getClassNameSignatureFromMethod, (J9Method*) aMethod);
+      auto recv = stream->read<std::string, std::string, std::string>();
+      const std::string str_className = std::get<0>(recv);
+      const std::string str_name = std::get<1>(recv);
+      const std::string str_signature = std::get<2>(recv);
+      className = str2utf8((char*)&str_className[0], str_className.length(), trMemory, heapAlloc);
+      name = str2utf8((char*)&str_name[0], str_name.length(), trMemory, heapAlloc);
+      signature = str2utf8((char*)&str_signature[0], str_signature.length(), trMemory, heapAlloc);
+      }
+   
 
    int32_t len = J9UTF8_LENGTH(className)+J9UTF8_LENGTH(name)+J9UTF8_LENGTH(signature)+3;
    char * s = len <= bufLen ? buf : (trMemory ? (char*)trMemory->allocateHeapMemory(len) : NULL);


### PR DESCRIPTION
This message is emitted from `TR_J9ServerVM::sampleSignature`
It requires a class name, method name and method signature.
All of these things are already cached and can be accesed
from client data. In cases when the corresponding class/method
is not cached, still need to make a remote call.