### PR TITLE
Thread.cleanup() invokes TerminatingThreadLocal.threadTerminated

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 package java.lang;
 
 /*******************************************************************************
@@ -27,7 +27,8 @@ import java.util.Map;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-/*[IF Sidecar19-SE]
+/*[IF Java11]
+import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.reflect.CallerSensitive;
 /*[ELSE]*/
 import sun.reflect.CallerSensitive;
@@ -1480,6 +1481,12 @@ void uncaughtException(Throwable e) {
  * @see J9VMInternals#threadCleanup()
  */
 void cleanup() {
+/*[IF Java11]*/
+	if (threadLocals != null && TerminatingThreadLocal.REGISTRY.isPresent()) {
+		TerminatingThreadLocal.threadTerminated();
+	}
+/*[ENDIF]*/
+
 	/*[PR 97317]*/
 	group = null;
 


### PR DESCRIPTION
**Thread.cleanup() invokes TerminatingThreadLocal.threadTerminated**

Modified `j.l.Thread.cleanup()` to invoke `TerminatingThreadLocal.threadTerminated()`.
Also replaced obsoleted JPP flags.

Verified that this PR fixes https://github.com/eclipse/openj9/issues/7167

close: https://github.com/eclipse/openj9/issues/7167

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>