### PR TITLE
AArch64: Temporarily disable UnresolvedDataSnippet

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.hpp
@@ -61,6 +61,8 @@ class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
       J9::UnresolvedDataSnippet(cg, node, symRef, isStore, isGCSafePoint),
       _memoryReference(NULL)
       {
+      // Implement this in OpenJ9 PR #5985
+      cg->comp()->failCompilation<TR::AssertionFailure>("UnresolvedDataSnippet");
       }
 
    /**


### PR DESCRIPTION
This commit disables the constructor of UnresolvedDataSnippet for
AArch64 temporarily.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>