### PR TITLE
Update Dockerfiles to use gcc-7 to build OpenJ9 JDK8

### DIFF
--- a/buildenv/docker/jdk8/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/ppc64le/ubuntu16/Dockerfile
@@ -41,8 +41,6 @@ RUN apt-get update \
     cmake \
     cpio \
     file \
-    g++-4.8 \
-    gcc-4.8 \
     git \
     git-core \
     libasound2-dev \
@@ -73,11 +71,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
+# Install GCC-7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.ppc64le.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/powerpc64le-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/powerpc64le-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk8/ppc64le/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/ppc64le/ubuntu18/Dockerfile
@@ -33,8 +33,6 @@ RUN apt-get update \
 	  cmake \
 	  cpio \
 	  file \
-	  g++-4.8 \
-	  gcc-4.8 \
 	  git \
 	  libasound2-dev \
 	  libcups2-dev \
@@ -64,11 +62,17 @@ RUN apt-get update \
 	  vim \
  && rm -rf /var/lib/apt/lists/*
 
-# Create links to the required compiler version.
-RUN ln -s gcc-4.8 /usr/bin/cc \
- && ln -s gcc-4.8 /usr/bin/gcc \
- && ln -s g++-4.8 /usr/bin/c++ \
- && ln -s g++-4.8 /usr/bin/g++
+# Install GCC-7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.ppc64le.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/powerpc64le-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/powerpc64le-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and unpack freemarker.
 RUN cd /root \

--- a/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
@@ -33,8 +33,6 @@ RUN apt-get update \
     cmake \
     cpio \
     file \
-    g++-4.8 \
-    gcc-4.8 \
     git \
     git-core \
     libasound2-dev \
@@ -63,11 +61,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
+# Install GCC-7.4
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc740+ccache.s390x.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk8/s390x/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu18/Dockerfile
@@ -33,8 +33,6 @@ RUN apt-get update \
 	  cmake \
 	  cpio \
 	  file \
-	  g++-4.8 \
-	  gcc-4.8 \
 	  git \
 	  libasound2-dev \
 	  libcups2-dev \
@@ -63,11 +61,17 @@ RUN apt-get update \
 	  vim \
  && rm -rf /var/lib/apt/lists/*
 
-# Create links to the required compiler version.
-RUN ln -s gcc-4.8 /usr/bin/cc \
- && ln -s gcc-4.8 /usr/bin/gcc \
- && ln -s g++-4.8 /usr/bin/c++ \
- && ln -s g++-4.8 /usr/bin/g++
+# Install GCC-7.4
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc740+ccache.s390x.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc
 
 # Download and unpack freemarker.
 RUN cd /root \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/Dockerfile
@@ -41,8 +41,6 @@ RUN apt-get update \
     cmake \
     cpio \
     file \
-    g++-4.8 \
-    gcc-4.8 \
     git \
     git-core \
     libasound2-dev \
@@ -74,11 +72,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
+# Add the GCC-7.3 Binary
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/Dockerfile
@@ -33,8 +33,6 @@ RUN apt-get update \
 	  cmake \
 	  cpio \
 	  file \
-	  g++-4.8 \
-	  gcc-4.8 \
 	  git \
 	  libasound2-dev \
 	  libcups2-dev \
@@ -65,11 +63,17 @@ RUN apt-get update \
 	  vim \
  && rm -rf /var/lib/apt/lists/*
 
-# Create links to the required compiler version.
-RUN ln -s gcc-4.8 /usr/bin/cc \
- && ln -s gcc-4.8 /usr/bin/gcc \
- && ln -s g++-4.8 /usr/bin/c++ \
- && ln -s g++-4.8 /usr/bin/g++
+# Add the GCC-7.3 Binary
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and unpack freemarker.
 RUN cd /root \


### PR DESCRIPTION
OpenJ9 JDK8 is built with gcc-7 since the start of 2019. JDK8
Dockerfiles are being updated to reflect the change in the build
environment.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>