### PR TITLE
Enable Docker images to be uploaded to servers 

### DIFF
--- a/buildenv/jenkins/docker-slaves/jenkinsfile-build-container
+++ b/buildenv/jenkins/docker-slaves/jenkinsfile-build-container
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 def ARCH = (params.ARCH) ? params.ARCH : "unknown"
 def OS = (params.OS) ? params.OS : "unknown"
 def validArch = ["x86", "s390x", "ppc64le"]
+def DOCKER_URL = (params.DOCKER_URL) ? params.DOCKER_URL : "https://hub.docker.com/r"
 if(params.ghprbPullId) {
     PARSE = "${ghprbCommentBody}".toLowerCase().split()
     for(i = 0; i < PARSE.length - 4; i++) {
@@ -37,15 +38,16 @@ if(params.ghprbPullId) {
 if("${OS}" == "unknown" || !(validArch.contains(ARCH))) {
     error("Invalid Parameters. Either ARCH:'${ARCH}' or OS:'${OS}' were not declared properly")
 } else {
-    NAMESPACE = "eclipse"
-    REPOSITORY = "${NAMESPACE}/openj9-jenkins-agent-${ARCH}-${OS}"
+    def NAMESPACE = (params.NAMESPACE) ? params.NAMESPACE : "eclipse"
+    def FOLDER = (params.FOLDER) ? "/" + params.FOLDER : ""
+    def REPOSITORY = "${NAMESPACE}${FOLDER}/openj9-jenkins-agent-${ARCH}-${OS}"
     timeout(time: 5, unit: 'HOURS') {
         timestamps {
             node("sw.tool.docker&&hw.arch.${ARCH}") {
                 try{
                     def TEMP_DESC = (currentBuild.description) ? currentBuild.description + "<br>" : ""
-                    currentBuild.description = TEMP_DESC + "<a href=https://ci.eclipse.org/openj9/computer/${NODE_NAME}>${NODE_NAME}</a><br>"
-                    currentBuild.description += "Docker image:<a href=https://hub.docker.com/r/${REPOSITORY}>${REPOSITORY}</a>"
+                    currentBuild.description = TEMP_DESC + "<a href=${JENKINS_URL}/computer/${NODE_NAME}>${NODE_NAME}</a><br>"
+                    currentBuild.description += "Docker image:<a href=${DOCKER_URL}/${REPOSITORY}>${REPOSITORY}</a>"
                     stage("Clone") {
                         checkout scm
                     }
@@ -65,10 +67,13 @@ if("${OS}" == "unknown" || !(validArch.contains(ARCH))) {
                         }
                     }
                     stage("Push") {
-                        withCredentials([usernamePassword(credentialsId: '7fb9f8f0-14bf-469a-9132-91db4dd80c48', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
-                            sh "docker login --username=\"${USER}\" --password=\"${PASS}\""
+                        def CREDENTIALS_ID = (params.credentialsId) ? params.credentialsId : '7fb9f8f0-14bf-469a-9132-91db4dd80c48'
+                        def DOCKER_LOGIN_URL = (params.DOCKER_LOGIN_URL) ? params.DOCKER_LOGIN_URL : ""
+                        sh 'docker images'
+                        withCredentials([usernamePassword(credentialsId: CREDENTIALS_ID, passwordVariable: 'PASS', usernameVariable: 'USER')]) {
+                            sh "docker login --username=\"${USER}\" --password=\"${PASS}\" ${DOCKER_LOGIN_URL}"
                         }
-                        if(params.ghprbPullId) {
+                        if (params.ghprbPullId) {
                             sh "docker push ${REPOSITORY}:PR${ghprbPullId}"
                         } else {
                             sh "docker push ${REPOSITORY}:${BUILD_NUMBER}"


### PR DESCRIPTION
Modified Build-Jenkins-Agent-Container
- Allowed options to be passed as parameters
- Enabled images to be uploaded to different
servers other than DockerHub

Signed-off-by: Jenny Chen <Jenny.Chen@ibm.com>