### PR TITLE
Update VM code & setting for RISC-V in OpenJ9 (part6/VM)

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2242,7 +2242,40 @@ typedef struct J9WalkStackFramesAndSlotsStorage {
 	UDATA* jit_r29;
 	UDATA* jit_r30;
 	UDATA* jit_r31;
-#elif defined(J9VM_ARCH_S390) /* J9VM_ARCH_POWER */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_POWER */
+	UDATA* jit_r0;
+	UDATA* jit_r1;
+	UDATA* jit_r2;
+	UDATA* jit_r3;
+	UDATA* jit_r4;
+	UDATA* jit_r5;
+	UDATA* jit_r6;
+	UDATA* jit_r7;
+	UDATA* jit_r8;
+	UDATA* jit_r9;
+	UDATA* jit_r10;
+	UDATA* jit_r11;
+	UDATA* jit_r12;
+	UDATA* jit_r13;
+	UDATA* jit_r14;
+	UDATA* jit_r15;
+	UDATA* jit_r16;
+	UDATA* jit_r17;
+	UDATA* jit_r18;
+	UDATA* jit_r19;
+	UDATA* jit_r20;
+	UDATA* jit_r21;
+	UDATA* jit_r22;
+	UDATA* jit_r23;
+	UDATA* jit_r24;
+	UDATA* jit_r25;
+	UDATA* jit_r26;
+	UDATA* jit_r27;
+	UDATA* jit_r28;
+	UDATA* jit_r29;
+	UDATA* jit_r30;
+	UDATA* jit_r31;
+#elif defined(J9VM_ARCH_S390) /* J9VM_ARCH_RISCV */
 	UDATA* jit_r0;
 	UDATA* jit_r1;
 	UDATA* jit_r2;
@@ -2511,7 +2544,40 @@ typedef struct J9SFJ2IFrame {
 #if !defined(J9VM_ENV_DATA64)
 	UDATA jit_r15;
 #endif /* !J9VM_ENV_DATA64 */
-#elif defined(J9VM_ARCH_S390) /* J9VM_ARCH_POWER */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_POWER */
+	UDATA jit_r0;
+	UDATA jit_r1;
+	UDATA jit_r2;
+	UDATA jit_r3;
+	UDATA jit_r4;
+	UDATA jit_r5;
+	UDATA jit_r6;
+	UDATA jit_r7;
+	UDATA jit_r8;
+	UDATA jit_r9;
+	UDATA jit_r10;
+	UDATA jit_r11;
+	UDATA jit_r12;
+	UDATA jit_r13;
+	UDATA jit_r14;
+	UDATA jit_r15;
+	UDATA jit_r16;
+	UDATA jit_r17;
+	UDATA jit_r18;
+	UDATA jit_r19;
+	UDATA jit_r20;
+	UDATA jit_r21;
+	UDATA jit_r22;
+	UDATA jit_r23;
+	UDATA jit_r24;
+	UDATA jit_r25;
+	UDATA jit_r26;
+	UDATA jit_r27;
+	UDATA jit_r28;
+	UDATA jit_r29;
+	UDATA jit_r30;
+	UDATA jit_r31;
+#elif defined(J9VM_ARCH_S390) /* J9VM_ARCH_RISCV */
 #if !defined(J9VM_ENV_DATA64)
 	UDATA jit_r28;
 	UDATA jit_r27;
@@ -4778,7 +4844,7 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t systemPropertiesMutex;
 	U_8* javaHome;
 	void* cInterpreter;
-	void* bytecodeLoop;
+	UDATA (*bytecodeLoop)(struct J9VMThread *currentThread);
 	struct J9CudaGlobals* cudaGlobals;
 	struct J9SharedClassConfig* sharedClassConfig;
 	U_8* bootstrapClassPath;
@@ -5346,6 +5412,11 @@ typedef struct J9CInterpreterStackFrame {
 	U_8 preservedFPRs[8 * 8]; /* v8-15 */
 	UDATA jitGPRs[32]; /* x0-x31 */
 	U_8 jitFPRs[32 * 8]; /* v0-v31 */
+#elif defined(J9VM_ARCH_RISCV) /* J9VM_ARCH_ARM */
+	UDATA preservedGPRs[13]; /* x2, x8, x9, and x18-x27  */
+	U_8 preservedFPRs[32 * 8]; /* f0-f31 */
+	UDATA jitGPRs[32]; /* x0-x31 */
+	U_8 jitFPRs[32 * 8]; /* f0-f31 */
 #elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_AARCH64 */
 #if defined(J9VM_ENV_DATA64) && defined(WIN32)
 	UDATA arguments[4]; /* outgoing arguments shadow */

--- a/runtime/oti/rv64helpers.m4
+++ b/runtime/oti/rv64helpers.m4
@@ -1,0 +1,40 @@
+dnl Copyright (c) 2019, 2020 IBM Corp. and others
+dnl
+dnl This program and the accompanying materials are made available under
+dnl the terms of the Eclipse Public License 2.0 which accompanies this
+dnl distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+dnl or the Apache License, Version 2.0 which accompanies this distribution and
+dnl is available at https://www.apache.org/licenses/LICENSE-2.0.
+dnl
+dnl This Source Code may also be made available under the following
+dnl Secondary Licenses when the conditions for such availability set
+dnl forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+dnl General Public License, version 2 with the GNU Classpath
+dnl Exception [1] and GNU General Public License, version 2 with the
+dnl OpenJDK Assembly Exception [2].
+dnl
+dnl [1] https://www.gnu.org/software/classpath/license.html
+dnl [2] http://openjdk.java.net/legal/assembly-exception.html
+dnl
+dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+dnl The source needs to be modified to enable JIT against the RISCV Instruction Sets Specification.
+dnl include(jilvalues.m4)
+
+changequote({,})dnl
+
+define({FUNC_LABEL},{$1})
+
+define({DECLARE_PUBLIC},{
+	.globl FUNC_LABEL($1)
+	.type FUNC_LABEL($1),@function
+})
+
+define({START_PROC},{
+	.text
+	DECLARE_PUBLIC($1)
+	.align 2
+	FUNC_LABEL($1):
+})
+
+define({END_PROC})

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8534,7 +8534,7 @@ protected:
 
 public:
 
-#if ((defined(WIN32) && defined(__clang__)) || ((defined(J9VM_ARCH_X86) || defined(S390)) && defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))))
+#if ((defined(WIN32) && defined(__clang__)) || ((defined(J9VM_ARCH_X86) || defined(S390) || defined(J9VM_ARCH_RISCV)) && defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))))
 	/*
 	 * This method can't be 'VMINLINE' because it declares local static data
 	 * triggering a warning with GCC compilers newer than 4.6.

--- a/runtime/vm/BytecodeInterpreter.inc
+++ b/runtime/vm/BytecodeInterpreter.inc
@@ -37,6 +37,8 @@
 #define USE_COMPUTED_GOTO
 #elif (defined(LINUX) && defined(J9HAMMER))
 #define USE_COMPUTED_GOTO
+#elif (defined(LINUX) && defined(__riscv))
+#define USE_COMPUTED_GOTO
 #elif (defined(LINUX) && defined(S390) && (__GNUC__ >= 7))
 #define USE_COMPUTED_GOTO
 #elif defined(OSX)

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2445,21 +2445,21 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_DEBUG_MODE)) {
 				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
-					vm->bytecodeLoop = (void*)debugBytecodeLoopCompressed;
+					vm->bytecodeLoop = debugBytecodeLoopCompressed;
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 				} else {
 #if defined(OMR_GC_FULL_POINTERS)
-					vm->bytecodeLoop = (void*)debugBytecodeLoopFull;
+					vm->bytecodeLoop = debugBytecodeLoopFull;
 #endif /* OMR_GC_FULL_POINTERS */
 				}
 			} else {
 				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
-					vm->bytecodeLoop = (void*)bytecodeLoopCompressed;
+					vm->bytecodeLoop = bytecodeLoopCompressed;
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 				} else {
 #if defined(OMR_GC_FULL_POINTERS)
-					vm->bytecodeLoop = (void*)bytecodeLoopFull;
+					vm->bytecodeLoop = bytecodeLoopFull;
 #endif /* OMR_GC_FULL_POINTERS */
 				}
 			}

--- a/runtime/vm/module.xml
+++ b/runtime/vm/module.xml
@@ -90,6 +90,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<makefilestub data="UMA_OBJECTS:=$(filter-out zcinterp%,$(UMA_OBJECTS))">
 				<exclude-if condition="spec.flags.arch_s390"/>
 			</makefilestub>
+			<makefilestub data="UMA_OBJECTS:=$(filter-out rv64cinterp%,$(UMA_OBJECTS))">
+				<exclude-if condition="spec.flags.arch_riscv and spec.flags.J9VM_ENV_DATA64"/>
+			</makefilestub>
+			<makefilestub data="UMA_OBJECTS:=$(filter-out rv64cinterpnojit%,$(UMA_OBJECTS))">
+				<exclude-if condition="spec.flags.arch_riscv and spec.flags.J9VM_ENV_DATA64"/>
+			</makefilestub>
 			<makefilestub data="UMA_OBJECTS:=$(filter-out leconditionexceptionsup$(UMA_DOT_O),$(UMA_OBJECTS))">
 				<exclude-if condition="spec.zos_390.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</makefilestub>
@@ -153,6 +159,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</vpath>
 			<vpath pattern="unsafeHelper.s" path="xr64" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_aarch64.*"/>
+			</vpath>
+			<vpath pattern="unsafeHelper.s" path="rv64" augmentObjects="true" type="relativepath">
+				<include-if condition="spec.linux_riscv64.*"/>
 			</vpath>
 		</vpaths>
 		<libraries>

--- a/runtime/vm/rv64/unsafeHelper.s
+++ b/runtime/vm/rv64/unsafeHelper.s
@@ -1,0 +1,176 @@
+# Copyright (c) 2019, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+	.text
+
+# Prototype: void unsafePut64(I_64 *address, I_64 value);
+# Defined in: #Args: 2
+	.align  2
+	.globl  unsafePut64
+	.type   unsafePut64, @function
+unsafePut64:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	sd      a1,-32(s0)
+	ld      a5,-24(s0)
+	ld      a4,-32(s0)
+	sd      a4,0(a5)
+	nop
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafePut64, .-unsafePut64
+
+# Prototype: void unsafePut32(I_32 *address, I_32 value);
+# Defined in: #Args: 2
+	.align  2
+	.globl  unsafePut32
+	.type   unsafePut32, @function
+unsafePut32:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	mv      a5,a1
+	sw      a5,-28(s0)
+	ld      a5,-24(s0)
+	lw      a4,-28(s0)
+	sw      a4,0(a5)
+	nop
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafePut32, .-unsafePut32
+
+# Prototype: void unsafePut16(I_16 *address, I_16 value);
+# Defined in: #Args: 2
+	.align  2
+	.globl  unsafePut16
+	.type   unsafePut16, @function
+unsafePut16:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	mv      a5,a1
+	sh      a5,-26(s0)
+	ld      a5,-24(s0)
+	lhu     a4,-26(s0)
+	sh      a4,0(a5)
+	nop
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafePut16, .-unsafePut16
+
+# Prototype: void unsafePut8(I_8 *address, I_8 value);
+# Defined in: #Args: 2
+	.align  2
+	.globl  unsafePut8
+	.type   unsafePut8, @function
+unsafePut8:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	mv      a5,a1
+	sb      a5,-25(s0)
+	ld      a5,-24(s0)
+	lbu     a4,-25(s0)
+	sb      a4,0(a5)
+	nop
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafePut8, .-unsafePut8
+
+# Prototype: I_64 unsafeGet64(I_64 *address);
+# Defined in: #Args: 1
+	.align  2
+	.globl  unsafeGet64
+	.type   unsafeGet64, @function
+unsafeGet64:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	ld      a5,-24(s0)
+	ld      a5,0(a5)
+	mv      a0,a5
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafeGet64, .-unsafeGet64
+
+# Prototype: I_32 unsafeGet32(I_32 *address);
+# Defined in: #Args: 1
+	.align  2
+	.globl  unsafeGet32
+	.type   unsafeGet32, @function
+unsafeGet32:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	ld      a5,-24(s0)
+	lw      a5,0(a5)
+	mv      a0,a5
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafeGet32, .-unsafeGet32
+
+# Prototype: I_16 unsafeGet16(I_16 *address);
+# Defined in: #Args: 1
+	.align  2
+	.globl  unsafeGet16
+	.type   unsafeGet16, @function
+unsafeGet16:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	ld      a5,-24(s0)
+	lh      a5,0(a5)
+	mv      a0,a5
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafeGet16, .-unsafeGet16
+
+# Prototype: I_8 unsafeGet8(I_8 *address);
+# Defined in: #Args: 1
+	.align  2
+	.globl  unsafeGet8
+	.type   unsafeGet8, @function
+unsafeGet8:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	sd      a0,-24(s0)
+	ld      a5,-24(s0)
+	lb      a5,0(a5)
+	mv      a0,a5
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+	.size   unsafeGet8, .-unsafeGet8

--- a/runtime/vm/rv64cinterp.m4
+++ b/runtime/vm/rv64cinterp.m4
@@ -1,0 +1,40 @@
+dnl Copyright (c) 2019, 2020 IBM Corp. and others
+dnl
+dnl This program and the accompanying materials are made available under
+dnl the terms of the Eclipse Public License 2.0 which accompanies this
+dnl distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+dnl or the Apache License, Version 2.0 which accompanies this distribution and
+dnl is available at https://www.apache.org/licenses/LICENSE-2.0.
+dnl
+dnl This Source Code may also be made available under the following
+dnl Secondary Licenses when the conditions for such availability set
+dnl forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+dnl General Public License, version 2 with the GNU Classpath
+dnl Exception [1] and GNU General Public License, version 2 with the
+dnl OpenJDK Assembly Exception [2].
+dnl
+dnl [1] https://www.gnu.org/software/classpath/license.html
+dnl [2] http://openjdk.java.net/legal/assembly-exception.html
+dnl
+dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+dnl We temporarily use rv64cinterpnojit to invoke interpreter without JIT.
+dnl The assembly here needs to be modified to enable JIT against the RISCV Instruction Sets Specification.
+
+include(rv64helpers.m4)
+
+	.file "rv64cinterp.s"
+
+DECLARE_PUBLIC(cInterpreter_placeholder)
+DECLARE_PUBLIC(cInterpreter)
+
+START_PROC(cInterpreter_placeholder)
+cInterpreter:
+	addi    sp,sp,-32
+	sd      s0,24(sp)
+	addi    s0,sp,32
+	nop
+	ld      s0,24(sp)
+	addi    sp,sp,32
+	jr      ra
+END_PROC(cInterpreter_placeholder)

--- a/runtime/vm/rv64cinterpnojit.cpp
+++ b/runtime/vm/rv64cinterpnojit.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "BytecodeInterpreter.hpp"
+#include "ut_j9vm.h"
+
+/* This code here should be removed once the JIT related code
+ * is implemented in rv64cinterp.m4.
+ */
+extern "C" {
+
+void
+c_cInterpreter(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	if (J9_BCLOOP_EXIT_INTERPRETER != vm->bytecodeLoop(currentThread)) {
+		Assert_VM_unreachable();
+	}
+}
+
+} /* extern "C" */


### PR DESCRIPTION
The changes mainly update & add interpreter specific code
(with placeholders to be replaced by JIT) & setting
to enable on RISC-V 64bit from the OpenJ9 perspective.

Issue: eclipse#7421

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>