### PR TITLE
Adding package `libxrandr-dev` to X86 and PPC64le JDK11 Dockerfile

### DIFF
--- a/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
     libx11-dev \
     libxext-dev \
     libxrender-dev \
+    libxrandr-dev \
     libxt-dev \
     libxtst-dev \
     make \

--- a/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
     libx11-dev \
     libxext-dev \
     libxrender-dev \
+    libxrandr-dev \
     libxt-dev \
     libxtst-dev \
     make \


### PR DESCRIPTION
Adding package `libxrandr-dev` to X86 and ppc64le JDK11 Dockerfile to fix the error: "Could not find all X11 headers", which may occur when attempting to build JDK11 within the built docker.

Signed-off-by: simonameng <simonameng97@gmail.com>