### PR TITLE
Add Xdump:exit agent and ExitOnOutOfMemoryError

### DIFF
--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -514,3 +514,19 @@ J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.system_action=The JVM exits.
 J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.user_response=Combine dump types, event types, and filters using '+' into a single option
 J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.link=
 # END NON-TRANSLATABLE
+
+J9NLS_DMP_EXIT_SHUTDOWN=VM is shutting down. Reason: %2$.*1$s
+# START NON-TRANSLATABLE
+J9NLS_DMP_EXIT_SHUTDOWN.explanation=User requested to exit
+J9NLS_DMP_EXIT_SHUTDOWN.system_action=The JVM exits.
+J9NLS_DMP_EXIT_SHUTDOWN.user_response=This exit was requested by the user.
+J9NLS_DMP_EXIT_SHUTDOWN.link=
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN=VM is shutting down. Reason: Unknown
+# START NON-TRANSLATABLE
+J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.explanation=User requested to exit
+J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.system_action=The JVM exits.
+J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.user_response=This exit was requested by the user.
+J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN.link=
+# END NON-TRANSLATABLE

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -330,6 +330,8 @@ enum INIT_STAGE {
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
 #define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
 #define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
+#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError"
+#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE "-Xdump:exit:none:events=throw+systhrow,filter=java/lang/OutOfMemoryError"
 
 #define VMOPT_XSOFTREFTHRESHOLD "-XSoftRefThreshold"
 #define VMOPT_XAGGRESSIVE "-Xaggressive"
@@ -504,6 +506,8 @@ enum INIT_STAGE {
 #define MAPOPT_XXMAXHEAPSIZE_EQUALS "-XX:MaxHeapSize="
 #define MAPOPT_XXINITIALHEAPSIZE_EQUALS "-XX:InitialHeapSize="
 #define MAPOPT_XXONOUTOFMEMORYERROR_EQUALS "-XX:OnOutOfMemoryError="
+#define MAPOPT_XXENABLEEXITONOUTOFMEMORYERROR "-XX:+ExitOnOutOfMemoryError"
+#define MAPOPT_XXDISABLEEXITONOUTOFMEMORYERROR "-XX:-ExitOnOutOfMemoryError"
 
 #define VMOPT_XXACTIVEPROCESSORCOUNT_EQUALS "-XX:ActiveProcessorCount="
 

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -609,6 +609,8 @@ configureDumpAgents(J9JavaVM *vm)
 							return J9VMDLLMAIN_FAILED;
 						}
 					}
+				} else {
+					GET_OPTION_VALUE(xdumpIndex, ':', &optionString);
 				}
 			} else {
 				GET_OPTION_VALUE(xdumpIndex, ':', &optionString);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4106,6 +4106,14 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XXONOUTOFMEMORYERROR_EQUALS, VMOPT_XDUMP_TOOL_OUTOFMEMORYERROR_EXEC_EQUALS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
+	/* Map -XX:+ExitOnOutOfMemoryError to -Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError */ 
+	if (registerCmdLineMapping(vm, MAPOPT_XXENABLEEXITONOUTOFMEMORYERROR, VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
+	/* Map -XX:-ExitOnOutOfMemoryError to -Xdump:exit:none:events=throw+systhrow,filter=java/lang/OutOfMemoryError */ 
+	if (registerCmdLineMapping(vm, MAPOPT_XXDISABLEEXITONOUTOFMEMORYERROR, VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
 
 	return 0;
 }

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
@@ -71,5 +71,25 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
         <output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">java (.)* -version</output>
         <output type="required" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
     </test>
+
+    <test id="Verify Xdump:exit behaves as expected">
+        <command>$EXE$ -Xdump:exit:events=vmstart</command>
+        <output type="success" caseSensitive="yes" regex="no">VM is shutting down. Reason: Unknown</output>
+        <output type="failure" caseSensitive="yes" regex="no">dump written to</output>
+    </test>
+
+    <!-- -XX:+ExitOnOutOfMemoryError -->
+    <test id="Verify -XX:+ExitOnOutOfMemoryError behaves as expected with OutOfMemoryError">
+        <command>$EXE$ $JVM_HEAP_LIMIT$ -XX:+ExitOnOutOfMemoryError $ONOUTOFMEMORYERROR_JAR$</command>
+        <output type="success" caseSensitive="yes" regex="no">dump written to</output>
+        <output type="success" caseSensitive="yes" regex="no">VM is shutting down. Reason: java/lang/OutOfMemoryError</output>
+    </test>
+
+    <!-- -XX:+ExitOnOutOfMemoryError -XX:-HeapDumpOnOutOfMemoryError -->
+    <test id="Verify -XX:+ExitOnOutOfMemoryError -XX:-HeapDumpOnOutOfMemoryError behaves as expected with OutOfMemoryError">
+        <command>$EXE$ $JVM_HEAP_LIMIT$ -XX:+ExitOnOutOfMemoryError -XX:-HeapDumpOnOutOfMemoryError $ONOUTOFMEMORYERROR_JAR$</command>
+        <output type="failure" caseSensitive="yes" regex="no">dump written to</output>
+        <output type="success" caseSensitive="yes" regex="no">VM is shutting down. Reason: java/lang/OutOfMemoryError</output>
+    </test>
 </suite>
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/6412
Doc issue: https://github.com/eclipse/openj9-docs/issues/414 and PR https://github.com/eclipse/openj9-docs/pull/418
Website issue: https://github.com/eclipse/openj9-website/pull/200

- Add "exit" agent to Xdump
- Updating tool agent priority to 1 instead of 0
- Add mapping for -XX:[+-]ExitOnOutOfMemoryError
  - Enable: exits vm on OutOfMemoryError, relevant default diagnostics are enabled
  - Disable: disables exit agent on OutOfMemoryError
- Add command line tests

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>