### PR TITLE
Stub com.sun.management.DiagnosticCommandMBean and ThreadMXBean

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/sun/management/DiagnosticCommandMBean.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/DiagnosticCommandMBean.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,14 +21,3 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-package com.sun.management;
-
-import java.lang.management.PlatformManagedObject;
-
-/**
- * Stub class to compile OpenJDK diagnostic management, see openj9.lang.management and com.ibm.lang.management packages instead.
- *
- */
-public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
-
-}

--- a/jcl/src/jdk.management/share/classes/com/sun/management/ThreadMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/ThreadMXBean.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,14 +21,3 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-package com.sun.management;
-
-import java.lang.management.PlatformManagedObject;
-
-/**
- * Stub class to compile OpenJDK diagnostic management, see openj9.lang.management and com.ibm.lang.management packages instead.
- *
- */
-public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
-
-}


### PR DESCRIPTION
and improve the javadoc comment for HotSpotDiagnosticMXBean.
HotSpotDiagnosticMXBean shows up in the OpenJ9 javadoc since it defines
an interface class. The other classes stub the OpenJDK equivalents, so
they don't show up in the javadoc.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>