### PR TITLE
Relax reference assert after Scavenger clearing

### DIFF
--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -173,9 +173,9 @@ public:
 			env->_cycleState->_referenceObjectOptions |= MM_CycleState::references_clear_weak;
 			env->_currentTask->releaseSynchronizedGCThreads(env);
 		}
-		Assert_GC_true_with_message(env, env->getGCEnvironment()->_referenceObjectBuffer->isEmpty(), "Non-empty reference buffer in MM_EnvironmentBase* env=%p\n", env);
+		Assert_GC_true_with_message(env, env->getGCEnvironment()->_referenceObjectBuffer->isEmpty(), "Non-empty reference buffer in MM_EnvironmentBase* env=%p before scanClearable\n", env);
 		_rootClearer.scanClearable(env);
-		Assert_GC_true_with_message(env, env->getGCEnvironment()->_referenceObjectBuffer->isEmpty(), "Non-empty reference buffer in MM_EnvironmentBase* env=%p\n", env);
+		Assert_GC_true_with_message(env, _extensions->isScavengerBackOutFlagRaised() || env->getGCEnvironment()->_referenceObjectBuffer->isEmpty(), "Non-empty reference buffer in MM_EnvironmentBase* env=%p after scanClearable\n", env);
 	}
 
 	virtual void


### PR DESCRIPTION
Normally, after a top level scan loop in Scavenger terminates, it's
expected that all thread local buffers (such as Soft reference list) are
flushed to the global list.

However, if abort scenario occurs, GC threads terminate the scan loop as
quickly as possible and may skip to flush the buffers.

Hence, the asserts that ensure that local buffers at the end of scan
loop are empty should be relaxed to ignore scenario if the scan loop
aborted.

This is already the case for Remembered Set thread local fragments
(which is non Java specific, hence in OMR side) - the
fix is to extent the logic on Soft Reference lists, too.

The relaxation is only needed after scan loops that invoked during
clearing phase, but not after the main scan loop finishes (or just
before entering clearable phase). If abort really occurred during main
scan phase (and potentially leaving thread local buffers non-empty), we
would not ever enter the clearable phase (where the assert resides), but
go straight to backout phase.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>