### PR TITLE
(v0.17.0-release) Change API access modifier for DiagnosticUtils.executeDiagnosticCommand

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -152,7 +152,7 @@ public class DiagnosticUtils {
 	 * @param diagnosticCommand String containing the command and options
 	 * @return command result or diagnostic information in case of error
 	 */
-	public static DiagnosticProperties executeDiagnosticCommand(String diagnosticCommand) {
+	static DiagnosticProperties executeDiagnosticCommand(String diagnosticCommand) {
 		IPC.logMessage("executeDiagnosticCommand: ", diagnosticCommand); //$NON-NLS-1$
 
 		DiagnosticProperties result;


### PR DESCRIPTION
**Change API access modifier for DiagnosticUtils.executeDiagnosticCommand**

Changed it to default package access which is sufficient.

Reviewer: @pshipton 

Port of #7468

Signed-off-by: Jason Feng <fengj@ca.ibm.com>