### PR TITLE
AArch64: Remove an obsolete comment from arm64nathelp.m4

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -18,8 +18,6 @@ dnl [2] http://openjdk.java.net/legal/assembly-exception.html
 dnl
 dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
-dnl **** NOT TESTED ****
-
 include(arm64helpers.m4)
 
 	.file "arm64nathelp.s"


### PR DESCRIPTION
This commit removes a "NOT TESTED" comment from arm64nathelp.m4.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>