### PR TITLE
Remove the unnecessary assert on checking TR_AOT

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2632,7 +2632,6 @@ J9::CodeGenerator::processRelocations()
 
    int32_t missedSite = -1;
 
-   TR_ASSERT_FATAL(self()->comp()->compileRelocatableCode() == self()->comp()->getOption(TR_AOT), "compileRelocatableCode() has different result from getOption(TR_AOT)");
    if (self()->comp()->compileRelocatableCode())
       {
       uint32_t inlinedCallSize = self()->comp()->getNumInlinedCallSites();


### PR DESCRIPTION
The original assert checks if `compileRelocatableCode()` and `getOption(TR_AOT)`renders the same result. `compileRelocatableCode()` is basically a wrapper of `fej9()->isAOT_DEPRECATED_DO_NOT_USE()`. If `fej9()->isAOT_DEPRECATED_DO_NOT_USE()` is true,
option bit `TR_AOT` will be set to true in `CompilationInfoPerThreadBase::wrappedCompile()`.
Therefore, the results should alway match. No need to add the assert.

This is a mirrored change of #7649 on the master branch. 

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>