### PR TITLE
Add knownObjectTable check for JITServer

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1429,7 +1429,9 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
       symRef->setReallySharesSymbol();
 
    TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
-   if (resolved
+   TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
+   if (knot
+       && resolved
        && isFinal
        && type == TR::Address
        && !comp()->compileRelocatableCode())
@@ -1466,11 +1468,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
 
             if (createKnownObject)
                {
-               TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-               if (knot)
-                  {
-                  knownObjectIndex = knot->getIndexAt((uintptrj_t*)dataAddress);
-                  }
+               knownObjectIndex = knot->getIndexAt((uintptrj_t*)dataAddress);
                }
             }
          }


### PR DESCRIPTION
In JITServer mode knownObjectTable is currently disabled. Check for getOrCreateKnownObjectTable() earlier so JITServer mode avoids entering the critical section.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>