### PR TITLE
J9 PrivateLinkage refactoring

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -24,7 +24,7 @@
 #include "codegen/Linkage_inlines.hpp"
 
 TR::ARM64JNILinkage::ARM64JNILinkage(TR::CodeGenerator *cg)
-   :TR::ARM64PrivateLinkage(cg)
+   : J9::ARM64PrivateLinkage(cg)
    {
    TR_UNIMPLEMENTED();
    }

--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
@@ -25,9 +25,10 @@
 
 #include "codegen/ARM64PrivateLinkage.hpp"
 
-namespace TR {
+namespace TR
+{
 
-class ARM64JNILinkage : public TR::ARM64PrivateLinkage
+class ARM64JNILinkage : public J9::ARM64PrivateLinkage
    {
    public:
 

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -44,7 +44,7 @@
 #include "infra/Assert.hpp"
 #include "infra/List.hpp"
 
-TR::ARM64PrivateLinkage::ARM64PrivateLinkage(TR::CodeGenerator *cg)
+J9::ARM64PrivateLinkage::ARM64PrivateLinkage(TR::CodeGenerator *cg)
    : J9::PrivateLinkage(cg),
    _interpretedMethodEntryPoint(NULL),
    _jittedMethodEntryPoint(NULL)
@@ -138,29 +138,29 @@ TR::ARM64PrivateLinkage::ARM64PrivateLinkage(TR::CodeGenerator *cg)
    _properties._offsetToFirstLocal            = -8;
    }
 
-TR::ARM64LinkageProperties& TR::ARM64PrivateLinkage::getProperties()
+TR::ARM64LinkageProperties& J9::ARM64PrivateLinkage::getProperties()
    {
    return _properties;
    }
 
-uint32_t TR::ARM64PrivateLinkage::getRightToLeft()
+uint32_t J9::ARM64PrivateLinkage::getRightToLeft()
    {
    return getProperties().getRightToLeft();
    }
 
 intptrj_t
-TR::ARM64PrivateLinkage::entryPointFromCompiledMethod()
+J9::ARM64PrivateLinkage::entryPointFromCompiledMethod()
    {
    return reinterpret_cast<intptrj_t>(getJittedMethodEntryPoint()->getBinaryEncoding());
    }
 
 intptrj_t
-TR::ARM64PrivateLinkage::entryPointFromInterpretedMethod()
+J9::ARM64PrivateLinkage::entryPointFromInterpretedMethod()
    {
    return reinterpret_cast<intptrj_t>(getInterpretedMethodEntryPoint()->getBinaryEncoding());
    }
 
-void TR::ARM64PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
+void J9::ARM64PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
    const TR::ARM64LinkageProperties& linkageProperties = getProperties();
    int32_t firstLocalOffset = linkageProperties.getOffsetToFirstLocal();
@@ -275,7 +275,7 @@ void TR::ARM64PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm - firstLocalOffset);
    }
 
-void TR::ARM64PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
+void J9::ARM64PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
    {
    int32_t roundup = (comp()->useCompressedPointers() && p->isLocalObject() ? TR::Compiler->om.objectAlignmentInBytes() : TR::Compiler->om.sizeofReferenceAddress()) - 1;
    int32_t roundedSize = (p->getSize() + roundup) & (~roundup);
@@ -291,7 +291,7 @@ static void lockRegister(TR::RealRegister *regToAssign)
    regToAssign->setAssignedRegister(regToAssign);
    }
 
-void TR::ARM64PrivateLinkage::initARM64RealRegisterLinkage()
+void J9::ARM64PrivateLinkage::initARM64RealRegisterLinkage()
    {
    TR::Machine *machine = cg()->machine();
    TR::RealRegister *reg;
@@ -333,7 +333,7 @@ void TR::ARM64PrivateLinkage::initARM64RealRegisterLinkage()
 
 
 void
-TR::ARM64PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
+J9::ARM64PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::ParameterSymbol> paramIterator(&(method->getParameterList()));
    TR::ParameterSymbol *paramCursor = paramIterator.getFirst();
@@ -377,7 +377,7 @@ TR::ARM64PrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymb
 
 
 int32_t
-TR::ARM64PrivateLinkage::calculatePreservedRegisterSaveSize(
+J9::ARM64PrivateLinkage::calculatePreservedRegisterSaveSize(
       uint32_t &registerSaveDescription,
       uint32_t &numGPRsSaved)
    {
@@ -402,7 +402,7 @@ TR::ARM64PrivateLinkage::calculatePreservedRegisterSaveSize(
    }
 
 
-void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
+void J9::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
    {
 
    // Prologues are emitted post-RA so it is fine to use real registers directly
@@ -641,7 +641,7 @@ void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
    setJittedMethodEntryPoint(beforeJittedMethodEntryPointInstruction->getNext());
    }
 
-void TR::ARM64PrivateLinkage::createEpilogue(TR::Instruction *cursor)
+void J9::ARM64PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
    const TR::ARM64LinkageProperties& properties = getProperties();
    TR::Machine *machine = cg()->machine();
@@ -691,7 +691,7 @@ void TR::ARM64PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    generateRegBranchInstruction(cg(), TR::InstOpCode::ret, lastNode, lr, cursor);
    }
 
-void TR::ARM64PrivateLinkage::pushOutgoingMemArgument(TR::Register *argReg, int32_t offset, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)
+void J9::ARM64PrivateLinkage::pushOutgoingMemArgument(TR::Register *argReg, int32_t offset, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)
    {
    const TR::ARM64LinkageProperties& properties = self()->getProperties();
    TR::RealRegister *javaSP = cg()->machine()->getRealRegister(properties.getStackPointerRegister()); // x20
@@ -702,13 +702,13 @@ void TR::ARM64PrivateLinkage::pushOutgoingMemArgument(TR::Register *argReg, int3
    memArg.opCode = opCode;
    }
 
-int32_t TR::ARM64PrivateLinkage::buildArgs(TR::Node *callNode,
+int32_t J9::ARM64PrivateLinkage::buildArgs(TR::Node *callNode,
    TR::RegisterDependencyConditions *dependencies)
    {
    return buildPrivateLinkageArgs(callNode, dependencies, TR_Private);
    }
 
-int32_t TR::ARM64PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
+int32_t J9::ARM64PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
    TR::RegisterDependencyConditions *dependencies,
    TR_LinkageConventions linkage)
    {
@@ -1007,7 +1007,7 @@ int32_t TR::ARM64PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
    return totalSize;
    }
 
-void TR::ARM64PrivateLinkage::buildDirectCall(TR::Node *callNode,
+void J9::ARM64PrivateLinkage::buildDirectCall(TR::Node *callNode,
    TR::SymbolReference *callSymRef,
    TR::RegisterDependencyConditions *dependencies,
    const TR::ARM64LinkageProperties &pp,
@@ -1060,7 +1060,7 @@ void TR::ARM64PrivateLinkage::buildDirectCall(TR::Node *callNode,
    gcPoint->ARM64NeedsGCMap(cg(), callSymbol->getLinkageConvention() == TR_Helper ? 0xffffffff : pp.getPreservedRegisterMapForGC());
    }
 
-TR::Register *TR::ARM64PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
+TR::Register *J9::ARM64PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
    {
    TR::SymbolReference *callSymRef = callNode->getSymbolReference();
    const TR::ARM64LinkageProperties &pp = getProperties();
@@ -1116,7 +1116,7 @@ static TR::Register *evaluateUpToVftChild(TR::Node *callNode, TR::CodeGenerator 
    return vftReg;
    }
 
-void TR::ARM64PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
+void J9::ARM64PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
    TR::RegisterDependencyConditions *dependencies,
    uint32_t argSize)
    {
@@ -1221,7 +1221,7 @@ void TR::ARM64PrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
    return;
    }
 
-TR::Register *TR::ARM64PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *J9::ARM64PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
    const TR::ARM64LinkageProperties &pp = getProperties();
    TR::RealRegister *sp = cg()->machine()->getRealRegister(pp.getStackPointerRegister());
@@ -1266,7 +1266,7 @@ TR::Register *TR::ARM64PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    }
 
 TR::Instruction *
-TR::ARM64PrivateLinkage::loadStackParametersToLinkageRegisters(TR::Instruction *cursor)
+J9::ARM64PrivateLinkage::loadStackParametersToLinkageRegisters(TR::Instruction *cursor)
    {
    TR::Machine *machine = cg()->machine();
    TR::ARM64LinkageProperties& properties = getProperties();
@@ -1312,7 +1312,7 @@ TR::ARM64PrivateLinkage::loadStackParametersToLinkageRegisters(TR::Instruction *
  * See OpenJ9 issue #6657.  Also consider merging with loadStackParametersToLinkageRegisters.
  */
 TR::Instruction *
-TR::ARM64PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
+J9::ARM64PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
    {
    TR::Machine *machine = cg()->machine();
    TR::ARM64LinkageProperties& properties = getProperties();
@@ -1353,7 +1353,7 @@ TR::ARM64PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
    return cursor;
    }
 
-void TR::ARM64PrivateLinkage::performPostBinaryEncoding()
+void J9::ARM64PrivateLinkage::performPostBinaryEncoding()
    {
    // --------------------------------------------------------------------------
    // Encode the size of the interpreter entry area into the linkage info word

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -45,7 +45,7 @@
 #include "infra/List.hpp"
 
 TR::ARM64PrivateLinkage::ARM64PrivateLinkage(TR::CodeGenerator *cg)
-   : TR::Linkage(cg),
+   : J9::PrivateLinkage(cg),
    _interpretedMethodEntryPoint(NULL),
    _jittedMethodEntryPoint(NULL)
    {

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -33,10 +33,10 @@ namespace TR { class Instruction; }
 namespace TR { class Register; }
 namespace TR { class ResolvedMethodSymbol; }
 
-namespace TR
+namespace J9
 {
 
-class ARM64PrivateLinkage : public J9::PrivateLinkage
+class ARM64PrivateLinkage : public PrivateLinkage
    {
    protected:
 
@@ -253,8 +253,12 @@ class ARM64PrivateLinkage : public J9::PrivateLinkage
    TR::Instruction *_jittedMethodEntryPoint;
 
    };
+}
 
-class ARM64HelperLinkage : public TR::ARM64PrivateLinkage
+namespace TR
+{
+
+class ARM64HelperLinkage : public J9::ARM64PrivateLinkage
    {
    public:
 
@@ -263,7 +267,7 @@ class ARM64HelperLinkage : public TR::ARM64PrivateLinkage
     * @param[in] cg : CodeGenerator
     * @param[in] helperLinkage : linkage convention
     */
-   ARM64HelperLinkage(TR::CodeGenerator *cg, TR_LinkageConventions helperLinkage) : _helperLinkage(helperLinkage), TR::ARM64PrivateLinkage(cg)
+   ARM64HelperLinkage(TR::CodeGenerator *cg, TR_LinkageConventions helperLinkage) : _helperLinkage(helperLinkage), J9::ARM64PrivateLinkage(cg)
       {
       TR_ASSERT(helperLinkage == TR_Helper || helperLinkage == TR_CHelper, "Unexpected helper linkage convention");
       }

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -24,6 +24,7 @@
 #define ARM64_PRIVATELINKAGE_INCL
 
 #include "codegen/Linkage.hpp"
+#include "codegen/PrivateLinkage.hpp"
 
 #include "infra/Assert.hpp"
 
@@ -32,9 +33,10 @@ namespace TR { class Instruction; }
 namespace TR { class Register; }
 namespace TR { class ResolvedMethodSymbol; }
 
-namespace TR {
+namespace TR
+{
 
-class ARM64PrivateLinkage : public TR::Linkage
+class ARM64PrivateLinkage : public J9::PrivateLinkage
    {
    protected:
 

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -59,7 +59,7 @@ J9::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    switch (lc)
       {
       case TR_Private:
-         linkage = new (self()->trHeapMemory()) TR::ARM64PrivateLinkage(self());
+         linkage = new (self()->trHeapMemory()) J9::ARM64PrivateLinkage(self());
          break;
       case TR_System:
          linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -74,7 +74,7 @@ static TR::RealRegister::RegNum _singleArgumentRegisters[] =
    };
 
 TR::ARMJNILinkage::ARMJNILinkage(TR::CodeGenerator *cg)
-   :TR::ARMPrivateLinkage(cg)
+   : J9::ARMPrivateLinkage(cg)
    {
    //Copy out SystemLinkage properties. Assumes no objects in TR::ARMLinkageProperties.
    TR::Linkage *sysLinkage = cg->getLinkage(TR_System);

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.hpp
@@ -23,7 +23,7 @@
 #ifndef ARM_JNILINKAGE_INCL
 #define ARM_JNILINKAGE_INCL
 
-#include "arm/codegen/ARMPrivateLinkage.hpp"
+#include "codegen/ARMPrivateLinkage.hpp"
 
 #include <stdint.h>
 #include "codegen/Linkage.hpp"
@@ -37,7 +37,7 @@ namespace TR { class RegisterDependencyConditions; }
 
 namespace TR {
 
-class ARMJNILinkage : public TR::ARMPrivateLinkage
+class ARMJNILinkage : public J9::ARMPrivateLinkage
    {
    public:
 

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "arm/codegen/ARMPrivateLinkage.hpp"
+#include "codegen/ARMPrivateLinkage.hpp"
 
 #include "arm/codegen/ARMInstruction.hpp"
 #include "codegen/CallSnippet.hpp"
@@ -50,7 +50,7 @@
 #define LOCK_R14
 // #define DEBUG_ARM_LINKAGE
 
-TR::ARMLinkageProperties TR::ARMPrivateLinkage::properties =
+TR::ARMLinkageProperties J9::ARMPrivateLinkage::properties =
    {                           // TR_Private
     0,                         // linkage properties
        {                        // register flags
@@ -160,7 +160,7 @@ TR::ARMLinkageProperties TR::ARMPrivateLinkage::properties =
        0                         // firstFloatReturnRegister
    };
 
-TR::ARMLinkageProperties& TR::ARMPrivateLinkage::getProperties()
+TR::ARMLinkageProperties& J9::ARMPrivateLinkage::getProperties()
    {
    return properties;
    }
@@ -171,7 +171,7 @@ static void lockRegister(TR::RealRegister *regToAssign)
    regToAssign->setAssignedRegister(regToAssign);
    }
 
-void TR::ARMPrivateLinkage::initARMRealRegisterLinkage()
+void J9::ARMPrivateLinkage::initARMRealRegisterLinkage()
    {
    TR::CodeGenerator           *codeGen     = cg();
    TR::Machine                 *machine = codeGen->machine();
@@ -210,12 +210,12 @@ void TR::ARMPrivateLinkage::initARMRealRegisterLinkage()
 #endif
    }
 
-uint32_t TR::ARMPrivateLinkage::getRightToLeft()
+uint32_t J9::ARMPrivateLinkage::getRightToLeft()
    {
    return getProperties().getRightToLeft();
    }
 
-void TR::ARMPrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
+void J9::ARMPrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
@@ -309,7 +309,7 @@ void TR::ARMPrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm - firstLocalOffset);
    }
 
-void TR::ARMPrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
+void J9::ARMPrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
    {
    int32_t roundedSize = (p->getSize()+3)&(~3);
    if (roundedSize == 0)
@@ -318,7 +318,7 @@ void TR::ARMPrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t 
    p->setOffset(stackIndex -= roundedSize);
    }
 
-void TR::ARMPrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
+void J9::ARMPrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::ParameterSymbol>   paramIterator(&(method->getParameterList()));
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
@@ -415,7 +415,7 @@ TR::RealRegister::RegNum getSingleAssignedRegister(TR::Machine *machine, const T
 //
 // * Linkage slots are not needed in leaf methods. (TODO)
 
-void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
+void J9::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
    {
    TR::CodeGenerator   *codeGen    = cg();
    TR::Machine         *machine    = codeGen->machine();
@@ -714,7 +714,7 @@ void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
       }
    }
 
-void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
+void J9::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
    TR::CodeGenerator   *codeGen    = cg();
    TR::Machine         *machine    = codeGen->machine();
@@ -831,7 +831,7 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
    cursor = generateTrg1Src1Instruction(codeGen, ARMOp_mov, lastNode, gr15, gr14, cursor);
    }
 
-TR::MemoryReference *TR::ARMPrivateLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
+TR::MemoryReference *J9::ARMPrivateLinkage::getOutgoingArgumentMemRef(int32_t               totalSize,
                                                                        int32_t               offset,
                                                                        TR::Register          *argReg,
                                                                        TR_ARMOpCodes         opCode,
@@ -850,7 +850,7 @@ printf("private: totalSize %d offset %d\n", totalSize, offset); fflush(stdout);
    return result;
    }
 
-int32_t TR::ARMPrivateLinkage::buildArgs(TR::Node                            *callNode,
+int32_t J9::ARMPrivateLinkage::buildArgs(TR::Node                            *callNode,
                                         TR::RegisterDependencyConditions *dependencies,
                                         TR::Register* &vftReg,
                                         bool                                isVirtual)
@@ -858,7 +858,7 @@ int32_t TR::ARMPrivateLinkage::buildArgs(TR::Node                            *ca
    return buildARMLinkageArgs(callNode, dependencies, vftReg, TR_Private, isVirtual);
    }
 
-void TR::ARMPrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
+void J9::ARMPrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
                         TR::RegisterDependencyConditions *dependencies,
                         TR::RegisterDependencyConditions *postDeps,
                         TR::Register                     *vftReg,
@@ -1044,7 +1044,7 @@ void TR::ARMPrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
    return;
    }
 
-TR::Register *TR::ARMPrivateLinkage::buildDirectDispatch(TR::Node *callNode)
+TR::Register *J9::ARMPrivateLinkage::buildDirectDispatch(TR::Node *callNode)
    {
    TR::MethodSymbol *callSym = callNode->getSymbol()->castToMethodSymbol();
    if (callSym->isJNI() &&
@@ -1061,7 +1061,7 @@ TR::Register *TR::ARMPrivateLinkage::buildDirectDispatch(TR::Node *callNode)
       }
    }
 
-TR::Register *TR::ARMPrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *J9::ARMPrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
    TR::CodeGenerator *codeGen = cg();
    TR::Machine       *machine = codeGen->machine();

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
@@ -30,9 +30,10 @@ namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
 namespace TR { class Register; }
 
-namespace TR {
+namespace J9
+{
 
-class ARMPrivateLinkage : public J9::PrivateLinkage
+class ARMPrivateLinkage : public PrivateLinkage
    {
    static TR::ARMLinkageProperties properties;
 
@@ -72,11 +73,17 @@ class ARMPrivateLinkage : public J9::PrivateLinkage
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
    };
 
-class ARMHelperLinkage : public TR::ARMPrivateLinkage
+}
+
+
+namespace TR
+{
+
+class ARMHelperLinkage : public J9::ARMPrivateLinkage
    {
    public:
 
-   ARMHelperLinkage(TR::CodeGenerator *codeGen) : TR::ARMPrivateLinkage(codeGen) {}
+   ARMHelperLinkage(TR::CodeGenerator *codeGen) : J9::ARMPrivateLinkage(codeGen) {}
 
    virtual int32_t buildArgs(TR::Node                            *callNode,
                              TR::RegisterDependencyConditions *dependencies,

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,7 @@
 #ifndef ARM_PRIVATELINKAGE_INCL
 #define ARM_PRIVATELINKAGE_INCL
 
-#include "codegen/Linkage.hpp"
-
+#include "codegen/PrivateLinkage.hpp"
 #include "infra/Assert.hpp"
 
 namespace TR { class CodeGenerator; }
@@ -33,13 +32,13 @@ namespace TR { class Register; }
 
 namespace TR {
 
-class ARMPrivateLinkage : public TR::Linkage
+class ARMPrivateLinkage : public J9::PrivateLinkage
    {
    static TR::ARMLinkageProperties properties;
 
    public:
 
-   ARMPrivateLinkage(TR::CodeGenerator *codeGen) : TR::Linkage(codeGen) {}
+   ARMPrivateLinkage(TR::CodeGenerator *cg) : J9::PrivateLinkage(cg) {}
 
    virtual uint32_t getRightToLeft();
    virtual void mapStack(TR::ResolvedMethodSymbol *method);

--- a/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
@@ -22,12 +22,12 @@
 
 #include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/ARMAOTRelocation.hpp"
+#include "codegen/ARMPrivateLinkage.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
-#include "arm/codegen/ARMPrivateLinkage.hpp"
 #include "arm/codegen/ARMSystemLinkage.hpp"
 #include "arm/codegen/ARMJNILinkage.hpp"
 #include "arm/codegen/ARMRecompilation.hpp"
@@ -335,7 +335,7 @@ TR::Linkage *J9::ARM::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 //       linkage = new (self()->trHeapMemory()) TR::ARMInterpretedStaticLinkage(this);
 //       break;
       case TR_Private:
-         linkage = new (self()->trHeapMemory()) TR::ARMPrivateLinkage(self());
+         linkage = new (self()->trHeapMemory()) J9::ARMPrivateLinkage(self());
          break;
       case TR_System:
          linkage = new (self()->trHeapMemory()) TR::ARMSystemLinkage(self());

--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -69,7 +69,6 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/z/codegen/J9Linkage.cpp \
     compiler/z/codegen/J9MemoryReference.cpp \
     compiler/z/codegen/J9S390CHelperLinkage.cpp \
-    compiler/z/codegen/J9S390PrivateLinkage.cpp \
     compiler/z/codegen/J9S390Snippet.cpp \
     compiler/z/codegen/J9SystemLinkageLinux.cpp \
     compiler/z/codegen/J9SystemLinkagezOS.cpp \
@@ -80,6 +79,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp \
     compiler/z/codegen/S390AOTRelocation.cpp \
     compiler/z/codegen/S390J9CallSnippet.cpp \
+    compiler/z/codegen/S390PrivateLinkage.cpp \
     compiler/z/codegen/S390Recompilation.cpp \
     compiler/z/codegen/S390Register.cpp \
     compiler/z/codegen/S390StackCheckFailureSnippet.cpp \

--- a/runtime/compiler/codegen/PrivateLinkage.hpp
+++ b/runtime/compiler/codegen/PrivateLinkage.hpp
@@ -20,24 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_LINKAGE_INCL
-#define TR_LINKAGE_INCL
+#include "codegen/Linkage.hpp"
 
-#include "codegen/J9Linkage.hpp"
+namespace TR { class CodeGenerator; }
 
-namespace TR
+namespace J9
 {
 
-class OMR_EXTENSIBLE Linkage : public J9::LinkageConnector
+class PrivateLinkage : public TR::Linkage
    {
-   public:
+public:
 
-   Linkage(TR::CodeGenerator *cg)
-      : J9::LinkageConnector(cg) {}
+   PrivateLinkage(TR::CodeGenerator *cg) :
+         TR::Linkage(cg)
+      {
+      }
 
-   Linkage(TR::CodeGenerator *cg, TR_S390LinkageConventions elc, TR_LinkageConventions le)
-      : J9::LinkageConnector(cg, elc, le) {}
    };
-}
 
-#endif
+}

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -136,7 +136,7 @@ J9::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    switch (lc)
       {
       case TR_Private:
-         linkage = new (self()->trHeapMemory()) TR::PPCPrivateLinkage(self());
+         linkage = new (self()->trHeapMemory()) J9::PPCPrivateLinkage(self());
          break;
       case TR_System:
          linkage = new (self()->trHeapMemory()) TR::PPCSystemLinkage(self());

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -49,7 +49,7 @@
 #include "p/codegen/StackCheckFailureSnippet.hpp"
 
 TR::PPCJNILinkage::PPCJNILinkage(TR::CodeGenerator *cg)
-   :TR::PPCPrivateLinkage(cg)
+   : J9::PPCPrivateLinkage(cg)
    {
    //Copy out SystemLinkage properties. Assumes no objects in TR::PPCLinkageProperties.
    TR::Linkage *sysLinkage = cg->getLinkage(TR_System);

--- a/runtime/compiler/p/codegen/PPCJNILinkage.hpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef PPC_JNILINKAGE_INCL
 #define PPC_JNILINKAGE_INCL
 
-#include "p/codegen/PPCPrivateLinkage.hpp"
+#include "codegen/PPCPrivateLinkage.hpp"
 
 #include "codegen/Linkage.hpp"
 #include "infra/Assert.hpp"
@@ -46,7 +46,7 @@ namespace TR { class ResolvedMethodSymbol; }
 
 namespace TR {
 
-class PPCJNILinkage : public TR::PPCPrivateLinkage
+class PPCJNILinkage : public J9::PPCPrivateLinkage
    {
    protected:
    TR::PPCLinkageProperties _properties;

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -59,7 +59,7 @@
 #define MAX_PROFILED_CALL_FREQUENCY (.90f)
 
 TR::PPCPrivateLinkage::PPCPrivateLinkage(TR::CodeGenerator *cg)
-   : TR::Linkage(cg)
+   : J9::PrivateLinkage(cg)
    {
    int i = 0;
    bool is32bitLinux = false;

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "p/codegen/PPCPrivateLinkage.hpp"
+#include "codegen/PPCPrivateLinkage.hpp"
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGeneratorUtils.hpp"
@@ -58,7 +58,7 @@
 #define MIN_PROFILED_CALL_FREQUENCY (.075f)
 #define MAX_PROFILED_CALL_FREQUENCY (.90f)
 
-TR::PPCPrivateLinkage::PPCPrivateLinkage(TR::CodeGenerator *cg)
+J9::PPCPrivateLinkage::PPCPrivateLinkage(TR::CodeGenerator *cg)
    : J9::PrivateLinkage(cg)
    {
    int i = 0;
@@ -352,12 +352,12 @@ TR::PPCPrivateLinkage::PPCPrivateLinkage(TR::CodeGenerator *cg)
    _properties._j9methodArgumentRegister    = TR::RealRegister::gr3; // TODO:JSR292: Confirm
    }
 
-const TR::PPCLinkageProperties& TR::PPCPrivateLinkage::getProperties()
+const TR::PPCLinkageProperties& J9::PPCPrivateLinkage::getProperties()
    {
    return _properties;
    }
 
-void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
+void J9::PPCPrivateLinkage::initPPCRealRegisterLinkage()
    {
    TR::Machine *machine = cg()->machine();
    const TR::PPCLinkageProperties &linkage = getProperties();
@@ -452,12 +452,12 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
    machine->setNumberOfLockedRegisters(TR_VRF, 0);
    }
 
-uint32_t TR::PPCPrivateLinkage::getRightToLeft()
+uint32_t J9::PPCPrivateLinkage::getRightToLeft()
    {
    return getProperties().getRightToLeft();
    }
 
-void TR::PPCPrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
+void J9::PPCPrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
@@ -600,7 +600,7 @@ void TR::PPCPrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm - firstLocalOffset);
    }
 
-void TR::PPCPrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
+void J9::PPCPrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
    {
    int32_t roundup = (comp()->useCompressedPointers() && p->isLocalObject() ? TR::Compiler->om.objectAlignmentInBytes() : TR::Compiler->om.sizeofReferenceAddress()) - 1;
    int32_t roundedSize = (p->getSize() + roundup) & (~roundup);
@@ -610,7 +610,7 @@ void TR::PPCPrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t 
    p->setOffset(stackIndex -= roundedSize);
    }
 
-void TR::PPCPrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
+void J9::PPCPrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::ParameterSymbol>   paramIterator(&(method->getParameterList()));
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
@@ -659,7 +659,7 @@ void TR::PPCPrivateLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodS
       }
    }
 
-bool TR::PPCPrivateLinkage::hasToBeOnStack(TR::ParameterSymbol *parm)
+bool J9::PPCPrivateLinkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    {
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    TR_OpaqueClassBlock *throwableClass;
@@ -937,7 +937,7 @@ static int32_t calculateFrameSize(TR::RealRegister::RegNum &intSavedFirst,
    return registerSaveDescription;
    }
 
-void TR::PPCPrivateLinkage::createPrologue(TR::Instruction *cursor)
+void J9::PPCPrivateLinkage::createPrologue(TR::Instruction *cursor)
    {
    TR::Machine *machine = cg()->machine();
    const TR::PPCLinkageProperties& properties = getProperties();
@@ -1301,7 +1301,7 @@ void TR::PPCPrivateLinkage::createPrologue(TR::Instruction *cursor)
       }
    }
 
-TR::MemoryReference *TR::PPCPrivateLinkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t length)
+TR::MemoryReference *J9::PPCPrivateLinkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t length)
    {
    TR::MemoryReference *result=new (trHeapMemory()) TR::MemoryReference(cg()->getStackPointerRegister(), argSize, length, cg());
    memArg.argRegister = argReg;
@@ -1310,7 +1310,7 @@ TR::MemoryReference *TR::PPCPrivateLinkage::getOutgoingArgumentMemRef(int32_t ar
    return(result);
    }
 
-void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
+void J9::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
    int32_t                   blockNumber = cursor->getNext()->getBlockIndex();
    TR::Machine *machine = cg()->machine();
@@ -1393,13 +1393,13 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
       }
    }
 
-int32_t TR::PPCPrivateLinkage::buildArgs(TR::Node *callNode,
+int32_t J9::PPCPrivateLinkage::buildArgs(TR::Node *callNode,
                                         TR::RegisterDependencyConditions *dependencies)
    {
    return buildPrivateLinkageArgs(callNode, dependencies, TR_Private);
    }
 
-int32_t TR::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                         *callNode,
+int32_t J9::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                         *callNode,
                                                        TR::RegisterDependencyConditions *dependencies,
                                                        TR_LinkageConventions             linkage)
    {
@@ -2225,7 +2225,7 @@ static TR::Register* evaluateUpToVftChild(TR::Node *callNode, TR::CodeGenerator 
    return vftReg;
    }
 
-void TR::PPCPrivateLinkage::buildVirtualDispatch(TR::Node                         *callNode,
+void J9::PPCPrivateLinkage::buildVirtualDispatch(TR::Node                         *callNode,
                                                 TR::RegisterDependencyConditions *dependencies,
                                                 uint32_t                           sizeOfArguments)
    {
@@ -2650,7 +2650,7 @@ void inlineCharacterIsMethod(TR::Node *node, TR::MethodSymbol* methodSymbol, TR:
    cg->stopUsingRegister(tmpReg);
    }
 
-void TR::PPCPrivateLinkage::buildDirectCall(TR::Node *callNode,
+void J9::PPCPrivateLinkage::buildDirectCall(TR::Node *callNode,
                                            TR::SymbolReference *callSymRef,
                                            TR::RegisterDependencyConditions *dependencies,
                                            const TR::PPCLinkageProperties &pp,
@@ -2713,7 +2713,7 @@ void TR::PPCPrivateLinkage::buildDirectCall(TR::Node *callNode,
    }
 
 
-TR::Register *TR::PPCPrivateLinkage::buildDirectDispatch(TR::Node *callNode)
+TR::Register *J9::PPCPrivateLinkage::buildDirectDispatch(TR::Node *callNode)
    {
    TR::SymbolReference *callSymRef = callNode->getSymbolReference();
 
@@ -2802,7 +2802,7 @@ TR::Register *TR::PPCPrivateLinkage::buildDirectDispatch(TR::Node *callNode)
    return(returnRegister);
    }
 
-TR::Register *TR::PPCPrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *J9::PPCPrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
    const TR::PPCLinkageProperties &pp = getProperties();
    TR::RegisterDependencyConditions *dependencies =
@@ -2863,7 +2863,7 @@ TR::Register *TR::PPCPrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    return(returnRegister);
    }
 
-TR::Register *TR::PPCPrivateLinkage::buildalloca(TR::Node *BIFCallNode)
+TR::Register *J9::PPCPrivateLinkage::buildalloca(TR::Node *BIFCallNode)
    {
    TR_ASSERT(0,"PPCPrivateLinkage does not support alloca.\n");
    return NULL;
@@ -2875,7 +2875,7 @@ int32_t TR::PPCHelperLinkage::buildArgs(TR::Node *callNode,
    return buildPrivateLinkageArgs(callNode, dependencies, _helperLinkage);
    }
 
-TR::MemoryReference *TR::PPCPrivateLinkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t length, const TR::PPCLinkageProperties& properties)
+TR::MemoryReference *J9::PPCPrivateLinkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t length, const TR::PPCLinkageProperties& properties)
    {
    TR::Machine *machine = cg()->machine();
 

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.hpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,7 @@
 #ifndef PPC_PRIVATELINKAGE_INCL
 #define PPC_PRIVATELINKAGE_INCL
 
-#include "codegen/Linkage.hpp"
-
+#include "codegen/PrivateLinkage.hpp"
 #include "infra/Assert.hpp"
 
 class TR_BitVector;
@@ -53,7 +52,7 @@ struct PPCPICItem
    };
 
 
-class PPCPrivateLinkage : public TR::Linkage
+class PPCPrivateLinkage : public J9::PrivateLinkage
    {
    public:
 

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.hpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.hpp
@@ -51,8 +51,13 @@ struct PPCPICItem
    float _frequency;
    };
 
+}
 
-class PPCPrivateLinkage : public J9::PrivateLinkage
+
+namespace J9
+{
+
+class PPCPrivateLinkage : public PrivateLinkage
    {
    public:
 
@@ -104,12 +109,17 @@ class PPCPrivateLinkage : public J9::PrivateLinkage
    virtual TR::Register *buildalloca(TR::Node *BIFCallNode);
    };
 
+}
 
-class PPCHelperLinkage : public TR::PPCPrivateLinkage
+
+namespace TR
+{
+
+class PPCHelperLinkage : public J9::PPCPrivateLinkage
    {
    public:
 
-   PPCHelperLinkage(TR::CodeGenerator *cg, TR_LinkageConventions helperLinkage) : _helperLinkage(helperLinkage), TR::PPCPrivateLinkage(cg)
+   PPCHelperLinkage(TR::CodeGenerator *cg, TR_LinkageConventions helperLinkage) : _helperLinkage(helperLinkage), J9::PPCPrivateLinkage(cg)
       {
       TR_ASSERT(helperLinkage == TR_Helper || helperLinkage == TR_CHelper, "Unexpected helper linkage convention");
       }

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.hpp
@@ -38,14 +38,15 @@ namespace TR { class RegisterDependencyConditions; }
 
 #define IMCOMPLETELINKAGE  "This class is only used to generate call-out sequence but no call-in sequence, so it is not used as a complete linkage."
 
-namespace TR {
+namespace TR
+{
 
-class AMD64JNILinkage : public TR::AMD64PrivateLinkage
+class AMD64JNILinkage : public J9::AMD64PrivateLinkage
    {
    public:
 
    AMD64JNILinkage(TR::AMD64SystemLinkage *systemLinkage, TR::CodeGenerator *cg) :
-      TR::AMD64PrivateLinkage(cg),
+      J9::AMD64PrivateLinkage(cg),
          _systemLinkage(systemLinkage) {}
 
    int32_t computeMemoryArgSize(TR::Node *callNode, int32_t first, int32_t last, bool passThread = true);

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -82,8 +82,8 @@ enum
 // Initialization
 //
 
-TR::AMD64PrivateLinkage::AMD64PrivateLinkage(TR::CodeGenerator *cg)
-   : TR::X86PrivateLinkage(cg)
+J9::AMD64PrivateLinkage::AMD64PrivateLinkage(TR::CodeGenerator *cg)
+   : J9::X86PrivateLinkage(cg)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
    const TR::RealRegister::RegNum noReg = TR::RealRegister::NoReg;
@@ -309,7 +309,7 @@ static int32_t flushArgumentSize(
    return size + (((offset >= -128 && offset <= 127)) ? 1 : 4);
    }
 
-uint8_t *TR::AMD64PrivateLinkage::flushArguments(
+uint8_t *J9::AMD64PrivateLinkage::flushArguments(
       TR::Node *callNode,
       uint8_t *cursor,
       bool calculateSizeOnly,
@@ -398,7 +398,7 @@ uint8_t *TR::AMD64PrivateLinkage::flushArguments(
    }
 
 TR::Instruction *
-TR::AMD64PrivateLinkage::generateFlushInstruction(
+J9::AMD64PrivateLinkage::generateFlushInstruction(
       TR::Instruction *prev,
       TR_MovOperandTypes operandType,
       TR::DataType dataType,
@@ -449,7 +449,7 @@ TR::AMD64PrivateLinkage::generateFlushInstruction(
    }
 
 TR::Instruction *
-TR::AMD64PrivateLinkage::flushArguments(
+J9::AMD64PrivateLinkage::flushArguments(
       TR::Instruction *prev,
       TR::ResolvedMethodSymbol *methodSymbol,
       bool isReturnAddressOnStack,
@@ -525,7 +525,7 @@ TR::AMD64PrivateLinkage::flushArguments(
    return prev;
    }
 
-uint8_t *TR::AMD64PrivateLinkage::generateVirtualIndirectThunk(TR::Node *callNode)
+uint8_t *J9::AMD64PrivateLinkage::generateVirtualIndirectThunk(TR::Node *callNode)
    {
    int32_t              codeSize;
    TR::SymbolReference  *glueSymRef;
@@ -606,7 +606,7 @@ uint8_t *TR::AMD64PrivateLinkage::generateVirtualIndirectThunk(TR::Node *callNod
    return thunkEntry;
    }
 
-TR_J2IThunk *TR::AMD64PrivateLinkage::generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature)
+TR_J2IThunk *J9::AMD64PrivateLinkage::generateInvokeExactJ2IThunk(TR::Node *callNode, char *signature)
    {
    TR::Compilation * comp = cg()->comp();
 
@@ -696,7 +696,7 @@ TR_J2IThunk *TR::AMD64PrivateLinkage::generateInvokeExactJ2IThunk(TR::Node *call
 // Prologue and Epilogue
 //
 
-void TR::AMD64PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
+void J9::AMD64PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    {
    TR_ASSERT(!getProperties().passArgsRightToLeft(), "Right-to-left not yet implemented on AMD64");
 
@@ -724,7 +724,7 @@ void TR::AMD64PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
 
    }
 
-TR::Instruction *TR::AMD64PrivateLinkage::savePreservedRegisters(TR::Instruction *cursor)
+TR::Instruction *J9::AMD64PrivateLinkage::savePreservedRegisters(TR::Instruction *cursor)
    {
    TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();
    const int32_t          localSize   = _properties.getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
@@ -764,7 +764,7 @@ TR::Instruction *TR::AMD64PrivateLinkage::savePreservedRegisters(TR::Instruction
    return cursor;
    }
 
-TR::Instruction *TR::AMD64PrivateLinkage::restorePreservedRegisters(TR::Instruction *cursor)
+TR::Instruction *J9::AMD64PrivateLinkage::restorePreservedRegisters(TR::Instruction *cursor)
    {
    TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();
    const int32_t          localSize   = _properties.getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
@@ -799,7 +799,7 @@ TR::Instruction *TR::AMD64PrivateLinkage::restorePreservedRegisters(TR::Instruct
 // Call node evaluation
 //
 
-int32_t TR::AMD64PrivateLinkage::argAreaSize(TR::ResolvedMethodSymbol *methodSymbol)
+int32_t J9::AMD64PrivateLinkage::argAreaSize(TR::ResolvedMethodSymbol *methodSymbol)
    {
    int32_t result = 0;
    ListIterator<TR::ParameterSymbol>   paramIterator(&(methodSymbol->getParameterList()));
@@ -811,7 +811,7 @@ int32_t TR::AMD64PrivateLinkage::argAreaSize(TR::ResolvedMethodSymbol *methodSym
    return result;
    }
 
-int32_t TR::AMD64PrivateLinkage::argAreaSize(TR::Node *callNode)
+int32_t J9::AMD64PrivateLinkage::argAreaSize(TR::Node *callNode)
    {
    // TODO: We only need this function because unresolved calls don't have a
    // TR::ResolvedMethodSymbol, and only TR::ResolvedMethodSymbol has
@@ -831,7 +831,7 @@ int32_t TR::AMD64PrivateLinkage::argAreaSize(TR::Node *callNode)
    return result;
    }
 
-int32_t TR::AMD64PrivateLinkage::buildArgs(TR::Node                             *callNode,
+int32_t J9::AMD64PrivateLinkage::buildArgs(TR::Node                             *callNode,
                                           TR::RegisterDependencyConditions  *dependencies)
    {
    TR::MethodSymbol *methodSymbol = callNode->getSymbol()->getMethodSymbol();
@@ -896,7 +896,7 @@ int32_t TR::AMD64PrivateLinkage::buildArgs(TR::Node                             
    return buildPrivateLinkageArgs(callNode, dependencies, rightToLeft, passArgsOnStack);
    }
 
-int32_t TR::AMD64PrivateLinkage::buildPrivateLinkageArgs(TR::Node                             *callNode,
+int32_t J9::AMD64PrivateLinkage::buildPrivateLinkageArgs(TR::Node                             *callNode,
                                                         TR::RegisterDependencyConditions  *dependencies,
                                                         bool                                 rightToLeft,
                                                         bool                                 passArgsOnStack)
@@ -1124,7 +1124,7 @@ static TR_AtomicRegion X86PicSlotAtomicRegion[] =
    };
 
 
-TR::Instruction *TR::AMD64PrivateLinkage::buildPICSlot(TR::X86PICSlot picSlot, TR::LabelSymbol *mismatchLabel, TR::LabelSymbol *doneLabel, TR::X86CallSite &site)
+TR::Instruction *J9::AMD64PrivateLinkage::buildPICSlot(TR::X86PICSlot picSlot, TR::LabelSymbol *mismatchLabel, TR::LabelSymbol *doneLabel, TR::X86CallSite &site)
    {
    TR::Register *cachedAddressRegister = cg()->allocateRegister();
 
@@ -1245,7 +1245,7 @@ static TR_AtomicRegion amd64IPicAtomicRegions[] =
    //{ 0x28, 4 }, // Call displacement 2  (no race here)
    };
 
-void TR::AMD64PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)
+void J9::AMD64PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg()->fe());
    int32_t numIPICs = 0;
@@ -1357,7 +1357,7 @@ void TR::AMD64PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *
    cg()->reserveNTrampolines(numIPICs);
    }
 
-void TR::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)
+void J9::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
    if (entryLabel)
@@ -1392,7 +1392,7 @@ void TR::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, 
       }
    }
 
-TR::Register *TR::AMD64PrivateLinkage::buildJNIDispatch(TR::Node *callNode)
+TR::Register *J9::AMD64PrivateLinkage::buildJNIDispatch(TR::Node *callNode)
    {
    TR_ASSERT(0, "AMD64 implements JNI dispatch using a system linkage");
    return NULL;

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,19 +25,16 @@
 
 #ifdef TR_TARGET_64BIT
 
-#include "x/codegen/X86PrivateLinkage.hpp"
+#include "codegen/X86PrivateLinkage.hpp"
 
 namespace TR { class AMD64PrivateLinkage; }
 class J2IThunk;
 
-namespace TR {
 
-// Pseudo-safe downcast function, since all linkages are AMD64PrivateLinkages
-//
-inline TR::AMD64PrivateLinkage * toAMD64PrivateLinkage(TR::Linkage *l) { return (TR::AMD64PrivateLinkage *)l; }
+namespace J9
+{
 
-
-class AMD64PrivateLinkage : public TR::X86PrivateLinkage
+class AMD64PrivateLinkage : public J9::X86PrivateLinkage
    {
    public:
 

--- a/runtime/compiler/x/amd64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/amd64/codegen/J9CodeGenerator.cpp
@@ -22,8 +22,8 @@
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
+#include "codegen/X86PrivateLinkage.hpp"
 #include "compile/Compilation.hpp"
-#include "x/codegen/X86PrivateLinkage.hpp"
 #include "x/codegen/X86HelperLinkage.hpp"
 #include "codegen/AMD64PrivateLinkage.hpp"
 #include "codegen/AMD64JNILinkage.hpp"
@@ -46,8 +46,8 @@ J9::X86::AMD64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
       case TR_Helper:
       case TR_Private:
          {
-         TR::X86PrivateLinkage *p = NULL;
-         p = new (self()->trHeapMemory()) TR::AMD64PrivateLinkage(self());
+         J9::X86PrivateLinkage *p = NULL;
+         p = new (self()->trHeapMemory()) J9::AMD64PrivateLinkage(self());
          p->IPicParameters.roundedSizeOfSlot = 10+3+2+5+2+2;
          p->IPicParameters.defaultNumberOfSlots = 2;
          p->IPicParameters.defaultSlotAddress = 0;

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -26,6 +26,7 @@
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/Relocation.hpp"
 #include "codegen/SnippetGCMap.hpp"
+#include "codegen/X86PrivateLinkage.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
 #include "env/jittypes.h"
@@ -38,7 +39,6 @@
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/StaticSymbol.hpp"
 #include "il/Symbol.hpp"
-#include "x/codegen/X86PrivateLinkage.hpp"
 
 bool TR::X86PicDataSnippet::shouldEmitJ2IThunkPointer()
    {
@@ -150,7 +150,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
 
    uint8_t *cursor = startOfSnippet;
 
-   TR::X86PrivateLinkage *x86Linkage = toX86PrivateLinkage(cg()->getLinkage());
+   J9::X86PrivateLinkage *x86Linkage = static_cast<J9::X86PrivateLinkage *>(cg()->getLinkage());
 
    int32_t disp32;
 

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -83,7 +83,7 @@ inline uint32_t lcm(uint32_t a, uint32_t b)
    {
    return a * b / gcd(a, b);
    }
-TR::X86PrivateLinkage::X86PrivateLinkage(TR::CodeGenerator *cg) : TR::Linkage(cg)
+TR::X86PrivateLinkage::X86PrivateLinkage(TR::CodeGenerator *cg) : J9::PrivateLinkage(cg)
    {
    // Stack alignment basic requirement:
    //    X86-32:  4 bytes, per hardware requirement

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "x/codegen/X86PrivateLinkage.hpp"
+#include "codegen/X86PrivateLinkage.hpp"
 
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/LiveRegister.hpp"
@@ -69,6 +69,7 @@ inline uint32_t align(uint32_t number, uint32_t requirement)
    TR_ASSERT(requirement && ((requirement & (requirement -1)) == 0), "INCORRECT ALIGNMENT");
    return (number + requirement - 1) & ~(requirement - 1);
    }
+
 inline uint32_t gcd(uint32_t a, uint32_t b)
    {
    while (b != 0)
@@ -79,11 +80,13 @@ inline uint32_t gcd(uint32_t a, uint32_t b)
       }
    return a;
    }
+
 inline uint32_t lcm(uint32_t a, uint32_t b)
    {
    return a * b / gcd(a, b);
    }
-TR::X86PrivateLinkage::X86PrivateLinkage(TR::CodeGenerator *cg) : J9::PrivateLinkage(cg)
+
+J9::X86PrivateLinkage::X86PrivateLinkage(TR::CodeGenerator *cg) : J9::PrivateLinkage(cg)
    {
    // Stack alignment basic requirement:
    //    X86-32:  4 bytes, per hardware requirement
@@ -94,7 +97,7 @@ TR::X86PrivateLinkage::X86PrivateLinkage(TR::CodeGenerator *cg) : J9::PrivateLin
                                            cg->fej9()->getLocalObjectAlignmentInBytes()));
    }
 
-const TR::X86LinkageProperties& TR::X86PrivateLinkage::getProperties()
+const TR::X86LinkageProperties& J9::X86PrivateLinkage::getProperties()
    {
    return _properties;
    }
@@ -107,7 +110,7 @@ const TR::X86LinkageProperties& TR::X86PrivateLinkage::getProperties()
 static const TR::RealRegister::RegNum NOT_ASSIGNED = (TR::RealRegister::RegNum)-1;
 
 
-void TR::X86PrivateLinkage::copyLinkageInfoToParameterSymbols()
+void J9::X86PrivateLinkage::copyLinkageInfoToParameterSymbols()
    {
    TR::ResolvedMethodSymbol              *bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
@@ -142,7 +145,7 @@ void TR::X86PrivateLinkage::copyLinkageInfoToParameterSymbols()
       }
    }
 
-void TR::X86PrivateLinkage::copyGlRegDepsToParameterSymbols(TR::Node *bbStart, TR::CodeGenerator *cg)
+void J9::X86PrivateLinkage::copyGlRegDepsToParameterSymbols(TR::Node *bbStart, TR::CodeGenerator *cg)
    {
    TR_ASSERT(bbStart->getOpCodeValue() == TR::BBStart, "assertion failure");
    if (bbStart->getNumChildren() > 0)
@@ -163,7 +166,7 @@ void TR::X86PrivateLinkage::copyGlRegDepsToParameterSymbols(TR::Node *bbStart, T
       }
    }
 
-TR::Instruction *TR::X86PrivateLinkage::copyStackParametersToLinkageRegisters(TR::Instruction *procEntryInstruction)
+TR::Instruction *J9::X86PrivateLinkage::copyStackParametersToLinkageRegisters(TR::Instruction *procEntryInstruction)
    {
    TR_ASSERT(procEntryInstruction && procEntryInstruction->getOpCodeValue() == PROCENTRY, "assertion failure");
    TR::Instruction *intrpPrev = procEntryInstruction->getPrev(); // The instruction before the interpreter entry point
@@ -171,7 +174,7 @@ TR::Instruction *TR::X86PrivateLinkage::copyStackParametersToLinkageRegisters(TR
    return intrpPrev->getNext();
    }
 
-TR::Instruction *TR::X86PrivateLinkage::movLinkageRegisters(TR::Instruction *cursor, bool isStore)
+TR::Instruction *J9::X86PrivateLinkage::movLinkageRegisters(TR::Instruction *cursor, bool isStore)
    {
    TR_ASSERT(cursor, "assertion failure");
 
@@ -217,7 +220,7 @@ TR::Instruction *TR::X86PrivateLinkage::movLinkageRegisters(TR::Instruction *cur
 // linkage register) to their "home location" where the method body will expect
 // to find them (either on stack or in a global register).
 //
-TR::Instruction *TR::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored)
+TR::Instruction *J9::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored)
    {
    TR::Machine *machine = cg()->machine();
    TR::RealRegister  *framePointer = machine->getRealRegister(TR::RealRegister::vfp);
@@ -481,7 +484,7 @@ static TR::Instruction *initializeLocals(TR::Instruction      *cursor,
 
 #define STACKCHECKBUFFER 512
 
-void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
+void J9::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
    {
 #if defined(DEBUG)
    // TODO:AMD64: Get this into the debug DLL
@@ -1007,20 +1010,20 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
 #endif
    }
 
-bool TR::X86PrivateLinkage::needsFrameDeallocation()
+bool J9::X86PrivateLinkage::needsFrameDeallocation()
    {
    // frame needs a deallocation if FrameSize == 0
    //
    return !_properties.getAlwaysDedicateFramePointerRegister() && cg()->getFrameSizeInBytes() == 0;
    }
 
-TR::Instruction *TR::X86PrivateLinkage::deallocateFrameIfNeeded(TR::Instruction *cursor, int32_t size)
+TR::Instruction *J9::X86PrivateLinkage::deallocateFrameIfNeeded(TR::Instruction *cursor, int32_t size)
    {
    return cursor;
    }
 
 
-void TR::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
+void J9::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
    TR::RealRegister* espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
@@ -1055,7 +1058,7 @@ void TR::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    }
 
 TR::Register *
-TR::X86PrivateLinkage::buildDirectDispatch(
+J9::X86PrivateLinkage::buildDirectDispatch(
       TR::Node *callNode,
       bool spillFPRegs)
    {
@@ -1470,7 +1473,8 @@ void TR::X86CallSite::computeProfiledTargets()
       // Disable lastITable logic if all the implementers can fit into the pic slots during non-startup state
       if (_useLastITableCache && TR::Compiler->target.is64Bit() && _interfaceClassOfMethod && comp()->getPersistentInfo()->getJitState() != STARTUP_STATE)
          {
-         int32_t numPICSlots = numStaticPICSlots + toX86PrivateLinkage(getLinkage())->IPicParameters.defaultNumberOfSlots;
+         J9::X86PrivateLinkage *privateLinkage = static_cast<J9::X86PrivateLinkage *>(getLinkage());
+         int32_t numPICSlots = numStaticPICSlots + privateLinkage->IPicParameters.defaultNumberOfSlots;
          TR_ResolvedMethod **implArray = new (comp()->trStackMemory()) TR_ResolvedMethod*[numPICSlots+1];
          TR_PersistentCHTable * chTable = comp()->getPersistentInfo()->getPersistentCHTable();
          int32_t cpIndex = getSymbolReference()->getCPIndex();
@@ -1621,7 +1625,7 @@ static bool indirectDispatchWillBuildVirtualGuard(TR::Compilation *comp, TR::X86
    return false;
    }
 
-TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
+TR::Register *J9::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
    TR::StackMemoryRegion stackMemoryRegion(*comp()->trMemory());
 
@@ -1889,7 +1893,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    return returnRegister;
    }
 
-void TR::X86PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef, TR::X86CallSite &site)
+void J9::X86PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef, TR::X86CallSite &site)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
    TR::MethodSymbol   *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
@@ -1978,7 +1982,7 @@ void TR::X86PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef, T
    }
 
 void
-TR::X86PrivateLinkage::buildInterfaceCall(
+J9::X86PrivateLinkage::buildInterfaceCall(
       TR::X86CallSite &site,
       TR::LabelSymbol *entryLabel,
       TR::LabelSymbol *doneLabel,
@@ -1992,7 +1996,7 @@ TR::X86PrivateLinkage::buildInterfaceCall(
    buildIPIC(site, entryLabel, doneLabel, thunk);
    }
 
-void TR::X86PrivateLinkage::buildRevirtualizedCall(TR::X86CallSite &site, TR::LabelSymbol *revirtualizeLabel, TR::LabelSymbol *doneLabel)
+void J9::X86PrivateLinkage::buildRevirtualizedCall(TR::X86CallSite &site, TR::LabelSymbol *revirtualizeLabel, TR::LabelSymbol *doneLabel)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    TR::Register *vftRegister = site.getCallNode()->getFirstChild()->getRegister(); // may be NULL; we don't need to evaluate it here
@@ -2031,12 +2035,12 @@ void TR::X86PrivateLinkage::buildRevirtualizedCall(TR::X86CallSite &site, TR::La
    cg()->addSnippet(snippet);
    }
 
-void TR::X86PrivateLinkage::buildCallArguments(TR::X86CallSite &site)
+void J9::X86PrivateLinkage::buildCallArguments(TR::X86CallSite &site)
    {
    site.setArgSize(buildArgs(site.getCallNode(), site.getPreConditionsUnderConstruction()));
    }
 
-bool TR::X86PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::LabelSymbol *revirtualizeLabel)
+bool J9::X86PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::LabelSymbol *revirtualizeLabel)
    {
    TR_ASSERT(site.getVirtualGuardKind() != TR_NoGuard, "site must require a virtual guard");
 
@@ -2066,7 +2070,7 @@ bool TR::X86PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::LabelSy
 
       if (TR::Compiler->target.isSMP())
          generatePatchableCodeAlignmentInstruction(vgnopAtomicRegions, patchable, cg());
-      // HCR in TR::X86PrivateLinkage::buildRevirtualizedCall
+      // HCR in J9::X86PrivateLinkage::buildRevirtualizedCall
       if (comp()->getOption(TR_EnableHCR))
          {
          TR_VirtualGuard* HCRGuard = TR_VirtualGuard::createGuardedDevirtualizationGuard(TR_HCRGuard, comp(), callNode);
@@ -2110,7 +2114,7 @@ bool TR::X86PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::LabelSy
       }
    }
 
-TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref)
+TR::Instruction *J9::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref)
    {
    TR::Node *callNode = site.getCallNode();
    if (cg()->enableSinglePrecisionMethods() &&
@@ -2199,7 +2203,7 @@ TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X
    return callInstr;
    }
 
-TR::Register *TR::X86PrivateLinkage::buildCallPostconditions(TR::X86CallSite &site)
+TR::Register *J9::X86PrivateLinkage::buildCallPostconditions(TR::X86CallSite &site)
    {
    TR::RegisterDependencyConditions *dependencies = site.getPostConditionsUnderConstruction();
    TR_ASSERT(dependencies != NULL, "assertion failure");
@@ -2391,7 +2395,7 @@ TR::Register *TR::X86PrivateLinkage::buildCallPostconditions(TR::X86CallSite &si
    }
 
 
-void TR::X86PrivateLinkage::buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel)
+void J9::X86PrivateLinkage::buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    TR_ASSERT(doneLabel, "a doneLabel is required for VPIC dispatches");
@@ -2462,7 +2466,7 @@ void TR::X86PrivateLinkage::buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *en
    cg()->reserveNTrampolines(VPicParameters.defaultNumberOfSlots);
    }
 
-void TR::X86PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86CallSite &site, int32_t numIPicSlots, TR::X86PICSlot &lastPicSlot, TR::Instruction *&slotPatchInstruction, TR::LabelSymbol *doneLabel, TR::LabelSymbol *lookupDispatchSnippetLabel, TR_OpaqueClassBlock *declaringClass, uintptrj_t itableIndex )
+void J9::X86PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86CallSite &site, int32_t numIPicSlots, TR::X86PICSlot &lastPicSlot, TR::Instruction *&slotPatchInstruction, TR::LabelSymbol *doneLabel, TR::LabelSymbol *lookupDispatchSnippetLabel, TR_OpaqueClassBlock *declaringClass, uintptrj_t itableIndex )
    {
    static char *breakBeforeInterfaceDispatchUsingLastITable = feGetEnv("TR_breakBeforeInterfaceDispatchUsingLastITable");
 

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef X86PRIVATELINKAGE_INCL
 #define X86PRIVATELINKAGE_INCL
 
-#include "codegen/Linkage.hpp"
+#include "codegen/PrivateLinkage.hpp"
 
 #include "env/jittypes.h"
 #include "codegen/RegisterDependency.hpp"
@@ -216,7 +216,7 @@ struct PicParameters
 
 
 
-class X86PrivateLinkage : public TR::Linkage
+class X86PrivateLinkage : public J9::PrivateLinkage
    {
    protected:
 

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -214,9 +214,13 @@ struct PicParameters
    int32_t defaultNumberOfSlots;
    };
 
+}
 
 
-class X86PrivateLinkage : public J9::PrivateLinkage
+namespace J9
+{
+
+class X86PrivateLinkage : public PrivateLinkage
    {
    protected:
 
@@ -290,7 +294,5 @@ class X86PrivateLinkage : public J9::PrivateLinkage
    };
 
 }
-
-inline TR::X86PrivateLinkage *toX86PrivateLinkage(TR::Linkage *l) {return (TR::X86PrivateLinkage *)l;}
 
 #endif

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -47,8 +47,8 @@
 #include "x/codegen/IA32LinkageUtils.hpp"
 #include "x/codegen/X86Instruction.hpp"
 
-TR::IA32PrivateLinkage::IA32PrivateLinkage(TR::CodeGenerator *cg)
-   : TR::X86PrivateLinkage(cg)
+J9::IA32PrivateLinkage::IA32PrivateLinkage(TR::CodeGenerator *cg)
+   : J9::X86PrivateLinkage(cg)
    {
    _properties._properties = 0;
    _properties._registerFlags[TR::RealRegister::NoReg] = 0;
@@ -146,7 +146,7 @@ TR::IA32PrivateLinkage::IA32PrivateLinkage(TR::CodeGenerator *cg)
    _properties._allocationOrder[14] = TR::RealRegister::st7;
    }
 
-TR::Instruction *TR::IA32PrivateLinkage::savePreservedRegisters(TR::Instruction *cursor)
+TR::Instruction *J9::IA32PrivateLinkage::savePreservedRegisters(TR::Instruction *cursor)
    {
    TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();
    const int32_t          localSize   = _properties.getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
@@ -176,7 +176,7 @@ TR::Instruction *TR::IA32PrivateLinkage::savePreservedRegisters(TR::Instruction 
    return cursor;
    }
 
-TR::Instruction *TR::IA32PrivateLinkage::restorePreservedRegisters(TR::Instruction *cursor)
+TR::Instruction *J9::IA32PrivateLinkage::restorePreservedRegisters(TR::Instruction *cursor)
    {
    TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();
    const int32_t          localSize   = _properties.getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
@@ -206,7 +206,7 @@ TR::Instruction *TR::IA32PrivateLinkage::restorePreservedRegisters(TR::Instructi
    }
 
 
-int32_t TR::IA32PrivateLinkage::buildArgs(
+int32_t J9::IA32PrivateLinkage::buildArgs(
       TR::Node *callNode,
       TR::RegisterDependencyConditions *dependencies)
    {
@@ -316,7 +316,7 @@ int32_t TR::IA32PrivateLinkage::buildArgs(
    }
 
 
-TR::UnresolvedDataSnippet *TR::IA32PrivateLinkage::generateX86UnresolvedDataSnippetWithCPIndex(
+TR::UnresolvedDataSnippet *J9::IA32PrivateLinkage::generateX86UnresolvedDataSnippetWithCPIndex(
       TR::Node *child,
       TR::SymbolReference *symRef,
       int32_t cpIndex)
@@ -334,7 +334,7 @@ TR::UnresolvedDataSnippet *TR::IA32PrivateLinkage::generateX86UnresolvedDataSnip
    return snippet;
    }
 
-TR::Register *TR::IA32PrivateLinkage::pushIntegerWordArg(TR::Node *child)
+TR::Register *J9::IA32PrivateLinkage::pushIntegerWordArg(TR::Node *child)
    {
    TR::Compilation *comp = cg()->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
@@ -402,7 +402,7 @@ TR::Register *TR::IA32PrivateLinkage::pushIntegerWordArg(TR::Node *child)
    return TR::IA32LinkageUtils::pushIntegerWordArg(child, cg());
    }
 
-TR::Register *TR::IA32PrivateLinkage::pushThis(TR::Node *child)
+TR::Register *J9::IA32PrivateLinkage::pushThis(TR::Node *child)
    {
    // Don't decrement the reference count on the "this" child until we've
    // had a chance to set up its dependency conditions
@@ -426,7 +426,7 @@ static TR_AtomicRegion X86PicCallAtomicRegion[] =
    };
 
 
-TR::Instruction *TR::IA32PrivateLinkage::buildPICSlot(
+TR::Instruction *J9::IA32PrivateLinkage::buildPICSlot(
       TR::X86PICSlot picSlot,
       TR::LabelSymbol *mismatchLabel,
       TR::LabelSymbol *doneLabel,
@@ -573,7 +573,7 @@ static TR_AtomicRegion ia32IPicAtomicRegionsRT[] =
    { 0,0 }      // (null terminator)
    };
 
-void TR::IA32PrivateLinkage::buildIPIC(
+void J9::IA32PrivateLinkage::buildIPIC(
       TR::X86CallSite &site,
       TR::LabelSymbol *entryLabel,
       TR::LabelSymbol *doneLabel,
@@ -686,7 +686,7 @@ void TR::IA32PrivateLinkage::buildIPIC(
    cg()->addSnippet(snippet);
    }
 
-void TR::IA32PrivateLinkage::buildVirtualOrComputedCall(
+void J9::IA32PrivateLinkage::buildVirtualOrComputedCall(
       TR::X86CallSite &site,
       TR::LabelSymbol *entryLabel,
       TR::LabelSymbol *doneLabel,
@@ -715,7 +715,7 @@ void TR::IA32PrivateLinkage::buildVirtualOrComputedCall(
       }
    else
       {
-      TR::X86PrivateLinkage::buildVPIC(site, entryLabel, doneLabel);
+      J9::X86PrivateLinkage::buildVPIC(site, entryLabel, doneLabel);
       }
    }
 

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.hpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,13 +23,14 @@
 #ifndef IA32LINKAGE_INCL
 #define IA32LINKAGE_INCL
 
-#include "x/codegen/X86PrivateLinkage.hpp"
+#include "codegen/X86PrivateLinkage.hpp"
 
 namespace TR { class UnresolvedDataSnippet; }
 
-namespace TR {
+namespace J9
+{
 
-class IA32PrivateLinkage : public TR::X86PrivateLinkage
+class IA32PrivateLinkage : public X86PrivateLinkage
    {
    public:
 
@@ -53,12 +54,24 @@ class IA32PrivateLinkage : public TR::X86PrivateLinkage
    virtual void buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk);
    };
 
+}
+
+
+/**
+ * The following is only required to assist with refactoring because they are
+ * referenced in J9_PROJECT_SPECIFIC parts of OMR.  Once the IA32PrivateLinkage
+ * class moves into the J9 namespace they can be easily removed in OMR and will
+ * be subsequently deleted here.
+ */
+namespace TR
+{
+
+typedef J9::IA32PrivateLinkage IA32PrivateLinkage;
+
 inline TR::IA32PrivateLinkage *toIA32PrivateLinkage(TR::Linkage *linkage)
    {
-   return (TR::IA32PrivateLinkage*)linkage;
+   return static_cast<TR::IA32PrivateLinkage *>(linkage);
    }
 
 }
-
 #endif
-

--- a/runtime/compiler/x/i386/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/i386/codegen/J9CodeGenerator.cpp
@@ -22,8 +22,8 @@
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
+#include "codegen/X86PrivateLinkage.hpp"
 #include "compile/Compilation.hpp"
-#include "x/codegen/X86PrivateLinkage.hpp"
 #include "x/codegen/X86HelperLinkage.hpp"
 #include "codegen/IA32PrivateLinkage.hpp"
 #include "codegen/IA32J9SystemLinkage.hpp"
@@ -44,8 +44,8 @@ J9::X86::i386::CodeGenerator::createLinkage(TR_LinkageConventions lc)
       case TR_Helper:
       case TR_Private:
          {
-         TR::X86PrivateLinkage *p = NULL;
-         p = new (self()->trHeapMemory()) TR::IA32PrivateLinkage(self());
+         J9::X86PrivateLinkage *p = NULL;
+         p = new (self()->trHeapMemory()) J9::IA32PrivateLinkage(self());
          p->IPicParameters.roundedSizeOfSlot = 6+2+5+2+1;
          p->IPicParameters.defaultNumberOfSlots = 2;
          p->IPicParameters.defaultSlotAddress = -1;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -36,18 +36,17 @@
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/ConstantDataSnippet.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 #include "env/VMJ9.h"
 #include "env/jittypes.h"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #include "z/codegen/J9SystemLinkageLinux.hpp"
 #include "z/codegen/J9SystemLinkagezOS.hpp"
 #include "z/codegen/J9S390CHelperLinkage.hpp"
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390Recompilation.hpp"
 #include "z/codegen/S390Register.hpp"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #include "z/codegen/ReduceSynchronizedFieldLoad.hpp"
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
@@ -205,7 +204,7 @@ J9::Z::CodeGenerator::createLinkage(TR_LinkageConventions lc)
          break;
 
       case TR_Private:
-         linkage = new (self()->trHeapMemory()) TR::S390PrivateLinkage(self());
+         linkage = new (self()->trHeapMemory()) J9::S390PrivateLinkage(self());
          break;
 
       case TR_J9JNILinkage:
@@ -3564,7 +3563,8 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
    TR::Instruction* vmCallHelperSnippetLabelInstruction = cursor;
 
    // Store all arguments to the stack for access by the interpreted method
-   cursor = static_cast<TR::Instruction*>(self()->getS390PrivateLinkage()->saveArguments(cursor, false, true));
+   J9::S390PrivateLinkage *privateLinkage = static_cast<J9::S390PrivateLinkage *>(self()->getLinkage());
+   cursor = static_cast<TR::Instruction*>(privateLinkage->saveArguments(cursor, false, true));
 
    // Load the EP register with the address of the next instruction
    cursor = generateRRInstruction(self(), TR::InstOpCode::BASR, node, self()->getEntryPointRealRegister(), self()->machine()->getRealRegister(TR::RealRegister::GPR0), cursor);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -36,14 +36,12 @@ namespace J9 { typedef J9::Z::CodeGenerator CodeGeneratorConnector; }
 #error J9::Z::CodeGenerator expected to be a primary connector, but a J9 connector is already defined
 #endif
 
-
-
 #include "compiler/codegen/J9CodeGenerator.hpp"
 #include "j9cfg.h"
+
 namespace TR { class S390EyeCatcherDataSnippet; }
-
-
 namespace TR { class Node; }
+
 
 namespace J9
 {
@@ -114,7 +112,7 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    bool canGeneratePDBinaryIntrinsic(TR::ILOpCodes opCode, TR::Node * op1PrecNode, TR::Node * op2PrecNode, TR::Node * resultPrecNode);
 
    bool constLoadNeedsLiteralFromPool(TR::Node *node);
-   
+
    bool supportsTrapsInTMRegion(){ return TR::Compiler->target.isZOS();}
 
    using J9::CodeGenerator::addAllocatedRegister;

--- a/runtime/compiler/z/codegen/J9Linkage.hpp
+++ b/runtime/compiler/z/codegen/J9Linkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,17 +51,20 @@ namespace J9 { typedef J9::Z::Linkage LinkageConnector; }
 
 namespace J9
 {
-    
+
 namespace Z
 {
 
 class OMR_EXTENSIBLE Linkage : public OMR::LinkageConnector
    {
    public:
-      
+
+   Linkage(TR::CodeGenerator * codeGen)
+     : OMR::LinkageConnector(codeGen) {}
+
    Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
      : OMR::LinkageConnector(codeGen,elc,lc) {}
-         
+
    TR::Instruction *loadUpArguments(TR::Instruction * cursor);
    };
 

--- a/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "z/codegen/J9S390PrivateLinkage.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 #include "z/codegen/J9S390CHelperLinkage.hpp"
 
 #include "codegen/CodeGenerator.hpp"

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -58,8 +58,10 @@
 // TR::S390PrivateLinkage for J9
 ////////////////////////////////////////////////////////////////////////////////
 TR::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
-   : TR::Linkage(codeGen,elc,lc)
+   : J9::PrivateLinkage(codeGen)
    {
+   setExplicitLinkageType(elc);
+
    // linkage properties
    setProperty(SplitLongParm);
    setProperty(TwoStackSlotsForLongAndDouble);

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,165 +23,11 @@
 #ifndef J9S390PRIVATELINKAGE_INCL
 #define J9S390PRIVATELINKAGE_INCL
 
-#include "codegen/PrivateLinkage.hpp"
+/**
+ * This file is only required because upstream OMR includes it in
+ * J9 project-specific code.  Redirect it to S390PrivateLinkage.hpp
+ * until OMR is cleaned up.
+ */
+#include "codegen/S390PrivateLinkage.hpp"
 
-namespace TR { class S390JNICallDataSnippet; }
-namespace TR { class AutomaticSymbol; }
-namespace TR { class CodeGenerator; }
-namespace TR { class RegisterDependencyConditions; }
-namespace TR { class ResolvedMethodSymbol; }
-namespace TR { class Snippet; }
-
-
-namespace TR {
-
-////////////////////////////////////////////////////////////////////////////////
-//  TR::S390PrivateLinkage Definition for J9
-////////////////////////////////////////////////////////////////////////////////
-
-class S390PrivateLinkage : public J9::PrivateLinkage
-   {
-   uint32_t _preservedRegisterMapForGC;
-
-   TR::RealRegister::RegNum _methodMetaDataRegister;
-
-public:
-
-   S390PrivateLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaPrivate, TR_LinkageConventions lc=TR_Private);
-
-   virtual void createPrologue(TR::Instruction * cursor);
-   virtual void createEpilogue(TR::Instruction * cursor);
-
-   /** \brief
-    *     Align the stackIndex to a multiple of localObjectAlignment and update the numberOfSlotMapped.
-    *
-    *  \param stackIndex
-    *     The current stack index to be aligned to \p localObjectAlignment.
-    *
-    *  \param localObjectAlignment
-    *     The stack object alignment.
-    */
-   void alignLocalsOffset(uint32_t &stackIndex, uint32_t localObjectAlignment);
-
-   void         mapCompactedStack(TR::ResolvedMethodSymbol * symbol);
-   virtual void mapStack(TR::ResolvedMethodSymbol * symbol);
-   virtual void mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex);
-   void         mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t size, uint32_t & stackIndex);
-   uint32_t     getS390RoundedSize(uint32_t size);
-   virtual bool hasToBeOnStack(TR::ParameterSymbol * parm);
-
-   virtual void initS390RealRegisterLinkage();
-   virtual void doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, bool isFastJNI, int64_t &killMask);
-   virtual void addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, int32_t& from, int32_t step);
-   virtual int32_t storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies, bool isFastJNI, int32_t stackOffset, int8_t gprSize, uint32_t &numIntegerArgs);
-   virtual int64_t addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType, TR::RegisterDependencyConditions * dependencies);
-
-   virtual void buildVirtualDispatch(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
-      TR::Register * vftReg, uint32_t sizeOfArguments);
-
-   virtual TR::RealRegister::RegNum setMethodMetaDataRegister(TR::RealRegister::RegNum r) { return _methodMetaDataRegister = r; }
-   virtual TR::RealRegister::RegNum getMethodMetaDataRegister() { return _methodMetaDataRegister; }
-   virtual TR::RealRegister *getMethodMetaDataRealRegister() {return getRealRegister(_methodMetaDataRegister);}
-
-   virtual uint32_t setPreservedRegisterMapForGC(uint32_t m)  { return _preservedRegisterMapForGC = m; }
-   virtual uint32_t getPreservedRegisterMapForGC()        { return _preservedRegisterMapForGC; }
-
-   virtual TR::RealRegister::RegNum getSystemStackPointerRegister();
-   virtual TR::RealRegister *getSystemStackPointerRealRegister() {return getRealRegister(getSystemStackPointerRegister());}
-
-   virtual int32_t setupLiteralPoolRegister(TR::Snippet *firstSnippet);
-
-   //called by buildNativeDispatch
-   virtual void setupRegisterDepForLinkage(TR::Node *, TR_DispatchType, TR::RegisterDependencyConditions * &, int64_t &, TR::SystemLinkage *, TR::Node * &, bool &, TR::Register **, TR::Register *&);
-   virtual void setupBuildArgForLinkage(TR::Node *, TR_DispatchType, TR::RegisterDependencyConditions *, bool, bool, int64_t &, TR::Node *, bool, TR::SystemLinkage *);
-
-   virtual int32_t calculateRegisterSaveSize(TR::RealRegister::RegNum f,
-                                             TR::RealRegister::RegNum l,
-                                             int32_t &rsd,
-                                             int32_t &numInts, int32_t &numFloats);
-
-protected:
-
-   virtual TR::Register * buildIndirectDispatch(TR::Node * callNode);
-   virtual TR::Register * buildDirectDispatch(TR::Node * callNode);
-   TR::Register * buildJNIDispatch(TR::Node * callNode);
-   TR::Instruction * buildDirectCall(TR::Node * callNode, TR::SymbolReference * callSymRef,
-   TR::RegisterDependencyConditions * dependencies, int32_t argSize);
-
-   virtual void mapIncomingParms(TR::ResolvedMethodSymbol *method);
-
-   void callPreJNICallOffloadCheck(TR::Node * callNode);
-   void callPostJNICallOffloadCheck(TR::Node * callNode);
-   void collapseJNIReferenceFrame(TR::Node * callNode, TR::RealRegister * javaStackPointerRealRegister,
-      TR::Register * javaLitPoolVirtualRegister, TR::Register * tempReg);
-
-   void setupJNICallOutFrame(TR::Node * callNode,
-      TR::RealRegister * javaStackPointerRealRegister,
-      TR::Register * methodMetaDataVirtualRegister,
-      TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet *jniCallDataSnippet);
-
-   };
-
-
-////////////////////////////////////////////////////////////////////////////////
-//  TR::S390HelperLinkage Definition for J9
-////////////////////////////////////////////////////////////////////////////////
-
-class S390HelperLinkage : public TR::S390PrivateLinkage
-   {
-public:
-
-   S390HelperLinkage(TR::CodeGenerator * cg)
-      : TR::S390PrivateLinkage(cg,TR_JavaHelper, TR_Helper)
-      {
-      setProperty(ParmsInReverseOrder);
-      }
-   };
-
-class J9S390JNILinkage : public TR::S390PrivateLinkage
-   {
-public:
-
-   J9S390JNILinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaPrivate, TR_LinkageConventions lc=TR_J9JNILinkage);
-   virtual TR::Register * buildDirectDispatch(TR::Node * callNode);
-
-   /**
-    * \brief
-    *   JNI return value processing:
-    *   1) Unwrap return value if needed for object return types, or
-    *   2) Enforce a return value of 0 or 1 for boolean return type
-    *
-    * \param callNode
-    *   The JNI call node to be evaluated.
-    *
-    * \param cg
-    *   The code generator object.
-    *
-    * \param javaReturnRegister
-    *   Register for the JNI call return value.
-   */
-   void processJNIReturnValue(TR::Node * callNode,
-                              TR::CodeGenerator* cg,
-                              TR::Register* javaReturnRegister);
-
-   void checkException(TR::Node * callNode, TR::Register *methodMetaDataVirtualRegister, TR::Register * tempReg);
-   void releaseVMAccessMask(TR::Node * callNode, TR::Register * methodMetaDataVirtualRegister,
-         TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps);
-   void acquireVMAccessMask(TR::Node * callNode, TR::Register * javaLitPoolVirtualRegister,
-      TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg);
-
-#ifdef J9VM_INTERP_ATOMIC_FREE_JNI
-   void releaseVMAccessMaskAtomicFree(TR::Node * callNode,
-                                      TR::Register * methodMetaDataVirtualRegister,
-                                      TR::Register * tempReg1);
-
-   void acquireVMAccessMaskAtomicFree(TR::Node * callNode,
-                                      TR::Register * methodMetaDataVirtualRegister,
-                                      TR::Register * tempReg1);
-#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-   };
-
-}
-
-#endif /* J9S390PRIVATELINKAGE_INCL */
+#endif

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
@@ -23,7 +23,7 @@
 #ifndef J9S390PRIVATELINKAGE_INCL
 #define J9S390PRIVATELINKAGE_INCL
 
-#include "codegen/Linkage.hpp"
+#include "codegen/PrivateLinkage.hpp"
 
 namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
@@ -39,7 +39,7 @@ namespace TR {
 //  TR::S390PrivateLinkage Definition for J9
 ////////////////////////////////////////////////////////////////////////////////
 
-class S390PrivateLinkage : public TR::Linkage
+class S390PrivateLinkage : public J9::PrivateLinkage
    {
    uint32_t _preservedRegisterMapForGC;
 

--- a/runtime/compiler/z/codegen/J9S390Snippet.cpp
+++ b/runtime/compiler/z/codegen/J9S390Snippet.cpp
@@ -29,6 +29,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GCStackMap.hpp"
 #include "codegen/Machine.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 #include "codegen/SnippetGCMap.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
@@ -38,7 +39,6 @@
 #include "il/Node_inlines.hpp"
 #include "env/VMJ9.h"
 #include "runtime/CodeCacheManager.hpp"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #include "z/codegen/S390Instruction.hpp"
 #include "z/codegen/S390Snippets.hpp"
 

--- a/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
@@ -28,6 +28,7 @@
 #include "codegen/GCStackMap.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 #include "compile/Compilation.hpp"
 #include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"
@@ -42,7 +43,6 @@
 #include "il/StaticSymbol.hpp"
 #include "il/Symbol.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #include "z/codegen/CallSnippet.hpp"
 #include "z/codegen/OpMemToMem.hpp"
 #include "z/codegen/S390Evaluator.hpp"
@@ -71,7 +71,7 @@ TR::J9S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode,
    {
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    TR::Register * javaLitPoolRegister = privateLinkage->getLitPoolRealRegister();
    TR::Register * javaStackRegister = privateLinkage->getStackPointerRealRegister();
    TR::Register * parm3 = deps->searchPreConditionRegister(getIntegerArgumentRegister(2));
@@ -190,7 +190,7 @@ TR::J9S390zLinuxSystemLinkage::setupRegisterDepForLinkage(TR::Node * callNode, T
    TR::Node * &GlobalRegDeps, bool &hasGlRegDeps, TR::Register ** methodAddressReg, TR::Register * &javaLitOffsetReg)
    {
    // call j9 private linkage specialization
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->setupRegisterDepForLinkage(callNode, dispatchType, deps, killMask, systemLinkage, GlobalRegDeps, hasGlRegDeps, methodAddressReg, javaLitOffsetReg);
    }
 
@@ -198,7 +198,7 @@ void
 TR::J9S390zLinuxSystemLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::RegisterDependencyConditions * deps, bool isFastJNI,
       bool isPassReceiver, int64_t & killMask, TR::Node * GlobalRegDeps, bool hasGlRegDeps, TR::SystemLinkage * systemLinkage)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->setupBuildArgForLinkage(callNode, dispatchType, deps, isFastJNI, isPassReceiver, killMask, GlobalRegDeps, hasGlRegDeps, systemLinkage);
    }
 
@@ -212,7 +212,7 @@ TR::J9S390zLinuxSystemLinkage::performCallNativeFunctionForLinkage(TR::Node * ca
    // get javaStack Real Register
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    TR::RealRegister * javaStackPointerRealRegister = privateLinkage->getStackPointerRealRegister();
 
    // get methodMetaDataVirtualRegister
@@ -226,21 +226,21 @@ TR::J9S390zLinuxSystemLinkage::performCallNativeFunctionForLinkage(TR::Node * ca
 void
 TR::J9S390zLinuxSystemLinkage::doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, bool isFastJNI, int64_t &killMask)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->doNotKillSpecialRegsForBuildArgs(linkage, isFastJNI, killMask);
    }
 
 void
 TR::J9S390zLinuxSystemLinkage::addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, int32_t& from, int32_t step)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->addSpecialRegDepsForBuildArgs(callNode, dependencies, from, step);
    }
 
 int64_t
 TR::J9S390zLinuxSystemLinkage::addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType, TR::RegisterDependencyConditions * dependencies)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    killMask = privateLinkage->addFECustomizedReturnRegDependency(killMask, linkage, resType, dependencies);
    return killMask;
    }
@@ -249,7 +249,7 @@ int32_t
 TR::J9S390zLinuxSystemLinkage::storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies,
       bool isFastJNI, int32_t stackOffset, int8_t gprSize, uint32_t &numIntegerArgs)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    stackOffset = privateLinkage->storeExtraEnvRegForBuildArgs(callNode, linkage, dependencies, isFastJNI, stackOffset, gprSize, numIntegerArgs);
    return stackOffset;
    }

--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -28,6 +28,7 @@
 #include "codegen/GCStackMap.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 #include "compile/Compilation.hpp"
 #include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"
@@ -42,7 +43,6 @@
 #include "il/StaticSymbol.hpp"
 #include "il/Symbol.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #include "z/codegen/CallSnippet.hpp"
 #include "z/codegen/OpMemToMem.hpp"
 #include "z/codegen/S390Evaluator.hpp"
@@ -71,9 +71,7 @@ TR::J9S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
    TR::Compilation *comp = codeGen->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
    // privateLinkage refers to linkage of caller
-   TR::Linkage * privateLinkage;
-
-   privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
 
    TR::Instruction * gcPoint;
    TR::Register * javaStackRegister = privateLinkage->getStackPointerRealRegister();
@@ -163,7 +161,7 @@ TR::J9S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
                systemEntryPointRegister, generateS390MemoryReference(methodAddressReg, 16, codeGen));
       }
    // call the JNI function
-   TR::Register * methodMetaDataVirtualRegister = ((TR::S390PrivateLinkage *) privateLinkage)->getMethodMetaDataRealRegister();
+   TR::Register * methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
 
    if (cg()->supportsJITFreeSystemStackPointer())
       {
@@ -225,7 +223,7 @@ TR::J9S390zOSSystemLinkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_D
    TR::Node * &GlobalRegDeps, bool &hasGlRegDeps, TR::Register ** methodAddressReg, TR::Register * &javaLitOffsetReg)
    {
    // call j9 private linkage specialization
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->setupRegisterDepForLinkage(callNode, dispatchType, deps, killMask, systemLinkage, GlobalRegDeps, hasGlRegDeps, methodAddressReg, javaLitOffsetReg);
    }
 
@@ -233,7 +231,7 @@ void
 TR::J9S390zOSSystemLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::RegisterDependencyConditions * deps, bool isFastJNI,
       bool isPassReceiver, int64_t & killMask, TR::Node * GlobalRegDeps, bool hasGlRegDeps, TR::SystemLinkage * systemLinkage)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->setupBuildArgForLinkage(callNode, dispatchType, deps, isFastJNI, isPassReceiver, killMask, GlobalRegDeps, hasGlRegDeps, systemLinkage);
    }
 
@@ -247,7 +245,7 @@ TR::J9S390zOSSystemLinkage::performCallNativeFunctionForLinkage(TR::Node * callN
    // get javaStack Real Register
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    TR::RealRegister * javaStackPointerRealRegister = privateLinkage->getStackPointerRealRegister();
 
    // get methodMetaDataVirtualRegister
@@ -261,14 +259,14 @@ TR::J9S390zOSSystemLinkage::performCallNativeFunctionForLinkage(TR::Node * callN
 void
 TR::J9S390zOSSystemLinkage::doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, bool isFastJNI, int64_t &killMask)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->doNotKillSpecialRegsForBuildArgs(linkage, isFastJNI, killMask);
    }
 
 void
 TR::J9S390zOSSystemLinkage::addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, int32_t& from, int32_t step)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    privateLinkage->addSpecialRegDepsForBuildArgs(callNode, dependencies, from, step);
    }
 
@@ -276,7 +274,7 @@ int32_t
 TR::J9S390zOSSystemLinkage::storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies,
       bool isFastJNI, int32_t stackOffset, int8_t gprSize, uint32_t &numIntegerArgs)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    stackOffset = privateLinkage->storeExtraEnvRegForBuildArgs(callNode, linkage, dependencies, isFastJNI, stackOffset, gprSize, numIntegerArgs);
    return stackOffset;
    }
@@ -284,7 +282,7 @@ TR::J9S390zOSSystemLinkage::storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR
 int64_t
 TR::J9S390zOSSystemLinkage::addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType, TR::RegisterDependencyConditions * dependencies)
    {
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = static_cast<J9::S390PrivateLinkage *>(cg()->getLinkage(TR_Private));
    killMask = privateLinkage->addFECustomizedReturnRegDependency(killMask, linkage, resType, dependencies);
    return killMask;
    }

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -44,6 +44,7 @@
 #include "codegen/J9WatchedStaticFieldSnippet.hpp"
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 #include "codegen/TreeEvaluator.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/VirtualGuard.hpp"
@@ -67,7 +68,6 @@
 #include "ras/Delimiter.hpp"
 #include "ras/DebugCounter.hpp"
 #include "env/VMJ9.h"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #include "z/codegen/J9S390Snippet.hpp"
 #include "z/codegen/J9S390CHelperLinkage.hpp"
 #include "z/codegen/BinaryCommutativeAnalyser.hpp"
@@ -4792,7 +4792,7 @@ VMarrayStoreCHKEvaluator(
    TR::InstOpCode::Mnemonic loadOp;
    TR::Instruction * cursor;
    TR::Instruction * gcPoint;
-   TR::S390PrivateLinkage * linkage = TR::toS390PrivateLinkage(cg->getLinkage());
+   J9::S390PrivateLinkage * linkage = static_cast<J9::S390PrivateLinkage *>(cg->getLinkage());
    int bytesOffset;
 
    TR::TreeEvaluator::genLoadForObjectHeadersMasked(cg, node, owningObjectRegVal, generateS390MemoryReference(owningObjectReg, (int32_t) TR::Compiler->om.offsetOfObjectVftField(), cg), NULL);
@@ -5033,7 +5033,7 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
    TR::MemoryReference * mr1, * mr2;
    TR::LabelSymbol * wbLabel, * cFlowRegionEnd, * simpleStoreLabel, * cFlowRegionStart;
    TR::RegisterDependencyConditions * conditions;
-   TR::S390PrivateLinkage * linkage = TR::toS390PrivateLinkage(cg->getLinkage());
+   J9::S390PrivateLinkage * linkage = static_cast<J9::S390PrivateLinkage *>(cg->getLinkage());
    TR::Register * tempReg = NULL;
    TR::Instruction *cursor;
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "z/codegen/J9S390PrivateLinkage.hpp"
+#include "codegen/S390PrivateLinkage.hpp"
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GCStackAtlas.hpp"
@@ -55,9 +55,9 @@
 #define MIN_PROFILED_CALL_FREQUENCY (.075f)
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage for J9
+// J9::S390PrivateLinkage for J9
 ////////////////////////////////////////////////////////////////////////////////
-TR::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
+J9::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
    : J9::PrivateLinkage(codeGen)
    {
    setExplicitLinkageType(elc);
@@ -165,11 +165,11 @@ TR::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390Li
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::initS390RealRegisterLinkage - initialize the state
+// J9::S390PrivateLinkage::initS390RealRegisterLinkage - initialize the state
 //    of real register for register allocator
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::initS390RealRegisterLinkage()
+J9::S390PrivateLinkage::initS390RealRegisterLinkage()
    {
    TR::RealRegister * sspReal = getSystemStackPointerRealRegister();
    TR::RealRegister * spReal  = getStackPointerRealRegister();
@@ -222,7 +222,7 @@ TR::S390PrivateLinkage::initS390RealRegisterLinkage()
       }
    }
 
-void TR::S390PrivateLinkage::alignLocalsOffset(uint32_t &stackIndex, uint32_t localObjectAlignment)
+void J9::S390PrivateLinkage::alignLocalsOffset(uint32_t &stackIndex, uint32_t localObjectAlignment)
    {
    if (stackIndex % localObjectAlignment != 0)
       {
@@ -244,7 +244,7 @@ void TR::S390PrivateLinkage::alignLocalsOffset(uint32_t &stackIndex, uint32_t lo
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::mapCompactedStack - maps variables onto the stack, sharing
+// J9::S390PrivateLinkage::mapCompactedStack - maps variables onto the stack, sharing
 //     stack slots for automatic variables with non-interfering live ranges.
 ////////////////////////////////////////////////////////////////////////////////
 #ifdef DEBUG
@@ -256,7 +256,7 @@ static uint32_t accumMappedSize = 0;
 #endif
 
 void
-TR::S390PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
+J9::S390PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    {
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
@@ -648,7 +648,7 @@ TR::S390PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    }
 
    void
-TR::S390PrivateLinkage::mapStack(TR::ResolvedMethodSymbol * method)
+J9::S390PrivateLinkage::mapStack(TR::ResolvedMethodSymbol * method)
    {
 
    if (cg()->getLocalsIG() && cg()->getSupportsCompactedLocals())
@@ -820,28 +820,28 @@ TR::S390PrivateLinkage::mapStack(TR::ResolvedMethodSymbol * method)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::mapSingleAutomatic - maps an automatic onto the stack
+// J9::S390PrivateLinkage::mapSingleAutomatic - maps an automatic onto the stack
 // with size p->getRoundedSize()
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
+J9::S390PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex)
    {
 
    mapSingleAutomatic(p, p->getRoundedSize(), stackIndex);
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::mapSingleAutomatic - maps an automatic onto the stack
+// J9::S390PrivateLinkage::mapSingleAutomatic - maps an automatic onto the stack
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t size, uint32_t & stackIndex)
+J9::S390PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t size, uint32_t & stackIndex)
    {
 
    p->setOffset(stackIndex -= size);
    }
 
 bool
-TR::S390PrivateLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
+J9::S390PrivateLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    TR::ResolvedMethodSymbol * bodySymbol = comp()->getJittedMethodSymbol();
@@ -945,7 +945,7 @@ initStg(TR::CodeGenerator * codeGen, TR::Node * node, TR::RealRegister * tmpReg,
    }
 
 int32_t
-TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum firstUsedReg,
+J9::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum firstUsedReg,
                                                  TR::RealRegister::RegNum lastUsedReg,
                                                  int32_t &registerSaveDescription,
                                                  int32_t &numIntSaved, int32_t &numFloatSaved)
@@ -989,7 +989,7 @@ TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum first
    }
 
 int32_t
-TR::S390PrivateLinkage::setupLiteralPoolRegister(TR::Snippet *firstSnippet)
+J9::S390PrivateLinkage::setupLiteralPoolRegister(TR::Snippet *firstSnippet)
    {
    // setup literal pool register if needed
    // on freeway:
@@ -1016,7 +1016,7 @@ TR::S390PrivateLinkage::setupLiteralPoolRegister(TR::Snippet *firstSnippet)
 // TS_390PrivateLinkage::createPrologue() - create prolog for private linkage
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
+J9::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
    {
    TR::RealRegister * spReg = getStackPointerRealRegister();
    TR::RealRegister * lpReg = getLitPoolRealRegister();
@@ -1109,7 +1109,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
 
    //  We assume frame size is less than 32k
    //TR_ASSERT(size<=MAX_IMMEDIATE_VAL,
-   //   "TR::S390PrivateLinkage::createPrologue -- Frame size (0x%x) greater than 0x7FFF\n",size);
+   //   "J9::S390PrivateLinkage::createPrologue -- Frame size (0x%x) greater than 0x7FFF\n",size);
 
    TR::MemoryReference * retAddrMemRef = NULL;
 
@@ -1358,7 +1358,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
 //  47 00 b0 00                    BC      GPR14
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
+J9::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
    {
    TR::RealRegister * spReg = getRealRegister(getStackPointerRegister());
    TR::Node * currentNode = cursor->getNode();
@@ -1491,10 +1491,10 @@ TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::buildVirtualDispatch - build virtual function call
+// J9::S390PrivateLinkage::buildVirtualDispatch - build virtual function call
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
+J9::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
    TR::Register * vftReg, uint32_t sizeOfArguments)
    {
    TR_S390RegisterDependencyGroup * Dgroup = dependencies->getPreConditions();
@@ -1855,7 +1855,7 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
       if (!TR::Compiler->cls.classesOnHeap() && methodSymRef == comp()->getSymRefTab()->findObjectNewInstanceImplSymbol())
          {
          classReg = RegThis;
-         TR_ASSERT( offset >= 0,"TR::S390PrivateLinkage::buildVirtualDispatch - Offset to instanceOf method is assumed positive\n");
+         TR_ASSERT( offset >= 0,"J9::S390PrivateLinkage::buildVirtualDispatch - Offset to instanceOf method is assumed positive\n");
          }
       else
          {
@@ -2252,7 +2252,7 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
    }
 
 TR::Instruction *
-TR::S390PrivateLinkage::buildDirectCall(TR::Node * callNode, TR::SymbolReference * callSymRef,
+J9::S390PrivateLinkage::buildDirectCall(TR::Node * callNode, TR::SymbolReference * callSymRef,
    TR::RegisterDependencyConditions * dependencies, int32_t argSize)
    {
    TR::Instruction * gcPoint = NULL;
@@ -2354,7 +2354,7 @@ TR::S390PrivateLinkage::buildDirectCall(TR::Node * callNode, TR::SymbolReference
 
 
 void
-TR::S390PrivateLinkage::callPreJNICallOffloadCheck(TR::Node * callNode)
+J9::S390PrivateLinkage::callPreJNICallOffloadCheck(TR::Node * callNode)
    {
    TR::CodeGenerator * codeGen = cg();
    TR::LabelSymbol * offloadOffRestartLabel = generateLabelSymbol(codeGen);
@@ -2371,7 +2371,7 @@ TR::S390PrivateLinkage::callPreJNICallOffloadCheck(TR::Node * callNode)
    }
 
 void
-TR::S390PrivateLinkage::callPostJNICallOffloadCheck(TR::Node * callNode)
+J9::S390PrivateLinkage::callPostJNICallOffloadCheck(TR::Node * callNode)
    {
    TR::CodeGenerator * codeGen = cg();
    TR::LabelSymbol * offloadOnRestartLabel = generateLabelSymbol(codeGen);
@@ -2386,7 +2386,7 @@ TR::S390PrivateLinkage::callPostJNICallOffloadCheck(TR::Node * callNode)
    generateS390LabelInstruction(codeGen, TR::InstOpCode::LABEL, callNode, offloadOnRestartLabel);
    }
 
-void TR::S390PrivateLinkage::collapseJNIReferenceFrame(TR::Node * callNode,
+void J9::S390PrivateLinkage::collapseJNIReferenceFrame(TR::Node * callNode,
    TR::RealRegister * javaStackPointerRealRegister,
    TR::Register * javaLitPoolVirtualRegister,
    TR::Register * tempReg)
@@ -2434,7 +2434,7 @@ void TR::S390PrivateLinkage::collapseJNIReferenceFrame(TR::Node * callNode,
 //                we potentially go out to call a helper before jumping to the native.
 //                but the helper call saves and restores all regs
 void
-TR::S390PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
+J9::S390PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
    TR::RealRegister * javaStackPointerRealRegister,
    TR::Register * methodMetaDataVirtualRegister,
    TR::LabelSymbol * returnFromJNICallLabel,
@@ -3054,11 +3054,11 @@ TR::Register * TR::J9S390JNILinkage::buildDirectDispatch(TR::Node * callNode)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::doNotKillSpecialRegsForBuildArgs -  Do not kill
+// J9::S390PrivateLinkage::doNotKillSpecialRegsForBuildArgs -  Do not kill
 // special regs (java stack ptr, system stack ptr, and method metadata reg)
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, bool isFastJNI, int64_t &killMask)
+J9::S390PrivateLinkage::doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, bool isFastJNI, int64_t &killMask)
    {
    TR::SystemLinkage * systemLinkage = (TR::SystemLinkage *) cg()->getLinkage(TR_System);
 
@@ -3093,11 +3093,11 @@ TR::S390PrivateLinkage::doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, 
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::addSpecialRegDepsForBuildArgs -  add special argument
+// J9::S390PrivateLinkage::addSpecialRegDepsForBuildArgs -  add special argument
 // register dependencies for buildArgs
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, int32_t& from, int32_t step)
+J9::S390PrivateLinkage::addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, int32_t& from, int32_t step)
    {
    TR::Node * child;
    TR::RealRegister::RegNum specialArgReg = TR::RealRegister::NoReg;
@@ -3135,11 +3135,11 @@ TR::S390PrivateLinkage::addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::R
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::storeExtraEnvRegForBuildArgs -  JNI specific,
+// J9::S390PrivateLinkage::storeExtraEnvRegForBuildArgs -  JNI specific,
 // account for extra env param. Return stackOffset.
 ////////////////////////////////////////////////////////////////////////////////
 int32_t
-TR::S390PrivateLinkage::storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies,
+J9::S390PrivateLinkage::storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies,
       bool isFastJNI, int32_t stackOffset, int8_t gprSize, uint32_t &numIntegerArgs)
    {
   //In XPLINK, when the called function has variable number of args, all args are passed on stack,
@@ -3162,11 +3162,11 @@ TR::S390PrivateLinkage::storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Li
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::addFECustomizedReturnRegDependency -  add extra
+// J9::S390PrivateLinkage::addFECustomizedReturnRegDependency -  add extra
 // linkage specific return register dependency
 ////////////////////////////////////////////////////////////////////////////////
 int64_t
-TR::S390PrivateLinkage::addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType,
+J9::S390PrivateLinkage::addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType,
       TR::RegisterDependencyConditions * dependencies)
    {
    TR::Register * javaResultReg;
@@ -3183,11 +3183,11 @@ TR::S390PrivateLinkage::addFECustomizedReturnRegDependency(int64_t killMask, TR:
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::buildDirectDispatch - build direct function call
+// J9::S390PrivateLinkage::buildDirectDispatch - build direct function call
 //   eg. Static, helpers... etc.
 ////////////////////////////////////////////////////////////////////////////////
 TR::Register *
-TR::S390PrivateLinkage::buildDirectDispatch(TR::Node * callNode)
+J9::S390PrivateLinkage::buildDirectDispatch(TR::Node * callNode)
    {
    TR::SymbolReference * callSymRef = callNode->getSymbolReference();
    TR::MethodSymbol * callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
@@ -3267,12 +3267,12 @@ TR::S390PrivateLinkage::buildDirectDispatch(TR::Node * callNode)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::buildIndirectDispatch - build indirect function call.
+// J9::S390PrivateLinkage::buildIndirectDispatch - build indirect function call.
 //   This function handles the arguments setup and the return register. It will
 //   buildVirtualDispatch() to handle the call sequence.
 ////////////////////////////////////////////////////////////////////////////////
 TR::Register *
-TR::S390PrivateLinkage::buildIndirectDispatch(TR::Node * callNode)
+J9::S390PrivateLinkage::buildIndirectDispatch(TR::Node * callNode)
    {
    TR::RegisterDependencyConditions * dependencies = NULL;
    int32_t argSize = 0;
@@ -3355,14 +3355,14 @@ TR::S390PrivateLinkage::buildIndirectDispatch(TR::Node * callNode)
    }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TR::S390PrivateLinkage::mapIncomingParms - maps parameters onto the stack for the given method.
+// J9::S390PrivateLinkage::mapIncomingParms - maps parameters onto the stack for the given method.
 //   This function iterates over the parameters, mapping them onto the stack, either right
 //   to left, or left to right, depending on S390Linkage properties.
-//   This code was removed from TR::S390PrivateLinkage::mapStack as it is common code that
-//   is now called by TR::S390PrivateLinkage::mapCompactedStack as well.
+//   This code was removed from J9::S390PrivateLinkage::mapStack as it is common code that
+//   is now called by J9::S390PrivateLinkage::mapCompactedStack as well.
 ////////////////////////////////////////////////////////////////////////////////
 void
-TR::S390PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
+J9::S390PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    TR::ParameterSymbol * parmCursor = parameterIterator.getFirst();
@@ -3402,7 +3402,7 @@ TR::S390PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    }
 
 void
-TR::S390PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::RegisterDependencyConditions * deps, bool isFastJNI,
+J9::S390PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::RegisterDependencyConditions * deps, bool isFastJNI,
       bool isPassReceiver, int64_t & killMask, TR::Node * GlobalRegDeps, bool hasGlRegDeps, TR::SystemLinkage * systemLinkage)
    {
    TR::CodeGenerator * codeGen = cg();
@@ -3417,7 +3417,7 @@ TR::S390PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_Dispatch
    if (dispatchType == TR_JNIDispatch)  return;
 
 
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = (J9::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
    TR::RealRegister * javaStackPointerRealRegister = privateLinkage->getStackPointerRealRegister();
    TR::Register * methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
 
@@ -3428,7 +3428,7 @@ TR::S390PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_Dispatch
    }
 
 void
-TR::S390PrivateLinkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_DispatchType dispatchType,
+J9::S390PrivateLinkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_DispatchType dispatchType,
    TR::RegisterDependencyConditions * &deps, int64_t & killMask, TR::SystemLinkage * systemLinkage,
    TR::Node * &GlobalRegDeps, bool &hasGlRegDeps, TR::Register ** methodAddressReg, TR::Register * &javaLitOffsetReg)
    {
@@ -3468,7 +3468,7 @@ TR::S390PrivateLinkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_Dispa
       }
 
    /*****************/
-   TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
+   J9::S390PrivateLinkage * privateLinkage = (J9::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
 
 
    TR::RealRegister * javaLitPoolRealRegister = privateLinkage->getLitPoolRealRegister();
@@ -3499,14 +3499,14 @@ TR::S390PrivateLinkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_Dispa
 
 
 TR::RealRegister::RegNum
-TR::S390PrivateLinkage::getSystemStackPointerRegister()
+J9::S390PrivateLinkage::getSystemStackPointerRegister()
    {
    return cg()->getLinkage(TR_System)->getStackPointerRegister();
    }
 
 
 TR::J9S390JNILinkage::J9S390JNILinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc, TR_LinkageConventions lc)
-   :TR::S390PrivateLinkage(cg, elc, lc)
+   :J9::S390PrivateLinkage(cg, elc, lc)
    {
    }
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef S390PRIVATELINKAGE_INCL
+#define S390PRIVATELINKAGE_INCL
+
+#include "codegen/PrivateLinkage.hpp"
+
+namespace TR { class S390JNICallDataSnippet; }
+namespace TR { class AutomaticSymbol; }
+namespace TR { class CodeGenerator; }
+namespace TR { class RegisterDependencyConditions; }
+namespace TR { class ResolvedMethodSymbol; }
+namespace TR { class Snippet; }
+
+
+namespace J9
+{
+
+////////////////////////////////////////////////////////////////////////////////
+//  J9::S390PrivateLinkage Definition for J9
+////////////////////////////////////////////////////////////////////////////////
+
+class S390PrivateLinkage : public PrivateLinkage
+   {
+   uint32_t _preservedRegisterMapForGC;
+
+   TR::RealRegister::RegNum _methodMetaDataRegister;
+
+public:
+
+   S390PrivateLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaPrivate, TR_LinkageConventions lc=TR_Private);
+
+   virtual void createPrologue(TR::Instruction * cursor);
+   virtual void createEpilogue(TR::Instruction * cursor);
+
+   /** \brief
+    *     Align the stackIndex to a multiple of localObjectAlignment and update the numberOfSlotMapped.
+    *
+    *  \param stackIndex
+    *     The current stack index to be aligned to \p localObjectAlignment.
+    *
+    *  \param localObjectAlignment
+    *     The stack object alignment.
+    */
+   void alignLocalsOffset(uint32_t &stackIndex, uint32_t localObjectAlignment);
+
+   void         mapCompactedStack(TR::ResolvedMethodSymbol * symbol);
+   virtual void mapStack(TR::ResolvedMethodSymbol * symbol);
+   virtual void mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex);
+   void         mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t size, uint32_t & stackIndex);
+   uint32_t     getS390RoundedSize(uint32_t size);
+   virtual bool hasToBeOnStack(TR::ParameterSymbol * parm);
+
+   virtual void initS390RealRegisterLinkage();
+   virtual void doNotKillSpecialRegsForBuildArgs (TR::Linkage *linkage, bool isFastJNI, int64_t &killMask);
+   virtual void addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, int32_t& from, int32_t step);
+   virtual int32_t storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies, bool isFastJNI, int32_t stackOffset, int8_t gprSize, uint32_t &numIntegerArgs);
+   virtual int64_t addFECustomizedReturnRegDependency(int64_t killMask, TR::Linkage* linkage, TR::DataType resType, TR::RegisterDependencyConditions * dependencies);
+
+   virtual void buildVirtualDispatch(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
+      TR::Register * vftReg, uint32_t sizeOfArguments);
+
+   virtual TR::RealRegister::RegNum setMethodMetaDataRegister(TR::RealRegister::RegNum r) { return _methodMetaDataRegister = r; }
+   virtual TR::RealRegister::RegNum getMethodMetaDataRegister() { return _methodMetaDataRegister; }
+   virtual TR::RealRegister *getMethodMetaDataRealRegister() {return getRealRegister(_methodMetaDataRegister);}
+
+   virtual uint32_t setPreservedRegisterMapForGC(uint32_t m)  { return _preservedRegisterMapForGC = m; }
+   virtual uint32_t getPreservedRegisterMapForGC()        { return _preservedRegisterMapForGC; }
+
+   virtual TR::RealRegister::RegNum getSystemStackPointerRegister();
+   virtual TR::RealRegister *getSystemStackPointerRealRegister() {return getRealRegister(getSystemStackPointerRegister());}
+
+   virtual int32_t setupLiteralPoolRegister(TR::Snippet *firstSnippet);
+
+   //called by buildNativeDispatch
+   virtual void setupRegisterDepForLinkage(TR::Node *, TR_DispatchType, TR::RegisterDependencyConditions * &, int64_t &, TR::SystemLinkage *, TR::Node * &, bool &, TR::Register **, TR::Register *&);
+   virtual void setupBuildArgForLinkage(TR::Node *, TR_DispatchType, TR::RegisterDependencyConditions *, bool, bool, int64_t &, TR::Node *, bool, TR::SystemLinkage *);
+
+   virtual int32_t calculateRegisterSaveSize(TR::RealRegister::RegNum f,
+                                             TR::RealRegister::RegNum l,
+                                             int32_t &rsd,
+                                             int32_t &numInts, int32_t &numFloats);
+
+protected:
+
+   virtual TR::Register * buildIndirectDispatch(TR::Node * callNode);
+   virtual TR::Register * buildDirectDispatch(TR::Node * callNode);
+   TR::Register * buildJNIDispatch(TR::Node * callNode);
+   TR::Instruction * buildDirectCall(TR::Node * callNode, TR::SymbolReference * callSymRef,
+   TR::RegisterDependencyConditions * dependencies, int32_t argSize);
+
+   virtual void mapIncomingParms(TR::ResolvedMethodSymbol *method);
+
+   void callPreJNICallOffloadCheck(TR::Node * callNode);
+   void callPostJNICallOffloadCheck(TR::Node * callNode);
+   void collapseJNIReferenceFrame(TR::Node * callNode, TR::RealRegister * javaStackPointerRealRegister,
+      TR::Register * javaLitPoolVirtualRegister, TR::Register * tempReg);
+
+   void setupJNICallOutFrame(TR::Node * callNode,
+      TR::RealRegister * javaStackPointerRealRegister,
+      TR::Register * methodMetaDataVirtualRegister,
+      TR::LabelSymbol * returnFromJNICallLabel,
+      TR::S390JNICallDataSnippet *jniCallDataSnippet);
+
+   };
+
+}
+
+
+namespace TR
+{
+
+////////////////////////////////////////////////////////////////////////////////
+//  TR::S390HelperLinkage Definition for J9
+////////////////////////////////////////////////////////////////////////////////
+
+class S390HelperLinkage : public J9::S390PrivateLinkage
+   {
+public:
+
+   S390HelperLinkage(TR::CodeGenerator * cg)
+      : J9::S390PrivateLinkage(cg,TR_JavaHelper, TR_Helper)
+      {
+      setProperty(ParmsInReverseOrder);
+      }
+   };
+
+class J9S390JNILinkage : public J9::S390PrivateLinkage
+   {
+public:
+
+   J9S390JNILinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaPrivate, TR_LinkageConventions lc=TR_J9JNILinkage);
+   virtual TR::Register * buildDirectDispatch(TR::Node * callNode);
+
+   /**
+    * \brief
+    *   JNI return value processing:
+    *   1) Unwrap return value if needed for object return types, or
+    *   2) Enforce a return value of 0 or 1 for boolean return type
+    *
+    * \param callNode
+    *   The JNI call node to be evaluated.
+    *
+    * \param cg
+    *   The code generator object.
+    *
+    * \param javaReturnRegister
+    *   Register for the JNI call return value.
+   */
+   void processJNIReturnValue(TR::Node * callNode,
+                              TR::CodeGenerator* cg,
+                              TR::Register* javaReturnRegister);
+
+   void checkException(TR::Node * callNode, TR::Register *methodMetaDataVirtualRegister, TR::Register * tempReg);
+   void releaseVMAccessMask(TR::Node * callNode, TR::Register * methodMetaDataVirtualRegister,
+         TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps);
+   void acquireVMAccessMask(TR::Node * callNode, TR::Register * javaLitPoolVirtualRegister,
+      TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg);
+
+#ifdef J9VM_INTERP_ATOMIC_FREE_JNI
+   void releaseVMAccessMaskAtomicFree(TR::Node * callNode,
+                                      TR::Register * methodMetaDataVirtualRegister,
+                                      TR::Register * tempReg1);
+
+   void acquireVMAccessMaskAtomicFree(TR::Node * callNode,
+                                      TR::Register * methodMetaDataVirtualRegister,
+                                      TR::Register * tempReg1);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+   };
+
+}
+
+#endif /* S390PRIVATELINKAGE_INCL */


### PR DESCRIPTION
* Introduce an architecture-agnostic PrivateLinkage base class
* Migrate ARM64PrivateLinkage from TR namespace to J9
* Migrate PPCPrivateLinkage from TR namespace to J9
* Migrate S390PrivateLinkage from TR namespace to J9
* Migrate X86PrivateLinkage from TR namespace to J9
* Migrate ARMPrivateLinkage from TR namespace to J9