### PR TITLE
Correct copyright for net.mk

### DIFF
--- a/runtime/compiler/build/files/net.mk
+++ b/runtime/compiler/build/files/net.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
This file was created in 2019, therefore setting the start time to 2019.
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>