### PR TITLE
Update loadAddressConstant call to generate relocatable code on…

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -8731,7 +8731,11 @@ void J9::Power::TreeEvaluator::genArrayCopyWithArrayStoreCHK(TR::Node* node, TR:
       }
    else
       {
-      iCursor = loadAddressConstant(cg, comp->compileRelocatableCode(), node, (intptrj_t) funcdescrptr, temp1Reg, NULL, false, TR_ArrayCopyHelper);
+      bool doRelocation = cg->comp()->compileRelocatableCode();
+#ifdef JITSERVER_SUPPORT
+      doRelocation = doRelocation || cg->comp()->isOutOfProcessCompilation();
+#endif
+      iCursor = loadAddressConstant(cg, doRelocation, node, (intptrj_t) funcdescrptr, temp1Reg, NULL, false, TR_ArrayCopyHelper);
       }
 
    iCursor = generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, temp1Reg, NULL, iCursor);


### PR DESCRIPTION
This API's definition was changed in OMR and so will need to be
updated in OpenJ9 as well. A check for remote compilations is
also added to make sure relocation records are created for those
cases as well.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>