### PR TITLE
Update JITServer build documentation

### DIFF
--- a/doc/compiler/jitserver/Build.md
+++ b/doc/compiler/jitserver/Build.md
@@ -95,7 +95,7 @@ cd /root \
 wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
  && tar -xvzf protobuf-cpp-3.5.1.tar.gz \
  && cd protobuf-3.5.1 \
- && ./configure && make && make install && ldconfig \
+ && ./configure --disable-shared --with-pic && make && make install && ldconfig \
  && rm -rf /protobuf-3.5.1 && rm -rf /protobuf-cpp-3.5.1.tar.gz
 
 export JAVA_HOME=/root/bootjdk8


### PR DESCRIPTION
Information about configuring protobuf library was stale.
We have switched to building the static library and using --with-pic flag

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>