### PR TITLE
Remove the `inlineMathSQRT()` function on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -8944,115 +8944,6 @@ inlineNanoTime(
 #endif
 #endif // LINUX
 
-static bool
-inlineMathSQRT(
-      TR::Node *node,
-      TR::CodeGenerator *cg)
-   {
-   // Sometimes the call can have 2 children, where the first one is loadaddr
-   TR::Node *operand = NULL;
-   TR::Node *firstChild = NULL;
-   TR::Register *targetRegister = NULL;
-
-   if (node->getNumChildren() == 1)
-      {
-      operand = node->getFirstChild();
-      }
-   else
-      {
-      firstChild = node->getFirstChild();
-      operand    = node->getSecondChild();
-      }
-
-   if (node->getReferenceCount()==1)
-      {
-      if (firstChild)
-         cg->recursivelyDecReferenceCount(firstChild);
-
-      cg->recursivelyDecReferenceCount(operand);
-      return true;
-      }
-
-
-   // The current Neutrino sqrt() runtime function does not always return
-   // a result in the expected precision.  Hence, do not fold constants
-   // at compile time.
-   //
-   // TODO: Instead of avoiding it altogether the preferred fix is to call
-   // the fdlibm version of sqrt (involves linking in the fdlibm library).
-   //
-   if (operand->getOpCode().isLoadConst())
-      {
-      union
-         {
-         struct
-            {
-            uint32_t lower;
-            uint32_t upper;
-            } s;
-         double   doubleVal;
-         int64_t  rawBits;
-         } d;
-
-      d.doubleVal = operand->getDouble();
-
-      // Do not assume that the C runtime will return the correct values that Java requires
-      // for a j/l/Math.sqrt() call.  Provide the correct values for the special cases.
-      //
-      if (d.s.upper & 0x80000000)
-         {
-         if (d.s.upper != 0x80000000 || d.s.lower != 0x00000000)
-            {
-            // -ve number other than -0.0 returns NaN.
-            // -0.0 returns -0.0.
-            //
-            d.s.lower = 0;
-            d.s.upper = 0x7ff80000;
-            }
-         }
-      else if (! ((d.s.lower == 0) && (d.s.upper == 0 || d.s.upper == 0x7ff00000 || d.s.upper == 0x7ff80000)))
-         {
-         // +0.0 or +INF or NaN returns the argument.
-         // Anything else can be computed from the sqrt() function.
-         //
-         d.doubleVal = sqrt(d.doubleVal);
-         }
-
-      auto cds = cg->findOrCreate8ByteConstant(operand, d.rawBits);
-
-      targetRegister = cg->allocateRegister(TR_FPR);
-      generateRegMemInstruction(MOVSDRegMem, node, targetRegister, generateX86MemoryReference(cds, cg), cg);
-      }
-   else
-      {
-      TR::Register *opRegister = NULL;
-      opRegister = cg->evaluate(operand);
-
-      if (opRegister->getKind() == TR_FPR)
-         {
-         if (operand->getReferenceCount()==1)
-            targetRegister = opRegister;
-         else
-            targetRegister = cg->allocateRegister(TR_FPR);
-
-         generateRegRegInstruction(SQRTSDRegReg, node, targetRegister, opRegister, cg);
-         }
-      else
-         {
-         targetRegister = cg->doubleClobberEvaluate(operand);
-         generateFPRegInstruction(DSQRTReg, node, targetRegister, cg);
-         }
-      }
-
-   node->setRegister(targetRegister);
-   if (firstChild)
-      cg->recursivelyDecReferenceCount(firstChild);
-
-   cg->decReferenceCount(operand);
-   return true;
-
-   }
-
 // Convert serial String.hashCode computation into vectorization copy and implement with SSE instruction
 //
 // Conversion process example:
@@ -10003,12 +9894,6 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
                }
             }
             break;
-
-         case TR::java_lang_Math_sqrt:
-         case TR::java_lang_StrictMath_sqrt:
-            {
-            return inlineMathSQRT(node, cg);
-            }
 
          case TR::java_lang_Long_reverseBytes:
          case TR::java_lang_Integer_reverseBytes:

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -393,4 +393,31 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+<!-- jit.test.recognizedMethod tests start here -->
+	<test>
+		<testCaseName>jit_recognizedMethod</testCaseName>
+		<variations>
+			<variation>-Xint</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	RecognizedMethodTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestJavaLangMath.java
+++ b/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestJavaLangMath.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package jit.test.recognizedMethod;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class TestJavaLangMath {
+
+    /**
+    * Tests the constant corner cases defined by the {@link Math.sqrt} method.
+    * <p>
+    * The JIT compiler will transform calls to {@link Math.sqrt} within this test
+    * into the following tree sequence:
+    *
+    * <code>
+    * dsqrt
+    *   dconst <x>
+    * </code>
+    *
+    * Subsequent tree simplification passes will attempt to reduce this constant
+    * operation to a <code>dsqrt</code> IL by performing the square root at compile
+    * time. The transformation will be performed when the function get executed 
+    * twice, therefore, the "invocationCount=2" is needed. However we must ensure the
+    * result of the square root done by the compiler at compile time will be exactly 
+    * the same as the result had it been done by the Java runtime at runtime. This 
+    * test validates the results are the same.
+    */
+    @Test(groups = {"level.sanity"}, invocationCount=2)
+    public void test_java_lang_Math_sqrt() {
+        AssertJUnit.assertTrue(Double.isNaN(Math.sqrt(Double.NEGATIVE_INFINITY)));
+        AssertJUnit.assertTrue(Double.isNaN(Math.sqrt(-42.25d)));
+        AssertJUnit.assertEquals(-0.0d, Math.sqrt(-0.0d));
+        AssertJUnit.assertEquals(+0.0d, Math.sqrt(+0.0d));
+        AssertJUnit.assertEquals(7.5d, Math.sqrt(56.25d));
+        AssertJUnit.assertEquals(Double.POSITIVE_INFINITY, Math.sqrt(Double.POSITIVE_INFINITY));
+        AssertJUnit.assertTrue(Double.isNaN(Math.sqrt(Double.NaN)));
+    }
+}

--- a/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestJavaLangStrictMath.java
+++ b/test/functional/JIT_Test/src/jit/test/recognizedMethod/TestJavaLangStrictMath.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package jit.test.recognizedMethod;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+public class TestJavaLangStrictMath {
+
+    /**
+    * Tests the constant corner cases defined by the {@link StrictMath.sqrt} method.
+    * <p>
+    * The JIT compiler will transform calls to {@link StrictMath.sqrt} within this test
+    * into the following tree sequence:
+    *
+    * <code>
+    * dsqrt
+    *   dconst <x>
+    * </code>
+    *
+    * Subsequent tree simplification passes will attempt to reduce this constant
+    * operation to a <code>dsqrt</code> IL by performing the square root at compile
+    * time. The transformation will be performed when the function get executed 
+    * twice, therefore, the "invocationCount=2" is needed. However we must ensure the
+    * result of the square root done by the compiler at compile time will be exactly 
+    * the same as the result had it been done by the Java runtime at runtime. This 
+    * test validates the results are the same.
+    */
+    @Test(groups = {"level.sanity"}, invocationCount=2)
+    public void test_java_lang_StrictMath_sqrt() {
+        AssertJUnit.assertTrue(Double.isNaN(StrictMath.sqrt(Double.NEGATIVE_INFINITY)));
+        AssertJUnit.assertTrue(Double.isNaN(StrictMath.sqrt(-42.25d)));
+        AssertJUnit.assertEquals(-0.0d, StrictMath.sqrt(-0.0d));
+        AssertJUnit.assertEquals(+0.0d, StrictMath.sqrt(+0.0d));
+        AssertJUnit.assertEquals(7.5d, StrictMath.sqrt(56.25d));
+        AssertJUnit.assertEquals(Double.POSITIVE_INFINITY, StrictMath.sqrt(Double.POSITIVE_INFINITY));
+        AssertJUnit.assertTrue(Double.isNaN(StrictMath.sqrt(Double.NaN)));
+    }
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -546,6 +546,14 @@
   <test name="ReadTest">
     <classes>
       <class name="jit.test.vich.ReadTest" />
+    </classes>
+  </test>
+
+  <!-- jit.test.recognizedMethod tests start here -->
+  <test name="RecognizedMethodTest">
+    <classes>
+      <class name="jit.test.recognizedMethod.TestJavaLangStrictMath" />
+      <class name="jit.test.recognizedMethod.TestJavaLangMath" />
     </classes>
   </test>
 </suite>


### PR DESCRIPTION
Removing `inlineMathSQRT()` function on X86, because we are implementing `dsqrtEvaluator` on X86, which `StrictMath.sqrt()` and `Math.sqrt()` will be reduced to instead of calling `inlineMathSQRT()`.

The PR of `dsqrtEvaluator`'s implementation: https://github.com/eclipse/omr/pull/4514