### PR TITLE
Add JVM_GetExtendedNPEMessage to support JDK 14 compilation

### DIFF
--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -334,6 +334,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_AreNestMates"/>
 		<export name="JVM_InitClassName"/>
 		<export name="JVM_InitializeFromArchive"/>
+
+		<!-- Additions for Java 14 (General) -->
+		<export name="JVM_GetExtendedNPEMessage"/>
+
 	</exports>
 
 </exportlists>

--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -30,3 +30,12 @@ JVM_InitializeFromArchive(JNIEnv *env, jclass clz)
 	/* A no-op implementation is ok. */
 }
 #endif /* JAVA_SPEC_VERSION >= 11 */
+
+#if JAVA_SPEC_VERSION >= 14
+JNIEXPORT jstring JNICALL
+JVM_GetExtendedNPEMessage(JNIEnv *env, jthrowable throwableObj)
+{
+	/* Returning NULL to allow JDK14 compilation, https://github.com/eclipse/openj9/issues/7500 */
+	return NULL;
+}
+#endif /* JAVA_SPEC_VERSION >= 14 */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -313,3 +313,5 @@ _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_AreNestMates,JNICALL,false,jboolean,JNIEnv *env,jclass clzOne, jclass clzTwo)])
 _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_InitializeFromArchive, JNICALL, false, void, JNIEnv *env, jclass clz)])
+_IF([JAVA_SPEC_VERSION >= 14],
+		[_X(JVM_GetExtendedNPEMessage, JNICALL, false, jstring, JNIEnv *env, jthrowable throwableObj)])


### PR DESCRIPTION
**Add JVM_GetExtendedNPEMessage to support JDK 14 compilation**

Added JVM_GetExtendedNPEMessage which returns NULL.

Verified that this PR allows JDK 14 compilation to complete.
`NullPointerException().getMessage()` is going to invoke this JVM method, return a `NULL` string for now. An actual implementation is still pending.

related: #7500 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>