### PR TITLE
Revert "Stop using the J9VM_JIT_32BIT_USES64BIT_REGISTERS from m4 asm"

### DIFF
--- a/runtime/codert_vm/CMakeLists.txt
+++ b/runtime/codert_vm/CMakeLists.txt
@@ -66,6 +66,10 @@ elseif(OMR_ARCH_S390)
 		endif()
 		# NOTE: no flags needed for 31 bit
 
+		if(J9VM_JIT_32BIT_USES64BIT_REGISTERS)
+			list(APPEND m4_defines J9VM_JIT_32BIT_USES64BIT_REGISTERS)
+		endif()
+
 		if(J9VM_JIT_FREE_SYSTEM_STACK_POINTER)
 			list(APPEND m4_defines J9VM_JIT_FREE_SYSTEM_STACK_POINTER)
 		endif()

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -369,6 +369,12 @@ ifeq ($(HOST_ARCH),z)
     M4_DEFINES+=$(HOST_DEFINES) $(TARGET_DEFINES)
     M4_DEFINES+=J9VM_TIERED_CODE_CACHE
 
+    ifeq ($(HOST_BITS),32)
+        ifneq (,$(shell grep 'define J9VM_JIT_32BIT_USES64BIT_REGISTERS' $(J9SRC)/include/j9cfg.h))
+            M4_DEFINES+=J9VM_JIT_32BIT_USES64BIT_REGISTERS
+        endif
+    endif
+
     ifeq ($(HOST_BITS),64)
         ifneq (,$(shell grep 'define J9VM_INTERP_COMPRESSED_OBJECT_HEADER' $(J9SRC)/include/j9cfg.h))
             M4_DEFINES+=J9VM_INTERP_COMPRESSED_OBJECT_HEADER

--- a/runtime/compiler/build/toolcfg/zos-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/zos-xlc/common.mk
@@ -186,6 +186,12 @@ M4_DEFINES+=\
     J9VM_TIERED_CODE_CACHE \
     J9VM_JIT_FREE_SYSTEM_STACK_POINTER
 
+ifeq ($(HOST_BITS),32)
+    ifneq (,$(shell grep 'define J9VM_JIT_32BIT_USES64BIT_REGISTERS' $(J9SRC)/include/j9cfg.h 2>/dev/null))
+        M4_DEFINES+=J9VM_JIT_32BIT_USES64BIT_REGISTERS
+    endif
+endif
+
 ifeq ($(HOST_BITS),64)
     M4_DEFINES+=TR_64Bit
 

--- a/runtime/compiler/z/runtime/Math.m4
+++ b/runtime/compiler/z/runtime/Math.m4
@@ -722,7 +722,7 @@ LABEL(LDIVExit)
     END_FUNC(_longDivide,_LDIV,7)
 
 SETVAL(rdsa,5)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
 SETVAL(dsaSize,32*PTR_SIZE)
 ],[dnl
 SETVAL(dsaSize,16*PTR_SIZE)
@@ -739,7 +739,7 @@ ZZ
     ST_GPR   r14,PTR_SIZE(,rdsa)
     AHI_GPR  rdsa,-dsaSize
     STM_GPR  r0,r15,0(rdsa)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,64(rdsa)
 ])dnl
 
@@ -769,7 +769,7 @@ ifdef([TR_HOST_64BIT],[dnl
 
     LR_GPR  rdsa,r8 #restore dsa from r8
     LM_GPR r0,r15,0(rdsa)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,64(rdsa)
 ])dnl
     AHI_GPR rdsa,dsaSize
@@ -789,7 +789,7 @@ ZZ
     ST_GPR   r14,PTR_SIZE(,rdsa)
     AHI_GPR  rdsa,-dsaSize
     STM_GPR  r0,r15,0(rdsa)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,64(rdsa)
 ])dnl
 
@@ -821,7 +821,7 @@ ZZ load up the C Environment addr into r5 and Entry point in R6
 
     LR_GPR  rdsa,r8
     LM_GPR r0,r15,0(rdsa)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,64(rdsa)
 ])dnl
     AHI_GPR rdsa,dsaSize

--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -2765,7 +2765,7 @@ ifdef([J9ZOS390],[dnl
 END_FUNC(_RITRIC,RITRIC,8)
 
 SETVAL(rdsa,5)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
 SETVAL(dsaSize,32*PTR_SIZE)
 ],[dnl
 SETVAL(dsaSize,16*PTR_SIZE)
@@ -2791,7 +2791,7 @@ ZZ ===================================================================
     ST_GPR   r14,PTR_SIZE(,rdsa)
     AHI_GPR  rdsa,-dsaSize
     STM_GPR  r0,r15,0(rdsa)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,64(rdsa)
 ])dnl
     LR_GPR   r8,rdsa      # save dsa in r8
@@ -2839,7 +2839,7 @@ ZZ  R2 contains return value
     LR_GPR   rdsa,r8 #restore dsa from r8
     LM_GPR   r0,r1,0(rdsa)
     LM_GPR   r3,r15,3*PTR_SIZE(rdsa)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR  r0,r15,64(rdsa)
 ])dnl
     AHI_GPR  rdsa,dsaSize

--- a/runtime/compiler/z/runtime/ValueProf.m4
+++ b/runtime/compiler/z/runtime/ValueProf.m4
@@ -4,7 +4,7 @@ define(`ZZ',`**')
 define(`ZZ',`##')
 ')dnl
 
-ZZ Copyright (c) 2000, 2019 IBM Corp. and others
+ZZ Copyright (c) 2000, 2017 IBM Corp. and others
 ZZ
 ZZ This program and the accompanying materials are made 
 ZZ available under the terms of the Eclipse Public License 2.0 
@@ -70,7 +70,7 @@ SETVAL(PVFPSize,0)
 SETVAL(PVFPSize,8*DblLen)
 ])dnl
 
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
 SETVAL(PVGPRSize,27*PTR_SIZE)
 ],[dnl
 SETVAL(PVGPRSize,11*PTR_SIZE)
@@ -506,7 +506,7 @@ START_FUNC(_jitProfileValueWrap,_jitPVW)
 
     AHI_GPR J9SP,-ProfileValueStackSize
     STM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,44(J9SP)
 ])dnl
 ifdef([J9_SOFT_FLOAT],[dnl
@@ -552,7 +552,7 @@ ZZ do nothing
     LD f7,ProfileVFPSlot7(J9SP)
 ])dnl
     LM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,44(J9SP)
 ])dnl
     AHI_GPR J9SP,ProfileValueStackSize
@@ -564,7 +564,7 @@ ZZ ------------------------------------------
 START_FUNC(_jitProfileAddressWrap,_jitPAW)
     AHI_GPR J9SP,-ProfileValueStackSize
     STM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,44(J9SP)
 ])dnl
 ifdef([J9_SOFT_FLOAT],[dnl
@@ -611,7 +611,7 @@ ZZ do nothing
     LD f7,ProfileVFPSlot7(J9SP)
 ])dnl
     LM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,44(J9SP)
 ])dnl
     AHI_GPR J9SP,ProfileValueStackSize
@@ -623,7 +623,7 @@ ZZ ------------------------------------------
 START_FUNC(_jitProfileLongValueWrap,_jitPLW)
     AHI_GPR J9SP,-ProfileValueStackSize
     STM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,44(J9SP)
 ])dnl
 ifdef([J9_SOFT_FLOAT],[dnl
@@ -669,7 +669,7 @@ ZZ do nothing
     LD f7,ProfileVFPSlot7(J9SP)
 ])dnl
     LM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,44(J9SP)
 ])dnl
     AHI_GPR J9SP,ProfileValueStackSize
@@ -681,7 +681,7 @@ ZZ ------------------------------------------
 START_FUNC(_jitProfileBigDecimalValueWrap,_jitPBDW)
     AHI_GPR J9SP,-ProfileValueStackSize
     STM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,44(J9SP)
 ])dnl
 ifdef([J9_SOFT_FLOAT],[dnl
@@ -727,7 +727,7 @@ ZZ do nothing
     LD f7,ProfileVFPSlot7(J9SP)
 ])dnl
     LM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,44(J9SP)
 ])dnl
     AHI_GPR J9SP,ProfileValueStackSize
@@ -739,7 +739,7 @@ ZZ ------------------------------------------
 START_FUNC(_jitProfileStringValueWrap,_jitPSW)
     AHI_GPR J9SP,-ProfileValueStackSize
     STM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     STMH_GPR r0,r15,44(J9SP)
 ])dnl
 ifdef([J9_SOFT_FLOAT],[dnl
@@ -785,7 +785,7 @@ ZZ do nothing
     LD f7,ProfileVFPSlot7(J9SP)
 ])dnl
     LM_GPR r5,r15,0(J9SP)
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
     LMH_GPR r0,r15,44(J9SP)
 ])dnl
     AHI_GPR J9SP,ProfileValueStackSize

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -473,7 +473,7 @@ ZZ ============================================================
 define(SaveRegs,
 [dnl
 
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
      AHI_GPR  r5,-(32*PTR_SIZE)
      STM_GPR  r0,r15,0(r5)            # save all registers
      STMH_GPR  r0,r15,64(r5)  # save all hi regs (16*4)
@@ -496,7 +496,7 @@ define(RestoreRegs,
 [dnl
 
      ST_GPR   r5,(5*PTR_SIZE)(r5)     # store the new J9SP
-ifdef([ASM_J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
+ifdef([J9VM_JIT_32BIT_USES64BIT_REGISTERS],[dnl
      LMH_GPR  r0,r15,64(r5) # restore all hi regs (16*4)
      LM_GPR   r0,r15,0(r5)            # restore all registers
      AHI_GPR  r5,(32*PTR_SIZE)

--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -92,6 +92,10 @@ ifdef j9vm_env_data64
   UMA_M4_FLAGS += -DTR_64Bit -DTR_HOST_64BIT
 endif
 
+ifdef j9vm_jit_32bitUses64bitRegisters
+  UMA_M4_FLAGS += -DJ9VM_JIT_32BIT_USES64BIT_REGISTERS
+endif
+
 ifdef j9vm_jit_freeSystemStackPointer
   UMA_M4_FLAGS += -DJ9VM_JIT_FREE_SYSTEM_STACK_POINTER
 endif

--- a/runtime/makelib/targets.mk.ztpf.inc.ftl
+++ b/runtime/makelib/targets.mk.ztpf.inc.ftl
@@ -177,6 +177,10 @@ UMA_EXE_POSTFIX_FLAGS += -Wl,--eh-frame-hdr
 UMA_EXE_POSTFIX_FLAGS += -lgcc
 UMA_EXE_POSTFIX_FLAGS += -lCTOE
 
+ifdef j9vm_jit_32bitUses64bitRegisters
+  UMA_M4_FLAGS += -DJ9VM_JIT_32BIT_USES64BIT_REGISTERS
+endif
+
 ifdef UMA_TREAT_WARNINGS_AS_ERRORS
   ifndef UMA_SUPPRESS_WARNINGS_AS_ERRORS
     CFLAGS += -Wimplicit -Wreturn-type -Werror


### PR DESCRIPTION
Reverts eclipse/openj9#7572

This seems to have broken zlinux and z/OS 31-bit. Many failures like *** Invalid JIT return address 100DEE50 in 7D208298. Reverting while we figure it out.