### PR TITLE
Fix to conservatively stash OSR argument info

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -137,6 +137,10 @@ private:
    TR::Node *    genInvokeWithVFTChild(TR::SymbolReference *);
    TR::Node *    getReceiverFor(TR::SymbolReference *);
    void          stashArgumentsForOSR(TR_J9ByteCode byteCode);
+   /** \brief
+    *    Tell if the current bytecode is at start of a basic block
+    */
+   bool          isAtBBStart(int32_t bcIndex);
 
    // Placeholder manipulation
    //

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1559,6 +1559,11 @@ TR_J9ByteCodeIlGenerator::handlePendingPushSaveSideEffects(TR::Node * n, TR::Nod
       }
    }
 
+bool
+TR_J9ByteCodeIlGenerator::isAtBBStart(int32_t bcIndex)
+   {
+   return blocks(bcIndex) && blocks(bcIndex)->getEntry()->getNode()->getByteCodeIndex() == bcIndex;
+   }
 /*
  * Stash the required number of arguments for the provided bytecode.
  * The current stack will be walked, determining pending push temps for
@@ -1568,7 +1573,9 @@ TR_J9ByteCodeIlGenerator::handlePendingPushSaveSideEffects(TR::Node * n, TR::Nod
 void
 TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
    {
-   if (!_couldOSRAtNextBC)
+   if (!_couldOSRAtNextBC &&
+       !isAtBBStart(_bcIndex)) // _couldOSRAtNextBC doesn't work if the curent bc is at bbstart,
+                               // conversatively assume OSR transition can happen at bbstart
       return;
    _couldOSRAtNextBC = false;
 


### PR DESCRIPTION
When stashing OSR argument info, _couldOSRAtNextBC had been used
to tell whether OSR can happen at a certain point. For post transition
OSR, when walking an potential OSR point ilgen will set
_couldOSRAtNextBC to indicate OSR could happen
at next bytecode. However, this doesn't work if the next bytecode is at
the start of another block because bytecode iterator can pick up a
different block to process. Fix to conservatively assumes OSR can
happen at any block start when stashing OSR argument info.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>