### PR TITLE
Replace binary length peeking in PPCRecompilationSnippet

### DIFF
--- a/runtime/compiler/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -179,7 +179,7 @@ TR::Instruction *TR_PPCRecompilation::generatePrologue(TR::Instruction *cursor)
       // this instruction is replaced after successful recompilation
       cursor = generateTrg1Src2Instruction   (cg(), TR::InstOpCode::OR,    firstNode, gr11,  gr11, gr11, cursor);
       cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::blt, firstNode, snippetLabel, cr0, cursor);
-      TR::Snippet     *snippet = new (cg()->trHeapMemory()) TR::PPCRecompilationSnippet(snippetLabel, cursor, cg());
+      TR::Snippet     *snippet = new (cg()->trHeapMemory()) TR::PPCRecompilationSnippet(snippetLabel, cursor->getPPCConditionalBranchInstruction(), cg());
       cg()->addSnippet(snippet);
       }
    return(cursor);

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
@@ -47,7 +47,7 @@ uint8_t *TR::PPCRecompilationSnippet::emitSnippetBody()
    uint8_t             *buffer = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
    TR::SymbolReference  *countingRecompMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCcountingRecompileMethod, false, false, false);
-   bool                 longPrologue = (getBranchToSnippet()->getBinaryLength() > 4);
+   bool                 longPrologue = getBranchToSnippet()->getFarRelocation();
 
    getSnippetLabel()->setCodeLocation(buffer);
 

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.hpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,20 +26,20 @@
 #include "codegen/Snippet.hpp"
 
 namespace TR { class CodeGenerator; }
-namespace TR { class Instruction; }
+namespace TR { class PPCConditionalBranchInstruction; }
 namespace TR { class LabelSymbol; }
 
 namespace TR {
 
 class PPCRecompilationSnippet : public TR::Snippet
    {
-   TR::Instruction *branchToSnippet;
+   TR::PPCConditionalBranchInstruction *branchToSnippet;
 
    public:
 
    PPCRecompilationSnippet(
          TR::LabelSymbol *snippetlab,
-         TR::Instruction *bts,
+         TR::PPCConditionalBranchInstruction *bts,
          TR::CodeGenerator *cg)
       : TR::Snippet(cg, 0, snippetlab, false), branchToSnippet(bts)
       {
@@ -47,7 +47,7 @@ class PPCRecompilationSnippet : public TR::Snippet
 
    virtual Kind getKind() { return IsRecompilation; }
 
-   TR::Instruction *getBranchToSnippet() {return branchToSnippet;}
+   TR::PPCConditionalBranchInstruction *getBranchToSnippet() {return branchToSnippet;}
 
    virtual uint8_t *emitSnippetBody();
 


### PR DESCRIPTION
Previously, there was code in PPCRecompilationSnippet which would peek
at the binary encoded length of a conditional branch to set a flag. This
code was trying to check whether the conditional branch to the snippet
was expanded into two instructions due to the branch distance being too
large for a conditional branch instruction.

While this worked in the past, the binary encoder in the Power codegen
is undergoing some work that will result in this check no longer working
correctly in the near future. Instead, PPCRecompilationSnippet will now
use getFarRelocation() to check the flag which is explicitly set when
such expansion occurs.

Signed-off-by: Ben Thomas <ben@benthomas.ca>