### PR TITLE
Always call methodCannotBeRecompiled() when failing a recompilation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10294,7 +10294,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
       // again and return the oldStartPC as the new startPC so the old (fixed up)
       // method body is run
       //
-      if (entry && !isJITServerMode)
+      if (!isJITServerMode)
          TR::Recompilation::methodCannotBeRecompiled(oldStartPC, trvm);
       startPC = oldStartPC;
 #if defined(JITSERVER_SUPPORT)


### PR DESCRIPTION
Previous code had a bug where the call to methodCannotBeRecompiled()
in compilationEnd() was conditioned by the existence of a compilation
entry. However, at shutdown we want to fail all incoming compilation
requests even before they start and when doing so we don't provide a
comp object or a valid entry to compilationEnd(). Thus, we should call
methodCannotBeRecompiled() regardless of the existentence of a valid
entry.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>