### PR TITLE
Upgrade to asm-7.2.jar in tests

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -77,11 +77,6 @@ my %asm_all = (
 	fname => 'asm-all.jar',
 	sha1 => '535f141f6c8fc65986a3469839a852a3266d1025'
 );
-my %asm_7_0 = (
-	url => 'https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/7.0-beta/asm-7.0-beta.jar',
-	fname => 'asm-7.0.jar',
-	sha1 => '7804855908e0a5e4f98e3364fa537426d9f5329c'
-);
 my %asm_7_2 = (
 	url => 'https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/7.2/asm-7.2.jar',
 	fname => 'asm-7.2.jar',
@@ -134,7 +129,6 @@ my %jaxb_api = (
 # Put all dependent jars hash to array to prepare downloading
 my @jars_info = (
 	\%asm_all,
-	\%asm_7_0,
 	\%asm_7_2,
 	\%commons_cli,
 	\%commons_exec,

--- a/test/functional/Java11andUp/build.xml
+++ b/test/functional/Java11andUp/build.xml
@@ -56,7 +56,7 @@
 			<include name="**/condy/BootstrapMethods.java" />
 			<include name="**/condy/CondyGenerator.java" />
 			<classpath>
-				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar" />
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.2.jar" />
 			</classpath>
 		</javac>
 	</target>
@@ -67,7 +67,7 @@
 		<java classname="org.openj9.test.condy.CondyGenerator" fork="true" failonerror="true" logError="true" jvm="${javaexecutable.java}">
 			<jvmarg value="-Xverify:none" />
 			<classpath>
-				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar" />
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.2.jar" />
 				<pathelement location="${build}" />
 			</classpath>
 		</java>
@@ -94,7 +94,7 @@
 			<classpath>
 				<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar"/>
 				<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar"/>
-				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar" />
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.2.jar" />
 				<pathelement location="${build}" />
 			</classpath>
 		</javac>

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -173,7 +173,7 @@
 			<variation>-Xgcpolicy:balanced</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-			-cp $(Q)$(LIB_DIR)$(D)asm-7.0.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			-cp $(Q)$(LIB_DIR)$(D)asm-7.2.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames GarbageCollectionCondyTest \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
@@ -205,7 +205,7 @@
 			<variation>-Xgcpolicy:metronome</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-			-cp $(Q)$(LIB_DIR)$(D)asm-7.0.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			-cp $(Q)$(LIB_DIR)$(D)asm-7.2.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames GarbageCollectionCondyTest \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \
@@ -237,7 +237,7 @@
 			<variation>-Xgcpolicy:metronome</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-			-cp $(Q)$(LIB_DIR)$(D)asm-7.0.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			-cp $(Q)$(LIB_DIR)$(D)asm-7.2.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames GarbageCollectionCondyTest \
 			-groups $(TEST_GROUP) \
 			-excludegroups $(DEFAULT_EXCLUDE); \


### PR DESCRIPTION
Some tests are using asm-7.0-beta.jar and some are using asm-7.2.jar.
Remove asm-7.0-beta.jar and upgrade tests to use asm-7.2.jar, so we have one
less dependent jar in tests

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>