### PR TITLE
Statically link libc++ when compiling with xlclang++

### DIFF
--- a/runtime/compiler/build/toolcfg/aix-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/aix-xlc/common.mk
@@ -213,6 +213,10 @@ endif
 
 SOLINK_SLINK+=$(PRODUCT_SLINK) m j9thr$(J9_VERSION) j9hookable$(J9_VERSION)
 
+ifneq (,$(findstring xlclang++,$(notdir $(CXX))))
+  SOLINK_FLAGS+=-bstatic -lc++ -bdynamic
+endif
+
 SOLINK_LIBPATH+=$(PRODUCT_LIBPATH)
 
 SOLINK_EXTRA_ARGS+=-E $(JIT_SCRIPT_DIR)/j9jit.aix.exp


### PR DESCRIPTION
Added -lc++ library to linker statically (for xlclang only). Since the linker command being used, makeC++SharedLib_r, is used to link legacy object files that
don't depend on -lc++, it does not automatically add this library, so it needs to be added manually.

Issue #5074

Signed-off-by: Jackie Midroni <jackie.midroni@mail.utoronto.ca>