### PR TITLE
CMake: update link flags for testjep178

### DIFF
--- a/runtime/tests/redirector/jep178/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/CMakeLists.txt
@@ -25,8 +25,15 @@ add_subdirectory(testjvmtiB)
 add_subdirectory(testlibA)
 add_subdirectory(testlibB)
 
-#TODO this is platform specific stuff
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic")
+
+#TODO: this is how its done in the module.xml, but its probably a toolchain thing
+if(OMR_OS_LINUX)
+    if(OMR_ARCH_X86 OR OMR_ARCH_S390)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic")
+    endif()
+elseif(OMR_OS_AIX)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -qpic -brtl -bexpall")
+endif()
 
 add_executable(testjep178_static
     static_agents.c


### PR DESCRIPTION
Only pass rdynamic on linux builds, also pass appropriate flags for aix

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>