### PR TITLE
Disable special.system jdk8 testing on Windows

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -481,6 +481,8 @@ x86-64_windows:
       13: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
       next: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
   excluded_tests:
+    8:
+      ? special.system
     11:
       ? special.system
     12:


### PR DESCRIPTION
There are two machines down this week and the remaining machines
can't handle the load. Will re-enable the testing when the machines
are back online. #7631

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>