### PR TITLE
Disable JNI specialCasing of java_util_zip_CRC32_updateBytes

### DIFF
--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -321,10 +321,15 @@ J9::Node::processJNICall(TR::TreeTop * callNodeTreeTop, TR::ResolvedMethodSymbol
       }
 
 #if defined(TR_TARGET_POWER)
+   // Recognizing these methods on Power allows us to take a shortcut 
+   // in the JNI dispatch where we mangle the register dependencies and call 
+   // optimized helpers in the JIT library using what amounts to system/C dispatch.
+   // The addresses of the optimized helpers in the server process will not necessarily
+   // match the client-side addresses, so we can't take this shortcut in JITServer mode.
    if (((methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_update) ||
         (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateBytes) ||
         (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateByteBuffer)) &&
-       !comp->requiresSpineChecks())
+       !comp->requiresSpineChecks() && !comp->isOutOfProcessCompilation())
       {
       self()->setPreparedForDirectJNI();
       return self();

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -117,7 +117,10 @@ TR::Register *TR::PPCJNILinkage::buildDirectDispatch(TR::Node *callNode)
    bool crc32m3 = (callSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateByteBuffer);
 
    // TODO: How to handle discontiguous array?
-   bool specialCaseJNI = (crc32m1 || crc32m2 || crc32m3) && !comp()->requiresSpineChecks();
+   // The specialCaseJNI shortcut will mangle register dependencies and use system/C dispatch.
+   // The addresses of the optimized helpers in the server process will not necessarily
+   // match the client-side addresses, so we can't take this shortcut in JITServer mode.
+   bool specialCaseJNI = (crc32m1 || crc32m2 || crc32m3) && !comp()->requiresSpineChecks() && !comp()->isOutOfProcessCompilation();
 
    bool isGPUHelper = callSymbol->isHelper() && (callSymRef->getReferenceNumber() == TR_estimateGPU ||
                                                  callSymRef->getReferenceNumber() == TR_getStateGPU ||


### PR DESCRIPTION
We disable Java's CRC32* type methods from being treated as special for remote compilations. In the special case the way the JNI arguments are built and the call is made is optimized. We disable this for now to achieve functional correctness on Power, and because this problem is confined to a small enough scope.

[skip ci]
Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>