### PR TITLE
Convert jar file path to UTF8 or system default for Windows

### DIFF
--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -622,3 +622,5 @@ TraceEntry=Trc_JVMTI_jvmtiSetHeapSamplingInterval_Entry Overhead=1 Level=5 Noenv
 TraceExit=Trc_JVMTI_jvmtiSetHeapSamplingInterval_Exit Overhead=1 Level=5 Noenv Template="SetHeapSamplingInterval: returning %d"
 TraceEntry=Trc_JVMTI_jvmtiHookSampledObjectAlloc_Entry Overhead=1 Level=5 Noenv Template="HookSampledObjectAlloc starts"
 TraceExit=Trc_JVMTI_jvmtiHookSampledObjectAlloc_Exit Overhead=1 Level=5 Noenv Template="HookSampledObjectAlloc"
+
+TraceException=Trc_JVMTI_issueAgentOnLoadAttach_strConvertFailed Overhead=1 Level=1 Noenv Template="issueAgentOnLoadAttach: j9str_convert (%s) failed"


### PR DESCRIPTION
**Convert jar file path to UTF8 or system default for Windows**

1. `executableJarPath` is retrieved from `JavaVMInitArgs.options[i].optionString` which was set by Java Launcher in system default code page encoding. It is required to be converted to `UTF8`;
2. The `jarPath` passed to `agentInitFunction` is going to be consumed by `java.instrument/share/native/libinstrument/InvocationAdapter.c` which expects `jarPath` in system default code page encoding. The `jarPath` is required to be converted to such encoding;
3. `addToSystemClassLoaderSearch` is called by `jvmtiAddToSystemClassLoaderSearch`, and eventually invoked by `java.instrument/share/native/libinstrument/InvocationAdapter.c` &
`JPLISAgent.c` which pass `pathSegment` in system default code page encoding. The `pathSegment` is required to be be converted to `UTF8`.

Note: JVM internal encoding is actually modified `UTF8` encoding which is different from `UTF8` only at `NULL` character. This PR targets the jar file path and in such case modified `UTF8` and `UTF8` are equivalent, and the references of `UTF8` are used instead.  

Verified that this PR fixed the testcase https://github.com/eclipse/openj9/issues/6722#issuecomment-524669315.

fixes: #6722

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>