### PR TITLE
AArch64: Set correct entry point instructions in createPrologue()

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -413,7 +413,7 @@ void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
    TR::RealRegister *vmThread = machine->getRealRegister(properties.getMethodMetaDataRegister());   // x19
    TR::RealRegister *javaSP = machine->getRealRegister(properties.getStackPointerRegister());       // x20
 
-   setInterpretedMethodEntryPoint(cursor);
+   TR::Instruction *beforeInterpreterMethodEntryPointInstruction = cursor;
 
    // --------------------------------------------------------------------------
    // Create the entry point when transitioning from an interpreted method.
@@ -422,7 +422,7 @@ void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
    //
    cursor = loadStackParametersToLinkageRegisters(cursor);
 
-   setJittedMethodEntryPoint(cursor);
+   TR::Instruction *beforeJittedMethodEntryPointInstruction = cursor;
 
    // Entry breakpoint
    //
@@ -636,6 +636,9 @@ void TR::ARM64PrivateLinkage::createPrologue(TR::Instruction *cursor)
    //
    cursor = copyParametersToHomeLocation(cursor);
 
+   // Set the instructions for method entry points
+   setInterpretedMethodEntryPoint(beforeInterpreterMethodEntryPointInstruction->getNext());
+   setJittedMethodEntryPoint(beforeJittedMethodEntryPointInstruction->getNext());
    }
 
 void TR::ARM64PrivateLinkage::createEpilogue(TR::Instruction *cursor)


### PR DESCRIPTION
This commit changes the code for setting the entry point instructions
in createPrologue().
The existing code sets the linkage info word to
interpretedMethodEntryPoint, and the last instruction from
loadStackParametersToLinkageRegisters() to jittedMethodEntryPoint,
respectively, instead of expected instructions.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>