### PR TITLE
Fix hook starttime report issue due to timestamp precision change

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -2019,7 +2019,8 @@ JavaCoreDumpWriter::writeHookInfo(struct OMRHookInfo4Dump *hookInfo)
 	}
 	_OutputStream.writeCharacters("\n");
 	_OutputStream.writeCharacters("4HKSTARTTIME          Start Time: ");
-	omrstr_ftime(timeStamp, _MaximumTimeStampLength, "%Y-%m-%dT%H:%M:%S", hookInfo->startTime);
+	/* timestamp(hookInfo->startTime) precision has been updated from millisecond to microsecond, hookInfo->startTime need to be changed back to millisecond for passing it to function omrstr_ftime() */
+	omrstr_ftime(timeStamp, _MaximumTimeStampLength, "%Y-%m-%dT%H:%M:%S", hookInfo->startTime/1000);
 	/* nul-terminate timestamp in case omrstr_ftime didn't have enough room to do so */
 	timeStamp[_MaximumTimeStampLength] = '\0';
 	_OutputStream.writeCharacters(timeStamp);


### PR DESCRIPTION
	- timestamp(hookInfo->startTime) precision has been updated
	from millisecond to microsecond, hookInfo->startTime need to
	be changed back to millisecond for passing it to function
	omrstr_ftime().

relate: https://github.com/eclipse/openj9/pull/6822

Signed-off-by: Lin Hu <linhu@ca.ibm.com>