### PR TITLE
Fix the -Xmso test to match #7304

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
@@ -191,7 +191,8 @@
 
  <test id="Xmso">
   <command>$EXE$ $CP$ -Xmso256K -verbose:sizes $TARGET$</command>
-  <output>.*Xmso256K.*</output>
+  <output platform="aix.*,linux.*,win.*,osx.*,zos_390-31.*">.*Xmso256K.*</output>
+  <output platform="zos_390-64.*">.*Xmso1M.*</output>
  </test>
 
  <test id="Xiss">

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java9.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java9.xml
@@ -189,7 +189,8 @@
 
  <test id="Xmso">
   <command>$EXE$ $CP$ -Xmso256K -verbose:sizes $TARGET$</command>
-  <output>.*Xmso256K.*</output>
+  <output platform="aix.*,linux.*,win.*,osx.*,zos_390-31.*">.*Xmso256K.*</output>
+  <output platform="zos_390-64.*">.*Xmso1M.*</output>
  </test>
 
  <test id="Xiss">


### PR DESCRIPTION
Tested in a jdk8 grinder on plinux, and z/OS internally.
https://ci.eclipse.org/openj9/view/Test/job/Grinder/532
```
git repo: 
  Fetch URL: https://github.com/pshipton/openj9.git
sha:
96d6f92a30723b75b51fd7cfcef9893fd5a7dbb9
```
```
14:29:31  Testing: Xmso
14:29:31  Test start time: 2019/10/10 14:29:30 Eastern Standard Time
14:29:31  Running command: "/home/jenkins/workspace/Grinder/openjdkbinary/j2sdk-image/bin/java" -Xcompressedrefs  -Xdump -cp "/home/jenkins/workspace/Grinder/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/functional/cmdLineTests/utils/utils.jar" -Xmso256K -verbose:sizes VMBench.FibBench
14:29:31  Time spent starting: 1 milliseconds
14:29:31  Time spent executing: 107 milliseconds
14:29:31  Test result: PASSED
```

Passed on z/OS 31 bit:
```
Testing: Xmso
Test start time: 2019/10/10 15:24:32 Eastern Standard Time
Running command: "bld_429588/sdk/xa6480/bin/java" -Xcompressedrefs  -Xdump -cp "bld_429588/jvmtest/test/SE80/functional/cmdLineTests/utils/utils.jar" -Xmso256K -verbose:sizes VMBench.FibBench
Time spent starting: 2 milliseconds
Time spent executing: 369 milliseconds
Test result: PASSED
```
and z/OS 64 bit:
```
Testing: Xmso
Test start time: 2019/10/10 15:44:33 Eastern Standard Time
Running command: "bld_429588/sdk/mz6480/bin/java" -Xcompressedrefs  -Xdump -cp "bld_429588/jvmtest/test/SE80/functional/cmdLineTests/utils/utils.jar" -Xmso256K -verbose:sizes VMBench.FibBench
Time spent starting: 4 milliseconds
Time spent executing: 765 milliseconds
Test result: PASSED
```