### PR TITLE
Make DFPCompareTo unconditionally use mfocrf

### DIFF
--- a/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/DFPTreeEvaluator.cpp
@@ -1817,7 +1817,7 @@ extern TR::Register *inlineBigDecimalCompareTo(
 
    TR::Register * crGPRegister = cg->allocateRegister();
    TR::Register * retRegister = cg->allocateRegister();
-   generateTrg1ImmInstruction(cg, TR::InstOpCode::mfcr, node, crGPRegister, 0x80);
+   generateTrg1ImmInstruction(cg, TR::InstOpCode::mfocrf, node, crGPRegister, 0x80);
    generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, retRegister, crGPRegister, 1, 0x1);
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::srawi, node, crGPRegister, crGPRegister, 30);
    generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, retRegister, retRegister, crGPRegister);


### PR DESCRIPTION
Previously, inlining of BigDecimal.DFPCompareTo was trying to use the
mfcr instruction with an immediate operand. In the past, converting this
to an mfocrf instruction would happen during binary encoding, contingent
upon support for this instruction. However, support for performing this
transformation during binary encoding will be removed shortly as part of
a series of refactors.

In order for this code to keep working, it will need to generate an
mfocrf instruction rather than an mfcr instruction if it wishes to use
that form. This change has now been made unconditionally, since mfocrf
is supported on POWER5 and above, which includes all of our supported
configurations.

Signed-off-by: Ben Thomas <ben@benthomas.ca>