### PR TITLE
Remove deprecated Multiply and Ternary unsigned ILOpcodes

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -628,7 +628,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::luRegLoad
    NULL,          // TR::iuRegStore
    NULL,          // TR::luRegStore
-   NULL,          // TR::iuternary
    NULL,          // TR::luternary
    NULL,          // TR::buternary
    NULL,          // TR::suternary

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -151,7 +151,6 @@ static const char * nvvmOpCodeNames[] =
    "fmul",        // TR::dmul
    "mul",         // TR::bmul
    "mul",         // TR::smul
-   "mul",         // TR::iumul
 
    "sdiv",        // TR::idiv
    "sdiv",        // TR::ldiv

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -628,7 +628,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::luRegLoad
    NULL,          // TR::iuRegStore
    NULL,          // TR::luRegStore
-   NULL,          // TR::suternary
    NULL,          // TR::cconst
 
    "load",        // TR::cload

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -628,7 +628,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::luRegLoad
    NULL,          // TR::iuRegStore
    NULL,          // TR::luRegStore
-   NULL,          // TR::luternary
    NULL,          // TR::suternary
    NULL,          // TR::cconst
 

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -629,7 +629,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::iuRegStore
    NULL,          // TR::luRegStore
    NULL,          // TR::luternary
-   NULL,          // TR::buternary
    NULL,          // TR::suternary
    NULL,          // TR::cconst
 


### PR DESCRIPTION
Clean up remnants of the following unsigned ILOpcodes from OpenJ9:
- `iumul` `cmul`
- `buternary` `iuternary` `luternary` `suternary`

The above ILOpcodes will be completely removed from OpenJ9 after this PR.

*Note that this PR needs to be merged with eclipse/omr#4512 simultaneously.*

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com