### PR TITLE
AArch64: Implement frem and drem evaluators

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -96,6 +96,15 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Instruction *generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *dstReg, TR::Register *srcReg, TR::Instruction *preced=NULL);
    static TR::Instruction *generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *reg, TR::Instruction *preced=NULL);
 
+   /*
+    * @brief Calls helper function for float/double remainder
+    * @param[in] node : node
+    * @param[in] cg   : CodeGenerator
+    * @param[in] isSinglePrecision : true if type is single precision float
+    */
+   static TR::Register *fremHelper(TR::Node *node, TR::CodeGenerator *cg, bool isSinglePrecision);
+   static TR::Register *fremEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dremEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    };
 
 }

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1543,6 +1543,8 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_ARM64interpreterSyncDoubleStaticGlue,   (void *) _interpreterSyncDoubleStaticGlue, TR_Helper);
    SET(TR_ARM64nativeStaticHelper,                (void *) _nativeStaticHelper,              TR_Helper);
    SET(TR_ARM64interfaceDispatch,                 (void *) _interfaceDispatch,               TR_Helper);
+   SET(TR_ARM64floatRemainder,                    (void *) helperCFloatRemainderFloat,       TR_Helper);
+   SET(TR_ARM64doubleRemainder,                   (void *) helperCDoubleRemainderDouble,     TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390double2Long,                                (void *) 0,                                              TR_Helper);


### PR DESCRIPTION
This commit adds Java compliant frem and drem evaluators.
These evaluators use helperCFloatRemainderFloat/helperCDoubleRemainderDouble
helper functions which is defined in runtime/util/fltrem.c.

Depends on https://github.com/eclipse/omr/pull/4507

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>