### PR TITLE
Enable ExpandInstructionsPhase

### DIFF
--- a/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -55,6 +55,7 @@
     RegisterAssigningPhase,
     MapStackPhase,
     PeepholePhase,
+    ExpandInstructionsPhase,
     BinaryEncodingPhase,
     EmitSnippetsPhase,
     ProcessRelocationsPhase

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -59,6 +59,7 @@
     RegisterAssigningPhase,
     MapStackPhase,
     PeepholePhase,
+    ExpandInstructionsPhase,
     BinaryEncodingPhase,
     EmitSnippetsPhase,
     ProcessRelocationsPhase


### PR DESCRIPTION
In eclipse/omr#4421, a new codegen phase was added called `ExpandInstructionsPhase` which is meant to be used to expand instructions prior to binary length estimation and binary encoding. This PR enables that phase in OpenJ9 so that it can actually be used.