### PR TITLE
Refactor inROMClass into JITServerHelpers class

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -543,3 +543,9 @@ JITServerHelpers::shouldRetryConnection(OMRPortLibrary *portLibrary)
    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
    return omrtime_current_time_millis() > _nextConnectionRetryTime;
    }
+
+bool
+JITServerHelpers::isAddressInROMClass(const void *address, const J9ROMClass *romClass)
+   {
+   return ((address >= romClass) && (address < (((uint8_t*) romClass) + romClass->romSize)));
+   }

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -95,6 +95,8 @@ class JITServerHelpers
 
    static uint32_t serverMsgTypeCount[JITServer::MessageType_ARRAYSIZE];
 
+   static bool isAddressInROMClass(const void *address, const J9ROMClass *romClass);
+
    private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
    static TR::Monitor *getClientStreamMonitor()

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -205,7 +205,6 @@ public:
    virtual uint16_t archetypeArgPlaceholderSlot() override;
 
    TR_ResolvedJ9Method *getRemoteMirror() const { return _remoteMirror; }
-   bool inROMClass(void *address);
    static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method);

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -21,10 +21,12 @@
  *******************************************************************************/
 
 #include "runtime/JITClientSession.hpp"
-#include "runtime/RuntimeAssumptions.hpp" // for TR_AddressSet
-#include "net/ServerStream.hpp" // for JITServer::ServerStream
-#include "control/MethodToBeCompiled.hpp" // for TR_MethodToBeCompiled
+
 #include "control/CompilationRuntime.hpp" // for CompilationInfo
+#include "control/MethodToBeCompiled.hpp" // for TR_MethodToBeCompiled
+#include "control/JITServerHelpers.hpp"
+#include "net/ServerStream.hpp" // for JITServer::ServerStream
+#include "runtime/RuntimeAssumptions.hpp" // for TR_AddressSet
 
 
 ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) : 
@@ -436,12 +438,6 @@ ClientSessionData::notifyAndDetachFirstWaitingThread()
    return entry;
    }
 
-bool
-ClientSessionData::ClassInfo::inROMClass(void * address)
-   {
-   return address >= _romClass && address < ((uint8_t*) _romClass) + _romClass->romSize;
-   }
-
 char *
 ClientSessionData::ClassInfo::getRemoteROMString(int32_t &len, void *basePtr, std::initializer_list<size_t> offsets)
    {
@@ -498,11 +494,11 @@ ClientSessionData::ClassInfo::getROMString(int32_t &len, void *basePtr, std::ini
    for (size_t offset : offsets)
       {
       ptr += offset;
-      if (!inROMClass(ptr))
+      if (!JITServerHelpers::isAddressInROMClass(ptr, _romClass))
          return getRemoteROMString(len, basePtr, offsets);
       ptr = ptr + *(J9SRP*)ptr;
       }
-   if (!inROMClass(ptr))
+   if (!JITServerHelpers::isAddressInROMClass(ptr, _romClass))
       return getRemoteROMString(len, basePtr, offsets);
    char *data = utf8Data((J9UTF8*) ptr, len);
    return data;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -263,7 +263,6 @@ class ClientSessionData
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDeclaringClassCache;
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
 
-      bool inROMClass(void *address);
       char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       }; // struct ClassInfo


### PR DESCRIPTION
Remove the duplicated definition of `inROMClass()`from `TR_ResolvedJ9JITServerMethod` and
`ClientSessionData::ClassInfo`. Define it as `isAddressInROMClass()` in `JITServerHelpers` so that `ClassEnv` could call this API as well. 

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>