### PR TITLE
Fix incorrect use of cmpli4 as PPCTrg1Src2Instruction

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -6293,7 +6293,7 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
             if (maxContiguousArraySize > UPPER_IMMED)
                {
                iCursor = loadConstant(cg, node, maxContiguousArraySize, temp2Reg, iCursor);
-               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::cmpli4, node, condReg, enumReg, temp2Reg, iCursor);
+               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::cmpl4, node, condReg, enumReg, temp2Reg, iCursor);
                }
             else
                iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, condReg, enumReg, maxContiguousArraySize, iCursor);


### PR DESCRIPTION
Due to a typo, genHeapAlloc was attempting to use the cmpli4 instruction
as a PPCTrg1Src2Instruction. This results in the binary encoding being
botched and a garbage value being encoded in the UI field of the
instruction. This has been switched to generate a cmpl4 instruction
instead, which matches the obviously intended semantics of comparing two
registers.

Signed-off-by: Ben Thomas <ben@benthomas.ca>