### PR TITLE
AArch64: Enable TR_ALLOC() in ARM64Relocation

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64AOTRelocation.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64AOTRelocation.hpp
@@ -34,7 +34,7 @@ namespace TR {
 class ARM64Relocation
    {
    public:
-   //TR_ALLOC(TR_Memory::ARM64Relocation)
+   TR_ALLOC(TR_Memory::ARM64Relocation)
 
    /**
     * @brief Constructor


### PR DESCRIPTION
This commit enables TR_ALLOC() in ARM64Relocation.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>