### PR TITLE
Improved code generation for compare and branch instructions

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -736,7 +736,7 @@ TR::Register * caseConversionHelper(TR::Node* node, TR::CodeGenerator* cg, bool 
    TR::Instruction* cursor;
 
    const int elementSizeMask = (isCompressedString) ? 0x0 : 0x1;    // byte or halfword mask
-   const int8_t sizeOfVector = cg->machine()->getVRFSize();
+   const int32_t sizeOfVector = cg->machine()->getVRFSize();
    const bool is64 = TR::Compiler->target.is64Bit();
    uintptrj_t headerSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
 
@@ -932,7 +932,7 @@ inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
    TR::Register* length = cg->gprClobberEvaluate(node->getChild(4));
 
 
-   const int8_t sizeOfVector = cg->machine()->getVRFSize();
+   const int32_t sizeOfVector = cg->machine()->getVRFSize();
 
    // load length isn't used after loop, size must is adjusted to become bytes left
    TR::Register* loopCounter = length;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -861,7 +861,7 @@ TR::Register * caseConversionHelper(TR::Node* node, TR::CodeGenerator* cg, bool 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, fullVectorConversion);
 
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node,
-                                           lengthRegister, static_cast<int32_t>(sizeOfVector),
+                                           lengthRegister, sizeOfVector,
                                            TR::InstOpCode::COND_BL, success, false);
 
    // Set the loopCounter to the amount of groups of 16 bytes left, ignoring already accounted for remainder
@@ -930,6 +930,9 @@ inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
    TR::Register* ch = cg->evaluate(node->getChild(2));
    TR::Register* offset = cg->evaluate(node->getChild(3));
    TR::Register* length = cg->gprClobberEvaluate(node->getChild(4));
+
+
+   const int8_t sizeOfVector = cg->machine()->getVRFSize();
 
    // load length isn't used after loop, size must is adjusted to become bytes left
    TR::Register* loopCounter = length;
@@ -1014,7 +1017,7 @@ inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, fullVectorLabel);
 
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node,
-                                           length, static_cast<int32_t>(cg->machine()->getVRFSize()),
+                                           length, sizeOfVector,
                                            TR::InstOpCode::COND_BL, failureLabel);
 
    // Set loopcounter to 1/16 of the length, remainder has already been accounted for

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -860,7 +860,9 @@ TR::Register * caseConversionHelper(TR::Node* node, TR::CodeGenerator* cg, bool 
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, fullVectorConversion);
 
-   generateRIEInstruction(cg, TR::InstOpCode::CIJ, node, lengthRegister, sizeOfVector, success, TR::InstOpCode::COND_BL);
+   generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node,
+                                           lengthRegister, static_cast<int32_t>(sizeOfVector),
+                                           TR::InstOpCode::COND_BL, success, false);
 
    // Set the loopCounter to the amount of groups of 16 bytes left, ignoring already accounted for remainder
    generateRSInstruction(cg, TR::InstOpCode::SRL, node, loopCounter, loopCounter, 4);
@@ -999,7 +1001,9 @@ inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK1, node, notFoundInResidue);
 
    generateVRScInstruction(cg, TR::InstOpCode::VLGV, node, scratch, resultVector, generateS390MemoryReference(7, cg), 0);
-   generateRIEInstruction(cg, TR::InstOpCode::CRJ, node, scratch, loadLength, foundLabelExtractedScratch, TR::InstOpCode::COND_BNH);
+   generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CR, node,
+                                           scratch, loadLength,
+                                           TR::InstOpCode::COND_BNH, foundLabelExtractedScratch);
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, notFoundInResidue);
 
@@ -1009,7 +1013,9 @@ inlineIntrinsicIndexOf(TR::Node * node, TR::CodeGenerator * cg, bool isLatin1)
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, fullVectorLabel);
 
-   generateRIEInstruction(cg, TR::InstOpCode::CIJ, node, length, cg->machine()->getVRFSize(), failureLabel, TR::InstOpCode::COND_BL);
+   generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node,
+                                           length, static_cast<int32_t>(cg->machine()->getVRFSize()),
+                                           TR::InstOpCode::COND_BL, failureLabel);
 
    // Set loopcounter to 1/16 of the length, remainder has already been accounted for
    generateRSInstruction(cg, TR::InstOpCode::SRL, node, loopCounter, loopCounter, 4);


### PR DESCRIPTION
Code generation for all compare and branch instructions has been
consolidated into `generateS390CompareAndBranchInstruction()` API.
Instructions consolidated in this commit are `CRJ` and `CIJ`.

This is allows for compare and branch instruction optimizations to be
applied through a common point. In addition to that, all compare and
branch instructions can now be to be disabled through
`Xjit:disableCompareAndBranch`.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>