### PR TITLE
Add tests for -XX:[+|-]ClassRelationshipVerifier

### DIFF
--- a/runtime/tests/bcverify/CMakeLists.txt
+++ b/runtime/tests/bcverify/CMakeLists.txt
@@ -70,8 +70,26 @@ omr_add_exports(bcuwhite
 	Java_com_ibm_j9_test_bcverify_TestNatives_bcvCheckMethodName
 )
 
+add_library(bcvrelationships SHARED
+	relationships/bcvrelationships.c
+)
+
+target_link_libraries(bcvrelationships
+	PRIVATE
+		j9vm_interface
+
+		j9avl
+		j9hashtable
+		j9pool
+		j9utilcore
+)
+
+omr_add_exports(bcvrelationships
+	Java_org_openj9_test_classRelationshipVerifier_TestClassRelationshipVerifier_isRelationshipRecorded
+)
+
 install(
-	TARGETS bcuwhite
+	TARGETS bcuwhite bcvrelationships
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}
 	RUNTIME DESTINATION ${j9vm_SOURCE_DIR}
 )

--- a/runtime/tests/bcverify/relationships/bcvrelationships.c
+++ b/runtime/tests/bcverify/relationships/bcvrelationships.c
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <jni.h>
+#include "j9protos.h"
+#include "omrlinkedlist.h"
+
+/**
+ * Check if a relationship has been recorded in the
+ * classloader relationship table for the specified
+ * child class and parent class.
+ *
+ * Class: org_openj9_test_classRelationshipVerifier_TestClassRelationshipVerifier
+ * Method: isRelationshipRecorded
+ * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)Z
+ *
+ * @param[in] env the JNI interface pointer
+ * @param[in] clazz the class on which the static method was invoked
+ * @param[in] childNameString the name of the child class
+ * @param[in] parentNameString the name of the parent class
+ * @param[in] classLoaderObject the class loader used to load the parent and child classes
+ */
+JNIEXPORT jboolean JNICALL
+Java_org_openj9_test_classRelationshipVerifier_TestClassRelationshipVerifier_isRelationshipRecorded(JNIEnv *env, jclass clazz, jstring childNameString, jstring parentNameString, jobject classLoaderObject)
+{
+	jboolean isRelationshipRecorded = JNI_FALSE;
+	J9VMThread *currentThread  = (J9VMThread *) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9ClassLoader *classLoader = NULL;
+	U_8 *childName = NULL;
+	U_8 *parentName = NULL;
+	char childNameStackBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH] = {0};
+	char parentNameStackBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH] = {0};
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	if ((NULL == childNameString) || (NULL == parentNameString)) {
+		goto done;
+	}
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	classLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(classLoaderObject));
+
+	if (NULL != classLoader) {
+		if (NULL != classLoader->classRelationshipsHashTable) {
+			UDATA childNameLength = 0;
+			childName = (U_8 *) vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(childNameString), J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, childNameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &childNameLength);
+
+			if (NULL != childName) {
+				J9ClassRelationship exemplar = {0};
+				J9ClassRelationship *childEntry = NULL;
+
+				exemplar.className = childName;
+				exemplar.classNameLength = childNameLength;
+				childEntry = hashTableFind(classLoader->classRelationshipsHashTable, &exemplar);
+
+				if (NULL != childEntry) {
+					UDATA parentNameLength = 0;
+					parentName = (U_8 *) vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(parentNameString), J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, parentNameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &parentNameLength);
+
+					if (NULL != parentName) {
+						J9ClassRelationshipNode *currentNode = J9_LINKED_LIST_START_DO(childEntry->root);
+
+						while (NULL != currentNode) {
+							if (J9UTF8_DATA_EQUALS(currentNode->className, currentNode->classNameLength, parentName, parentNameLength)) {
+								isRelationshipRecorded = JNI_TRUE;
+								break;
+							}
+							currentNode = J9_LINKED_LIST_NEXT_DO(childEntry->root, currentNode);
+						}
+					} else {
+						vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+					}
+				}
+			} else {
+				vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+			}
+		}
+	}
+
+done:
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	if ((U_8*) childNameStackBuffer != childName) {
+		j9mem_free_memory(childName);
+	}
+
+	if ((U_8*) parentNameStackBuffer != parentName) {
+		j9mem_free_memory(parentName);
+	}
+
+	return isRelationshipRecorded;
+}

--- a/runtime/tests/bcverify/relationships/module.xml
+++ b/runtime/tests/bcverify/relationships/module.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Copyright (c) 2019, 2019 IBM Corp. and others
+
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which accompanies this
+   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+   or the Apache License, Version 2.0 which accompanies this distribution and
+   is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+   This Source Code may also be made available under the following
+   Secondary Licenses when the conditions for such availability set
+   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+   General Public License, version 2 with the GNU Classpath
+   Exception [1] and GNU General Public License, version 2 with the
+   OpenJDK Assembly Exception [2].
+
+   [1] https://www.gnu.org/software/classpath/license.html
+   [2] http://openjdk.java.net/legal/assembly-exception.html
+
+   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<module>
+	<exports group="all">
+		<export name='Java_org_openj9_test_classRelationshipVerifier_TestClassRelationshipVerifier_isRelationshipRecorded'/>
+	</exports>
+
+	<artifact type="shared" name="bcvrelationships" appendrelease="false">
+		<options>
+			<option name="dllDescription" data="Verifier Test Class Relationships"/>
+		</options>
+		<phase>core j2se</phase>
+		<exports>
+			<group name="all"/>
+		</exports>
+		<flags />
+
+		<includes>
+			<include path="j9include"/>
+			<include path="j9oti"/>
+		</includes>
+		
+		<makefilestubs>
+			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="UMA_DISABLE_DDRGEN=1"/>
+		</makefilestubs>
+
+		<objects>
+			<object name="bcvrelationships"/>
+		</objects>
+
+		<libraries>
+			<library name="j9avl" type="external"/>
+			<library name="j9hashtable" type="external"/>
+			<library name="j9pool" type="external"/>
+			<library name="j9utilcore"/>
+		</libraries>
+	</artifact>
+</module>

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -2308,4 +2308,30 @@
 		</groups>
 	</test>
 
+	<test>
+		<testCaseName>classRelationshipVerifierTests</testCaseName>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)  \
+			-XX:+ClassRelationshipVerifier \
+			-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+			-testnames classRelationshipVerifierTests \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
 </playlist>

--- a/test/functional/Java8andUp/src/org/openj9/test/classRelationshipVerifier/ClassGenerator.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/classRelationshipVerifier/ClassGenerator.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.classRelationshipVerifier;
+
+import org.objectweb.asm.*;
+
+public class ClassGenerator implements Opcodes {
+	/*
+		public class A {
+			public void passBtoAcceptC(B b) {
+				acceptC(b);
+			}
+			public void acceptC(C c) {}
+			public void passBtoAcceptInterfaceC(B b) {
+				acceptInterfaceC(b);
+			}
+			public void acceptInterfaceC(C c) {
+				c.method();
+			}
+		}
+	 */
+	public static byte[] classA_dump() throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(52, ACC_PUBLIC | ACC_SUPER, "A", null, "java/lang/Object", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "passBtoAcceptC", "(LB;)V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitVarInsn(ALOAD, 1);
+			mv.visitMethodInsn(INVOKEVIRTUAL, "A", "acceptC", "(LC;)V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(2, 2);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "acceptC", "(LC;)V", null, null);
+			mv.visitCode();
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 2);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "passBtoAcceptInterfaceC", "(LB;)V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitVarInsn(ALOAD, 1);
+			mv.visitMethodInsn(INVOKEVIRTUAL, "A", "acceptInterfaceC", "(LC;)V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(2, 2);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "acceptInterfaceC", "(LC;)V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 1);
+			mv.visitMethodInsn(INVOKEINTERFACE, "C", "method", "()V", true);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 2);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	 /*
+		public class B {}
+	 */
+	public static byte[] classB_dump() throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(52, ACC_PUBLIC | ACC_SUPER, "B", null, "java/lang/Object", null);
+		{
+		mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ALOAD, 0);
+		mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+		mv.visitInsn(RETURN);
+		mv.visitMaxs(1, 1);
+		mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	/*
+		public class C {}
+	 */
+	public static byte[] classC_dump() throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(52, ACC_PUBLIC | ACC_SUPER, "C", null, "java/lang/Object", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	/*
+		public interface C {
+			public void method();
+		}
+	 */
+	public static byte[] interfaceC_dump() throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(52, ACC_PUBLIC | ACC_ABSTRACT | ACC_INTERFACE, "C", null, "java/lang/Object", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC + ACC_ABSTRACT, "method", "()V", null, null);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	/*
+		public class B extends C {}
+	 */
+	public static byte[] classB_extends_classC_dump() throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(52, ACC_PUBLIC | ACC_SUPER, "B", null, "C", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "C", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+
+	/*
+		public class B implements C {}
+	 */
+	public static byte[] classB_implements_interfaceC_dump() throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(52, ACC_PUBLIC | ACC_SUPER, "B", null, "java/lang/Object", new String[] { "C" });
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+
+		return cw.toByteArray();
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/classRelationshipVerifier/CustomClassLoader.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/classRelationshipVerifier/CustomClassLoader.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.classRelationshipVerifier;
+
+class CustomClassLoader extends ClassLoader {
+	public Class<?> getClass(String name, byte[] bytes) {
+		return defineClass(name, bytes, 0, bytes.length);
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/classRelationshipVerifier/TestClassRelationshipVerifier.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/classRelationshipVerifier/TestClassRelationshipVerifier.java
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.classRelationshipVerifier;
+
+import java.lang.reflect.*;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.objectweb.asm.*;
+
+/**
+ * Definitions:
+ * 	- Caller: the calling class, represented by A
+ * 	- Source: the child class, represented by B
+ * 	- Target: the parent class/interface, represented by C
+ */
+
+@Test(groups = { "level.sanity" })
+public class TestClassRelationshipVerifier {
+	static {
+		try {
+			System.loadLibrary("bcvrelationships");
+		} catch (UnsatisfiedLinkError e) {
+			Assert.fail(e.getMessage() + "\nlibrary path = " + System.getProperty("java.library.path"));
+		}
+	}
+
+	native static boolean isRelationshipRecorded(String sourceClassName, String targetClassName, ClassLoader classLoader);
+
+	/**
+	 * Target class is not loaded, but source class is loaded.
+	 * Check that a relationship is recorded for the source and target classes.
+	 *
+	 * @throws Throwable
+	 */
+	@Test
+	static public void testOnlySourceLoaded() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+		byte[] bytesClassB = ClassGenerator.classB_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+		Class<?> clazzB = classLoader.getClass("B", bytesClassB);
+
+		try {
+			Object instanceB = clazzB.getDeclaredConstructor().newInstance();
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+
+			if (!isRelationshipRecorded("B", "C", classLoader)) {
+				Assert.fail("relationship was not recorded");
+			}
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+	/**
+	 * Source class is not loaded, but target class is loaded.
+	 * Check that a relationship is recorded for the source and target classes.
+	 *
+	 * @throws Throwable
+	 */
+	@Test
+	static public void testOnlyTargetLoaded() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+		byte[] bytesClassC = ClassGenerator.classC_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+		Class<?> clazzC = classLoader.getClass("C", bytesClassC);
+
+		try {
+			Object instanceC = clazzC.getDeclaredConstructor().newInstance();
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+
+			if (!isRelationshipRecorded("B", "C", classLoader)) {
+				Assert.fail("relationship was not recorded");
+			}
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+	/**
+	 * Neither source nor target classes are loaded.
+	 * Check that a relationship is recorded for the source and target classes.
+	 *
+	 * @throws Throwable
+	 */
+	@Test
+	static public void testNeitherLoaded() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+
+		try {
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+
+			if (!isRelationshipRecorded("B", "C", classLoader)) {
+				Assert.fail("relationship was not recorded");
+			}
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+	/**
+	 * Both source and target classes are loaded, and share a relationship.
+	 * Verify that the source class extends the target class.
+	 *
+	 * @throws Throwable
+	 */
+	@Test
+	static public void testSourceSubclassOfTarget() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+		byte[] bytesClassB = ClassGenerator.classB_extends_classC_dump();
+		byte[] bytesClassC = ClassGenerator.classC_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+		Class<?> clazzC = classLoader.getClass("C", bytesClassC);
+		Class<?> clazzB = classLoader.getClass("B", bytesClassB);
+
+		try {
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+			Method passBtoAcceptC = clazzA.getDeclaredMethod("passBtoAcceptC", clazzB);
+			Object instanceB = clazzB.getDeclaredConstructor().newInstance();
+			passBtoAcceptC.invoke(instanceA, instanceB);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+	/**
+	 * Both the source class and the target interface are loaded, and share a relationship.
+	 * Verify that the source class implements the target interface.
+	 *
+	 * @throws Throwable
+	 */
+	@Test
+	static public void testSourceImplementsTarget() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+		byte[] bytesClassB = ClassGenerator.classB_implements_interfaceC_dump();
+		byte[] bytesInterfaceC = ClassGenerator.interfaceC_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+		Class<?> interfaceC = classLoader.getClass("C", bytesInterfaceC);
+		Class<?> clazzB = classLoader.getClass("B", bytesClassB);
+
+		try {
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+			Method passBtoAcceptC = clazzA.getDeclaredMethod("passBtoAcceptC", clazzB);
+			Object instanceB = clazzB.getDeclaredConstructor().newInstance();
+			passBtoAcceptC.invoke(instanceA, instanceB);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+ 	/**
+	 * Both source and target classes are loaded, but are unrelated.
+	 * Verify that the source class is not a subclass of the target class.
+	 *
+	 * @throws Throwable
+	 */
+	@Test(expectedExceptions = java.lang.VerifyError.class)
+	static public void testSourceNotSubclassOfTarget() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+		byte[] bytesClassB = ClassGenerator.classB_dump();
+		byte[] bytesClassC = ClassGenerator.classC_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+		Class<?> clazzB = classLoader.getClass("B", bytesClassB);
+		Class<?> clazzC = classLoader.getClass("C", bytesClassC);
+
+		try {
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+			/**
+			 * Verification should fail since B and C do not share a
+			 * relationship; VerifyError is expected.
+			 */
+			Assert.fail("should throw exception on new instance of Class A");
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+	/**
+	 * Both the source class and the target interface are loaded, but are unrelated.
+	 * Verify that the source class does not implement the target interface.
+	 *
+	 * @throws Throwable
+	 */
+	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class)
+	static public void testSourceDoesNotImplementTarget() throws Throwable {
+		CustomClassLoader classLoader = new CustomClassLoader();
+
+		byte[] bytesClassA = ClassGenerator.classA_dump();
+		byte[] bytesClassB = ClassGenerator.classB_dump();
+		byte[] bytesInterfaceC = ClassGenerator.interfaceC_dump();
+
+		Class<?> clazzA = classLoader.getClass("A", bytesClassA);
+		Class<?> clazzB = classLoader.getClass("B", bytesClassB);
+		Class<?> interfaceC = classLoader.getClass("C", bytesInterfaceC);
+
+		try {
+			Object instanceA = clazzA.getDeclaredConstructor().newInstance();
+			/**
+			 * Verification is permissive for interface targets, so there should 
+			 * be no VerifyError generated.
+			 */
+			Method passBtoAcceptInterfaceC = clazzA.getDeclaredMethod("passBtoAcceptInterfaceC", clazzB);
+			Object instanceB = clazzB.getDeclaredConstructor().newInstance();
+			passBtoAcceptInterfaceC.invoke(instanceA, instanceB);
+			/**
+			 * Source and target types are incompatible (B does not implement C),
+			 * so an IncompatibleClassChangeError is expected to be thrown.
+			 */
+			Assert.fail("should throw exception on invocation of passBtoAcceptInterfaceC");
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/vmcheck/TestLoadingClassesFromJarfile.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/vmcheck/TestLoadingClassesFromJarfile.java
@@ -142,6 +142,7 @@ public class TestLoadingClassesFromJarfile {
 			"java.util.PropertyPermission",
 			"javax.imageio.ImageIO",
 			"javax.swing",
+			"org.openj9.test.classRelationshipVerifier.TestClassRelationshipVerifier",
 			"sun.applet",
 			"sun.awt",
 			"sun.font",

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -462,5 +462,10 @@
 			<class name="org.openj9.test.jdk.internal.agent.Test_FileSystem"/>
 		</classes>
 	</test>
+	<test name="classRelationshipVerifierTests">
+		<classes>
+			<class name="org.openj9.test.classRelationshipVerifier.TestClassRelationshipVerifier"/>
+		</classes>
+	</test>
 </suite>
 <!-- Suite -->


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/7360

TestClassRelationshipVerifier is excluded from TestLoadingClassesFromJarfile (testvmcheck) since it is incompatible with that test and does not benefit from being tested with `-Xverify:all` or `-Xcheck:vm`.

Related:
- Original PR for tests (reverted): https://github.com/eclipse/openj9/pull/7306
- PR for `-XX:[+|-]ClassRelationshipVerifier`: https://github.com/eclipse/openj9/pull/7089

Tests the following cases when `-XX:+ClassRelationshipVerifier` is used:
- only source class loaded
- only target class loaded
- neither target nor source classes loaded
- source is subclass of target
- source implements target
- source is not subclass of target
- source does not implement target