### PR TITLE
Remove self() in Z linkages

### DIFF
--- a/runtime/compiler/z/codegen/J9Linkage.cpp
+++ b/runtime/compiler/z/codegen/J9Linkage.cpp
@@ -27,39 +27,39 @@
 TR::Instruction *
 J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
    {
-   TR::RealRegister * stackPtr = self()->getStackPointerRealRegister();
-   TR::ResolvedMethodSymbol * bodySymbol = self()->comp()->getJittedMethodSymbol();
+   TR::RealRegister * stackPtr = getStackPointerRealRegister();
+   TR::ResolvedMethodSymbol * bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol> paramIterator(&(bodySymbol->getParameterList()));
    TR::ParameterSymbol * paramCursor = paramIterator.getFirst();
-   TR::Node * firstNode = self()->comp()->getStartTree()->getNode();
+   TR::Node * firstNode = comp()->getStartTree()->getNode();
    int32_t numIntArgs = 0, numFloatArgs = 0;
    uint32_t binLocalRegs = 0x1<<14;   // Binary pattern representing reg14 as free for local alloc
 
    bool isRecompilable = false;
-   if (self()->comp()->getRecompilationInfo() && self()->comp()->getRecompilationInfo()->couldBeCompiledAgain())
+   if (comp()->getRecompilationInfo() && comp()->getRecompilationInfo()->couldBeCompiledAgain())
       {
       isRecompilable = true;
       }
 
-   while ((paramCursor != NULL) && ((numIntArgs < self()->getNumIntegerArgumentRegisters()) || (numFloatArgs < self()->getNumFloatArgumentRegisters())))
+   while ((paramCursor != NULL) && ((numIntArgs < getNumIntegerArgumentRegisters()) || (numFloatArgs < getNumFloatArgumentRegisters())))
       {
       TR::RealRegister * argRegister;
       int32_t offset = paramCursor->getParameterOffset();
 
       // If FSD, the JIT will conservatively store all parameters to stack later in saveArguments.
       // Hence, we need to load the value into a parameter register for I2J transitions.
-      bool hasToLoadFromStack = paramCursor->isReferencedParameter() || paramCursor->isParmHasToBeOnStack() || self()->comp()->getOption(TR_FullSpeedDebug);
+      bool hasToLoadFromStack = paramCursor->isReferencedParameter() || paramCursor->isParmHasToBeOnStack() || comp()->getOption(TR_FullSpeedDebug);
 
       switch (paramCursor->getDataType())
          {
          case TR::Int8:
          case TR::Int16:
          case TR::Int32:
-            if (hasToLoadFromStack && numIntArgs < self()->getNumIntegerArgumentRegisters())
+            if (hasToLoadFromStack && numIntArgs < getNumIntegerArgumentRegisters())
                {
-               argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs));
-               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
-               cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, argRegister,
+               argRegister = getRealRegister(getIntegerArgumentRegister(numIntArgs));
+               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, cg());
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::L, firstNode, argRegister,
                            memRef, cursor);
                cursor->setBinLocalFreeRegs(binLocalRegs);
                }
@@ -67,29 +67,29 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
             break;
          case TR::Address:
             if ((hasToLoadFromStack || isRecompilable) &&
-                 numIntArgs < self()->getNumIntegerArgumentRegisters())
+                 numIntArgs < getNumIntegerArgumentRegisters())
                {
-               argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs));
-               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
-               cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode, argRegister,
+               argRegister = getRealRegister(getIntegerArgumentRegister(numIntArgs));
+               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, cg());
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), firstNode, argRegister,
                            memRef, cursor);
                cursor->setBinLocalFreeRegs(binLocalRegs);
                }
             numIntArgs++;
             break;
          case TR::Int64:
-            if (hasToLoadFromStack && numIntArgs < self()->getNumIntegerArgumentRegisters())
+            if (hasToLoadFromStack && numIntArgs < getNumIntegerArgumentRegisters())
                {
-               argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs));
-               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
-               cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode, argRegister,
+               argRegister = getRealRegister(getIntegerArgumentRegister(numIntArgs));
+               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, cg());
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), firstNode, argRegister,
                            memRef, cursor);
                cursor->setBinLocalFreeRegs(binLocalRegs);
-               if (TR::Compiler->target.is32Bit() && numIntArgs < self()->getNumIntegerArgumentRegisters() - 1)
+               if (TR::Compiler->target.is32Bit() && numIntArgs < getNumIntegerArgumentRegisters() - 1)
                   {
-                  argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs + 1));
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, argRegister,
-                              generateS390MemoryReference(stackPtr, offset + 4, self()->cg()), cursor);
+                  argRegister = getRealRegister(getIntegerArgumentRegister(numIntArgs + 1));
+                  cursor = generateRXInstruction(cg(), TR::InstOpCode::L, firstNode, argRegister,
+                              generateS390MemoryReference(stackPtr, offset + 4, cg()), cursor);
                   cursor->setBinLocalFreeRegs(binLocalRegs);
                   }
                }
@@ -97,11 +97,11 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
             break;
          case TR::Float:
          case TR::DecimalFloat:
-            if (hasToLoadFromStack && numFloatArgs < self()->getNumFloatArgumentRegisters())
+            if (hasToLoadFromStack && numFloatArgs < getNumFloatArgumentRegisters())
                {
-               argRegister = self()->getRealRegister(self()->getFloatArgumentRegister(numFloatArgs));
-               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
-               cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, argRegister,
+               argRegister = getRealRegister(getFloatArgumentRegister(numFloatArgs));
+               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, cg());
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::LE, firstNode, argRegister,
                            memRef, cursor);
                cursor->setBinLocalFreeRegs(binLocalRegs);
                }
@@ -109,11 +109,11 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
             break;
          case TR::Double:
          case TR::DecimalDouble:
-            if (hasToLoadFromStack && numFloatArgs < self()->getNumFloatArgumentRegisters())
+            if (hasToLoadFromStack && numFloatArgs < getNumFloatArgumentRegisters())
                {
-               argRegister = self()->getRealRegister(self()->getFloatArgumentRegister(numFloatArgs));
-               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
-               cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, argRegister,
+               argRegister = getRealRegister(getFloatArgumentRegister(numFloatArgs));
+               TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, cg());
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::LD, firstNode, argRegister,
                            memRef, cursor);
                cursor->setBinLocalFreeRegs(binLocalRegs);
                }

--- a/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
@@ -266,7 +266,7 @@ TR::Register * TR::S390CHelperLinkage::buildDirectDispatch(TR::Node * callNode, 
    traceMsg(comp(),"%s: Internal Control Flow in OOL : %s\n",callNode->getOpCode().getName(),isHelperCallWithinICF  ? "true" : "false" );
    for (int i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters; i++)
       {
-      if (!self()->getPreserved(REGNUM(i)) && cg()->machine()->getRealRegister(i)->getState() != TR::RealRegister::Locked)
+      if (!getPreserved(REGNUM(i)) && cg()->machine()->getRealRegister(i)->getState() != TR::RealRegister::Locked)
          {
          RealRegisters.use((TR::RealRegister::RegNum)i);
          }
@@ -280,7 +280,7 @@ TR::Register * TR::S390CHelperLinkage::buildDirectDispatch(TR::Node * callNode, 
    // TODO For Time Being, it is expected that param number won't increase beyond 3 need to fix this when support for stack is there
    for (int i=0; i< callNode->getNumChildren(); i++)
       {
-      if (i < self()->getNumIntegerArgumentRegisters()-1)
+      if (i < getNumIntegerArgumentRegisters()-1)
          preDeps->addPreCondition(cg()->gprClobberEvaluate(callNode->getChild(i)), getIntegerArgumentRegister(i+1));
       else
          TR_ASSERT(false,"Parameters on Stack not supported yet");
@@ -292,7 +292,7 @@ TR::Register * TR::S390CHelperLinkage::buildDirectDispatch(TR::Node * callNode, 
    * Following line will use the System linkage's return address register for fast path
    * And for regular dual mode helper, private linkage's return address register
    */
-   TR::RealRegister::RegNum regRANum = isFastPathOnly ? self()->getReturnAddressRegister() : cg()->getReturnAddressRegister();
+   TR::RealRegister::RegNum regRANum = isFastPathOnly ? getReturnAddressRegister() : cg()->getReturnAddressRegister();
    TR::Register *regRA = RealRegisters.use(regRANum);
 #if defined(J9ZOS390)
    TR::Register *DSAPointerReg = NULL;

--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -195,8 +195,8 @@ TR::J9S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
     * The BASR and NOP padding must stick together and can't have reverse spills in the middle.
     * Hence, splitting the dependencies to avoid spill instructions.
     */
-   TR::RegisterDependencyConditions* callPreDeps = new (self()->trHeapMemory()) TR::RegisterDependencyConditions(deps->getPreConditions(), NULL, deps->getAddCursorForPre(), 0, codeGen);
-   TR::RegisterDependencyConditions* callPostDeps = new (self()->trHeapMemory()) TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), codeGen);
+   TR::RegisterDependencyConditions* callPreDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(deps->getPreConditions(), NULL, deps->getAddCursorForPre(), 0, codeGen);
+   TR::RegisterDependencyConditions* callPostDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), codeGen);
 
    gcPoint = generateRRInstruction(codeGen, TR::InstOpCode::BASR, callNode, systemReturnAddressRegister, systemEntryPointRegister, callPreDeps);
    if (isJNIGCPoint)


### PR DESCRIPTION
Removing self() in all the Z linkages as they are not required and help
in code clarity. These changes reflect the conversation found in #7453.

The changes pertain to:
- Following files: J9Linkage.cpp / J9S390CHelperLinkage.cpp/
J9S390PrivateLinkage.cpp / J9SystemLinkagezOS.cpp .
- 0xdaryl (issue creator) explanation: Subclasses that derive from
TR::Linkage are not components of the extensible part of the hierarchy,
and they do not need to use self() methods to refer to the member
functions that are part of the extensible part of the hierarchy.
- The self() calls should be removed to make the code cleaner and to
not confuse developers into thinking these are extensible classes.


Closes: #7453
Signed-off-by: Ajay Shanmuganathan <ajaypal95@gmail.com>