### PR TITLE
Override OMR::Node's dontEliminateStores

### DIFF
--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -129,6 +129,20 @@ J9::Node::~Node()
    _unionPropertyB = UnionPropertyB();
    }
 
+bool
+J9::Node::dontEliminateStores(bool isForLocalDeadStore)
+   {
+   // Disallow store sinking of BCD operations in Java because such operations may be under a BCDCHK node, implying that
+   // an exception path may be taken at runtime to evaluate the tree. Sinking such potentially exceptional operations
+   // violates the assumption that all such operations are to be anchored on a BCDCHK treetop, which the codegen expects
+   // to be able to generate the exception handling fallback code.
+   if (self()->getFirstChild()->getOpCode().isBinaryCodedDecimalOp())
+      return true;
+   else
+      return OMR::NodeConnector::dontEliminateStores(isForLocalDeadStore);
+   }
+
+
 void
 J9::Node::copyValidProperties(TR::Node *fromNode, TR::Node *toNode)
    {

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -70,6 +70,8 @@ public:
 
    uint32_t getSize();
 
+   bool dontEliminateStores(bool isForLocalDeadStore = false);
+
    /// given a direct call to Object.clone node, return the class of the receiver.
    ///
    TR_OpaqueClassBlock* getCloneClassInNode();


### PR DESCRIPTION
This is done so that the storeSinking optmization does not sink PackedDecimal store operations. Packed Decimal IL is only defined in OpenJ9.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>