### PR TITLE
Port ilgen-related JITServer changes

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -152,8 +152,7 @@ TR_J9ByteCodeIlGenerator::genIL()
           * if DelayRelocationForAOT don't persist iprofiler info now.
           * instead, persist iprofiler info when loading the aot compilation
           */
-         TR_J9SharedCacheVM *fej9sc = (TR_J9SharedCacheVM *)(comp()->fej9());
-         if(comp()->getOption(TR_DisableDelayRelocationForAOTCompilations) || !fej9sc->shouldDelayAotLoad())
+         if (comp()->getOption(TR_DisableDelayRelocationForAOTCompilations) || !fej9()->shouldDelayAotLoad())
             {
             sc->persistIprofileInfo(_methodSymbol->getResolvedMethodSymbol(), comp());
             }
@@ -260,21 +259,19 @@ bool TR_J9ByteCodeIlGenerator::internalGenIL()
             TR_OpaqueClassBlock *callerClass  = caller  ? caller->classOfMethod() : 0;
             TR_OpaqueClassBlock *callerClass1 = caller1 ? caller1->classOfMethod() : 0;
 
-            bool doIt = ! ( fej9()->stackWalkerMaySkipFrames(caller->getPersistentIdentifier(),callerClass) ||
-                           fej9()->stackWalkerMaySkipFrames(caller1->getPersistentIdentifier(),callerClass1));
+            bool doIt = !(fej9()->stackWalkerMaySkipFrames(caller->getPersistentIdentifier(),callerClass) ||
+                          fej9()->stackWalkerMaySkipFrames(caller1->getPersistentIdentifier(),callerClass1));
 
 
             if (doIt && !comp()->compileRelocatableCode())
                {
-               if (recognizedMethod == TR::java_lang_ClassLoader_callerClassLoader
-                  )
+               if (recognizedMethod == TR::java_lang_ClassLoader_callerClassLoader)
                   {
                   createGeneratedFirstBlock();
                   // check for bootstrap classloader, if so
                   // return null (see semantics of ClassLoader.callerClassLoader())
                   //
-                  if ((void *)fej9()->getClassLoader(caller->classOfMethod()) ==
-                        (void *)fej9()->getSystemClassLoader())
+                  if (fej9()->isClassLoadedBySystemClassLoader(caller->classOfMethod()))
                      {
                      loadConstant(TR::aconst, (void *)0);
                      }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2884,13 +2884,11 @@ TR_J9ByteCodeIlGenerator::genInvokeSpecial(int32_t cpIndex)
       {
       _invokeSpecialSeen = true;
 
-      J9Class * const textualDefClass =
-         TR::Compiler->cls.convertClassOffsetToClassPtr(_method->containingClass());
       // For this purpose, an anonymous class whose host class is an interface
       // is expected to behave as though its code is contained within that
       // interface. For non-anonymous classes, hostClass is circular.
       TR_OpaqueClassBlock * const defClass =
-         fej9()->convertClassPtrToClassOffset(textualDefClass->hostClass);
+         fej9()->getHostClass(_method->containingClass());
       if (TR::Compiler->cls.isInterfaceClass(comp(), defClass))
          _invokeSpecialInterface = defClass;
 
@@ -4245,7 +4243,7 @@ break
             TR_OpaqueClassBlock *orbClass = fej9()->getClassFromSignature(ORB_REPLACE_CLASS_NAME, ORB_REPLACE_CLASS_LEN, callNode->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod());
 
             if (comp()->getOption(TR_TraceILGen))
-               traceMsg(comp(), "orbClass = %p, orbClassLoader %s systemClassLoader\n", orbClass, (fej9()->getClassLoader(cl) != fej9()->getSystemClassLoader()) ? "!=" : "==");
+               traceMsg(comp(), "orbClass = %p, orbClassLoader %s systemClassLoader\n", orbClass, (!fej9()->isClassLoadedBySystemClassLoader(cl)) ? "!=" : "==");
 
             // PR107804 if the ORB class is loaded we cannot do the serialization opt since the
             // ObjectInputStream.redirectedReadObject cannot handle ORB for some reason
@@ -4254,7 +4252,7 @@ break
                canDoSerializationOpt = false;
                }
 
-            if (orbClass && (fej9()->getClassLoader(cl) != fej9()->getSystemClassLoader()))
+            if (orbClass && !fej9()->isClassLoadedBySystemClassLoader(cl))
                {
                TR_ScratchList<TR_ResolvedMethod> methods(trMemory());
                fej9()->getResolvedMethods(trMemory(), orbClass, &methods);
@@ -4330,8 +4328,8 @@ break
                   {
                   TR_OpaqueClassBlock *serialClass = fej9()->getClassFromSignature(JAVA_SERIAL_REPLACE_CLASS_NAME, JAVA_SERIAL_REPLACE_CLASS_LEN, callNode->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod());
                   if (comp()->getOption(TR_TraceILGen))
-                     traceMsg(comp(), "serialClass = %p, serialClassLoader %s systemClassLoader\n", serialClass, (fej9()->getClassLoader(cl) != fej9()->getSystemClassLoader()) ? "!=" : "==");
-                  if (serialClass && (fej9()->getClassLoader(cl) != fej9()->getSystemClassLoader()))
+                     traceMsg(comp(), "serialClass = %p, serialClassLoader %s systemClassLoader\n", serialClass, (!fej9()->isClassLoadedBySystemClassLoader(cl)) ? "!=" : "==");
+                  if (serialClass && !fej9()->isClassLoadedBySystemClassLoader(cl))
                      {
                      TR_ScratchList<TR_ResolvedMethod> methods(trMemory());
                      fej9()->getResolvedMethods(trMemory(), serialClass, &methods);
@@ -6923,6 +6921,11 @@ void TR_J9ByteCodeIlGenerator::genFullFence(TR::Node *node)
 
 void TR_J9ByteCodeIlGenerator::performClassLookahead(TR_PersistentClassInfo *classInfo)
    {
+#if defined(JITSERVER_SUPPORT)
+   // Do not perform class lookahead in server mode
+   if (comp()->isOutOfProcessCompilation())
+      return;
+#endif
    // Do not perform class lookahead when peeking (including recursive class lookahead)
    //
    if (comp()->isPeekingMethod())

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -2394,8 +2394,11 @@ void TR_DebugExt::dxPrintMethodToBeCompiled(TR_MethodToBeCompiled *remoteCompEnt
    _dbgPrintf("\tint16_t                       _index = %d\n",localCompEntry->_index);
    _dbgPrintf("\tbool                          _freeTag = %d\n",localCompEntry->_freeTag);
    _dbgPrintf("\tuint8_t                       _weight = %u\n",localCompEntry->_weight);
-   _dbgPrintf("\tbool                          _hasIncrementedNumCompThreadsCompilingHotterMethods = %d\n\n",localCompEntry->_hasIncrementedNumCompThreadsCompilingHotterMethods);
-
+   _dbgPrintf("\tbool                          _hasIncrementedNumCompThreadsCompilingHotterMethods = %d\n",localCompEntry->_hasIncrementedNumCompThreadsCompilingHotterMethods);
+#if defined(JITSERVER_SUPPORT)   
+   _dbgPrintf("\tTR_Hotness                    _origOptLevel = 0x%p\n\n", localCompEntry->_origOptLevel);
+#endif
+   
    struct J9Method *ramMethod = (struct J9Method *)dxGetJ9MethodFromMethodToBeCompiled(remoteCompEntry);
    if (ramMethod)
       _dbgPrintf("\tAssociated J9Method = !trprint j9method 0x%p\n", ramMethod);


### PR DESCRIPTION
There are some leftover ilgen refactorings still present in jitaas, sync them to master branch.
- Apply uses of frontend query "getHostClass()"
- Apply uses of frontend query "isClassLoadedBySystemClassLoader()"
- Disable class lookahead in JITServer mode

Signed-off-by: Harry Yu <harryyu1994@gmail.com>