### PR TITLE
Update large heap build platform list in release notes

### DIFF
--- a/doc/release-notes/0.15/0.15.md
+++ b/doc/release-notes/0.15/0.15.md
@@ -173,8 +173,8 @@ The v0.15.1 release contains the following known issues and limitations:
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
-<td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
-<td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
+<td valign="top">AIX, Linux on Z, Linux on Power</td>
+<td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86, Windows, and macOS. </td>
 <td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 

--- a/doc/release-notes/0.16/0.16.md
+++ b/doc/release-notes/0.16/0.16.md
@@ -133,8 +133,8 @@ The v0.16 release contains the following known issues and limitations:
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
-<td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
-<td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
+<td valign="top">AIX, Linux on Z, Linux on Power</td>
+<td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86, Windows, and macOS. </td>
 <td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 

--- a/doc/release-notes/0.17/0.17.md
+++ b/doc/release-notes/0.17/0.17.md
@@ -146,8 +146,8 @@ The v0.17 release contains the following known issues and limitations:
 
 <tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/479">#479</a></td>
 <td valign="top">Non-compressed references VM builds not available</td>
-<td valign="top">AIX, Windows, Linux on Z, Linux on Power</td>
-<td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86. </td>
+<td valign="top">AIX, Linux on Z, Linux on Power</td>
+<td valign="top">Non-compressed references VM builds, which support heaps larger than 57GB, are built on Linux on x86, Windows, and macOS. </td>
 <td valign="top">Manual builds on other platforms are possible by following our <a href="https://github.com/eclipse/openj9/blob/master/buildenv/Build_Instructions_V8.md">detailed build instructions</a>.</td>
 </tr>
 


### PR DESCRIPTION
Large heap builds are also available at AdoptOpenJDK.net for Windows and
macOS.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>