### PR TITLE
AArch64: Fix build break with J9UnresolvedDataSnippet

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.cpp
@@ -25,6 +25,14 @@
 #include "compile/Compilation.hpp"
 #include "il/StaticSymbol.hpp"
 
+J9::ARM64::UnresolvedDataSnippet::UnresolvedDataSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, bool isStore, bool isGCSafePoint) :
+   J9::UnresolvedDataSnippet(cg, node, symRef, isStore, isGCSafePoint),
+   _memoryReference(NULL)
+   {
+   // Implement this in OpenJ9 PR #5985
+   cg->comp()->failCompilation<TR::AssertionFailure>("UnresolvedDataSnippet");
+   }
+
 uint8_t *
 J9::ARM64::UnresolvedDataSnippet::emitSnippetBody()
    {

--- a/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/aarch64/codegen/J9UnresolvedDataSnippet.hpp
@@ -57,13 +57,7 @@ class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
    /**
     * @brief Constructor
     */
-   UnresolvedDataSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, bool isStore, bool isGCSafePoint) :
-      J9::UnresolvedDataSnippet(cg, node, symRef, isStore, isGCSafePoint),
-      _memoryReference(NULL)
-      {
-      // Implement this in OpenJ9 PR #5985
-      cg->comp()->failCompilation<TR::AssertionFailure>("UnresolvedDataSnippet");
-      }
+   UnresolvedDataSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, bool isStore, bool isGCSafePoint);
 
    /**
     * @brief Answers the Snippet kind


### PR DESCRIPTION
This commit moves the use of TR::CodeGenerator from
J9UnresolvedDataSnippet.hpp to its .cpp file, for resolving a build
break.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>