### PR TITLE
Update definition of J9CONST to avoid quotes

### DIFF
--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -39,19 +39,14 @@ static jint
 writeHeader(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 {
 	jint rc = JNI_OK;
-	char const *changequote = "changequote({,})dnl\n";
-	char const *j9Const = "define({J9CONST},{{$1}ifelse($2,,,{{($2}ifelse($3,,,{,$3}){)}})})dnl\n";
-	if (0 != omrfile_write_text(fd, changequote, strlen(changequote))) {
-fail:
-		omrtty_printf("ERROR: Failed to write changequote\n");
+	char const *headertext =
+		"changequote({,})dnl\n"
+		"define({J9CONST},{define({$1},{{$2}ifelse($}{#,0,,($}{@))})})dnl\n";
+
+	if (0 != omrfile_write_text(fd, headertext, strlen(headertext))) {
 		rc = JNI_ERR;
-		goto done;
-	}
-	if (0 != omrfile_write_text(fd, j9Const, strlen(j9Const))) {
-		goto fail;
 	}
 
-done:
 	return rc;
 }
 
@@ -70,7 +65,7 @@ static IDATA
 createConstant(OMRPortLibrary *OMRPORTLIB, char const *name, UDATA value)
 {
 	if (values) {
-		return omrstr_printf(line, sizeof(line), "define({%s},{J9CONST(%zu,$1,$2)})dnl\n", name, value);
+		return omrstr_printf(line, sizeof(line), "J9CONST({%s},%zu)dnl\n", name, value);
 	}
 #if defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_ARM)
 	return omrstr_printf(line, sizeof(line), "#define %s %zu\n", name, value);

--- a/runtime/oti/arm64helpers.m4
+++ b/runtime/oti/arm64helpers.m4
@@ -20,7 +20,7 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exc
 
 include(jilvalues.m4)
 
-define({CINTERP_STACK_SIZE},{J9CONST(J9TR_cframe_sizeof,$1,$2)})
+J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 ifelse(eval(CINTERP_STACK_SIZE % 16),0,,{ERROR stack size CINTERP_STACK_SIZE is not 16-aligned})
 
 define({ALen},{8})

--- a/runtime/oti/armhelpers.m4
+++ b/runtime/oti/armhelpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 1991, 2017 IBM Corp. and others
+dnl Copyright (c) 1991, 2019 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exc
 
 include(jilvalues.m4)
 
-define({CINTERP_STACK_SIZE},{J9CONST(J9TR_cframe_sizeof,$1,$2)})
+J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 ifelse(eval(CINTERP_STACK_SIZE % 8),0,,{ERROR stack size CINTERP_STACK_SIZE is not 8-aligned})
 
 ifdef({ASM_J9VM_ENV_DATA64},{

--- a/runtime/oti/phelpers.m4
+++ b/runtime/oti/phelpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 1991, 2018 IBM Corp. and others
+dnl Copyright (c) 1991, 2019 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,7 @@ define({fp29},29)
 define({fp30},30)
 define({fp31},31)
 
-define({CINTERP_STACK_SIZE},{J9CONST(J9TR_cframe_sizeof,$1,$2)})
+J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 
 ifdef({ASM_J9VM_ENV_DATA64},{
 
@@ -100,7 +100,7 @@ define({staddrx},stdx)
 define({staddru},stdu)
 define({cmpliaddr},{cmpli 0,1,})
 define({ADDR},.llong)
-define({ALen},{J9CONST(8,$1,$2)})
+J9CONST({ALen},8)
 define({J9VMTHREAD},{r15})
 
 },{ dnl ASM_J9VM_ENV_DATA64
@@ -115,7 +115,7 @@ define({staddrx},stwx)
 define({staddru},stwu)
 define({cmpliaddr},{cmpli 0,0,})
 define({ADDR},.long)
-define({ALen},{J9CONST(4,$1,$2)})     
+J9CONST({ALen},4)
 
 define({J9VMTHREAD},{r13})
 
@@ -183,14 +183,14 @@ define({CALL_DIRECT},{
 	cror 31,31,31
 })
 
-define({TOC_SAVE_OFFSET},{J9CONST(J9TR_cframe_currentTOC,$1,$2)})
+J9CONST({TOC_SAVE_OFFSET},J9TR_cframe_currentTOC)
 define({SAVE_R13})
 define({GPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedGPRs+((($1)-13)*ALen))})
 define({GPR_SAVE_SLOT},{GPR_SAVE_OFFSET($1)(r1)})
 define({FPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedFPRs+((($1)-14)*8))})
 define({FPR_SAVE_SLOT},{FPR_SAVE_OFFSET($1)(r1)})
-define({CR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR),$1,$2)})
-define({LR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR),$1,$2)})
+J9CONST({CR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR))
+J9CONST({LR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR))
 
 },{ dnl AIXPPC
 
@@ -238,13 +238,13 @@ define({START_PROC},{
 
 define({END_PROC})
 
-define({TOC_SAVE_OFFSET},{J9CONST(J9TR_cframe_currentTOC,$1,$2)})
+J9CONST({TOC_SAVE_OFFSET},J9TR_cframe_currentTOC)
 define({GPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedGPRs+((($1)-14)*ALen))})
 define({GPR_SAVE_SLOT},{GPR_SAVE_OFFSET($1)(r1)})
 define({FPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedFPRs+((($1)-14)*8))})
 define({FPR_SAVE_SLOT},{FPR_SAVE_OFFSET($1)(r1)})
-define({CR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR),$1,$2)})
-define({LR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR),$1,$2)})
+J9CONST({CR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR))
+J9CONST({LR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR))
 
 },{ dnl ASM_J9VM_ENV_LITTLE_ENDIAN
 
@@ -302,13 +302,13 @@ define({START_PROC},{
 
 define({END_PROC})
 
-define({TOC_SAVE_OFFSET},{J9CONST(J9TR_cframe_currentTOC,$1,$2)})
+J9CONST({TOC_SAVE_OFFSET},J9TR_cframe_currentTOC)
 define({GPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedGPRs+((($1)-14)*ALen))})
 define({GPR_SAVE_SLOT},{GPR_SAVE_OFFSET($1)(r1)})
 define({FPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedFPRs+((($1)-14)*8))})
 define({FPR_SAVE_SLOT},{FPR_SAVE_OFFSET($1)(r1)})
-define({CR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR),$1,$2)})
-define({LR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR),$1,$2)})
+J9CONST({CR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR))
+J9CONST({LR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR))
 
 define({CALL_DIRECT},{
 	ld FUNC_PTR, .tocL_$1@toc(r2)
@@ -361,12 +361,12 @@ define({SAVE_R29_FOR_ALL})
 define({RESTORE_R29_FOR_ALL})
 
 define({SAVE_R13})
-define({CR_SAVE_OFFSET},{J9CONST(J9TR_cframe_preservedCR,$1,$2)})
+J9CONST({CR_SAVE_OFFSET},J9TR_cframe_preservedCR)
 define({GPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedGPRs+((($1)-13)*ALen))})
 define({GPR_SAVE_SLOT},{GPR_SAVE_OFFSET($1)(r1)})
 define({FPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedFPRs+((($1)-14)*8))})
 define({FPR_SAVE_SLOT},{FPR_SAVE_OFFSET($1)(r1)})
-define({LR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR),$1,$2)})
+J9CONST({LR_SAVE_OFFSET},eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR))
 
 }) dnl ASM_J9VM_ENV_DATA64
 }) dnl AIXPPC
@@ -386,9 +386,9 @@ define({JIT_GPR_SAVE_OFFSET},{eval(J9TR_cframe_jitGPRs+(($1)*ALen))})
 define({JIT_GPR_SAVE_SLOT},{JIT_GPR_SAVE_OFFSET($1)(r1)})
 define({JIT_FPR_SAVE_OFFSET},{eval(J9TR_cframe_jitFPRs+(($1)*8))})
 define({JIT_FPR_SAVE_SLOT},{JIT_FPR_SAVE_OFFSET($1)(r1)})
-define({JIT_CR_SAVE_OFFSET},{J9CONST(J9TR_cframe_jitCR,$1,$2)})
+J9CONST({JIT_CR_SAVE_OFFSET},J9TR_cframe_jitCR)
 define({JIT_CR_SAVE_SLOT},{JIT_CR_SAVE_OFFSET(r1)})
-define({JIT_LR_SAVE_OFFSET},{J9CONST(J9TR_cframe_jitLR,$1,$2)})
+J9CONST({JIT_LR_SAVE_OFFSET},J9TR_cframe_jitLR)
 define({JIT_LR_SAVE_SLOT},{JIT_LR_SAVE_OFFSET(r1)})
 
 define({SAVE_LR},{

--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -20,7 +20,7 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exc
 
 include(jilvalues.m4)
 
-define({CINTERP_STACK_SIZE},{J9CONST(J9TR_cframe_sizeof,$1,$2)})
+J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 
 ifdef({WIN32},{
 

--- a/runtime/oti/zhelpers.m4
+++ b/runtime/oti/zhelpers.m4
@@ -20,7 +20,7 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exc
 
 include(jilvalues.m4)
 
-define({CINTERP_STACK_SIZE},{J9CONST(J9TR_cframe_sizeof,$1,$2)})
+J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 
 define({r0},0)
 define({r1},1)
@@ -182,7 +182,7 @@ define({CARG2},2)
 define({CARG3},3)
 define({CRA},7)
 define({CRINT},3)
-define({STACK_BIAS},{J9CONST(2048,$1,$2)})
+J9CONST({STACK_BIAS},2048)
 define({LABEL_NAME},{translit({$*},{a-z},{A-Z})})
 define({PLACE_LABEL},{
 LABEL_NAME($1) DS 0H
@@ -347,12 +347,12 @@ CONCAT(PPA,TAGGED_SHORT) DS 0F
     DC CONCAT(CL,len(TAGGED_SHORT))'TAGGED_SHORT'
 })
 
-define({ARG_SAVE_OFFSET},{J9CONST(eval(STACK_BIAS+J9TR_cframe_argRegisterSave),$1,$2)})
-define({OUTGOING_ARG_OFFSET},{J9CONST(eval(ARG_SAVE_OFFSET+(4*J9TR_pointerSize)),$1,$2)})
+J9CONST({ARG_SAVE_OFFSET},eval(STACK_BIAS+J9TR_cframe_argRegisterSave))
+J9CONST({OUTGOING_ARG_OFFSET},eval(ARG_SAVE_OFFSET+(4*J9TR_pointerSize)))
 define({FPR_SAVE_OFFSET},{eval(STACK_BIAS+J9TR_cframe_preservedFPRs+(($1)*8))})
 define({VR_SAVE_OFFSET},{eval(STACK_BIAS+J9TR_cframe_preservedVRs+(($1)*16))})
 ifdef({ASM_J9VM_PORT_ZOS_CEEHDLRSUPPORT},{
-define({CEEHDLR_FPC_SAVE_OFFSET},{J9CONST(eval(STACK_BIAS+J9TR_cframe_fpcCEEHDLR),$1,$2)})
+J9CONST({CEEHDLR_FPC_SAVE_OFFSET},eval(STACK_BIAS+J9TR_cframe_fpcCEEHDLR))
 define({CEEHDLR_GPR_SAVE_OFFSET},{eval(STACK_BIAS+J9TR_cframe_gprCEEHDLR+(($1)*J9TR_pointerSize))})
 })
 
@@ -366,7 +366,7 @@ define({CARG2},3)
 define({CARG3},4)
 define({CRA},14)
 define({CRINT},2)
-define({STACK_BIAS},{J9CONST(0,$1,$2)})
+J9CONST({STACK_BIAS}, 0)
 define({LABEL_NAME},{.$1})
 define({PLACE_LABEL},{
 LABEL_NAME($1):


### PR DESCRIPTION
Avoid using quotes to allow compatability with the s390 jit m4 assembly
which uses the [ and ] as quote characters rather than { and }. This new
version of J9CONST is not perfect as it can fail if the first argument
is a macro which could be expanded. However this is not possible with
the current usage as the first arguemnt will always be a UDATA value

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>