### PR TITLE
Port runtime-related JITServer changes

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -400,11 +400,16 @@ J9::CodeCache::addFreeBlock(void  *voidMetaData)
             // (IsAotedBody==false when addFreeBlock is called during compilation)
             if (!pmi || !pmi->isInDataCache())
                {
-               TR_Memory::jitPersistentFree(bi);
-               // If we free bodyInfo, we need to also free metaData->bodyInfo->mapTable by calling freeFastWalkCache()
-               J9VMThread *currentVMThread = _manager->javaVM()->internalVMFunctions->currentVMThread(_manager->javaVM());
-               freeFastWalkCache(currentVMThread, metaData);
-               metaData->bodyInfo = NULL;
+               // If compiled remotely, the body info is currently also in the DataCache so don't free it but still consider freeing
+               // the MethodInfo below since it is independent
+               if (!bi->getIsRemoteCompileBody())
+                  {
+                  TR_Memory::jitPersistentFree(bi);
+                  // If we free bodyInfo, we need to also free metaData->bodyInfo->mapTable by calling freeFastWalkCache()
+                  J9VMThread *currentVMThread = _manager->javaVM()->internalVMFunctions->currentVMThread(_manager->javaVM());
+                  freeFastWalkCache(currentVMThread, metaData);
+                  metaData->bodyInfo = NULL;
+                  }
                }
 
             // Attempt to free the persistentMethodInfo

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -706,7 +706,7 @@ J9::CodeCacheManager::printRemainingSpaceInCodeCaches()
    CacheListCriticalSection scanCacheList(self());
    for (TR::CodeCache *codeCache = self()->getFirstCodeCache(); codeCache; codeCache = codeCache->next())
       {
-      fprintf(stderr, "cache %p has %u bytes empty\n", codeCache, codeCache->getFreeContiguousSpace());
+      fprintf(stderr, "cache %p has %lu bytes empty\n", codeCache, codeCache->getFreeContiguousSpace());
       if (codeCache->isReserved())
          fprintf(stderr, "Above cache is reserved by compThread %d\n", codeCache->getReservingCompThreadID());
       }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -176,7 +176,11 @@ createExceptionTable(
          *(uint32_t *)cursor = e->_instructionEndPC, cursor += 4;
          *(uint32_t *)cursor = e->_instructionHandlerPC, cursor += 4;
          *(uint32_t *)cursor = e->_catchType, cursor += 4;
-         if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
+         if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE()
+#if defined(JITSERVER_SUPPORT)
+            || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+#endif
+            )
             *(uintptrj_t *)cursor = (uintptrj_t)e->_byteCodeInfo.getCallerIndex(), cursor += sizeof(uintptrj_t);
          else
             *(uintptrj_t *)cursor = (uintptrj_t)e->_method->resolvedMethodAddress(), cursor += sizeof(uintptrj_t);
@@ -1077,7 +1081,11 @@ populateBodyInfo(
    //
    if (recompInfo)
       {
-      if (vm->isAOT_DEPRECATED_DO_NOT_USE())
+      if (vm->isAOT_DEPRECATED_DO_NOT_USE()
+#if defined(JITSERVER_SUPPORT)
+         || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+#endif
+         )
          {
          // The allocation for the Persistent Method Info and the Persistent Jitted Body Info used to be allocated with the exception table.
          // Exception tables are now being reaped on method recompilation.  As these need to be persistent, we need to allocate them separately.
@@ -1112,6 +1120,7 @@ populateBodyInfo(
          TR_PersistentJittedBodyInfo *bodyInfoSrc = recompInfo->getJittedBodyInfo();
          TR_PersistentMethodInfo *methodInfoSrc = recompInfo->getMethodInfo();
          methodInfoSrc->setIsInDataCache(true);
+         bodyInfoSrc->setIsRemoteCompileBody(true);
          data->bodyInfo = locationPersistentJittedBodyInfo;
          TR_PersistentJittedBodyInfo *newBodyInfo = (TR_PersistentJittedBodyInfo *)locationPersistentJittedBodyInfo;
 
@@ -1138,7 +1147,11 @@ populateBodyInfo(
       }
    else
       {
-      if (vm->isAOT_DEPRECATED_DO_NOT_USE())
+      if (vm->isAOT_DEPRECATED_DO_NOT_USE()
+#if defined(JITSERVER_SUPPORT)
+         || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+#endif
+         )
          {
          J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
          TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
@@ -1217,10 +1230,13 @@ static void populateInlineCalls(
          traceMsg(comp, "inlineIdx %d, callSiteCursor %p, inlinedCallSite->methodInfo = %p\n", i, callSiteCursor, inlinedCallSite->_methodInfo);
          }
 
-      if (!vm->isAOT_DEPRECATED_DO_NOT_USE()) // For AOT, we should only have returned resolved info about a method if the method came from same class loaders.
+      if (!vm->isAOT_DEPRECATED_DO_NOT_USE()
+#if defined(JITSERVER_SUPPORT)
+         && TR::comp()->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER
+#endif
+         ) // For AOT, we should only have returned resolved info about a method if the method came from same class loaders.
          {
-         J9Class *j9clazz = (J9Class *) J9_CLASS_FROM_CP(((J9RAMConstantPoolItem *) J9_CP_FROM_METHOD(((J9Method *) inlinedCallSite->_methodInfo))));
-         TR_OpaqueClassBlock *clazzOfInlinedMethod = ((TR_J9VMBase*) comp->fej9())->convertClassPtrToClassOffset(j9clazz);
+         TR_OpaqueClassBlock *clazzOfInlinedMethod = vm->getClassFromMethodBlock(inlinedCallSite->_methodInfo);
          if (comp->fej9()->isUnloadAssumptionRequired(clazzOfInlinedMethod, comp->getCurrentMethod()))
             {
             if (comp->getOption(TR_AOT) && comp->getOption(TR_TraceRelocatableDataDetailsCG))
@@ -1234,9 +1250,9 @@ static void populateInlineCalls(
                        callSiteCursor);
                }
 #if (defined(TR_HOST_64BIT) && defined(TR_HOST_POWER))
-            createClassUnloadPicSite((void*) j9clazz, (void*) (callSiteCursor+(TR::Compiler->target.cpu.isBigEndian()?4:0)), 4, comp->getMetadataAssumptionList());
+            createClassUnloadPicSite((void*) clazzOfInlinedMethod, (void*) (callSiteCursor+(TR::Compiler->target.cpu.isBigEndian()?4:0)), 4, comp->getMetadataAssumptionList());
 #else
-            createClassUnloadPicSite((void*) j9clazz, (void*) callSiteCursor, sizeof(uintptrj_t), comp->getMetadataAssumptionList());
+            createClassUnloadPicSite((void*) clazzOfInlinedMethod, (void*) callSiteCursor, sizeof(uintptrj_t), comp->getMetadataAssumptionList());
 #endif
             }
          }
@@ -1472,12 +1488,19 @@ createMethodMetaData(
    data->registerSaveDescription = comp->cg()->getRegisterSaveDescription();
 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
-   if (vm->isAOT_DEPRECATED_DO_NOT_USE())
+   if (vm->isAOT_DEPRECATED_DO_NOT_USE()
+#if defined(JITSERVER_SUPPORT)
+      || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+#endif
+      )
       {
       TR::CodeCache * codeCache = comp->cg()->getCodeCache(); // MCT
 
-      /* Align code caches */
-      codeCache->alignWarmCodeAlloc(3);
+#if defined(JITSERVER_SUPPORT)
+      if (comp->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER)
+#endif
+         /* Align code caches */
+         codeCache->alignWarmCodeAlloc(3);
 
       J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
       TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);
@@ -1555,7 +1578,11 @@ createMethodMetaData(
 
    populateInlineCalls(comp, vm, data, callSiteCursor, numberOfMapBytes);
 
-   if (!(vm->_jitConfig->runtimeFlags & J9JIT_TOSS_CODE) && !vm->isAOT_DEPRECATED_DO_NOT_USE())
+   if (!(vm->_jitConfig->runtimeFlags & J9JIT_TOSS_CODE) && !vm->isAOT_DEPRECATED_DO_NOT_USE()
+#if defined(JITSERVER_SUPPORT)
+      && comp->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER
+#endif
+      )
       {
       TR_TranslationArtifactManager *artifactManager = TR_TranslationArtifactManager::getGlobalArtifactManager();
       TR_TranslationArtifactManager::CriticalSection updateMetaData;

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -178,7 +178,7 @@ createExceptionTable(
          *(uint32_t *)cursor = e->_catchType, cursor += 4;
          if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
-            || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+            || comp->isOutOfProcessCompilation()
 #endif
             )
             *(uintptrj_t *)cursor = (uintptrj_t)e->_byteCodeInfo.getCallerIndex(), cursor += sizeof(uintptrj_t);
@@ -1083,7 +1083,7 @@ populateBodyInfo(
       {
       if (vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
-         || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+         || comp->isOutOfProcessCompilation()
 #endif
          )
          {
@@ -1149,7 +1149,7 @@ populateBodyInfo(
       {
       if (vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
-         || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+         || comp->isOutOfProcessCompilation()
 #endif
          )
          {
@@ -1232,7 +1232,7 @@ static void populateInlineCalls(
 
       if (!vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
-         && TR::comp()->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER
+         && !comp->isOutOfProcessCompilation()
 #endif
          ) // For AOT, we should only have returned resolved info about a method if the method came from same class loaders.
          {
@@ -1490,14 +1490,14 @@ createMethodMetaData(
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
    if (vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
-      || comp->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER
+      || comp->isOutOfProcessCompilation()
 #endif
       )
       {
       TR::CodeCache * codeCache = comp->cg()->getCodeCache(); // MCT
 
 #if defined(JITSERVER_SUPPORT)
-      if (comp->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER)
+      if (!comp->isOutOfProcessCompilation())
 #endif
          /* Align code caches */
          codeCache->alignWarmCodeAlloc(3);
@@ -1580,7 +1580,7 @@ createMethodMetaData(
 
    if (!(vm->_jitConfig->runtimeFlags & J9JIT_TOSS_CODE) && !vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
-      && comp->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER
+      && !comp->isOutOfProcessCompilation()
 #endif
       )
       {

--- a/runtime/compiler/runtime/MetaDataDebug.cpp
+++ b/runtime/compiler/runtime/MetaDataDebug.cpp
@@ -554,7 +554,8 @@ void
 TR_Debug::printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, char * indent)
    {
 #if defined(JITSERVER_SUPPORT)
-   return ;
+   if (_comp->isOutOfProcessCompilation() || _comp->isRemoteCompilation())
+      return;
 #endif
    if (!_comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
       {

--- a/runtime/compiler/runtime/MetaDataDebug.cpp
+++ b/runtime/compiler/runtime/MetaDataDebug.cpp
@@ -553,35 +553,38 @@ extern "C" void jitBytecodePrintFunction(void *userData, char *format, ...)
 void
 TR_Debug::printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, char * indent)
    {
-      if (!_comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
+#if defined(JITSERVER_SUPPORT)
+   return ;
+#endif
+   if (!_comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE())
+      {
+      J9Method * ramMethod;
+      void *bcPrintFunc = (void *)jitBytecodePrintFunction;
+      if (parentStackIndex == -1)
          {
-         J9Method * ramMethod;
-         void *bcPrintFunc = (void *)jitBytecodePrintFunction;
-         if (parentStackIndex == -1)
-            {
-            sprintf(indent, " \\\\");
-            trfprintf(_file, "%s %s\n", indent, _comp->getCurrentMethod()->signature(comp()->trMemory(), heapAlloc));
-            ramMethod = (J9Method *)_comp->getCurrentMethod()->resolvedMethodAddress();
-            }
-         else
-            {
-            TR_InlinedCallSite & site = _comp->getInlinedCallSite(parentStackIndex);
-            printByteCodeStack(site._byteCodeInfo.getCallerIndex(), site._byteCodeInfo.getByteCodeIndex(), indent);
-            ramMethod = (J9Method *)site._methodInfo;
-            }
-
-         #ifdef J9VM_ENV_LITTLE_ENDIAN
-            uint32_t flags = BCT_LittleEndianOutput;
-         #else
-            uint32_t flags = BCT_BigEndianOutput;
-         #endif
-
-         j9bcutil_dumpBytecodes(((TR_J9VMBase *)_comp->fej9())->_portLibrary,
-                                J9_CLASS_FROM_METHOD(ramMethod)->romClass,
-                                J9_BYTECODE_START_FROM_RAM_METHOD(ramMethod),
-                                byteCodeIndex, byteCodeIndex, flags, bcPrintFunc, this, indent);
-         sprintf(indent, "%s   ", indent);
+         sprintf(indent, " \\\\");
+         trfprintf(_file, "%s %s\n", indent, _comp->getCurrentMethod()->signature(comp()->trMemory(), heapAlloc));
+         ramMethod = (J9Method *)_comp->getCurrentMethod()->resolvedMethodAddress();
          }
+      else
+         {
+         TR_InlinedCallSite & site = _comp->getInlinedCallSite(parentStackIndex);
+         printByteCodeStack(site._byteCodeInfo.getCallerIndex(), site._byteCodeInfo.getByteCodeIndex(), indent);
+         ramMethod = (J9Method *)site._methodInfo;
+         }
+
+      #ifdef J9VM_ENV_LITTLE_ENDIAN
+         uint32_t flags = BCT_LittleEndianOutput;
+      #else
+         uint32_t flags = BCT_BigEndianOutput;
+      #endif
+
+      j9bcutil_dumpBytecodes(((TR_J9VMBase *)_comp->fej9())->_portLibrary,
+                             J9_CLASS_FROM_METHOD(ramMethod)->romClass,
+                             J9_BYTECODE_START_FROM_RAM_METHOD(ramMethod),
+                             byteCodeIndex, byteCodeIndex, flags, bcPrintFunc, this, indent);
+      sprintf(indent, "%s   ", indent);
+      }
    }
 
 // copied from jit.dev/rossa.cpp - needed to link on WinCE

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1603,6 +1603,10 @@ TR_RelocationRecordDataAddress::applyRelocation(TR_RelocationRuntime *reloRuntim
    {
    uint8_t *newAddress = findDataAddress(reloRuntime, reloTarget);
 
+#if defined(JITSERVER_SUPPORT)
+   RELO_LOG(reloRuntime->reloLogger(), 6, "applyRelocation old ptr %p, new ptr %p\n", reloTarget->loadPointer(reloLocation), newAddress);
+#endif
+
    if (!newAddress)
       return compilationAotStaticFieldReloFailure;
 

--- a/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
+++ b/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
@@ -164,11 +164,11 @@ TR_RelocationRuntimeLogger::exceptionTable()
    JITRT_PRINTF(jitConfig())(jitConfig(), "%-14s",   "gcStackAtlas");
    JITRT_PRINTF(jitConfig())(jitConfig(), "%-12s\n", "bodyInfo");
 
-   JITRT_PRINTF(jitConfig())(jitConfig(), "%-12x",   data->startPC);
-   JITRT_PRINTF(jitConfig())(jitConfig(), "%-12x",   data->endPC);
+   JITRT_PRINTF(jitConfig())(jitConfig(), "%-12p",   data->startPC);
+   JITRT_PRINTF(jitConfig())(jitConfig(), "%-12p",   data->endPC);
    JITRT_PRINTF(jitConfig())(jitConfig(), "%-8x",    data->size);
-   JITRT_PRINTF(jitConfig())(jitConfig(), "%-14x",   data->gcStackAtlas);
-   JITRT_PRINTF(jitConfig())(jitConfig(), "%-12x\n", data->bodyInfo);
+   JITRT_PRINTF(jitConfig())(jitConfig(), "%-14p",   data->gcStackAtlas);
+   JITRT_PRINTF(jitConfig())(jitConfig(), "%-12p\n", data->bodyInfo);
 
    JITRT_PRINTF(jitConfig())(jitConfig(), "%-12s\n", "inlinedCalls");
    JITRT_PRINTF(jitConfig())(jitConfig(), "%-12x\n", data->inlinedCalls);

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -239,6 +239,12 @@ TR_RelocationTarget::performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmH
    TR_ASSERT(0, "Error: performThunkRelocation not implemented in relocation target base class");
    }
 
+void
+TR_RelocationTarget::performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk)
+   {
+   TR_ASSERT(0, "Error: performInvokeExactJ2IThunkRelocation not implemented in relocation target base class");
+   }
+
 uint8_t *
 TR_RelocationTarget::arrayCopyHelperAddress(J9JavaVM *javaVM)
    {

--- a/runtime/compiler/runtime/RelocationTarget.hpp
+++ b/runtime/compiler/runtime/RelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@
 class TR_OpaqueClassBlock;
 class TR_RelocationRecord;
 class TR_RelocationRuntimeLogger;
+class TR_J2IThunk;
 
 // TR_RelocationTarget defines how a platform target implements the individual steps of processing
 //    relocation records.
@@ -133,6 +134,14 @@ class TR_RelocationTarget
       virtual uint32_t loadCPIndex(uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
 
       virtual void performThunkRelocation(uint8_t *thunkAddress, uintptr_t vmHelper);
+      /**
+       * @brief Identifies the correct runtime helper based on thunk signature and relocates helper
+       * address. Needed for JITServer.
+       *
+       * @param thunk Pointer to a thunk to be relocated.
+       */
+      virtual void performInvokeExactJ2IThunkRelocation(TR_J2IThunk *thunk);
+
       virtual uint8_t *arrayCopyHelperAddress(J9JavaVM *javaVM);
 
       virtual void patchNonVolatileFieldMemoryFence(J9ROMFieldShape* resolvedField, UDATA cpAddr, U_8 descriptorByte, U_8 *instructionAddress, U_8 *snippetStartAddress, J9JavaVM *javaVM);

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -685,7 +685,7 @@ TR::SymbolValidationManager::addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9
    if (inHeuristicRegion())
       return true; // to make sure not to modify _classesFromAnyCPIndex
 
-   TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);;
+   TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
    SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
    if (isWellKnownClass(clazz))
       return true;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -371,16 +371,24 @@ struct MethodValidationRecord : public SymbolValidationRecord
    {
    MethodValidationRecord(TR_ExternalRelocationTargetKind kind, TR_OpaqueMethodBlock *method)
       : SymbolValidationRecord(kind),
-        _method(method)
+        _method(method),
+        _definingClass(NULL)
       {}
 
    TR_OpaqueClassBlock *definingClass()
       {
-      return reinterpret_cast<TR_OpaqueClassBlock *>(
-         J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(_method)));
+      TR_ASSERT(_definingClass, "defining class must be already cached");
+      return _definingClass;
+      }
+
+   TR_OpaqueClassBlock *definingClass(TR_J9VM *fe)
+      {
+      _definingClass = fe->getClassOfMethod(_method);
+      return _definingClass;
       }
 
    TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_definingClass;
    };
 
 struct MethodFromClassRecord : public MethodValidationRecord

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -82,6 +82,10 @@ getJitEntryOffset(TR_LinkageInfo * linkageInfo)
 TR_PersistentJittedBodyInfo *
 J9::Recompilation::getJittedBodyInfoFromPC(void * startPC)
    {
+#if defined(JITSERVER_SUPPORT)
+   TR_ASSERT_FATAL(!TR::CompilationInfo::getStream(), "This routine must not be used on the Server for a remote compile!");
+#endif
+
    TR_ASSERT(startPC, "startPC is null");
    TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(startPC);
    if (!linkageInfo->isRecompMethodBody())


### PR DESCRIPTION
- Add SVM JITServer support
- Add various JITServer guards
- Update uses of `getClassFromNewArrayTypeNonNull()`, `getClassFromCP()`, `setIsRemoteCompileBody()` and `TR::Compiler->cls.romClassOf(clazz)` which contains JITServer support
- Add class unloading JITServer supprt
- Fix potential memory leak in `TR_PersistentClassInfo::removeSubClasses()`, which is only used by JITServer

Signed-off-by: Harry Yu <harryyu1994@gmail.com>