### PR TITLE
Use getROMMethodFromRAMMethod for JITServer

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -874,7 +874,7 @@ uint8_t *J9::ARM64::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
 
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
-         J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
+         J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
          uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));

--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -128,7 +128,7 @@ J9::KnownObjectTable::dumpObjectTo(TR::FILE *file, Index i, const char *fieldNam
          {
          J9Method *j9method  = (J9Method*)J9VMJAVALANGINVOKEPRIMITIVEHANDLE_VMSLOT(j9fe->vmThread(), (J9Object*)(*ref));
          J9UTF8   *className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(j9method)->romClass);
-         J9UTF8   *methName  = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(j9method));
+         J9UTF8   *methName  = J9ROMMETHOD_NAME(static_cast<TR_J9VM *>(j9fe)->getROMMethodFromRAMMethod(j9method));
          int32_t offs = simpleNameOffset(utf8Data(className), J9UTF8_LENGTH(className));
          trfprintf(file, "  vmSlot: %.*s.%.*s",
             J9UTF8_LENGTH(className)-offs, utf8Data(className)+offs,

--- a/runtime/compiler/env/annotations/GPUAnnotation.cpp
+++ b/runtime/compiler/env/annotations/GPUAnnotation.cpp
@@ -212,7 +212,7 @@ void TR_SharedMemoryAnnotations::setParmNum(TR::Compilation *comp, TR::SymbolRef
 
 bool currentMethodHasFpreductionAnnotation(TR::Compilation *comp, bool trace)
    {
-    J9ROMMethod * romMethod = (J9ROMMethod *)J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)comp->getCurrentMethod()->getPersistentIdentifier());
+    J9ROMMethod * romMethod = static_cast<TR_J9VM *>(comp->fej9())->getROMMethodFromRAMMethod((J9Method *)comp->getCurrentMethod()->getPersistentIdentifier());
 
     U_32 * annotationsData = getMethodAnnotationsDataFromROMMethod(romMethod);
 

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -1058,7 +1058,7 @@ uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
 
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
-         J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
+         J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
          uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -877,7 +877,7 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
 
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
-         J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
+         J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
          uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -602,7 +602,7 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
                reinterpret_cast<TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *>(cursor);
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
-         J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
+         J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
          uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
          binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));


### PR DESCRIPTION
Replace codegen's J9_ROM_METHOD_FROM_RAM_METHOD with frontend method getROMMethodFromRAMMethod for JITServer. When JITServer is disabled, getROMMethodFromRAMMethod calls J9_ROM_METHOD_FROM_RAM_METHOD.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>