### PR TITLE
Fix debug build error of the undefined inROMClass() in ClassEnv

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -517,9 +517,7 @@ J9::ClassEnv::getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *cla
    {
    J9ROMConstantPoolItem *romCP = self()->getROMConstantPool(comp, clazz);
    J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&romCP[cpIndex];
-   TR_ASSERT(inROMClass(romFieldRef), "field ref must be in ROM class");
    J9ROMClassRef *romClassRef = (J9ROMClassRef *)&romCP[romFieldRef->classRefCPIndex];
-   TR_ASSERT(inROMClass(romClassRef), "class ref must be in ROM class");
 #if defined(JITSERVER_SUPPORT)
    if (comp->isOutOfProcessCompilation())
       {


### PR DESCRIPTION
Remove the `TR_ASSERTs` for now. `TR_ASSERTs` are added in #7292 but `inROMClass()` is not declared/defined for `ClassEnv`.

Fix #7518

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>