### PR TITLE
Disable JIT compilation for RISC-V in OpenJ9 (part3/JIT)

### DIFF
--- a/runtime/codert_vm/module.xml
+++ b/runtime/codert_vm/module.xml
@@ -23,6 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module>
 	<artifact type="static" name="j9codert_vm">
 		<include-if condition="spec.flags.module_codert_vm" />
+		<exclude-if condition="spec.linux_riscv.*" />
 		<phase>core</phase>
 		<flags>
 			<flag name="$(TR_HOST)"/>

--- a/runtime/compiler/module.xml
+++ b/runtime/compiler/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2000, 2019 IBM Corp. and others
+Copyright (c) 2000, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module>
 	<artifact type="target" name="j9jitlauncher">
 		<include-if condition="spec.flags.interp_nativeSupport"/>
+		<exclude-if condition="spec.linux_riscv.*" />
 		<phase>jit j2se</phase>
 
 		<dependencies>

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -1753,6 +1753,9 @@ void jitAddSpilledRegisters(J9StackWalkState * walkState, void * stackMap)
          }
       while (savedGPRs != 0);
       }
+#elif defined(TR_HOST_RISCV)
+   // TODO: Implement this
+   assert(0);
 #else
 #error Unknown TR_HOST type
 #endif

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2019 IBM Corp. and others
+Copyright (c) 2017, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 -->
 <module>
 	<artifact type="executable" name="constgen">
+		<exclude-if condition="spec.linux_riscv.*" />
 		<options>
 			<option name="isCPlusPlus"/>
 			<option name="doesNotRequireCMAIN"/>
@@ -92,6 +93,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</artifact>
 
 	<artifact type="target" name="run_constgen">
+		<exclude-if condition="spec.linux_riscv.*" />
 		<phase>core j2se</phase>
 		<dependencies>
 			<dependency name="constgen"/>

--- a/runtime/jit_vm/module.xml
+++ b/runtime/jit_vm/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module>
 	<artifact type="static" name="j9jit_vm">
 		<include-if condition="spec.flags.module_jit_vm" />
+		<exclude-if condition="spec.linux_riscv.*" />
 		<phase> core</phase>
 		<flags>
 			<flag name="$(TR_HOST)"/>
@@ -46,6 +47,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</flag>
 			<flag name="TR_TARGET_POWER">
 				<include-if condition="spec.flags.module_jit_ppc"/>
+			</flag>
+			<flag name="TR_TARGET_RISCV">
+				<include-if condition="spec.flags.module_jit_riscv"/>
 			</flag>
 			<flag name="TR_TARGET_S390">
 				<include-if condition="spec.flags.module_jit_s390"/>

--- a/runtime/oti/JITInterface.hpp
+++ b/runtime/oti/JITInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,6 +123,49 @@ typedef struct {
 	U_64 fpr[32];
 } J9JITRegisters;
 
+#elif defined(J9VM_ARCH_RISCV)
+
+typedef struct {
+	union {
+		UDATA numbered[32];
+		struct {
+			UDATA PC;
+			UDATA RA;
+			UDATA SP;
+			UDATA GP;
+			UDATA TP;
+			UDATA T0;
+			UDATA T1;
+			UDATA T2;
+			UDATA S0;
+			UDATA S1;
+			UDATA A0;
+			UDATA A1;
+			UDATA A2;
+			UDATA A3;
+			UDATA A4;
+			UDATA A5;
+			UDATA A6;
+			UDATA A7;
+			UDATA S2;
+			UDATA S3;
+			UDATA S4;
+			UDATA S5;
+			UDATA S6;
+			UDATA S7;
+			UDATA S8;
+			UDATA S9;
+			UDATA S10;
+			UDATA S11;
+			UDATA T3;
+			UDATA T4;
+			UDATA T5;
+			UDATA T6;
+		} named;
+	} gpr;
+	U_64 fpr[32];
+} J9JITRegisters;
+
 #else
 #error UNKNOWN PROCESSOR
 #endif
@@ -216,6 +259,8 @@ public:
 		}
 #elif defined(J9VM_ARCH_S390)
 		/* The vtable index is always in the register */
+#elif defined(J9VM_ARCH_RISCV)
+		/* To be implmeneted in JIT */
 #else
 #error UNKNOWN PROCESSOR
 #endif
@@ -235,6 +280,8 @@ public:
 		return (void*)((J9JITRegisters*)vmThread->entryLocalStorage->jitGlobalStorageBase)->gpr.numbered[30]; // LR
 #elif defined(J9VM_ARCH_S390)
 		return (void*)((J9JITRegisters*)vmThread->entryLocalStorage->jitGlobalStorageBase)->gpr.numbered[14];
+#elif defined(J9VM_ARCH_RISCV)
+		return (void*)((J9JITRegisters*)vmThread->entryLocalStorage->jitGlobalStorageBase)->gpr.named.RA;
 #else
 #error UNKNOWN PROCESSOR
 #endif
@@ -253,6 +300,8 @@ public:
 		((J9JITRegisters*)vmThread->entryLocalStorage->jitGlobalStorageBase)->gpr.numbered[30] = (UDATA)returnAddress; // LR
 #elif defined(J9VM_ARCH_S390)
 		((J9JITRegisters*)vmThread->entryLocalStorage->jitGlobalStorageBase)->gpr.numbered[14] = (UDATA)returnAddress;
+#elif defined(J9VM_ARCH_RISCV)
+		((J9JITRegisters*)vmThread->entryLocalStorage->jitGlobalStorageBase)->gpr.named.RA = (UDATA)returnAddress;
 #else
 #error UNKNOWN PROCESSOR
 #endif

--- a/runtime/util/jitregs.c
+++ b/runtime/util/jitregs.c
@@ -404,7 +404,77 @@ U_8 jitCalleeSavedRegisterList[] = {
 	0x1C	/* jit_r28 */
 };
 
-#else /* J9VM_ARCH_AARCH64 */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_AARCH64 */
+
+U_8 jitArgumentRegisterNumbers[] = { 10, 11, 12, 13, 14, 15, 16, 17 };
+U_8 jitFloatArgumentRegisterNumbers[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+char * jitRegisterNames[] = {
+	"jit_r0",
+	"jit_r1",
+	"jit_r2",
+	"jit_r3",
+	"jit_r4",
+	"jit_r5",
+	"jit_r6",
+	"jit_r7",
+	"jit_r8",
+	"jit_r9",
+	"jit_r10",
+	"jit_r11",
+	"jit_r12",
+	"jit_r13",
+	"jit_r14",
+	"jit_r15",
+	"jit_r16",
+	"jit_r17",
+	"jit_r18",
+	"jit_r19",
+	"jit_r20",
+	"jit_r21",
+	"jit_r22",
+	"jit_r23",
+	"jit_r24",
+	"jit_r25",
+	"jit_r26",
+	"jit_r27",
+	"jit_r28",
+	"jit_r29",
+	"jit_r30",
+	"jit_r31"
+};
+U_8 jitCalleeDestroyedRegisterList[] = {
+	0x01,	/* jit_r1 */
+	0x02,	/* jit_r2 */
+	0x03,	/* jit_r3 */
+	0x04,	/* jit_r4 */
+	0x05,	/* jit_r5 */
+	0x06,	/* jit_r6 */
+	0x07,	/* jit_r7 */
+	0x0A,	/* jit_r10 */
+	0x0B,	/* jit_r11 */
+	0x0C,	/* jit_r12 */
+	0x0D,	/* jit_r13 */
+	0x0E,	/* jit_r14 */
+	0x0F,	/* jit_r15 */
+	0x10,	/* jit_r16 */
+	0x11,	/* jit_r17 */
+};
+U_8 jitCalleeSavedRegisterList[] = {
+	0x08,	/* jit_r8 */
+	0x09,	/* jit_r9 */
+	0x12,	/* jit_r18 */
+	0x13,	/* jit_r19 */
+	0x14,	/* jit_r20 */
+	0x15,	/* jit_r21 */
+	0x16,	/* jit_r22 */
+	0x17,	/* jit_r23 */
+	0x18,	/* jit_r24 */
+	0x19,	/* jit_r25 */
+	0x1A,	/* jit_r26 */
+	0x1B,	/* jit_r27 */
+};
+
+#else /* J9VM_ARCH_RISCV */
 
 #error Unsupported platform
 


### PR DESCRIPTION
The changes mainly include miscellaneous code (with
placeholders for JIT) & setting to disable JIT compilation
on RISC-V 64bit from the OpenJ9 perspective.

Issue: eclipse#7421

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>