### PR TITLE
Create debug object at the JITServer in the prod build

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3012,7 +3012,7 @@ J9::Options::setLogFileForClientOptions(int suffixNumber)
          self()->openLogFile(_compilationSequenceNumber);
          }
 
-      if (!_logFile)
+      if (_logFile)
          {
          J9JITConfig *jitConfig = (J9JITConfig*)_feBase;
          if (!jitConfig->tracingHook)


### PR DESCRIPTION

PR #6627 changed `if (_logFile != NULL)` to `if (!_logFile)` when it should just be `if (_logFile)`.
The bug prevented `jitConfig->tracingHook` from being set and eventually prevented the debug object being created in `OMR::Compilation::compile()` at the server.

Fixes: #7598

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>