### PR TITLE
Remove deprecated Shift and Shift Logical unsigned ILOpcodes

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -780,15 +780,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::getstack
    NULL,          // TR::dealloca
 
-   NULL,          // TR::ishfl
-   NULL,          // TR::lshfl
-   NULL,          // TR::iushfl
-   NULL,          // TR::lushfl
-   NULL,          // TR::bshfl
-   NULL,          // TR::sshfl
-   NULL,          // TR::bushfl
-   NULL,          // TR::sushfl
-
    NULL,          // TR::idoz
 
    NULL,          // TR::dcos

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -614,7 +614,6 @@ static const char * nvvmOpCodeNames[] =
    "sub",         // TR::busub
    "sub",         // TR::iuneg
    "sub",         // TR::luneg
-   "shl",         // TR::lushl
    "fptoui",      // TR::f2iu
    "fptoui",      // TR::f2lu
    "fptoui",      // TR::f2bu

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -614,7 +614,6 @@ static const char * nvvmOpCodeNames[] =
    "sub",         // TR::busub
    "sub",         // TR::iuneg
    "sub",         // TR::luneg
-   "shl",         // TR::iushl
    "shl",         // TR::lushl
    "fptoui",      // TR::f2iu
    "fptoui",      // TR::f2lu


### PR DESCRIPTION
Clean up remnants of the following unsigned ILOpcodes from OpenJ9:
- `cshl` `iushl` `lushl`
- `ishfl` `lshfl` `iushfl` `lushfl` `bshfl` `sshfl` `bushfl` `sushfl`
The above ILOpcodes will be completely removed from OpenJ9 after this PR.

*Note that this PR needs to be merged with eclipse/omr#4522 simultaneously.

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com