### PR TITLE
Memset the shared classes CacheUniqueID

### DIFF
--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -573,6 +573,7 @@ SH_CacheMap::startup(J9VMThread* currentThread, J9SharedClassPreinitConfig* pico
 						I_8 preLayer = 0;
 						char cacheNameBuf[USER_SPECIFIED_CACHE_NAME_MAXLEN];
 
+						memset(cacheUniqueID, 0, sizeof(cacheUniqueID));
 						strncpy(cacheUniqueID, cacheUniqueIDPtr, idLen);
 						SH_OSCache::getCacheNameAndLayerFromUnqiueID(vm, cacheDirBuf, cacheUniqueID, idLen, cacheNameBuf, USER_SPECIFIED_CACHE_NAME_MAXLEN, &preLayer);
 						const char* cacheName = cacheNameBuf;


### PR DESCRIPTION
Previously, the CacheUniqueID is not reset before it does the strncpy, which may cause an issue when using the command lines with createLayer.
For example, when using the following commands:
```
java -Xscmx16m -Xshareclasses:name=shareclass -version
java -Xshareclasses:name=shareclass,createLayer -version
java -Xshareclasses:name=shareclass,createLayer -version
```
the 3rd command will fail since the CacheUniqueID could be : 
```
Before strncpy:
/root/javasharedresources/C290M12F1A64P_ShareClassesCMLTest_G41L01-12c00000_5dae0f63

The cacheUniqueIDPtr: 
/root/javasharedresources/C290M12F1A64P_ShareClassesCMLTest_G41L00-1000000_5dae0f5d

After strncpy:
/root/javasharedresources/C290M12F1A64P_ShareClassesCMLTest_G41L00-1000000_5dae0f5d3
```
which makes the CacheUniqueID have an extra garbage digit '3' at the end.

This issue has been fixed by resetting the CacheUniqueID before it does the strncpy.

Signed-off-by: Jiahan Xi <doomerXe@gmail.com>