### PR TITLE
Update DDR code & setting for RISC-V in OpenJ9 (part2/DDR)

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFDumpReader.java
@@ -25,6 +25,7 @@ import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_AMD64;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_IA32;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_PPC32;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_PPC64;
+import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_RISCV64;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_S390;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.ARCH_ARM;
 import static com.ibm.j9ddr.corereaders.elf.ELFFileReader.AT_ENTRY;
@@ -233,6 +234,8 @@ public abstract class ELFDumpReader implements ILibraryDependentCore
 			} else {
 				return new ELFARM32DumpReader(reader);
 			}
+		case (ARCH_RISCV64) :
+			return new ELFRISCV64DumpReader(reader);
 		default:
 			throw new IOException("Unrecognised machine type: " + reader.getMachineType());
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,6 +73,7 @@ public abstract class ELFFileReader
 	public final static int ARCH_ARM = 40;
 	public final static int ARCH_IA64 = 50;
 	public final static int ARCH_AMD64 = 62;
+	public final static int ARCH_RISCV64 = 243;
 
 	public final static int DT_NULL = 0;
 	public final static int DT_DEBUG = 21;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFRISCV64DumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFRISCV64DumpReader.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.corereaders.elf;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import com.ibm.j9ddr.corereaders.InvalidDumpFormatException;
+
+/**
+ * @author Cheng Jin <jincheng@ca.ibm.com>
+ *
+ */
+public class ELFRISCV64DumpReader extends ELFDumpReader
+{
+	private final static String[] registerNames = ("pc,ra,sp,gp,tp,t0,t1,t2,s0,s1,a0,a1,a2,a3,a4,a5,a6,a7,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11"
+					+ ",t3,t4,t5,t6,ft0,ft1,ft2,ft3,ft4,ft5,ft6,ft7,fs0,fs1,fa0,fa1,fa2,fa3,fa4,fa5,fa6,fa7"
+					+ ",fs2,fs3,fs4,fs5,fs6,fs7,fs8,fs9,fs10,fs11,ft8,ft9,ft10,ft11,fcsr").split(",");
+
+	protected ELFRISCV64DumpReader(ELFFileReader reader) throws IOException, InvalidDumpFormatException
+	{
+		super(reader);
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.j9ddr.corereaders.elf.ELFDumpReader#readUID()
+	 */
+	@Override
+	protected long readUID() throws IOException
+	{
+		return _reader.readInt() & 0xffffffffL;
+	}
+
+	@Override
+	protected String getProcessorType()
+	{
+		return "riscv64";
+	}
+
+	@Override
+	protected long getBasePointerFrom(Map<String, Number> registers)
+	{
+		return getStackPointerFrom(registers);
+	}
+
+	@Override
+	protected long getInstructionPointerFrom(Map<String, Number> registers)
+	{
+		return registers.get("pc").longValue();
+	}
+
+	@Override
+	protected long getLinkRegisterFrom(Map<String, Number> registers)
+	{
+		return registers.get("ra").longValue();
+	}
+
+	@Override
+	protected String getStackPointerRegisterName()
+	{
+		return "sp";
+	}
+
+	@Override
+	protected String[] getDwarfRegisterKeys()
+	{
+		/* Need to consult the platform ABI to map register names to dwarf numbers */
+		return registerNames.clone();
+	}
+	
+	@Override
+	protected SortedMap<String, Number> readRegisters() throws IOException
+	{
+		SortedMap<String, Number> registers = new TreeMap<String, Number>(new RegisterComparator());
+		for (int i = 0; i < registerNames.length; i++)
+			registers.put(registerNames[i], _reader.readLong());
+		return registers;
+	}
+	
+	@Override
+	protected void readHighwordRegisters(DataEntry entry, Map<String, Number> registers) throws IOException, InvalidDumpFormatException
+	{
+		throw new InvalidDumpFormatException("Unexpected data entry in RISCV64 ELF dump");
+	}
+
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/LibraryCollector.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/LibraryCollector.java
@@ -310,7 +310,7 @@ public class LibraryCollector {
 		return libraryName.equals("lib.so") // the SOname that appears in executables
 				// ABI: i386, ia64, sh
 				|| libraryName.startsWith("linux-gate")
-				// ABI: aarch64, arm, mips, x86_64, x86/32
+				// ABI: aarch64, arm, mips, riscv, x86_64, x86/32
 				|| libraryName.startsWith("linux-vdso.so.1")
 				// ABI: ppc/32, s390
 				|| libraryName.startsWith("linux-vdso32.so.1")

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ConfigFlags.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ConfigFlags.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ public final class J9ConfigFlags {
 
 	public static final boolean arch_arm;
 	public static final boolean arch_power;
+	public static final boolean arch_riscv;
 	public static final boolean arch_s390;
 	public static final boolean arch_x86;
 
@@ -49,6 +50,7 @@ public final class J9ConfigFlags {
 
 		arch_arm = getFlag(flagsClass, "arch_arm", "J9VM_ARCH_ARM");
 		arch_power = getFlag(flagsClass, "arch_power", "J9VM_ARCH_POWER");
+		arch_riscv = getFlag(flagsClass, "arch_riscv", "J9VM_ARCH_RISCV");
 		arch_s390 = getFlag(flagsClass, "arch_s390", "J9VM_ARCH_S390");
 		arch_x86 = getFlag(flagsClass, "arch_x86", "J9VM_ARCH_X86");
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -96,6 +96,13 @@ public class StackWalkerUtils
 			jitArgumentRegisterNumbers = new int[] { 3, 4, 5, 6, 7, 8, 9, 10 };
 		} else if (J9ConfigFlags.arch_s390) {
 			jitArgumentRegisterNumbers = new int[] { 1, 2, 3 };
+		} else if (J9ConfigFlags.arch_riscv) {
+			/* The setting is based on the description of RISC-V Spec as follows:
+			 * Register  ABI Name  Description                      Saver
+			 * x10~11     a0~1     Function arguments/return values Caller
+			 * x12~17     a2~7     Function arguments               Caller
+			 */
+			jitArgumentRegisterNumbers = new int[] { 10, 11, 12, 13, 14, 15, 16, 17 };
 		} else {
 			throw new IllegalArgumentException("Unsupported platform");
 		}

--- a/runtime/ddr/jitflagsddr.c
+++ b/runtime/ddr/jitflagsddr.c
@@ -64,6 +64,13 @@ J9DDRConstantTableEntryWithValue("host_POWER",host_POWER)
 #endif
 J9DDRConstantTableEntryWithValue("host_PPC", host_PPC)
 
+#if defined(TR_HOST_RISCV)
+	#define host_RISCV 1
+#else
+	#define host_RISCV 0
+#endif
+J9DDRConstantTableEntryWithValue("host_RISCV", host_RISCV)
+
 #if defined(TR_HOST_S390)
 	#define host_S390 1
 #else

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -58,6 +58,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<flag name="TR_TARGET_POWER">
 				<include-if condition="spec.flags.module_jit_ppc"/>
 			</flag>
+			<flag name="TR_TARGET_RISCV">
+				<include-if condition="spec.flags.module_jit_riscv"/>
+			</flag>
 			<flag name="TR_TARGET_S390">
 				<include-if condition="spec.flags.module_jit_s390"/>
 			</flag>
@@ -154,6 +157,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<flag name="TR_TARGET_POWER">
 				<include-if condition="spec.flags.module_jit_ppc"/>
 			</flag>
+			<flag name="TR_TARGET_RISCV">
+				<include-if condition="spec.flags.module_jit_riscv"/>
+			</flag>
 			<flag name="TR_TARGET_S390">
 				<include-if condition="spec.flags.module_jit_s390"/>
 			</flag>
@@ -208,6 +214,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.linux_x86-64.*"/>
 			</vpath>
 
+			<vpath pattern="%" path="$(OMR_DIR)/port/linuxriscv64" augmentIncludes="true" type="relativepath">
+				<include-if condition="spec.linux_riscv64.*"/>
+			</vpath>
+			
 			<vpath pattern="%" path="$(OMR_DIR)/port/linuxs39064" augmentIncludes="true" type="relativepath">
 				<include-if condition="spec.linux_390-64.*"/>
 				<include-if condition="spec.linux_ztpf.*"/>
@@ -405,11 +415,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<makefilestub data="CFLAGS += -femit-class-debug-always">
 				<include-if condition="spec.linux_390.*"/>
 				<include-if condition="spec.linux_ppc.*_gcc"/>
+				<include-if condition="spec.linux_riscv64.*"/>
 				<include-if condition="spec.linux_x86.*"/>
 			</makefilestub>
 			<makefilestub data="CXXFLAGS += -femit-class-debug-always">
 				<include-if condition="spec.linux_390.*"/>
 				<include-if condition="spec.linux_ppc.*_gcc"/>
+				<include-if condition="spec.linux_riscv64.*"/>
 				<include-if condition="spec.linux_x86.*"/>
 			</makefilestub>
 			<makefilestub data="UMA_DLL_LINK_FLAGS += -bexpall">

--- a/runtime/oti/stackwalk.h
+++ b/runtime/oti/stackwalk.h
@@ -345,6 +345,67 @@ extern "C" {
 #define J9SW_LOWEST_MEMORY_PRESERVED_REGISTER jit_r21
 #define J9SW_JIT_CALLEE_PRESERVED_SIZE 8
 
+#elif defined(J9VM_ARCH_RISCV)
+
+/* RISCV */
+
+/* @ddr_namespace: map_to_type=J9StackWalkFlags */
+
+#undef  J9SW_JIT_FLOATS_PASSED_AS_DOUBLES
+#undef  J9SW_JIT_HELPERS_PASS_PARAMETERS_ON_STACK
+#undef  J9SW_NEEDS_JIT_2_INTERP_CALLEE_ARG_POP
+#define J9SW_REGISTER_MAP_WALK_REGISTERS_LOW_TO_HIGH
+
+/* @ddr_namespace: map_to_type=J9StackWalkConstants */
+
+#define J9SW_JIT_STACK_SLOTS_USED_BY_CALL 0x1
+#define J9SW_ARGUMENT_REGISTER_COUNT 0x8
+#define J9SW_JIT_FLOAT_ARGUMENT_REGISTER_COUNT 0x8
+#define J9SW_POTENTIAL_SAVED_REGISTERS 0xC
+
+#if defined(J9VM_ENV_DATA64)
+
+/* RISCV-64 */
+
+/* @ddr_namespace: map_to_type=J9StackWalkFlags */
+
+#define J9SW_NEEDS_JIT_2_INTERP_THUNKS
+#define J9SW_PARAMETERS_IN_REGISTERS
+
+/* @ddr_namespace: map_to_type=J9StackWalkConstants */
+
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->walkedEntryLocalStorage->jitGlobalStorageBase[jitArgumentRegisterNumbers[(parmNumber) - 1]])
+#define J9SW_REGISTER_MAP_MASK 0xFFFF
+#define J9SW_JIT_FIRST_RESOLVE_PARM_REGISTER 0x3
+#define J9SW_JIT_CALLEE_PRESERVED_SIZE 8
+#undef  J9SW_JIT_LOOKUP_INTERFACE_RESOLVE_OFFSET_TO_SAVED_RECEIVER
+#undef  J9SW_JIT_VIRTUAL_METHOD_RESOLVE_OFFSET_TO_SAVED_RECEIVER
+#define J9SW_LOWEST_MEMORY_PRESERVED_REGISTER
+
+#else /* J9VM_ENV_DATA64 */
+
+/* RISCV-32 */
+
+/* @ddr_namespace: map_to_type=J9StackWalkFlags */
+
+#undef  J9SW_JIT_FLOATS_PASSED_AS_DOUBLES
+#define J9SW_JIT_HELPERS_PASS_PARAMETERS_ON_STACK
+#define J9SW_NEEDS_JIT_2_INTERP_CALLEE_ARG_POP
+#undef  J9SW_NEEDS_JIT_2_INTERP_THUNKS
+#undef  J9SW_PARAMETERS_IN_REGISTERS
+
+/* @ddr_namespace: map_to_type=J9StackWalkConstants */
+
+#define JIT_RESOLVE_PARM(parmNumber) (walkState->bp[parmNumber])
+#define J9SW_REGISTER_MAP_MASK 0x7F
+#undef  J9SW_JIT_FIRST_RESOLVE_PARM_REGISTER
+#define J9SW_JIT_VIRTUAL_METHOD_RESOLVE_OFFSET_TO_SAVED_RECEIVER 0x0
+#define J9SW_JIT_LOOKUP_INTERFACE_RESOLVE_OFFSET_TO_SAVED_RECEIVER 0x0
+#define J9SW_JIT_CALLEE_PRESERVED_SIZE 3
+#define J9SW_LOWEST_MEMORY_PRESERVED_REGISTER
+
+#endif /* J9VM_ENV_DATA64 */
+
 #else
 #error Unsupported platform
 #endif


### PR DESCRIPTION
The changes mainly include the DDR related code & setting
to enable RISC-V 64bit from the OpenJ9 perspective.

Issue: eclipse#7421

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>