### PR TITLE
Add control-related JITServer changes

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2144,6 +2144,11 @@ J9::Options::setupJITServerOptions()
          // IProfiler thread is not needed at JITServer because
          // no IProfiler info is collected at the server itself
          self()->setOption(TR_DisableIProfilerThread);
+
+         // This option is used to generate SIMD instructions on Z. Currently the infrastructure
+         // to support the relocation of some of those instructions is not available. Thus we disable
+         // this option for remote compilations.
+         self()->setOption(TR_DisableSIMDArrayTranslate);
          }
 
       // In the JITServer world, expensive compilations are performed remotely so there is no risk of blowing the footprint limit on the JVM
@@ -2163,6 +2168,7 @@ J9::Options::setupJITServerOptions()
                persistentInfo->getJITServerAddress().c_str(), persistentInfo->getJITServerPort(),
                persistentInfo->getSocketTimeout());
       }
+
    }
 #endif /* defined(JITSERVER_SUPPORT) */
 


### PR DESCRIPTION
- Add JITServer/JITClient CHTable and IProfiler initializations
- Add JITServer's J9HOOK_VM_INITIALIZED routine
- Add TR_PrintJITServerMsgStats, TR_PrintJITServerCHTableStats and TR_PrintJITServerIPMsgStats routines for JITServer's remote messages, CHTable and IProfiler stats
- Add various JITServer persistent collection initializations (i.e. _unloadedClassesTempList, _newlyExtendedClasses)

Signed-off-by: Harry Yu <harryyu1994@gmail.com>