### PR TITLE
Simplify TKG java

### DIFF
--- a/test/TestConfig/TKGJ/src/org/testKitGen/MainRunner.java
+++ b/test/TestConfig/TKGJ/src/org/testKitGen/MainRunner.java
@@ -33,11 +33,11 @@ public class MainRunner {
 	}
 
 	public static void start() {
-		System.out.println("\nSTART TEST KIT GEN\n");
+		System.out.println("\nStarting to generate test make files.\n");
 		ModesDictionary.parse();
 		MkTreeGen.start();
 		UtilsGen.start();
 		Counter.generateFile();
-		System.out.println("\nTEST KIT GEN SUCCESSFUL\n");
+		System.out.println("\nMake files are generated successfully.\n");
 	}
 }

--- a/test/TestConfig/TKGJ/src/org/testKitGen/MkTreeGen.java
+++ b/test/TestConfig/TKGJ/src/org/testKitGen/MkTreeGen.java
@@ -69,39 +69,15 @@ public class MkTreeGen {
 		File[] dir = directory.listFiles();
 
 		for (File entry : dir) {
-			boolean tempExclude = false;
-
-			// TODO clean up JCL_VERSION
-			// Temporary exclusion, remove this block when JCL_VERSION separation is removed
-			if ((!Options.getJdkVersion().equalsIgnoreCase("Panama")) && (!Options.getJdkVersion().equalsIgnoreCase("Valhalla"))) {
-				String JCL_VERSION = "";
-				if (System.getenv("JCL_VERSION") != null) {
-					JCL_VERSION = System.getenv("JCL_VERSION");
-				} else {
-					JCL_VERSION = "latest";
-				}
-
-				// Temporarily exclude projects for CCM build (i.e., when JCL_VERSION is latest)
-				String latestDisabledDir = "proxyFieldAccess Panama";
-
-				// Temporarily exclude SVT_Modularity tests from integration build where we are
-				// still using b148 JCL level
-				String currentDisableDir = "SVT_Modularity OpenJ9_Jsr_292_API";
-
-				tempExclude = ((JCL_VERSION.equals("latest")) && latestDisabledDir.contains(entry.getName()))
-						|| ((JCL_VERSION.equals("current")) && currentDisableDir.contains(entry.getName()));
-			}
 			File file = new File(absolutedir + '/' + entry.getName());
-			if (!tempExclude) {
-				if (file.isFile() && entry.getName().equals(Constants.PLAYLIST)) {
-					playlistXML = file;
-				} else if (file.isDirectory()) {
-					currentdirs.add(entry.getName());
-					if (traverse(currentdirs)) {
-						subdirs.add(entry.getName());
-					}
-					currentdirs.remove(currentdirs.size() - 1);
+			if (file.isFile() && entry.getName().equals(Constants.PLAYLIST)) {
+				playlistXML = file;
+			} else if (file.isDirectory()) {
+				currentdirs.add(entry.getName());
+				if (traverse(currentdirs)) {
+					subdirs.add(entry.getName());
 				}
+				currentdirs.remove(currentdirs.size() - 1);
 			}
 		}
 

--- a/test/TestConfig/makeGen.mk
+++ b/test/TestConfig/makeGen.mk
@@ -44,9 +44,7 @@ autoconfig:
 	perl configure.pl
 
 autogen: autoconfig
-	${TEST_JDK_HOME}/bin/java -cp ./TKGJ/TestKitGen.jar org.testKitGen.MainRunner --spec=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) $(OPTS);
-	cd $(CURRENT_DIR)$(D)scripts$(D)testKitGen; \
-	perl testKitGen.pl --graphSpecs=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) --validate $(OPTS)
+	${TEST_JDK_HOME}/bin/java -cp ./TKGJ/TestKitGen.jar org.testKitGen.MainRunner --spec=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) $(OPTS)
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)
 AUTOGEN_FILES += $(wildcard $(CURRENT_DIR)$(D)machineConfigure.mk)

--- a/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
@@ -36,6 +36,10 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<!-- runtimes/backlog/issues/163 -->
+		<impls>
+			<impl>ibm</impl>
+		</impls>
 		<subsets>
 			<subset>8</subset>
 		</subsets>
@@ -53,6 +57,10 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<!-- runtimes/backlog/issues/163 -->
+		<impls>
+			<impl>ibm</impl>
+		</impls>
 		<subsets>
 			<subset>9+</subset>
 		</subsets>


### PR DESCRIPTION
- completely switch over to TKG java
- remove obsoleted JCL_VERSION check from TKG java
- set proxyfieldaccess impl to ibm as it was disabled for JCL_VERSION=latest
- stop running TKG perl and result validation

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>