### PR TITLE
Change diagnostics tool help text wording

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -339,12 +339,12 @@ public class DiagnosticUtils {
 			+ " Options:%n"
 			+ "          all : include all objects, including dead objects (this is the default option)%n"
 			+ "         live : include all objects after a global GC collection%n"
-			+ "NOTE: this utility may significantly affect the performance of the target VM.%n";
+			+ "NOTE: this utility might significantly affect the performance of the target VM.%n";
 
 	@SuppressWarnings("nls")
 	private static final String DIAGNOSTICS_GC_RUN_HELP = "Run the garbage collector.%n"
 			+ FORMAT_PREFIX + DIAGNOSTICS_GC_RUN + "%n"
-			+ "NOTE: this utility may significantly affect the performance of the target VM.%n";
+			+ "NOTE: this utility might significantly affect the performance of the target VM.%n";
 
 	@SuppressWarnings("nls")
 	private static final String DIAGNOSTICS_THREAD_PRINT_HELP = "List thread information.%n"
@@ -366,7 +366,7 @@ public class DiagnosticUtils {
 
 	private static final String DIAGNOSTICS_JSTAT_CLASS_HELP = "Show JVM classloader statistics.%n" //$NON-NLS-1$
 			+ FORMAT_PREFIX + DIAGNOSTICS_STAT_CLASS + "%n" //$NON-NLS-1$
-			+ "NOTE: this utility may significantly affect the performance of the target VM.%n"; //$NON-NLS-1$
+			+ "NOTE: this utility might significantly affect the performance of the target VM.%n"; //$NON-NLS-1$
 
 	/* Initialize the command and help text tables */
 	static {

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jcmd.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jcmd.java
@@ -55,7 +55,7 @@ public class Jcmd {
 			+ "%n"
 			+ "list JVM processes on the local machine. Default behavior when no options are specified.%n"
 			+ "%n"
-			+ "NOTE: this utility may significantly affect the performance of the target JVM.%n"
+			+ "NOTE: this utility might significantly affect the performance of the target JVM.%n"
 			+ "    The available diagnostic commands are determined by%n"
 			+ "    the target VM and may vary between VMs.%n";
 	@SuppressWarnings("nls")

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jmap.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jmap.java
@@ -51,7 +51,7 @@ public class Jmap {
 			+ "    -histo: print statistics about classes on the heap, including number of objects and aggregate size%n"
 			+ "    -histo:live : Print only live objects%n"
 			+ "    -J: supply arguments to the Java VM running jmap%n"
-			+ "NOTE: this utility may significantly affect the performance of the target VM.%n"
+			+ "NOTE: this utility might significantly affect the performance of the target VM.%n"
 			+ "At least one option must be selected.%n";
 
 	/**

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstat.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/tools/Jstat.java
@@ -61,7 +61,7 @@ public class Jstat {
 			+ "   -options : list the available command options%n"
 			+ "   -class : Classloading statistics%n"
 			+ "  <vmid>: Attach API VM ID as shown in jps or other Attach API-based tools%n"
-			+ "NOTE: this utility may significantly affect the performance of the target VM.%n"
+			+ "NOTE: this utility might significantly affect the performance of the target VM.%n"
 			+ "At least one option must be selected.%n";
 
 	/**


### PR DESCRIPTION
**Change diagnostics tool help text wording**

`May` tends to imply permission and `might` means possibility.
Replaced `may` with `might` for better description.

Note: this change was made based on https://github.com/eclipse/openj9-docs/issues/400#issuecomment-546005690

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>