### PR TITLE
Use asm v7.2 for lockWordAlignment test in JDK8+

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -82,6 +82,11 @@ my %asm_7_0 = (
 	fname => 'asm-7.0.jar',
 	sha1 => '7804855908e0a5e4f98e3364fa537426d9f5329c'
 );
+my %asm_7_2 = (
+	url => 'https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/7.2/asm-7.2.jar',
+	fname => 'asm-7.2.jar',
+	sha1 => 'fa637eb67eb7628c915d73762b681ae7ff0b9731'
+);
 my %commons_cli = (
 	url => 'http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar',
 	fname => 'commons-cli.jar',
@@ -130,6 +135,7 @@ my %jaxb_api = (
 my @jars_info = (
 	\%asm_all,
 	\%asm_7_0,
+	\%asm_7_2,
 	\%commons_cli,
 	\%commons_exec,
 	\%javassist,

--- a/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
+++ b/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
@@ -26,5 +26,5 @@ ASM_JAR=$(LIB_DIR)$(D)asm-all.jar
 # if JDK_VERSION is not 8
 ifeq ($(filter 8, $(JDK_VERSION)),)
  ADD_EXPORTS=--add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED
- ASM_JAR=$(LIB_DIR)$(D)asm-7.0.jar
+ ASM_JAR=$(LIB_DIR)$(D)asm-7.2.jar
 endif


### PR DESCRIPTION
Fix: #7409
[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>