### PR TITLE
Merge JITServer PR7533 refactor inROMClass

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -543,3 +543,9 @@ JITServerHelpers::shouldRetryConnection(OMRPortLibrary *portLibrary)
    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
    return omrtime_current_time_millis() > _nextConnectionRetryTime;
    }
+
+bool
+JITServerHelpers::isAddressInROMClass(const void *address, const J9ROMClass *romClass)
+   {
+   return ((address >= romClass) && (address < (((uint8_t*) romClass) + romClass->romSize)));
+   }

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -95,6 +95,8 @@ class JITServerHelpers
 
    static uint32_t serverMsgTypeCount[JITServer::MessageType_ARRAYSIZE];
 
+   static bool isAddressInROMClass(const void *address, const J9ROMClass *romClass);
+
    private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
    static TR::Monitor *getClientStreamMonitor()

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -516,13 +516,18 @@ uint8_t *
 J9::ClassEnv::getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t cpIndex, int &classRefLen)
    {
    J9ROMConstantPoolItem *romCP = self()->getROMConstantPool(comp, clazz);
-   J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&romCP[cpIndex];
-   J9ROMClassRef *romClassRef = (J9ROMClassRef *)&romCP[romFieldRef->classRefCPIndex];
 #if defined(JITSERVER_SUPPORT)
    if (comp->isOutOfProcessCompilation())
       {
+      J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&romCP[cpIndex];
+      TR_ASSERT(JITServerHelpers::isAddressInROMClass(romFieldRef, self()->romClassOf(clazz)), "Field ref must be in ROM class");
+
+      J9ROMClassRef *romClassRef = (J9ROMClassRef *)&romCP[romFieldRef->classRefCPIndex];
+      TR_ASSERT(JITServerHelpers::isAddressInROMClass(romClassRef, self()->romClassOf(clazz)), "Class ref must be in ROM class");
+
       TR::CompilationInfoPerThread *compInfoPT = TR::compInfoPT;
-      char *name;
+      char *name = NULL;
+
       OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor()); 
       auto &classMap = compInfoPT->getClientData()->getROMClassMap();
       auto it = classMap.find(reinterpret_cast<J9Class *>(clazz));
@@ -534,6 +539,8 @@ J9::ClassEnv::getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *cla
       return (uint8_t *) name;
       }
 #endif /* defined(JITSERVER_SUPPORT) */
+   J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&romCP[cpIndex];
+   J9ROMClassRef *romClassRef = (J9ROMClassRef *)&romCP[romFieldRef->classRefCPIndex];
    J9UTF8 *classRefNameUtf8 = J9ROMCLASSREF_NAME(romClassRef);
    classRefLen = J9UTF8_LENGTH(classRefNameUtf8);
    uint8_t *classRefName = J9UTF8_DATA(classRefNameUtf8);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -205,7 +205,6 @@ public:
    virtual uint16_t archetypeArgPlaceholderSlot() override;
 
    TR_ResolvedJ9Method *getRemoteMirror() const { return _remoteMirror; }
-   bool inROMClass(void *address);
    static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method);

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -264,7 +264,6 @@ class ClientSessionData
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDeclaringClassCache;
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
 
-      bool inROMClass(void *address);
       char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       char* getRemoteROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);
       }; // struct ClassInfo


### PR DESCRIPTION
PR #7533 removed the duplicated definition of `inROMClass()`
from `TR_ResolvedJ9JITServerMethod` and
`ClientSessionData::ClassInfo`. Define it as `isAddressInROMClass()`  in `JITServerHelpers`
so that `ClassEnv` could call this API as well.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>