### PR TITLE
Support platform specific signals on Linux, AIX and MacOS

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -452,7 +452,7 @@ static const J9SignalMapping signalMap[] = {
 #endif /* defined(SIGPOLL) */
 #if defined(SIGCLD)
 	J9_SIGNAL_MAP_ENTRY("CLD", SIGCLD),
-#endif /* defined(SIGPWR) */
+#endif /* defined(SIGCLD) */
 #if defined(SIGPWR)
 	J9_SIGNAL_MAP_ENTRY("PWR", SIGPWR),
 #endif /* defined(SIGPWR) */

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -450,6 +450,48 @@ static const J9SignalMapping signalMap[] = {
 #if defined(SIGPOLL)
 	J9_SIGNAL_MAP_ENTRY("POLL", SIGPOLL),
 #endif /* defined(SIGPOLL) */
+#if defined(SIGPWR)
+	J9_SIGNAL_MAP_ENTRY("CLD", SIGCLD),
+#endif /* defined(SIGPWR) */
+#if defined(SIGPWR)
+	J9_SIGNAL_MAP_ENTRY("PWR", SIGPWR),
+#endif /* defined(SIGPWR) */
+#if defined(SIGSTKFLT)
+	J9_SIGNAL_MAP_ENTRY("STKFLT", SIGSTKFLT),
+#endif /* defined(SIGSTKFLT) */
+#if defined(SIGCPUFAIL)
+	J9_SIGNAL_MAP_ENTRY("CPUFAIL", SIGCPUFAIL),
+#endif /* defined(SIGCPUFAIL) */
+#if defined(SIGDANGER)
+	J9_SIGNAL_MAP_ENTRY("DANGER", SIGDANGER),
+#endif /* defined(SIGDANGER) */
+#if defined(SIGEMT)
+	J9_SIGNAL_MAP_ENTRY("EMT", SIGEMT),
+#endif /* defined(SIGEMT) */
+#if defined(SIGGRANT)
+	J9_SIGNAL_MAP_ENTRY("GRANT", SIGGRANT),
+#endif /* defined(SIGGRANT) */
+#if defined(SIGLOST)
+	J9_SIGNAL_MAP_ENTRY("LOST", SIGLOST),
+#endif /* defined(SIGLOST) */
+#if defined(SIGMIGRATE)
+	J9_SIGNAL_MAP_ENTRY("MIGRATE", SIGMIGRATE),
+#endif /* defined(SIGMIGRATE) */
+#if defined(SIGMSG)
+	J9_SIGNAL_MAP_ENTRY("MSG", SIGMSG),
+#endif /* defined(SIGMSG) */
+#if defined(SIGPRE)
+	J9_SIGNAL_MAP_ENTRY("PRE", SIGPRE),
+#endif /* defined(SIGPRE) */
+#if defined(SIGRETRACT)
+	J9_SIGNAL_MAP_ENTRY("RETRACT", SIGRETRACT),
+#endif /* defined(SIGRETRACT) */
+#if defined(SIGSAK)
+	J9_SIGNAL_MAP_ENTRY("SAK", SIGSAK),
+#endif /* defined(SIGSAK) */
+#if defined(SIGSOUND)
+	J9_SIGNAL_MAP_ENTRY("SOUND", SIGSOUND),
+#endif /* defined(SIGSOUND) */
 	{NULL, J9_SIG_ERR}
 };
 

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -450,7 +450,7 @@ static const J9SignalMapping signalMap[] = {
 #if defined(SIGPOLL)
 	J9_SIGNAL_MAP_ENTRY("POLL", SIGPOLL),
 #endif /* defined(SIGPOLL) */
-#if defined(SIGPWR)
+#if defined(SIGCLD)
 	J9_SIGNAL_MAP_ENTRY("CLD", SIGCLD),
 #endif /* defined(SIGPWR) */
 #if defined(SIGPWR)


### PR DESCRIPTION
The following platform specific signals are now supported by OpenJ9:

- Linux: SIGCLD, SIGPWR, SIGSTKFLT.
- AIX: SIGCLD, SIGCPUFAIL, SIGDANGER, SIGEMT, SIGGRANT, SIGLOST,
SIGMIGRATE, SIGMSG, SIGPRE, SIGPWR, SIGRETRACT, SIGSAK, SIGSOUND.
- MacOS: SIGEMT.

Closes #6967.
Dependent on https://github.com/eclipse/omr/pull/4407.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>