### PR TITLE
Integrate libffi for RISC-V in OpenJ9 (part5/libffi)

### DIFF
--- a/runtime/libffi/module.xml
+++ b/runtime/libffi/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2014, 2019 IBM Corp. and others
+Copyright (c) 2014, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<makefilestub data="FFI_TARGET_DIR := powerpc">
 				<include-if condition="spec.flags.arch_power" />
 			</makefilestub>
+			<makefilestub data="FFI_TARGET_DIR := riscv">
+				<include-if condition="spec.linux_riscv64.*" />
+			</makefilestub>
 			<makefilestub data="FFI_TARGET_DIR := s390">
 				<include-if condition="spec.linux_390.*" />
 				<include-if condition="spec.linux_ztpf.*" />
@@ -112,6 +115,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.osx_x86.* and spec.flags.J9VM_ENV_DATA64" />
 			</makefilestub>
 
+			<makefilestub data="FFI_PRECONF_DIR := rv64">
+				<include-if condition="spec.linux_riscv64.*" />
+			</makefilestub>
 
 			<makefilestub data="FFI_PRECONF_DIR := wa">
 				<include-if condition="spec.win_x86.* and spec.flags.J9VM_ENV_DATA64" />
@@ -203,6 +209,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</vpath>
 			<vpath pattern="sysv.S" path="aarch64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_aarch64.*" />
+			</vpath>
+
+			<!-- vpaths for riscv -->
+			<vpath pattern="ffi.c" path="riscv" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_riscv64.*" />
+			</vpath>
+			<vpath pattern="sysv.S" path="riscv" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_riscv64.*" />
 			</vpath>
 
 			<!-- vpaths for x86 -->

--- a/runtime/libffi/preconf/rv64/ffi.h
+++ b/runtime/libffi/preconf/rv64/ffi.h
@@ -1,0 +1,534 @@
+/* -----------------------------------------------------------------*-C-*-
+   libffi 3.3 - Copyright (c) 2011, 2014 Anthony Green
+                    - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the ``Software''), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------
+   Most of the API is documented in doc/libffi.texi.
+
+   The raw API is designed to bypass some of the argument packing and
+   unpacking on architectures for which it can be avoided.  Routines
+   are provided to emulate the raw API if the underlying platform
+   doesn't allow faster implementation.
+
+   More details on the raw API can be found in:
+
+   http://gcc.gnu.org/ml/java/1999-q3/msg00138.html
+
+   and
+
+   http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
+   -------------------------------------------------------------------- */
+/*
+ * ===========================================================================
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ * ===========================================================================
+ */
+
+#ifndef LIBFFI_H
+#define LIBFFI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Specify which architecture libffi is configured for. */
+#ifndef RISCV64
+#define RISCV64
+#endif
+
+/* ---- System configuration information --------------------------------- */
+
+#include <ffitarget.h>
+
+#ifndef LIBFFI_ASM
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define __attribute__(X)
+#endif
+
+#include <stddef.h>
+#include <limits.h>
+
+/* LONG_LONG_MAX is not always defined (not if STRICT_ANSI, for example).
+   But we can find it either under the correct ANSI name, or under GNU
+   C's internal name.  */
+
+#define FFI_64_BIT_MAX 9223372036854775807
+
+#ifdef LONG_LONG_MAX
+# define FFI_LONG_LONG_MAX LONG_LONG_MAX
+#else
+# ifdef LLONG_MAX
+#  define FFI_LONG_LONG_MAX LLONG_MAX
+#  ifdef _AIX52 /* or newer has C99 LLONG_MAX */
+#   undef FFI_64_BIT_MAX
+#   define FFI_64_BIT_MAX 9223372036854775807LL
+#  endif /* _AIX52 or newer */
+# else
+#  ifdef __GNUC__
+#   define FFI_LONG_LONG_MAX __LONG_LONG_MAX__
+#  endif
+#  ifdef _AIX /* AIX 5.1 and earlier have LONGLONG_MAX */
+#   ifndef __PPC64__
+#    if defined (__IBMC__) || defined (__IBMCPP__)
+#     define FFI_LONG_LONG_MAX LONGLONG_MAX
+#    endif
+#   endif /* __PPC64__ */
+#   undef  FFI_64_BIT_MAX
+#   define FFI_64_BIT_MAX 9223372036854775807LL
+#  endif
+# endif
+#endif
+
+/* The closure code assumes that this works on pointers, i.e. a size_t
+   can hold a pointer.  */
+
+typedef struct _ffi_type
+{
+  size_t size;
+  unsigned short alignment;
+  unsigned short type;
+  struct _ffi_type **elements;
+} ffi_type;
+
+/* Need minimal decorations for DLLs to work on Windows.  GCC has
+   autoimport and autoexport.  Always mark externally visible symbols
+   as dllimport for MSVC clients, even if it means an extra indirection
+   when using the static version of the library.
+   Besides, as a workaround, they can define FFI_BUILDING if they
+   *know* they are going to link with the static library.  */
+#if defined _MSC_VER
+# if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
+#  define FFI_API __declspec(dllexport)
+# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+#  define FFI_API __declspec(dllimport)
+# else                        /* Building/linking static library */
+#  define FFI_API
+# endif
+#else
+# define FFI_API
+#endif
+
+/* The externally visible type declarations also need the MSVC DLL
+   decorations, or they will not be exported from the object file.  */
+#if defined LIBFFI_HIDE_BASIC_TYPES
+# define FFI_EXTERN FFI_API
+#else
+# define FFI_EXTERN extern FFI_API
+#endif
+
+#ifndef LIBFFI_HIDE_BASIC_TYPES
+#if SCHAR_MAX == 127
+# define ffi_type_uchar                ffi_type_uint8
+# define ffi_type_schar                ffi_type_sint8
+#else
+ #error "char size not supported"
+#endif
+
+#if SHRT_MAX == 32767
+# define ffi_type_ushort       ffi_type_uint16
+# define ffi_type_sshort       ffi_type_sint16
+#elif SHRT_MAX == 2147483647
+# define ffi_type_ushort       ffi_type_uint32
+# define ffi_type_sshort       ffi_type_sint32
+#else
+ #error "short size not supported"
+#endif
+
+#if INT_MAX == 32767
+# define ffi_type_uint         ffi_type_uint16
+# define ffi_type_sint         ffi_type_sint16
+#elif INT_MAX == 2147483647
+# define ffi_type_uint         ffi_type_uint32
+# define ffi_type_sint         ffi_type_sint32
+#elif INT_MAX == 9223372036854775807
+# define ffi_type_uint         ffi_type_uint64
+# define ffi_type_sint         ffi_type_sint64
+#else
+ #error "int size not supported"
+#endif
+
+#if LONG_MAX == 2147483647
+# if FFI_LONG_LONG_MAX != FFI_64_BIT_MAX
+ #error "no 64-bit data type supported"
+# endif
+#elif LONG_MAX != FFI_64_BIT_MAX
+ #error "long size not supported"
+#endif
+
+#if LONG_MAX == 2147483647
+# define ffi_type_ulong        ffi_type_uint32
+# define ffi_type_slong        ffi_type_sint32
+#elif LONG_MAX == FFI_64_BIT_MAX
+# define ffi_type_ulong        ffi_type_uint64
+# define ffi_type_slong        ffi_type_sint64
+#else
+ #error "long size not supported"
+#endif
+
+/* These are defined in types.c.  */
+FFI_EXTERN ffi_type ffi_type_void;
+FFI_EXTERN ffi_type ffi_type_uint8;
+FFI_EXTERN ffi_type ffi_type_sint8;
+FFI_EXTERN ffi_type ffi_type_uint16;
+FFI_EXTERN ffi_type ffi_type_sint16;
+FFI_EXTERN ffi_type ffi_type_uint32;
+FFI_EXTERN ffi_type ffi_type_sint32;
+FFI_EXTERN ffi_type ffi_type_uint64;
+FFI_EXTERN ffi_type ffi_type_sint64;
+FFI_EXTERN ffi_type ffi_type_float;
+FFI_EXTERN ffi_type ffi_type_double;
+FFI_EXTERN ffi_type ffi_type_pointer;
+
+#if 1
+FFI_EXTERN ffi_type ffi_type_longdouble;
+#else
+#define ffi_type_longdouble ffi_type_double
+#endif
+
+#ifdef FFI_TARGET_HAS_COMPLEX_TYPE
+FFI_EXTERN ffi_type ffi_type_complex_float;
+FFI_EXTERN ffi_type ffi_type_complex_double;
+#if 1
+FFI_EXTERN ffi_type ffi_type_complex_longdouble;
+#else
+#define ffi_type_complex_longdouble ffi_type_complex_double
+#endif
+#endif
+#endif /* LIBFFI_HIDE_BASIC_TYPES */
+
+typedef enum {
+  FFI_OK = 0,
+  FFI_BAD_TYPEDEF,
+  FFI_BAD_ABI
+} ffi_status;
+
+typedef struct {
+  ffi_abi abi;
+  unsigned nargs;
+  ffi_type **arg_types;
+  ffi_type *rtype;
+  unsigned bytes;
+  unsigned flags;
+#ifdef FFI_EXTRA_CIF_FIELDS
+  FFI_EXTRA_CIF_FIELDS;
+#endif
+} ffi_cif;
+
+#if 0
+/* Used to adjust size/alignment of ffi types.  */
+void ffi_prep_types (ffi_abi abi);
+#endif
+
+/* Used internally, but overridden by some architectures */
+ffi_status ffi_prep_cif_core(ffi_cif *cif,
+			     ffi_abi abi,
+			     unsigned int isvariadic,
+			     unsigned int nfixedargs,
+			     unsigned int ntotalargs,
+			     ffi_type *rtype,
+			     ffi_type **atypes);
+
+/* ---- Definitions for the raw API -------------------------------------- */
+
+#ifndef FFI_SIZEOF_ARG
+# if LONG_MAX == 2147483647
+#  define FFI_SIZEOF_ARG        4
+# elif LONG_MAX == FFI_64_BIT_MAX
+#  define FFI_SIZEOF_ARG        8
+# endif
+#endif
+
+#ifndef FFI_SIZEOF_JAVA_RAW
+#  define FFI_SIZEOF_JAVA_RAW FFI_SIZEOF_ARG
+#endif
+
+typedef union {
+  ffi_sarg  sint;
+  ffi_arg   uint;
+  float	    flt;
+  char      data[FFI_SIZEOF_ARG];
+  void*     ptr;
+} ffi_raw;
+
+#if FFI_SIZEOF_JAVA_RAW == 4 && FFI_SIZEOF_ARG == 8
+/* This is a special case for mips64/n32 ABI (and perhaps others) where
+   sizeof(void *) is 4 and FFI_SIZEOF_ARG is 8.  */
+typedef union {
+  signed int	sint;
+  unsigned int	uint;
+  float		flt;
+  char		data[FFI_SIZEOF_JAVA_RAW];
+  void*		ptr;
+} ffi_java_raw;
+#else
+typedef ffi_raw ffi_java_raw;
+#endif
+
+
+FFI_API 
+void ffi_raw_call (ffi_cif *cif,
+		   void (*fn)(void),
+		   void *rvalue,
+		   ffi_raw *avalue);
+
+FFI_API void ffi_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_raw *raw);
+FFI_API void ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args);
+FFI_API size_t ffi_raw_size (ffi_cif *cif);
+
+/* This is analogous to the raw API, except it uses Java parameter
+   packing, even on 64-bit machines.  I.e. on 64-bit machines longs
+   and doubles are followed by an empty 64-bit word.  */
+
+#if !FFI_NATIVE_RAW_API
+FFI_API
+void ffi_java_raw_call (ffi_cif *cif,
+			void (*fn)(void),
+			void *rvalue,
+			ffi_java_raw *avalue);
+#endif
+
+FFI_API
+void ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw);
+FFI_API
+void ffi_java_raw_to_ptrarray (ffi_cif *cif, ffi_java_raw *raw, void **args);
+FFI_API
+size_t ffi_java_raw_size (ffi_cif *cif);
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#if FFI_CLOSURES
+
+#ifdef _MSC_VER
+__declspec(align(8))
+#endif
+typedef struct {
+#if 0
+  void *trampoline_table;
+  void *trampoline_table_entry;
+#else
+  char tramp[FFI_TRAMPOLINE_SIZE];
+#endif
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+  void      *user_data;
+} ffi_closure
+#ifdef __GNUC__
+    __attribute__((aligned (8)))
+#endif
+    ;
+
+#ifndef __GNUC__
+# ifdef __sgi
+#  pragma pack 0
+# endif
+#endif
+
+FFI_API void *ffi_closure_alloc (size_t size, void **code);
+FFI_API void ffi_closure_free (void *);
+
+FFI_API ffi_status
+ffi_prep_closure (ffi_closure*,
+		  ffi_cif *,
+		  void (*fun)(ffi_cif*,void*,void**,void*),
+		  void *user_data)
+#if defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 405)
+  __attribute__((deprecated ("use ffi_prep_closure_loc instead")))
+#elif defined(__GNUC__) && __GNUC__ >= 3
+  __attribute__((deprecated))
+#endif
+  ;
+
+FFI_API ffi_status
+ffi_prep_closure_loc (ffi_closure*,
+		      ffi_cif *,
+		      void (*fun)(ffi_cif*,void*,void**,void*),
+		      void *user_data,
+		      void*codeloc);
+
+#ifdef __sgi
+# pragma pack 8
+#endif
+typedef struct {
+#if 0
+  void *trampoline_table;
+  void *trampoline_table_entry;
+#else
+  char tramp[FFI_TRAMPOLINE_SIZE];
+#endif
+  ffi_cif   *cif;
+
+#if !FFI_NATIVE_RAW_API
+
+  /* If this is enabled, then a raw closure has the same layout 
+     as a regular closure.  We use this to install an intermediate 
+     handler to do the transaltion, void** -> ffi_raw*.  */
+
+  void     (*translate_args)(ffi_cif*,void*,void**,void*);
+  void      *this_closure;
+
+#endif
+
+  void     (*fun)(ffi_cif*,void*,ffi_raw*,void*);
+  void      *user_data;
+
+} ffi_raw_closure;
+
+typedef struct {
+#if 0
+  void *trampoline_table;
+  void *trampoline_table_entry;
+#else
+  char tramp[FFI_TRAMPOLINE_SIZE];
+#endif
+
+  ffi_cif   *cif;
+
+#if !FFI_NATIVE_RAW_API
+
+  /* If this is enabled, then a raw closure has the same layout 
+     as a regular closure.  We use this to install an intermediate 
+     handler to do the translation, void** -> ffi_raw*.  */
+
+  void     (*translate_args)(ffi_cif*,void*,void**,void*);
+  void      *this_closure;
+
+#endif
+
+  void     (*fun)(ffi_cif*,void*,ffi_java_raw*,void*);
+  void      *user_data;
+
+} ffi_java_raw_closure;
+
+FFI_API ffi_status
+ffi_prep_raw_closure (ffi_raw_closure*,
+		      ffi_cif *cif,
+		      void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+		      void *user_data);
+
+FFI_API ffi_status
+ffi_prep_raw_closure_loc (ffi_raw_closure*,
+			  ffi_cif *cif,
+			  void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+			  void *user_data,
+			  void *codeloc);
+
+#if !FFI_NATIVE_RAW_API
+FFI_API ffi_status
+ffi_prep_java_raw_closure (ffi_java_raw_closure*,
+		           ffi_cif *cif,
+		           void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
+		           void *user_data);
+
+FFI_API ffi_status
+ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
+			       ffi_cif *cif,
+			       void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
+			       void *user_data,
+			       void *codeloc);
+#endif
+
+#endif /* FFI_CLOSURES */
+
+#if FFI_GO_CLOSURES
+
+typedef struct {
+  void      *tramp;
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+} ffi_go_closure;
+
+FFI_API ffi_status ffi_prep_go_closure (ffi_go_closure*, ffi_cif *,
+				void (*fun)(ffi_cif*,void*,void**,void*));
+
+FFI_API void ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
+		  void **avalue, void *closure);
+
+#endif /* FFI_GO_CLOSURES */
+
+/* ---- Public interface definition -------------------------------------- */
+
+FFI_API 
+ffi_status ffi_prep_cif(ffi_cif *cif,
+			ffi_abi abi,
+			unsigned int nargs,
+			ffi_type *rtype,
+			ffi_type **atypes);
+
+FFI_API
+ffi_status ffi_prep_cif_var(ffi_cif *cif,
+			    ffi_abi abi,
+			    unsigned int nfixedargs,
+			    unsigned int ntotalargs,
+			    ffi_type *rtype,
+			    ffi_type **atypes);
+
+FFI_API
+void ffi_call(ffi_cif *cif,
+	      void (*fn)(void),
+	      void *rvalue,
+	      void **avalue);
+
+FFI_API
+ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
+				   size_t *offsets);
+
+/* Useful for eliminating compiler warnings.  */
+#define FFI_FN(f) ((void (*)(void))f)
+
+/* ---- Definitions shared with assembly code ---------------------------- */
+
+#endif
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0    
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2    
+#define FFI_TYPE_DOUBLE     3
+#if 1
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5   
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7 
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+#define FFI_TYPE_COMPLEX    15
+
+/* This should always refer to the last type code (for sanity checks).  */
+#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/libffi/preconf/rv64/fficonfig.h
+++ b/runtime/libffi/preconf/rv64/fficonfig.h
@@ -1,0 +1,220 @@
+/* fficonfig.h.  Generated from fficonfig.h.in by configure.  */
+/* fficonfig.h.in.  Generated from configure.ac by autoheader.  */
+/*
+ * ===========================================================================
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ * ===========================================================================
+ */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+   systems. This function is required for `alloca.c' support on those systems.
+   */
+/* #undef CRAY_STACKSEG_END */
+
+/* Define to 1 if using `alloca.c'. */
+/* #undef C_ALLOCA */
+
+/* Define to the flags needed for the .section .eh_frame directive. */
+#define EH_FRAME_FLAGS "a"
+
+/* Define this if you want extra debugging. */
+/* #undef FFI_DEBUG */
+
+/* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
+/* #undef FFI_EXEC_TRAMPOLINE_TABLE */
+
+/* Define this if you want to enable pax emulated trampolines */
+/* #undef FFI_MMAP_EXEC_EMUTRAMP_PAX */
+
+/* Cannot use malloc on this target, so, we revert to alternative means */
+/* #undef FFI_MMAP_EXEC_WRIT */
+
+/* Define this if you do not want support for the raw API. */
+/* #undef FFI_NO_RAW_API */
+
+/* Define this if you do not want support for aggregate types. */
+/* #undef FFI_NO_STRUCTS */
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#define HAVE_ALLOCA 1
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+#define HAVE_ALLOCA_H 1
+
+/* Define if your assembler supports .ascii. */
+#define HAVE_AS_ASCII_PSEUDO_OP 1
+
+/* Define if your assembler supports .cfi_* directives. */
+#define HAVE_AS_CFI_PSEUDO_OP 1
+
+/* Define if your assembler supports .register. */
+/* #undef HAVE_AS_REGISTER_PSEUDO_OP */
+
+/* Define if your assembler and linker support unaligned PC relative relocs.
+   */
+/* #undef HAVE_AS_SPARC_UA_PCREL */
+
+/* Define if your assembler supports .string. */
+#define HAVE_AS_STRING_PSEUDO_OP 1
+
+/* Define if your assembler supports unwind section type. */
+/* #undef HAVE_AS_X86_64_UNWIND_SECTION_TYPE */
+
+/* Define if your assembler supports PC relative relocs. */
+/* #undef HAVE_AS_X86_PCREL */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define if __attribute__((visibility("hidden"))) is supported. */
+#define HAVE_HIDDEN_VISIBILITY_ATTRIBUTE 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if you have the long double type and it is bigger than a double */
+#define HAVE_LONG_DOUBLE 1
+
+/* Define if you support more than one size of the long double type */
+/* #undef HAVE_LONG_DOUBLE_VARIANT */
+
+/* Define to 1 if you have the `memcpy' function. */
+#define HAVE_MEMCPY 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `mkostemp' function. */
+#define HAVE_MKOSTEMP 1
+
+/* Define to 1 if you have the `mmap' function. */
+#define HAVE_MMAP 1
+
+/* Define if mmap with MAP_ANON(YMOUS) works. */
+#define HAVE_MMAP_ANON 1
+
+/* Define if mmap of /dev/zero works. */
+#define HAVE_MMAP_DEV_ZERO 1
+
+/* Define if read-only mmap of a plain file works. */
+#define HAVE_MMAP_FILE 1
+
+/* Define if .eh_frame sections should be read-only. */
+/* #undef HAVE_RO_EH_FRAME */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+/* #undef NO_MINUS_C_MINUS_O */
+
+/* Name of package */
+#define PACKAGE "libffi"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "http://github.com/atgreen/libffi/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libffi"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libffi 3.2.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libffi"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "3.2.1"
+
+/* The size of `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE 8
+
+/* The size of `long double', as computed by sizeof. */
+#define SIZEOF_LONG_DOUBLE 16
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 8
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+/* #undef STACK_DIRECTION */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define if symbols are underscored. */
+/* #undef SYMBOL_UNDERSCORE */
+
+/* Define this if you are using Purify and want to suppress spurious messages.
+   */
+/* #undef USING_PURIFY */
+
+/* Version number of package */
+#define VERSION "3.2.1"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+
+#ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name) .hidden name
+#else
+#define FFI_HIDDEN __attribute__ ((visibility ("hidden")))
+#endif
+#else
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name)
+#else
+#define FFI_HIDDEN
+#endif
+#endif
+

--- a/runtime/libffi/riscv/ffi.c
+++ b/runtime/libffi/riscv/ffi.c
@@ -1,0 +1,486 @@
+/* -----------------------------------------------------------------------
+   ffi.c - Copyright (c) 2015 Michael Knyszek <mknyszek@berkeley.edu>
+                         2015 Andrew Waterman <waterman@cs.berkeley.edu>
+                         2018 Stef O'Rear <sorear2@gmail.com>
+   Based on MIPS N32/64 port
+
+   RISC-V Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+/*
+ * ===========================================================================
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ * ===========================================================================
+ */
+
+#include <ffi.h>
+#include <ffi_common.h>
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#if __riscv_float_abi_double
+#define ABI_FLEN 64
+#define ABI_FLOAT double
+#elif __riscv_float_abi_single
+#define ABI_FLEN 32
+#define ABI_FLOAT float
+#endif
+
+#define NARGREG 8
+#define STKALIGN 16
+#define MAXCOPYARG (2 * sizeof(double))
+
+typedef struct call_context
+{
+#if ABI_FLEN
+    ABI_FLOAT fa[8];
+#endif
+    size_t a[8];
+    /* used by the assembly code to in-place construct its own stack frame */
+    char frame[16];
+} call_context;
+
+typedef struct call_builder
+{
+    call_context *aregs;
+    int used_integer;
+    int used_float;
+    size_t *used_stack;
+} call_builder;
+
+/* integer (not pointer) less than ABI XLEN */
+/* FFI_TYPE_INT does not appear to be used */
+#if __SIZEOF_POINTER__ == 8
+#define IS_INT(type) ((type) >= FFI_TYPE_UINT8 && (type) <= FFI_TYPE_SINT64)
+#else
+#define IS_INT(type) ((type) >= FFI_TYPE_UINT8 && (type) <= FFI_TYPE_SINT32)
+#endif
+
+#if ABI_FLEN
+typedef struct {
+    char as_elements, type1, offset2, type2;
+} float_struct_info;
+
+#if ABI_FLEN >= 64
+#define IS_FLOAT(type) ((type) >= FFI_TYPE_FLOAT && (type) <= FFI_TYPE_DOUBLE)
+#else
+#define IS_FLOAT(type) ((type) == FFI_TYPE_FLOAT)
+#endif
+
+static ffi_type **flatten_struct(ffi_type *in, ffi_type **out, ffi_type **out_end) {
+    int i;
+    if (out == out_end) return out;
+    if (in->type != FFI_TYPE_STRUCT) {
+        *(out++) = in;
+    } else {
+        for (i = 0; in->elements[i]; i++)
+            out = flatten_struct(in->elements[i], out, out_end);
+    }
+    return out;
+}
+
+/* Structs with at most two fields after flattening, one of which is of
+   floating point type, are passed in multiple registers if sufficient
+   registers are available. */
+static float_struct_info struct_passed_as_elements(call_builder *cb, ffi_type *top) {
+    float_struct_info ret = {0, 0, 0, 0};
+    ffi_type *fields[3];
+    int num_floats, num_ints;
+    int num_fields = flatten_struct(top, fields, fields + 3) - fields;
+
+    if (num_fields == 1) {
+        if (IS_FLOAT(fields[0]->type)) {
+            ret.as_elements = 1;
+            ret.type1 = fields[0]->type;
+        }
+    } else if (num_fields == 2) {
+        num_floats = IS_FLOAT(fields[0]->type) + IS_FLOAT(fields[1]->type);
+        num_ints = IS_INT(fields[0]->type) + IS_INT(fields[1]->type);
+        if (num_floats == 0 || num_floats + num_ints != 2)
+            return ret;
+        if (cb->used_float + num_floats > NARGREG || cb->used_integer + (2 - num_floats) > NARGREG)
+            return ret;
+        if (!IS_FLOAT(fields[0]->type) && !IS_FLOAT(fields[1]->type))
+            return ret;
+
+        ret.type1 = fields[0]->type;
+        ret.type2 = fields[1]->type;
+        ret.offset2 = ALIGN(fields[0]->size, fields[1]->alignment);
+        ret.as_elements = 1;
+    }
+
+    return ret;
+}
+#endif
+
+/* allocates a single register, float register, or XLEN-sized stack slot to a datum */
+static void marshal_atom(call_builder *cb, int type, void *data) {
+    size_t value = 0;
+    switch (type) {
+        case FFI_TYPE_UINT8: value = *(uint8_t *)data; break;
+        case FFI_TYPE_SINT8: value = *(int8_t *)data; break;
+        case FFI_TYPE_UINT16: value = *(uint16_t *)data; break;
+        case FFI_TYPE_SINT16: value = *(int16_t *)data; break;
+        /* 32-bit quantities are always sign-extended in the ABI */
+        case FFI_TYPE_UINT32: value = *(int32_t *)data; break;
+        case FFI_TYPE_SINT32: value = *(int32_t *)data; break;
+#if __SIZEOF_POINTER__ == 8
+        case FFI_TYPE_UINT64: value = *(uint64_t *)data; break;
+        case FFI_TYPE_SINT64: value = *(int64_t *)data; break;
+#endif
+        case FFI_TYPE_POINTER: value = *(size_t *)data; break;
+
+        /* float values may be recoded in an implementation-defined way
+           by hardware conforming to 2.1 or earlier, so use asm to
+           reinterpret floats as doubles */
+#if ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(float *)data));
+            return;
+#endif
+#if ABI_FLEN >= 64
+        case FFI_TYPE_DOUBLE:
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(double *)data));
+            return;
+#endif
+        default: FFI_ASSERT(0); break;
+    }
+
+    if (cb->used_integer == NARGREG) {
+        *cb->used_stack++ = value;
+    } else {
+        cb->aregs->a[cb->used_integer++] = value;
+    }
+}
+
+static void unmarshal_atom(call_builder *cb, int type, void *data) {
+    size_t value;
+    switch (type) {
+#if ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            return;
+#endif
+#if ABI_FLEN >= 64
+        case FFI_TYPE_DOUBLE:
+            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            return;
+#endif
+    }
+
+    if (cb->used_integer == NARGREG) {
+        value = *cb->used_stack++;
+    } else {
+        value = cb->aregs->a[cb->used_integer++];
+    }
+
+    switch (type) {
+        case FFI_TYPE_UINT8: *(uint8_t *)data = value; break;
+        case FFI_TYPE_SINT8: *(uint8_t *)data = value; break;
+        case FFI_TYPE_UINT16: *(uint16_t *)data = value; break;
+        case FFI_TYPE_SINT16: *(uint16_t *)data = value; break;
+        case FFI_TYPE_UINT32: *(uint32_t *)data = value; break;
+        case FFI_TYPE_SINT32: *(uint32_t *)data = value; break;
+#if __SIZEOF_POINTER__ == 8
+        case FFI_TYPE_UINT64: *(uint64_t *)data = value; break;
+        case FFI_TYPE_SINT64: *(uint64_t *)data = value; break;
+#endif
+        case FFI_TYPE_POINTER: *(size_t *)data = value; break;
+        default: FFI_ASSERT(0); break;
+    }
+}
+
+/* adds an argument to a call, or a not by reference return value */
+static void marshal(call_builder *cb, ffi_type *type, int var, void *data) {
+    size_t realign[2];
+
+#if ABI_FLEN
+    if (!var && type->type == FFI_TYPE_STRUCT) {
+        float_struct_info fsi = struct_passed_as_elements(cb, type);
+        if (fsi.as_elements) {
+            marshal_atom(cb, fsi.type1, data);
+            if (fsi.offset2)
+                marshal_atom(cb, fsi.type2, ((char*)data) + fsi.offset2);
+            return;
+        }
+    }
+
+    if (!var && cb->used_float < NARGREG && IS_FLOAT(type->type)) {
+        marshal_atom(cb, type->type, data);
+        return;
+    }
+#endif
+
+    if (type->size > 2 * __SIZEOF_POINTER__) {
+        /* pass by reference */
+        marshal_atom(cb, FFI_TYPE_POINTER, &data);
+    } else if (IS_INT(type->type) || type->type == FFI_TYPE_POINTER) {
+        marshal_atom(cb, type->type, data);
+    } else {
+        /* overlong integers, soft-float floats, and structs without special
+           float handling are treated identically from this point on */
+
+        /* variadics are aligned even in registers */
+        if (type->alignment > __SIZEOF_POINTER__) {
+            if (var)
+                cb->used_integer = ALIGN(cb->used_integer, 2);
+            cb->used_stack = (size_t *)ALIGN(cb->used_stack, 2*__SIZEOF_POINTER__);
+        }
+
+        memcpy(realign, data, type->size);
+        if (type->size > 0)
+            marshal_atom(cb, FFI_TYPE_POINTER, realign);
+        if (type->size > __SIZEOF_POINTER__)
+            marshal_atom(cb, FFI_TYPE_POINTER, realign + 1);
+    }
+}
+
+/* for arguments passed by reference returns the pointer, otherwise the arg is copied (up to MAXCOPYARG bytes) */
+static void *unmarshal(call_builder *cb, ffi_type *type, int var, void *data) {
+    size_t realign[2];
+    void *pointer;
+
+#if ABI_FLEN
+    if (!var && type->type == FFI_TYPE_STRUCT) {
+        float_struct_info fsi = struct_passed_as_elements(cb, type);
+        if (fsi.as_elements) {
+            unmarshal_atom(cb, fsi.type1, data);
+            if (fsi.offset2)
+                unmarshal_atom(cb, fsi.type2, ((char*)data) + fsi.offset2);
+            return data;
+        }
+    }
+
+    if (!var && cb->used_float < NARGREG && IS_FLOAT(type->type)) {
+        unmarshal_atom(cb, type->type, data);
+        return data;
+    }
+#endif
+
+    if (type->size > 2 * __SIZEOF_POINTER__) {
+        /* pass by reference */
+        unmarshal_atom(cb, FFI_TYPE_POINTER, (char*)&pointer);
+        return pointer;
+    } else if (IS_INT(type->type) || type->type == FFI_TYPE_POINTER) {
+        unmarshal_atom(cb, type->type, data);
+        return data;
+    } else {
+        /* overlong integers, soft-float floats, and structs without special
+           float handling are treated identically from this point on */
+
+        /* variadics are aligned even in registers */
+        if (type->alignment > __SIZEOF_POINTER__) {
+            if (var)
+                cb->used_integer = ALIGN(cb->used_integer, 2);
+            cb->used_stack = (size_t *)ALIGN(cb->used_stack, 2*__SIZEOF_POINTER__);
+        }
+
+        if (type->size > 0)
+            unmarshal_atom(cb, FFI_TYPE_POINTER, realign);
+        if (type->size > __SIZEOF_POINTER__)
+            unmarshal_atom(cb, FFI_TYPE_POINTER, realign + 1);
+        memcpy(data, realign, type->size);
+        return data;
+    }
+}
+
+static int passed_by_ref(call_builder *cb, ffi_type *type, int var) {
+#if ABI_FLEN
+    if (!var && type->type == FFI_TYPE_STRUCT) {
+        float_struct_info fsi = struct_passed_as_elements(cb, type);
+        if (fsi.as_elements) return 0;
+    }
+#endif
+
+    return type->size > 2 * __SIZEOF_POINTER__;
+}
+
+/* Perform machine dependent cif processing */
+ffi_status ffi_prep_cif_machdep(ffi_cif *cif) {
+    cif->riscv_nfixedargs = cif->nargs;
+    return FFI_OK;
+}
+
+/* Perform machine dependent cif processing when we have a variadic function */
+
+ffi_status ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned int nfixedargs, unsigned int ntotalargs) {
+    cif->riscv_nfixedargs = nfixedargs;
+    return FFI_OK;
+}
+
+/* Low level routine for calling functions */
+extern void ffi_call_asm (void *stack, struct call_context *regs,
+			  void (*fn) (void), void *closure) FFI_HIDDEN;
+
+static void
+ffi_call_int (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue,
+	      void *closure)
+{
+    /* this is a conservative estimate, assuming a complex return value and
+       that all remaining arguments are long long / __int128 */
+    size_t arg_bytes = cif->nargs <= 3 ? 0 :
+        ALIGN(2 * sizeof(size_t) * (cif->nargs - 3), STKALIGN);
+    size_t rval_bytes = 0;
+    if (rvalue == NULL && cif->rtype->size > 2*__SIZEOF_POINTER__)
+        rval_bytes = ALIGN(cif->rtype->size, STKALIGN);
+    size_t alloc_size = arg_bytes + rval_bytes + sizeof(call_context);
+
+    /* the assembly code will deallocate all stack data at lower addresses
+       than the argument region, so we need to allocate the frame and the
+       return value after the arguments in a single allocation */
+    size_t alloc_base;
+    /* Argument region must be 16-byte aligned */
+    if (_Alignof(max_align_t) >= STKALIGN) {
+        /* since sizeof long double is normally 16, the compiler will
+           guarantee alloca alignment to at least that much */
+        alloc_base = (size_t)alloca(alloc_size);
+    } else {
+        alloc_base = ALIGN(alloca(alloc_size + STKALIGN - 1), STKALIGN);
+    }
+
+    if (rval_bytes)
+        rvalue = (void*)(alloc_base + arg_bytes);
+
+    call_builder cb;
+    cb.used_float = cb.used_integer = 0;
+    cb.aregs = (call_context*)(alloc_base + arg_bytes + rval_bytes);
+    cb.used_stack = (void*)alloc_base;
+
+    int return_by_ref = passed_by_ref(&cb, cif->rtype, 0);
+    if (return_by_ref)
+        marshal(&cb, &ffi_type_pointer, 0, &rvalue);
+
+    int i;
+    for (i = 0; i < cif->nargs; i++)
+        marshal(&cb, cif->arg_types[i], i >= cif->riscv_nfixedargs, avalue[i]);
+
+    ffi_call_asm ((void *) alloc_base, cb.aregs, fn, closure);
+
+    cb.used_float = cb.used_integer = 0;
+    if (!return_by_ref && rvalue)
+        unmarshal(&cb, cif->rtype, 0, rvalue);
+}
+
+void
+ffi_call (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue)
+{
+  ffi_call_int(cif, fn, rvalue, avalue, NULL);
+}
+
+void
+ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
+	     void **avalue, void *closure)
+{
+  ffi_call_int(cif, fn, rvalue, avalue, closure);
+}
+
+extern void ffi_closure_asm(void) FFI_HIDDEN;
+
+ffi_status ffi_prep_closure_loc(ffi_closure *closure, ffi_cif *cif, void (*fun)(ffi_cif*,void*,void**,void*), void *user_data, void *codeloc)
+{
+    uint32_t *tramp = (uint32_t *) &closure->tramp[0];
+    uint64_t fn = (uint64_t) (uintptr_t) ffi_closure_asm;
+
+    if (cif->abi <= FFI_FIRST_ABI || cif->abi >= FFI_LAST_ABI)
+        return FFI_BAD_ABI;
+
+    /* we will call ffi_closure_inner with codeloc, not closure, but as long
+       as the memory is readable it should work */
+
+    tramp[0] = 0x00000317; /* auipc t1, 0 (i.e. t0 <- codeloc) */
+#if __SIZEOF_POINTER__ == 8
+    tramp[1] = 0x01033383; /* ld t2, 16(t1) */
+#else
+    tramp[1] = 0x01032383; /* lw t2, 16(t1) */
+#endif
+    tramp[2] = 0x00038067; /* jr t2 */
+    tramp[3] = 0x00000013; /* nop */
+    tramp[4] = fn;
+    tramp[5] = fn >> 32;
+
+    closure->cif = cif;
+    closure->fun = fun;
+    closure->user_data = user_data;
+
+    __builtin___clear_cache(codeloc, codeloc + FFI_TRAMPOLINE_SIZE);
+
+    return FFI_OK;
+}
+
+extern void ffi_go_closure_asm (void) FFI_HIDDEN;
+
+ffi_status
+ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif *cif,
+		     void (*fun) (ffi_cif *, void *, void **, void *))
+{
+  if (cif->abi <= FFI_FIRST_ABI || cif->abi >= FFI_LAST_ABI)
+    return FFI_BAD_ABI;
+
+  closure->tramp = (void *) ffi_go_closure_asm;
+  closure->cif = cif;
+  closure->fun = fun;
+
+  return FFI_OK;
+}
+
+/* Called by the assembly code with aregs pointing to saved argument registers
+   and stack pointing to the stacked arguments.  Return values passed in
+   registers will be reloaded from aregs. */
+void FFI_HIDDEN
+ffi_closure_inner (ffi_cif *cif,
+		   void (*fun) (ffi_cif *, void *, void **, void *),
+		   void *user_data,
+		   size_t *stack, call_context *aregs)
+{
+    void **avalue = alloca(cif->nargs * sizeof(void*));
+    /* storage for arguments which will be copied by unmarshal().  We could
+       theoretically avoid the copies in many cases and use at most 128 bytes
+       of memory, but allocating disjoint storage for each argument is
+       simpler. */
+    char *astorage = alloca(cif->nargs * MAXCOPYARG);
+    void *rvalue;
+    call_builder cb;
+    int return_by_ref;
+    int i;
+
+    cb.aregs = aregs;
+    cb.used_integer = cb.used_float = 0;
+    cb.used_stack = stack;
+
+    return_by_ref = passed_by_ref(&cb, cif->rtype, 0);
+    if (return_by_ref)
+        unmarshal(&cb, &ffi_type_pointer, 0, &rvalue);
+    else
+        rvalue = alloca(cif->rtype->size);
+
+    for (i = 0; i < cif->nargs; i++)
+        avalue[i] = unmarshal(&cb, cif->arg_types[i],
+            i >= cif->riscv_nfixedargs, astorage + i*MAXCOPYARG);
+
+    fun (cif, rvalue, avalue, user_data);
+
+    if (!return_by_ref && cif->rtype->type != FFI_TYPE_VOID) {
+        cb.used_integer = cb.used_float = 0;
+        marshal(&cb, cif->rtype, 0, rvalue);
+    }
+}

--- a/runtime/libffi/riscv/ffitarget.h
+++ b/runtime/libffi/riscv/ffitarget.h
@@ -1,0 +1,74 @@
+/* -----------------------------------------------------------------*-C-*-
+   ffitarget.h - 2014 Michael Knyszek
+
+   Target configuration macros for RISC-V.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+/*
+ * ===========================================================================
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ * ===========================================================================
+ */
+
+#ifndef LIBFFI_TARGET_H
+#define LIBFFI_TARGET_H
+
+#ifndef LIBFFI_H
+#error "Please do not include ffitarget.h directly into your source.  Use ffi.h instead."
+#endif
+
+#ifndef __riscv
+#error "libffi was configured for a RISC-V target but this does not appear to be a RISC-V compiler."
+#endif
+
+#ifndef LIBFFI_ASM
+
+typedef unsigned long ffi_arg;
+typedef   signed long ffi_sarg;
+
+/* FFI_UNUSED_NN and riscv_unused are to maintain ABI compatibility with a
+   distributed Berkeley patch from 2014, and can be removed at SONAME bump */
+typedef enum ffi_abi {
+    FFI_FIRST_ABI = 0,
+    FFI_SYSV,
+    FFI_UNUSED_1,
+    FFI_UNUSED_2,
+    FFI_UNUSED_3,
+    FFI_LAST_ABI,
+
+    FFI_DEFAULT_ABI = FFI_SYSV
+} ffi_abi;
+
+#endif /* LIBFFI_ASM */
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#define FFI_CLOSURES 1
+#define FFI_GO_CLOSURES 1
+#define FFI_TRAMPOLINE_SIZE 24
+#define FFI_NATIVE_RAW_API 0
+#define FFI_EXTRA_CIF_FIELDS unsigned riscv_nfixedargs; unsigned riscv_unused;
+#define FFI_TARGET_SPECIFIC_VARIADIC
+
+#endif
+

--- a/runtime/libffi/riscv/sysv.S
+++ b/runtime/libffi/riscv/sysv.S
@@ -1,0 +1,298 @@
+/* -----------------------------------------------------------------------
+   ffi.c - Copyright (c) 2015 Michael Knyszek <mknyszek@berkeley.edu>
+                         2015 Andrew Waterman <waterman@cs.berkeley.edu>
+                         2018 Stef O'Rear <sorear2@gmail.com>
+
+   RISC-V Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+/*
+ * ===========================================================================
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ * ===========================================================================
+ */
+
+#define LIBFFI_ASM
+#include <fficonfig.h>
+#include <ffi.h>
+
+/* Define aliases so that we can handle all ABIs uniformly */
+
+#if __SIZEOF_POINTER__ == 8
+#define PTRS 8
+#define LARG ld
+#define SARG sd
+#else
+#define PTRS 4
+#define LARG lw
+#define SARG sw
+#endif
+
+#if __riscv_float_abi_double
+#define FLTS 8
+#define FLARG fld
+#define FSARG fsd
+#elif __riscv_float_abi_single
+#define FLTS 4
+#define FLARG flw
+#define FSARG fsw
+#else
+#define FLTS 0
+#endif
+
+#define fp s0
+
+    .text
+    .globl  ffi_call_asm
+    .type   ffi_call_asm, @function
+    .hidden ffi_call_asm
+/*
+  struct call_context {
+      floatreg fa[8];
+      intreg a[8];
+      intreg pad[rv32 ? 2 : 0];
+      intreg save_fp, save_ra;
+  }
+  void ffi_call_asm (size_t *stackargs, struct call_context *regargs,
+                     void (*fn) (void), void *closure);
+*/
+
+#define FRAME_LEN (8 * FLTS + 8 * PTRS + 16)
+
+ffi_call_asm:
+    .cfi_startproc
+
+    /*
+      We are NOT going to set up an ordinary stack frame.  In order to pass
+      the stacked args to the called function, we adjust our stack pointer to
+      a0, which is in the _caller's_ alloca area.  We establish our own stack
+      frame at the end of the call_context.
+
+      Anything below the arguments will be freed at this point, although we
+      preserve the call_context so that it can be read back in the caller.
+    */
+
+    .cfi_def_cfa 11, FRAME_LEN # interim CFA based on a1
+    SARG    fp, FRAME_LEN - 2*PTRS(a1)
+    .cfi_offset 8, -2*PTRS
+    SARG    ra, FRAME_LEN - 1*PTRS(a1)
+    .cfi_offset 1, -1*PTRS
+
+    addi    fp, a1, FRAME_LEN
+    mv      sp, a0
+    .cfi_def_cfa 8, 0 # our frame is fully set up
+
+    # Load arguments
+    mv      t1, a2
+    mv      t2, a3
+
+#if FLTS
+    FLARG   fa0, -FRAME_LEN+0*FLTS(fp)
+    FLARG   fa1, -FRAME_LEN+1*FLTS(fp)
+    FLARG   fa2, -FRAME_LEN+2*FLTS(fp)
+    FLARG   fa3, -FRAME_LEN+3*FLTS(fp)
+    FLARG   fa4, -FRAME_LEN+4*FLTS(fp)
+    FLARG   fa5, -FRAME_LEN+5*FLTS(fp)
+    FLARG   fa6, -FRAME_LEN+6*FLTS(fp)
+    FLARG   fa7, -FRAME_LEN+7*FLTS(fp)
+#endif
+
+    LARG    a0, -FRAME_LEN+8*FLTS+0*PTRS(fp)
+    LARG    a1, -FRAME_LEN+8*FLTS+1*PTRS(fp)
+    LARG    a2, -FRAME_LEN+8*FLTS+2*PTRS(fp)
+    LARG    a3, -FRAME_LEN+8*FLTS+3*PTRS(fp)
+    LARG    a4, -FRAME_LEN+8*FLTS+4*PTRS(fp)
+    LARG    a5, -FRAME_LEN+8*FLTS+5*PTRS(fp)
+    LARG    a6, -FRAME_LEN+8*FLTS+6*PTRS(fp)
+    LARG    a7, -FRAME_LEN+8*FLTS+7*PTRS(fp)
+
+    /* Call */
+    jalr    t1
+
+    /* Save return values - only a0/a1 (fa0/fa1) are used */
+#if FLTS
+    FSARG   fa0, -FRAME_LEN+0*FLTS(fp)
+    FSARG   fa1, -FRAME_LEN+1*FLTS(fp)
+#endif
+
+    SARG    a0, -FRAME_LEN+8*FLTS+0*PTRS(fp)
+    SARG    a1, -FRAME_LEN+8*FLTS+1*PTRS(fp)
+
+    /* Restore and return */
+    addi    sp, fp, -FRAME_LEN
+    .cfi_def_cfa 2, FRAME_LEN
+    LARG    ra, -1*PTRS(fp)
+    .cfi_restore 1
+    LARG    fp, -2*PTRS(fp)
+    .cfi_restore 8
+    ret
+    .cfi_endproc
+    .size   ffi_call_asm, .-ffi_call_asm
+
+
+/*
+  ffi_closure_asm. Expects address of the passed-in ffi_closure in t1.
+  void ffi_closure_inner (ffi_cif *cif,
+		          void (*fun) (ffi_cif *, void *, void **, void *),
+		          void *user_data,
+		          size_t *stackargs, struct call_context *regargs)
+*/
+
+    .globl ffi_closure_asm
+    .hidden ffi_closure_asm
+    .type ffi_closure_asm, @function
+ffi_closure_asm:
+    .cfi_startproc
+
+    addi    sp,  sp, -FRAME_LEN
+    .cfi_def_cfa_offset FRAME_LEN
+
+    /* make a frame */
+    SARG    fp, FRAME_LEN - 2*PTRS(sp)
+    .cfi_offset 8, -2*PTRS
+    SARG    ra, FRAME_LEN - 1*PTRS(sp)
+    .cfi_offset 1, -1*PTRS
+    addi    fp, sp, FRAME_LEN
+
+    /* save arguments */
+#if FLTS
+    FSARG   fa0, 0*FLTS(sp)
+    FSARG   fa1, 1*FLTS(sp)
+    FSARG   fa2, 2*FLTS(sp)
+    FSARG   fa3, 3*FLTS(sp)
+    FSARG   fa4, 4*FLTS(sp)
+    FSARG   fa5, 5*FLTS(sp)
+    FSARG   fa6, 6*FLTS(sp)
+    FSARG   fa7, 7*FLTS(sp)
+#endif
+
+    SARG    a0, 8*FLTS+0*PTRS(sp)
+    SARG    a1, 8*FLTS+1*PTRS(sp)
+    SARG    a2, 8*FLTS+2*PTRS(sp)
+    SARG    a3, 8*FLTS+3*PTRS(sp)
+    SARG    a4, 8*FLTS+4*PTRS(sp)
+    SARG    a5, 8*FLTS+5*PTRS(sp)
+    SARG    a6, 8*FLTS+6*PTRS(sp)
+    SARG    a7, 8*FLTS+7*PTRS(sp)
+
+    /* enter C */
+    LARG    a0, FFI_TRAMPOLINE_SIZE+0*PTRS(t1)
+    LARG    a1, FFI_TRAMPOLINE_SIZE+1*PTRS(t1)
+    LARG    a2, FFI_TRAMPOLINE_SIZE+2*PTRS(t1)
+    addi    a3, sp, FRAME_LEN
+    mv      a4, sp
+
+    call    ffi_closure_inner
+
+    /* return values */
+#if FLTS
+    FLARG   fa0, 0*FLTS(sp)
+    FLARG   fa1, 1*FLTS(sp)
+#endif
+
+    LARG    a0, 8*FLTS+0*PTRS(sp)
+    LARG    a1, 8*FLTS+1*PTRS(sp)
+
+    /* restore and return */
+    LARG    ra, FRAME_LEN-1*PTRS(sp)
+    .cfi_restore 1
+    LARG    fp, FRAME_LEN-2*PTRS(sp)
+    .cfi_restore 8
+    addi    sp, sp, FRAME_LEN
+    .cfi_def_cfa_offset 0
+    ret
+    .cfi_endproc
+    .size ffi_closure_asm, .-ffi_closure_asm
+
+/*
+  ffi_go_closure_asm.  Expects address of the passed-in ffi_go_closure in t2.
+  void ffi_closure_inner (ffi_cif *cif,
+		          void (*fun) (ffi_cif *, void *, void **, void *),
+		          void *user_data,
+		          size_t *stackargs, struct call_context *regargs)
+*/
+
+    .globl ffi_go_closure_asm
+    .hidden ffi_go_closure_asm
+    .type ffi_go_closure_asm, @function
+ffi_go_closure_asm:
+    .cfi_startproc
+
+    addi    sp,  sp, -FRAME_LEN
+    .cfi_def_cfa_offset FRAME_LEN
+
+    /* make a frame */
+    SARG    fp, FRAME_LEN - 2*PTRS(sp)
+    .cfi_offset 8, -2*PTRS
+    SARG    ra, FRAME_LEN - 1*PTRS(sp)
+    .cfi_offset 1, -1*PTRS
+    addi    fp, sp, FRAME_LEN
+
+    /* save arguments */
+#if FLTS
+    FSARG   fa0, 0*FLTS(sp)
+    FSARG   fa1, 1*FLTS(sp)
+    FSARG   fa2, 2*FLTS(sp)
+    FSARG   fa3, 3*FLTS(sp)
+    FSARG   fa4, 4*FLTS(sp)
+    FSARG   fa5, 5*FLTS(sp)
+    FSARG   fa6, 6*FLTS(sp)
+    FSARG   fa7, 7*FLTS(sp)
+#endif
+
+    SARG    a0, 8*FLTS+0*PTRS(sp)
+    SARG    a1, 8*FLTS+1*PTRS(sp)
+    SARG    a2, 8*FLTS+2*PTRS(sp)
+    SARG    a3, 8*FLTS+3*PTRS(sp)
+    SARG    a4, 8*FLTS+4*PTRS(sp)
+    SARG    a5, 8*FLTS+5*PTRS(sp)
+    SARG    a6, 8*FLTS+6*PTRS(sp)
+    SARG    a7, 8*FLTS+7*PTRS(sp)
+
+    /* enter C */
+    LARG    a0, 1*PTRS(t2)
+    LARG    a1, 2*PTRS(t2)
+    mv      a2, t2
+    addi    a3, sp, FRAME_LEN
+    mv      a4, sp
+
+    call    ffi_closure_inner
+
+    /* return values */
+#if FLTS
+    FLARG   fa0, 0*FLTS(sp)
+    FLARG   fa1, 1*FLTS(sp)
+#endif
+
+    LARG    a0, 8*FLTS+0*PTRS(sp)
+    LARG    a1, 8*FLTS+1*PTRS(sp)
+
+    /* restore and return */
+    LARG    ra, FRAME_LEN-1*PTRS(sp)
+    .cfi_restore 1
+    LARG    fp, FRAME_LEN-2*PTRS(sp)
+    .cfi_restore 8
+    addi    sp, sp, FRAME_LEN
+    .cfi_def_cfa_offset 0
+    ret
+    .cfi_endproc
+    .size ffi_go_closure_asm, .-ffi_go_closure_asm


### PR DESCRIPTION
The changes mainly to integrate the RISC-V specific
libffi module from the open source with modifications
for the existing version of libffi in OpenJ9 to
enable RISC-V 64bit from the OpenJ9 perspective.

Issue: eclipse#7421

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>