### PR TITLE
Prevent infinite loop in illegal field modification hook

### DIFF
--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -602,7 +602,6 @@ TR_RuntimeAssumptionTable::notifyIllegalStaticFinalFieldModificationEvent(TR_Fro
 
    OMR::RuntimeAssumption **headPtr = getBucketPtr(RuntimeAssumptionOnStaticFinalFieldModification, hashCode((uintptrj_t)key));
    OMR::RuntimeAssumption* cursor = *headPtr;
-   OMR::RuntimeAssumption* prev = NULL;
    bool found = false;
 
    while (cursor)
@@ -622,9 +621,7 @@ TR_RuntimeAssumptionTable::notifyIllegalStaticFinalFieldModificationEvent(TR_Fro
             }
          cursor->compensate(vm, 0, 0);
          markForDetachFromRAT(cursor);
-         continue;
          }
-      prev = cursor;
       cursor = next;
       }
 


### PR DESCRIPTION
The loop run by the JIT when notified of an illegal field write will enter an
infinite loop if we find a field to patch - we fail to update the next pointer.
This change fixes the handling of the next pointer and removes the unused prev
pointer to save code complexity since maintaining prev with the RAT mark then
sweeep scheme will be tricky and the value is not currently used.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>