### PR TITLE
Outlining CFG generation from ECS

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -869,29 +869,26 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
       calltarget->_calleeSymbol->setHasThisCalls(true);
 
 
-   //if (callExists)
-   //if (true) // Need to run the below code to inline partially anyway (even if there are no calls in this callee)
-      //{
-      TR_Array<TR_J9ByteCodeIterator::TryCatchInfo> tryCatchInfo(
-            comp()->trMemory(),
-            calltarget->_calleeMethod->numberOfExceptionHandlers(), true,
-            stackAlloc);
+   TR_Array<TR_J9ByteCodeIterator::TryCatchInfo> tryCatchInfo(
+         comp()->trMemory(),
+         calltarget->_calleeMethod->numberOfExceptionHandlers(), true,
+         stackAlloc);
 
-      int32_t i;
-      for (i = calltarget->_calleeMethod->numberOfExceptionHandlers() - 1; i
-            >= 0; --i)
-         {
-         int32_t start, end, type;
-         int32_t handler = calltarget->_calleeMethod->exceptionData(i, &start,
-               &end, &type);
+   int32_t i;
+   for (i = calltarget->_calleeMethod->numberOfExceptionHandlers() - 1; i
+         >= 0; --i)
+      {
+      int32_t start, end, type;
+      int32_t handler = calltarget->_calleeMethod->exceptionData(i, &start,
+            &end, &type);
 
-         flags[start].set(bbStart);
-         flags[end + 1].set(bbStart);
-         flags[handler].set(bbStart);
+      flags[start].set(bbStart);
+      flags[end + 1].set(bbStart);
+      flags[handler].set(bbStart);
 
-         tryCatchInfo[i].initialize((uint16_t) start, (uint16_t) end,
-               (uint16_t) handler, (uint32_t) type);
-         }
+      tryCatchInfo[i].initialize((uint16_t) start, (uint16_t) end,
+            (uint16_t) handler, (uint32_t) type);
+      }
 
       calltarget->_cfg = new (cfgRegion) TR::CFG(comp(), calltarget->_calleeSymbol, cfgRegion);
       TR::CFG &cfg = *(calltarget->_cfg);
@@ -926,186 +923,186 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
          endNodeIndex = 0;
          }
 
-      setupNode(cfg.getStart()->asBlock()->getEntry()->getNode(), 0,
-            calltarget->_calleeMethod, comp());
-      setupNode(cfg.getStart()->asBlock()->getExit()->getNode(), 0,
-            calltarget->_calleeMethod, comp());
-      setupNode(cfg.getEnd()->asBlock()->getEntry()->getNode(),
-            endNodeIndex, calltarget->_calleeMethod, comp());
-      setupNode(cfg.getEnd()->asBlock()->getExit()->getNode(),
-            endNodeIndex, calltarget->_calleeMethod, comp());
+   setupNode(cfg.getStart()->asBlock()->getEntry()->getNode(), 0,
+         calltarget->_calleeMethod, comp());
+   setupNode(cfg.getStart()->asBlock()->getExit()->getNode(), 0,
+         calltarget->_calleeMethod, comp());
+   setupNode(cfg.getEnd()->asBlock()->getEntry()->getNode(),
+         endNodeIndex, calltarget->_calleeMethod, comp());
+   setupNode(cfg.getEnd()->asBlock()->getExit()->getNode(),
+         endNodeIndex, calltarget->_calleeMethod, comp());
 
 
-      debugTrace(tracer(),"PECS: startblock %p %d endblock %p %d",cfg.getStart()->asBlock(), cfg.getStart()->getNumber(), cfg.getEnd()->asBlock(), cfg.getEnd()->getNumber());
+   debugTrace(tracer(),"PECS: startblock %p %d endblock %p %d",cfg.getStart()->asBlock(), cfg.getStart()->getNumber(), cfg.getEnd()->asBlock(), cfg.getEnd()->getNumber());
 
-      bool addFallThruEdge = true;
+   bool addFallThruEdge = true;
 
-      debugTrace(tracer(),"PECS: iterating over bc indexes in CFG creation. maxIndex =%d", maxIndex);
-      int32_t blockStartSize = 0;
-      int32_t startIndex = 0;
-      for (TR_J9ByteCode bc = bci.first(); bc != J9BCunknown; bc = bci.next())
+   debugTrace(tracer(),"PECS: iterating over bc indexes in CFG creation. maxIndex =%d", maxIndex);
+   int32_t blockStartSize = 0;
+   int32_t startIndex = 0;
+   for (TR_J9ByteCode bc = bci.first(); bc != J9BCunknown; bc = bci.next())
+      {
+      int32_t i = bci.bcIndex();
+      if (flags[i].testAny(bbStart))
          {
-         int32_t i = bci.bcIndex();
-         if (flags[i].testAny(bbStart))
+         debugTrace(tracer(),"Calling getBlock.  blocks[%d] = %p", i, blocks[i]);
+         TR::Block * newBlock = getBlock(comp(), blocks,
+               calltarget->_calleeMethod, i, cfg);
+
+         if (i != startIndex)
             {
-            debugTrace(tracer(),"Calling getBlock.  blocks[%d] = %p", i, blocks[i]);
-            TR::Block * newBlock = getBlock(comp(), blocks,
-                  calltarget->_calleeMethod, i, cfg);
+            currentBlock->setBlockSize(bcSizes[i] - blockStartSize);
+            if (cfg.getMethodSymbol())
+               cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
+            }
 
-            if (i != startIndex)
-               {
-               currentBlock->setBlockSize(bcSizes[i] - blockStartSize);
-               if (cfg.getMethodSymbol())
-                  cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
-               }
+         if (addFallThruEdge)
+            {
+            debugTrace(tracer(),"adding a fallthrough edge between block %p %d and %p %d", currentBlock, currentBlock->getNumber(), newBlock, newBlock->getNumber());
+            debugTrace(tracer(),"joining nodes between blocks %p %d and %p %d", currentBlock, currentBlock->getNumber(), newBlock, newBlock->getNumber());
+            currentBlock->getExit()->join(newBlock->getEntry());
+            cfg.addEdge(currentBlock, newBlock);
+            }
+         else
+            {
+            addFallThruEdge = true;
+            }
+         currentBlock = newBlock;
 
-            if (addFallThruEdge)
+         startIndex = i;
+         blockStartSize = bcSizes[i];
+         }
+
+      if (flags[i].testAny(isCold))
+         {
+         partialTrace(tracer(), "Setting block %p[%d] blocks[%d]=%p as cold because bytecode %d was identified as cold",currentBlock, currentBlock->getNumber(), i, blocks[i], i);
+         currentBlock->setIsCold();
+         currentBlock->setFrequency(0);
+         }
+      if (flags[i].testAny(isUnsanitizeable))
+         {
+         partialTrace(tracer(), "Setting unsanitizeable flag on block %p[%d] blocks[%d]=%p",currentBlock, currentBlock->getNumber(), i, blocks[i]);
+         currentBlock->setIsUnsanitizeable();
+         }
+
+      if (flags[i].testAny(isBranch))
+         {
+         if (startIndex != i)
+            {
+            currentBlock->setBlockSize(bcSizes[i] - blockStartSize);
+            if (cfg.getMethodSymbol())
+               cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
+            }
+         else
+            {
+            currentBlock->setBlockSize(1); // if there startIndex is the same as the current index then the block consists only of a branch
+            if (cfg.getMethodSymbol())
+               cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
+            }
+
+         switch (bc)
+            {
+            case J9BCificmpeq:
+            case J9BCificmpne:
+            case J9BCificmplt:
+            case J9BCificmpge:
+            case J9BCificmpgt:
+            case J9BCificmple:
+            case J9BCifacmpeq:
+            case J9BCifacmpne:
+            case J9BCifeq:
+            case J9BCifne:
+            case J9BCiflt:
+            case J9BCifge:
+            case J9BCifgt:
+            case J9BCifle:
+            case J9BCifnull:
+            case J9BCifnonnull:
                {
-               debugTrace(tracer(),"adding a fallthrough edge between block %p %d and %p %d", currentBlock, currentBlock->getNumber(), newBlock, newBlock->getNumber());
-               debugTrace(tracer(),"joining nodes between blocks %p %d and %p %d", currentBlock, currentBlock->getNumber(), newBlock, newBlock->getNumber());
-               currentBlock->getExit()->join(newBlock->getEntry());
-               cfg.addEdge(currentBlock, newBlock);
-               } 
-            else 
-               {
+               debugTrace(tracer(),"if branch.i = %d adding edge between blocks %p %d and %p %d",
+                                    i, currentBlock, currentBlock->getNumber(), getBlock(comp(), blocks, calltarget->_calleeMethod, i+ bci.relativeBranch(), cfg),
+                                    getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg)->getNumber());
+
+               setupLastTreeTop(currentBlock, bc, i, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), calltarget->_calleeMethod, comp());
+               cfg.addEdge(currentBlock, getBlock(comp(), blocks,
+                     calltarget->_calleeMethod, i + bci.relativeBranch(),
+                     cfg));
                addFallThruEdge = true;
+               break;
                }
-            currentBlock = newBlock;
-
-            startIndex = i;
-            blockStartSize = bcSizes[i];
-            }
-
-         if (flags[i].testAny(isCold))
-            {
-            partialTrace(tracer(), "Setting block %p[%d] blocks[%d]=%p as cold because bytecode %d was identified as cold",currentBlock, currentBlock->getNumber(), i, blocks[i], i);
-            currentBlock->setIsCold();
-            currentBlock->setFrequency(0);
-            }
-         if (flags[i].testAny(isUnsanitizeable))
-            {
-            partialTrace(tracer(), "Setting unsanitizeable flag on block %p[%d] blocks[%d]=%p",currentBlock, currentBlock->getNumber(), i, blocks[i]);
-            currentBlock->setIsUnsanitizeable();
-            }
-
-         if (flags[i].testAny(isBranch))
-            {
-            if (startIndex != i)
+            case J9BCgoto:
+            case J9BCgotow:
+               setupLastTreeTop(currentBlock, bc, i, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), calltarget->_calleeMethod, comp());
+               cfg.addEdge(currentBlock, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg));
+               addFallThruEdge = false;
+               break;
+            case J9BCReturnC:
+            case J9BCReturnS:
+            case J9BCReturnB:
+            case J9BCReturnZ:
+            case J9BCgenericReturn:
+            case J9BCathrow:
+               setupLastTreeTop(currentBlock, bc, i, cfg.getEnd()->asBlock(), calltarget->_calleeMethod, comp());
+               cfg.addEdge(currentBlock, cfg.getEnd());
+               addFallThruEdge = false;
+               break;
+            case J9BCtableswitch:
                {
-               currentBlock->setBlockSize(bcSizes[i] - blockStartSize);
-               if (cfg.getMethodSymbol())
-                  cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
-               }
-            else
-               {
-               currentBlock->setBlockSize(1); // if there startIndex is the same as the current index then the block consists only of a branch
-               if (cfg.getMethodSymbol())
-                  cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
-               }
-
-            switch (bc)
-               {
-               case J9BCificmpeq:
-               case J9BCificmpne:
-               case J9BCificmplt:
-               case J9BCificmpge:
-               case J9BCificmpgt:
-               case J9BCificmple:
-               case J9BCifacmpeq:
-               case J9BCifacmpne:
-               case J9BCifeq:
-               case J9BCifne:
-               case J9BCiflt:
-               case J9BCifge:
-               case J9BCifgt:
-               case J9BCifle:
-               case J9BCifnull:
-               case J9BCifnonnull:
-                  {
-                  debugTrace(tracer(),"if branch.i = %d adding edge between blocks %p %d and %p %d",
-                                       i, currentBlock, currentBlock->getNumber(), getBlock(comp(), blocks, calltarget->_calleeMethod, i+ bci.relativeBranch(), cfg),
-                                       getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg)->getNumber());
-
-                  setupLastTreeTop(currentBlock, bc, i, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), calltarget->_calleeMethod, comp());
+               int32_t index = bci.defaultTargetIndex();
+               TR::Block *defaultBlock = getBlock(comp(), blocks,
+               calltarget->_calleeMethod, i + bci.nextSwitchValue(
+                           index), cfg);
+               setupLastTreeTop(currentBlock, bc, i, defaultBlock,
+                     calltarget->_calleeMethod, comp());
+               cfg.addEdge(currentBlock, defaultBlock);
+               int32_t low = bci.nextSwitchValue(index);
+               int32_t high = bci.nextSwitchValue(index) - low + 1;
+               for (int32_t j = 0; j < high; ++j)
                   cfg.addEdge(currentBlock, getBlock(comp(), blocks,
-                        calltarget->_calleeMethod, i + bci.relativeBranch(),
-                        cfg));
-                  addFallThruEdge = true;
-                  break;
-                  }
-               case J9BCgoto:
-               case J9BCgotow:
-                  setupLastTreeTop(currentBlock, bc, i, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg));
-                  addFallThruEdge = false;
-                  break;
-               case J9BCReturnC:
-               case J9BCReturnS:
-               case J9BCReturnB:
-               case J9BCReturnZ:
-               case J9BCgenericReturn:
-               case J9BCathrow:
-                  setupLastTreeTop(currentBlock, bc, i, cfg.getEnd()->asBlock(), calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, cfg.getEnd());
-                  addFallThruEdge = false;
-                  break;
-               case J9BCtableswitch:
-                  {
-                  int32_t index = bci.defaultTargetIndex();
-                  TR::Block *defaultBlock = getBlock(comp(), blocks,
                         calltarget->_calleeMethod, i + bci.nextSwitchValue(
-                              index), cfg);
-                  setupLastTreeTop(currentBlock, bc, i, defaultBlock,
-                        calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, defaultBlock);
-                  int32_t low = bci.nextSwitchValue(index);
-                  int32_t high = bci.nextSwitchValue(index) - low + 1;
-                  for (int32_t j = 0; j < high; ++j)
-                     cfg.addEdge(currentBlock, getBlock(comp(), blocks,
-                           calltarget->_calleeMethod, i + bci.nextSwitchValue(
-                                 index), cfg));
-                  addFallThruEdge = false;
-                  break;
-                  }
-               case J9BClookupswitch:
-                  {
-                  int32_t index = bci.defaultTargetIndex();
-                  TR::Block *defaultBlock = getBlock(comp(), blocks,
-                        calltarget->_calleeMethod, i + bci.nextSwitchValue(
-                              index), cfg);
-                  setupLastTreeTop(currentBlock, bc, i, defaultBlock,
-                        calltarget->_calleeMethod, comp());
-                  cfg.addEdge(currentBlock, defaultBlock);
-                  int32_t tableSize = bci.nextSwitchValue(index);
-                  for (int32_t j = 0; j < tableSize; ++j)
-                     {
-                     index += 4; // match value
-                     cfg.addEdge(currentBlock, getBlock(comp(), blocks,
-                           calltarget->_calleeMethod, i + bci.nextSwitchValue(
-                                 index), cfg));
-                     }
-                  addFallThruEdge = false;
-                  break;
-                  }
-               default:
-               	break;
+                              index), cfg));
+               addFallThruEdge = false;
+               break;
                }
+            case J9BClookupswitch:
+               {
+               int32_t index = bci.defaultTargetIndex();
+               TR::Block *defaultBlock = getBlock(comp(), blocks,
+                     calltarget->_calleeMethod, i + bci.nextSwitchValue(
+                           index), cfg);
+               setupLastTreeTop(currentBlock, bc, i, defaultBlock,
+                     calltarget->_calleeMethod, comp());
+               cfg.addEdge(currentBlock, defaultBlock);
+               int32_t tableSize = bci.nextSwitchValue(index);
+               for (int32_t j = 0; j < tableSize; ++j)
+                  {
+                  index += 4; // match value
+                  cfg.addEdge(currentBlock, getBlock(comp(), blocks,
+                        calltarget->_calleeMethod, i + bci.nextSwitchValue(
+                              index), cfg));
+                  }
+               addFallThruEdge = false;
+               break;
+               }
+            default:
+               break;
             }
-         //      printf("Iterating through sizes array.  bcSizes[%d] = %d maxIndex = %d\n",i,bcSizes[i],maxIndex);
          }
+      //      printf("Iterating through sizes array.  bcSizes[%d] = %d maxIndex = %d\n",i,bcSizes[i],maxIndex);
+      }
 
-      for (i = 0; i < (int32_t) tryCatchInfo.size(); ++i)
-         {
-         TR_J9ByteCodeIterator::TryCatchInfo * handlerInfo = &tryCatchInfo[i];
+   for (i = 0; i < (int32_t) tryCatchInfo.size(); ++i)
+      {
+      TR_J9ByteCodeIterator::TryCatchInfo * handlerInfo = &tryCatchInfo[i];
 
-         blocks[handlerInfo->_handlerIndex]->setHandlerInfoWithOutBCInfo(
-               handlerInfo->_catchType, 0, handlerInfo->_handlerIndex,
-               calltarget->_calleeMethod, comp());
+      blocks[handlerInfo->_handlerIndex]->setHandlerInfoWithOutBCInfo(
+            handlerInfo->_catchType, 0, handlerInfo->_handlerIndex,
+            calltarget->_calleeMethod, comp());
 
-         for (int32_t j = handlerInfo->_startIndex; j <= handlerInfo->_endIndex; ++j)
-            if (blocks[j])
-               cfg.addExceptionEdge(blocks[j], blocks[handlerInfo->_handlerIndex]);
-         }
+      for (int32_t j = handlerInfo->_startIndex; j <= handlerInfo->_endIndex; ++j)
+         if (blocks[j])
+            cfg.addExceptionEdge(blocks[j], blocks[handlerInfo->_handlerIndex]);
+      }
 
 
 
@@ -1245,7 +1242,6 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
 
    TR::CFG &cfg = processBytecodeAndGenerateCFG(calltarget, cfgRegion, bci, nph, blocks, flags);
-
    int size = calltarget->_fullSize;
 
    // Adjust call frequency for unknown or direct calls, for which we don't get profiling information
@@ -1275,267 +1271,266 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       cfg._calledFrequency = 10000;
       }
 
-      cfg.propagateColdInfo(callGraphEnabled); // propagate coldness but also generate frequency information
-      // for blocks if call graph profiling is enabled
+   cfg.propagateColdInfo(callGraphEnabled); // propagate coldness but also generate frequency information
+   // for blocks if call graph profiling is enabled
 
-      if (tracer()->heuristicLevel())
+   if (tracer()->heuristicLevel())
+      {
+      heuristicTrace(tracer(), "After propagating the coldness info\n");
+      heuristicTrace(tracer(), "<cfg>");
+      for (TR::CFGNode* node = cfg.getFirstNode(); node; node = node->getNext())
          {
-         heuristicTrace(tracer(), "After propagating the coldness info\n");
-         heuristicTrace(tracer(), "<cfg>");
-         for (TR::CFGNode* node = cfg.getFirstNode(); node; node = node->getNext())
-            {
-            comp()->findOrCreateDebug()->print(comp()->getOutFile(), node, 6);
-            }
-         heuristicTrace(tracer(), "</cfg>");
+         comp()->findOrCreateDebug()->print(comp()->getOutFile(), node, 6);
          }
+      heuristicTrace(tracer(), "</cfg>");
+      }
 
 
-      TR_prevArgs pca;
-      TR::Block *currentInlinedBlock = NULL;
-      TR_J9ByteCode bc = bci.first(), nextBC;
-      if (wasPeekingSuccessfull
-          && comp()->getOrCreateKnownObjectTable()
-          && calltarget->_calleeMethod->convertToMethod()->isArchetypeSpecimen())
+   TR_prevArgs pca;
+   TR::Block *currentInlinedBlock = NULL;
+   TR_J9ByteCode bc = bci.first(), nextBC;
+   if (wasPeekingSuccessfull
+       && comp()->getOrCreateKnownObjectTable()
+       && calltarget->_calleeMethod->convertToMethod()->isArchetypeSpecimen())
+      {
+      // call sites in method handle thunks are created from trees so skip bytecode iteration below
+      bc = J9BCunknown;
+      TR::NodeChecklist visited(comp());
+      for (TR::TreeTop* tt = methodSymbol->getFirstTreeTop(); tt; tt = tt->getNextTreeTop())
          {
-         // call sites in method handle thunks are created from trees so skip bytecode iteration below
-         bc = J9BCunknown;
-         TR::NodeChecklist visited(comp());
-         for (TR::TreeTop* tt = methodSymbol->getFirstTreeTop(); tt; tt = tt->getNextTreeTop())
-            {
-            if (tt->getNode()->getOpCodeValue() == TR::BBStart)
-               /*
-                * TODO: we should use the proper block with correct block frequency info
-                * but profiling for method handle thunks doesn't work yet
-                */
-               currentInlinedBlock = tt->getEnclosingBlock();
+         if (tt->getNode()->getOpCodeValue() == TR::BBStart)
+         /*
+          * TODO: we should use the proper block with correct block frequency info
+          * but profiling for method handle thunks doesn't work yet
+          */
+         currentInlinedBlock = tt->getEnclosingBlock();
 
-            if (tt->getNode()->getNumChildren()>0 &&
-                tt->getNode()->getFirstChild()->getOpCode().isCall())
+         if (tt->getNode()->getNumChildren()>0 &&
+             tt->getNode()->getFirstChild()->getOpCode().isCall())
+            {
+            TR::Node* parent = tt->getNode();
+            TR::Node* callNode = tt->getNode()->getFirstChild();
+            TR::SymbolReference* symRef =  callNode->getSymbolReference();
+            if (!callNode->getSymbolReference()->isUnresolved() && !visited.contains(callNode))
                {
-               TR::Node* parent = tt->getNode();
-               TR::Node* callNode = tt->getNode()->getFirstChild();
-               TR::SymbolReference* symRef =  callNode->getSymbolReference();
-               if (!callNode->getSymbolReference()->isUnresolved() && !visited.contains(callNode))
+               int i = callNode->getByteCodeIndex();
+               visited.add(callNode);
+               TR_ResolvedMethod* resolvedMethod = callNode->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod();
+               TR::RecognizedMethod rm = resolvedMethod->getRecognizedMethod();
+
+               TR_CallSite *callsite = TR_CallSite::create(tt, parent, callNode,
+                                                         resolvedMethod->classOfMethod(), symRef, resolvedMethod,
+                                                         comp(), comp()->trMemory() , heapAlloc, calltarget->_calleeMethod, _recursionDepth, false);
+
+               TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+
+               callsite->_callerBlock = currentInlinedBlock;
+               if (isInlineable(&callStack, callsite))
                   {
-                  int i = callNode->getByteCodeIndex();
-                  visited.add(callNode);
-                  TR_ResolvedMethod* resolvedMethod = callNode->getSymbol()->getResolvedMethodSymbol()->getResolvedMethod();
-                  TR::RecognizedMethod rm = resolvedMethod->getRecognizedMethod();
+                  callSites[i] = callsite;
+                  inlineableCallExists = true;
 
-                  TR_CallSite *callsite = TR_CallSite::create(tt, parent, callNode,
-                                                            resolvedMethod->classOfMethod(), symRef, resolvedMethod,
-                                                            comp(), comp()->trMemory() , heapAlloc, calltarget->_calleeMethod, _recursionDepth, false);
-
-                  TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
-
-                  callsite->_callerBlock = currentInlinedBlock;
-                  if (isInlineable(&callStack, callsite))
-                     {
-                     callSites[i] = callsite;
-                     inlineableCallExists = true;
-
-                     if (!currentInlinedBlock->isCold())
-                          nonColdCallExists = true;
-                     for (int j = 0; j < callSites[i]->numTargets(); j++)
-                        callSites[i]->getTarget(j)->_originatingBlock = currentInlinedBlock;
-                     }
-                  else
-                     {
-                     //support counters
-                     calltarget->addDeadCallee(callsite);
-                     }
-                  flags[i].set(isUnsanitizeable);
+                  if (!currentInlinedBlock->isCold())
+                      nonColdCallExists = true;
+                  for (int j = 0; j < callSites[i]->numTargets(); j++)
+                      callSites[i]->getTarget(j)->_originatingBlock = currentInlinedBlock;
                   }
-               }
-            }
-         }
-
-      for (; bc != J9BCunknown; bc = bci.next())
-         {
-         TR_ResolvedMethod * resolvedMethod;
-         int32_t cpIndex;
-         bool isVolatile, isPrivate, isUnresolvedInCP, resolved;
-         TR::DataType type = TR::NoType;
-         void * staticAddress;
-         uint32_t fieldOffset;
-
-         newBCInfo.setByteCodeIndex(bci.bcIndex());
-         int32_t i = bci.bcIndex();
-
-         if (flags[i].testAny(bbStart))
-            {
-            currentInlinedBlock = getBlock(comp(), blocks,
-                  calltarget->_calleeMethod, i, cfg);
-            debugTrace(tracer(),"Found current block %p, number %d\n", currentInlinedBlock, (currentInlinedBlock) ? currentInlinedBlock->getNumber() : -1);
-            }
-
-         switch (bc)
-            {
-            case J9BCinvokedynamic:
-               {
-               cpIndex = bci.next2Bytes();
-               bool isInterface = false;
-               bool isIndirectCall = false;
-               TR::Method *interfaceMethod = 0;
-               TR::TreeTop *callNodeTreeTop = 0;
-               TR::Node *parent = 0;
-               TR::Node *callNode = 0;
-               TR::ResolvedMethodSymbol *resolvedSymbol = 0;
-
-               TR_ResolvedMethod * owningMethod = methodSymbol->getResolvedMethod();
-               TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-               if (knot && !owningMethod->isUnresolvedCallSiteTableEntry(cpIndex))
+               else
                   {
-                  isIndirectCall = true;
-                  uintptrj_t *entryLocation = (uintptrj_t*)owningMethod->callSiteTableEntryAddress(cpIndex);
-                  // Add callsite handle to known object table
-                  knot->getIndexAt((uintptrj_t*)entryLocation);
-                  resolvedMethod = comp()->fej9()->createMethodHandleArchetypeSpecimen(comp()->trMemory(), entryLocation, owningMethod);
-                  bool allconsts= false;
-
-                  heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-                  if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
-                     allconsts = true;
-
-                  TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite( callStack._method, callNodeTreeTop,   parent,
-                                                                                    callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                                    (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
-                                                                                    resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
-                                                                                    _recursionDepth, allconsts);
-
-                  TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
-                  callsite->_callerBlock = currentInlinedBlock;
-                  if (isInlineable(&callStack, callsite))
-                     {
-                     callSites[i] = callsite;
-                     inlineableCallExists = true;
-
-                     if (!currentInlinedBlock->isCold())
-                          nonColdCallExists = true;
-
-                     if (wasPeekingSuccessfull)
-                        {
-                        TR_PrexArgInfo::propagateArgsFromCaller(methodSymbol, callsite, argInfo, tracer());
-                        if (tracer()->heuristicLevel())
-                           {
-                           alwaysTrace(tracer(), "propagateArgs :");
-                           if (callsite->numTargets() && callsite->getTarget(0)->_ecsPrexArgInfo)
-                              tracer()->dumpPrexArgInfo(callsite->getTarget(0)->_ecsPrexArgInfo);
-                           }
-                        }
-                     }
-                  else
-                     //support counters
-                     calltarget->addDeadCallee(callsite);
-
+                  //support counters
+                  calltarget->addDeadCallee(callsite);
                   }
-               }
                flags[i].set(isUnsanitizeable);
-               break;
+               }
+            }
+         }
+      }
 
-            case J9BCinvokevirtual:
+   for (; bc != J9BCunknown; bc = bci.next())
+      {
+      TR_ResolvedMethod * resolvedMethod;
+      int32_t cpIndex;
+      bool isVolatile, isPrivate, isUnresolvedInCP, resolved;
+      TR::DataType type = TR::NoType;
+      void * staticAddress;
+      uint32_t fieldOffset;
+
+      newBCInfo.setByteCodeIndex(bci.bcIndex());
+      int32_t i = bci.bcIndex();
+
+      if (flags[i].testAny(bbStart))
+         {
+         currentInlinedBlock = getBlock(comp(), blocks,
+               calltarget->_calleeMethod, i, cfg);
+         debugTrace(tracer(),"Found current block %p, number %d\n", currentInlinedBlock, (currentInlinedBlock) ? currentInlinedBlock->getNumber() : -1);
+         }
+
+      switch (bc)
+         {
+         case J9BCinvokedynamic:
+            {
+            cpIndex = bci.next2Bytes();
+            bool isInterface = false;
+            bool isIndirectCall = false;
+            TR::Method *interfaceMethod = 0;
+            TR::TreeTop *callNodeTreeTop = 0;
+            TR::Node *parent = 0;
+            TR::Node *callNode = 0;
+            TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+
+            TR_ResolvedMethod * owningMethod = methodSymbol->getResolvedMethod();
+            TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
+            if (knot && !owningMethod->isUnresolvedCallSiteTableEntry(cpIndex))
                {
-               cpIndex = bci.next2Bytes();
-               auto calleeMethod = (TR_ResolvedJ9Method*)calltarget->_calleeMethod;
-               resolvedMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, true, &isUnresolvedInCP);
-               bool isIndirectCall =
-                  resolvedMethod == NULL
-                  || (!resolvedMethod->isFinal() && !resolvedMethod->isPrivate());
-               bool isInterface = false;
-               TR::Method *interfaceMethod = 0;
-               TR::TreeTop *callNodeTreeTop = 0;
-               TR::Node *parent = 0;
-               TR::Node *callNode = 0;
-               TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+               isIndirectCall = true;
+               uintptrj_t *entryLocation = (uintptrj_t*)owningMethod->callSiteTableEntryAddress(cpIndex);
+               // Add callsite handle to known object table
+               knot->getIndexAt((uintptrj_t*)entryLocation);
+               resolvedMethod = comp()->fej9()->createMethodHandleArchetypeSpecimen(comp()->trMemory(), entryLocation, owningMethod);
+               bool allconsts= false;
 
-               ///if (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), true))
-               if ((isUnresolvedInCP && !resolvedMethod) || (resolvedMethod && resolvedMethod->isCold(comp(), true)))
+               heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
+               if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+                  allconsts = true;
+
+               TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite( callStack._method, callNodeTreeTop,   parent,
+                                                                                 callNode, interfaceMethod, resolvedMethod->classOfMethod(),
+                                                                                 (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                                 resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
+                                                                                 _recursionDepth, allconsts);
+
+               TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+               callsite->_callerBlock = currentInlinedBlock;
+               if (isInlineable(&callStack, callsite))
                   {
-                  if(tracer()->heuristicLevel())
-                      {
-                      if(resolvedMethod)
-                         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
-                      else
-                         {
-                         TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
-                         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
-                         }
-                      }
-                  if (unresolvedSymbolsAreCold)
-                     flags[i].set(isCold);
-                  _isLeaf = false;
-                  }
-               else if (resolvedMethod)
-                  {
-                  bool allconsts= false;
+                  callSites[i] = callsite;
+                  inlineableCallExists = true;
 
-
-                  heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-                  if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
-                     allconsts = true;
-
-
-                  TR_CallSite *callsite;
-
-                  if (resolvedMethod->convertToMethod()->isArchetypeSpecimen() && resolvedMethod->getMethodHandleLocation())
-                     {
-                     callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite( callStack._method, callNodeTreeTop,   parent,
-                                                                                    callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                                    (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
-                                                                                    resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
-                                                                                    _recursionDepth, allconsts);
-                     }
-                  else if (resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact)
-                     {
-                     callsite = new (comp()->trHeapMemory()) TR_J9MutableCallSite( callStack._method, callNodeTreeTop,   parent,
-                                                                  callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                  (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
-                                                                  resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
-                                                                  _recursionDepth, allconsts);
-                     }
-                  else if (isIndirectCall)
-                     {
-                     callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite( callStack._method, callNodeTreeTop, parent,
-                                                                                    callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                                    (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
-                                                                                    resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
-                                                                                    _recursionDepth, allconsts);
-
-                     }
-                        else
-                            {
-                            callsite = new (comp()->trHeapMemory()) TR_DirectCallSite( callStack._method, callNodeTreeTop, parent,
-                                                                                    callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                                    (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
-                                                                                    resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
-                                                                                    _recursionDepth, allconsts);
-
-                            }
-
-
-                  if(tracer()->debugLevel())
-                     {
-                     pca.printIndexes(comp());
-                     }
-
-                  TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+                  if (!currentInlinedBlock->isCold())
+                       nonColdCallExists = true;
 
                   if (wasPeekingSuccessfull)
                      {
-                     TR_PrexArgInfo::propagateReceiverInfoIfAvailable(methodSymbol, callsite, argInfo, tracer());
+                     TR_PrexArgInfo::propagateArgsFromCaller(methodSymbol, callsite, argInfo, tracer());
                      if (tracer()->heuristicLevel())
                         {
-                        alwaysTrace(tracer(), "propagateReceiverInfoIfAvailable :");
-                        if (callsite->_ecsPrexArgInfo)
-                           tracer()->dumpPrexArgInfo(callsite->_ecsPrexArgInfo);
+                        alwaysTrace(tracer(), "propagateArgs :");
+                        if (callsite->numTargets() && callsite->getTarget(0)->_ecsPrexArgInfo)
+                           tracer()->dumpPrexArgInfo(callsite->getTarget(0)->_ecsPrexArgInfo);
                         }
                      }
+                  }
+               else
+                  //support counters
+                  calltarget->addDeadCallee(callsite);
 
-                  callsite->_callerBlock = currentInlinedBlock;
-                  if (isInlineable(&callStack, callsite))
+               }
+            flags[i].set(isUnsanitizeable);
+            break;
+            }
+
+         case J9BCinvokevirtual:
+            {
+            cpIndex = bci.next2Bytes();
+            auto calleeMethod = (TR_ResolvedJ9Method*)calltarget->_calleeMethod;
+            resolvedMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, true, &isUnresolvedInCP);
+            bool isIndirectCall =
+               resolvedMethod == NULL
+               || (!resolvedMethod->isFinal() && !resolvedMethod->isPrivate());
+            bool isInterface = false;
+            TR::Method *interfaceMethod = 0;
+            TR::TreeTop *callNodeTreeTop = 0;
+            TR::Node *parent = 0;
+            TR::Node *callNode = 0;
+            TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+            ///if (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), true))
+            if ((isUnresolvedInCP && !resolvedMethod) || (resolvedMethod && resolvedMethod->isCold(comp(), true)))
+               {
+               if(tracer()->heuristicLevel())
+                  {
+                  if(resolvedMethod)
+                     heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
+                  else
                      {
-                     callSites[i] = callsite;
-                     inlineableCallExists = true;
+                     TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                     heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
+                     }
+                  }
+               if (unresolvedSymbolsAreCold)
+                  flags[i].set(isCold);
+                  _isLeaf = false;
+               }
+            else if (resolvedMethod)
+               {
+               bool allconsts= false;
+
+
+               heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
+               if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+                  allconsts = true;
+
+
+               TR_CallSite *callsite;
+
+               if (resolvedMethod->convertToMethod()->isArchetypeSpecimen() && resolvedMethod->getMethodHandleLocation())
+                  {
+                  callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite( callStack._method, callNodeTreeTop,   parent,
+                                                                                 callNode, interfaceMethod, resolvedMethod->classOfMethod(),
+                                                                                 (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                                 resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
+                                                                                 _recursionDepth, allconsts);
+                  }
+               else if (resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact)
+                  {
+                  callsite = new (comp()->trHeapMemory()) TR_J9MutableCallSite( callStack._method, callNodeTreeTop,   parent,
+                                                               callNode, interfaceMethod, resolvedMethod->classOfMethod(),
+                                                               (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                               resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
+                                                               _recursionDepth, allconsts);
+                  }
+               else if (isIndirectCall)
+                  {
+                  callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite( callStack._method, callNodeTreeTop, parent,
+                                                                                 callNode, interfaceMethod, resolvedMethod->classOfMethod(),
+                                                                                 (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                                 resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
+                                                                                 _recursionDepth, allconsts);
+
+                  }
+               else
+                  {
+                  callsite = new (comp()->trHeapMemory()) TR_DirectCallSite( callStack._method, callNodeTreeTop, parent,
+                                                                                 callNode, interfaceMethod, resolvedMethod->classOfMethod(),
+                                                                                 (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                                 resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
+                                                                                 _recursionDepth, allconsts);
+
+                  }
+
+
+               if(tracer()->debugLevel())
+                  {
+                  pca.printIndexes(comp());
+                  }
+
+               TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+
+               if (wasPeekingSuccessfull)
+                  {
+                  TR_PrexArgInfo::propagateReceiverInfoIfAvailable(methodSymbol, callsite, argInfo, tracer());
+                  if (tracer()->heuristicLevel())
+                     {
+                     alwaysTrace(tracer(), "propagateReceiverInfoIfAvailable :");
+                     if (callsite->_ecsPrexArgInfo)
+                        tracer()->dumpPrexArgInfo(callsite->_ecsPrexArgInfo);
+                     }
+                  }
+
+              callsite->_callerBlock = currentInlinedBlock;
+              if (isInlineable(&callStack, callsite))
+                  {
+                  callSites[i] = callsite;
+                  inlineableCallExists = true;
 
                   if (wasPeekingSuccessfull)
                      {
@@ -1554,13 +1549,13 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   else
                      //support counters
                      calltarget->addDeadCallee(callsite);
-                  }
                }
-               flags[i].set(isUnsanitizeable);
-               break;
+            flags[i].set(isUnsanitizeable);
+            break;
+            }
 
-            case J9BCinvokespecial:
-            case J9BCinvokespecialsplit:
+         case J9BCinvokespecial:
+         case J9BCinvokespecialsplit:
             {
             cpIndex = bci.next2Bytes();
             resolvedMethod = calltarget->_calleeMethod->getResolvedSpecialMethod(comp(), (bc == J9BCinvokespecialsplit)?cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
@@ -1572,206 +1567,103 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
             TR::Node *callNode = 0;
             TR::ResolvedMethodSymbol *resolvedSymbol = 0;
             if (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), false))
-                  {
-                  if(tracer()->heuristicLevel())
-                      {
-                      if(resolvedMethod)
-                         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
-                      else
-                         {
-                         if (bc == J9BCinvokespecialsplit)
-                            cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
-                         TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
-                         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
-                         }
-                      }
-                  if (unresolvedSymbolsAreCold)
-                     flags[i].set(isCold);
-                  _isLeaf = false;
-                  }
-               else
-                  {
-                  bool allconsts= false;
-
-                  heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-                  if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
-                     allconsts = true;
-
-                  TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite( callStack._method, callNodeTreeTop, parent,
-                                                                                    callNode, interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
-                                                                                    resolvedMethod, resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
-                                                                                    _recursionDepth, allconsts);
-
-                  TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
-                  callsite->_callerBlock = currentInlinedBlock;
-
-                  if (isInlineable(&callStack, callsite))
-                     {
-
-                     if (wasPeekingSuccessfull)
-                        {
-                        TR_PrexArgInfo::propagateArgsFromCaller(methodSymbol, callsite, argInfo, tracer());
-                        }
-
-                     callSites[i] = callsite;
-                     inlineableCallExists = true;
-                     if (!currentInlinedBlock->isCold())
-                          nonColdCallExists = true;
-                     }
-                  else
-                     calltarget->addDeadCallee(callsite);
-                  }
-               }
-               flags[i].set(isUnsanitizeable);
-               break;
-
-            case J9BCinvokestatic:
-            case J9BCinvokestaticsplit:
                {
-               cpIndex = bci.next2Bytes();
-               resolvedMethod = calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (bc == J9BCinvokestaticsplit)?cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
-               bool isIndirectCall = false;
-               bool isInterface = false;
-               TR::Method *interfaceMethod = 0;
-               TR::TreeTop *callNodeTreeTop = 0;
-               TR::Node *parent = 0;
-               TR::Node *callNode = 0;
-               TR::ResolvedMethodSymbol *resolvedSymbol = 0;
-               if (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), false))
-                  {
-                  if (unresolvedSymbolsAreCold)
-                     flags[i].set(isCold);
-                  if(tracer()->heuristicLevel())
+               if(tracer()->heuristicLevel())
+                   {
+                   if(resolvedMethod)
+                      heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
+                   else
                       {
-                      if(resolvedMethod)
-                         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
-                      else
-                         {
-                         if (bc == J9BCinvokestaticsplit)
-                            cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
-                         TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
-                         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
-                         }
+                      if (bc == J9BCinvokespecialsplit)
+                         cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
+                      TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                      heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
                       }
-                  }
-               else
-                  {
-                  bool allconsts= false;
-
-                  heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
-                  if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
-                     allconsts = true;
-
-                  TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite( callStack._method, callNodeTreeTop, parent, callNode, interfaceMethod,
-                                                                                    resolvedMethod->classOfMethod(), -1, cpIndex, resolvedMethod, resolvedSymbol,
-                                                                                    isIndirectCall, isInterface, newBCInfo, _inliner->comp(),
-                                                                                    _recursionDepth, allconsts);
-
-                  TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
-                  callsite->_callerBlock = currentInlinedBlock;
-                  if (isInlineable(&callStack, callsite))
-                     {
-
-                     if (wasPeekingSuccessfull)
-                        {
-                        TR_PrexArgInfo::propagateArgsFromCaller(methodSymbol, callsite, argInfo, tracer());
-                        }
-
-                     callSites[i] = callsite;
-                     inlineableCallExists = true;
-                     if (!currentInlinedBlock->isCold())
-                        nonColdCallExists = true;
-                     }
-                  else
-                     calltarget->addDeadCallee(callsite);
-                  }
+                   }
+               if (unresolvedSymbolsAreCold)
+                  flags[i].set(isCold);
+               _isLeaf = false;
                }
-               flags[i].set(isUnsanitizeable);
-               break;
-
-            case J9BCinvokeinterface:
+            else
                {
-               cpIndex = bci.next2Bytes();
-
-               auto calleeMethod = (TR_ResolvedJ9Method*)calltarget->_calleeMethod;
-               resolvedMethod = calleeMethod->getResolvedImproperInterfaceMethod(comp(), cpIndex);
-               bool isIndirectCall = true;
-               bool isInterface = true;
-               if (resolvedMethod != NULL)
-                  {
-                  isInterface = false;
-                  isIndirectCall =
-                     !resolvedMethod->isPrivate()
-                     && !resolvedMethod->convertToMethod()->isFinalInObject();
-                  }
-
-               TR::Method * interfaceMethod = NULL;
-               if (isInterface)
-                  interfaceMethod = comp()->fej9()->createMethod( comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
-
-               TR::TreeTop *callNodeTreeTop = 0;
-               TR::Node *parent = 0;
-               TR::Node *callNode = 0;
-               TR::ResolvedMethodSymbol *resolvedSymbol = 0;
-
-               uint32_t explicitParams = 0;
-               if (isInterface)
-                  explicitParams = interfaceMethod->numberOfExplicitParameters();
-               else
-                  explicitParams = resolvedMethod->numberOfExplicitParameters();
-
                bool allconsts= false;
-               heuristicTrace(tracer(), "numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n", explicitParams, pca.getNumPrevConstArgs(explicitParams));
-               if (explicitParams > 0 && explicitParams <= pca.getNumPrevConstArgs(explicitParams))
+
+               heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
+               if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
                   allconsts = true;
 
-               TR_CallSite *callsite = NULL;
-               if (isInterface)
-                  {
-                  TR_OpaqueClassBlock * thisClass = NULL;
-                  callsite = new (comp()->trHeapMemory()) TR_J9InterfaceCallSite(
-                     callStack._method, callNodeTreeTop, parent, callNode,
-                     interfaceMethod, thisClass, -1, cpIndex, resolvedMethod,
-                     resolvedSymbol, isIndirectCall, isInterface, newBCInfo,
-                     comp(), _recursionDepth, allconsts);
-                  }
-               else if (isIndirectCall)
-                  {
-                  callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(
-                     callStack._method, callNodeTreeTop, parent, callNode,
-                     interfaceMethod, resolvedMethod->classOfMethod(), (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex,
-                     resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
-                     newBCInfo, comp(), _recursionDepth, allconsts);
-                  }
-               else
-                  {
-                  callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(
-                     callStack._method, callNodeTreeTop, parent, callNode,
-                     interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
-                     resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
-                     newBCInfo, comp(), _recursionDepth, allconsts);
-                  }
+               TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite( callStack._method, callNodeTreeTop, parent,
+                                                                                 callNode, interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
+                                                                                 resolvedMethod, resolvedSymbol, isIndirectCall, isInterface, newBCInfo, comp(),
+                                                                                 _recursionDepth, allconsts);
 
-              if(tracer()->debugLevel())
-                 {
-                 pca.printIndexes(comp());
-                 }
-              if(isInterface && pca.isArgAtIndexReceiverObject(interfaceMethod->numberOfExplicitParameters()))
+               TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+               callsite->_callerBlock = currentInlinedBlock;
+
+               if (isInlineable(&callStack, callsite))
                   {
-                  //heuristicTrace(tracer(),"Arg at index %d is receiver object.  Propagating prexarginfo",interfaceMethod->numberOfExplicitParameters());
-                  //callsite->_ecsPrexArgInfo = calltarget->_ecsPrexArgInfo;
-                  }
-
-
-                  TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
 
                   if (wasPeekingSuccessfull)
                      {
-                     TR_PrexArgInfo::propagateReceiverInfoIfAvailable(methodSymbol, callsite, argInfo, tracer());
+                     TR_PrexArgInfo::propagateArgsFromCaller(methodSymbol, callsite, argInfo, tracer());
                      }
 
-               callsite->_callerBlock = currentInlinedBlock;
+                  callSites[i] = callsite;
+                  inlineableCallExists = true;
+                  if (!currentInlinedBlock->isCold())
+                       nonColdCallExists = true;
+                  }
+               else
+                  calltarget->addDeadCallee(callsite);
+               }
+            flags[i].set(isUnsanitizeable);
+            break;
+            }
 
+         case J9BCinvokestatic:
+         case J9BCinvokestaticsplit:
+            {
+            cpIndex = bci.next2Bytes();
+            resolvedMethod = calltarget->_calleeMethod->getResolvedStaticMethod(comp(), (bc == J9BCinvokestaticsplit)?cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG:cpIndex, &isUnresolvedInCP);
+            bool isIndirectCall = false;
+            bool isInterface = false;
+            TR::Method *interfaceMethod = 0;
+            TR::TreeTop *callNodeTreeTop = 0;
+            TR::Node *parent = 0;
+            TR::Node *callNode = 0;
+            TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+            if (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), false))
+               {
+               if (unresolvedSymbolsAreCold)
+                  flags[i].set(isCold);
+               if(tracer()->heuristicLevel())
+                  {
+                  if(resolvedMethod)
+                     heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(resolvedMethod));
+                   else
+                      {
+                      if (bc == J9BCinvokestaticsplit)
+                         cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
+                      TR::Method *meth = comp()->fej9()->createMethod(comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+                      heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s",_recursionDepth,i,tracer()->traceSignature(meth));
+                      }
+                   }
+               }
+            else
+               {
+               bool allconsts= false;
+
+               heuristicTrace(tracer(),"numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n",resolvedMethod->numberOfExplicitParameters() ,pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()));
+               if ( resolvedMethod->numberOfExplicitParameters() > 0 && resolvedMethod->numberOfExplicitParameters() <= pca.getNumPrevConstArgs(resolvedMethod->numberOfExplicitParameters()))
+                  allconsts = true;
+
+               TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite( callStack._method, callNodeTreeTop, parent, callNode, interfaceMethod,
+                                                                                 resolvedMethod->classOfMethod(), -1, cpIndex, resolvedMethod, resolvedSymbol,
+                                                                                 isIndirectCall, isInterface, newBCInfo, _inliner->comp(),
+                                                                                 _recursionDepth, allconsts);
+
+               TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+               callsite->_callerBlock = currentInlinedBlock;
                if (isInlineable(&callStack, callsite))
                   {
 
@@ -1788,89 +1680,192 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                else
                   calltarget->addDeadCallee(callsite);
                }
-               flags[i].set(isUnsanitizeable);
-               break;
-            default:
-               break;
+            flags[i].set(isUnsanitizeable);
+            break;
             }
-
-           pca.updateArg(bc );
-
-           if (callSites[i])
-              {
-              for (int kk = 0; kk < callSites[i]->numTargets(); kk++)
-                 callSites[i]->getTarget(kk)->_originatingBlock = currentInlinedBlock;
-              }
-           }
-      _hasNonColdCalls = nonColdCallExists;
-
-      if (comp()->isServerInlining())
-         {
-         int coldCode = 0;
-         int executedCode = 0;
-         bool isCold = false;
-         int coldBorderFrequency = 20;
-
-         for (TR_J9ByteCode bc = bci.first(); bc != J9BCunknown; bc = bci.next());
+         case J9BCinvokeinterface:
             {
-            int32_t i = bci.bcIndex();
-            if (blocks[i])
-               if (!blocks[i]->isCold() && blocks[i]->getFrequency() > coldBorderFrequency)
-                  isCold = false;
-               else
-                  isCold = true;
+            cpIndex = bci.next2Bytes();
 
-            if (isCold)
-               coldCode++;
-            else
-               executedCode++;
-            }
-
-         if (executedCode != 0)
-            {
-            float ratio = ((float) executedCode) / ((float) (coldCode
-                  + executedCode));
-
-            if (recurseDown)
+            auto calleeMethod = (TR_ResolvedJ9Method*)calltarget->_calleeMethod;
+            resolvedMethod = calleeMethod->getResolvedImproperInterfaceMethod(comp(), cpIndex);
+            bool isIndirectCall = true;
+            bool isInterface = true;
+            if (resolvedMethod != NULL)
                {
-               if (ratio < 0.7f)
-                  {
-                  ratio = 0.7f;
-                  }
+               isInterface = false;
+               isIndirectCall =
+                  !resolvedMethod->isPrivate()
+                  && !resolvedMethod->convertToMethod()->isFinalInObject();
+               }
+
+            TR::Method * interfaceMethod = NULL;
+            if (isInterface)
+               interfaceMethod = comp()->fej9()->createMethod( comp()->trMemory(), calltarget->_calleeMethod->containingClass(), cpIndex);
+
+            TR::TreeTop *callNodeTreeTop = 0;
+            TR::Node *parent = 0;
+            TR::Node *callNode = 0;
+            TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+
+            uint32_t explicitParams = 0;
+            if (isInterface)
+               explicitParams = interfaceMethod->numberOfExplicitParameters();
+            else
+               explicitParams = resolvedMethod->numberOfExplicitParameters();
+
+            bool allconsts= false;
+            heuristicTrace(tracer(), "numberOfExplicitParameters = %d  pca.getNumPrevConstArgs = %d\n", explicitParams, pca.getNumPrevConstArgs(explicitParams));
+            if (explicitParams > 0 && explicitParams <= pca.getNumPrevConstArgs(explicitParams))
+               allconsts = true;
+
+            TR_CallSite *callsite = NULL;
+            if (isInterface)
+               {
+               TR_OpaqueClassBlock * thisClass = NULL;
+               callsite = new (comp()->trHeapMemory()) TR_J9InterfaceCallSite(
+                  callStack._method, callNodeTreeTop, parent, callNode,
+                  interfaceMethod, thisClass, -1, cpIndex, resolvedMethod,
+                  resolvedSymbol, isIndirectCall, isInterface, newBCInfo,
+                  comp(), _recursionDepth, allconsts);
+               }
+            else if (isIndirectCall)
+               {
+               callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(
+                  callStack._method, callNodeTreeTop, parent, callNode,
+                  interfaceMethod, resolvedMethod->classOfMethod(), (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex,
+                  resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
+                  newBCInfo, comp(), _recursionDepth, allconsts);
                }
             else
                {
-               if (ratio < 0.1f)
-                  {
-                  ratio = 0.1f;
-                  }
+               callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(
+                  callStack._method, callNodeTreeTop, parent, callNode,
+                  interfaceMethod, resolvedMethod->classOfMethod(), -1, cpIndex,
+                  resolvedMethod, resolvedSymbol, isIndirectCall, isInterface,
+                  newBCInfo, comp(), _recursionDepth, allconsts);
                }
 
-            calltarget->_fullSize = (int) ((float) calltarget->_fullSize * ratio);
-            heuristicTrace(tracer(),"Depth %d: Opt Server is reducing size of call to %d",_recursionDepth,calltarget->_fullSize);
+            if(tracer()->debugLevel())
+               {
+               pca.printIndexes(comp());
+               }
+            if(isInterface && pca.isArgAtIndexReceiverObject(interfaceMethod->numberOfExplicitParameters()))
+               {
+               //heuristicTrace(tracer(),"Arg at index %d is receiver object.  Propagating prexarginfo",interfaceMethod->numberOfExplicitParameters());
+               //callsite->_ecsPrexArgInfo = calltarget->_ecsPrexArgInfo;
+               }
+
+
+            TR_PrexArgInfo *argInfo = calltarget->_ecsPrexArgInfo;
+
+            if (wasPeekingSuccessfull)
+               {
+               TR_PrexArgInfo::propagateReceiverInfoIfAvailable(methodSymbol, callsite, argInfo, tracer());
+               }
+
+            callsite->_callerBlock = currentInlinedBlock;
+
+            if (isInlineable(&callStack, callsite))
+               {
+
+               if (wasPeekingSuccessfull)
+                  {
+                  TR_PrexArgInfo::propagateArgsFromCaller(methodSymbol, callsite, argInfo, tracer());
+                  }
+
+               callSites[i] = callsite;
+               inlineableCallExists = true;
+               if (!currentInlinedBlock->isCold())
+                  nonColdCallExists = true;
+               }
+            else
+               calltarget->addDeadCallee(callsite);
+
+            flags[i].set(isUnsanitizeable);
+            break;
             }
+         default:
+            break;
          }
-      else if (_inliner->getPolicy()->aggressiveSmallAppOpts())
+
+      pca.updateArg(bc );
+
+      if (callSites[i])
          {
+         for (int kk = 0; kk < callSites[i]->numTargets(); kk++)
+            callSites[i]->getTarget(kk)->_originatingBlock = currentInlinedBlock;
+         }
+      }
+   _hasNonColdCalls = nonColdCallExists;
+
+   if (comp()->isServerInlining())
+      {
+      int coldCode = 0;
+      int executedCode = 0;
+      bool isCold = false;
+      int coldBorderFrequency = 20;
+
+      for (TR_J9ByteCode bc = bci.first(); bc != J9BCunknown; bc = bci.next())
+         {
+         int32_t i = bci.bcIndex();
+         if (blocks[i])
+            if (!blocks[i]->isCold() && blocks[i]->getFrequency() > coldBorderFrequency)
+               isCold = false;
+            else
+               isCold = true;
+
+         if (isCold)
+            coldCode++;
+         else
+            executedCode++;
+         }
+
+      if (executedCode != 0)
+         {
+         float ratio = ((float) executedCode) / ((float) (coldCode
+               + executedCode));
+
+         if (recurseDown)
+            {
+            if (ratio < 0.7f)
+               {
+               ratio = 0.7f;
+               }
+            }
+         else
+            {
+            if (ratio < 0.1f)
+               {
+               ratio = 0.1f;
+               }
+            }
+
+         calltarget->_fullSize = (int) ((float) calltarget->_fullSize * ratio);
+         heuristicTrace(tracer(),"Depth %d: Opt Server is reducing size of call to %d",_recursionDepth,calltarget->_fullSize);
+         }
+      }
+   else if (_inliner->getPolicy()->aggressiveSmallAppOpts())
+      {
          TR_J9InlinerPolicy *j9inlinerPolicy = (TR_J9InlinerPolicy *) _inliner->getPolicy();
-         if (j9inlinerPolicy->aggressivelyInlineInLoops() && calltarget && calltarget->_calleeMethod && strncmp(calltarget->_calleeMethod->classNameChars(),"java/math/BigDecimal",calltarget->_calleeMethod->classNameLength())!=0)
-            {
-            if ((callStack._inALoop) &&
-                (calltarget->_fullSize > 10))
-                {
-                calltarget->_fullSize = 10;
-                heuristicTrace(tracer(),"Opt Server is reducing size of call to %d",calltarget->_fullSize);
-                }
-            }
-        else
-          heuristicTrace(tracer(),"Omitting Big Decimal method from size readjustment, calltarget = %p calleemethod = %p",calltarget,calltarget ? calltarget->_calleeMethod : 0);
-         }
-
-      if (_inliner->forceInline(calltarget))
+      if (j9inlinerPolicy->aggressivelyInlineInLoops() && calltarget && calltarget->_calleeMethod && strncmp(calltarget->_calleeMethod->classNameChars(),"java/math/BigDecimal",calltarget->_calleeMethod->classNameLength())!=0)
          {
-         calltarget->_fullSize = 0;
-         calltarget->_partialSize = 0;
+         if ((callStack._inALoop) &&
+                (calltarget->_fullSize > 10))
+             {
+             calltarget->_fullSize = 10;
+             heuristicTrace(tracer(),"Opt Server is reducing size of call to %d",calltarget->_fullSize);
+             }
          }
+      else
+         heuristicTrace(tracer(),"Omitting Big Decimal method from size readjustment, calltarget = %p calleemethod = %p",calltarget,calltarget ? calltarget->_calleeMethod : 0);
+      }
+
+   if (_inliner->forceInline(calltarget))
+      {
+      calltarget->_fullSize = 0;
+      calltarget->_partialSize = 0;
+      }
 
 
       /*************** PHASE 3:  Optimistically Assume we can partially inline calltarget and add to an optimisticSize ******************/
@@ -1878,284 +1873,281 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       TR_Queue<TR::Block> callBlocks(comp()->trMemory());
       bool isCandidate = trimBlocksForPartialInlining(calltarget, &callBlocks);
 
-      switch (calltarget->_calleeMethod->getRecognizedMethod())
-         {
-         case TR::java_util_HashMap_get:
-         case TR::java_util_HashMap_findNonNullKeyEntry:
+   switch (calltarget->_calleeMethod->getRecognizedMethod())
+      {
+      case TR::java_util_HashMap_get:
+      case TR::java_util_HashMap_findNonNullKeyEntry:
          calltarget->_isPartialInliningCandidate = false;
          isCandidate = false;
-            break;
-         default:
-         	break;
+         break;
+      default:
+         break;
+      }
+
+   if (isCandidate)
+      _optimisticSize += calltarget->_partialSize;
+   else
+      _optimisticSize += calltarget->_fullSize;
+
+   int32_t sizeThreshold = _sizeThreshold;
+   if (isCandidate)
+      sizeThreshold = std::max(4096, sizeThreshold);
+   ///if(_optimisticSize > _sizeThreshold)   // even optimistically we've blown our budget
+   heuristicTrace(tracer(),"--- Depth %d: Checking Optimistic size vs Size Threshold: _optimisticSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _optimisticSize, _sizeThreshold, sizeThreshold);
+
+   if (_optimisticSize > sizeThreshold) // even optimistically we've blown our budget
+      {
+      calltarget->_isPartialInliningCandidate = false;
+      heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. optimisticSize exceeds Size Threshold", _recursionDepth, calltarget, callerName);
+      return returnCleanup(2);
+      }
+
+   if (!recurseDown)
+      {
+      heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. recurseDown set to false. size = %d _fullSize = %d", _recursionDepth, calltarget, callerName, size, calltarget->_fullSize);
+      return returnCleanup(0);
+      }
+
+   /****************** Phase 4: Deal with Inlineable Calls **************************/
+   TR::Block *currentBlock = NULL;
+   for (TR_J9ByteCode bc = bci.first(); bc != J9BCunknown && inlineableCallExists; bc = bci.next())
+      {
+      int32_t i = bci.bcIndex();
+      //heuristicTrace(tracer(),"--- Depth %d: Checking _real size vs Size Threshold: _realSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _realSize, _sizeThreshold, sizeThreshold);
+
+      if (_realSize > sizeThreshold)
+         {
+         heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. real size %d exceeds sizeThreshold %d", _recursionDepth,calltarget, callerName,_realSize,sizeThreshold);
+         return returnCleanup(4);
          }
 
-      if (isCandidate)
-         _optimisticSize += calltarget->_partialSize;
-      else
-         _optimisticSize += calltarget->_fullSize;
+      if (blocks[i])
+         currentBlock = blocks[i];
 
-      int32_t sizeThreshold = _sizeThreshold;
-      if (isCandidate)
-         sizeThreshold = std::max(4096, sizeThreshold);
-      ///if(_optimisticSize > _sizeThreshold)   // even optimistically we've blown our budget
-      heuristicTrace(tracer(),"--- Depth %d: Checking Optimistic size vs Size Threshold: _optimisticSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _optimisticSize, _sizeThreshold, sizeThreshold);
-
-      if (_optimisticSize > sizeThreshold) // even optimistically we've blown our budget
+      newBCInfo.setByteCodeIndex(i);
+      if (callSites[i])
          {
-         calltarget->_isPartialInliningCandidate = false;
-         heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. optimisticSize exceeds Size Threshold", _recursionDepth, calltarget, callerName);
-         return returnCleanup(2);
-         }
+         callSites[i]->setDepth(_recursionDepth);
+         debugTrace(tracer(),"Found a call at bytecode %d, depth = %d", i, _recursionDepth);
 
-      if (!recurseDown)
-         {
-         heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. recurseDown set to false. size = %d _fullSize = %d", _recursionDepth, calltarget, callerName, size, calltarget->_fullSize);
-         return returnCleanup(0);
-         }
+         // TODO: Investigate if we should add BigAppOpts opts here
 
-      /****************** Phase 4: Deal with Inlineable Calls **************************/
-      TR::Block *currentBlock = NULL;
-      for (TR_J9ByteCode bc = bci.first(); bc != J9BCunknown && inlineableCallExists; bc = bci.next())
-         {
-         int32_t i = bci.bcIndex();
-         //heuristicTrace(tracer(),"--- Depth %d: Checking _real size vs Size Threshold: _realSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _realSize, _sizeThreshold, sizeThreshold);
 
-         if (_realSize > sizeThreshold)
+         for (int32_t j = 0; j < callSites[i]->numTargets(); j++)
             {
-            heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. real size %d exceeds sizeThreshold %d", _recursionDepth,calltarget, callerName,_realSize,sizeThreshold);
-            return returnCleanup(4);
-            }
+            TR_CallTarget *targetCallee = callSites[i]->getTarget(j);
 
-         if (blocks[i])
-            currentBlock = blocks[i];
+            char nameBuffer[1024];
+            const char *calleeName = NULL;
+            if (tracer()->heuristicLevel())
+               calleeName = comp()->fej9()->sampleSignature(targetCallee->_calleeMethod->getPersistentIdentifier(), nameBuffer, 1024, comp()->trMemory());
 
-         newBCInfo.setByteCodeIndex(i);
-         if (callSites[i])
-            {
-            callSites[i]->setDepth(_recursionDepth);
-            debugTrace(tracer(),"Found a call at bytecode %d, depth = %d", i, _recursionDepth);
-
-            // TODO: Investigate if we should add BigAppOpts opts here
-
-
-            for (int32_t j = 0; j < callSites[i]->numTargets(); j++)
+            if (callGraphEnabled && !currentBlock->isCold())
                {
-               TR_CallTarget *targetCallee = callSites[i]->getTarget(j);
-
-               char nameBuffer[1024];
-               const char *calleeName = NULL;
-               if (tracer()->heuristicLevel())
-                  calleeName = comp()->fej9()->sampleSignature(targetCallee->_calleeMethod->getPersistentIdentifier(), nameBuffer, 1024, comp()->trMemory());
-
-               if (callGraphEnabled && !currentBlock->isCold())
+               // if call-graph profiling is enabled and the call is special or static (!indirect)
+               // then update the block frequency information because we don't profile predictable calls
+               if (!callSites[i]->isIndirectCall())
                   {
-                  // if call-graph profiling is enabled and the call is special or static (!indirect)
-                  // then update the block frequency information because we don't profile predictable calls
-                  if (!callSites[i]->isIndirectCall())
-                     {
-                     profileManager->updateCallGraphProfilingCount( currentBlock, calltarget->_calleeMethod->getPersistentIdentifier(), i, comp());
-                     heuristicTrace(tracer(),"Depth %d: Updating Call Graph Profiling Count for calltarget %p count = %d",_recursionDepth, calltarget,profileManager->getCallGraphProfilingCount(calltarget->_calleeMethod->getPersistentIdentifier(), i, comp()));
-                     }
-
-                  // TODO: This coldCallInfoIsReliable logic should be in a more
-                  // central place so everyone agrees on it.  It shouldn't just be
-                  // for inliner.
-                  //
-                  bool coldCallInfoIsReliable = !cameFromArchetypeSpecimen(calltarget->_calleeMethod);
-
-                  if (_inliner->getPolicy()->tryToInline(targetCallee, &callStack, true))
-                     {
-                     heuristicTrace(tracer(),"tryToInline filter matched %s", targetCallee->_calleeMethod->signature(comp()->trMemory()));
-                     }
-                  else
-                     {
-                     int32_t freqCutoff = 40;
-                     bool isColdCall = (((comp()->getMethodHotness() <= warm) && profileManager->isColdCall(targetCallee->_calleeMethod->getPersistentIdentifier(), calltarget->_calleeMethod->getPersistentIdentifier(), i, comp())) || (currentBlock->getFrequency() < freqCutoff)) && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL);
-
-                     if (coldCallInfoIsReliable && isColdCall)
-                        {
-                        heuristicTrace(tracer(),"Depth %d: Skipping estimate on call %s, with count=%d and block frequency %d, because it's cold.",_recursionDepth,calleeName,profileManager->getCallGraphProfilingCount(targetCallee->_calleeMethod->getPersistentIdentifier(), calltarget->_calleeMethod->getPersistentIdentifier(), i, comp()), currentBlock->getFrequency());
-                        callSites[i]->removecalltarget(j, tracer(), Cold_Call);
-                        j--;
-                        continue;
-                        }
-
-                     if (comp()->getMethodHotness() <= warm && comp()->isServerInlining() && calltarget->_calleeMethod->isWarmCallGraphTooBig(i, comp()) && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL))
-                        {
-                        heuristicTrace(tracer(), "Depth %d: Skipping estimate on call %s, with count=%d, because its warm call graph is too big.",
-                                               _recursionDepth, calleeName,
-                                               profileManager->getCallGraphProfilingCount(calltarget->_calleeMethod->getPersistentIdentifier(),i, comp())
-                                             );
-                        callSites[i]->removecalltarget(j, tracer(), Cold_Call);
-                        j--;
-                        continue;
-                        }
-                     }
+                  profileManager->updateCallGraphProfilingCount( currentBlock, calltarget->_calleeMethod->getPersistentIdentifier(), i, comp());
+                  heuristicTrace(tracer(),"Depth %d: Updating Call Graph Profiling Count for calltarget %p count = %d",_recursionDepth, calltarget,profileManager->getCallGraphProfilingCount(calltarget->_calleeMethod->getPersistentIdentifier(), i, comp()));
                   }
 
-               //inline Native method even if it is cold as the Natives
-               //are usually very small and inlining them would not hurt
-               if (currentBlock->isCold() && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, callSites[i]->_callNode))
+               // TODO: This coldCallInfoIsReliable logic should be in a more
+               // central place so everyone agrees on it.  It shouldn't just be
+               // for inliner.
+               //
+               bool coldCallInfoIsReliable = !cameFromArchetypeSpecimen(calltarget->_calleeMethod);
+
+               if (_inliner->getPolicy()->tryToInline(targetCallee, &callStack, true))
                   {
-                  heuristicTrace(tracer(),"Depth %d: Skipping estimate on call %s, because it's in a cold block.",_recursionDepth, calleeName);
-                  callSites[i]->removecalltarget(j, tracer(), Cold_Block);
-                  j--;
-                  continue;
-                  }
-
-               if (_optimisticSize <= sizeThreshold) // for multiple calltargets, is this the desired behaviour?
-                  {
-                  _recursionDepth++;
-                  _numOfEstimatedCalls++;
-
-                  _lastCallBlockFrequency = currentBlock->getFrequency();
-
-                  debugTrace(tracer(),"About to call ecs on call target %p at depth %d _optimisticSize = %d _realSize = %d _sizeThreshold = %d",
-                                       targetCallee, _recursionDepth, _optimisticSize, _realSize, _sizeThreshold);
-                  heuristicTrace(tracer(),"--- Depth %d: EstimateCodeSize to recursively estimate call from %s to %s",_recursionDepth, callerName, calleeName);
-
-                  int32_t origOptimisticSize = _optimisticSize;
-                  int32_t origRealSize = _realSize;
-                  bool prevNonColdCalls = _hasNonColdCalls;
-                  bool estimateSuccess = estimateCodeSize(targetCallee, &callStack); //recurseDown = true
-                  bool calltargetSetTooBig = false;
-                  bool calleeHasNonColdCalls = _hasNonColdCalls;
-                  _hasNonColdCalls = prevNonColdCalls;// reset the bool for the parent
-
-                  // update optimisticSize and cull candidates
-
-                  if ((comp()->getMethodHotness() >= warm) && comp()->isServerInlining())
-                     {
-                     int32_t bigCalleeThreshold;
-                     int32_t freqCutoff = comp()->getMethodHotness() <= warm ?
-                                             comp()->getOptions()->getBigCalleeFrequencyCutoffAtWarm() :
-                                             comp()->getOptions()->getBigCalleeFrequencyCutoffAtHot();
-                     bool isColdCall = ((profileManager->isColdCall(targetCallee->_calleeMethod->getPersistentIdentifier(), calltarget->_calleeMethod->getPersistentIdentifier(), i, comp()) ||
-                           (currentBlock->getFrequency() <= freqCutoff)) && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL));
-
-                     if (comp()->getMethodHotness() <= warm)
-                        {
-                        bigCalleeThreshold = isColdCall ?
-                                                comp()->getOptions()->getBigCalleeThresholdForColdCallsAtWarm():
-                                                comp()->getOptions()->getBigCalleeThreshold();
-                        }
-                     else // above warm
-                        {
-
-                        if(isColdCall)
-                           {
-                           bigCalleeThreshold = comp()->getOptions()->getBigCalleeThresholdForColdCallsAtHot();
-                           }
-                        else
-                           {
-                           if (comp()->getMethodHotness() == scorching ||
-                              (comp()->getMethodHotness() == veryHot && comp()->isProfilingCompilation()))
-                              {
-                              bigCalleeThreshold = comp()->getOptions()->getBigCalleeScorchingOptThreshold();
-                              }
-                           else
-                              {
-                              bigCalleeThreshold = comp()->getOptions()->getBigCalleeHotOptThreshold();
-                              }
-                           }
-                        }
-
-
-                     if (_optimisticSize - origOptimisticSize > bigCalleeThreshold)
-                        {
-                        ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);
-                        calltarget->_calleeMethod->setWarmCallGraphTooBig( newBCInfo.getByteCodeIndex(), comp());
-                        traceMsg(comp(), "set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo.getByteCodeIndex());
-                        //_optimisticSize = origOptimisticSize;
-                        //_realSize = origRealSize;
-                        calltargetSetTooBig = true;
-                        }
-                     }
-
-                  if (!estimateSuccess && !calltargetSetTooBig)
-                     {
-                     int32_t estimatedSize = (_optimisticSize - origOptimisticSize);
-                     int32_t bytecodeSize = targetCallee->_calleeMethod->maxBytecodeIndex();
-                     bool inlineAnyway = false;
-
-                     if ((_optimisticSize - origOptimisticSize) < 40)
-                        inlineAnyway = true;
-                     else if (estimatedSize < 100)
-                        {
-                        if ((estimatedSize < bytecodeSize) || ((bytecodeSize - estimatedSize)< 20))
-                           inlineAnyway = true;
-                        }
-
-                     if (inlineAnyway && !calleeHasNonColdCalls)
-                        {
-                        _optimisticSize = origOptimisticSize;
-                        _realSize = origRealSize;
-                        }
-                     else if (!_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL))
-                        {
-                        calltarget->_isPartialInliningCandidate = false;
-                        callSites[i]->removecalltarget(j, tracer(),
-                              Callee_Too_Many_Bytecodes);
-                        _optimisticSize = origOptimisticSize;
-                        _realSize = origRealSize;
-                        calltarget->addDeadCallee(callSites[i]);
-                        j--;
-                        _numOfEstimatedCalls--;
-                        }
-
-                     if(comp()->getVisitCount() > HIGH_VISIT_COUNT)
-                        {
-                        heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
-                        return returnCleanup(3);
-                        }
-                     }
-                  else if (calltargetSetTooBig)
-                     {
-                     _optimisticSize = origOptimisticSize;
-                     _realSize = origRealSize;
-
-                     if (!_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL))
-                        {
-                        calltarget->_isPartialInliningCandidate = false;
-                        callSites[i]->removecalltarget(j, tracer(),
-                              Callee_Too_Many_Bytecodes);
-                        calltarget->addDeadCallee(callSites[i]);
-                        j--;
-                        _numOfEstimatedCalls--;
-                        }
-
-                     if(comp()->getVisitCount() > HIGH_VISIT_COUNT)
-                        {
-                        heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
-                        return returnCleanup(3);
-                        }
-                     }
-                  else
-                     {
-                     }
-
-                  _recursionDepth--;
+                  heuristicTrace(tracer(),"tryToInline filter matched %s", targetCallee->_calleeMethod->signature(comp()->trMemory()));
                   }
                else
                   {
-                  heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to _optimisticSize: %d > sizeThreshold: %d",_optimisticSize,sizeThreshold);
-                  break;
+                  int32_t freqCutoff = 40;
+                  bool isColdCall = (((comp()->getMethodHotness() <= warm) && profileManager->isColdCall(targetCallee->_calleeMethod->getPersistentIdentifier(), calltarget->_calleeMethod->getPersistentIdentifier(), i, comp())) || (currentBlock->getFrequency() < freqCutoff)) && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL);
+
+                  if (coldCallInfoIsReliable && isColdCall)
+                     {
+                     heuristicTrace(tracer(),"Depth %d: Skipping estimate on call %s, with count=%d and block frequency %d, because it's cold.",_recursionDepth,calleeName,profileManager->getCallGraphProfilingCount(targetCallee->_calleeMethod->getPersistentIdentifier(), calltarget->_calleeMethod->getPersistentIdentifier(), i, comp()), currentBlock->getFrequency());
+                     callSites[i]->removecalltarget(j, tracer(), Cold_Call);
+                     j--;
+                     continue;
+                     }
+
+                  if (comp()->getMethodHotness() <= warm && comp()->isServerInlining() && calltarget->_calleeMethod->isWarmCallGraphTooBig(i, comp()) && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL))
+                     {
+                     heuristicTrace(tracer(), "Depth %d: Skipping estimate on call %s, with count=%d, because its warm call graph is too big.",
+                                            _recursionDepth, calleeName,
+                                            profileManager->getCallGraphProfilingCount(calltarget->_calleeMethod->getPersistentIdentifier(),i, comp())
+                                          );
+                     callSites[i]->removecalltarget(j, tracer(), Cold_Call);
+                     j--;
+                     continue;
+                     }
                   }
                }
 
-            if (callSites[i]->numTargets()) //only add a callSite once, even though it may have more than one call target.
+            //inline Native method even if it is cold as the Natives
+            //are usually very small and inlining them would not hurt
+            if (currentBlock->isCold() && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, callSites[i]->_callNode))
                {
-               calltarget->addCallee(callSites[i]);
-               heuristicTrace(tracer(), "Depth %d: Subtracting %d from optimistic and real size to account for eliminating call", _recursionDepth, bci.estimatedCodeSize());
-               if (_optimisticSize > bci.estimatedCodeSize())
-                  _optimisticSize -= bci.estimatedCodeSize(); // subtract what we added before for the size of the call instruction
-               if (_realSize > bci.estimatedCodeSize())
-                  _realSize -= bci.estimatedCodeSize();
+               heuristicTrace(tracer(),"Depth %d: Skipping estimate on call %s, because it's in a cold block.",_recursionDepth, calleeName);
+               callSites[i]->removecalltarget(j, tracer(), Cold_Block);
+               j--;
+               continue;
+               }
+
+            if (_optimisticSize <= sizeThreshold) // for multiple calltargets, is this the desired behaviour?
+               {
+               _recursionDepth++;
+               _numOfEstimatedCalls++;
+
+               _lastCallBlockFrequency = currentBlock->getFrequency();
+
+               debugTrace(tracer(),"About to call ecs on call target %p at depth %d _optimisticSize = %d _realSize = %d _sizeThreshold = %d",
+                                    targetCallee, _recursionDepth, _optimisticSize, _realSize, _sizeThreshold);
+               heuristicTrace(tracer(),"--- Depth %d: EstimateCodeSize to recursively estimate call from %s to %s",_recursionDepth, callerName, calleeName);
+
+               int32_t origOptimisticSize = _optimisticSize;
+               int32_t origRealSize = _realSize;
+               bool prevNonColdCalls = _hasNonColdCalls;
+               bool estimateSuccess = estimateCodeSize(targetCallee, &callStack); //recurseDown = true
+               bool calltargetSetTooBig = false;
+               bool calleeHasNonColdCalls = _hasNonColdCalls;
+               _hasNonColdCalls = prevNonColdCalls;// reset the bool for the parent
+
+               // update optimisticSize and cull candidates
+
+               if ((comp()->getMethodHotness() >= warm) && comp()->isServerInlining())
+                  {
+                  int32_t bigCalleeThreshold;
+                  int32_t freqCutoff = comp()->getMethodHotness() <= warm ?
+                                          comp()->getOptions()->getBigCalleeFrequencyCutoffAtWarm() :
+                                         comp()->getOptions()->getBigCalleeFrequencyCutoffAtHot();
+                  bool isColdCall = ((profileManager->isColdCall(targetCallee->_calleeMethod->getPersistentIdentifier(), calltarget->_calleeMethod->getPersistentIdentifier(), i, comp()) ||
+                        (currentBlock->getFrequency() <= freqCutoff)) && !_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL));
+
+                  if (comp()->getMethodHotness() <= warm)
+                     {
+                     bigCalleeThreshold = isColdCall ?
+                                             comp()->getOptions()->getBigCalleeThresholdForColdCallsAtWarm():
+                                             comp()->getOptions()->getBigCalleeThreshold();
+                     }
+                  else // above warm
+                     {
+
+                     if(isColdCall)
+                        {
+                        bigCalleeThreshold = comp()->getOptions()->getBigCalleeThresholdForColdCallsAtHot();
+                        }
+                     else
+                        {
+                        if (comp()->getMethodHotness() == scorching ||
+                           (comp()->getMethodHotness() == veryHot && comp()->isProfilingCompilation()))
+                           {
+                           bigCalleeThreshold = comp()->getOptions()->getBigCalleeScorchingOptThreshold();
+                           }
+                        else
+                           {
+                           bigCalleeThreshold = comp()->getOptions()->getBigCalleeHotOptThreshold();
+                           }
+                        }
+                     }
+
+
+                  if (_optimisticSize - origOptimisticSize > bigCalleeThreshold)
+                     {
+                     ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);
+                     calltarget->_calleeMethod->setWarmCallGraphTooBig( newBCInfo.getByteCodeIndex(), comp());
+                     traceMsg(comp(), "set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo.getByteCodeIndex());
+                     //_optimisticSize = origOptimisticSize;
+                     //_realSize = origRealSize;
+                     calltargetSetTooBig = true;
+                     }
+                  }
+
+               if (!estimateSuccess && !calltargetSetTooBig)
+                  {
+                  int32_t estimatedSize = (_optimisticSize - origOptimisticSize);
+                  int32_t bytecodeSize = targetCallee->_calleeMethod->maxBytecodeIndex();
+                  bool inlineAnyway = false;
+
+                  if ((_optimisticSize - origOptimisticSize) < 40)
+                     inlineAnyway = true;
+                  else if (estimatedSize < 100)
+                     {
+                     if ((estimatedSize < bytecodeSize) || ((bytecodeSize - estimatedSize)< 20))
+                        inlineAnyway = true;
+                     }
+
+                  if (inlineAnyway && !calleeHasNonColdCalls)
+                     {
+                     _optimisticSize = origOptimisticSize;
+                     _realSize = origRealSize;
+                     }
+                  else if (!_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL))
+                     {
+                     calltarget->_isPartialInliningCandidate = false;
+                     callSites[i]->removecalltarget(j, tracer(),
+                           Callee_Too_Many_Bytecodes);
+                     _optimisticSize = origOptimisticSize;
+                     _realSize = origRealSize;
+                     calltarget->addDeadCallee(callSites[i]);
+                     j--;
+                     _numOfEstimatedCalls--;
+                     }
+
+                  if(comp()->getVisitCount() > HIGH_VISIT_COUNT)
+                     {
+                     heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
+                     return returnCleanup(3);
+                     }
+                  }
+               else if (calltargetSetTooBig)
+                  {
+                  _optimisticSize = origOptimisticSize;
+                  _realSize = origRealSize;
+
+                  if (!_inliner->alwaysWorthInlining(targetCallee->_calleeMethod, NULL))
+                     {
+                     calltarget->_isPartialInliningCandidate = false;
+                     callSites[i]->removecalltarget(j, tracer(),
+                           Callee_Too_Many_Bytecodes);
+                     calltarget->addDeadCallee(callSites[i]);
+                     j--;
+                     _numOfEstimatedCalls--;
+                     }
+
+                  if(comp()->getVisitCount() > HIGH_VISIT_COUNT)
+                     {
+                     heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
+                     return returnCleanup(3);
+                     }
+                  }
+
+               _recursionDepth--;
+               }
+            else
+               {
+               heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to _optimisticSize: %d > sizeThreshold: %d",_optimisticSize,sizeThreshold);
+               break;
                }
             }
-         }
 
-	auto partialSizeBeforeAdjustment = calltarget->_partialSize;
+         if (callSites[i]->numTargets()) //only add a callSite once, even though it may have more than one call target.
+            {
+            calltarget->addCallee(callSites[i]);
+            heuristicTrace(tracer(), "Depth %d: Subtracting %d from optimistic and real size to account for eliminating call", _recursionDepth, bci.estimatedCodeSize());
+            if (_optimisticSize > bci.estimatedCodeSize())
+               _optimisticSize -= bci.estimatedCodeSize(); // subtract what we added before for the size of the call instruction
+            if (_realSize > bci.estimatedCodeSize())
+               _realSize -= bci.estimatedCodeSize();
+            }
+         }
+      }
+
+   auto partialSizeBeforeAdjustment = calltarget->_partialSize;
 
    if (adjustEstimateForStringCompression(calltarget->_calleeMethod, calltarget->_partialSize, STRING_COMPRESSION_ADJUSTMENT_FACTOR))
       {
@@ -2176,32 +2168,31 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       heuristicTrace(tracer(), "*** Depth %d: Adjusting real size for %s because of string compression from %d to %d", _recursionDepth, callerName, realSizeBeforeAdjustment, _realSize);
       }
 
-      reduceDAAWrapperCodeSize(calltarget);
+   reduceDAAWrapperCodeSize(calltarget);
 
-      /****************** PHASE 5: Figure out if We're really going to do a partial Inline and add whatever we do to the realSize. *******************/
-      if (isPartialInliningCandidate(calltarget, &callBlocks))
-         {
-         if (comp()->getOption(TR_TraceBFGeneration))
-            traceMsg(comp(), "Call Target %s is a partial inline Candidate with a partial size of %d",callerName,calltarget->_partialSize);
+   /****************** PHASE 5: Figure out if We're really going to do a partial Inline and add whatever we do to the realSize. *******************/
+   if (isPartialInliningCandidate(calltarget, &callBlocks))
+      {
+      if (comp()->getOption(TR_TraceBFGeneration))
+         traceMsg(comp(), "Call Target %s is a partial inline Candidate with a partial size of %d",callerName,calltarget->_partialSize);
 
-         heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. It is a partial inline Candidate with a partial size of %d", _recursionDepth, calltarget, callerName, calltarget->_partialSize);
-         _realSize += calltarget->_partialSize;
-         }
-      else
-         {
-         heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. It is a full inline Candidate with a full size of %d", _recursionDepth, calltarget, callerName, calltarget->_fullSize);
-         _realSize += calltarget->_fullSize;
-         }
+      heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. It is a partial inline Candidate with a partial size of %d", _recursionDepth, calltarget, callerName, calltarget->_partialSize);
+      _realSize += calltarget->_partialSize;
+      }
+   else
+      {
+      heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. It is a full inline Candidate with a full size of %d", _recursionDepth, calltarget, callerName, calltarget->_fullSize);
+      _realSize += calltarget->_fullSize;
+      }
 
 
-      heuristicTrace(tracer(),"--- Depth %d: Checking _real size vs Size Threshold A second Time: _realSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _realSize, _sizeThreshold, sizeThreshold);
+   heuristicTrace(tracer(),"--- Depth %d: Checking _real size vs Size Threshold A second Time: _realSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _realSize, _sizeThreshold, sizeThreshold);
 
-      if (_realSize > sizeThreshold)
-         {
-         heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. real size exceeds Size Threshold", _recursionDepth,calltarget, callerName);
-         return returnCleanup(4);
-         }
-      //}
+   if (_realSize > sizeThreshold)
+      {
+      heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. real size exceeds Size Threshold", _recursionDepth,calltarget, callerName);
+      return returnCleanup(4);
+      }
 
    return returnCleanup(0);
    }

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -37,6 +37,7 @@
 #include "optimizer/EstimateCodeSize.hpp"
 
 class TR_ResolvedMethod;
+class NeedsPeekingHeuristic;
 
 class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
    {
@@ -77,6 +78,37 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
 
    protected:
       bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true);
+      
+     /** \brief
+      *     Generates a CFG for the calltarget->_calleeMethod.
+      *
+      *  \param calltarget
+      *     The calltarget which we wish to generate a CFG for.
+      *
+      *  \param cfgRegion
+      *     The memory region where the cfg is going to be stored
+      *
+      *  \param bci
+      *     The bytecode iterator. Must be instantiated in the following way:
+      *     \code
+      *        bci(0, static_cast<TR_ResolvedJ9Method *> (calltarget->_calleeMethod), ...)
+      *     \endcode
+      *
+      *  \param nph
+      *     Pointer to NeedsPeekingHeuristic.
+      *
+      *  \param blocks
+      *     Array of block pointers. Size of array must be equal to the maximum
+      *     bytecode index in calltarget->_calleeMethod
+      *
+      *  \param flags
+      *     Array of flags8_t. Size of array must be equal to maximum bytecode
+      *     index in calltarget->_calleeMethod
+      *
+      *  \return
+      *     Reference to cfg
+      */
+      TR::CFG &processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, TR::Region &cfgRegion, TR_J9ByteCodeIterator &bci, NeedsPeekingHeuristic &nph, TR::Block** blocks, flags8_t * flags);
       bool realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallStack *prevCallStack, bool recurseDown, TR::Region &cfgRegion);
 
       bool reduceDAAWrapperCodeSize(TR_CallTarget* target);


### PR DESCRIPTION
In this commit we are outlining the CFG generation from `realEstimateCodeSize` and fixing whitespace in ECS. Outlining the logic of CFG generation will allow for creating CFGs without generating IL. I understand that the interface for `generateCFG` might not be the most adequate, but at the moment the code for generating the CFG is very tightly coupled with calculating the size of the CFG. Comments are welcomed.