### PR TITLE
AArch64: Resolve C++ compiler warnings

### DIFF
--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -310,7 +310,7 @@ uint8_t *TR::ARM64UnresolvedCallSnippet::emitSnippetBody()
 
    TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
    TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
-   int32_t helperLookupOffset;
+   intptrj_t helperLookupOffset;
 
    TR::Compilation* comp = cg()->comp();
 

--- a/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
@@ -218,5 +218,6 @@ TR::ARM64StackCheckFailureSnippet::getLength(int32_t estimatedSnippetStart)
    else
       {
       TR_ASSERT(false, "Frame size too big.  Not supported yet");
+      return 0;
       }
    }


### PR DESCRIPTION
This commit resolves some C++ compiler warnings in building the JIT
compiler for AArch64.

* Shifting more than the width of an int32_t value
* Reaching the end of a non-void function without a return

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>