### PR TITLE
Port TR_J9JITServerSharedCache from jitaas to master

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -468,7 +468,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, methods, methodsInfo);
          }
          break;
-#if defined(JITSERVER_TODO)
       case MessageType::VM_getVMInfo:
          {
          ClientSessionData::VMInfo vmInfo = {};
@@ -524,7 +523,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, vmInfo, listOfCacheStartAddress, listOfCacheSizeBytes);
          }
          break;
-#endif /* defined(JITSERVER_TODO) */
       case MessageType::VM_isPrimitiveArray:
          {
          TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
@@ -1428,7 +1426,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, offset);
          }
          break;
-#if defined(JITSERVER_TODO)
       case MessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, I_32>();
@@ -1437,7 +1434,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          J9Method *j9method = NULL;
             {
             TR::VMAccessCriticalSection getResolvedHandleMethod(fe);
-            j9method = jitGetImproperInterfaceMethodFromCP(fe->vmThread(), mirror->cp(), cpIndex);
+            j9method = jitGetImproperInterfaceMethodFromCP(fe->vmThread(), mirror->cp(), cpIndex, NULL);
             }
          // Create a mirror right away
          TR_ResolvedJ9JITServerMethodInfo methodInfo;
@@ -1447,7 +1444,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, j9method, methodInfo);
          }
          break;
-#endif /* defined(JITSERVER_TODO) */
       case MessageType::ResolvedMethod_startAddressForJNIMethod:
          {
          TR_ResolvedJ9Method *ramMethod = std::get<0>(client->getRecvData<TR_ResolvedJ9Method *>());
@@ -2053,7 +2049,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, JITServer::Void());
          }
          break;
-#if defined(JITSERVER_TODO)
       case MessageType::SharedCache_storeSharedData:
          {
          auto recv = client->getRecvData<std::string, J9SharedDataDescriptor, std::string>();
@@ -2065,7 +2060,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, ptr);
          }
          break;
-#endif /* defined(JITSERVER_TODO) */
       case MessageType::runFEMacro_derefUintptrjPtr:
          {
          TR::VMAccessCriticalSection deref(fe);

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -303,13 +303,11 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          _vm = TR_J9VMBase::get(_jitConfig, compThread, TR_J9VMBase::J9_SERVER_VM);
          }
 
-#if defined(JITSERVER_TODO)
       if (_vm->sharedCache())
          // Set/update stream pointer in shared cache.
          // Note that if remote-AOT is enabled, even regular J9_SERVER_VM will have a shared cache
          // This behaviour is consistent with non-JITServer
          ((TR_J9JITServerSharedCache *) _vm->sharedCache())->setStream(stream);
-#endif /* defined(JITSERVER_TODO) */
 
       //if (seqNo == 100)
       //   throw JITServer::StreamFailure(); // stress testing

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -35,6 +35,8 @@
 #include "env/j9method.h"
 #include "runtime/IProfiler.hpp"
 #include "env/ClassLoaderTable.hpp"
+#include "control/CompilationThread.hpp" // for TR::compInfoPT
+#include "runtime/JITClientSession.hpp"
 
 #define   LOG(n,c) \
    if (_logLevel >= (3*n)) \
@@ -101,6 +103,8 @@ TR_J9SharedCache::TR_J9SharedCache(TR_J9VMBase *fe)
    _sharedCacheConfig = _javaVM->sharedClassConfig;
    _numDigitsForCacheOffsets = 8;
 
+   TR_ASSERT_FATAL(_sharedCacheConfig, "Must have _sharedCacheConfig");
+  
    UDATA totalCacheSize = 0;
    J9SharedClassCacheDescriptor *curCache = _sharedCacheConfig->cacheDescriptorList;
    do
@@ -127,6 +131,19 @@ TR_J9SharedCache::TR_J9SharedCache(TR_J9VMBase *fe)
 
    LOG(5, { log("\t_sharedCacheConfig %p\n", _sharedCacheConfig); });
    LOG(5, { log("\ttotalCacheSize %p\n", totalCacheSize); });
+   }
+
+J9SharedClassCacheDescriptor *
+TR_J9SharedCache::getCacheDescriptorList()
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_j9SharedClassCacheDescriptorList;
+      }
+#endif /* defined(JITSERVER_SUPPORT) */
+   return _sharedCacheConfig ? _sharedCacheConfig->cacheDescriptorList : NULL;
    }
 
 void
@@ -167,7 +184,6 @@ TR_J9SharedCache::getHint(J9VMThread * vmThread, J9Method *method)
    if ((find == (uint32_t *)descriptor.address) && (dataIsCorrupt == -1))
       result = *find;
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-
    return result;
    }
 
@@ -176,7 +192,6 @@ TR_J9SharedCache::getAllEnabledHints(J9Method *method)
    {
    uint16_t hintFlags = 0;
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-   if (_hintsEnabledMask)
       {
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
       J9VMThread * vmThread = fej9->getCurrentVMThread();
@@ -184,7 +199,6 @@ TR_J9SharedCache::getAllEnabledHints(J9Method *method)
       hintFlags = *((uint16_t *)&scHints) & _hintsEnabledMask;
       }
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-   return hintFlags;
    }
 
 
@@ -263,7 +277,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
       if (scHintData == 0) // If no prior hints exist, we can perform a "storeAttachedData" operation
          {
          uint32_t bytesToPersist = 0;
-
+ 
          if (!SCfull)
             {
             *hintFlags |= newHint;
@@ -271,7 +285,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
                *hintCount = 10 * _initialHintSCount;
 
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8*)hintFlags;
+            descriptor.address = (U_8 *)(uintptrj_t)hintFlags;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -318,14 +332,14 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
             if (isFailedValidationHint)
                *hintCount = 10 * _initialHintSCount;
             }
-         else
+         else 
             {
             // hint already exists, but maybe we need to update the count
             if (isFailedValidationHint)
                {
                uint16_t oldCount = *hintCount;
                uint16_t newCount = std::min(oldCount * 10, TR_DEFAULT_INITIAL_COUNT);
-
+               
                if (newCount != oldCount)
                   {
                   updateHint = true;
@@ -343,7 +357,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
          if (updateHint)
             {
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8*)hintFlags;
+            descriptor.address = (U_8 *)(uintptrj_t)hintFlags;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -409,7 +423,7 @@ TR_J9SharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
    {
 #if defined(J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE)
    // The cache descriptor list is linked last to first and is circular, so last->previous == first.
-   J9SharedClassCacheDescriptor *firstCache = _sharedCacheConfig->cacheDescriptorList->previous;
+   J9SharedClassCacheDescriptor *firstCache = getCacheDescriptorList()->previous;
    J9SharedClassCacheDescriptor *curCache = firstCache;
    do
       {
@@ -422,7 +436,7 @@ TR_J9SharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
       }
    while (curCache != firstCache);
 #else // !J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
-   J9SharedClassCacheDescriptor *curCache = _sharedCacheConfig->cacheDescriptorList;
+   J9SharedClassCacheDescriptor *curCache = getCacheDescriptorList();
    if (offset < curCache->cacheSizeBytes)
       {
       return (void *)(offset + (uintptr_t)curCache->cacheStartAddress);
@@ -451,7 +465,7 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset)
 #if defined(J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE)
    uintptr_t offset = 0;
    // The cache descriptor list is linked last to first and is circular, so last->previous == first.
-   J9SharedClassCacheDescriptor *firstCache = _sharedCacheConfig->cacheDescriptorList->previous;
+   J9SharedClassCacheDescriptor *firstCache = getCacheDescriptorList()->previous;
    J9SharedClassCacheDescriptor *curCache = firstCache;
    do
       {
@@ -469,7 +483,7 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset)
       }
    while (curCache != firstCache);
 #else // !J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
-   J9SharedClassCacheDescriptor *curCache = _sharedCacheConfig->cacheDescriptorList;
+   J9SharedClassCacheDescriptor *curCache = getCacheDescriptorList();
    if (isPointerInCache(curCache, ptr))
       {
       if (cacheOffset)
@@ -480,7 +494,6 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset)
       return true;
       }
 #endif // J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
-
    return false;
    }
 
@@ -519,11 +532,13 @@ UDATA *
 TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   J9UTF8 * className = J9ROMCLASS_CLASSNAME(clazz->romClass);
-   LOG(5,{ log("rememberClass class %p %.*s\n", clazz, J9UTF8_LENGTH(className), J9UTF8_DATA(className)); });
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(fej9->convertClassPtrToClassOffset(clazz));
+
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+   LOG(5,{ log("rememberClass class %p romClass %p %.*s\n", clazz, romClass, J9UTF8_LENGTH(className), J9UTF8_DATA(className)); });
 
    uintptrj_t classOffsetInCache;
-   if (!isPointerInSharedCache(clazz->romClass, &classOffsetInCache))
+   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(5,{ log("\trom class not in shared cache, returning\n"); });
       return NULL;
@@ -542,7 +557,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
       return chainData;
       }
 
-   int32_t numSuperclasses =  J9CLASS_DEPTH(clazz);
+   int32_t numSuperclasses = TR::Compiler->cls.classDepthOf(fe()->convertClassPtrToClassOffset(clazz));
    int32_t numInterfaces = numInterfacesImplemented(clazz);
 
    LOG(9, { log("\tcreating chain now: 1 + 1 + %d superclasses + %d interfaces\n", numSuperclasses, numInterfaces); });
@@ -638,11 +653,11 @@ uint32_t
 TR_J9SharedCache::numInterfacesImplemented(J9Class *clazz)
    {
    uint32_t count=0;
-   J9ITable *element = (J9ITable *)clazz->iTable;
+   J9ITable *element = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
    while (element != NULL)
       {
       count++;
-      element = element->next;
+      element = TR::Compiler->cls.iTableNext(element);
       }
    return count;
    }
@@ -664,13 +679,13 @@ TR_J9SharedCache::writeClassToChain(J9ROMClass *romClass, UDATA * & chainPtr)
    }
 
 bool
-TR_J9SharedCache::writeClassesToChain(J9Class **superclasses, int32_t numSuperclasses, UDATA * & chainPtr)
+TR_J9SharedCache::writeClassesToChain(J9Class *clazz, int32_t numSuperclasses, UDATA * & chainPtr)
    {
    LOG(9, { log("\t\twriteClassesToChain:\n"); });
 
    for (int32_t index=0; index < numSuperclasses;index++)
       {
-      J9ROMClass *romClass = superclasses[index]->romClass;
+      J9ROMClass *romClass = TR::Compiler->cls.romClassOfSuperClass(fe()->convertClassPtrToClassOffset(clazz), index);
       if (! writeClassToChain(romClass, chainPtr))
          return false;
       }
@@ -682,14 +697,14 @@ TR_J9SharedCache::writeInterfacesToChain(J9Class *clazz, UDATA * & chainPtr)
    {
    LOG(9, { log("\t\twriteInterfacesToChain:\n"); });
 
-   J9ITable *element = (J9ITable *)clazz->iTable;
+   J9ITable *element = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
    while (element != NULL)
       {
-      J9ROMClass *romClass = element->interfaceClass->romClass;
+      J9ROMClass *romClass = TR::Compiler->cls.iTableRomClass(element);
       if (!writeClassToChain(romClass, chainPtr))
          return false;
 
-      element = element->next;
+      element = TR::Compiler->cls.iTableNext(element);
       }
 
    return true;
@@ -703,13 +718,14 @@ TR_J9SharedCache::fillInClassChain(J9Class *clazz, UDATA *chainData, uint32_t ch
 
    UDATA *chainPtr = chainData;
    *chainPtr++ = chainLength;
-   writeClassToChain(clazz->romClass, chainPtr);
-   if (! writeClassesToChain(clazz->superclasses, numSuperclasses, chainPtr))
+   J9ROMClass* romClass = TR::Compiler->cls.romClassOf(fe()->convertClassPtrToClassOffset(clazz));
+   writeClassToChain(romClass, chainPtr);
+   if (!writeClassesToChain(clazz, numSuperclasses, chainPtr))
       {
       return false;
       }
 
-   if (! writeInterfacesToChain(clazz, chainPtr))
+   if (!writeInterfacesToChain(clazz, chainPtr))
       {
       return false;
       }
@@ -755,11 +771,12 @@ TR_J9SharedCache::findChainForClass(J9Class *clazz, const char *key, uint32_t ke
 bool
 TR_J9SharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
    {
-   J9UTF8 * className = J9ROMCLASS_CLASSNAME(clazz->romClass);
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(fe()->convertClassPtrToClassOffset(clazz));
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
    LOG(5, { log("classMatchesCachedVersion class %p %.*s\n", clazz, J9UTF8_LENGTH(className), J9UTF8_DATA(className)); });
 
    uintptrj_t classOffsetInCache;
-   if (!isPointerInSharedCache(clazz->romClass, &classOffsetInCache))
+   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(5, { log("\tclass not in shared cache, returning false\n"); });
       return false;
@@ -784,32 +801,33 @@ TR_J9SharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
    UDATA *chainEnd = (UDATA *) (((U_8*)chainData) + chainLength);
    LOG(9, { log("\tfound chain: %p with length %d\n", chainData, chainLength); });
 
-   if (! romclassMatchesCachedVersion(clazz->romClass, chainPtr, chainEnd))
+   if (!romclassMatchesCachedVersion(romClass, chainPtr, chainEnd))
       {
          LOG(5, { log("\tClass did not match, returning false\n"); });
          return false;
       }
 
-   int32_t numSuperclasses = J9CLASS_DEPTH(clazz);
-   J9Class **superclasses = clazz->superclasses;
+   int32_t numSuperclasses = TR::Compiler->cls.classDepthOf(fe()->convertClassPtrToClassOffset(clazz));
    for (int32_t index=0; index < numSuperclasses;index++)
       {
-      if (! romclassMatchesCachedVersion(superclasses[index]->romClass, chainPtr, chainEnd))
+      J9ROMClass *romClass = TR::Compiler->cls.romClassOfSuperClass(fe()->convertClassPtrToClassOffset(clazz), index);
+      if (!romclassMatchesCachedVersion(romClass, chainPtr, chainEnd))
          {
          LOG(5, { log("\tClass in hierarchy did not match, returning false\n"); });
          return false;
          }
       }
 
-   J9ITable *interfaceElement = (J9ITable *) clazz->iTable;
+   J9ITable *interfaceElement = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
    while (interfaceElement)
       {
-      if (! romclassMatchesCachedVersion(interfaceElement->interfaceClass->romClass, chainPtr, chainEnd))
+      J9ROMClass * romClass = TR::Compiler->cls.iTableRomClass(interfaceElement);
+      if (!romclassMatchesCachedVersion(romClass, chainPtr, chainEnd))
          {
          LOG(5, { log("\tInterface class did not match, returning false\n"); });
          return false;
          }
-      interfaceElement = interfaceElement->next;
+      interfaceElement = TR::Compiler->cls.iTableNext(interfaceElement);
       }
 
    if (chainPtr != chainEnd)
@@ -848,3 +866,85 @@ TR_J9SharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR
    uintptrj_t classChainOffsetInSharedCache = offsetInSharedCacheFromPointer(classChainIdentifyingLoaderForClazz);
    return classChainOffsetInSharedCache;
    }
+
+const void *
+TR_J9SharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+   {
+   return _sharedCacheConfig->storeSharedData(
+         vmThread,
+         key,
+         strlen(key),
+         descriptor);
+   }
+
+#if defined(JITSERVER_SUPPORT)
+TR_J9JITServerSharedCache::TR_J9JITServerSharedCache(TR_J9VMBase *fe)
+   : TR_J9SharedCache(fe)
+   {
+   _stream = NULL;
+   }
+
+UDATA *
+TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   auto clientData = TR::compInfoPT->getClientData();
+   PersistentUnorderedMap<J9Class *, UDATA *> & cache = clientData->getClassClainDataCache();
+      {
+      OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
+      auto it = cache.find(clazz);
+      if (it != cache.end())
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Chain exists (%p) so nothing to store \n", it->second);
+         return it->second;
+         }
+      }
+   _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create);
+   UDATA * chainData = std::get<0>(_stream->read<UDATA *>());
+   if (chainData)
+      {
+      if (!create)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "not asked to create but could create, returning non-null \n");
+         }
+      else
+         {
+         OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
+         cache.insert(std::make_pair(clazz, chainData));
+         }
+      }
+   return chainData;
+   }
+
+uintptrj_t
+TR_J9JITServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   _stream->write(JITServer::MessageType::SharedCache_getClassChainOffsetInSharedCache, clazz);
+   return std::get<0>(_stream->read<uintptrj_t>());
+   }
+
+void
+TR_J9JITServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
+   if (vmInfo->_hasSharedClassCache)
+      {
+      _stream->write(JITServer::MessageType::SharedCache_addHint, method, theHint);
+      _stream->read<JITServer::Void>();
+      }
+   }
+
+const void *
+TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   std::string dataStr((char *) descriptor->address, descriptor->length);
+
+   _stream->write(JITServer::MessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);
+   return std::get<0>(_stream->read<const void *>());
+   }
+#endif

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -748,7 +748,7 @@ TR_J9VMBase::TR_J9VMBase(
       )
       // shared classes and AOT must be enabled, or we should be on the JITServer with remote AOT enabled
       {
-#if defined(JITSERVER_SUPPORT) && defined(JITSERVER_TODO)
+#if defined(JITSERVER_SUPPORT)
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          _sharedCache = new (PERSISTENT_NEW) TR_J9JITServerSharedCache(this);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -22,7 +22,7 @@
 
 #define J9_EXTERNAL_TO_VM
 
-#if defined(JITSERVER_SUPPORT) && defined(JITSERVER_TODO)
+#if defined(JITSERVER_SUPPORT)
 #include "env/VMJ9Server.hpp"
 #endif
 

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -94,7 +94,6 @@ class TR_BitVector;
 class TR_J9VMBase;
 class TR_J9SharedCache;
 
-
 #if defined (_MSC_VER)
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #if _MSC_VER < 1600

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -72,7 +72,10 @@ ClientSessionData::~ClientSessionData()
       }
    _staticMapMonitor->destroy();
    if (_vmInfo)
+      {
+      destroyJ9SharedClassCacheDescriptorList();
       jitPersistentFree(_vmInfo);
+      }
    _thunkSetMonitor->destroy();
    }
 
@@ -327,9 +330,57 @@ ClientSessionData::getOrCacheVMInfo(JITServer::ServerStream *stream)
    if (!_vmInfo)
       {
       stream->write(JITServer::MessageType::VM_getVMInfo, JITServer::Void());
-      _vmInfo = new (PERSISTENT_NEW) VMInfo(std::get<0>(stream->read<VMInfo>()));
+      auto recv = stream->read<VMInfo, std::vector<uintptr_t>, std::vector<uintptr_t> >();
+      _vmInfo = new (PERSISTENT_NEW) VMInfo(std::get<0>(recv));
+      _vmInfo->_j9SharedClassCacheDescriptorList = reconstructJ9SharedClassCacheDescriptorList(std::get<1>(recv), std::get<2>(recv));
       }
    return _vmInfo;
+   }
+
+J9SharedClassCacheDescriptor *
+ClientSessionData::reconstructJ9SharedClassCacheDescriptorList(const std::vector<uintptr_t> &listOfCacheStartAddress, const std::vector<uintptr_t> &listOfCacheSizeBytes)
+   {
+   J9SharedClassCacheDescriptor * cur = NULL;
+   J9SharedClassCacheDescriptor * prev = NULL;
+   J9SharedClassCacheDescriptor * head = NULL;
+   for (size_t i = 0; i < listOfCacheStartAddress.size(); i++)
+      {
+      cur = new (PERSISTENT_NEW) J9SharedClassCacheDescriptor();
+      cur->cacheStartAddress = (J9SharedCacheHeader*)(listOfCacheStartAddress[i]);
+      cur->cacheSizeBytes = listOfCacheSizeBytes[i];
+      if (prev)
+         {
+         prev->next = cur;
+         cur->previous = prev;
+         }
+      else
+         {
+         head = cur;
+         }
+      prev = cur;
+      }
+   if (!head)
+      return NULL;
+   head->previous = prev; // assign head's previous to tail
+   prev->next = head; // assign tail's previous to head
+   return head;
+   }
+
+void
+ClientSessionData::destroyJ9SharedClassCacheDescriptorList()
+   {
+   if (!_vmInfo->_j9SharedClassCacheDescriptorList)
+      return;
+   J9SharedClassCacheDescriptor * cur = _vmInfo->_j9SharedClassCacheDescriptorList;
+   J9SharedClassCacheDescriptor * next = NULL;
+   _vmInfo->_j9SharedClassCacheDescriptorList->previous->next = NULL; // break the circular links by setting tail's next pointer to be NULL 
+   while (cur)
+      {
+      next = cur->next;
+      jitPersistentFree(cur);
+      cur = next;
+      }
+   _vmInfo->_j9SharedClassCacheDescriptorList = NULL;
    }
 
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -295,12 +295,12 @@ class ClientSessionData
       int32_t _arrayletLeafSize;
       uint64_t _overflowSafeAllocSize;
       int32_t _compressedReferenceShift;
-      UDATA _cacheStartAddress;
+      J9SharedClassCacheDescriptor *_j9SharedClassCacheDescriptorList;
       bool _stringCompressionEnabled;
       bool _hasSharedClassCache;
       bool _elgibleForPersistIprofileInfo;
-      TR_OpaqueClassBlock *_arrayTypeClasses[8];
       bool _reportByteCodeInfoAtCatchBlock;
+      TR_OpaqueClassBlock *_arrayTypeClasses[8];
       MM_GCReadBarrierType _readBarrierType;
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;
@@ -384,6 +384,9 @@ class ClientSessionData
 
    template <typename map, typename key>
    void purgeCache(std::vector<ClassUnloadedData> *unloadedClasses, map m, key ClassUnloadedData::*k);
+
+   J9SharedClassCacheDescriptor * reconstructJ9SharedClassCacheDescriptorList(const std::vector<uintptr_t> &listOfCacheStartAddress, const std::vector<uintptr_t> &listOfCacheSizeBytes);
+   void destroyJ9SharedClassCacheDescriptorList();
 
    private:
    const uint64_t _clientUID;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -778,29 +778,6 @@ TR_RelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)
    return false;
    }
 
-#if defined(JITSERVER_SUPPORT)
-void *
-TR_RelocationRuntime::isROMClassInSharedCaches(UDATA romClassValue)
-   {
-   TR_ASSERT_FATAL(0, "Error: isROMClassInSharedCaches not supported in TR_RelocationRuntime");
-   return NULL;
-   }
-
-bool
-TR_RelocationRuntime::isRomClassForMethodInSharedCache(J9Method *method)
-   {
-   TR_ASSERT_FATAL(0, "Error: isRomClassForMethodInSharedCache not supported in TR_RelocationRuntime");
-   return false;
-   }
-
-TR_YesNoMaybe
-TR_RelocationRuntime::isMethodInSharedCache(J9Method *method)
-   {
-   TR_ASSERT_FATAL(0, "Error: isMethodInSharedCache not supported in TR_RelocationRuntime");
-   return TR_no;
-   }
-#endif /* defined(JITSERVER_SUPPORT) */
-
 TR_OpaqueClassBlock *
 TR_RelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)
    {
@@ -1213,55 +1190,6 @@ TR_SharedCacheRelocationRuntime::storeAOTHeader(TR_FrontEnd *fe, J9VMThread *cur
       return false;
       }
    }
-
-
-#if defined(JITSERVER_SUPPORT)
-void *
-TR_SharedCacheRelocationRuntime::isROMClassInSharedCaches(UDATA romClassValue)
-   {
-   j9thread_monitor_enter(javaVM()->sharedClassConfig->configMonitor);
-   J9SharedClassCacheDescriptor *currentCacheDescriptor = javaVM()->sharedClassConfig->cacheDescriptorList;
-   bool matchFound = false;
-
-   while (!matchFound && currentCacheDescriptor)
-      {
-      if (((romClassValue < (UDATA)currentCacheDescriptor->metadataStartAddress)&& (romClassValue >= (UDATA)currentCacheDescriptor->romclassStartAddress)))
-         {
-         matchFound = true;
-         break;
-         }
-      if (currentCacheDescriptor->next == javaVM()->sharedClassConfig->cacheDescriptorList)
-         break; // Since the list is circular, break if we are about to loop back
-      currentCacheDescriptor = currentCacheDescriptor->next;
-      }
-   j9thread_monitor_exit(javaVM()->sharedClassConfig->configMonitor);
-   if (matchFound)
-      {
-      return (void *)currentCacheDescriptor;
-      }
-   else
-      {
-      return NULL;
-      }
-   }
-
-bool
-TR_SharedCacheRelocationRuntime::isRomClassForMethodInSharedCache(J9Method *method)
-   {
-   J9ROMClass *romClass = J9_CLASS_FROM_METHOD(method)->romClass;
-   bool isRomClassForMethodInSharedCache = isROMClassInSharedCaches((UDATA)romClass) ? true : false;
-   return isRomClassForMethodInSharedCache;
-   }
-
-TR_YesNoMaybe
-TR_SharedCacheRelocationRuntime::isMethodInSharedCache(J9Method *method)
-   {
-   if (isRomClassForMethodInSharedCache(method))
-      return TR_maybe;
-   else
-      return TR_no;
-   }
-#endif /* defined(JITSERVER_SUPPORT) */
 
 TR_OpaqueClassBlock *
 TR_SharedCacheRelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -391,18 +391,12 @@ public:
       TR_ALLOC(TR_Memory::Relocation)
       void * operator new(size_t, J9JITConfig *);
       TR_JITServerRelocationRuntime(J9JITConfig *jitCfg) : TR_RelocationRuntime(jitCfg) {}
-
       // The following public APIs should not be used with this class
-      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-
-      virtual void *isROMClassInSharedCaches(UDATA romClassValue)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0; }
-      virtual bool isRomClassForMethodInSharedCache(J9Method *method)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0; }
-      virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!");  return TR_no; }
+      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
+      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
+      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
 
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0; }
-
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 
 private:

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -181,12 +181,6 @@ class TR_RelocationRuntime {
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
 
-#if defined(JITSERVER_SUPPORT)
-      virtual void *isROMClassInSharedCaches(UDATA romClassValue);
-      virtual bool isRomClassForMethodInSharedCache(J9Method *method);
-      virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method);
-#endif /* defined(JITSERVER_SUPPORT) */
-
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
 
       static uintptr_t    getGlobalValue(uint32_t g)
@@ -355,12 +349,6 @@ public:
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-
-#if defined(JITSERVER_SUPPORT)
-      virtual void *isROMClassInSharedCaches(UDATA romClassValue);
-      virtual bool isRomClassForMethodInSharedCache(J9Method *method);
-      virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method);
-#endif /* defined(JITSERVER_SUPPORT) */
 
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
 


### PR DESCRIPTION
TR_J9JITServerSharedCache is an extension to TR_J9SharedCache that overrides a few APIs from TR_J9SharedCache. This class is used by JITServer to remotely obtain shared-cache-related information from JITClient.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>