### PR TITLE
Add JITServer SharedCache support

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -468,7 +468,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, methods, methodsInfo);
          }
          break;
-#if defined(JITSERVER_TODO)
       case MessageType::VM_getVMInfo:
          {
          ClientSessionData::VMInfo vmInfo = {};
@@ -482,7 +481,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._arrayletLeafSize = TR::Compiler->om.arrayletLeafSize();
          vmInfo._overflowSafeAllocSize = static_cast<uint64_t>(fe->getOverflowSafeAllocSize());
          vmInfo._compressedReferenceShift = TR::Compiler->om.compressedReferenceShift();
-         vmInfo._cacheStartAddress = fe->sharedCache() ? fe->sharedCache()->getCacheStartAddress() : 0;
+         vmInfo._j9SharedClassCacheDescriptorList = NULL;
          vmInfo._stringCompressionEnabled = fe->isStringCompressionEnabledVM();
          vmInfo._hasSharedClassCache = TR::Options::sharedClassCache();
          vmInfo._elgibleForPersistIprofileInfo = vmInfo._isIProfilerEnabled ? fe->getIProfiler()->elgibleForPersistIprofileInfo(comp) : false;
@@ -503,10 +502,27 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._floatInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false)->getMethodAddress();
          vmInfo._doubleInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false)->getMethodAddress();
          vmInfo._interpreterVTableOffset = TR::Compiler->vm.getInterpreterVTableOffset();
-         client->write(response, vmInfo);
+
+         // For multi-layered SCC support
+         std::vector<uintptr_t> listOfCacheStartAddress;
+         std::vector<uintptr_t> listOfCacheSizeBytes;
+         if (fe->sharedCache() && fe->sharedCache()->getCacheDescriptorList())
+            {
+            // The cache descriptor list is linked last to first and is circular, so last->previous == first.
+            J9SharedClassCacheDescriptor *head = fe->sharedCache()->getCacheDescriptorList();
+            J9SharedClassCacheDescriptor *curCache = head;
+            do
+               {
+               listOfCacheStartAddress.push_back((uintptr_t)curCache->cacheStartAddress);
+               listOfCacheSizeBytes.push_back(curCache->cacheSizeBytes);
+               curCache = curCache->next;
+               }
+            while (curCache != head);
+            }
+
+         client->write(response, vmInfo, listOfCacheStartAddress, listOfCacheSizeBytes);
          }
          break;
-#endif /* defined(JITSERVER_TODO) */
       case MessageType::VM_isPrimitiveArray:
          {
          TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
@@ -2035,7 +2051,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, JITServer::Void());
          }
          break;
-#if defined(JITSERVER_TODO)
       case MessageType::SharedCache_storeSharedData:
          {
          auto recv = client->getRecvData<std::string, J9SharedDataDescriptor, std::string>();
@@ -2047,7 +2062,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, ptr);
          }
          break;
-#endif /* defined(JITSERVER_TODO) */
       case MessageType::runFEMacro_derefUintptrjPtr:
          {
          TR::VMAccessCriticalSection deref(fe);

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1426,26 +1426,25 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, offset);
          }
          break;
-#if defined(JITSERVER_TODO)
       case MessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, I_32>();
          auto mirror = std::get<0>(recv);
          auto cpIndex = std::get<1>(recv);
+         UDATA vtableOffset = 0;
          J9Method *j9method = NULL;
             {
             TR::VMAccessCriticalSection getResolvedHandleMethod(fe);
-            j9method = jitGetImproperInterfaceMethodFromCP(fe->vmThread(), mirror->cp(), cpIndex);
+            j9method = jitGetImproperInterfaceMethodFromCP(fe->vmThread(), mirror->cp(), cpIndex, &vtableOffset);
             }
          // Create a mirror right away
          TR_ResolvedJ9JITServerMethodInfo methodInfo;
          if (j9method)
-            TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) j9method, 0, mirror, fe, trMemory);
+            TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) j9method, (uint32_t)vtableOffset, mirror, fe, trMemory);
 
          client->write(response, j9method, methodInfo);
          }
          break;
-#endif /* defined(JITSERVER_TODO) */
       case MessageType::ResolvedMethod_startAddressForJNIMethod:
          {
          TR_ResolvedJ9Method *ramMethod = std::get<0>(client->getRecvData<TR_ResolvedJ9Method *>());

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -303,13 +303,11 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          _vm = TR_J9VMBase::get(_jitConfig, compThread, TR_J9VMBase::J9_SERVER_VM);
          }
 
-#if defined(JITSERVER_TODO)
       if (_vm->sharedCache())
          // Set/update stream pointer in shared cache.
          // Note that if remote-AOT is enabled, even regular J9_SERVER_VM will have a shared cache
          // This behaviour is consistent with non-JITServer
          ((TR_J9JITServerSharedCache *) _vm->sharedCache())->setStream(stream);
-#endif /* defined(JITSERVER_TODO) */
 
       //if (seqNo == 100)
       //   throw JITServer::StreamFailure(); // stress testing

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -885,7 +885,7 @@ TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)
    {
    TR_ASSERT(_stream, "stream must be initialized by now");
    auto clientData = TR::compInfoPT->getClientData();
-   PersistentUnorderedMap<J9Class *, UDATA *> & cache = clientData->getClassClainDataCache();
+   PersistentUnorderedMap<J9Class *, UDATA *> & cache = clientData->getClassChainDataCache();
       {
       OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
       auto it = cache.find(clazz);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -35,6 +35,10 @@
 #include "env/j9method.h"
 #include "runtime/IProfiler.hpp"
 #include "env/ClassLoaderTable.hpp"
+#if defined(JITSERVER_SUPPORT)
+#include "control/CompilationThread.hpp" // for TR::compInfoPT
+#include "runtime/JITClientSession.hpp"
+#endif
 
 #define   LOG(n,c) \
    if (_logLevel >= (3*n)) \
@@ -101,6 +105,8 @@ TR_J9SharedCache::TR_J9SharedCache(TR_J9VMBase *fe)
    _sharedCacheConfig = _javaVM->sharedClassConfig;
    _numDigitsForCacheOffsets = 8;
 
+   TR_ASSERT_FATAL(_sharedCacheConfig, "Must have _sharedCacheConfig");
+  
    UDATA totalCacheSize = 0;
    J9SharedClassCacheDescriptor *curCache = _sharedCacheConfig->cacheDescriptorList;
    do
@@ -127,6 +133,12 @@ TR_J9SharedCache::TR_J9SharedCache(TR_J9VMBase *fe)
 
    LOG(5, { log("\t_sharedCacheConfig %p\n", _sharedCacheConfig); });
    LOG(5, { log("\ttotalCacheSize %p\n", totalCacheSize); });
+   }
+
+J9SharedClassCacheDescriptor *
+TR_J9SharedCache::getCacheDescriptorList()
+   {
+   return _sharedCacheConfig ? _sharedCacheConfig->cacheDescriptorList : NULL;
    }
 
 void
@@ -167,7 +179,6 @@ TR_J9SharedCache::getHint(J9VMThread * vmThread, J9Method *method)
    if ((find == (uint32_t *)descriptor.address) && (dataIsCorrupt == -1))
       result = *find;
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-
    return result;
    }
 
@@ -263,7 +274,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
       if (scHintData == 0) // If no prior hints exist, we can perform a "storeAttachedData" operation
          {
          uint32_t bytesToPersist = 0;
-
+ 
          if (!SCfull)
             {
             *hintFlags |= newHint;
@@ -271,7 +282,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
                *hintCount = 10 * _initialHintSCount;
 
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8*)hintFlags;
+            descriptor.address = (U_8 *)hintFlags;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -318,14 +329,13 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
             if (isFailedValidationHint)
                *hintCount = 10 * _initialHintSCount;
             }
-         else
+         else 
             {
             // hint already exists, but maybe we need to update the count
             if (isFailedValidationHint)
                {
                uint16_t oldCount = *hintCount;
                uint16_t newCount = std::min(oldCount * 10, TR_DEFAULT_INITIAL_COUNT);
-
                if (newCount != oldCount)
                   {
                   updateHint = true;
@@ -343,7 +353,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
          if (updateHint)
             {
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8*)hintFlags;
+            descriptor.address = (U_8 *)hintFlags;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -409,7 +419,7 @@ TR_J9SharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
    {
 #if defined(J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE)
    // The cache descriptor list is linked last to first and is circular, so last->previous == first.
-   J9SharedClassCacheDescriptor *firstCache = _sharedCacheConfig->cacheDescriptorList->previous;
+   J9SharedClassCacheDescriptor *firstCache = getCacheDescriptorList()->previous;
    J9SharedClassCacheDescriptor *curCache = firstCache;
    do
       {
@@ -422,7 +432,7 @@ TR_J9SharedCache::pointerFromOffsetInSharedCache(uintptr_t offset)
       }
    while (curCache != firstCache);
 #else // !J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
-   J9SharedClassCacheDescriptor *curCache = _sharedCacheConfig->cacheDescriptorList;
+   J9SharedClassCacheDescriptor *curCache = getCacheDescriptorList();
    if (offset < curCache->cacheSizeBytes)
       {
       return (void *)(offset + (uintptr_t)curCache->cacheStartAddress);
@@ -451,7 +461,7 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset)
 #if defined(J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE)
    uintptr_t offset = 0;
    // The cache descriptor list is linked last to first and is circular, so last->previous == first.
-   J9SharedClassCacheDescriptor *firstCache = _sharedCacheConfig->cacheDescriptorList->previous;
+   J9SharedClassCacheDescriptor *firstCache = getCacheDescriptorList()->previous;
    J9SharedClassCacheDescriptor *curCache = firstCache;
    do
       {
@@ -469,7 +479,7 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset)
       }
    while (curCache != firstCache);
 #else // !J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
-   J9SharedClassCacheDescriptor *curCache = _sharedCacheConfig->cacheDescriptorList;
+   J9SharedClassCacheDescriptor *curCache = getCacheDescriptorList();
    if (isPointerInCache(curCache, ptr))
       {
       if (cacheOffset)
@@ -480,7 +490,6 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset)
       return true;
       }
 #endif // J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
-
    return false;
    }
 
@@ -519,11 +528,13 @@ UDATA *
 TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   J9UTF8 * className = J9ROMCLASS_CLASSNAME(clazz->romClass);
-   LOG(5,{ log("rememberClass class %p %.*s\n", clazz, J9UTF8_LENGTH(className), J9UTF8_DATA(className)); });
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(fej9->convertClassPtrToClassOffset(clazz));
+
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+   LOG(5,{ log("rememberClass class %p romClass %p %.*s\n", clazz, romClass, J9UTF8_LENGTH(className), J9UTF8_DATA(className)); });
 
    uintptrj_t classOffsetInCache;
-   if (!isPointerInSharedCache(clazz->romClass, &classOffsetInCache))
+   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(5,{ log("\trom class not in shared cache, returning\n"); });
       return NULL;
@@ -542,7 +553,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
       return chainData;
       }
 
-   int32_t numSuperclasses =  J9CLASS_DEPTH(clazz);
+   int32_t numSuperclasses = TR::Compiler->cls.classDepthOf(fe()->convertClassPtrToClassOffset(clazz));
    int32_t numInterfaces = numInterfacesImplemented(clazz);
 
    LOG(9, { log("\tcreating chain now: 1 + 1 + %d superclasses + %d interfaces\n", numSuperclasses, numInterfaces); });
@@ -638,11 +649,11 @@ uint32_t
 TR_J9SharedCache::numInterfacesImplemented(J9Class *clazz)
    {
    uint32_t count=0;
-   J9ITable *element = (J9ITable *)clazz->iTable;
+   J9ITable *element = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
    while (element != NULL)
       {
       count++;
-      element = element->next;
+      element = TR::Compiler->cls.iTableNext(element);
       }
    return count;
    }
@@ -664,13 +675,13 @@ TR_J9SharedCache::writeClassToChain(J9ROMClass *romClass, UDATA * & chainPtr)
    }
 
 bool
-TR_J9SharedCache::writeClassesToChain(J9Class **superclasses, int32_t numSuperclasses, UDATA * & chainPtr)
+TR_J9SharedCache::writeClassesToChain(J9Class *clazz, int32_t numSuperclasses, UDATA * & chainPtr)
    {
    LOG(9, { log("\t\twriteClassesToChain:\n"); });
 
    for (int32_t index=0; index < numSuperclasses;index++)
       {
-      J9ROMClass *romClass = superclasses[index]->romClass;
+      J9ROMClass *romClass = TR::Compiler->cls.romClassOfSuperClass(fe()->convertClassPtrToClassOffset(clazz), index);
       if (! writeClassToChain(romClass, chainPtr))
          return false;
       }
@@ -682,14 +693,14 @@ TR_J9SharedCache::writeInterfacesToChain(J9Class *clazz, UDATA * & chainPtr)
    {
    LOG(9, { log("\t\twriteInterfacesToChain:\n"); });
 
-   J9ITable *element = (J9ITable *)clazz->iTable;
+   J9ITable *element = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
    while (element != NULL)
       {
-      J9ROMClass *romClass = element->interfaceClass->romClass;
+      J9ROMClass *romClass = TR::Compiler->cls.iTableRomClass(element);
       if (!writeClassToChain(romClass, chainPtr))
          return false;
 
-      element = element->next;
+      element = TR::Compiler->cls.iTableNext(element);
       }
 
    return true;
@@ -703,13 +714,14 @@ TR_J9SharedCache::fillInClassChain(J9Class *clazz, UDATA *chainData, uint32_t ch
 
    UDATA *chainPtr = chainData;
    *chainPtr++ = chainLength;
-   writeClassToChain(clazz->romClass, chainPtr);
-   if (! writeClassesToChain(clazz->superclasses, numSuperclasses, chainPtr))
+   J9ROMClass* romClass = TR::Compiler->cls.romClassOf(fe()->convertClassPtrToClassOffset(clazz));
+   writeClassToChain(romClass, chainPtr);
+   if (!writeClassesToChain(clazz, numSuperclasses, chainPtr))
       {
       return false;
       }
 
-   if (! writeInterfacesToChain(clazz, chainPtr))
+   if (!writeInterfacesToChain(clazz, chainPtr))
       {
       return false;
       }
@@ -755,11 +767,12 @@ TR_J9SharedCache::findChainForClass(J9Class *clazz, const char *key, uint32_t ke
 bool
 TR_J9SharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
    {
-   J9UTF8 * className = J9ROMCLASS_CLASSNAME(clazz->romClass);
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(fe()->convertClassPtrToClassOffset(clazz));
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
    LOG(5, { log("classMatchesCachedVersion class %p %.*s\n", clazz, J9UTF8_LENGTH(className), J9UTF8_DATA(className)); });
 
    uintptrj_t classOffsetInCache;
-   if (!isPointerInSharedCache(clazz->romClass, &classOffsetInCache))
+   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(5, { log("\tclass not in shared cache, returning false\n"); });
       return false;
@@ -784,32 +797,33 @@ TR_J9SharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
    UDATA *chainEnd = (UDATA *) (((U_8*)chainData) + chainLength);
    LOG(9, { log("\tfound chain: %p with length %d\n", chainData, chainLength); });
 
-   if (! romclassMatchesCachedVersion(clazz->romClass, chainPtr, chainEnd))
+   if (!romclassMatchesCachedVersion(romClass, chainPtr, chainEnd))
       {
          LOG(5, { log("\tClass did not match, returning false\n"); });
          return false;
       }
 
-   int32_t numSuperclasses = J9CLASS_DEPTH(clazz);
-   J9Class **superclasses = clazz->superclasses;
+   int32_t numSuperclasses = TR::Compiler->cls.classDepthOf(fe()->convertClassPtrToClassOffset(clazz));
    for (int32_t index=0; index < numSuperclasses;index++)
       {
-      if (! romclassMatchesCachedVersion(superclasses[index]->romClass, chainPtr, chainEnd))
+      J9ROMClass *romClass = TR::Compiler->cls.romClassOfSuperClass(fe()->convertClassPtrToClassOffset(clazz), index);
+      if (!romclassMatchesCachedVersion(romClass, chainPtr, chainEnd))
          {
          LOG(5, { log("\tClass in hierarchy did not match, returning false\n"); });
          return false;
          }
       }
 
-   J9ITable *interfaceElement = (J9ITable *) clazz->iTable;
+   J9ITable *interfaceElement = TR::Compiler->cls.iTableOf(fe()->convertClassPtrToClassOffset(clazz));
    while (interfaceElement)
       {
-      if (! romclassMatchesCachedVersion(interfaceElement->interfaceClass->romClass, chainPtr, chainEnd))
+      J9ROMClass * romClass = TR::Compiler->cls.iTableRomClass(interfaceElement);
+      if (!romclassMatchesCachedVersion(romClass, chainPtr, chainEnd))
          {
          LOG(5, { log("\tInterface class did not match, returning false\n"); });
          return false;
          }
-      interfaceElement = interfaceElement->next;
+      interfaceElement = TR::Compiler->cls.iTableNext(interfaceElement);
       }
 
    if (chainPtr != chainEnd)
@@ -848,3 +862,92 @@ TR_J9SharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR
    uintptrj_t classChainOffsetInSharedCache = offsetInSharedCacheFromPointer(classChainIdentifyingLoaderForClazz);
    return classChainOffsetInSharedCache;
    }
+
+const void *
+TR_J9SharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+   {
+   return _sharedCacheConfig->storeSharedData(
+         vmThread,
+         key,
+         strlen(key),
+         descriptor);
+   }
+
+#if defined(JITSERVER_SUPPORT)
+TR_J9JITServerSharedCache::TR_J9JITServerSharedCache(TR_J9VMBase *fe)
+   : TR_J9SharedCache(fe)
+   {
+   _stream = NULL;
+   }
+
+UDATA *
+TR_J9JITServerSharedCache::rememberClass(J9Class *clazz, bool create)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   auto clientData = TR::compInfoPT->getClientData();
+   PersistentUnorderedMap<J9Class *, UDATA *> & cache = clientData->getClassClainDataCache();
+      {
+      OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
+      auto it = cache.find(clazz);
+      if (it != cache.end())
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Chain exists (%p) so nothing to store \n", it->second);
+         return it->second;
+         }
+      }
+   _stream->write(JITServer::MessageType::SharedCache_rememberClass, clazz, create);
+   UDATA * chainData = std::get<0>(_stream->read<UDATA *>());
+   if (chainData)
+      {
+      if (!create)
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "not asked to create but could create, returning non-null \n");
+         }
+      else
+         {
+         OMR::CriticalSection classChainDataMapMonitor(clientData->getClassChainDataMapMonitor());
+         cache.insert(std::make_pair(clazz, chainData));
+         }
+      }
+   return chainData;
+   }
+
+J9SharedClassCacheDescriptor *
+TR_J9JITServerSharedCache::getCacheDescriptorList()
+   {
+   auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
+   return vmInfo->_j9SharedClassCacheDescriptorList;
+   }
+
+uintptrj_t
+TR_J9JITServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   _stream->write(JITServer::MessageType::SharedCache_getClassChainOffsetInSharedCache, clazz);
+   return std::get<0>(_stream->read<uintptrj_t>());
+   }
+
+void
+TR_J9JITServerSharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(_stream);
+   if (vmInfo->_hasSharedClassCache)
+      {
+      _stream->write(JITServer::MessageType::SharedCache_addHint, method, theHint);
+      _stream->read<JITServer::Void>();
+      }
+   }
+
+const void *
+TR_J9JITServerSharedCache::storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor)
+   {
+   TR_ASSERT(_stream, "stream must be initialized by now");
+   std::string dataStr((char *) descriptor->address, descriptor->length);
+
+   _stream->write(JITServer::MessageType::SharedCache_storeSharedData, std::string(key, strlen(key)), *descriptor, dataStr);
+   return std::get<0>(_stream->read<const void *>());
+   }
+#endif

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -38,6 +38,10 @@ namespace TR { class CompilationInfo; }
 namespace JITServer { class ServerStream; }
 #endif
 
+struct J9SharedClassConfig;
+struct J9SharedClassCacheDescriptor;
+struct J9SharedDataDescriptor;
+
 /**
  * \brief An interface to the VM's shared class cache.
  *

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -34,6 +34,9 @@
 class TR_J9VMBase;
 class TR_ResolvedMethod;
 namespace TR { class CompilationInfo; }
+#if defined(JITSERVER_SUPPORT)
+namespace JITServer { class ServerStream; }
+#endif
 
 /**
  * \brief An interface to the VM's shared class cache.
@@ -58,12 +61,12 @@ public:
 
    TR_J9SharedCache(TR_J9VMBase *fe);
 
-   bool isHint(TR_ResolvedMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL);
-   bool isHint(J9Method *, TR_SharedCacheHint, uint16_t *dataField = NULL);
-   uint16_t getAllEnabledHints(J9Method *method);
-   void addHint(J9Method *, TR_SharedCacheHint);
-   void addHint(TR_ResolvedMethod *, TR_SharedCacheHint);
-   bool isMostlyFull();
+   virtual bool isHint(TR_ResolvedMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL);
+   virtual bool isHint(J9Method *, TR_SharedCacheHint, uint16_t *dataField = NULL);
+   virtual uint16_t getAllEnabledHints(J9Method *method);
+   virtual void addHint(J9Method *, TR_SharedCacheHint);
+   virtual void addHint(TR_ResolvedMethod *, TR_SharedCacheHint);
+   virtual bool isMostlyFull();
 
    /**
     * \brief Converts a shared cache offset into a pointer.
@@ -81,31 +84,31 @@ public:
     */
    virtual uintptr_t offsetInSharedCacheFromPointer(void *ptr);
 
-   void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp);
-   void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp);
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp);
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp);
 
-   bool canRememberClass(TR_OpaqueClassBlock *classPtr)
+   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr)
       {
       return (rememberClass((J9Class *) classPtr, false) != NULL);
       }
 
-   uintptrj_t *rememberClass(TR_OpaqueClassBlock *classPtr)
+   virtual uintptrj_t *rememberClass(TR_OpaqueClassBlock *classPtr)
       {
       return (uintptrj_t *) rememberClass((J9Class *) classPtr, true);
       }
 
-   UDATA *rememberClass(J9Class *clazz, bool create=true);
+   virtual UDATA *rememberClass(J9Class *clazz, bool create=true);
 
-   UDATA rememberDebugCounterName(const char *name);
-   const char *getDebugCounterName(UDATA offset);
+   virtual UDATA rememberDebugCounterName(const char *name);
+   virtual const char *getDebugCounterName(UDATA offset);
 
-   bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL);
-   bool classMatchesCachedVersion(TR_OpaqueClassBlock *classPtr, UDATA *chainData=NULL)
+   virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL);
+   virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *classPtr, UDATA *chainData=NULL)
       {
       return classMatchesCachedVersion((J9Class *) classPtr, chainData);
       }
 
-   TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *chainData, void *classLoader);
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *chainData, void *classLoader);
 
    /**
     * \brief Checks whether the specified pointer points into the shared cache.
@@ -114,11 +117,13 @@ public:
     * \param[out] cacheOffset If ptr points into the shared cache and this parameter is not NULL the result of converting ptr into an offset will be returned here. If ptr does not point into the shared cache this parameter is ignored.
     * \return True if the pointer points into the shared cache, false otherwise.
     */
-   bool isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset = NULL);
+   virtual bool isPointerInSharedCache(void *ptr, uintptrj_t *cacheOffset = NULL);
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
 
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz);
+
+   virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
 
    enum TR_J9SharedCacheDisabledReason
       {
@@ -130,17 +135,18 @@ public:
       J9_SHARED_CACHE_FAILED_TO_ALLOCATE,
       SHARED_CACHE_STORE_ERROR,
       SHARED_CACHE_FULL,
-      // The following are probably equivalent to SHARED_CACHE_FULL -
+      // The following are probably equivalent to SHARED_CACHE_FULL - 
       // they could have failed because of no space but no error code is returned.
       SHARED_CACHE_CLASS_CHAIN_STORE_FAILED,
       AOT_HEADER_STORE_FAILED
       };
-
+   
    static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { _sharedCacheState = state; }
    static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { return _sharedCacheState; }
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo);
    static void setStoreSharedDataFailedLength(UDATA length) {_storeSharedDataFailedLength = length; }
-
+   virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
+   
 private:
    J9JITConfig *jitConfig() { return _jitConfig; }
    J9JavaVM *javaVM() { return _javaVM; }
@@ -159,7 +165,7 @@ private:
    uint32_t numInterfacesImplemented(J9Class *clazz);
 
    bool writeClassToChain(J9ROMClass *romClass, UDATA * & chainPtr);
-   bool writeClassesToChain(J9Class **superclasses, int32_t numSuperclasses, UDATA * & chainPtr);
+   bool writeClassesToChain(J9Class *clazz, int32_t numSuperclasses, UDATA * & chainPtr);
    bool writeInterfacesToChain(J9Class *clazz, UDATA * & chainPtr);
    bool fillInClassChain(J9Class *clazz, UDATA *chainData, uint32_t chainLength,
                          uint32_t numSuperclasses, uint32_t numInterfaces);
@@ -183,10 +189,64 @@ private:
 
    uint32_t _logLevel;
    bool _verboseHints;
-
+   
    static TR_J9SharedCacheDisabledReason _sharedCacheState;
    static TR_YesNoMaybe                  _sharedCacheDisabledBecauseFull;
    static UDATA                          _storeSharedDataFailedLength;
    };
+
+
+#if defined(JITSERVER_SUPPORT)                                                                                                                                                                               
+/**                                                                                                                                                                                                          
+* @class TR_J9JITServerSharedCache                                                                                                                                                                           
+* @brief Class used by JITServer for querying client-side SharedCache information                                                                                                                            
+*                                                                                                                                                                                                            
+* This class is an extension of the TR_J9SharedCache class which overrides a number                                                                                                                          
+* of TR_J9SharedCache's APIs. TR_J9JITServerSharedCache is used by JITServer and                                                                                                                             
+* the overridden APIs mostly send remote messages to JITClient to query information from                                                                                                                     
+* the TR_J9SharedCache on the client. The information is needed for JITServer to                                                                                                                             
+* compile code that is compatible with the client-side VM. To minimize the                                                                                                                                   
+* number of remote messages as a way to optimize JITServer performance, a                                                                                                                                    
+* lot of client-side TR_J9SharedCache information are cached on JITServer.                                                                                                                                   
+*/
+
+class TR_J9JITServerSharedCache : public TR_J9SharedCache
+   {
+public:
+   TR_ALLOC(TR_Memory::SharedCache)
+
+   TR_J9JITServerSharedCache(TR_J9VMBase *fe);
+
+   virtual bool isHint(TR_ResolvedMethod *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT(false, "called"); return false;}
+   virtual bool isHint(J9Method *, TR_SharedCacheHint, uint16_t *dataField = NULL) override { TR_ASSERT(false, "called"); return false;}
+   virtual uint16_t getAllEnabledHints(J9Method *method) override { TR_ASSERT(false, "called"); return 0;}
+   virtual void addHint(J9Method *, TR_SharedCacheHint) override;
+   virtual bool isMostlyFull() override { TR_ASSERT(false, "called"); return false;}
+
+   virtual UDATA *rememberClass(J9Class *clazz, bool create=true) override;
+
+   virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT(false, "called"); return 0;}
+   virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT(false, "called"); return NULL;}
+
+   virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL) override { TR_ASSERT(false, "called"); return false;}
+
+   virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *chainData, void *classLoader) override { TR_ASSERT(false, "called"); return NULL;}
+   
+   static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { TR_ASSERT(false, "called"); }
+   static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { TR_ASSERT(false, "called"); return TR_J9SharedCache::TR_J9SharedCacheDisabledReason::UNINITIALIZED;}
+   static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo) { TR_ASSERT(false, "called"); return TR_no;}
+   static void setStoreSharedDataFailedLength(UDATA length) { TR_ASSERT(false, "called"); }
+   
+   virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
+
+   virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
+
+   void setStream(JITServer::ServerStream *stream) { _stream = stream; }
+   virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
+
+private:
+   JITServer::ServerStream *_stream;
+   };
+#endif /* defined(JITSERVER_SUPPORT) */
 
 #endif

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -22,7 +22,7 @@
 
 #define J9_EXTERNAL_TO_VM
 
-#if defined(JITSERVER_SUPPORT) && defined(JITSERVER_TODO)
+#if defined(JITSERVER_SUPPORT)
 #include "env/VMJ9Server.hpp"
 #endif
 
@@ -748,7 +748,7 @@ TR_J9VMBase::TR_J9VMBase(
       )
       // shared classes and AOT must be enabled, or we should be on the JITServer with remote AOT enabled
       {
-#if defined(JITSERVER_SUPPORT) && defined(JITSERVER_TODO)
+#if defined(JITSERVER_SUPPORT)
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {
          _sharedCache = new (PERSISTENT_NEW) TR_J9JITServerSharedCache(this);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1932,7 +1932,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::storeValidationRecordIfNecessary(TR::Co
 
    UDATA *classChain = NULL;
    auto clientData = _fe->_compInfoPT->getClientData();
-   PersistentUnorderedMap<J9Class *, UDATA *> &classChainCache = clientData->getClassClainDataCache();
+   PersistentUnorderedMap<J9Class *, UDATA *> &classChainCache = clientData->getClassChainDataCache();
    if (definingClass)
       {
       // if defining class is known, check if we already have a corresponding class chain cached

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -94,7 +94,6 @@ class TR_BitVector;
 class TR_J9VMBase;
 class TR_J9SharedCache;
 
-
 #if defined (_MSC_VER)
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #if _MSC_VER < 1600

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -72,7 +72,10 @@ ClientSessionData::~ClientSessionData()
       }
    _staticMapMonitor->destroy();
    if (_vmInfo)
+      {
+      destroyJ9SharedClassCacheDescriptorList();
       jitPersistentFree(_vmInfo);
+      }
    _thunkSetMonitor->destroy();
    }
 
@@ -327,9 +330,57 @@ ClientSessionData::getOrCacheVMInfo(JITServer::ServerStream *stream)
    if (!_vmInfo)
       {
       stream->write(JITServer::MessageType::VM_getVMInfo, JITServer::Void());
-      _vmInfo = new (PERSISTENT_NEW) VMInfo(std::get<0>(stream->read<VMInfo>()));
+      auto recv = stream->read<VMInfo, std::vector<uintptr_t>, std::vector<uintptr_t> >();
+      _vmInfo = new (PERSISTENT_NEW) VMInfo(std::get<0>(recv));
+      _vmInfo->_j9SharedClassCacheDescriptorList = reconstructJ9SharedClassCacheDescriptorList(std::get<1>(recv), std::get<2>(recv));
       }
    return _vmInfo;
+   }
+
+J9SharedClassCacheDescriptor *
+ClientSessionData::reconstructJ9SharedClassCacheDescriptorList(const std::vector<uintptr_t> &listOfCacheStartAddress, const std::vector<uintptr_t> &listOfCacheSizeBytes)
+   {
+   J9SharedClassCacheDescriptor * cur = NULL;
+   J9SharedClassCacheDescriptor * prev = NULL;
+   J9SharedClassCacheDescriptor * head = NULL;
+   for (size_t i = 0; i < listOfCacheStartAddress.size(); i++)
+      {
+      cur = new (PERSISTENT_NEW) J9SharedClassCacheDescriptor();
+      cur->cacheStartAddress = (J9SharedCacheHeader*)(listOfCacheStartAddress[i]);
+      cur->cacheSizeBytes = listOfCacheSizeBytes[i];
+      if (prev)
+         {
+         prev->next = cur;
+         cur->previous = prev;
+         }
+      else
+         {
+         head = cur;
+         }
+      prev = cur;
+      }
+   if (!head)
+      return NULL;
+   head->previous = prev; // assign head's previous to tail
+   prev->next = head; // assign tail's previous to head
+   return head;
+   }
+
+void
+ClientSessionData::destroyJ9SharedClassCacheDescriptorList()
+   {
+   if (!_vmInfo->_j9SharedClassCacheDescriptorList)
+      return;
+   J9SharedClassCacheDescriptor * cur = _vmInfo->_j9SharedClassCacheDescriptorList;
+   J9SharedClassCacheDescriptor * next = NULL;
+   _vmInfo->_j9SharedClassCacheDescriptorList->previous->next = NULL; // break the circular links by setting tail's next pointer to be NULL 
+   while (cur)
+      {
+      next = cur->next;
+      jitPersistentFree(cur);
+      cur = next;
+      }
+   _vmInfo->_j9SharedClassCacheDescriptorList = NULL;
    }
 
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -295,12 +295,12 @@ class ClientSessionData
       int32_t _arrayletLeafSize;
       uint64_t _overflowSafeAllocSize;
       int32_t _compressedReferenceShift;
-      UDATA _cacheStartAddress;
+      J9SharedClassCacheDescriptor *_j9SharedClassCacheDescriptorList;
       bool _stringCompressionEnabled;
       bool _hasSharedClassCache;
       bool _elgibleForPersistIprofileInfo;
-      TR_OpaqueClassBlock *_arrayTypeClasses[8];
       bool _reportByteCodeInfoAtCatchBlock;
+      TR_OpaqueClassBlock *_arrayTypeClasses[8];
       MM_GCReadBarrierType _readBarrierType;
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;
@@ -384,6 +384,9 @@ class ClientSessionData
 
    template <typename map, typename key>
    void purgeCache(std::vector<ClassUnloadedData> *unloadedClasses, map m, key ClassUnloadedData::*k);
+
+   J9SharedClassCacheDescriptor * reconstructJ9SharedClassCacheDescriptorList(const std::vector<uintptr_t> &listOfCacheStartAddress, const std::vector<uintptr_t> &listOfCacheSizeBytes);
+   void destroyJ9SharedClassCacheDescriptorList();
 
    private:
    const uint64_t _clientUID;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -326,7 +326,7 @@ class ClientSessionData
    PersistentUnorderedMap<J9Class*, ClassInfo> & getROMClassMap() { return _romClassMap; }
    PersistentUnorderedMap<J9Method*, J9MethodInfo> & getJ9MethodMap() { return _J9MethodMap; }
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassByNameMap() { return _classByNameMap; }
-   PersistentUnorderedMap<J9Class *, UDATA *> & getClassClainDataCache() { return _classChainDataMap; }
+   PersistentUnorderedMap<J9Class *, UDATA *> & getClassChainDataCache() { return _classChainDataMap; }
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock*> & getConstantPoolToClassMap() { return _constantPoolToClassMap; }
    void processUnloadedClasses(JITServer::ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes);
    TR::Monitor *getROMMapMonitor() { return _romMapMonitor; }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -778,29 +778,6 @@ TR_RelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)
    return false;
    }
 
-#if defined(JITSERVER_SUPPORT)
-void *
-TR_RelocationRuntime::isROMClassInSharedCaches(UDATA romClassValue)
-   {
-   TR_ASSERT_FATAL(0, "Error: isROMClassInSharedCaches not supported in TR_RelocationRuntime");
-   return NULL;
-   }
-
-bool
-TR_RelocationRuntime::isRomClassForMethodInSharedCache(J9Method *method)
-   {
-   TR_ASSERT_FATAL(0, "Error: isRomClassForMethodInSharedCache not supported in TR_RelocationRuntime");
-   return false;
-   }
-
-TR_YesNoMaybe
-TR_RelocationRuntime::isMethodInSharedCache(J9Method *method)
-   {
-   TR_ASSERT_FATAL(0, "Error: isMethodInSharedCache not supported in TR_RelocationRuntime");
-   return TR_no;
-   }
-#endif /* defined(JITSERVER_SUPPORT) */
-
 TR_OpaqueClassBlock *
 TR_RelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)
    {
@@ -1213,55 +1190,6 @@ TR_SharedCacheRelocationRuntime::storeAOTHeader(TR_FrontEnd *fe, J9VMThread *cur
       return false;
       }
    }
-
-
-#if defined(JITSERVER_SUPPORT)
-void *
-TR_SharedCacheRelocationRuntime::isROMClassInSharedCaches(UDATA romClassValue)
-   {
-   j9thread_monitor_enter(javaVM()->sharedClassConfig->configMonitor);
-   J9SharedClassCacheDescriptor *currentCacheDescriptor = javaVM()->sharedClassConfig->cacheDescriptorList;
-   bool matchFound = false;
-
-   while (!matchFound && currentCacheDescriptor)
-      {
-      if (((romClassValue < (UDATA)currentCacheDescriptor->metadataStartAddress)&& (romClassValue >= (UDATA)currentCacheDescriptor->romclassStartAddress)))
-         {
-         matchFound = true;
-         break;
-         }
-      if (currentCacheDescriptor->next == javaVM()->sharedClassConfig->cacheDescriptorList)
-         break; // Since the list is circular, break if we are about to loop back
-      currentCacheDescriptor = currentCacheDescriptor->next;
-      }
-   j9thread_monitor_exit(javaVM()->sharedClassConfig->configMonitor);
-   if (matchFound)
-      {
-      return (void *)currentCacheDescriptor;
-      }
-   else
-      {
-      return NULL;
-      }
-   }
-
-bool
-TR_SharedCacheRelocationRuntime::isRomClassForMethodInSharedCache(J9Method *method)
-   {
-   J9ROMClass *romClass = J9_CLASS_FROM_METHOD(method)->romClass;
-   bool isRomClassForMethodInSharedCache = isROMClassInSharedCaches((UDATA)romClass) ? true : false;
-   return isRomClassForMethodInSharedCache;
-   }
-
-TR_YesNoMaybe
-TR_SharedCacheRelocationRuntime::isMethodInSharedCache(J9Method *method)
-   {
-   if (isRomClassForMethodInSharedCache(method))
-      return TR_maybe;
-   else
-      return TR_no;
-   }
-#endif /* defined(JITSERVER_SUPPORT) */
 
 TR_OpaqueClassBlock *
 TR_SharedCacheRelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -181,12 +181,6 @@ class TR_RelocationRuntime {
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
 
-#if defined(JITSERVER_SUPPORT)
-      virtual void *isROMClassInSharedCaches(UDATA romClassValue);
-      virtual bool isRomClassForMethodInSharedCache(J9Method *method);
-      virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method);
-#endif /* defined(JITSERVER_SUPPORT) */
-
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
 
       static uintptr_t    getGlobalValue(uint32_t g)
@@ -356,12 +350,6 @@ public:
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
 
-#if defined(JITSERVER_SUPPORT)
-      virtual void *isROMClassInSharedCaches(UDATA romClassValue);
-      virtual bool isRomClassForMethodInSharedCache(J9Method *method);
-      virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method);
-#endif /* defined(JITSERVER_SUPPORT) */
-
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
 
 private:
@@ -391,18 +379,12 @@ public:
       TR_ALLOC(TR_Memory::Relocation)
       void * operator new(size_t, J9JITConfig *);
       TR_JITServerRelocationRuntime(J9JITConfig *jitCfg) : TR_RelocationRuntime(jitCfg) {}
-
       // The following public APIs should not be used with this class
-      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-
-      virtual void *isROMClassInSharedCaches(UDATA romClassValue)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0; }
-      virtual bool isRomClassForMethodInSharedCache(J9Method *method)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0; }
-      virtual TR_YesNoMaybe isMethodInSharedCache(J9Method *method)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!");  return TR_no; }
+      virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
+      virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
+      virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
 
       virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0; }
-
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 
 private:


### PR DESCRIPTION
TR_J9JITServerSharedCache is an extension to TR_J9SharedCache that overrides a few APIs from TR_J9SharedCache. This class is used by JITServer to remotely obtain shared-cache-related information from JITClient. Some modifications to TR_J9SharedCache was made to prevent dereferencing of client pointers in J9SharedCache.cpp. The direct dereferencing of client pointers were replaced by API's that can handle remote calls to the client to retrieve information when on JITServer. Additionally, there are some jitGetImproperInterfaceMethodFromCP API changes found in #6993 that are applied to JITClient code.

Signed-off-by: Harry Yu harryyu1994@gmail.com