### PR TITLE
Fix JITServer init bug

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -7167,13 +7167,13 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
             // free `statsThreadObj` and set the corresponding jitConfig field to NULL
             }
          }
-      }
 
-   // Give the JIT a chance to do stuff after the VM is initialized
-   if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_INITIALIZED, jitHookVMInitialized, OMR_GET_CALLSITE(), NULL))
-      {
-      j9tty_printf(PORTLIB, "Error: Unable to install J9HOOK_VM_INITIALIZED\n");
-      return -1;
+      // Give the JIT a chance to do stuff after the VM is initialized
+      if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_INITIALIZED, jitHookVMInitialized, OMR_GET_CALLSITE(), NULL))
+         {
+         j9tty_printf(PORTLIB, "Error: Unable to install J9HOOK_VM_INITIALIZED\n");
+         return -1;
+         }
       }
 #endif // JITSERVER_SUPPORT
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -722,7 +722,7 @@ TR::SymbolValidationManager::addDefiningClassFromCPRecord(TR_OpaqueClassBlock *c
 bool
 TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex)
    {
-   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
+   TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
    SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
    if (skipFieldRefClassRecord(clazz, beholder, cpIndex))
        return true;


### PR DESCRIPTION
- Move "jitHookVMInitialized()" to be called only in JITServer::SERVER mode
- Replace J9_CLASS_FROM_CP with getClassFromCP API

Signed-off-by: Harry Yu <harryyu1994@gmail.com>