### PR TITLE
Disable use of TR_VMField on JITServer

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -5584,7 +5584,9 @@ break
          }
       }
 
-   if (cg()->getEnforceStoreOrder() && calledMethod->isConstructor())
+   // We disable this optimization for JITServer because TR_VMField is not supported on JITServer yet. Once we have decided how to build the data structures
+   // required by this optimization efficiently, we can re-enable this optimization.
+   if (!cg()->comp()->isOutOfProcessCompilation() && cg()->getEnforceStoreOrder() && calledMethod->isConstructor())
       {
       if (resolvedMethodSymbol)
          {


### PR DESCRIPTION
We disable use of this data structure currently because it is not supported on JITServer currently.

[skip ci]
Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>