### PR TITLE
(v0.17.0) Add a javadoc comment to the jdk.jcmd module.

### DIFF
--- a/jcl/src/jdk.jcmd/share/classes/module-info.java
+++ b/jcl/src/jdk.jcmd/share/classes/module-info.java
@@ -23,6 +23,10 @@
 
 /*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
+/**
+ * Defines the jcmd tool, used for obtaining information about a running JVM, or requesting a
+ * running JVM to do operations such as creating diagnotic files or performing a GC.
+ */
 module jdk.jcmd {
   requires java.base;
   requires java.management;


### PR DESCRIPTION
Cherry pick #7416 for the 0.17 release