### PR TITLE
Add JITServer support for J9ObjectModel

### DIFF
--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,14 @@ TR_J2IThunk::allocate(
    {
    int16_t terseSignatureBufLength = thunkTable->terseSignatureLength(signature)+1;
    int16_t totalSize = (int16_t)sizeof(TR_J2IThunk) + codeSize + terseSignatureBufLength;
-   TR_J2IThunk *result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
+   TR_J2IThunk *result;
+#if defined(JITSERVER_SUPPORT)
+   if (cg->comp()->isOutOfProcessCompilation())
+      // Don't need to use code cache because the entire thunk will be copied and sent to the client 
+      result = (TR_J2IThunk*)cg->comp()->trMemory()->allocateMemory(totalSize, heapAlloc);
+   else
+#endif
+      result = (TR_J2IThunk*)cg->allocateCodeMemory(totalSize, true, false);
    result->_codeSize  = codeSize;
    result->_totalSize = totalSize;
    thunkTable->getTerseSignature(result->terseSignature(), terseSignatureBufLength, signature);

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -43,6 +43,10 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "env/VMJ9.h"
+#if defined(JITSERVER_SUPPORT)
+#include "control/CompilationThread.hpp"
+#include "runtime/JITClientSession.hpp"
+#endif
 
 #define DEFAULT_OBJECT_ALIGNMENT (8)
 
@@ -306,6 +310,13 @@ J9::ObjectModel::compressedReferenceShiftOffset()
 int32_t
 J9::ObjectModel::compressedReferenceShift()
    {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_compressedReferenceShift;
+      }
+#endif
    if (compressObjectReferences())
       {
       J9JavaVM *javaVM = TR::Compiler->javaVM;
@@ -561,4 +572,82 @@ uintptrj_t
 J9::ObjectModel::decompressReference(TR::Compilation* comp, uintptrj_t compressedReference)
    {
    return (compressedReference << TR::Compiler->om.compressedReferenceShift()) + TR::Compiler->vm.heapBaseAddress();
+   }
+
+bool
+J9::ObjectModel::usesDiscontiguousArraylets()
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_usesDiscontiguousArraylets;
+      }
+#endif
+   return _usesDiscontiguousArraylets;
+   }
+
+int32_t 
+J9::ObjectModel::arrayletLeafSize() 
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_arrayletLeafSize;
+      }
+#endif
+   return _arrayLetLeafSize;
+   }
+
+int32_t
+J9::ObjectModel::arrayletLeafLogSize() 
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_arrayletLeafLogSize;
+      }
+#endif
+   return _arrayLetLeafLogSize;
+   }
+
+MM_GCReadBarrierType
+J9::ObjectModel::readBarrierType()
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_readBarrierType;
+      }
+#endif
+   return _readBarrierType;
+   }
+
+MM_GCWriteBarrierType
+J9::ObjectModel::writeBarrierType()
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_writeBarrierType;
+      }
+#endif
+   return _writeBarrierType;
+   }
+
+bool
+J9::ObjectModel::compressObjectReferences()
+   {
+#if defined(JITSERVER_SUPPORT)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_compressObjectReferences;
+      }
+#endif
+   return _compressObjectReferences;
    }

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -86,11 +86,11 @@ public:
 
    bool generateCompressedObjectHeaders();
 
-   bool usesDiscontiguousArraylets() { return _usesDiscontiguousArraylets; }
+   bool usesDiscontiguousArraylets();
    bool canGenerateArraylets() { return usesDiscontiguousArraylets(); }
    bool useHybridArraylets() { return usesDiscontiguousArraylets(); }
-   int32_t arrayletLeafSize() { return _arrayLetLeafSize; }
-   int32_t arrayletLeafLogSize() { return _arrayLetLeafLogSize; }
+   int32_t arrayletLeafSize();
+   int32_t arrayletLeafLogSize();
 
    int32_t compressedReferenceShiftOffset();
    int32_t compressedReferenceShift();
@@ -115,17 +115,17 @@ public:
    /**
    * @brief Returns the read barrier type of VM's GC
    */
-   MM_GCReadBarrierType  readBarrierType()  { return _readBarrierType;  }
+   MM_GCReadBarrierType  readBarrierType();
 
    /**
    * @brief Returns the write barrier type of VM's GC
    */
-   MM_GCWriteBarrierType writeBarrierType() { return _writeBarrierType; }
+   MM_GCWriteBarrierType writeBarrierType();
 
    /**
    * @brief Returns whether or not object references are compressed
    */
-   bool compressObjectReferences() { return _compressObjectReferences; }
+   bool compressObjectReferences();
 
 private:
 

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -133,7 +133,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _remoteCompilationMode(JITServer::NONE),
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
-         _socketTimeoutMs(1000),
+         _socketTimeoutMs(2000),
          _clientUID(0),
 #endif /* defined(JITSERVER_SUPPORT) */
       OMR::PersistentInfoConnector(pm)


### PR DESCRIPTION
JITServer needs to obtain JITClient J9ObjectModel information.
It's done by adding JITServer remote calls in J9ObjectModel APIs 
and they will be triggered on JITServer. Add an additional JITServer 
change for J2IThunk.cpp, where we don't need to use code cache
for thunks because the entire thunk will be copied and sent to JITClient.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>