### PR TITLE
Enable scan all slots in a class during Scavenge

### DIFF
--- a/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
@@ -115,17 +115,10 @@ MM_ReadBarrierVerifier::poisonMonitorReferenceSlots(MM_EnvironmentBase *env)
 }
 
 void
-MM_ReadBarrierVerifier::poisonStaticClassSlots(MM_EnvironmentBase *env)
+MM_ReadBarrierVerifier::poisonClass(MM_EnvironmentBase *env)
 {
 	MM_RootScannerReadBarrierVerifier scanner(env, true, true);
-	scanner.scanClassStaticSlots(env);
-}
-
-void
-MM_ReadBarrierVerifier::poisonConstantPoolObjects(MM_EnvironmentBase *env)
-{
-	MM_RootScannerReadBarrierVerifier scanner(env, true, true);
-	scanner.scanConstantPoolObjectSlots(env);
+	scanner.scanClass(env);
 }
 
 void
@@ -139,8 +132,7 @@ MM_ReadBarrierVerifier::poisonSlots(MM_EnvironmentBase *env)
 		poisonMonitorReferenceSlots(env);
 	}
 	if (1 == extensions->fvtest_enableClassStaticsReadBarrierVerification) {
-		poisonStaticClassSlots(env);
-		poisonConstantPoolObjects(env);
+		poisonClass(env);
 	}
 }
 
@@ -196,17 +188,10 @@ MM_ReadBarrierVerifier::healMonitorReferenceSlots(MM_EnvironmentBase *env)
 }
 
 void
-MM_ReadBarrierVerifier::healStaticClassSlots(MM_EnvironmentBase *env)
+MM_ReadBarrierVerifier::healClass(MM_EnvironmentBase *env)
 {
 	MM_RootScannerReadBarrierVerifier scanner(env, true);
-	scanner.scanClassStaticSlots(env);
-}
-
-void
-MM_ReadBarrierVerifier::healConstantPoolObjects(MM_EnvironmentBase *env)
-{
-	MM_RootScannerReadBarrierVerifier scanner(env, true);
-	scanner.scanConstantPoolObjectSlots(env);
+	scanner.scanClass(env);
 }
 
 void
@@ -220,8 +205,7 @@ MM_ReadBarrierVerifier::healSlots(MM_EnvironmentBase *env)
 		healMonitorReferenceSlots(env);
 	}
 	if (1 == extensions->fvtest_enableClassStaticsReadBarrierVerification) {
-		healStaticClassSlots(env);
-		healConstantPoolObjects(env);
+		healClass(env);
 	}
 
 }

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
@@ -65,16 +65,14 @@ public:
 	void poisonSlot(MM_GCExtensionsBase *extensions, omrobjectptr_t *slot);
 	void poisonJniWeakReferenceSlots(MM_EnvironmentBase *env);
 	void poisonMonitorReferenceSlots(MM_EnvironmentBase *env);
-	void poisonStaticClassSlots(MM_EnvironmentBase *env);
-	void poisonConstantPoolObjects(MM_EnvironmentBase *env);
+	void poisonClass(MM_EnvironmentBase *env);
 	virtual void poisonSlots(MM_EnvironmentBase *env);
 
 	void healSlot(MM_GCExtensionsBase *extensions, fomrobject_t *srcAddress);
 	void healSlot(MM_GCExtensionsBase *extensions, omrobjectptr_t *slot);
 	void healJniWeakReferenceSlots(MM_EnvironmentBase *env);
 	void healMonitorReferenceSlots(MM_EnvironmentBase *env);
-	void healStaticClassSlots(MM_EnvironmentBase *env);
-	void healConstantPoolObjects(MM_EnvironmentBase *env);
+	void healClass(MM_EnvironmentBase *env);
 	virtual void healSlots(MM_EnvironmentBase *env);
 
 

--- a/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.cpp
@@ -49,7 +49,7 @@ MM_RootScannerReadBarrierVerifier::doJNIWeakGlobalReference(omrobjectptr_t *slot
 }
 
 void
-MM_RootScannerReadBarrierVerifier::scanConstantPoolObjectSlots(MM_EnvironmentBase *env)
+MM_RootScannerReadBarrierVerifier::scanClass(MM_EnvironmentBase *env)
 {
 	OMR_VMThread *omrVMThread = env->getOmrVMThread();
 	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
@@ -61,18 +61,16 @@ MM_RootScannerReadBarrierVerifier::scanConstantPoolObjectSlots(MM_EnvironmentBas
 		while (NULL != (clazz = classHeapIterator.nextClass())) {
 
 			volatile omrobjectptr_t *slotPtr = NULL;
-			GC_ConstantPoolObjectSlotIterator constantPoolObjectSlotIterator((J9JavaVM*)omrVMThread->_vm->_language_vm, clazz, true);
-			while (NULL != (slotPtr = (omrobjectptr_t*)constantPoolObjectSlotIterator.nextSlot())) {
-				if (NULL != *slotPtr) {
-					doConstantPoolObjectSlots((omrobjectptr_t *)slotPtr);
-				}
+			GC_ClassIterator classIterator(env, clazz);
+			while (NULL != (slotPtr = (omrobjectptr_t*)classIterator.nextSlot())) {
+				doClassVerify((omrobjectptr_t *)slotPtr);
 			}
 		}
 	}
 }
 
 void
-MM_RootScannerReadBarrierVerifier::doConstantPoolObjectSlots(omrobjectptr_t *slotPtr)
+MM_RootScannerReadBarrierVerifier::doClassVerify(omrobjectptr_t *slotPtr)
 {
 	if (_poison) {
 		((MM_ReadBarrierVerifier*)_extensions->accessBarrier)->poisonSlot(_env->getExtensions(), slotPtr);
@@ -80,36 +78,4 @@ MM_RootScannerReadBarrierVerifier::doConstantPoolObjectSlots(omrobjectptr_t *slo
 		((MM_ReadBarrierVerifier*)_extensions->accessBarrier)->healSlot(_env->getExtensions(), slotPtr);
 	}
 }
-
-void
-MM_RootScannerReadBarrierVerifier::scanClassStaticSlots(MM_EnvironmentBase *env)
-{
-	OMR_VMThread *omrVMThread = env->getOmrVMThread();
-	GC_SegmentIterator segmentIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm)->classMemorySegments, MEMORY_TYPE_RAM_CLASS);
-
-	while (J9MemorySegment *segment = segmentIterator.nextSegment()) {
-		GC_ClassHeapIterator classHeapIterator(static_cast<J9JavaVM*>(omrVMThread->_vm->_language_vm), segment);
-		J9Class *clazz = NULL;
-
-		while (NULL != (clazz = classHeapIterator.nextClass())) {
-
-			volatile omrobjectptr_t *slotPtr = NULL;
-			GC_ClassStaticsIterator classStaticsIterator(env, clazz);
-			while (NULL != (slotPtr = (omrobjectptr_t*)classStaticsIterator.nextSlot())) {
-				doClassStaticSlots((omrobjectptr_t *)slotPtr);
-			}
-		}
-	}
-}
-
-void
-MM_RootScannerReadBarrierVerifier::doClassStaticSlots(omrobjectptr_t *slotPtr)
-{
-	if (_poison) {
-		((MM_ReadBarrierVerifier*)_extensions->accessBarrier)->poisonSlot(_env->getExtensions(), slotPtr);
-	} else {
-		((MM_ReadBarrierVerifier*)_extensions->accessBarrier)->healSlot(_env->getExtensions(), slotPtr);
-	}
-}
-
 #endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */

--- a/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.hpp
+++ b/runtime/gc_modron_standard/RootScannerReadBarrierVerifier.hpp
@@ -45,11 +45,8 @@ class MM_RootScannerReadBarrierVerifier : public MM_RootScanner
 		virtual void doMonitorReference(J9ObjectMonitor *objectMonitor, GC_HashTableIterator *monitorReferenceIterator);
 		virtual void doJNIWeakGlobalReference(omrobjectptr_t *slotPtr);
 		
-		virtual void scanConstantPoolObjectSlots(MM_EnvironmentBase *env);
-		virtual void doConstantPoolObjectSlots(omrobjectptr_t *slotPtr);
-
-		virtual void scanClassStaticSlots(MM_EnvironmentBase *env);
-		virtual void doClassStaticSlots(omrobjectptr_t *slotPtr);
+		virtual void scanClass(MM_EnvironmentBase *env);
+		virtual void doClassVerify(omrobjectptr_t *slotPtr);
 
 		virtual void doSlot(J9Object** slotPtr) {};
 		virtual void doClass(J9Class *clazz) {};

--- a/runtime/gc_structs/ConstantPoolObjectSlotIterator.cpp
+++ b/runtime/gc_structs/ConstantPoolObjectSlotIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,20 +35,11 @@
 
 
 /**
- * If condyOnly flag is not set:
  * @return the next object slot in the constant pool
  * @return NULL if there are no more object references
- *
- * If condyOnly flag is set and Java version is SE11 and above:
- * @return the next Condy reference from the constant pool
- * @return NULL if there are no more references
  */
 j9object_t *
 GC_ConstantPoolObjectSlotIterator::nextSlot() {
-	/* Return NULL if _condyOnly is true but system is not condy-enabled */
-	if (_condyOnly && !_condyEnabled) {
-		return NULL;
-	}
 	U_32 slotType;
 	j9object_t *slotPtr;
 	j9object_t *result = NULL;
@@ -63,41 +54,27 @@ GC_ConstantPoolObjectSlotIterator::nextSlot() {
 		slotType = _cpDescription & J9_CP_DESCRIPTION_MASK;
 		slotPtr = _cpEntry;
 
-		/* If _condyOnly is TRUE, return the next constant dynamic slot in constant pool
-		 * Otherwise return the next object */
-		if (_condyOnly) {
-			/* Determine if the slot is constant dynamic */
-			if (slotType == J9CPTYPE_CONSTANT_DYNAMIC) {
-				if (NULL != (result = _constantDynamicSlotIterator.nextSlot(slotPtr))) {
-					/* Do not progress through the function.
-					 * Avoids advancing the slot while a constant dynamic is being iterated */
-					return result;
-				}
+		/* Determine if the slot should be processed */
+		switch (slotType) {
+		case J9CPTYPE_STRING: /* fall through */
+		case J9CPTYPE_ANNOTATION_UTF8:
+			result = &(((J9RAMStringRef *) slotPtr)->stringObject);
+			break;
+		case J9CPTYPE_METHOD_TYPE:
+			result = &(((J9RAMMethodTypeRef *) slotPtr)->type);
+			break;
+		case J9CPTYPE_METHODHANDLE:
+			result = &(((J9RAMMethodHandleRef *) slotPtr)->methodHandle);
+			break;
+		case J9CPTYPE_CONSTANT_DYNAMIC:
+			if (NULL != (result = _constantDynamicSlotIterator.nextSlot(slotPtr))) {
+				/* Do not progress through the function.
+				 * Avoids advancing the slot while a constant dynamic is being iterated */
+				return result;
 			}
-		} else {
-			/* Determine if the slot should be processed */
-			switch (slotType) {
-			case J9CPTYPE_STRING: /* fall through */
-			case J9CPTYPE_ANNOTATION_UTF8:
-				result = &(((J9RAMStringRef *) slotPtr)->stringObject);
-				break;
-			case J9CPTYPE_METHOD_TYPE:
-				result = &(((J9RAMMethodTypeRef *) slotPtr)->type);
-				break;
-			case J9CPTYPE_METHODHANDLE:
-				result = &(((J9RAMMethodHandleRef *) slotPtr)->methodHandle);
-				break;
-			case J9CPTYPE_CONSTANT_DYNAMIC:
-				if (NULL != (result = _constantDynamicSlotIterator.nextSlot(slotPtr))) {
-					/* Do not progress through the function.
-					 * Avoids advancing the slot while a constant dynamic is being iterated */
-					return result;
-				}
-				break;
-			default:
-				break;
-			}
-
+			break;
+		default:
+			break;
 		}
 
 		/* Adjust the CP slot and description information */

--- a/runtime/gc_structs/ConstantPoolObjectSlotIterator.hpp
+++ b/runtime/gc_structs/ConstantPoolObjectSlotIterator.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,28 +53,19 @@ class GC_ConstantPoolObjectSlotIterator
 	U_32 *_cpDescriptionSlots;
 	U_32 _cpDescription;
 	UDATA _cpDescriptionIndex;
-	bool _condyOnly;
-	bool _condyEnabled;
 	GC_ConstantDynamicSlotIterator _constantDynamicSlotIterator;
 
 public:
 
-	GC_ConstantPoolObjectSlotIterator(J9JavaVM *vm, J9Class *clazz, bool condyOnly = false) :
+	GC_ConstantPoolObjectSlotIterator(J9JavaVM *vm, J9Class *clazz) :
 		_cpEntry((j9object_t *)J9_CP_FROM_CLASS(clazz)),
 		_cpEntryCount(clazz->romClass->ramConstantPoolCount),
 		_constantDynamicSlotIterator()
 	{
-		_condyOnly = condyOnly;
 		_cpEntryTotal = _cpEntryCount;
 		if(_cpEntryCount) {
 			_cpDescriptionSlots = SRP_PTR_GET(&clazz->romClass->cpShapeDescription, U_32 *);
 			_cpDescriptionIndex = 0;
-		}
-		/* Check if the system is condy-enabled */
-		if (J2SE_VERSION(vm) < J2SE_V11) {
-			_condyEnabled = false;
-		} else {
-			_condyEnabled = true;
 		}
 	};
 


### PR DESCRIPTION
	Remove _condyOnly and _condyEnabled from
	 GC_ConstantPoolObjectSlotIterator
	Scan whole class objects(classStatics,constantPoolObject,
	callSites, methodTypes, varHandlesMethodTypes, valueTypesIterator)
	during Scavenge.
	Replace poisonConstantPoolObjects(), poisonStaticClassSlots()
	 with poisonClass() for ReadBarrierVerifier.
	(only the class, which contains the object references are in
	nursery, will be scaned)

fix: https://github.com/eclipse/openj9/issues/7486

Signed-off-by: Lin Hu <linhu@ca.ibm.com>