### PR TITLE
Remove "return" from CodeGenerator setSupports*() functions

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -419,7 +419,7 @@ public:
    /** \brief
     *    The code generator supports inlining of java/lang/String.toUpperCase() and toLowerCase()
     */
-   void setSupportsInlineStringCaseConversion() { return _j9Flags.set(SupportsInlineStringCaseConversion);}
+   void setSupportsInlineStringCaseConversion() { _j9Flags.set(SupportsInlineStringCaseConversion);}
 
    /** \brief
     *    Determines whether the code generator supports inlining of java/lang/String.indexOf()
@@ -429,7 +429,7 @@ public:
    /** \brief
     *    The code generator supports inlining of java/lang/String.indexOf()
     */
-   void setSupportsInlineStringIndexOf() { return _j9Flags.set(SupportsInlineStringIndexOf);}
+   void setSupportsInlineStringIndexOf() { _j9Flags.set(SupportsInlineStringIndexOf);}
 
    /** \brief
    *    Determines whether the code generator supports inlining of java/lang/String.hashCode()
@@ -439,7 +439,7 @@ public:
    /** \brief
    *    The code generator supports inlining of java/lang/String.hashCode()
    */
-   void setSupportsInlineStringHashCode() { return _j9Flags.set(SupportsInlineStringHashCode); }
+   void setSupportsInlineStringHashCode() { _j9Flags.set(SupportsInlineStringHashCode); }
 
    /** \brief
    *    Determines whether the code generator supports inlining of java_util_concurrent_ConcurrentLinkedQueue_tm*
@@ -450,7 +450,7 @@ public:
    /** \brief
    *    The code generator supports inlining of java_util_concurrent_ConcurrentLinkedQueue_tm* methods
    */
-   void setSupportsInlineConcurrentLinkedQueue() { return _j9Flags.set(SupportsInlineConcurrentLinkedQueue); }
+   void setSupportsInlineConcurrentLinkedQueue() { _j9Flags.set(SupportsInlineConcurrentLinkedQueue); }
 
    /**
     * \brief


### PR DESCRIPTION
This commit removes unnecessary "return" from some of CodeGenerator
setSupports*() functions of type void.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>