### PR TITLE
Clean up jitaas branch

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1429,8 +1429,6 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
       symRef->setReallySharesSymbol();
 
    TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
-   // check for KnownObjectTable first, in JITServer mode, this will return NULL,
-   // so we never enter the critical section
    TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
    if (knot
        && resolved
@@ -1470,11 +1468,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
 
             if (createKnownObject)
                {
-               TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-               if (knot)
-                  {
-                  knownObjectIndex = knot->getIndexAt((uintptrj_t*)dataAddress);
-                  }
+               knownObjectIndex = knot->getIndexAt((uintptrj_t*)dataAddress);
                }
             }
          }

--- a/runtime/compiler/env/ClassLoaderTable.cpp
+++ b/runtime/compiler/env/ClassLoaderTable.cpp
@@ -80,7 +80,6 @@ TR_PersistentClassLoaderTable::associateClassLoaderWithClass(void *classLoaderPo
    TR_ClassLoaderInfo *info = _loaderTable[index];
    while (info != NULL && info->_classLoaderPointer != classLoaderPointer)
       info = info->_next;
-
    if (!info)
       {
       void *classChainPointer = (void *) sharedCache()->rememberClass(clazz);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -159,7 +159,6 @@ private:
    void log(char *format, ...);
 
    uint32_t getHint(J9VMThread * vmThread, J9Method *method);
-   uint32_t getHint(J9VMThread * vmThread, J9ROMMethod *method);
 
    void convertUnsignedOffsetToASCII(UDATA offset, char *myBuffer);
    void createClassKey(UDATA classOffsetInCache, char *key, uint32_t & keyLength);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -44,7 +44,6 @@
 #include "env/J9SharedCache.hpp"
 #include "infra/Array.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentCollections.hpp"
 
 class TR_CallStack;
 namespace TR { class CompilationInfo; }

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -267,23 +267,20 @@ bool TR_J9ByteCodeIlGenerator::internalGenIL()
                {
                if (recognizedMethod == TR::java_lang_ClassLoader_callerClassLoader)
                   {
+                  createGeneratedFirstBlock();
                   // check for bootstrap classloader, if so
                   // return null (see semantics of ClassLoader.callerClassLoader())
                   //
                   if (fej9()->isClassLoadedBySystemClassLoader(caller->classOfMethod()))
                      {
-                     createGeneratedFirstBlock();
                      loadConstant(TR::aconst, (void *)0);
-                     genTreeTop(TR::Node::create(method()->returnOpCode(), 1, pop()));
-                     return true;
                      }
                   else
                      {
-                     createGeneratedFirstBlock();
                      loadSymbol(TR::aload, symRefTab()->findOrCreateClassLoaderSymbolRef(caller));
-                     genTreeTop(TR::Node::create(method()->returnOpCode(), 1, pop()));
-                     return true;
                      }
+                  genTreeTop(TR::Node::create(method()->returnOpCode(), 1, pop()));
+                  return true;
                   }
                if (recognizedMethod == TR::com_ibm_oti_vm_VM_callerClass)
                   {

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -929,7 +929,6 @@ J9::TransformUtil::foldReliableStaticFinalField(TR::Compilation *comp, TR::Node 
 bool
 J9::TransformUtil::foldStaticFinalFieldAssumingProtection(TR::Compilation *comp, TR::Node *node)
    {
-   TR_ASSERT(node->getOpCode().isLoadVarDirect(), "Expecting direct load; found %s %p", node->getOpCode().getName(), node);
    TR_ASSERT(node->isLoadOfStaticFinalField(),
              "Expecting load of static final field on %s %p",
              node->getOpCode().getName(), node);

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1589,6 +1589,7 @@ TR_RelocationRecordDataAddress::findDataAddress(TR_RelocationRuntime *reloRuntim
    if (address == NULL)
       {
       RELO_LOG(reloRuntime->reloLogger(), 6, "\t\tfindDataAddress: unresolved\n");
+      return 0;
       }
 
    address = address + extraOffset;

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -204,7 +204,6 @@ struct TR_RelocationRecordDebugCounterBinaryTemplate : public TR_RelocationRecor
    };
 
 typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordClassUnloadAssumptionBinaryTemplate;
-typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordClassUnloadBinaryTemplate;
 
 struct TR_RelocationRecordValidateClassByNameBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {


### PR DESCRIPTION
It looks like a typo introduced by a master to jitaas merge (https://github.com/eclipse/openj9/pull/3571)

The latter commit did not add back the "return 0":
https://github.com/eclipse/openj9/commit/012bce09366b8a0fb3d4f5efe8b761870ade288f
https://github.com/eclipse/openj9/commit/dd0a22dcc70a115b5543308f9e5ae828c4c352d3

Signed-off-by: Harry Yu <harryyu1994@gmail.com>