### PR TITLE
Update draft release notes ready for 0.17 GA.

### DIFF
--- a/doc/release-notes/0.17/0.17.md
+++ b/doc/release-notes/0.17/0.17.md
@@ -30,13 +30,16 @@ These release notes support the [Eclipse OpenJ9 0.17 release plan](https://proje
 
 OpenJ9 release 0.17 supports OpenJDK 8, 11, and 13.
 
-<!--Binaries are available at the AdoptOpenJDK project:
+Binaries are available at the AdoptOpenJDK project:
 
 - [OpenJDK 8 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
 - [OpenJDK 11 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 - [OpenJDK 13 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk13&jvmVariant=openj9)
 
-All builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.-->
+All builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
+
+<b>NOTE:</b> Builds at AdoptOpenJDK are now CUDA-enabled. On systems that have the correct hardware and software pre-requisites, certain processing
+tasks can be offloaded to a graphics processing unit (GPU). For more information, read the [user documentation](https://www.eclipse.org/openj9/docs/introduction/#exploiting-gpus).
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](https://eclipse.org/openj9/docs/openj9_support/index.html).
 
@@ -81,19 +84,40 @@ The following table covers notable changes in v0.17. Further information about t
 </tr>
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7213">#7213</a></td>
-<td valign="top">New experimental <tt>-Xshareclasses</tt> sub-options for Docker containers</td>
-<td valign="top">OpenJDK8 and later</td>
-<td valign="top">The <tt>-Xshareclasses:createLayer</tt> and <tt>-Xshareclasses:layer=<number></tt> options are intended
-for users who are running Java applications in docker containers. These options allow the shared classes cache to be
-built into different layers of a docker image. These options are experimental.</td>
+<td valign="top">New experimental <tt>-Xshareclasses</tt> sub-options for creating layered caches</td>
+<td valign="top">OpenJDK8 and later (64-bit only)</td>
+<td valign="top">The <tt>-Xshareclasses:createLayer</tt> and <tt>-Xshareclasses:layer=<number></tt> options can be used to
+create layered caches, where a cache builds on another cache with the same name. Further options (<tt>printTopLayerStats</tt> and
+<tt>destroyAllLayers</tt>) are also available for managing layered caches. These options are experimental.</td>
 </tr>
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/5884">#5884</a></td>
-<td valign="top">Support for the IBM z15 processor.</td>
+<td valign="top">Support for the IBM z15 processor</td>
 <td valign="top">OpenJDK8 and later</td>
 <td valign="top">This release adds JIT compiler support for exploiting z15 instructions.</td>
 </tr>
 
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/7332">#7332</a></td>
+<td valign="top">Change to default value of <tt>-Dcom.ibm.enableClassCaching=[true|false]</tt></td>
+<td valign="top">OpenJDK8 and later</td>
+<td valign="top">In earlier releases the default value for this option was <tt>true</tt>. The value for this option is now <tt>false</tt>, disabling LUDCL whilst
+[issue 7332](https://github.com/eclipse/openj9/issues/7332) is investigated.
+</td>
+</tr>
+
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/pull/6822">#6822</a></td>
+<td valign="top">Change to Java dump output for HOOKS</td>
+<td valign="top">OpenJDK8 and later</td>
+<td valign="top">Output for internal VM event callbacks is changed from milliseconds to microseconds. A new field, <tt>3HKTOTALTIME</tt>, provides
+the total duration of previous events. Hook data is now reset after each Java dump. </td>
+</tr>
+
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7064">#7064</a></td>
+<td valign="top">Restriction removed for analyzing system (core) dumps</td>
+<td valign="top">Linux and Windows</td>
+<td valign="top">In earlier releases a restriction was in place whereby you had to use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction is now removed.</td>
+<td valign="top">None</td>
+</tr>
 </table>
 
 
@@ -113,10 +137,10 @@ The v0.17 release contains the following known issues and limitations:
 </thead>
 <tbody>
 
-<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/2507">#2507</a></td>
-<td valign="top">Restriction analyzing system (core) dumps</td>
-<td valign="top">Linux and Windows</td>
-<td valign="top">You must use a 32-bit JVM to look at a 32-bit core, and a 64-bit JVM to look at a 64-bit core. This restriction will be fixed in a later version of OpenJ9.</td>
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/7459">#7549</a></td>
+<td valign="top">Startup regression on AIX</td>
+<td valign="top">AIX (64-bit POWER)</td>
+<td valign="top">A 40 - 80% startup regression is under investigation for OpenJDK 8 and 11.</td>
 <td valign="top">None</td>
 </tr>
 
@@ -144,7 +168,7 @@ The v0.17 release contains the following known issues and limitations:
 </tbody>
 </table>
 
-<!--
+
 ## Other changes
 
-A full commit history for this release is available at [Eclipse OpenJ9 v0.17.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.17.0).-->
+A full commit history for this release is available at [Eclipse OpenJ9 v0.17.0](https://github.com/eclipse/openj9/releases/tag/openj9-0.17.0).


### PR DESCRIPTION
Add final updates:

- DDR enabled (remove restriction)
- update layered cache entry with further information
- add change to default value for LUDCL processing
- add Java dump HOOK information
- mention that AdoptOpenJDK builds are now CUDA-enabled

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>