### PR TITLE
Fix compiler issues with SCC hint pointers

### DIFF
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -164,26 +164,26 @@ TR_J9SharedCache::log(char *format, ...)
    JITRT_UNLOCK_LOG(jitConfig());
    }
 
-uint32_t
+TR_J9SharedCache::SCCHint
 TR_J9SharedCache::getHint(J9VMThread * vmThread, J9Method *method)
    {
-   uint32_t result = 0;
+   SCCHint result;
 
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 
-   unsigned char storeBuffer[4];
-   uint32_t bufferLength = 4;
    J9SharedDataDescriptor descriptor;
-   descriptor.address = storeBuffer;
-   descriptor.length = bufferLength;
+   descriptor.address = (U_8 *)&result;
+   descriptor.length = sizeof(result);
    descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
    descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
    IDATA dataIsCorrupt;
-   uint32_t *find = (uint32_t *)sharedCacheConfig()->findAttachedData(vmThread, romMethod, &descriptor, &dataIsCorrupt);
+   SCCHint *find = (SCCHint *)sharedCacheConfig()->findAttachedData(vmThread, romMethod, &descriptor, &dataIsCorrupt);
 
-   if ((find == (uint32_t *)descriptor.address) && (dataIsCorrupt == -1))
-      result = *find;
+   if ((find != (SCCHint *)descriptor.address) || (dataIsCorrupt != -1))
+      {
+      result.clear();
+      }
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    return result;
    }
@@ -197,8 +197,8 @@ TR_J9SharedCache::getAllEnabledHints(J9Method *method)
       {
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
       J9VMThread * vmThread = fej9->getCurrentVMThread();
-      uint32_t scHints = getHint(vmThread, method);
-      hintFlags = *((uint16_t *)&scHints) & _hintsEnabledMask;
+      SCCHint scHints = getHint(vmThread, method);
+      hintFlags = scHints.flags & _hintsEnabledMask;
       }
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    return hintFlags;
@@ -217,20 +217,19 @@ TR_J9SharedCache::isHint(J9Method *method, TR_SharedCacheHint theHint, uint16_t 
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
       J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
       J9VMThread * vmThread = fej9->getCurrentVMThread();
-      uint32_t scHints = getHint(vmThread, method);
-      uint16_t hintFlags = *((uint16_t *)&scHints);
+      SCCHint scHints = getHint(vmThread, method);
 
       if (dataField)
-         *dataField = *(((uint16_t *)&scHints) + 1);
+         *dataField = scHints.data;
 
       if (_verboseHints)
          {
          char methodSignature[500];
          int32_t maxSignatureLength = 500;
          fej9->printTruncatedSignature(methodSignature, maxSignatureLength, (TR_OpaqueMethodBlock *) method);
-         TR_VerboseLog::writeLineLocked(TR_Vlog_SCHINTS,"is hint %x(%x) %s", hintFlags, hint, methodSignature);
+         TR_VerboseLog::writeLineLocked(TR_Vlog_SCHINTS,"is hint %x(%x) %s", scHints.flags, hint, methodSignature);
          }
-      isHint = (hintFlags & hint) != 0;
+      isHint = (scHints.flags & hint) != 0;
       }
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    return isHint;
@@ -271,24 +270,21 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
       // won't be registered. The affect, however is minimal, and likely to correct itself in the current run
       // (if the inlining hint is missed) or a subsequent run (if the other hint is missed).
 
-      uint32_t scHintData = getHint(vmThread, method);
-      uint16_t *hintFlags = (uint16_t *)&scHintData;
-      uint16_t *hintCount = ((uint16_t *)&scHintData) + 1; // Flags and new count field needs to be in contiguous location to be stored into sharecache
+      SCCHint scHints = getHint(vmThread, method);
+      const uint32_t scHintDataLength = sizeof(scHints);
 
-      const uint32_t scHintDataLength = sizeof(scHintData);
-
-      if (scHintData == 0) // If no prior hints exist, we can perform a "storeAttachedData" operation
+      if (scHints.flags == 0) // If no prior hints exist, we can perform a "storeAttachedData" operation
          {
          uint32_t bytesToPersist = 0;
  
          if (!SCfull)
             {
-            *hintFlags |= newHint;
+            scHints.flags |= newHint;
             if (isFailedValidationHint)
-               *hintCount = 10 * _initialHintSCount;
+               scHints.data = 10 * _initialHintSCount;
 
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8 *)hintFlags;
+            descriptor.address = (U_8 *)&scHints;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -297,7 +293,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
             if (store == 0)
                {
                if (_verboseHints)
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_SCHINTS,"hint added 0x%x, key = %s, scount: %d", *hintFlags, methodSignature, *hintCount);
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_SCHINTS,"hint added 0x%x, key = %s, scount: %d", scHints.flags, methodSignature, scHints.data);
                }
             else if (store != J9SHR_RESOURCE_STORE_FULL)
                {
@@ -327,25 +323,25 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
       else // Some hints already exist for this method. We must perform an "updateAttachedData"
          {
          bool updateHint = false;
-         bool hintDidNotExist = ((newHint & *hintFlags) == 0);
+         bool hintDidNotExist = ((newHint & scHints.flags) == 0);
          if (hintDidNotExist)
             {
             updateHint = true;
-            *hintFlags |= newHint;
+            scHints.flags |= newHint;
             if (isFailedValidationHint)
-               *hintCount = 10 * _initialHintSCount;
+               scHints.data = 10 * _initialHintSCount;
             }
          else 
             {
             // hint already exists, but maybe we need to update the count
             if (isFailedValidationHint)
                {
-               uint16_t oldCount = *hintCount;
+               uint16_t oldCount = scHints.data;
                uint16_t newCount = std::min(oldCount * 10, TR_DEFAULT_INITIAL_COUNT);
                if (newCount != oldCount)
                   {
                   updateHint = true;
-                  *hintCount = newCount;
+                  scHints.data = newCount;
                   }
                else
                   {
@@ -359,7 +355,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
          if (updateHint)
             {
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8 *)hintFlags;
+            descriptor.address = (U_8 *)&scHints;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -369,7 +365,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
                {
                if (update == 0)
                   {
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_SCHINTS,"hint updated 0x%x, key = %s, scount: %d", *hintFlags, methodSignature, *hintCount);
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_SCHINTS,"hint updated 0x%x, key = %s, scount: %d", scHints.flags, methodSignature, scHints.data);
                   }
                else
                   {

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -139,19 +139,28 @@ public:
       J9_SHARED_CACHE_FAILED_TO_ALLOCATE,
       SHARED_CACHE_STORE_ERROR,
       SHARED_CACHE_FULL,
-      // The following are probably equivalent to SHARED_CACHE_FULL - 
+      // The following are probably equivalent to SHARED_CACHE_FULL -
       // they could have failed because of no space but no error code is returned.
       SHARED_CACHE_CLASS_CHAIN_STORE_FAILED,
       AOT_HEADER_STORE_FAILED
       };
-   
+
    static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { _sharedCacheState = state; }
    static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { return _sharedCacheState; }
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo);
    static void setStoreSharedDataFailedLength(UDATA length) {_storeSharedDataFailedLength = length; }
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
-   
+
 private:
+   // This class is intended to be a POD; keep it simple.
+   struct SCCHint
+      {
+      SCCHint() : flags(0), data(0) {}
+      void clear() { flags = 0; data = 0; }
+      uint16_t flags;
+      uint16_t data;
+      };
+
    J9JITConfig *jitConfig() { return _jitConfig; }
    J9JavaVM *javaVM() { return _javaVM; }
    TR_J9VMBase *fe() { return _fe; }
@@ -161,7 +170,7 @@ private:
 
    void log(char *format, ...);
 
-   uint32_t getHint(J9VMThread * vmThread, J9Method *method);
+   SCCHint getHint(J9VMThread * vmThread, J9Method *method);
 
    void convertUnsignedOffsetToASCII(UDATA offset, char *myBuffer);
    void createClassKey(UDATA classOffsetInCache, char *key, uint32_t & keyLength);
@@ -193,25 +202,25 @@ private:
 
    uint32_t _logLevel;
    bool _verboseHints;
-   
+
    static TR_J9SharedCacheDisabledReason _sharedCacheState;
    static TR_YesNoMaybe                  _sharedCacheDisabledBecauseFull;
    static UDATA                          _storeSharedDataFailedLength;
    };
 
 
-#if defined(JITSERVER_SUPPORT)                                                                                                                                                                               
-/**                                                                                                                                                                                                          
-* @class TR_J9JITServerSharedCache                                                                                                                                                                           
-* @brief Class used by JITServer for querying client-side SharedCache information                                                                                                                            
-*                                                                                                                                                                                                            
-* This class is an extension of the TR_J9SharedCache class which overrides a number                                                                                                                          
-* of TR_J9SharedCache's APIs. TR_J9JITServerSharedCache is used by JITServer and                                                                                                                             
-* the overridden APIs mostly send remote messages to JITClient to query information from                                                                                                                     
-* the TR_J9SharedCache on the client. The information is needed for JITServer to                                                                                                                             
-* compile code that is compatible with the client-side VM. To minimize the                                                                                                                                   
-* number of remote messages as a way to optimize JITServer performance, a                                                                                                                                    
-* lot of client-side TR_J9SharedCache information are cached on JITServer.                                                                                                                                   
+#if defined(JITSERVER_SUPPORT)
+/**
+* @class TR_J9JITServerSharedCache
+* @brief Class used by JITServer for querying client-side SharedCache information
+*
+* This class is an extension of the TR_J9SharedCache class which overrides a number
+* of TR_J9SharedCache's APIs. TR_J9JITServerSharedCache is used by JITServer and
+* the overridden APIs mostly send remote messages to JITClient to query information from
+* the TR_J9SharedCache on the client. The information is needed for JITServer to
+* compile code that is compatible with the client-side VM. To minimize the
+* number of remote messages as a way to optimize JITServer performance, a
+* lot of client-side TR_J9SharedCache information are cached on JITServer.
 */
 
 class TR_J9JITServerSharedCache : public TR_J9SharedCache
@@ -235,12 +244,12 @@ public:
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL) override { TR_ASSERT(false, "called"); return false;}
 
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptrj_t *chainData, void *classLoader) override { TR_ASSERT(false, "called"); return NULL;}
-   
+
    static void setSharedCacheDisabledReason(TR_J9SharedCacheDisabledReason state) { TR_ASSERT(false, "called"); }
    static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { TR_ASSERT(false, "called"); return TR_J9SharedCache::TR_J9SharedCacheDisabledReason::UNINITIALIZED;}
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo) { TR_ASSERT(false, "called"); return TR_no;}
    static void setStoreSharedDataFailedLength(UDATA length) { TR_ASSERT(false, "called"); }
-   
+
    virtual uintptrj_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz) override;
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();


### PR DESCRIPTION
Certain versions of XL C/C++ generate incorrect
code when accessing the individual fields of a
uint32_t SCC hint stored in a local variable via
uint16_t pointers.

As a result of this behaviour we sometimes write
corrupt hints to the SCC (specifically the previous
content of the stack location the hint variable is
mapped to), which can cause performance problems.

The problem was thought to be fixed by

cda6447d9d9698f1a1c531f979e8a5f8a2077634

but that turned out to be insufficient.

This patch introduces a struct with named uint16_t
fields to represent the hint and simplifies some
of the associated code. The struct is returned by
value and because of its size, the types of its
members, its trivial copy-ctor and dtor, etc. it
should be returned in a single register on many
ABIs, making it equivalent to the old code in most
cases.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>

This addresses part of the start-up performance problem
discussed in #7459.