### PR TITLE
WIP Stub unsupported Bean classes in JDK8 for improved javadoc

### DIFF
--- a/jcl/src/java.management/share/classes/sun/management/DiagnosticCommandImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/DiagnosticCommandImpl.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9&!Sidecar19-SE]*/
 
 /*******************************************************************************
  * Copyright (c) 2019, 2019 IBM Corp. and others

--- a/jcl/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2019 IBM Corp. and others
@@ -21,6 +21,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+/*[IF Sidecar19-SE]*/
 package com.sun.management;
 
 import java.lang.management.PlatformManagedObject;
@@ -32,3 +33,4 @@ import java.lang.management.PlatformManagedObject;
 public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
 
 }
+/*[ENDIF]*/

--- a/jcl/src/jdk.management/share/classes/com/sun/management/ThreadMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/ThreadMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2019, 2019 IBM Corp. and others

--- a/jcl/src/jdk.management/share/classes/com/sun/management/VMOption.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/VMOption.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
In com.sun.management stub:
DiagnosticCommandMBean
HotSpotDiagnosticMXBean
ThreadMXBean
VMOption

In sun.management stub:
DiagnosticCommandImpl

See also #7467

Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/340

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>