### PR TITLE
Tests added for -Xshareclasses:printStats=startuphint

### DIFF
--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/SCCTestHelper.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/SCCTestHelper.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package j9vm.test.corehelper;
+
+public class SCCTestHelper {
+    public static void main(String[] args) {
+        System.out.println("Running helper class for the -Xshareclasses:printStats=startuphint DDR test");
+    }
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -169,6 +169,10 @@ public class Constants {
 	public static final String SHRC_BYTESTATS_SUCCESS_KEY_JAVA9 = "BYTEDATA !j9x";
 	public static final String SHRC_BYTESTATS_FAILURE_KEY = "UNKNOWN\\(,no shared cache";
 
+	// To check the startuphint
+	public static final String SHRC_STARTUPHINT_SUCCESS_KEY = "STARTUPHINT BYTEDATA";
+	public static final String SHRC_STARTUPHINT_FAILURE_KEY = "STARTUPHINTS 0";
+
 	public static final String SHRC_UBYTESTATS = "ubytestats";
 
 	// currently our dump does not contain any data for this

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestSharedClassesExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestSharedClassesExt.java
@@ -112,6 +112,14 @@ public class TestSharedClassesExt extends DDRExtTesterBase {
 		}
 	}
 
+	//Test whether the startuphint shows up.
+	public void testShrcStartUpHintExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_BYTESTATS });
+		assertTrue(validate(statsOutput, Constants.SHRC_STARTUPHINT_SUCCESS_KEY,
+				Constants.SHRC_STARTUPHINT_FAILURE_KEY, true));
+	}
+
 	public void testShrcUByteStatsExt() {
 		String statsOutput = exec(Constants.SHRC_CMD,
 				new String[] { Constants.SHRC_UBYTESTATS });

--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -131,6 +131,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<echo>DUMP_OPTION: ${DUMP_OPTION}</echo>
 		<echo>EXTRADUMPOPT: ${EXTRADUMPOPT}</echo>
 
+		<!-- We use the -Xint option to store the startup hint into the shared chache. -->
+		<exec executable="${JAVA_COMMAND}" failonerror="true">
+			<arg line="-Xscmx16m -Xshareclasses:name=ddrextjunitSCC -Xgcpolicy:gencon" />
+			<arg line="-Xint" />
+			<arg value="-cp" />
+			<arg value="${TEST_RESROOT}/DDR_Test.jar" />
+			<arg value="j9vm.test.corehelper.SCCTestHelper" />
+		</exec>
+
 		<exec executable="${JAVA_COMMAND}" failonerror="true">
 			<arg line="${DUMP_OPTION}" />
 			<arg line="-Xitsn1000" />

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -24,7 +24,7 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<!-- Test 200-a to Test 207 cleanup: 83 tests -->
+<!-- Test 200-a to Test 208 cleanup: 88 tests -->
 
 <suite id="Shared Classes CommandLineOptionTests Suite">
 
@@ -41,6 +41,7 @@
 	
 	<variable name="CP_HANOI" value="-cp $UTILSDIR$$PATHSEP$utils.jar" />
  	<variable name="PROGRAM_HANOI" value="org.openj9.test.ivj.Hanoi 2" />
+ 	<variable name="PROGRAM_HANOI_2" value="org.openj9.test.ivj.Hanoi 3" />
  	
  	<variable name="CP_FIB" value="-cp $UTILSDIR$$PATHSEP$utilsBK.jar" />
  	<variable name="PROGRAM_FIB" value="VMBench/FibBench" />
@@ -925,6 +926,62 @@
 
 	<test id="Test 207 cleanup: destroy non-persistent cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="failure" caseSensitive="no"  regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<!-- Since running Hanoi with -Xjit option does not store the startup hint to the shared chache, we use -Xint here -->
+	<test id="Test 208-a: Create a new cache to test -Xshareclasses:printStats=startuphint" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ -Xint $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 208-b: Check whether -Xshareclasses:printStats=startuphint works properly" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,printStats=startuphint</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">STARTUP HINTS KEY:</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 1</output>
+
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Startup hint bytes[\s]*= 0</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 0</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<!-- Since running Hanoi with -Xjit option does not store the startup hint to the shared chache, we use -Xint here -->
+	<test id="Test 208-c: Run the test again with a different argument" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ -Xint $CP_HANOI$ $PROGRAM_HANOI_2$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 208-d: Make sure -Xshareclasses:printStats=startuphint still works properly for another test" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,printStats=startuphint</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">STARTUP HINTS KEY:</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 2</output>
+
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Startup hint bytes[\s]*= 0</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 0</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 1</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 208 cleanup" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>


### PR DESCRIPTION
CML tests and DDR tests have been added for the -Xshareclasses:printStats=startuphint option

Fixes:#4123

Signed-off-by: Jiahan Xi <doomerXe@gmail.com>