### PR TITLE
Eliminate VM_getConstantPoolFromMethod(Class) messages

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -707,18 +707,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getOffsetOfClassFromJavaLangClassField());
          }
          break;
-      case MessageType::VM_getConstantPoolFromMethod:
-         {
-         TR_OpaqueMethodBlock *method = std::get<0>(client->getRecvData<TR_OpaqueMethodBlock *>());
-         client->write(response, fe->getConstantPoolFromMethod(method));
-         }
-         break;
-      case MessageType::VM_getConstantPoolFromClass:
-         {
-         TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
-         client->write(response, fe->getConstantPoolFromClass(clazz));
-         }
-         break;
       case MessageType::VM_getIdentityHashSaltPolicy:
          {
          client->getRecvData<JITServer::Void>();

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -467,6 +467,11 @@ JITServerHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo,
          *(J9Method **)data = classInfo._methodsOfClass;
          }
          break;
+      case CLASSINFO_CONSTANT_POOL :
+         {
+         *(J9ConstantPool **)data = classInfo._constantPool;
+         }
+         break;
       default :
          {
          TR_ASSERT(0, "Class Info not supported %u \n", dataType);

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -51,6 +51,7 @@ class JITServerHelpers
       CLASSINFO_REMOTE_ROM_CLASS,
       CLASSINFO_CLASS_FLAGS,
       CLASSINFO_METHODS_OF_CLASS,
+      CLASSINFO_CONSTANT_POOL
       };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -932,17 +932,17 @@ TR_J9ServerVM::getOffsetOfClassFromJavaLangClassField()
 uintptrj_t
 TR_J9ServerVM::getConstantPoolFromMethod(TR_OpaqueMethodBlock *method)
    {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getConstantPoolFromMethod, method);
-   return std::get<0>(stream->read<uintptrj_t>());
+   TR_OpaqueClassBlock *owningClass = getClassFromMethodBlock(method);
+   return getConstantPoolFromClass(owningClass);
    }
 
 uintptrj_t
 TR_J9ServerVM::getConstantPoolFromClass(TR_OpaqueClassBlock *clazz)
    {
+   J9ConstantPool *cp;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getConstantPoolFromClass, clazz);
-   return std::get<0>(stream->read<uintptrj_t>());
+   JITServerHelpers::getAndCacheRAMClassInfo((J9Class *) clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CONSTANT_POOL, (void *)&cp);
+   return reinterpret_cast<uintptrj_t>(cp);
    }
 
 uintptrj_t

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -180,7 +180,6 @@ enum MessageType
    VM_getArrayLengthInElements = 256;
    VM_getClassFromJavaLangClass = 257;
    VM_getOffsetOfClassFromJavaLangClassField = 258;
-   VM_getConstantPoolFromMethod = 259;
    /* VM_getProcessID = 260; */
    VM_getIdentityHashSaltPolicy = 261;
    VM_getOffsetOfJLThreadJ9Thread = 262;
@@ -220,7 +219,6 @@ enum MessageType
    /* VM_getSystemClassLoader = 296; */
    VM_instanceOfOrCheckCast = 297;
    VM_getNewArrayTypeFromClass = 298;
-   VM_getConstantPoolFromClass = 299;
    VM_getResolvedMethodsAndMirror = 300;
    VM_getVMInfo = 301;
    VM_isAnonymousClass = 302;


### PR DESCRIPTION
We already cache pointer to client's RAM constant pool in
`ClassInfo`, so just access it from there.