### PR TITLE
AArch64: Use VirtualUnresolvedSnippet when compileRelocatableCode()

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -614,7 +614,7 @@ void TR::ARM64PrivateLinkage::buildDirectCall(TR::Node *callNode,
       TR::LabelSymbol *label = generateLabelSymbol(cg());
       TR::Snippet *snippet;
 
-      if (callSymRef->isUnresolved())
+      if (callSymRef->isUnresolved() || comp()->compileRelocatableCode())
          {
          snippet = new (trHeapMemory()) TR::ARM64UnresolvedCallSnippet(cg(), callNode, label, argSize);
          }


### PR DESCRIPTION
This commit adds a condition in buildDirectCall() so that the function
uses ARM64UnresolvedCallSnippet instead of ARM64CallSnippet when it is
compiling for relocatable code.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>