### PR TITLE
Clean up compressed object defines from compiler m4 asm

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -375,15 +375,6 @@ ifeq ($(HOST_ARCH),z)
         endif
     endif
 
-    ifeq ($(HOST_BITS),64)
-        ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
-            M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
-        endif
-        ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
-            M4_DEFINES+=OMR_GC_COMPRESSED_POINTERS
-        endif
-    endif
-
     ifeq ($(BUILD_CONFIG),debug)
         M4_DEFINES+=$(M4_DEFINES_DEBUG)
         M4_FLAGS+=$(M4_FLAGS_DEBUG)

--- a/runtime/compiler/build/toolcfg/zos-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/zos-xlc/common.mk
@@ -192,18 +192,6 @@ ifeq ($(HOST_BITS),32)
     endif
 endif
 
-ifeq ($(HOST_BITS),64)
-    M4_DEFINES+=TR_64Bit
-
-    ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
-        M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
-    endif
-
-    ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
-        M4_DEFINES+=OMR_GC_COMPRESSED_POINTERS
-    endif
-endif
-
 ifeq ($(BUILD_CONFIG),debug)
     M4_FLAGS+=$(M4_FLAGS_DEBUG)
 endif

--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -203,15 +203,6 @@ ifeq ($(HOST_ARCH),z)
     M4_DEFINES+=OMRZTPF
     M4_DEFINES+=J9ZTPF
 
-    ifeq ($(HOST_BITS),64)
-        ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
-            M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER
-        endif
-        ifneq (,$(shell grep 'define J9VM_GC_COMPRESSED_POINTERS' $(J9SRC)/include/j9cfg.h))
-            M4_DEFINES+=OMR_GC_COMPRESSED_POINTERS
-        endif
-    endif
-
     ifeq ($(BUILD_CONFIG),debug)
         M4_DEFINES+=$(M4_DEFINES_DEBUG)
         M4_FLAGS+=$(M4_FLAGS_DEBUG)

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1181,7 +1181,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticField)
     LR_GPR  r0,r14
     BASR    r14,rEP                      # Call jitResolvedStaticField
 
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     LHI     r1,2                                 # shift for addr
 ],[dnl
     LHI     r1,3                                 # shift for addr
@@ -1192,7 +1192,7 @@ ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
     JZ      LMTStaticAddressLoadNoneIsolated
 
     MTComputeStaticAddress(AddressLoad,Obj)
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     LLGF    r3,0(,r2)                        # load compressed val
     SLLG    r3,r3,0(r1)                       # decompress
     STG     r3,(2*PTR_SIZE)(,r5)             # store val into r2
@@ -1350,7 +1350,7 @@ LOAD_ADDR_FROM_TOC(rEP,TR_S390jitResolveStaticFieldSetter)
     LG      r1,28(,r14)               # load CP word
     LG      r7,(PTR_SIZE)(,r5)        # load JIT r1, obj to store
 
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     SLLG    r2,r2,2                   # col offset, data size
     SLLG    r6,r6,2                   # row offset, compressed
     LLGF    r3,8(r6,r3)               # tenantData[row]
@@ -1883,7 +1883,7 @@ LABEL(LcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)  # Load this
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load lookup class offset
     LLGFR   r1,r1
@@ -1900,7 +1900,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
     LR_GPR  r14,r0
 ZZ                                  # return interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)  # Load this
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -1918,7 +1918,7 @@ LABEL(LcommonJitDispatch)         # interpVtable offset in r2
     LNR_GPR r2,r2                 # negative the interpVtable offset
     AHI_GPR r2,J9TR_InterpVTableOffset
     LR_GPR  r0,r2                 # J9 requires the offset in R0
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -1988,7 +1988,7 @@ LABEL(ifCH1LcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load lookup class offset
     LLGFR   r1,r1
@@ -2005,7 +2005,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
 
 ZZ                                # return interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -2018,7 +2018,7 @@ ZZ # Load the addr of the lookup class
     TM   eq_methodCompiledFlagOffset(r3),J9TR_MethodNotCompiledBit
     JNZ     ifCH1LcommonJitDispatch
 
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r2,r2
@@ -2162,7 +2162,7 @@ LABEL(ifCH1LcommonJitDispatch)      # interpVtable offset in rEP
     AHI_GPR rEP,J9TR_InterpVTableOffset
     LR_GPR  r0,rEP                  # J9 requires the offset in R0
     L_GPR   r1,(2*PTR_SIZE)(J9SP)   # Restore "this"
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of lookup class
     LLGFR   r3,r3
@@ -2231,7 +2231,7 @@ LABEL(ifCHMLcontinueLookup)
 ZZ  # Load address of interface table & slot number
     LA      r2,eq_intfAddr_inInterfaceSnippet(,r14)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r1,J9TR_J9Object_class(,r1)
 ZZ # Load offset of lookup class
     LLGFR   r1,r1
@@ -2248,7 +2248,7 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitLookupInterfaceMethod)
 
 ZZ                          # returned interpVtable offset in r2
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Load this
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3
@@ -2263,7 +2263,7 @@ ZZ # Load the address of the lookup class
     JNZ     ifCHMLcommonJitDispatch
 
 ZZ  #Load receiving object classPtr in R2
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r2,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r2,r2
@@ -2327,7 +2327,7 @@ LABEL(ifCHMLoopTillUpdate)
 
 ZZ  current slot is now updated,
 ZZ  Lets see if it has same classPtr as we are trying to store
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r0,J9TR_J9Object_class(,r1)
 ZZ # Read class offset
     LLGFR   r0,r0
@@ -2349,7 +2349,7 @@ ZZ slot we contended for last time
 LABEL(ifCHMUpdateCacheSlot)
 ZZ store class pointer and method EP in the current empty slot
     ST_GPR  r3,PTR_SIZE(,r1)
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     ST  r2,0(,r1)
 ],[dnl
     ST_GPR  r2,0(,r1)
@@ -2363,7 +2363,7 @@ ZZ  Load pic address as second address
     L_GPR   r0,J9TR_J9Class_classLoader(CARG1)
 
 ZZ  Load class pointer as first argument
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       CARG1,0(CARG2)   # May need to convert offset to J9Class
     LLGFR   CARG1,CARG1
 ],[dnl
@@ -2447,7 +2447,7 @@ LABEL(ifCHMLcommonJitDispatch)    # interpVtable offset in rEP
     AHI_GPR rEP,J9TR_InterpVTableOffset
     LR_GPR  r0,rEP                # J9 requires the offset in R0
     L_GPR   r1,(2*PTR_SIZE)(J9SP) # Restore "this"
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     L       r3,J9TR_J9Object_class(,r1)
 ZZ # Load offset of the lookup class
     LLGFR   r3,r3

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -540,7 +540,7 @@ define(MTComputeStaticAddress,[dnl
     NILH    r2,0                      # get col index
     SLLG    r2,r2,0(r1)               # col offset, data size
 
-ifdef([OMR_GC_COMPRESSED_POINTERS],[dnl
+ifdef([ASM_OMR_GC_COMPRESSED_POINTERS],[dnl
     LGR     r14,r0                    # restore r14
     LG      r1,28(,r14)               # load CP word
     SRLG    r1,r1,8                   # shift amount


### PR DESCRIPTION
- Replace useage of `OMR_GC_COMPRESSED_POINTERS` with
  `ASM_OMR_GC_COMPRESSED_POINTERS`
- Remove definition of `J9VM_INTERP_COMPRESSED_OBJECT_HEADER` as it is
  unused

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>