### PR TITLE
Migrate Cachemanagement test project

### DIFF
--- a/test/functional/CacheManagement/.settings/org.eclipse.jdt.ui.prefs
+++ b/test/functional/CacheManagement/.settings/org.eclipse.jdt.ui.prefs
@@ -1,0 +1,3 @@
+#Tue Jul 03 11:07:55 BST 2007
+eclipse.preferences.version=1
+internal.default.compliance=default

--- a/test/functional/CacheManagement/.settings/org.eclipse.jdt.ui.prefs
+++ b/test/functional/CacheManagement/.settings/org.eclipse.jdt.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 03 11:07:55 BST 2007
-eclipse.preferences.version=1
-internal.default.compliance=default

--- a/test/functional/CacheManagement/CacheManagement.mk
+++ b/test/functional/CacheManagement/CacheManagement.mk
@@ -1,0 +1,17 @@
+export DFLT_CONFIG_FILE=-Dtest.target.config=config.defaults
+export RT_CONFIG_FILE=-Dtest.target.config=config.realtime.defaults
+export REALTIME_PLATFORM=FALSE
+
+ifeq ("$(PLATFORM)","linux_x86-32_hrt")
+export DFLT_CONFIG_FILE=$(RT_CONFIG_FILE)
+export REALTIME_PLATFORM=TRUE
+endif
+
+SYSV_CLEANUP :=perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all
+ifeq ("$(PLATFORM)", "wind") 
+	SYSV_CLEANUP := ""
+else ifeq ("$(PLATFORM)", "aix") 
+	SYSV_CLEANUP :=perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all aix
+else ifeq ("$(PLATFORM)", "zos") 
+	SYSV_CLEANUP :=perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos
+endif

--- a/test/functional/CacheManagement/CacheManagement.mk
+++ b/test/functional/CacheManagement/CacheManagement.mk
@@ -2,16 +2,16 @@ export DFLT_CONFIG_FILE=-Dtest.target.config=config.defaults
 export RT_CONFIG_FILE=-Dtest.target.config=config.realtime.defaults
 export REALTIME_PLATFORM=FALSE
 
-ifeq ("$(PLATFORM)","linux_x86-32_hrt")
+ifeq ("$(SPEC)","linux_x86-32_hrt")
 export DFLT_CONFIG_FILE=$(RT_CONFIG_FILE)
 export REALTIME_PLATFORM=TRUE
 endif
 
 SYSV_CLEANUP :=perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all
-ifeq ("$(PLATFORM)", "wind") 
+ifneq (,$(findstring win,$(SPEC)))
 	SYSV_CLEANUP := ""
-else ifeq ("$(PLATFORM)", "aix") 
+else ifneq (,$(findstring aix,$(SPEC)))
 	SYSV_CLEANUP :=perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all aix
-else ifeq ("$(PLATFORM)", "zos") 
+else ifneq (,$(findstring zos,$(SPEC)))
 	SYSV_CLEANUP :=perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos
 endif

--- a/test/functional/CacheManagement/CacheManagement.mk
+++ b/test/functional/CacheManagement/CacheManagement.mk
@@ -1,3 +1,24 @@
+##############################################################################
+#  Copyright (c) 2019, 2019 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
 export DFLT_CONFIG_FILE=-Dtest.target.config=config.defaults
 export RT_CONFIG_FILE=-Dtest.target.config=config.realtime.defaults
 export REALTIME_PLATFORM=FALSE

--- a/test/functional/CacheManagement/CacheManagement_win.xml
+++ b/test/functional/CacheManagement/CacheManagement_win.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+<suite id="CacheManagementTests launcher">
+
+	<!-- running locally we expect TEST_JAVA_HOME to be supplied, running on nescafe we will not be using it and rely on TESTBASE -->
+	<if testVariable="TEST_JAVA_HOME" testValue="" resultVariable="TEST_JAVA_HOME" resultValue="./testjdk/$BUILDNAME$/sdk"/>
+	<if testVariable="REFJAVAEXE" testValue="" resultVariable="REFJAVAEXE" resultValue="./refjdk/sdk/jre/bin/java"/>
+	
+	<variable name="JAVAEXE" value="$TEST_JAVA_HOME$/jre/bin/java"/>
+	<envvar name="JAVAEXE" value="$TEST_JAVA_HOME$/jre/bin/java"/>
+    <envvar name="JAVACEXE" value="$TEST_JAVA_HOME$/bin/javac"/>
+    <variable name="JAVACEXE" value="$TEST_JAVA_HOME$/bin/javac"/>
+    <variable name="TESTFOLDER" value="./testsuite60/SharedClasses/CacheManagement"/>
+	
+    <test id="Copy the resources across to the bin folder" timeout="600" runPath="$TESTFOLDER$">
+      <makedirectory value="bin"/>
+      <command>$JAVAEXE$ -classpath bin tests.sharedclasses.CopyResources src bin</command>
+      <return value="0"/>
+    </test>
+	
+    <test id="Create the config file" timeout="600" runPath="$TESTFOLDER$">
+      <command>$JAVAEXE$ -Dcachedir=c:/temp/testCacheDir -Dtestjava=$JAVAEXE$ -Drefjava=$REFJAVAEXE$ -classpath bin tests.sharedclasses.CreateConfig</command>
+      <return value="0"/>
+    </test>
+	
+    <test id="Run CacheManagement tests" timeout="600" runPath="$TESTFOLDER$">
+      <command>$JAVAEXE$ -Dconfig.properties=config.properties -classpath junit.jar;bin junit.textui.TestRunner tests.sharedclasses.options.junit.TestOptionsDefault</command>
+      <return value="0"/>
+    </test>
+</suite>

--- a/test/functional/CacheManagement/CacheManagement_win.xml
+++ b/test/functional/CacheManagement/CacheManagement_win.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright (c) 2010, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 <suite id="CacheManagementTests launcher">
 

--- a/test/functional/CacheManagement/build.xml
+++ b/test/functional/CacheManagement/build.xml
@@ -1,0 +1,68 @@
+<project name="CacheManagement" default="clean" basedir=".">
+	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+	<description>
+		Build CacheManagement Tests 
+	</description>
+	<import file="${TEST_ROOT}/functional/build.xml"/>
+	
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/CacheManagement" />
+	<property name="src" location="./src"/>
+	<property name="src_80" location="./src_80"/>
+	<property name="src_90_up" location="./src_90_up"/>
+	<property name="build" location="./bin"/>
+	<property name="testcodebuild" location="./testcodebuild"/>
+	
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+		<mkdir dir="${testcodebuild}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="./testcode" destdir="${testcodebuild}" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"/>
+		<javac srcdir="./testcode" destdir="${build}" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"/>
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}"/>
+			<classpath>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/junit4.jar" />
+			</classpath>
+		</javac>
+	</target>
+	<target name="dist" depends="compile" description="generate the distribution" >
+		<!-- CONFIG ARTEFACTS & TEST ARTEFACTS - move them to the build dir... -->	
+		<copy todir="${build}">
+			<fileset dir="./configs"/>
+			<fileset dir="./testcode"/>
+		</copy>
+		<jar jarfile="${build}/testcode.jar" filesonly="true">
+			<fileset dir="${testcodebuild}"/>
+		</jar>
+		<jar jarfile="${DEST}/CacheManagement.jar" filesonly="true">
+			<fileset dir="${build}"/>
+			<fileset dir="${src}"/>
+			<fileset dir="${src}/../" includes="*.properties,*.xml" />
+		</jar>
+		<jar jarfile="${DEST}/testcode.jar" filesonly="true">
+			<fileset dir="${testcodebuild}"/>
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.mk" />
+		</copy>
+	</target>
+    <target name="clean" depends="dist" description="clean up" >
+       <!-- Delete the ${build} directory trees -->
+       <delete dir="${build}"/>
+    </target>
+	
+    <target name="build">
+		<antcall target="clean" inheritall="true" />	
+    </target>
+</project>

--- a/test/functional/CacheManagement/build.xml
+++ b/test/functional/CacheManagement/build.xml
@@ -1,3 +1,25 @@
+<!--
+  Copyright (c) 2010, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
 <project name="CacheManagement" default="clean" basedir=".">
 	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
 	<description>

--- a/test/functional/CacheManagement/configs/config.defaults
+++ b/test/functional/CacheManagement/configs/config.defaults
@@ -1,0 +1,33 @@
+# commands 
+# %n% indicates an insert supplied for a particular command instance
+# %xx% indicates something replaced by a value elsewhere in this config file
+cmd.getCacheFileName=%java_exe% -Xshareclasses:printCacheFilename,name=%1%,persistent 
+cmd.getSnapshotFileName=%java_exe% -Xshareclasses:name=%1%,printSnapshotFilename
+cmd.getCacheFileNameNonPersist=%java_exe% -Xshareclasses:printCacheFilename,name=%1%,nonpersistent
+cmd.destroyCache=%java_exe% -Xshareclasses:name=%1%,destroy
+cmd.destroyPersistentCache=%java_exe% -Xshareclasses:name=%1%,destroy
+cmd.destroyNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,destroy
+cmd.destroyAllCaches=%java_exe% -Xshareclasses:destroyAll%1%
+cmd.destroyAllSnapshots=%java_exe% -Xshareclasses:destroyAllSnapshots%1%
+cmd.runSimpleJavaProgramWithPersistentCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,verbose -cp . SimpleApp
+cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,nonpersistent,verbose -cp . SimpleApp
+cmd.runSimpleJavaProgram=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,verbose -cp . SimpleApp
+cmd.listAllCaches=%java_exe% -Xshareclasses:listAllCaches%1%
+cmd.createNonPersistentCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,nonpersistent,verbose -cp . SimpleApp
+cmd.createCacheSnapshot=%java_exe% -Xshareclasses:name=%1%,nonpersistent,snapshotCache
+cmd.expireAllCaches=%java_exe% -Xshareclasses:expire=0,verbose%1% -cp . SimpleApp
+cmd.createIncompatibleCache=%java_exe% -Xshareclasses:name=%1%,verbose -cp . SimpleApp
+cmd.runPrintStats=%java_exe% -Xshareclasses:name=%1%,printStats%2%,verbose%3%
+cmd.runPrintAllStats=%java_exe% -Xshareclasses:name=%1%,printAllStats,verbose%2%
+cmd.runResetPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,verbose -cp . ResetApp
+cmd.runResetNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,nonpersistent,verbose -cp . ResetApp
+cmd.runComplexJavaProgram=%java_exe% -Xshareclasses:name=%1%,verbose -Dconfig.properties=%2% %apploc% tests.sharedclasses.options.TestCorruptedCaches04Helper %1% 
+cmd.runSimpleJavaProgramWithPersistentCachePlusOptions=%java_exe% -Xshareclasses:name=%1%,verbose  %2% -cp . SimpleApp
+cmd.runSimpleJavaProgramWithPersistentCacheCheckStringTable=%java_exe% -Xtrace:none=j9shr.1547 -Xshareclasses:name=%1%,verbose,checkStringTable,verboseIntern -cp . SimpleApp
+cmd.runInfiniteLoopJavaProgramWithPersistentCache=%java_exe% -Xshareclasses:name=%1%,verbose -cp . InfiniteLoop
+cmd.runInfiniteLoopJavaProgramWithNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -cp . InfiniteLoop
+cmd.expireAllCachesWithTime=%java_exe% -Xshareclasses:expire=%1%,verbose%2% -cp . SimpleApp
+cmd.runHanoiProgramWithCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xshareclasses:name=%1%,verbose %2% -cp utils.jar org.openj9.test.ivj.Hanoi 15
+cmd.runSimpleJavaProgramWithAgentWithPersistentCache=%java_exe% -Xshareclasses:name=%1%,verbose -agentlib:jvmtitest=test:%2%,args:%3% -cp . SimpleApp
+cmd.runSimpleJavaProgramWithAgentWithNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -agentlib:jvmtitest=test:%2%,args:%3% -cp . SimpleApp
+cmd.checkJavaVersion=%java_exe% -version

--- a/test/functional/CacheManagement/configs/config.defaults
+++ b/test/functional/CacheManagement/configs/config.defaults
@@ -4,6 +4,9 @@
 cmd.getCacheFileName=%java_exe% -Xshareclasses:printCacheFilename,name=%1%,persistent 
 cmd.getSnapshotFileName=%java_exe% -Xshareclasses:name=%1%,printSnapshotFilename
 cmd.getCacheFileNameNonPersist=%java_exe% -Xshareclasses:printCacheFilename,name=%1%,nonpersistent
+cmd.getCacheFileNameGroupAccess=%java_exe% -Xshareclasses:printCacheFilename,name=%1%,persistent,groupaccess
+cmd.getSnapshotFileNameGroupAccess=%java_exe% -Xshareclasses:name=%1%,printSnapshotFilename,groupaccess
+cmd.getCacheFileNameNonPersistGroupAccess=%java_exe% -Xshareclasses:printCacheFilename,name=%1%,nonpersistent,groupaccess
 cmd.destroyCache=%java_exe% -Xshareclasses:name=%1%,destroy
 cmd.destroyPersistentCache=%java_exe% -Xshareclasses:name=%1%,destroy
 cmd.destroyNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,destroy

--- a/test/functional/CacheManagement/configs/config.defaults
+++ b/test/functional/CacheManagement/configs/config.defaults
@@ -1,3 +1,24 @@
+##############################################################################
+#  Copyright (c) 2010, 2019 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
 # commands 
 # %n% indicates an insert supplied for a particular command instance
 # %xx% indicates something replaced by a value elsewhere in this config file

--- a/test/functional/CacheManagement/configs/config.realtime.defaults
+++ b/test/functional/CacheManagement/configs/config.realtime.defaults
@@ -1,0 +1,23 @@
+# commands 
+# %n% indicates an insert supplied for a particular command instance
+# %xx% indicates something replaced by a value elsewhere in this config file
+cmd.getCacheFileName=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,printCacheFilename,name=%1%,persistent 
+cmd.getCacheFileNameNonPersist=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,printCacheFilename,name=%1%,nonpersistent
+cmd.destroyCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:name=%1%,destroy
+cmd.destroyPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:name=%1%,destroy
+cmd.destroyNonPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:name=%1%,nonpersistent,destroy
+cmd.destroyAllCaches=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:destroyAll%1%
+cmd.runSimpleJavaProgramWithPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,verbose -cp . SimpleApp
+cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,nonpersistent,verbose -cp . SimpleApp
+cmd.runSimpleJavaProgram=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,verbose -cp . SimpleApp
+cmd.listAllCaches=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:listAllCaches%1%
+cmd.createNonPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,nonpersistent,verbose -cp . SimpleApp
+cmd.expireAllCaches=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:expire=0,verbose%1% -cp . SimpleApp
+cmd.createIncompatibleCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,verbose -cp . SimpleApp
+cmd.runPrintStats=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,printStats,verbose%2%
+cmd.runPrintAllStats=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,printAllStats,verbose%2%
+cmd.runResetPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,reset,verbose -cp . ResetApp
+cmd.runResetNonPersistentCache=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,reset,nonpersistent,verbose -cp . ResetApp
+cmd.runComplexJavaProgram=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:grow,name=%1%,verbose -Dconfig.properties=%2% %apploc% tests.sharedclasses.options.TestCorruptedCaches04Helper %1% 
+cmd.runSimpleJavaProgramWithPersistentCachePlusOptions=%java_exe% -Xtrace:maximal=j9shr -Xrealtime -Xshareclasses:name=%1%,verbose  %2% -cp . SimpleApp
+cmd.runInfiniteLoopJavaProgramWithPersistentCache=%java_exe% -Xrealtime -Xshareclasses:grow,name=%1%,verbose -cp . InfiniteLoop

--- a/test/functional/CacheManagement/configs/config.realtime.defaults
+++ b/test/functional/CacheManagement/configs/config.realtime.defaults
@@ -1,3 +1,24 @@
+##############################################################################
+#  Copyright (c) 2010, 2019 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
 # commands 
 # %n% indicates an insert supplied for a particular command instance
 # %xx% indicates something replaced by a value elsewhere in this config file

--- a/test/functional/CacheManagement/exclude.xml
+++ b/test/functional/CacheManagement/exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+<suite id="CacheManagement Excluded Test Case List">
+
+	
+</suite>

--- a/test/functional/CacheManagement/exclude.xml
+++ b/test/functional/CacheManagement/exclude.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright (c) 2010, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
 <!DOCTYPE suite SYSTEM "excludes.dtd">
 <?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
 <suite id="CacheManagement Excluded Test Case List">

--- a/test/functional/CacheManagement/playlist.xml
+++ b/test/functional/CacheManagement/playlist.xml
@@ -47,6 +47,47 @@
 		-DJAVA_TEST_COMMAND=$(Q)$(JAVA_COMMAND) $(JVM_OPTIONS)$(Q)\
 		-DJAVA5_HOME=$(JAVA_HOME) \
 		$(Q)-DTEST_JVM_OPTIONS=$(JVM_OPTIONS)$(Q) \
+		-cp $(Q)CacheManagement.jar$(P)$(LIB_DIR)$(D)junit4.jar$(Q) \
+		junit.textui.TestRunner tests.sharedclasses.options.junit.AllTests; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<platformRequirements>^os.win</platformRequirements>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+		<test>
+		<testCaseName>testSCCacheManagement_win</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+		$(SYSV_CLEANUP) ; \
+		cp $(Q)$(TEST_RESROOT)$(D)CacheManagement.jar$(Q) .; \
+		cp $(Q)$(LIB_DIR)$(D)junit4.jar$(Q) .; \
+		cp $(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) .; \
+		true CacheManagement.jar ; \
+		true junit4.jar ; \
+		true utils.jar ; \
+		$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf CacheManagement.jar; \
+		$(CONVERT_TO_EBCDIC_CMD) \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		$(DFLT_CONFIG_FILE) \
+		-agentlib:jvmtitest=test:sca001 \
+		-DREALTIME=$(REALTIME_PLATFORM) \
+		-DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) \
+		-DJAVA_TEST_COMMAND=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ)\
+		-DJAVA5_HOME=$(SQ)$(JAVA_HOME)$(SQ) \
+		$(Q)-DTEST_JVM_OPTIONS=$(JVM_OPTIONS)$(Q) \
 		-cp $(Q)CacheManagement.jar$(P)$(LIB_DIR)$(D)junit4.jar$Q \
 		junit.textui.TestRunner tests.sharedclasses.options.junit.AllTests; \
 	$(TEST_STATUS)</command>
@@ -59,6 +100,7 @@
 		<types>
 			<type>native</type>
 		</types>
+		<platformRequirements>os.win</platformRequirements>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/CacheManagement/playlist.xml
+++ b/test/functional/CacheManagement/playlist.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2016, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+	<include>CacheManagement.mk</include>
+	<test>
+		<testCaseName>testSCCacheManagement</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+		$(SYSV_CLEANUP) ; \
+		cp $(Q)$(TEST_RESROOT)$(D)CacheManagement.jar$(Q) .; \
+		cp $(Q)$(LIB_DIR)$(D)junit4.jar$(Q) .; \
+		cp $(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) .; \
+		true CacheManagement.jar ; \
+		true junit4.jar ; \
+		true utils.jar ; \
+		$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf CacheManagement.jar; \
+		$(CONVERT_TO_EBCDIC_CMD) \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		$(DFLT_CONFIG_FILE) \
+		-agentlib:jvmtitest=test:sca001 \
+		-DREALTIME=$(REALTIME_PLATFORM) \
+		-DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) \
+		-DJAVA_TEST_COMMAND=$(Q)$(JAVA_COMMAND) $(JVM_OPTIONS)$(Q)\
+		-DJAVA5_HOME=$(JAVA_HOME) \
+		$(Q)-DTEST_JVM_OPTIONS=$(JVM_OPTIONS)$(Q) \
+		-cp $(Q)CacheManagement.jar$(P)$(LIB_DIR)$(D)junit4.jar$Q \
+		junit.textui.TestRunner tests.sharedclasses.options.junit.AllTests; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/CacheManagement/playlist.xml
+++ b/test/functional/CacheManagement/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/functional/CacheManagement/readme.txt
+++ b/test/functional/CacheManagement/readme.txt
@@ -1,3 +1,25 @@
+<!--
+Copyright (c) 2010, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
 This project contains an infrastructure and tests for exercising the shared classes command line options.
 
 The infrastructure is all in 'tests.sharedclasses' and the most important class there is 

--- a/test/functional/CacheManagement/readme.txt
+++ b/test/functional/CacheManagement/readme.txt
@@ -1,0 +1,36 @@
+This project contains an infrastructure and tests for exercising the shared classes command line options.
+
+The infrastructure is all in 'tests.sharedclasses' and the most important class there is 
+TestUtils.  It provides a lot of infrastructure that subclasses can use.  The subclasses
+are in tests.sharedclasses.options and each of those is a single test, with a main method.
+They can all be invoked standalone.  However, they are also pulled together into a Junit
+testcase in 'tests.shared.options.junit'.  The TestOptionsBase class pulls together all
+the tests but is abstract - the further subtypes of TestOptionsBase are the real testcases
+but all they do is provide alternative setUp/tearDown methods that will run executed around
+each of the testcases in TestOptionsBase.  The testsuite AllTests pulls together the 
+variations of running the testcases.  For example, TestOptionsDefault runs all the tests
+letting the cache directory default whilst TestOptionsCacheDir runs all the tests whilst
+setting the cacheDir explicitly to a destination.
+
+When writing a testcase main method, the runXXX methods inherited from the superclass TestUtils
+will invoke a command, the output of the command is collected and can be examined directly or
+checked via helper checkOutputXXX methods.
+
+TestUtils currently distinguishes Windows from 'every other platform' - other distinctions may
+be required if running on further platforms.  The distinction is made due to differences in 
+how the control files manifest on windows and unix platforms.
+
+Some of the shared memory tests are also likely to be linux only.
+
+The testcode directory contains some simple classes that can be invoked by the commands that are
+spawned - if the testcode is changed, the testcode.jar file at the top level should be updated by
+running this command whilst in the testcode subdirectory:
+	jar -cvMf ../src/testcode.jar *
+The testcode jar is kept in the src tree so it can be treated as a java resource and will be
+found by a classloader lookup - meaning the user wont have to supply the path to it.
+	
+===
+The tests can be launched as JUnit tests and the five possible combinations are included as launch profiles here.
+You must edit the config.properties to choose the JVM that needs testing before you launch them.
+
+There is a lightweight cmdlinetester script that invokes JUnit and that is what is used on nescafe.

--- a/test/functional/CacheManagement/src/Temp.java
+++ b/test/functional/CacheManagement/src/Temp.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 public class Temp {
  // just here to test the compilation step in blah.xml
 }

--- a/test/functional/CacheManagement/src/Temp.java
+++ b/test/functional/CacheManagement/src/Temp.java
@@ -1,0 +1,3 @@
+public class Temp {
+ // just here to test the compilation step in blah.xml
+}

--- a/test/functional/CacheManagement/src/config.base.properties
+++ b/test/functional/CacheManagement/src/config.base.properties
@@ -1,0 +1,22 @@
+#### Should be no need to change these
+# commands 
+# %n% indicates an insert supplied for a particular command instance
+# %xx% indicates something replaced by a value elsewhere in this config file
+cmd.destroyCache=%java_exe% -Xshareclasses:name=%1%,destroy
+cmd.destroyPersistentCache=%java_exe% -Xshareclasses:name=%1%,destroy
+cmd.destroyNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,destroy
+cmd.destroyAllCaches=%java_exe% -Xshareclasses:destroyAll%1%
+cmd.runSimpleJavaProgramWithPersistentCache=%java_exe% -Xshareclasses:name=%1%,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.runSimpleJavaProgram=%java_exe% -Xshareclasses:name=%1%,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.destroyPersistentCache=%java_exe% -Xshareclasses:name=%1%,destroy
+cmd.listAllCaches=%java_exe% -Xshareclasses:listAllCaches%1%
+cmd.createNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.expireAllCaches=%java_exe% -Xshareclasses:expire=0,verbose%1% -classpath %apploc%/testcode.jar SimpleApp
+cmd.createIncompatibleCache=%java5_exe% -Xshareclasses:name=%1%,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.runPrintStats=%java_exe% -Xshareclasses:name=%1%,printStats,verbose%2%
+cmd.runPrintAllStats=%java_exe% -Xshareclasses:name=%1%,printAllStats,verbose%2%
+cmd.runResetPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,verbose -classpath %apploc%/testcode.jar ResetApp
+cmd.runResetNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.runComplexJavaProgram=%java_exe% -Xshareclasses:name=%1%,verbose -Dconfig.properties=%2% -classpath %apploc% tests.sharedclasses.options.TestCorruptedCaches04Helper %1% 
+cmd.runSimpleJavaProgramWithPersistentCacheCheckStringTable=%java_exe% -Xtrace:none=j9shr.1547 -Xshareclasses:name=%1%,verbose,checkStringTable,verboseIntern -classpath %apploc%/testcode.jar SimpleApp

--- a/test/functional/CacheManagement/src/config.base.properties
+++ b/test/functional/CacheManagement/src/config.base.properties
@@ -1,3 +1,24 @@
+##############################################################################
+#  Copyright (c) 2010, 2019 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
 #### Should be no need to change these
 # commands 
 # %n% indicates an insert supplied for a particular command instance

--- a/test/functional/CacheManagement/src/tests/sharedclasses/CopyResources.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/CopyResources.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses;
 
 import java.io.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/CopyResources.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/CopyResources.java
@@ -1,0 +1,74 @@
+package tests.sharedclasses;
+
+import java.io.*;
+
+/**
+ * Supplied an input and output folder, will copy any resources (ignoring .java and .class files) from input to output.
+ */
+public class CopyResources {
+
+	public static void main(String[] args) throws Exception {
+
+		if (args==null || args.length!=2) {
+			throw new IllegalArgumentException("CopyResources <inputfolder> <outputfolder>");
+		}
+		
+		File fIn = new File(args[0]);
+		File fOut = new File(args[1]);
+		
+		if (!fIn.exists() || !fIn.isDirectory()) {
+			throw new IllegalArgumentException("inputfolder must be an existing directory");
+		}
+		if (!fOut.exists()) {
+			fOut.mkdir();
+		} else if (!fOut.isDirectory()) { 
+			throw new IllegalArgumentException("outputfolder specifies an already existing file, when it should specify a directory");
+		}
+		
+		copyStuff(fIn,fOut);
+	}
+	
+	private static void copyStuff(File from,File to) throws Exception {
+		String[] files = from.list(new StripNonResourcesFilter());
+		if (files!=null) {
+			for (int i = 0; i < files.length; i++) {
+				File fFrom = new File(from,files[i]);
+				File fTo = new File(to,files[i]);
+				if (fFrom.isFile()) {
+					copyFile(fFrom,fTo);
+				} else if (fFrom.isDirectory()) {
+					fTo.mkdir();
+					copyStuff(fFrom,fTo);
+				} else {
+					System.out.println("how to handle? "+fFrom);
+				}
+			}
+		}
+	}
+	
+	static class StripNonResourcesFilter implements FilenameFilter {
+		public boolean accept(File dir, String name) {
+			if (name.endsWith(".java")) return false;
+			if (name.indexOf("CVS")!=-1) return false;
+			return true;
+		}
+	}
+	
+	private static void copyFile(File from,File to) throws Exception {
+	  System.out.println("Copying '"+from+"' to '"+to+"'");
+	  int i =0;
+	  byte[] buff = new byte[1000];
+	  FileInputStream fis = new FileInputStream(from);
+	  FileOutputStream fos = new FileOutputStream(to);
+	  int read=1;
+	  while (true && read>0) {
+		  read = fis.read(buff);
+		  i+=read;
+		  if (read>-1) fos.write(buff,0,read);
+	  }
+	  fos.flush();
+	  fos.close();
+	  fis.close();
+	}
+	
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/CreateConfig.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/CreateConfig.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses;
 
 import java.io.FileWriter;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/CreateConfig.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/CreateConfig.java
@@ -1,0 +1,54 @@
+package tests.sharedclasses;
+
+import java.io.FileWriter;
+
+/**
+ * Based on input parameters and environment variables, this will create a config.properties file suitable for 
+ * running the tests.
+ */
+public class CreateConfig {
+
+	public static void main(String[] args) throws Exception {
+
+//		Properties p = System.getProperties();
+//		p.list(System.out);
+		
+		// format is:
+//		# Which java.exe to call
+//		#java_exe=c:/andyc/j9vmwi3224/sdk/jre/bin/java.exe
+//		#java_exe=c:/ipartrid/j9vmwi3224/jre/bin/java.exe
+//		java_exe=c:/ben/j9vmwi3224/sdk/jre/bin/java.exe
+//
+//		# Default location for cache files and javasharedresources
+//		defaultCacheLocation=C:/Documents and Settings/clemas/Local Settings/Application Data
+//		# These are used if set, otherwise just the default is assumed
+//		# cacheDir=
+//		# controlDir=
+//
+//		# and a java for creating old incompatible cache files
+//		java5_exe=c:/andyc/j9vmwi3223/sdk/jre/bin/java.exe
+//
+//		# If set, this will tell us what commands are executing
+//		logCommands=true
+		
+		String javaForTesting = System.getProperty("testjava");
+		String cacheDir = System.getProperty("cachedir");
+		String java5 = System.getProperty("refjava");
+		
+		// make sure '/' the right way round!
+		javaForTesting = javaForTesting.replace('\\','/');
+		cacheDir = cacheDir.replace('\\','/');
+		java5 = java5.replace('\\','/');
+		
+		FileWriter writer = new FileWriter("config.properties");
+		writer.write("# Java to be tested\n");
+		writer.write("java_exe="+javaForTesting+"\n\n");
+		writer.write("# Cache directory\n");
+		writer.write("cacheDir="+cacheDir+"\n\n");
+		writer.write("# Old jdk for creating old caches\n");
+		writer.write("java5_exe="+java5+"\n");
+		writer.flush();
+		writer.close();
+	}
+	
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/RunCommand.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/RunCommand.java
@@ -1,0 +1,231 @@
+package tests.sharedclasses;
+
+import java.io.InputStream;
+
+import java.util.*;
+import java.io.*;
+
+/** 
+ * Instances of StreamGobbler are used to capture output from the spawned process
+ */
+class StreamGobbler extends Thread {
+    private InputStream is; // Can be used for stderr/stdout
+    private String type; // some identifier tag for this gobbler (possibly STDERR or STDOUT)
+    
+    private List<String> expected = new ArrayList<String>(); // Expected lines of output to be found in the gobbled output
+    private String waitForMessage;
+    
+    private StringBuffer gobbledData = new StringBuffer();
+    private List lines = new ArrayList();
+    public volatile boolean finished = false;
+    public volatile boolean waitForMessageFound = false;
+    public volatile boolean ignoreRest = false;
+    
+    StreamGobbler(InputStream is, String type, String[] expected, String waitForMessage) {
+        this.is = is;
+        this.type= type;
+        this.waitForMessage = waitForMessage;
+        if (expected!=null) {
+	        for (int i = 0; i < expected.length; i++) {
+				String string = expected[i];
+				if (string!=null)
+				this.expected.add(string);
+			}
+        }
+    }
+    
+    public String getType() { return type; }
+    
+    public void run() {
+        try {
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+            String line=null;
+            while ( (line = br.readLine()) != null) {
+            	//System.out.println(type + ">" + line);
+                gobbledData.append(/*type + ">" + */line+"\n");
+                lines.add(line);
+                int pos = 0;
+                int found =-1;
+                for (Iterator iterator = expected.iterator(); iterator.hasNext();) {
+					String name = (String) iterator.next();
+					if (line.indexOf(name) != -1) {
+						found = pos;
+						break;
+					}
+					pos++;
+				}
+                if (found != -1) {
+                	expected.remove(found);
+                }
+                if ((false == waitForMessageFound) && (null != waitForMessage) && (line.indexOf(waitForMessage) != -1)) {
+                	waitForMessageFound = true;
+                }
+            }
+            finished=true;
+        } catch (IOException ioe) {
+        	if (ignoreRest == false) {
+        		ioe.printStackTrace();
+        	}
+        }
+    }
+    
+    public boolean allExpectedMessagesWereFound() {
+    	return expected.isEmpty();
+    }
+
+	public void dumpOutput() {
+		System.out.println(gobbledData.toString());
+	}
+	
+	public String getOutput() {
+		return gobbledData.toString();
+	}
+
+	public String[] getOutputAsLines() {
+		return (String[])lines.toArray(new String[]{});
+	}
+}
+
+public class RunCommand {
+	private static Process lastProcess;
+	public static String lastCommand, the2ndLastCommand;
+	public static String lastCommandStdout, the2ndLastCommandStdout;
+	public static String[] lastCommandStdoutLines;
+	public static String lastCommandStderr, the2ndLastCommandStderr;
+	public static String[] lastCommandStderrLines;
+	public static boolean logCommands = false;
+	public static int processRunawayTimeout = 120000; // 2 min timer, kill process if its taking longer!
+	
+	/* if the process executed last is still running, it returns the process object, else returns null */
+	public static Process getLastProcess() {
+		try {
+			if (null != lastProcess) {
+				lastProcess.exitValue();
+			}
+			/* process got terminated */
+			return null;
+		} catch (IllegalThreadStateException e) {
+			/* process is still running */
+			return lastProcess;
+		}
+	}
+	
+	public static void executeMayFail(String cmd) {
+		execute(cmd,(String[])null,(String[])null,true,true, null);
+	}
+	
+	public static void execute(String cmd) {
+		execute(cmd,(String[])null,(String[])null,true,false, null);
+	}
+	
+	public static void execute(String cmd,boolean careAboutExitValue) {
+		execute(cmd,(String[])null,(String[])null,careAboutExitValue,false, null);
+	}
+	
+	public static void execute(String cmd, String waitForMessage) {
+		execute(cmd,(String[])null, (String[])null, false, false, waitForMessage);
+	}
+	
+	public static void execute(String cmd,String sysoutMessages,String syserrMessages,boolean careAboutExitValue) {
+		execute(cmd,new String[]{sysoutMessages},new String[]{syserrMessages},careAboutExitValue,false, null);
+	}
+	
+    public static void execute(String cmd,String[] expectedSysoutMessages,String[] expectedSyserrMessages,boolean careAboutExitValue, boolean MayFail, String waitForMessage)
+    {
+    	int exitVal = 0;
+        Runtime rt = Runtime.getRuntime();
+        the2ndLastCommand = lastCommand;
+        the2ndLastCommandStdout = lastCommandStdout;
+        the2ndLastCommandStderr = lastCommandStderr;
+        lastCommand = null;
+        lastCommandStdout = null;lastCommandStderr = null;
+        lastCommandStdoutLines = null;lastCommandStderrLines = null;
+        lastProcess = null;
+        
+        try {
+        	if (logCommands) {
+        		System.out.println("Executing command: "+cmd);
+        	}
+        	long processStartTime = System.currentTimeMillis();
+        	lastProcess = rt.exec(cmd);
+        	// any error message?
+        	StreamGobbler errorGobbler = new 
+            	StreamGobbler(lastProcess.getErrorStream(), "ERROR",expectedSyserrMessages, null);            
+        
+        	// any output?
+        	StreamGobbler outputGobbler = new 
+            	StreamGobbler(lastProcess.getInputStream(), "OUTPUT",expectedSysoutMessages, waitForMessage);
+            
+        	// kick them off
+        	errorGobbler.start();
+        	outputGobbler.start();
+                                
+        	// any error???
+        	if (null == waitForMessage) {
+	        	exitVal = lastProcess.waitFor();
+	            while (!outputGobbler.finished || !errorGobbler.finished) {
+	            	try { Thread.sleep(250); } catch (Exception e) {}
+	            	if ((System.currentTimeMillis()-processStartTime)>processRunawayTimeout) {
+	            		// kill the process, it is taking too long!
+	            		lastProcess.destroy();
+	            		try {
+	            			lastProcess.waitFor();
+						} catch (java.lang.InterruptedException e) {
+							e.printStackTrace();
+						}
+	            		System.err.println("Process killed, was executing for longer than "+(processRunawayTimeout/1000)+"seconds");
+	            	}
+	            }
+		        
+		        lastCommandStdout = outputGobbler.getOutput();
+		        lastCommandStderr = errorGobbler.getOutput();
+		        lastCommandStdoutLines = outputGobbler.getOutputAsLines();
+		        lastCommandStderrLines = errorGobbler.getOutputAsLines();
+		        lastCommand = cmd;
+		        if (!outputGobbler.allExpectedMessagesWereFound()) {
+		        	outputGobbler.dumpOutput();
+		        	errorGobbler.dumpOutput();
+		        	throw new RuntimeException("Not all expected messages were found");
+		        }
+		        if (!errorGobbler.allExpectedMessagesWereFound()) {
+		        	outputGobbler.dumpOutput();
+		        	errorGobbler.dumpOutput();
+		        	throw new RuntimeException("Not all expected messages were found");
+		        }
+		        //System.out.println("ExitValue: " + exitVal);       
+		        if (careAboutExitValue && exitVal!=0) {
+		        	if (MayFail==false) {
+		        		outputGobbler.dumpOutput();
+		        		errorGobbler.dumpOutput();
+		        		throw new RuntimeException("TestFailed: exitvalue="+exitVal);
+		        	}
+		        }
+	        } else {
+	        	while (false == outputGobbler.waitForMessageFound) {
+	        		try { 
+	        			Thread.sleep(250); 
+	        		} catch (Exception e) {
+	        		}
+	            	if ((System.currentTimeMillis() - processStartTime) > processRunawayTimeout) {
+	            		// kill the process, it is taking too long!
+	            		lastProcess.destroy();
+	            		try {
+	            			lastProcess.waitFor();
+						} catch (java.lang.InterruptedException e) {
+							e.printStackTrace();
+						}
+	            		System.err.println("Process killed, was taking longer than "+(processRunawayTimeout/1000)+" seconds to generate expected output");
+	            	}
+	        	}
+	        	outputGobbler.ignoreRest = true;
+                errorGobbler.ignoreRest = true;
+	        }
+        } catch (IOException ioe) {
+        	throw new RuntimeException("Problem invoking command: "+ioe.toString());
+        } catch (InterruptedException ie) {
+        	throw new RuntimeException("Problem invoking command: "+ie.toString());
+		}
+    
+    }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/RunCommand.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/RunCommand.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses;
 
 import java.io.InputStream;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestFailedException.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestFailedException.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses;
 
 public class TestFailedException extends RuntimeException {

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestFailedException.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestFailedException.java
@@ -1,0 +1,9 @@
+package tests.sharedclasses;
+
+public class TestFailedException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
+	TestFailedException(String reason) {
+	  super(reason);
+    }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses;
 
 import java.io.File;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
@@ -1,0 +1,1494 @@
+package tests.sharedclasses;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+
+/**
+ * A superclass for test programs that provides lots of helpful methods for setting up
+ * a shared classes environment and running shared classes commands.
+ * 
+ * Configuration is done from a config file.  The default name is config.properties, which can
+ * be overridden with a -Dconfig.properties=<pathToConfigFile>
+ */
+public class TestUtils {
+	
+	public static boolean debug = false;
+	
+	// Known commands, defined in the config file
+	public static final String DestroyCacheCommand = "destroyCache";
+	public static final String DestroyPersistentCacheCommand = "destroyPersistentCache";
+	public static final String DestroyNonPersistentCacheCommand = "destroyNonPersistentCache";
+	public static final String RunSimpleJavaProgram = "runSimpleJavaProgram";
+	public static final String RunComplexJavaProgramWithPersistentCache = "runComplexJavaProgram";
+	public static final String RunPrintStats = "runPrintStats";
+	public static final String RunPrintAllStats = "runPrintAllStats";
+	public static final String RunResetPersistentCache = "runResetPersistentCache";
+	public static final String RunResetNonPersistentCache = "runResetNonPersistentCache";
+	public static final String RunSimpleJavaProgramWithPersistentCache = "runSimpleJavaProgramWithPersistentCache";
+	public static final String RunSimpleJavaProgramWithPersistentCacheCheckStringTable = "runSimpleJavaProgramWithPersistentCacheCheckStringTable";
+	public static final String RunSimpleJavaProgramWithNonPersistentCache = "runSimpleJavaProgramWithNonPersistentCache";
+	public static final String CreateNonPersistentCache = "createNonPersistentCache";
+	public static final String CreateCacheSnapshot = "createCacheSnapshot";
+	public static final String ListAllCaches = "listAllCaches";
+	public static final String ExpireAllCaches = "expireAllCaches";
+	public static final String DestroyAllCaches = "destroyAllCaches";
+	public static final String DestroyAllSnapshots = "destroyAllSnapshots";
+	public static final String CreateIncompatibleCache = "createIncompatibleCache";
+	public static final String RunInfiniteLoopJavaProgramWithPersistentCache = "runInfiniteLoopJavaProgramWithPersistentCache";
+	public static final String RunInfiniteLoopJavaProgramWithNonPersistentCache = "runInfiniteLoopJavaProgramWithNonPersistentCache";
+	public static final String ExpireAllCachesWithTime = "expireAllCachesWithTime";
+	public static final String RunSimpleJavaProgramWithAgentWithPersistentCache = "runSimpleJavaProgramWithAgentWithPersistentCache";
+	public static final String RunSimpleJavaProgramWithAgentWithNonPersistentCache = "runSimpleJavaProgramWithAgentWithNonPersistentCache";
+	public static final String RunHanoiProgramWithCache = "runHanoiProgramWithCache";
+	public static final String CheckJavaVersion = "checkJavaVersion";
+	
+	private static final String CMD_PREFIX="cmd.";
+
+	private static boolean isRealtimeDefined = false;
+	
+	static Properties config;
+	
+	/** 
+	 * Load the properties from the configuration file - some of these can be overridden
+	 * with -D - these are cacheDir and controlDir
+	 */
+	static {
+		try {
+				
+			config = new Properties();
+						
+			// Load the target specific properties ... note that we default to windows ...
+			String configFile = System.getProperty("test.target.config", "config.defaults");
+			InputStream is = TestUtils.class.getClassLoader().getResourceAsStream(configFile);
+			config.load(is);
+					
+			if (config.getProperty("logCommands","false").equalsIgnoreCase("true")) {
+				RunCommand.logCommands=true;
+			}
+			
+			if (config.getProperty("debug","false").equalsIgnoreCase("true")) {
+				debug = true;
+			}
+			// Allow some sys props to override the config
+			//String override = System.getProperty("cacheDir");
+			//if (override!=null) config.put("cacheDir",override);
+			//override = System.getProperty("controlDir");
+			//if (override!=null) config.put("controlDir",override);
+			//override = System.getProperty("defaultCacheLocation");
+			//if (override!=null) config.put("defaultCacheLocation",override);
+
+			// Check if the defaultCacheLocation was set, otherwise lets work it out
+		    if (config.getProperty("defaultCacheLocation")==null) {
+		    	if (config.getProperty("cacheDir")==null && config.getProperty("controlDir")==null) {
+		    		System.out.println("Please set either defaultCacheLocation or cacheDir or controlDir in the config file or with -D!");
+		    	}
+		    }
+		    
+		    if (config.get("apploc")==null) {
+		    	// work it out...
+				URL url = TestUtils.class.getClassLoader().getResource("testcode.jar");
+				String thePath = new File(url.getFile()).getParentFile().getAbsolutePath();
+				thePath = thePath.replace('\\','/');
+				config.put("apploc", thePath);
+		    }
+
+		    /* */
+		    String javaTestCommand = System.getProperty("JAVA_TEST_COMMAND","");
+		    String java5home = System.getProperty("JAVA5_HOME","");
+		    String exesuff = System.getProperty("EXECUTABLE_SUFFIX","");
+		    String realtime = System.getProperty("REALTIME","");
+		    javaTestCommand=javaTestCommand.replace('\\','/');
+		    java5home=java5home.replace('\\','/');
+ 
+		    if (!realtime.equals("") && !realtime.equalsIgnoreCase("false")) {
+		    	isRealtimeDefined = true;
+		    }
+		    
+		    config.put("java_exe",javaTestCommand); 
+
+		    config.put("java5_exe",java5home + "/" + "jre" + "/" + "bin" + "/" + "java"+exesuff);
+		    config.put("java5c_exe",java5home + "/" + "bin" + "/" + "javac"+exesuff);
+		    config.put("java5jar_exe",java5home + "/" + "bin" + "/" + "jar"+exesuff);
+
+		    
+		    config.put("cmd.runCompileSimpleApp","%java5c_exe% %1%/SimpleApp.java");
+		    config.put("cmd.runCompileSimpleApp2","%java5c_exe% %1%/SimpleApp2.java");
+		    config.put("cmd.runJarClassesInDir","%java5jar_exe% cf MySimpleApp.jar -C %1% .");
+		    config.put("cmd.runProgramSimpleApp","%java_exe% "+(isRealtimeDefined ? "-Xrealtime " : "")+"-Xshareclasses:"+(isRealtimeDefined ? "grow," : "")+"persistent,name=%1%,verbose  -classpath %2% SimpleApp");
+		    
+		    System.out.println("\n--------- PROGRAM RUN COMMANDLINE INFO ---------");
+		    System.out.println("java_exe =\t" + config.get("java_exe"));
+		    System.out.println("cmd.runProgramSimpleApp =\t" + config.get("cmd.runProgramSimpleApp" + "\n"));
+		    		    
+		    if (config.getProperty("logCommands","false").equalsIgnoreCase("true")) {
+				RunCommand.logCommands=true;
+			}
+		    		    
+		    if (exesuff.equals(".exe")==true)
+		    {
+		    	String appdata = System.getenv("APPDATA");		 
+		    	String defaultCacheLocation = new File(appdata+"\\..\\Local Settings\\Application Data").getAbsolutePath();
+		    	config.put("defaultCacheLocation",defaultCacheLocation);		    		    	
+		    }
+		    else
+		    {
+		    	config.put("defaultCacheLocation","/tmp/"); 
+		    }
+		    
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public static boolean realtimeTestsSelected(){
+		return isRealtimeDefined;
+	}
+	
+	public static void registerCommand(String key, String command) {
+		config.put("cmd."+key,command);
+	}
+	
+	public static String getCacheDir() { return (String)config.get("cacheDir");}
+	public static void setCacheDir(String dir) {
+		if (dir==null) config.remove("cacheDir");
+		else {
+			config.put("cacheDir",dir);
+		}
+	}
+	
+	public static String getControlDir() { return (String)config.get("controlDir");}
+	public static void setControlDir(String dir) {
+		if (dir==null) config.remove("controlDir");
+		else config.put("controlDir",dir);
+	}
+
+	
+	
+	
+	public static String getCommand(String commandKey) {
+		return getCommand(commandKey,"","","");
+	}
+	
+	public static String getCommand(String commandKey,String insert1) {
+		return getCommand(commandKey,insert1,"","");
+	}
+
+	public static String getCommand(String commandKey,String insert1,String insert2) {
+		return getCommand(commandKey,insert1,insert2,"");
+	}
+	
+	public static String getCommand(String commandKey,String insert,String insert2,String insert3) {
+		String theCommand=(String)config.get(CMD_PREFIX+commandKey);
+		if (theCommand==null) {
+			fail("Could not find command "+commandKey);
+		}
+		Enumeration keys = config.keys();
+		while (keys.hasMoreElements()) {
+			String k = (String)keys.nextElement();
+			if (k.startsWith(CMD_PREFIX)) continue; // not something to apply
+			String replaceVal = config.getProperty(k);
+			theCommand = theCommand.replaceAll("%"+k+"%", replaceVal);
+		}
+		if (insert!=null) {
+			
+			// need to copy with one special case, where we are using a back level
+			// VM to create an incompatible cache - since it wont understand cacheDir
+			// yet we want to create the cache in a particular directory. we will
+			// need to use controlDir in this case...
+			if (commandKey.equals(CreateIncompatibleCache)) {
+				if (config.get("cacheDir")!=null) {
+					insert = insert+",controlDir="+config.getProperty("cacheDir"); // gotta use controlDir...
+				}
+				if (config.get("controlDir")!=null) {
+					insert = insert+",controlDir="+config.getProperty("controlDir");
+				}	
+			} 
+			else if (commandKey.equals("runCompileSimpleApp") || commandKey.equals("runCompileSimpleApp2") ||commandKey.equals("runJarClassesInDir")) 
+			{
+				
+			}
+			//getCacheFileName getCacheFileNameNonPersist
+			else {
+			
+				// Insert %1% is always the cache name "name=%1%"
+				// we can add subsequent options through a tiny extension to that
+				if (config.get("cacheDir")!=null) {
+					insert = insert+",cacheDir="+config.getProperty("cacheDir");
+				}
+				if (config.get("controlDir")!=null) {
+					insert = insert+",controlDir="+config.getProperty("controlDir");
+				}
+			}
+			theCommand = fixup(theCommand,"%1%",insert);
+			theCommand = fixup(theCommand,"%2%",insert2);
+			theCommand = fixup(theCommand,"%3%",insert3);
+		}
+		return theCommand;
+	}
+	
+	public static String fixup(String what,String from,String to) {
+		String result = what;
+		int idx = what.indexOf(from);
+		while (idx!=-1) {
+			StringBuffer s = new StringBuffer(what.substring(0,idx));
+			s.append(to);
+			s.append(what.substring(idx+from.length()));
+			what =  s.toString();
+			idx = what.indexOf(from);
+		}
+		return what;
+	}
+
+	public static void createNonPersistentCache(String cachename) {
+		log("Creating non-persistent cache '"+cachename+"'");
+		RunCommand.execute(getCommand(CreateNonPersistentCache,cachename));
+	}
+	
+	public static void createCacheSnapshot(String cachename) {
+		log("Creating snapshot of cache'" + cachename + "'");
+		String expectedErrorMessages[] = new String[] { 
+			"JVMSHRC700I" /* Snapshot of non-persistent shared cache <cachename> has been created */ 
+		};
+		RunCommand.execute(getCommand(CreateCacheSnapshot, cachename), null, expectedErrorMessages, false, false, null);
+	}
+
+	public static void createPersistentCache(String cachename) {
+		log("Creating persistent cache '"+cachename+"'");
+		RunCommand.execute(getCommand(RunSimpleJavaProgram,cachename));
+	}
+
+
+	public static void listAllCaches() {
+		RunCommand.execute(getCommand(ListAllCaches),false);
+	}
+	
+	public static void expireAllCaches() {
+		RunCommand.execute(getCommand(ExpireAllCaches),false);
+	}
+	
+	public static void expireAllCachesWithTime(String timeInMins) {
+		RunCommand.execute(getCommand(ExpireAllCachesWithTime, timeInMins),false);
+	}
+	
+	public static void runDestroyAllCaches() {
+		RunCommand.execute(getCommand(DestroyAllCaches),false);
+	}
+	
+	public static void runDestroyAllSnapshots() {
+		RunCommand.execute(getCommand(DestroyAllSnapshots), false);
+	}
+
+	public static void createIncompatibleCache(String cachename) {
+		RunCommand.execute(getCommand(CreateIncompatibleCache,cachename));
+	}
+
+	public static void runSimpleJavaProgram(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgram,cachename));
+	}
+	
+	public static void checkJavaVersion() {
+		RunCommand.execute(getCommand(CheckJavaVersion), false);
+	}
+	
+	/**
+	 * @example runPrintStats("foo",false,"classpath");
+	 * @example runPrintStats("foo",false,"url");
+	 * @example runPrintStats("foo",false,"token");
+	 * @example runPrintStats("foo",false,"romclass");
+	 * @example runPrintStats("foo",true,"rommethod");
+	 * @example runPrintStats("foo",true,"aot");
+	 * @example runPrintStats("foo",true,"jitprofile");
+	 * @example runPrintStats("foo",true,"zipcache");
+	 */
+	public static void runPrintStats(String cachename,boolean isPersistent, String option) {
+		RunCommand.execute(getCommand(RunPrintStats,cachename,"="+option,(isPersistent?"":",nonpersistent")),false);
+	}
+	public static void runPrintStats(String cachename,boolean isPersistent) {
+		RunCommand.execute(getCommand(RunPrintStats,cachename,"",(isPersistent?"":",nonpersistent")),false);
+	}
+
+	public static void runResetPersistentCache(String cachename) {
+		RunCommand.execute(getCommand(RunResetPersistentCache,cachename),false);
+	}
+	
+	public static void runResetNonPersistentCache(String cachename) {
+		RunCommand.execute(getCommand(RunResetNonPersistentCache,cachename),false);
+	}
+	
+	public static void runPrintAllStats(String cachename,boolean isPersistent) {
+		RunCommand.execute(getCommand(RunPrintAllStats,cachename,(isPersistent?"":",nonpersistent")),false);
+	}
+	public static void runSimpleJavaProgramWithPersistentCache(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,cachename));
+		checkOutputForDump(false);
+	}
+	public static void runSimpleJavaProgramWithPersistentCacheCheckStringTable(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCacheCheckStringTable,cachename));
+		checkOutputForDump(false);
+	}
+	public static void runSimpleJavaProgramWithPersistentCache(String cachename,boolean careAboutExitValue) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,cachename),careAboutExitValue);
+		checkOutputForDump(false);
+	}
+	public static void runSimpleJavaProgramWithPersistentCacheCheckForDump(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,cachename));
+		checkOutputForDump(true);
+	}
+	public static void runSimpleJavaProgramWithPersistentCacheCheckForDump(String cachename, boolean careAboutExitValue) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,cachename), careAboutExitValue);
+		checkOutputForDump(true);
+	}
+	/* waitForMessage is the message for which this process waits */
+	public static void runInfiniteLoopJavaProgramWithPersistentCache(String cachename, String waitForMessage) {
+		RunCommand.execute(getCommand(RunInfiniteLoopJavaProgramWithPersistentCache, cachename), waitForMessage);
+		checkOutputForDump(false);
+	}
+	/* waitForMessage is the message for which this process waits */
+	public static void runInfiniteLoopJavaProgramWithNonPersistentCache(String cachename, String waitForMessage) {
+		RunCommand.execute(getCommand(RunInfiniteLoopJavaProgramWithNonPersistentCache, cachename), waitForMessage);
+		checkOutputForDump(false);
+	}
+
+	/**
+	 * Will execute a simple java program using the named cache, extra options like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string that is used to launch the program.
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 */
+	public static void runSimpleJavaProgramWithPersistentCache(String cachename,String extraSharedClassesOptions) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		runSimpleJavaProgramWithPersistentCache(cachename+
+				(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""));
+	}
+
+	/**
+	 * Will execute a simple java program using the named cache, extra options like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string that is used to launch the program.
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 * @param waitForMessage message for which this process waits 
+	 */
+	public static void runInfiniteLoopJavaProgramWithPersistentCache(String cachename,String extraSharedClassesOptions,String waitForMessage) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		runInfiniteLoopJavaProgramWithPersistentCache(cachename+
+				(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""), waitForMessage);
+	}
+	
+	/**
+	 * Will execute a simple java program using the named cache, extra options like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string that is used to launch the program.
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 */
+	public static void runSimpleJavaProgramWithNonPersistentCache(String cachename,String extraSharedClassesOptions) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		runSimpleJavaProgramWithNonPersistentCache(cachename+
+				(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""));
+	}
+	
+	/**
+	 * Will execute a simple java program using the named cache, extra options like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string that is used to launch the program.
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 * @param waitForMessage message for which this process waits 
+	 */
+	public static void runInfiniteLoopJavaProgramWithNonPersistentCache(String cachename,String extraSharedClassesOptions,String waitForMessage) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		runInfiniteLoopJavaProgramWithNonPersistentCache(cachename+
+				(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""), waitForMessage);
+	}
+	
+	protected static void checkOutputForDump(boolean dumpGenerated) {
+		if (dumpGenerated) {
+			checkOutputContains("JVMDUMP....", "The JVM is dumping!!");
+		} else {
+			checkOutputDoesNotContain("JVMDUMP....", "The JVM is dumping!!");
+		}
+	}
+
+	public static void runSimpleJavaProgramWithPersistentCacheAndReset(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,cachename+",reset"));
+	}
+	
+	public static void runSimpleJavaProgramWithNonPersistentCacheMayFail(String cachename) {
+		RunCommand.executeMayFail(getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename));
+	}
+	
+	public static void runSimpleJavaProgramWithNonPersistentCache(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename));
+	}
+	
+	public static void runSimpleJavaProgramWithNonPersistentCache(String cachename,boolean careAboutExitValue) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename),careAboutExitValue);
+	}
+
+	public static void runSimpleJavaProgramWithNonPersistentCacheAndReset(String cachename) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename+",reset"));
+	}
+	/**
+	 * @param cachename name of the cache to use
+	 * @param agentName name of the JVMTI agent. Actually it needs to be one of the JVMTI test in com.ibm.jvmti.tests package.
+	 * 					See TestSharedCacheEnableBCI.java for an example.
+	 * @param agentArgs	arguments to JVMTI agent. Again, these are the arguments passed to JVMTI test in com.ibm.jvmti.tests package.
+	 * 					See TestSharedCacheEnableBCI.java for an example.
+	 */
+	public static void runSimpleJavaProgramWithAgentWithPersistentCache(String cachename, String agentName, String agentArgs) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithAgentWithPersistentCache, cachename, agentName, agentArgs));
+		checkOutputForDump(false);
+	}
+	/**
+	 * Will execute a simple java program with a JVMTI agent using the named cache, extra options like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string that is used to launch the program.
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 */
+	public static void runSimpleJavaProgramWithAgentWithPersistentCache(String cachename, String extraSharedClassesOptions, String agentName, String agentArgs) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		runSimpleJavaProgramWithAgentWithPersistentCache(cachename+
+				(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""),
+				agentName, agentArgs);
+	}
+	/**
+	 * @param cachename name of the cache to use
+	 * @param agentName name of the JVMTI agent. Actually it needs to be one of the JVMTI test in com.ibm.jvmti.tests package.
+	 * 					See TestSharedCacheEnableBCI.java for an example.
+	 * @param agentArgs	arguments to JVMTI agent. Again, these are the arguments passed to JVMTI test in com.ibm.jvmti.tests package.
+	 * 					See TestSharedCacheEnableBCI.java for an example.
+	 */
+	public static void runSimpleJavaProgramWithAgentWithNonPersistentCache(String cachename, String agentName, String agentArgs) {
+		RunCommand.execute(getCommand(RunSimpleJavaProgramWithAgentWithNonPersistentCache, cachename, agentName, agentArgs));
+		checkOutputForDump(false);
+	}
+	/**
+	 * Will execute a simple java program with a JVMTI agent using the named cache, extra options like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string that is used to launch the program.
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 */
+	public static void runSimpleJavaProgramWithAgentWithNonPersistentCache(String cachename, String extraSharedClassesOptions, String agentName, String agentArgs) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		runSimpleJavaProgramWithAgentWithNonPersistentCache(cachename+
+				(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""),
+				agentName, agentArgs);
+	}
+	
+	/**
+	 * Will execute a hanoi program using the named cache, extraSharedClassesOptions like "verbose,silent" can be specified
+	 * and they will be appended to the constructed -Xshareclasses option string. extraJavaOpt like "-Xint" can also be 
+	 * specified that is used to launch the program. 
+	 * 
+	 * @param cachename name of the cache to use
+	 * @param extraSharedClassesOptions extra shared classes options, eg "verbose,silent"
+	 */
+	public static void runHanoiProgramWithCache(String cachename,String extraSharedClassesOptions, String extraJavaOpt) {
+		// this hides the magic rule that due to the command construction, the "name=" is always the last part of the
+		// -Xshareclasses string in the defined commands.  So to add more shared classes options we just have to append
+		// them to the cache name.
+		RunCommand.execute(getCommand(RunHanoiProgramWithCache, 
+				cachename+(extraSharedClassesOptions!=null&&extraSharedClassesOptions.length()>0?","+extraSharedClassesOptions:""),
+				(extraJavaOpt!=null&&extraJavaOpt.length()>0?" "+extraJavaOpt:"")
+				));
+		checkOutputForDump(false);
+	}
+	
+	protected static String getCacheFileLocationForNonPersistentCache(String cachename) {
+		String cacheDir = getCacheDir(cachename,false);		
+		String expectedFileLocation = 
+				cacheDir+File.separator+
+				getCacheFileName(cachename,false);
+		return expectedFileLocation;
+	}
+	protected static String getCacheFileDirectory(boolean forPersistentCache) {
+		String defaultLoc = getConfigParameter("defaultCacheLocation");
+		String cacheDirLoc = getConfigParameter("cacheDir");
+		String controlDirLoc=getConfigParameter("controlDir");
+		String theDir = null;
+		if (cacheDirLoc!=null) theDir = cacheDirLoc+(forPersistentCache?"":File.separator+"javasharedresources");
+		else if (controlDirLoc!=null) theDir = controlDirLoc+(forPersistentCache?"":File.separator+"javasharedresources");
+		else theDir = defaultLoc+File.separator+"javasharedresources";
+		return theDir;
+	}
+
+	protected static String getCacheFileLocationForPersistentCache(String cachename) {
+		String cacheDir = getCacheDir(cachename,true);		
+		String expectedFileLocation = 
+				cacheDir+File.separator+
+				getCacheFileName(cachename,true);
+		return expectedFileLocation;
+	}
+	
+	protected static String getCacheFileLocationForCacheSnapshot(String cachename) {
+		String cacheDir = getCacheDir(cachename, false);		
+		String expectedFileLocation = 
+				cacheDir + File.separator +
+				getSnapshotFileName(cachename);
+		return expectedFileLocation;
+	}
+
+	public static void checkFileExists(String location) {
+		  if (!new File(location).exists()) {
+		  	  fail("No file found at '"+location+"'");
+		  }
+	  }
+
+	public static void checkFileDoesNotExist(String location) {
+		  if (new File(location).exists()) {
+			  fail("Did not expect to find file at '"+location+"'");
+		  }
+	  }
+
+	public static void fail(String msg) {
+		showOutput();
+		System.err.println(msg);
+		System.err.println("\tLast command: "+RunCommand.lastCommand);
+		throw new TestFailedException(msg);
+	}
+
+	private static String lastcmd_getCacheDir = "";
+	private static String lastresult_getCacheDir = "";
+	public static String getCacheDir(String cachename,boolean persistent) 
+	{
+		//NOTE: use above statics to save some time when running tests ...
+		
+		String cmd = "";
+		
+		if (persistent==true)
+		{
+			cmd = getCommand("getCacheFileName",cachename);
+		}
+		else
+		{
+			cmd = getCommand("getCacheFileNameNonPersist",cachename);
+		}
+		
+		if (lastcmd_getCacheDir.equals(cmd) && lastresult_getCacheDir.equals("")!=false)
+		{
+			return lastresult_getCacheDir;
+		}
+		lastcmd_getCacheDir=cmd;
+
+		RunCommand.execute(cmd,false);
+		String stderr = RunCommand.lastCommandStderr;
+
+		System.out.println("stderr is :"+ stderr);
+		String[] stderrarray = stderr.split("\n");
+
+		for (int j=0; j<stderrarray.length;j+=1)
+		{
+			String test = stderrarray[j];
+			if (test.indexOf("/")==0 || test.indexOf(":\\")==1)
+			{
+				
+				int i = test.lastIndexOf(java.io.File.separator);
+				if (i<1)
+				{
+					fail("Error: for cachename "+cachename+" not sure what happened but i is "+i);
+					return "";
+				}
+				String cacheDir = test.substring(0,i);//read just the dir
+				System.out.println("HERE(getCacheDir):"+test+" "+cacheDir);
+				
+				lastresult_getCacheDir = cacheDir;
+				return cacheDir;
+			}
+		}		
+		fail("Error: should never hit this code.");
+		return "";
+	}
+	
+	
+	private static String lastcmd_getCacheFileName = "";
+	private static String lastresult_getCacheFileName = "";
+	public static String getCacheFileName(String cachename,boolean persistent) {
+	
+		//NOTE: use above statics to save some time when running tests ...
+				
+		String cmd = "";
+		
+		if (persistent==true)
+		{
+			cmd = getCommand("getCacheFileName",cachename);
+		}
+		else
+		{
+			cmd = getCommand("getCacheFileNameNonPersist",cachename);
+		}
+
+		if (lastcmd_getCacheFileName.equals(cmd) && lastresult_getCacheFileName.equals("")!=false)
+		{
+			return lastresult_getCacheFileName;
+		}
+		lastcmd_getCacheFileName=cmd;
+		
+		RunCommand.execute(cmd,false);
+		String stderr = RunCommand.lastCommandStderr;
+		
+		String[] stderrarray = stderr.split("\n");
+
+		for (int j=0; j<stderrarray.length;j+=1)
+		{
+			String test = stderrarray[j];
+			if (test.indexOf("/")==0 || test.indexOf(":\\")==1)
+			{
+				int i = test.lastIndexOf(java.io.File.separator);
+				if (i>=test.length())
+				{
+					fail("Error: for cachename "+cachename+" not sure what happened but i is "+i);
+					return "";
+				}				
+				String cachefile =test.substring(i+1,test.length());
+				//System.out.println("HERE(getCacheFileName):"+test+" "+cachefile);
+				lastresult_getCacheFileName = cachefile;
+				return cachefile;
+			}
+		}		
+		fail("Error: should never hit this code.");
+		return "";
+		
+			
+	  }
+
+	public static String getSnapshotFileName(String snapshotname) {
+		
+		//NOTE: use above statics to save some time when running tests ...
+				
+		String cmd = getCommand("getSnapshotFileName", snapshotname);
+
+		if (lastcmd_getCacheFileName.equals(cmd) && lastresult_getCacheFileName.equals("") != false) {
+			return lastresult_getCacheFileName;
+		}
+		lastcmd_getCacheFileName = cmd;
+		
+		RunCommand.execute(cmd, false);
+		String stderr = RunCommand.lastCommandStderr;
+		
+		String[] stderrarray = stderr.split("\n");
+
+		for (int j = 0; j < stderrarray.length; j += 1) {
+			String test = stderrarray[j];
+			if (test.indexOf("/") == 0 || test.indexOf(":\\") == 1) {
+				int i = test.lastIndexOf(java.io.File.separator);
+				if (i >= test.length()) {
+					fail("Error: for snapshotname " + snapshotname + " not sure what happened but i is " + i);
+					return "";
+				}				
+				String snapshotfile = test.substring(i + 1, test.length());
+				lastresult_getCacheFileName = snapshotfile;
+				return snapshotfile;
+			}
+		}		
+		fail("Error: should never hit this code.");
+		return "";		
+	  }
+
+	protected static String getConfigParameter(String string) {
+		  return (String)config.get(string);
+	  }
+	
+	protected static void setConfigParameter(String key,String value) {
+		if (value==null) config.remove(key);
+		else config.put(key,value);
+	}
+
+	public static boolean destroyCache(String cachename) {
+		RunCommand.execute(getCommand(DestroyCacheCommand,cachename),false);
+		if (messageOccurred("JVMSHRC023E")) return false;
+		else 								return true;
+	}
+	
+	public static boolean destroyPersistentCache(String cachename) {
+		RunCommand.execute(getCommand(DestroyPersistentCacheCommand,cachename),false);
+		if (messageOccurred("JVMSHRC023E")) return false;
+		else 								return true;
+	}
+
+	public static boolean destroyNonPersistentCache(String cachename) {
+		RunCommand.execute(getCommand(DestroyNonPersistentCacheCommand,cachename),false);
+		if (messageOccurred("JVMSHRC023E")) return false;
+		else 								return true;
+	}
+
+	public static boolean messageOccurred(String msgId) {
+		if (RunCommand.lastCommandStderr.indexOf(msgId)!=-1) return true;
+		if (RunCommand.lastCommandStdout.indexOf(msgId)!=-1) return true;
+		return false;
+	}
+	
+	public static void showOutput() { 
+      System.out.println("Command executed: '"+RunCommand.lastCommand+"'");
+	  System.out.println("vvv STDOUT vvv");
+	  System.out.println(RunCommand.lastCommandStdout);
+	  System.out.println("^^^ STDOUT ^^^");
+  	  System.out.println("vvv STDERR vvv");
+	  System.out.println(RunCommand.lastCommandStderr);
+	  System.out.println("^^^ STDERR ^^^");
+	  System.out.println("vvv STACK TRACE vvv");
+	  new Throwable().printStackTrace(System.out);
+	  System.out.println("^^^ STACK TRACE ^^^");
+	  
+	  if (RunCommand.the2ndLastCommand != null) {
+	      System.out.println("2nd last command executed: '"+RunCommand.the2ndLastCommand+"'");
+		  System.out.println("vvv 2ND LAST STDOUT vvv");
+  		  System.out.println(RunCommand.the2ndLastCommandStdout);
+		  System.out.println("^^^ 2ND LAST STDOUT ^^^");
+	  	  System.out.println("vvv 2ND LAST STDERR vvv");
+  		  System.out.println(RunCommand.the2ndLastCommandStderr);
+		  System.out.println("^^^ 2ND LAST STDERR ^^^");
+	  }
+	}
+
+	public static void checkOutputContains(String regex,String explanation) {
+		String[] lines = RunCommand.lastCommandStderrLines;
+		boolean found = false;
+		if (lines!=null) {
+			for (int i = 0; i < lines.length; i++) {
+				if (lines[i].matches("^.*"+regex+".*$")) {
+//					System.out.println("this line '"+lines[i]+"' matches "+regex);
+					found=true;
+					break;
+				}
+			}
+		}
+		if (!found) { 
+			// check stdout
+		    lines = RunCommand.lastCommandStdoutLines;
+		    found = false;
+			if (lines!=null) {
+				for (int i = 0; i < lines.length; i++) {
+					if (lines[i].matches("^.*"+regex+".*$")) {
+	//					System.out.println("this line '"+lines[i]+"' matches "+regex);
+						found=true;
+					}
+				}
+			}
+		}
+		if (!found) {
+			fail(explanation);
+		}
+	}
+	public static void checkOutputDoesNotContain(String regex,String explanation) {
+		String[] lines = RunCommand.lastCommandStderrLines;
+		boolean isFound = false;
+		if (lines!=null) {
+			for (int i = 0; i < lines.length; i++) {
+				if (lines[i].matches("^.*"+regex+".*$")) {
+//					System.out.println("this line '"+lines[i]+"' matches "+regex);
+					isFound=true;
+				}
+			}
+		}
+		if (isFound) {
+			fail(explanation);
+		}
+	}
+
+	public static void checkForMessage(String msgid, String explanation) {
+		  if (!messageOccurred(msgid)) {
+			  fail(explanation);
+		  }
+	  }
+	public static void checkNoFileForPersistentCache(String cachename) {
+			checkFileDoesNotExist(getCacheFileLocationForPersistentCache(cachename));
+	  }
+	//TODO isnt this the same as that other method below?
+	public static void checkNoFileForNonPersistentCache(String cachename) {
+		if (isWindows()) {
+			checkFileDoesNotExist(getCacheFileLocationForNonPersistentCache(cachename));
+		} else {	checkFileDoesNotExist(getCacheFileLocationForNonPersistentCache(cachename));
+			checkFileDoesNotExist(getCacheFileLocationForNonPersistentCache(cachename).replace("memory","semaphore"));
+		}
+	  }
+	
+	public static void checkFileDoesNotExistForPersistentCache(String cachename) {
+		checkFileDoesNotExist(getCacheFileLocationForPersistentCache(cachename));
+	}
+	
+	public static void checkFileDoesNotExistForCacheSnapshot(String cachename) {
+		checkFileDoesNotExist(getCacheFileLocationForCacheSnapshot(cachename));
+	}
+	
+	public static void checkFileDoesNotExistForNonPersistentCache(String cachename) {
+		if (isWindows()) {
+		checkFileDoesNotExist(getCacheFileLocationForNonPersistentCache(cachename));
+		} else {
+			checkFileDoesNotExist(getCacheFileLocationForNonPersistentCache(cachename));
+			checkFileDoesNotExist(getCacheFileLocationForNonPersistentCache(cachename).replace("memory","semaphore"));
+		}
+	}
+	
+	public static void checkFileExistsForPersistentCache(String cachename) {
+			checkFileExists(getCacheFileLocationForPersistentCache(cachename));
+	  }
+	
+	public static void checkFileExistsForNonPersistentCache(String cachename) {
+		Properties p = System.getProperties();
+		if (isWindows()) {
+			checkFileExists(getCacheFileLocationForNonPersistentCache(cachename)); 
+		} else {
+			// linux is harder, there is a memory file and a semaphore file to worry about
+			checkFileExists(getCacheFileLocationForNonPersistentCache(cachename));
+			checkFileExists(getCacheFileLocationForNonPersistentCache(cachename).replace("memory","semaphore"));
+		}
+	}
+	
+	public static void checkFileExistsForCacheSnapshot(String cachename) {
+		checkFileExists(getCacheFileLocationForCacheSnapshot(cachename));
+	}
+	
+		
+	public static boolean isWindows() {
+		return System.getProperty("os.name").toLowerCase().startsWith("windows");
+	}
+
+	public static boolean isMVS() {
+		return System.getProperty("os.name").toLowerCase().startsWith("z/os");
+	}
+	
+	public static boolean isLinux() {
+		return System.getProperty("os.name").toLowerCase().startsWith("linux");
+	}
+	
+	public static String getOS() {
+		return System.getProperty("os.name");
+	}
+	
+	public static boolean isCompressedRefEnabled() {
+		checkJavaVersion();
+		if (messageOccurred("Compressed References")) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	public static void checkForSuccessfulPersistentCacheOpenMessage(
+			String cachename) {
+			checkOutputContains("JVMSHRC237I.*" + cachename,
+					"Did not get expected message about successful cache open");
+	}
+
+	public static void checkForSuccessfulPersistentCacheCreationMessage(
+			String cachename) {
+			checkOutputContains("JVMSHRC236I.*" + cachename,
+					"Did not get expected message about successful cache creation");
+	}
+
+	public static void checkForSuccessfulPersistentCacheDestroyMessage(
+			String cachename) {
+			checkOutputContains(cachename + ".*has been destroyed",
+					"Did not get expected message about successful cache destroy");
+	}
+
+	public static void checkForSuccessfulNonPersistentCacheOpenMessage(
+			String cachename) {
+		checkOutputContains("JVMSHRC159I.*" + cachename,
+				"Did not get expected message about successful cache open");
+	}
+
+	public static void checkForSuccessfulNonPersistentCacheCreationMessage(
+			String cachename) {
+		checkOutputContains("JVMSHRC158I.*" + cachename,
+				"Did not get expected message about successful cache creation");
+	}
+
+	public static void checkForSuccessfulNonPersistentCacheDestoryMessage(
+			String cachename) {
+		checkOutputContains(cachename + ".*is destroyed",
+				"Did not get expected message about successful cache destroy");
+	}
+
+	public static void checkOutputForCompatiblePersistentCache(String cachename,boolean shouldBeFound) {
+		checkOutputForCompatibleCache(cachename, true, shouldBeFound);
+	}
+	
+	public static void checkOutputForCompatibleNonPersistentCache(String cachename,boolean shouldBeFound) {
+		checkOutputForCompatibleCache(cachename, false, shouldBeFound);
+	}
+	
+	/**
+	 * In the most recent command output (RunCommand.lastCommandStderrLines) this method checks for
+	 * the named cache in the 'Incompatible caches' section.  The flag shouldBeFound indicates whether
+	 * it should be named in the section.
+	 */
+	public static void checkOutputForIncompatibleCache(String name,boolean shouldBeFound) {
+		  String[] lines = RunCommand.lastCommandStderrLines;
+		  boolean isFound = false;
+		  if (lines!=null) {
+			  int i=0;
+			  boolean inCompatSection = false;
+			  while (i<lines.length) {
+				  if (inCompatSection) {
+					  // Ok, this might be our entry
+					  if (lines[i].matches(name+"[ \\t].*$")) {
+						  isFound=true;
+					  }
+				  }
+				  if (lines[i].startsWith("Incompatible")) inCompatSection=true;
+				  if (lines[i].trim().equals("")) inCompatSection=false;
+				  i++;
+			  }
+		  }
+		  if (shouldBeFound) {
+			  if (!isFound) {
+				  fail("Cache '"+name+"' was not found to be incompatible");
+			  }
+		  } else {
+			  if (isFound) {
+				  fail("Cache '"+name+"' was unexpectedly found to be incompatible");
+			  }			  
+		  }
+	  }
+	
+	
+	
+	public static void checkOutputForCompatibleCache(String name, boolean isPersistent,boolean shouldBeFound) {
+		  String[] lines = RunCommand.lastCommandStderrLines;
+		  boolean isFound = false;
+		  if (lines!=null) {
+			  int i=0;
+			  boolean inCompatSection = false;
+			  while (i<lines.length) {
+				  if (inCompatSection) {
+					  // Ok, this might be our entry
+					  if (lines[i].matches(name+".*"+(isPersistent?"(yes|persistent)":"(no|non-persistent)")+".*$")) {
+						  isFound=true;
+					  }
+				  }
+				  if (lines[i].startsWith("Compatible")) inCompatSection=true;
+				  if (lines[i].trim().equals("")) inCompatSection=false;
+				  i++;
+			  }
+		  }
+		  if (shouldBeFound) {
+			  if (!isFound) {
+				  fail((isPersistent?"":"Non-")+"Persistent cache '"+name+"' was not found to be compatible");
+			  }
+		  } else {
+			  if (isFound) {
+				  fail((isPersistent?"":"Non-")+"Persistent cache '"+name+"' was unexpectedly found to be compatible");
+			  }
+		  }
+	 }
+	
+	public static List processOutputForCompatibleCacheList() {
+		List compatibleCaches = new ArrayList();
+		String[] lines = RunCommand.lastCommandStderrLines;
+		if (lines!=null) {
+		  int i=0;
+		  boolean inCompatSection = false;
+		  while (i<lines.length) {
+			  if (inCompatSection) {
+				  // Chop from position 0 to the first non-space or tab
+//				  System.out.println(">>>"+lines[i]+"<<<");
+				  if (lines[i].length()!=0) { // this will avoid including the final line of compatible section
+					  int p=0; while (p<lines[i].length() && lines[i].charAt(p)!=' ' && lines[i].charAt(p)!='\t') p++;
+					  compatibleCaches.add(lines[i].substring(0,p));
+				  }
+			  }
+			  if (lines[i].startsWith("Compatible")) inCompatSection=true;
+			  if (lines[i].trim().equals("")) {
+				  inCompatSection=false;
+			  }
+			  i++;
+		  }
+		}
+		return compatibleCaches;
+	}
+	
+	public static void deleteTemporaryDirectory(String path) {		
+		File f = new File(path);
+		if (f.exists()) {
+			File[] files = f.listFiles();
+			for (int i = 0; i < files.length; i++) {
+				if (files[i].isDirectory()) {
+					deleteTemporaryDirectory((files[i]).getAbsolutePath());
+				} else {
+					files[i].delete();
+					if (files[i].exists()) {
+						fail("Couldn't delete temp file " + files[i].getAbsolutePath());
+					}
+				}
+			}
+			f.delete();
+		}		
+		if (f.exists()) {
+			fail("Couldn't delete temp dir " + f.getAbsolutePath());
+		}
+		//System.out.println("Deleted Tmp Folder: " + f.getAbsolutePath());
+	}
+
+	public static String createTemporaryDirectory(String testname) {
+		try {
+		  File f = File.createTempFile("testSC"+testname,"dir");
+
+		  //System.out.println("Created Tmp Folder: "+f.getAbsolutePath());
+		  
+		  if (!f.delete()) fail("Couldn't create the temp dir");
+		  if (!f.mkdir()) fail("Couldnt create the temp dir");
+		  return f.getAbsolutePath();  
+		} catch (IOException e) {
+			fail("Couldnt create temp dir: "+e);
+			return null;
+		}
+	  }
+	
+	/**
+	   * Create some caches that are generation 07 and 01
+	   */
+	protected static void createGenerations01() {
+		log("Creating cache generations...");
+		createPersistentCache("Foo");	createPersistentCache("Bar");
+		createNonPersistentCache("Foo");createNonPersistentCache("Bar");
+		renameGenerations("G07","G01"); // rename generation 03 files to generation 02
+		createPersistentCache("Foo");	createPersistentCache("Bar");
+		createNonPersistentCache("Foo");createNonPersistentCache("Bar");
+	}
+	public static void log(String s) {
+		if (debug) System.out.println(s);
+	}
+	
+	/**
+	 * Create some caches that are generation 03 and 02
+	 */
+	protected static void createGenerations02() {
+		createPersistentCache("Foo");	createPersistentCache("Bar");
+		createNonPersistentCache("Foo");createNonPersistentCache("Bar");
+		renameGenerations("G07","G02"); // rename generation 03 files to generation 01
+		
+		createPersistentCache("Foo");	createPersistentCache("Bar");
+		createNonPersistentCache("Foo");createNonPersistentCache("Bar");
+		
+	}
+
+	public static void renameGenerations(String from, String to) {
+		  renameGeneration("Foo",true,from,to);
+		  renameGeneration("Bar",true,from,to);
+		  renameGeneration("Foo",false,from,to);
+		  renameGeneration("Bar",false,from,to);
+	}
+
+	/** 
+	 * Passed a generation number like 'G07', it will change that to 'to' (eg. G02).
+	 */
+	public static void renameGeneration(String name, boolean isPersistent,
+			String from, String to) {
+	  log("Changing generation numbers for "+(isPersistent?"":"non-")+"persistent cache '"+name+"' from "+from+" to "+to);
+	  if (isWindows() || isPersistent) {
+		  String cachefilename = getCacheFileName(name, isPersistent); // TODO null will need fixing for linux and non-persistent caches
+	  
+		  String expectedFileLocation = null;
+		  if (isPersistent) {
+			  expectedFileLocation = getCacheFileLocationForPersistentCache(name);
+		  } else {
+			  expectedFileLocation = getCacheFileLocationForNonPersistentCache(name);
+		  }
+		  
+//		  String expectedFileLocation = 
+//			  getConfigParameter("defaultCacheLocation")+File.separator+
+//			  "javasharedresources"+File.separator+cachefilename;
+		  
+		  File currentCache = new File(expectedFileLocation);
+		  if (!currentCache.exists()) {
+			  fail("Unexpectedly couldn't find cache file: "+expectedFileLocation);
+		  }
+		  
+		  if (expectedFileLocation.endsWith(from)) {
+			  String newLocation = expectedFileLocation.substring(0,expectedFileLocation.length()-from.length())+to;
+			  if (!currentCache.renameTo(new File(newLocation))) {
+				  fail("Could not rename from '"+expectedFileLocation+"' to '"+newLocation+"'");
+			  }
+		  }
+	  } else {
+		  // non-persistent caches on non-windows have two control files
+		  String locMemory = getCacheFileLocationForNonPersistentCache(name);
+		  File f = new File(locMemory);
+		  if (!f.exists()) fail("Unexpectedly couldn't find cache file: "+locMemory);
+		  if (locMemory.endsWith(from)) {
+			  String newLocation = locMemory.substring(0,locMemory.length()-from.length())+to;
+			  if (!f.renameTo(new File(newLocation))) {
+				  fail("Could not rename from '"+locMemory+"' to '"+newLocation+"'");
+			  }
+		  }
+		  String locSemaphore = getCacheFileLocationForNonPersistentCache(name).replace("memory","semaphore");
+		  f = new File(locSemaphore);
+		  if (!f.exists()) fail("Unexpectedly couldn't find cache file: "+locSemaphore);
+		  if (locSemaphore.endsWith(from)) {
+			  String newLocation = null;
+			  if (to.equals("G01") || to.equals("G02")) {
+				  // semaphore doesnt have generation number on for gen1/2
+				  newLocation = locSemaphore.substring(0,locSemaphore.length()-from.length()-1);
+			  } else {
+				  newLocation = locSemaphore.substring(0,locSemaphore.length()-from.length())+to;
+			  }
+			  if (!f.renameTo(new File(newLocation))) {
+				  fail("Could not rename from '"+locSemaphore+"' to '"+newLocation+"'");
+			  }
+		  }
+	  }
+  }
+			//  
+			//	public void touchFiles(String listForTouching) {
+			//
+			//		if (listForTouching.length()==0) return;
+			//		StringTokenizer st = new StringTokenizer(listForTouching,",");
+			//		try { Thread.sleep(1000); } catch (Exception e) {} // allow for filesystem with crap resolution timer
+			//		while (st.hasMoreTokens()) {
+			//			String touch = st.nextToken();
+			//			File f = new File(touch);
+			//			f.r
+			//			if (!f.exists()) throw new RuntimeException("Can't find: "+touch);
+			//			boolean b = f.setLastModified(System.currentTimeMillis());
+			//			log("Touched: "+f+" : "+(b?"successful":"unsuccessful"));
+			//		}
+			//	}
+
+	public static void corruptCache(String cachename, boolean isPersistent, String howToCorruptIt) {
+		String theFile = (isPersistent?getCacheFileLocationForPersistentCache(cachename):
+            getCacheFileLocationForNonPersistentCache(cachename));
+		
+		 //if (!isPersistent && !isWindows()) {
+		 //		System.out.println("corruptCache is not implemented on this target");
+		 //		return;
+		 //}
+		
+		  if (howToCorruptIt.equals("truncate")) {
+			  
+			  File f = new File(theFile);
+			  File fNew = new File(theFile+".tmp");
+			  // chop it to 1000 bytes
+			  int i =0;
+			  byte[] buff = new byte[1000];
+			  try {
+				  FileInputStream fis = new FileInputStream(f);				  
+				  FileOutputStream fos = new FileOutputStream(fNew);
+				  while (i<10000) {
+					  int read = fis.read(buff);					  
+					  if (read>0)
+					  {
+						  i+=read;
+						  fos.write(buff,0,read);
+					  }
+					  else
+					  {
+						  fail("Could not create the fake corrupt file.");
+						  break;
+					  }
+				  }
+				  fos.flush();
+				  fos.close();
+				  fis.close();
+				  if (!f.delete()) fail("Failed to delete existing cache");
+				  if (!fNew.renameTo(f)) fail("Could not rename new truncated cache");
+			  } catch (Exception e) {
+				  fail("Cannot truncate file "+e);
+			  }
+		  } else if (howToCorruptIt.equals("ftpascii")) {
+			  File f = new File(theFile);
+			  File fNew = new File(theFile+".tmp");
+			  // chop it to 10000 bytes
+			  int i =0;
+			  byte[] buff = new byte[1000];
+			  try {
+				  FileInputStream fis = new FileInputStream(f);
+				  FileOutputStream fos = new FileOutputStream(fNew);
+				  int read=1;
+				  while (true && read>0) {
+					  read = fis.read(buff);
+					  i+=read;
+					  byte b = 0x7f;
+					  if (read>-1) {
+						  for (int j=0;j<read;j++) {
+							  buff[j]=(byte)(buff[j]&b);
+						  }
+						  fos.write(buff,0,read);
+					  }
+				  }
+				  fos.flush();fos.close();
+				  fis.close();
+//				  System.out.println("Copied "+i+" bytes");
+				  if (!f.delete()) fail("Failed to delete existing cache");
+				  if (!fNew.renameTo(f)) fail("Could not rename new ftpascii cache");
+			  } catch (Exception e) {
+				  e.printStackTrace();
+				  fail("Cannot ftpascii file "+e);
+			  }
+		  } else if (howToCorruptIt.equals("zero")) {
+			  File f = new File(theFile);
+			  File fNew = new File(theFile+".tmp");
+			  byte[] buff = new byte[1000];
+			  try {
+				  FileInputStream fis = new FileInputStream(f);
+				  FileOutputStream fos = new FileOutputStream(fNew);
+				  int read=1;
+				  int blocksToZero = 200;
+				  int offsetForZero=5000;
+				  boolean corrupted=false;
+				  
+				  if (realtimeTestsSelected()){
+					  offsetForZero=100000;
+				  }
+				 
+				  while (read > 0) {
+					  read = fis.read(buff);
+					  offsetForZero-=read;
+					  if (read > -1) {
+						  if (offsetForZero<=0 && !corrupted) {
+							  if ((blocksToZero--)<0) {
+								  corrupted=true;
+							  }
+							  for (int j=0;j<read;j++) {
+								  buff[j]=0;
+							  }
+						  }
+						  fos.write(buff,0,read);
+					  }
+				  }
+				  fos.flush();fos.close();
+				  fis.close();
+				  if (!f.delete()) fail("Failed to delete existing cache");
+				  if (!fNew.renameTo(f)) fail("Could not rename new zerod cache");
+			  } catch (Exception e) {
+				  e.printStackTrace();
+				  fail("Cannot zero file "+e);
+			  }				
+		  } else if (howToCorruptIt.equals("zeroStringCache")) {
+			  File f = new File(theFile);
+			  File fNew = new File(theFile+".tmp");
+			  byte[] buff = new byte[1000];
+			  try {
+				  FileInputStream fis = new FileInputStream(f);
+				  FileOutputStream fos = new FileOutputStream(fNew);
+				  int read=1;
+				  int blocksToZero = 3;
+				  int offsetForZero=2000;
+				  boolean corrupted=false;
+				  
+				  while (read > 0) {
+					  read = fis.read(buff);
+					  offsetForZero-=read;
+					  if (read > -1) {
+						  if (offsetForZero<=0 && !corrupted) {
+							  if ((blocksToZero--)<0) {
+								  corrupted=true;
+							  }
+							  for (int j=0;j<read;j++) {
+								  buff[j]=0;
+							  }
+						  }
+						  fos.write(buff,0,read);
+					  }
+				  }
+				  fos.flush();fos.close();
+				  fis.close();
+				  if (!f.delete()) fail("Failed to delete existing cache");
+				  if (!fNew.renameTo(f)) fail("Could not rename new zeroStringCache cache");
+			  } catch (Exception e) {
+				  e.printStackTrace();
+				  fail("Cannot zeroStringCache file "+e);
+			  }				
+		  } else if (howToCorruptIt.equals("zeroFirstPage")) {
+			  File f = new File(theFile);
+			  File fNew = new File(theFile+".tmp");
+			  byte[] buff = new byte[1024];
+			  try {
+				  FileInputStream fis = new FileInputStream(f);
+				  FileOutputStream fos = new FileOutputStream(fNew);
+				  int read=1;
+				  boolean corrupted=false;
+				  
+				  while (read > 0) {
+					  read = fis.read(buff);
+					  if (read > -1) {
+						  if (!corrupted) {
+							  for (int j=0;j<read;j++) {
+								  buff[j]=0;
+							  }
+							  corrupted = true;
+						  }
+						  fos.write(buff,0,read);
+					  }
+				  }
+				  fos.flush();fos.close();
+				  fis.close();
+				  if (!f.delete()) fail("Failed to delete existing cache");
+				  if (!fNew.renameTo(f)) fail("Could not rename new zerod cache");
+			  } catch (Exception e) {
+				  e.printStackTrace();
+				  fail("Cannot zero file "+e);
+			  }				
+		  }
+	  }
+	
+	protected static boolean copyFile(File from,File to) {
+		int i =0;
+		  byte[] buff = new byte[1000];
+		  try {
+			  FileInputStream fis = new FileInputStream(from);
+			  FileOutputStream fos = new FileOutputStream(to);
+			  int read=1;
+			  while (true && read>0) {
+				  read = fis.read(buff);
+				  i+=read;
+				  if (read>-1) fos.write(buff,0,read);
+			  }
+			  fos.flush();fos.close();
+			  fis.close();
+//			  System.out.println("Copied "+i+" bytes from "+from+" to "+to);
+		  } catch (Exception e) {
+			  fail("Cannot copy file '"+from+"' "+e);
+		  }
+		  return true;
+	}
+	public static void moveControlFilesForNonPersistentCache(String name,
+			String whereFrom, String whereTo) {
+				  if (isWindows()) {
+					  File f = new File(whereFrom+File.separator+getCacheFileName(name,false));
+					  File fNew = new File(whereTo+File.separator+getCacheFileName(name, false));
+					  if (!f.renameTo(fNew)) fail("Could not rename the control file");
+				  } else {
+					  File f = new File(whereFrom+File.separator+getCacheFileName(name,false));
+					  File fNew = new File(whereTo+File.separator+getCacheFileName(name, false));
+					  if (!f.renameTo(fNew)) fail("Could not rename the memory file from "+f.getAbsolutePath()+" to "+fNew.getAbsolutePath());
+					  
+					  f = new File(whereFrom+File.separator+getCacheFileName(name,false).replace("memory", "semaphore"));
+					  fNew = new File(whereTo+File.separator+getCacheFileName(name, false).replace("memory", "semaphore"));
+					  if (!f.renameTo(fNew)) fail("Could not rename the semaphore file from "+f.getAbsolutePath()+" to "+fNew.getAbsolutePath());	  
+				  }
+			  }
+	public static Set getSharedMemorySegments() {	
+	  Set shmSegments = new HashSet();
+	  RunCommand.execute("ipcs");
+	  String[] lines = RunCommand.lastCommandStdoutLines;
+	  if (lines!=null) {
+		  int i=0;
+		  boolean inSharedMemorySegmentSection = false;
+		  while (i<lines.length) {
+			  if (inSharedMemorySegmentSection) {
+				  if (lines[i].startsWith("0x")) {
+					  String shm = lines[i].substring(11,21).trim();
+	//				  System.out.println("From line '"+lines[i]+"' we have "+shm);
+					  shmSegments.add(shm);
+				  }
+			  }
+			  if (lines[i].indexOf("Shared Memory Segments")!=-1) inSharedMemorySegmentSection=true;
+			  if (lines[i].trim().equals("")) inSharedMemorySegmentSection=false;
+			  i++;
+		  }
+	  }
+	  return shmSegments;
+	}
+	public static Set getSharedSemaphores() {	
+		  Set shmSegments = new HashSet();
+		  RunCommand.execute("ipcs");
+		  String[] lines = RunCommand.lastCommandStdoutLines;
+		  if (lines!=null) {
+			  int i=0;
+			  boolean inSharedSemaphoresSection = false;
+			  while (i<lines.length) {
+				  if (inSharedSemaphoresSection) {
+					  if (lines[i].startsWith("0x")) {
+						  String sem = lines[i].substring(11,21).trim();
+	//					  System.out.println("From line '"+lines[i]+"' we have "+sem);
+						  shmSegments.add(sem);
+					  }
+				  }
+				  if (lines[i].indexOf("Semaphore Arrays")!=-1) inSharedSemaphoresSection=true;
+				  if (lines[i].trim().equals("")) inSharedSemaphoresSection=false;
+				  i++;
+			  }
+		  }
+		  return shmSegments;
+		}
+	
+	public static boolean removeSemaphoreForCache(String cacheName) {
+		StringBuffer removeSemCmd = new StringBuffer("ipcrm -s ");
+		String semid = null;
+		RunCommand.execute(getCommand(ListAllCaches), false);
+		String[] lines = RunCommand.lastCommandStderrLines;
+		for (int i = 0; i < lines.length; i++) {
+			if (lines[i].startsWith(cacheName)) {
+				String token[] = lines[i].split("(\\s)+");
+				/* verify cache name */
+				if (token[0].trim().equals(cacheName) == false) {
+					continue;
+				}
+				/* verify non-persistent cache */
+				if ((token[3].trim().equals("no") == false) && (token[3].trim().equals("non-persistent") == false)) {
+					continue;
+				}
+				/* get semaphore */
+				semid = token[7].trim();
+			}
+		}
+			
+		if (semid != null) {
+			removeSemCmd.append(semid);
+			RunCommand.execute(removeSemCmd.toString());
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	public static boolean removeSharedMemoryForCache(String cacheName) {
+		StringBuffer removeShmCmd = new StringBuffer("ipcrm -m ");
+		String shmid = null;
+		RunCommand.execute(getCommand(ListAllCaches), false);
+		String[] lines = RunCommand.lastCommandStderrLines;
+		for (int i = 0; i < lines.length; i++) {
+			if (lines[i].startsWith(cacheName)) {
+				String token[] = lines[i].split("(\\s)+");
+				/* verify cache name */
+				if (token[0].trim().equals(cacheName) == false) {
+					continue;
+				}
+				/* verify non-persistent cache */
+				if ((token[3].trim().equals("no") == false) && (token[3].trim().equals("non-persistent") == false)) {
+					continue;
+				}
+				/* get shared memory */
+				shmid = token[6].trim();
+			}
+			
+		}
+		if (shmid != null) {
+			removeShmCmd.append(shmid);
+			RunCommand.execute(removeShmCmd.toString());
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	public static String[] getLastCommandStdout() {
+		return RunCommand.lastCommandStdoutLines;
+	}
+	
+	public static String[] getLastCommandStderr() {
+		return RunCommand.lastCommandStderrLines;
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying01.java
@@ -1,0 +1,52 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create the four caches (2 persistent, 2 non-persistent) and check they list OK, and they destroy OK
+ */
+public class TestCacheCreationListingDestroying01 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+
+	  if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+	  
+	checkNoFileForNonPersistentCache("Foo");
+	checkNoFileForNonPersistentCache("Bar");
+	checkNoFileForPersistentCache("Foo");
+	checkNoFileForPersistentCache("Bar");
+	
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+	checkFileExistsForNonPersistentCache("Foo");
+	checkFileExistsForNonPersistentCache("Bar");
+	checkFileExistsForPersistentCache("Foo");
+	checkFileExistsForPersistentCache("Bar");
+
+	listAllCaches();
+	
+	if (isMVS())
+	{
+		checkOutputContains("Foo.*(no|non-persistent)","Did not find a non-persistent cache called Foo");
+		checkOutputContains("Bar.*(no|non-persistent)","Did not find a non-persistent cache called Bar");
+	}
+	else
+	{
+		checkOutputContains("Foo.*(yes|persistent)","Did not find a persistent cache called Foo");
+		checkOutputContains("Foo.*(no|non-persistent)","Did not find a non-persistent cache called Foo");
+		checkOutputContains("Bar.*(yes|persistent)","Did not find a persistent cache called Bar");
+		checkOutputContains("Bar.*(no|non-persistent)","Did not find a non-persistent cache called Bar");
+	}	
+	runDestroyAllCaches();
+	checkNoFileForNonPersistentCache("Foo");
+	checkNoFileForNonPersistentCache("Bar");
+	checkNoFileForPersistentCache("Foo");
+	checkNoFileForPersistentCache("Bar");
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying02.java
@@ -1,0 +1,83 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create the four caches (2 persistent, 2 non-persistent) and check they list OK
+ * then destroy them one at a time, check the right files disappear as we go.
+ */
+public class TestCacheCreationListingDestroying02 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  
+	  if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+	  
+		checkNoFileForNonPersistentCache("Foo");
+		checkNoFileForNonPersistentCache("Bar");
+		checkNoFileForPersistentCache("Foo");
+		checkNoFileForPersistentCache("Bar");
+		
+		createNonPersistentCache("Bar");
+		createNonPersistentCache("Foo");
+		createPersistentCache("Bar");
+		createPersistentCache("Foo");
+		checkFileExistsForNonPersistentCache("Foo");
+		checkFileExistsForNonPersistentCache("Bar");
+		checkFileExistsForPersistentCache("Foo");
+		checkFileExistsForPersistentCache("Bar");
+
+		listAllCaches();
+		if (isMVS())
+		{
+			checkOutputContains("Foo.*(no|non-persistent)","Did not find a non-persistent cache called Foo");
+			checkOutputContains("Bar.*(no|non-persistent)","Did not find a non-persistent cache called Bar");
+		}
+		else
+		{
+			checkOutputContains("Foo.*(yes|persistent)","Did not find a persistent cache called Foo");
+			checkOutputContains("Foo.*(no|non-persistent)","Did not find a non-persistent cache called Foo");
+			checkOutputContains("Bar.*(yes|persistent)","Did not find a persistent cache called Bar");
+			checkOutputContains("Bar.*(no|non-persistent)","Did not find a non-persistent cache called Bar");
+		}
+		if (isMVS())
+		{
+			destroyNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Bar");
+			
+			destroyNonPersistentCache("Bar");
+			checkNoFileForNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Bar");
+		}
+		else
+		{
+			destroyNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Bar");
+			checkFileExistsForPersistentCache("Foo");
+			checkFileExistsForPersistentCache("Bar");
+	
+			destroyPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Bar");
+			checkNoFileForPersistentCache("Foo");
+			checkFileExistsForPersistentCache("Bar");
+			
+			destroyPersistentCache("Bar");
+			checkNoFileForNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Bar");
+			checkNoFileForPersistentCache("Foo");
+			checkNoFileForPersistentCache("Bar");
+			
+			destroyNonPersistentCache("Bar");
+			checkNoFileForNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Bar");
+			checkNoFileForPersistentCache("Foo");
+			checkNoFileForPersistentCache("Bar");
+		}
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying03.java
@@ -1,0 +1,27 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create two non-persistent caches and check they list OK, and they destroy OK
+ */
+public class TestCacheCreationListingDestroying03 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+	checkNoFileForNonPersistentCache("Foo");
+	checkNoFileForNonPersistentCache("Bar");
+	
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+	checkFileExistsForNonPersistentCache("Foo");
+	checkFileExistsForNonPersistentCache("Bar");
+
+	listAllCaches();
+	checkOutputContains("Foo.*no","Did not find a non-persistent cache called Foo");
+	checkOutputContains("Bar.*no","Did not find a non-persistent cache called Bar");
+	
+	runDestroyAllCaches();
+	checkNoFileForNonPersistentCache("Foo");
+	checkNoFileForNonPersistentCache("Bar");
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheCreationListingDestroying04.java
@@ -1,0 +1,32 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create two non-persistent caches, check they list OK
+ * then destroy them one at a time, check the right files disappear as we go.
+ */
+public class TestCacheCreationListingDestroying04 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+		checkNoFileForNonPersistentCache("Foo");
+		checkNoFileForNonPersistentCache("Bar");
+		
+		createNonPersistentCache("Bar");
+		createNonPersistentCache("Foo");
+		checkFileExistsForNonPersistentCache("Foo");
+		checkFileExistsForNonPersistentCache("Bar");
+
+		listAllCaches();
+		checkOutputContains("Foo.*no","Did not find a non-persistent cache called Foo");
+		checkOutputContains("Bar.*no","Did not find a non-persistent cache called Bar");
+		
+		destroyNonPersistentCache("Foo");
+		checkNoFileForNonPersistentCache("Foo");
+		checkFileExistsForNonPersistentCache("Bar");
+		
+		destroyNonPersistentCache("Bar");
+		checkNoFileForNonPersistentCache("Foo");
+		checkNoFileForNonPersistentCache("Bar");
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir01.java
@@ -1,0 +1,32 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that when cacheDir is used, the files go to the right place.
+ * If cacheDir is used, the persistent cache files go directly where it points whilst
+ * the non-persistent cache control files go in the subdirectory javasharedresources 
+ */
+public class TestCacheDir01 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+	  String dir = createTemporaryDirectory("TestCacheDir01");
+	  String currentCacheDir = getCacheDir();
+	  setCacheDir(dir);
+	  try {
+		  createPersistentCache("Foo");	  
+		  checkFileExistsForPersistentCache("Foo");
+		  createNonPersistentCache("Foo2");	  
+		  checkFileExistsForNonPersistentCache("Foo2");
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir02.java
@@ -1,0 +1,23 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Set cacheDir to rubbish and run something
+ */
+public class TestCacheDir02 extends TestUtils {
+  public static void main(String[] args) {
+	  String currentCacheDir = getCacheDir();
+	  try {
+		  setCacheDir("!<><><><><><\\");
+		  runSimpleJavaProgramWithPersistentCache("Foo",false);
+		  showOutput();
+		  fail("Did not expect the port layer error line did I?  (although I know the cache name is invalid)");		  
+	  } finally {
+		  runDestroyAllCaches();
+		  deleteTemporaryDirectory("!<><><><><><\\");
+		  setCacheDir(currentCacheDir);
+	  }
+	  fail("Did not expect the port layer error did I?  (I know the cache name is invalid)");
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir03.java
@@ -1,0 +1,22 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Set cacheDir to rubbish and run something
+ */
+public class TestCacheDir03 extends TestUtils {
+  public static void main(String[] args) {
+	  String currentCacheDir = getCacheDir();
+	  deleteTemporaryDirectory("!%#&^%#");
+	  try {
+		  setCacheDir("!%#&^%#"); // this is horrible, but valid - at least on windows...
+		  runSimpleJavaProgramWithPersistentCache("Foo");
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  // try and tidy up a bit?
+		  deleteTemporaryDirectory("!%#&^%#");
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir04.java
@@ -1,0 +1,25 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that when cacheDir is used, the files go to the right place.
+ * If cacheDir is used, the persistent cache files go directly where it points whilst
+ * the non-persistent cache control files go in the subdirectory javasharedresources 
+ */
+public class TestCacheDir04 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  String dir = createTemporaryDirectory("TestCacheDir04");
+	  String currentCacheDir = getCacheDir();
+	  setCacheDir(dir);
+	  try {
+		  createNonPersistentCache("Foo2");	  
+		  checkFileExistsForNonPersistentCache("Foo2");		  
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir05.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.File;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir05.java
@@ -1,0 +1,31 @@
+package tests.sharedclasses.options;
+
+import java.io.File;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that when cacheDir is used, we never get a javasharedresources sub folder
+ */
+public class TestCacheDir05 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  String dir = createTemporaryDirectory("TestCacheDir05");
+	  String currentCacheDir = getCacheDir();
+	  File javaSharedResourcesFolder = new File(dir+File.separator+"javasharedresources");
+	  setCacheDir(dir);
+	  try {
+		  createPersistentCache("Foo");	  
+		  if (javaSharedResourcesFolder.exists()) 
+			  fail("Did not expect a javasharedresources folder to be created after creating a persistent cache when cacheDir is used");
+		  createNonPersistentCache("Bar");	  
+		  if (javaSharedResourcesFolder.exists()) 
+			  fail("Did not expect a javasharedresources folder to be created after creating a non-persistent cache when cacheDir is used");
+		  runDestroyAllCaches();
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir06.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.File;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir06.java
@@ -1,0 +1,29 @@
+package tests.sharedclasses.options;
+
+import java.io.File;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that when cacheDir is used and a persistent cache created, we create the directory if it does not exist
+ */
+public class TestCacheDir06 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  String dir = createTemporaryDirectory("TestCacheDir06");
+	  String currentCacheDir = getCacheDir();
+	  String subdir = dir+File.separator+"subdir";
+	  setCacheDir(subdir);
+	  try {
+		  runSimpleJavaProgramWithPersistentCache("Foo",false);
+		  checkOutputDoesNotContain("JVMSHRC215E", 
+				  "Did not expect message about the path not being found, it should have been constructed: "+
+				  subdir);		  
+		  runDestroyAllCaches();
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir07.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir07.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.File;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir07.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheDir07.java
@@ -1,0 +1,29 @@
+package tests.sharedclasses.options;
+
+import java.io.File;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that when cacheDir is used and a non-persistent cache is used, we create the directory if it does not exist
+ */
+public class TestCacheDir07 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  String dir = createTemporaryDirectory("TestCacheDir07");
+	  String currentCacheDir = getCacheDir();
+	  String subdir = dir+File.separator+"subdir";
+	  setCacheDir(subdir);
+	  try {
+		  runSimpleJavaProgramWithNonPersistentCache("Foo",false);
+		  checkOutputDoesNotContain("JVMSHRC022E", 
+				  "Did not expect message creating shared memory region, did we build the cacheDir ok? "+
+				  subdir);		  
+		  runDestroyAllCaches();
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations01.java
@@ -1,0 +1,42 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 1 and 3 around), then listAllCaches - 
+ * compatible previous generations should not show up.
+ */
+public class TestCacheGenerations01 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+    
+    if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+    
+    createGenerations01();
+    listAllCaches();
+    List /*String*/ compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be at most two entries for Foo and Bar (persistent and non-persistent variants of each)
+    // If there are 4 of each then generations are not being hidden
+    int fooCount = 0;
+    int barCount = 0;
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fooCount++;
+		if (name.equals("Bar")) barCount++;
+	}
+
+    if (fooCount==4) fail("The generations are not being hidden, there are 4 entries for Foo in the list");
+    if (barCount==4) fail("The generations are not being hidden, there are 4 entries for Bar in the list");
+    if (fooCount!=2) fail("Expected to find two entries for cache 'Foo' (one persistent, one non-persistent)");
+    if (barCount!=2) fail("Expected to find two entries for cache 'Bar' (one persistent, one non-persistent)");
+
+    runDestroyAllCaches();   
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations02.java
@@ -1,0 +1,25 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 1 and 3 around), run destroyAll and check all generations of all caches disappear
+ */
+public class TestCacheGenerations02 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+    createGenerations01();
+    runDestroyAllCaches();
+    listAllCaches();
+    List compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be no entries for Foo or Bar in that list!
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fail("Did not expect to find an entry for 'Foo' in the compatible cache list");
+		if (name.equals("Bar")) fail("Did not expect to find an entry for 'Bar' in the compatible cache list");
+	}
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations03.java
@@ -1,0 +1,26 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 1 and 3 around), run expire=0 and check all generations of Foo and Bar vanish
+ */
+public class TestCacheGenerations03 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();  
+    createGenerations01();
+    expireAllCaches();
+    listAllCaches();
+    List compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be no entries for Foo or Bar in that list!
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fail("Did not expect to find an entry for 'Foo' in the compatible cache list");
+		if (name.equals("Bar")) fail("Did not expect to find an entry for 'Bar' in the compatible cache list");
+	}
+  }
+  
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations04.java
@@ -1,0 +1,60 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 1 and 3 around), run destroy on each in turn and check the right caches vanish
+ */
+public class TestCacheGenerations04 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();  
+    
+    if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+    
+    createGenerations01();
+    // Now have two generations of Foo and Bar (in both persistent and non-persistent forms)
+    
+    // Lets check that
+    listAllCaches();
+    List /*String*/ compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be at most two entries for Foo and Bar (persistent and non-persistent variants of each)
+    // If there are 4 of each then generations are not being hidden
+    int fooCount = 0;
+    int barCount = 0;
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fooCount++;
+		if (name.equals("Bar")) barCount++;
+	}
+
+    if (fooCount==4) fail("The generations are not being hidden, there are 6 entries for Foo in the list");
+    if (barCount==4) fail("The generations are not being hidden, there are 6 entries for Bar in the list");
+    if (fooCount!=2) fail("Expected to find two entries for cache 'Foo' (one persistent, one non-persistent)");
+    if (barCount!=2) fail("Expected to find two entries for cache 'Bar' (one persistent, one non-persistent)");
+
+    // Now let's start deletions
+    destroyNonPersistentCache("Foo");
+    listAllCaches();
+    checkOutputForCompatibleCache("Foo", false, false);
+    
+    destroyPersistentCache("Bar");
+    listAllCaches();
+    checkOutputForCompatibleCache("Bar", true, false);
+
+    destroyPersistentCache("Foo");
+    listAllCaches();
+    checkOutputForCompatibleCache("Foo", true, false);
+
+    destroyNonPersistentCache("Bar");
+    listAllCaches();
+    checkOutputForCompatibleCache("Bar", false, false);
+    
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations05.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations05.java
@@ -1,0 +1,43 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 2 and 3 around), then listAllCaches - 
+ * compatible previous generations should not show up.
+ */
+public class TestCacheGenerations05 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();   
+    
+    if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+    
+    createGenerations02();
+    listAllCaches();
+    List /*String*/ compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be at most two entries for Foo and Bar (persistent and non-persistent variants of each)
+    // If there are 4 of each then generations are not being hidden
+    int fooCount = 0;
+    int barCount = 0;
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fooCount++;
+		if (name.equals("Bar")) barCount++;
+	}
+
+
+    if (fooCount==4) fail("The generations are not being hidden, there are 4 entries for Foo in the list");
+    if (barCount==4) fail("The generations are not being hidden, there are 4 entries for Bar in the list");
+    if (fooCount!=2) fail("Expected to find two entries for cache 'Foo' (one persistent, one non-persistent)");
+    if (barCount!=2) fail("Expected to find two entries for cache 'Bar' (one persistent, one non-persistent)");
+
+    runDestroyAllCaches();   
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations06.java
@@ -1,0 +1,25 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 2 and 3 around), run destroyAll and check all generations of all caches disappear
+ */
+public class TestCacheGenerations06 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+    createGenerations02();
+    runDestroyAllCaches();
+    listAllCaches();
+    List compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be no entries for Foo or Bar in that list!
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fail("Did not expect to find an entry for 'Foo' in the compatible cache list");
+		if (name.equals("Bar")) fail("Did not expect to find an entry for 'Bar' in the compatible cache list");
+	}
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations06.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations07.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations07.java
@@ -1,0 +1,26 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 2 and 3 around), run expire=0 and check all generations of Foo and Bar vanish
+ */
+public class TestCacheGenerations07 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();  
+    createGenerations02();
+    expireAllCaches();
+    listAllCaches();
+    List compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be no entries for Foo or Bar in that list!
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fail("Did not expect to find an entry for 'Foo' in the compatible cache list");
+		if (name.equals("Bar")) fail("Did not expect to find an entry for 'Bar' in the compatible cache list");
+	}
+  }
+  
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations07.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations07.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations08.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations08.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations08.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCacheGenerations08.java
@@ -1,0 +1,65 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create cache generations (we will have generations 2 and 3 around), run destroy on each in turn and check the right caches vanish
+ */
+public class TestCacheGenerations08 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }	
+    
+    createGenerations02();
+    // Now have two generations of Foo and Bar (in both persistent and non-persistent forms)
+    
+    // Lets check that
+    listAllCaches();
+    List /*String*/ compatibleCaches = processOutputForCompatibleCacheList();
+    // Should be at most two entries for Foo and Bar (persistent and non-persistent variants of each)
+    // If there are 4 of each then generations are not being hidden
+    int fooCount = 0;
+    int barCount = 0;
+    for (Iterator iterator = compatibleCaches.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("Foo")) fooCount++;
+		if (name.equals("Bar")) barCount++;
+	}
+    if (isMVS())
+    {
+       	if (fooCount!=1) fail("Expected to find 1 entries for cache 'Foo' (one non-persistent)");
+    	if (barCount!=1) fail("Expected to find 1 entries for cache 'Bar' (one non-persistent)");
+    }
+    else
+    {
+    	if (fooCount==4) fail("The generations are not being hidden, there are 6 entries for Foo in the list");
+    	if (barCount==4) fail("The generations are not being hidden, there are 6 entries for Bar in the list");
+    	if (fooCount!=2) fail("Expected to find two entries for cache 'Foo' (one persistent, one non-persistent)");
+    	if (barCount!=2) fail("Expected to find two entries for cache 'Bar' (one persistent, one non-persistent)");
+    }
+    // Now let's start deletions
+    destroyNonPersistentCache("Foo");
+    listAllCaches();
+    checkOutputForCompatibleCache("Foo", false, false);
+    
+    destroyPersistentCache("Bar");
+    listAllCaches();
+    checkOutputForCompatibleCache("Bar", true, false);
+
+    destroyPersistentCache("Foo");
+    listAllCaches();
+    checkOutputForCompatibleCache("Foo", true, false);
+
+    destroyNonPersistentCache("Bar");
+    listAllCaches();
+    checkOutputForCompatibleCache("Bar", false, false);
+    
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionModified.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionModified.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionModified.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionModified.java
@@ -1,0 +1,26 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Use the modification context command line option and check some entries in the cache are
+ * stored against it.
+ */
+public class TestCommandLineOptionModified extends TestUtils {
+  public static void main(String[] args) {
+	
+	runDestroyAllCaches();
+	runSimpleJavaProgramWithNonPersistentCache("testCache");
+	runPrintAllStats("testCache",false);
+	checkOutputDoesNotContain("ModContext", "Did not expect to find modContext mentioned in the stats output");
+
+	runSimpleJavaProgramWithNonPersistentCache("testCache,modified=mod1");
+	runPrintAllStats("testCache",false);
+	// example output:
+    //3: 0x4343DC10 ROMCLASS: java/net/URI at 0x42589CC8.
+    //	Index 1 in classpath 0x4349F6FC
+    //	ModContext mod1
+	checkOutputContains("ModContext.*mod1", "Expected the ModContext to be mentioned for some entries");
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName01.java
@@ -1,0 +1,34 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the 'name=' option 
+ * - does it work at all?
+ * - the value '*' should give us a sensible error message
+ * - the value '$' should give us a sensible error message
+ */
+public class TestCommandLineOptionName01 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+
+	// the basics
+	runSimpleJavaProgramWithNonPersistentCache("elephant");
+	listAllCaches();
+	checkOutputForCompatibleCache("elephant",false,true);
+	
+	// rogue character
+	runPrintStats("*",false);
+	checkOutputContains("JVMSHRC147E", "expected message about '*' not being valid for cache name");
+
+	// rogue character
+	runSimpleJavaProgramWithNonPersistentCache("$%u",false);
+	checkOutputContains("JVMSHRC147E", "expected message about '$' not being valid for cache name");
+
+	// rogue character
+	runSimpleJavaProgramWithNonPersistentCache("&%u",false);
+	checkOutputContains("JVMSHRC147E", "expected message about '&' not being valid for cache name");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName02.java
@@ -1,0 +1,20 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the 'name=' option 
+ * - the value '%d' should not be ok
+ */
+public class TestCommandLineOptionName02 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+
+	// %d - should not be fine
+	runSimpleJavaProgramWithNonPersistentCache("%d",false);
+	checkOutputContains("JVMSHRC154E.*character d", 
+			            "Did not get expected message about 'escape character d' being invalid");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName03.java
@@ -1,0 +1,41 @@
+package tests.sharedclasses.options;
+
+import java.util.Iterator;
+import java.util.List;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the 'name=' option 
+ * - the value '%u' should be the userid
+ * - the value '%g' should be the group id
+ */
+public class TestCommandLineOptionName03 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+
+	// %u - should be fine
+	runSimpleJavaProgramWithNonPersistentCache("%u");
+
+	if (isWindows()) {
+		// %g - not supported
+		runSimpleJavaProgramWithNonPersistentCache("%g",false);
+		checkOutputContains("JVMSHRC154E.*character g", "Did not get expected message about escape character G not being supported on windows");		
+	} else {
+		// %g - should be fine
+		runSimpleJavaProgramWithNonPersistentCache("%g");
+	}
+	listAllCaches();
+
+	List l = processOutputForCompatibleCacheList();
+	for (Iterator iterator = l.iterator(); iterator.hasNext();) {
+		String name = (String) iterator.next();
+		if (name.equals("")) {
+			listAllCaches();
+			fail("Cache found with a blank name!!!!");
+		}
+	}
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.util.Iterator;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionName04.java
@@ -1,0 +1,23 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the 'name=' option 
+ * - name longer than 64chars
+ */
+public class TestCommandLineOptionName04 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+
+	StringBuffer name= new StringBuffer();
+	for (int i=0;i<10;i++) {
+		name.append("thisIsAString");
+	}
+
+	runSimpleJavaProgramWithNonPersistentCache(name.toString(),false);
+	checkOutputContains("JVMSHRC061E","Did not get message about name of length greater than 64 chars not allowed");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.RunCommand;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent01.java
@@ -1,0 +1,30 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check 'silent' hides output
+ */
+public class TestCommandLineOptionSilent01 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+
+	String cachename="$%u"; // invalid
+	
+    // Need to do a bit of a hack-job to ensure this particular command isnt run with verbose on
+	String command = getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename);
+
+	// this should give the error
+	RunCommand.execute(command,false);
+	checkOutputContains("JVMSHRC147E", "expected message about '$' not being valid for cache name");
+
+	command = command.replaceAll("verbose", "silent");
+	
+	// this should not give the error
+	RunCommand.execute(command,false);
+	checkOutputDoesNotContain("JVMSHRC147E", "expected message about '$' not being valid for cache name");
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent02.java
@@ -1,0 +1,30 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check 'silent' overrides verbose
+ */
+public class TestCommandLineOptionSilent02 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+
+	String cachename="$%u"; // invalid
+	
+    // Need to do a bit of a hack-job to ensure this particular command isnt run with verbose on
+	String command = getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename);
+	
+	// this should not give the error
+	RunCommand.execute(command,false);
+	checkOutputContains("JVMSHRC147E", "expected message about '$' not being valid for cache name");
+	
+	command = getCommand(RunSimpleJavaProgramWithNonPersistentCache,cachename);
+	// this should not give the error
+	command = command.replaceAll("verbose", "verbose,silent");
+	RunCommand.execute(command,false);
+	checkOutputDoesNotContain("JVMSHRC147E", "did not expect message about '$' being valid for cache name");
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionSilent02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.RunCommand;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
@@ -1,0 +1,37 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check -Xscmcx
+ */
+public class TestCommandLineOptionXscmx01 extends TestUtils {
+  public static void main(String[] args) {	
+	runDestroyAllCaches();
+	
+	/* Note: AOT is turned off for the below tests. In some cases the JIT has 
+	 * enough time to store information in the already small cache. During this 
+	 * test this may cause the alredy to small cache to be marked as full 
+	 * (when this is not expected to occur).
+	 */
+	
+	// set 4k cache, too small
+	RunCommand.execute(getCommand("runSimpleJavaProgramWithPersistentCachePlusOptions","Foo","-Xscmx4k -Xnoaot"));
+	checkOutputContains("JVMSHRC096I.*is full", "Did not see expected message about the cache being full");
+	
+	runDestroyAllCaches();
+	
+	// set 5000k cache, ok
+	RunCommand.execute(getCommand("runSimpleJavaProgramWithPersistentCachePlusOptions","Foo","-Xscmx5000k -Xnoaot"));
+	checkOutputDoesNotContain("JVMSHRC096I.*is full", "Did not expect message about the cache being full");
+
+	runDestroyAllCaches();
+	
+	// set 8M cache, ok
+	RunCommand.execute(getCommand("runSimpleJavaProgramWithPersistentCachePlusOptions","Foo","-Xscmx8M -Xnoaot"));
+	checkOutputDoesNotContain("JVMSHRC096I.*is full", "Did not expect message about the cache being full");
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCommandLineOptionXscmx01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.RunCommand;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestComplexSequence.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestComplexSequence.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestComplexSequence.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestComplexSequence.java
@@ -1,0 +1,54 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create persistent cache Foo - check file is in right place
+ * Create non-persistent cache Bar - check cache control file is in right place
+ * Try to attach to persistent cache Foo - check attach to existing
+ * Try to attach to non-persistent cache Bar - check attach to existing
+ * Create non-persistent cache Foo - check new cache is created (and we dont connect to existing)
+ * Create persistent cache Bar - check new cache is created (and we dont connect to existing)
+ * Try to attach to non-persistent cache Foo - check attach to correct cache
+ * Try to attach to persistent cache Bar - check attach to correct cache
+ */
+public class TestComplexSequence extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  
+	  if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+	  
+	  createPersistentCache("Foo");
+	  checkFileExistsForPersistentCache("Foo");
+	  checkNoFileForNonPersistentCache("Foo");
+	  
+	  createNonPersistentCache("Bar");
+	  checkFileExistsForNonPersistentCache("Bar");
+	  checkNoFileForPersistentCache("Bar");
+	  
+	  runSimpleJavaProgramWithPersistentCache("Foo");
+	  checkOutputContains("JVMSHRC237I.*Foo", "Did not find expected message 'JVMSHRC237I Opened shared classes persistent cache Foo'");
+	  runSimpleJavaProgramWithNonPersistentCache("Bar");
+	  checkOutputContains("JVMSHRC159I.*Bar", "Did not find expected message 'JVMSHRC159I Successfully opened shared class cache \"Bar\"'");
+	  
+	  createNonPersistentCache("Foo");
+	  checkOutputContains("JVMSHRC158I.*Foo", "Did not find expected message 'JVMSHRC158I Successfully created shared class cache \"Foo\"'");
+	  checkFileExistsForNonPersistentCache("Foo");
+
+	  createPersistentCache("Bar");
+	  checkForSuccessfulPersistentCacheCreationMessage("Bar");
+	  checkFileExistsForPersistentCache("Bar");
+	  
+	  runSimpleJavaProgramWithNonPersistentCache("Foo");
+	  checkForSuccessfulNonPersistentCacheOpenMessage("Foo");
+	  
+	  runSimpleJavaProgramWithPersistentCache("Bar");
+	  checkForSuccessfulPersistentCacheOpenMessage("Bar");
+	  
+	  runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir01.java
@@ -1,0 +1,67 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that controlDir and cacheDir work the same.  Set the cacheDir, create a persistent cache and use it
+ * then reset cacheDir and point controlDir at the same place and check we can see the same cache.
+ */
+public class TestControlDirCacheDir01 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  if (isMVS())
+	  {
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	  }
+	  String dir = createTemporaryDirectory("TestControlDirCacheDir01");
+	  String currentCacheDir = getCacheDir();
+	  String currentControlDir = getControlDir();
+	  try {
+		  //tidy up default area
+		  setCacheDir(null);setControlDir(null);
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);setControlDir(currentControlDir);
+
+		  setCacheDir(dir);
+
+		  runDestroyAllCaches();
+		  createPersistentCache("Foo");
+		  runSimpleJavaProgramWithPersistentCache("Foo");
+		  checkForSuccessfulPersistentCacheOpenMessage("Foo");
+		  checkFileExistsForPersistentCache("Foo");
+		  
+		  setCacheDir(null);
+		  checkFileDoesNotExistForPersistentCache("Foo");
+		  
+		  setControlDir(dir);
+		  checkFileExistsForPersistentCache("Foo");
+		  
+		  runSimpleJavaProgramWithPersistentCache("Foo");
+		  checkForSuccessfulPersistentCacheOpenMessage("Foo");
+		  
+		  // Delete the cache and check it has vanished when viewed via cacheDir
+		  destroyPersistentCache("Foo");
+		  setControlDir(null);
+		  setCacheDir(dir);
+		  checkFileDoesNotExistForPersistentCache("Foo");		  
+	  } finally {
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);
+		  setControlDir(currentControlDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }
+//  
+//  public static String createTemporaryDirectory() {
+//	try {
+//	  File f = File.createTempFile("testSC","dir");
+//	  if (!f.delete()) fail("Couldn't create the temp dir");
+//	  if (!f.mkdir()) fail("Couldnt create the temp dir");
+//	  return f.getAbsolutePath();  
+//	} catch (IOException e) {
+//		fail("Couldnt create temp dir: "+e);
+//		return null;
+//	}
+//  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestControlDirCacheDir02.java
@@ -1,0 +1,55 @@
+package tests.sharedclasses.options;
+
+
+import java.io.File;
+import java.io.IOException;
+
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check that controlDir and cacheDir work the same.  Set the cacheDir, create a non-persistent cache and use it
+ * then reset cacheDir and point controlDir at the same place and check we can see the same cache.
+ */
+public class TestControlDirCacheDir02 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  
+	  String dir = createTemporaryDirectory("TestControlDirCacheDir02");
+	  String currentCacheDir = getCacheDir();
+	  String currentControlDir = getControlDir();
+	  try {
+		  // tidyup before we go...
+		  setCacheDir(null);setControlDir(null);
+		  runDestroyAllCaches();
+		  setCacheDir(currentCacheDir);setControlDir(currentControlDir);
+
+		  setCacheDir(dir);
+
+		  runDestroyAllCaches();
+		  createNonPersistentCache("Foo");
+		  runSimpleJavaProgramWithNonPersistentCache("Foo");
+		  checkForSuccessfulNonPersistentCacheOpenMessage("Foo");
+		  checkFileExistsForNonPersistentCache("Foo");
+		  
+		  setCacheDir(null);
+		  checkFileDoesNotExistForNonPersistentCache("Foo");
+		  
+		  setControlDir(dir);
+		  checkFileExistsForNonPersistentCache("Foo");
+		  
+		  runSimpleJavaProgramWithNonPersistentCache("Foo");
+		  checkForSuccessfulNonPersistentCacheOpenMessage("Foo");
+		  
+		  // Delete the cache and check it has vanished when viewed via cacheDir
+		  destroyNonPersistentCache("Foo");
+		  setControlDir(null);
+		  setCacheDir(dir);
+		  checkFileDoesNotExistForNonPersistentCache("Foo");		  
+	  } finally {
+		  setCacheDir(currentCacheDir);
+		  setControlDir(currentControlDir);
+		  deleteTemporaryDirectory(dir);
+	  }
+  }  
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches01.java
@@ -1,0 +1,24 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a persistent cache, chop it (truncate it) then try and use it - check we detect the problem.
+ */
+public class TestCorruptedCaches01 extends TestUtils {
+	public static void main(String[] args) {
+		runDestroyAllCaches();
+		if (isMVS()) {
+			// disabling for ZOS ... it doesn't make sense to corrupt the file
+			// (it only contains os id for shared mem chunk) ...
+			return;
+		}
+		createPersistentCache("Foo");
+		corruptCache("Foo", true, "truncate");
+		runSimpleJavaProgramWithPersistentCache("Foo", "disablecorruptcachedumps");
+		checkOutputContains("SimpleApp running",
+				"Did not get expected message about the application running");
+		checkOutputContains("JVMSHRC442E.*\"Foo\"",
+				"Did not get expected message JVMSHRC442E about the Foo cache being corrupted");
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches02.java
@@ -1,0 +1,24 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a persistent cache, simulate it being ftp'd in ascii mode - check we detect the problem when trying to use it
+ */
+public class TestCorruptedCaches02 extends TestUtils {
+	public static void main(String[] args) {
+		runDestroyAllCaches();
+		if (isMVS()) {
+			// disabling for ZOS ... it doesn't make sense to corrupt the file
+			// (it only contains os id for shared mem chunk) ...
+			return;
+		}
+		createPersistentCache("Foo");
+		corruptCache("Foo", true, "ftpascii");
+		runSimpleJavaProgramWithPersistentCache("Foo", "disablecorruptcachedumps");
+		checkOutputContains("SimpleApp running",
+				"Did not get expected message about the application running");
+		checkOutputContains("JVMSHRC442E.*\"Foo\"",
+				"Did not get expected message JVMSHRC442E about the Foo cache being corrupted");
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches03.java
@@ -1,0 +1,29 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a persistent cache, zero some of it - check we detect the problem when trying to use it
+ */
+public class TestCorruptedCaches03 extends TestUtils {
+	public static void main(String[] args) {
+		runDestroyAllCaches();
+		if (isMVS()) {
+			// disabling for ZOS ... it doesn't make sense to corrupt the file
+			// (it only contains os id for shared mem chunk) ...
+			return;
+		}
+		createPersistentCache("Foo");
+		corruptCache("Foo", true, "zero");
+		
+		runSimpleJavaProgramWithPersistentCache("Foo", "disablecorruptcachedumps");
+		
+		if (! realtimeTestsSelected() ) {
+			checkOutputContains("SimpleApp running",
+			"Did not get expected message about the application running");
+		}
+		
+		checkOutputContains("JVMSHRC442E.*\"Foo\"",
+				"Did not get expected message JVMSHRC442E about the Foo cache being corrupted");
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.RunCommand;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04.java
@@ -1,0 +1,32 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Complex corruption - CMVC defect 123221
+ * 1. start a VM using a cache
+ * 2. start/stop a second VM using the same cache
+ * 3. ask the first VM to change the cache (load something new)
+ * 4. start/stop a third VM using the same cache (will crash!)
+ * 
+ * To achieve this, this test program launches the VM described in step 1.  See the type
+ * TestCorruptedCaches04Helper to see the other steps.
+ */
+public class TestCorruptedCaches04 extends TestUtils {
+	public static void main(String[] args) {
+		runDestroyAllCaches();
+		if (isMVS()) {
+			// disabling for ZOS ... it doesn't make sense to corrupt the file
+			// (it only contains os id for shared mem chunk) ...
+			return;
+		}
+		createPersistentCache("Foo");
+
+		String cmd = getCommand(RunComplexJavaProgramWithPersistentCache,
+				"Foo", System.getProperty("config.properties",
+						"config.properties"));
+		RunCommand.execute(cmd);
+		showOutput();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04Helper.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04Helper.java
@@ -1,0 +1,31 @@
+package tests.sharedclasses.options;
+
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Complex corruption.
+ * This Helper class is running in a VM instance attached to a cache - the name of the
+ * cache is passed in as args[0].  It then starts a second VM running attached to the
+ * same cache (which should work fine).  When that completes it loads some classes itself
+ * which will affect the cache, then it starts another VM attached to this same cache.
+ * This reveals if there is a problem with CRC checking - it used to be that the CRC
+ * was updated at the end of a VMs lifetime and checked at the start of any VMs lifetime.
+ * If that were the case then this test would fail because the intermediate forName() calls
+ * change the contents of the cache and would render the CRC incorrect.  The fix is to
+ * mark the CRC invalid when any write occurs on the cache - thus the forname() calls will
+ * end up marking the CRC invalid and the final started task wont try and check it.
+ */
+public class TestCorruptedCaches04Helper extends TestUtils {
+  public static void main(String[] args) throws Exception {
+	  RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,args[0]));
+
+	  Class.forName("tests.sharedclasses.options.TestIncompatibleCaches01");
+	  Class.forName("tests.sharedclasses.options.TestIncompatibleCaches02");
+	  Class.forName("tests.sharedclasses.options.TestIncompatibleCaches03");
+	  Class.forName("tests.sharedclasses.options.TestIncompatibleCaches01");
+	  
+	  RunCommand.execute(getCommand(RunSimpleJavaProgramWithPersistentCache,args[0]));
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04Helper.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches04Helper.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches05.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCorruptedCaches05.java
@@ -1,0 +1,24 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a persistent cache, zero some of it - check we detect the problem when trying to use it
+ */
+public class TestCorruptedCaches05 extends TestUtils {
+	public static void main(String[] args) {
+		runDestroyAllCaches();
+		if (isMVS()) {
+			// disabling for ZOS ... it doesn't make sense to corrupt the file
+			// (it only contains os id for shared mem chunk) ...
+			return;
+		}
+		createPersistentCache("Foo");
+		corruptCache("Foo", true, "zeroStringCache");
+		
+		runSimpleJavaProgramWithPersistentCacheCheckStringTable("Foo");
+		
+		checkOutputContains("Resetting shared string table",
+				"Did not get expected message Resetting shared string table");
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreatingNonpersistentCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreatingNonpersistentCache.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreatingNonpersistentCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreatingNonpersistentCache.java
@@ -1,0 +1,33 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a new non-persistent cache using default options and check the file goes to the
+ * default location as expected.
+ */
+public class TestCreatingNonpersistentCache extends TestUtils {
+  public static void main(String[] args) {
+	  
+	 if (isMVS()) {
+			// this test checks persistent and non persistent cahces ... zos
+			// only has nonpersistent ... so we assume other tests cover this
+			return;
+		}
+	  
+	destroyPersistentCache("Bar");
+	destroyNonPersistentCache("Bar");
+	checkNoFileForPersistentCache("Bar");
+	checkNoFileForNonPersistentCache("Bar");
+	
+	createNonPersistentCache("Bar");
+	checkForSuccessfulNonPersistentCacheCreationMessage("Bar");
+	
+	checkFileExistsForNonPersistentCache("Bar");
+	checkNoFileForPersistentCache("Bar");
+	destroyCache("Bar");
+	
+	runDestroyAllCaches();
+  }
+	
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreationAndCompatibility.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreationAndCompatibility.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreationAndCompatibility.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestCreationAndCompatibility.java
@@ -1,0 +1,38 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create Java6 caches, list them all and check they are marked compatible
+ */
+public class TestCreationAndCompatibility extends TestUtils {
+  public static void main(String[] args) {
+    destroyPersistentCache("Foo");
+	destroyPersistentCache("Bar");
+	destroyNonPersistentCache("Foo");
+	destroyNonPersistentCache("Bar");
+	
+	 if (isMVS()) {
+			// this test checks persistent and non persistent cahces ... zos
+			// only has nonpersistent ... so we assume other tests cover this
+			return;
+		}
+	
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+
+	listAllCaches();
+
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+
+	checkOutputForCompatibleNonPersistentCache("Foo",true);
+	checkOutputForCompatibleNonPersistentCache("Bar",true);
+
+	
+	runDestroyAllCaches();
+  }
+	
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyAllWhenNoCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyAllWhenNoCaches.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyAllWhenNoCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyAllWhenNoCaches.java
@@ -1,0 +1,23 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Call destroyAll when there are no caches - expect sensible message
+ */
+public class TestDestroyAllWhenNoCaches extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();   
+    String tdir = createTemporaryDirectory("TestDestroyAllWhenNoCaches");
+    String currentCacheDir = getCacheDir();
+    setCacheDir(tdir);
+    try {
+    	runDestroyAllCaches();
+	    checkOutputContains("JVMSHRC005I", "Did not get expected message about there being no caches available");
+	    checkOutputDoesNotContain("JVMSHRC...E", "unexpected error received");
+    } finally {
+    	setCacheDir(currentCacheDir);
+    	deleteTemporaryDirectory(tdir);
+    }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyCache.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyCache.java
@@ -1,0 +1,442 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.*;
+import java.io.*;
+
+/*
+ * Check various scenarios handled in j9shr_destroy_cache() 
+ * with respect to deleting old and current generation cache.
+ * For details see JAZZ design 37044.
+ */
+public class TestDestroyCache extends TestUtils {
+	String cacheName = "testcache";
+	String destroyPersistentCache, destroyNonPersistentCache;
+	String infiniteLoopOutput = "Running infinite loop";
+
+	public static void main(String args[]) {
+		TestDestroyCache tdc = new TestDestroyCache();
+		tdc.destroyPersistentCache = getCommand(DestroyPersistentCacheCommand, tdc.cacheName);
+		tdc.destroyNonPersistentCache = getCommand(DestroyNonPersistentCacheCommand, tdc.cacheName);
+		tdc.testCase1();
+		tdc.testCase2();
+		tdc.testCase3();
+		tdc.testCase4();
+		tdc.testCase5();
+		tdc.testCase6();
+	}
+
+	private void testCase1() {
+		String expectedErrorMessages[] = new String[] { 
+			"JVMSHRC428I" /* Removed older generation of shared class cache "<cache name>" */ 
+		};
+		
+   		runDestroyAllCaches();
+   		
+   		/* When only older generation cache exists and is not in use */
+   		if (isMVS() == false) {
+			runSimpleJavaProgramWithPersistentCache(cacheName, "createOldGen");
+			RunCommand.execute(destroyPersistentCache, null, expectedErrorMessages, false, false, null);
+   		}
+   		
+   		if (realtimeTestsSelected() == false) {
+			runSimpleJavaProgramWithNonPersistentCache(cacheName, "createOldGen");
+			RunCommand.execute(destroyNonPersistentCache, null, expectedErrorMessages, false, false, null);
+   		}
+   		
+		runDestroyAllCaches();
+	}
+	
+	private void testCase2() {
+		Process p1 = null;
+		String expectedErrorMessages[];
+		
+		runDestroyAllCaches();
+		
+		/* When only current generation cache exists and is in use */
+   		if (isMVS() == false) {
+			try {
+				if (isWindows()) {
+					expectedErrorMessages = new String[] {
+						"JVMSHRC430I" /* Failed to remove current generation of shared class cache "<cache name>" */
+					};
+				} else {
+					/* Linux, AIX allow to destroy an active persistent cache */
+					expectedErrorMessages = new String[] {
+						"has been destroyed" /* Persistent shared cache "<cache name>" has been destroyed */
+					};
+				}
+				if (realtimeTestsSelected()) {
+					/* Need to create realtime cache before it is used by InfiniteLoop. Otherwise, it won't be written to disk */ 
+					runSimpleJavaProgramWithPersistentCache(cacheName);
+				}
+				runInfiniteLoopJavaProgramWithPersistentCache(cacheName, infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (realtimeTestsSelected()) {
+					destroyPersistentCache(cacheName);
+				}
+			}
+   		}
+   		
+		if (realtimeTestsSelected() == false) {
+			try {
+				expectedErrorMessages = new String[] {
+					"JVMSHRC430I" /* Failed to remove current generation of shared class cache "<cache name>" */
+				};
+				runInfiniteLoopJavaProgramWithNonPersistentCache(cacheName, infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyNonPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+		
+		runDestroyAllCaches();
+	}
+	
+	private void testCase3() {
+		Process p1 = null;
+		String expectedErrorMessages[];
+		
+		runDestroyAllCaches();
+
+		/* When only older generation cache exists and is in use */
+   		if (isMVS() == false) {
+			try {
+				if (isWindows()) {
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC429I" /* Failed to remove older generation of shared class cache "<cache name>" */
+					};
+				} else {
+					/* Linux, AIX allow to destroy an active persistent cache */
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC428I" /* Removed older generation of shared class cache "<cache name>" */
+					};
+				}
+				if (realtimeTestsSelected()) {
+					/* Need to create realtime cache before it is used by InfiniteLoop. Otherwise, it won't be written to disk */
+					runSimpleJavaProgramWithPersistentCache(cacheName, "createOldGen");
+				}
+				runInfiniteLoopJavaProgramWithPersistentCache(cacheName, "createOldGen", infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (realtimeTestsSelected()) {
+					destroyPersistentCache(cacheName);
+				}
+			}
+   		}
+   		
+		if (realtimeTestsSelected() == false) {
+			try {
+				expectedErrorMessages = new String[] { 
+					"JVMSHRC429I" /* Failed to remove older generation of shared class cache "<cache name>" */
+				};
+				runInfiniteLoopJavaProgramWithNonPersistentCache(cacheName, "createOldGen", infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyNonPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+		
+		runDestroyAllCaches();
+	}
+	
+	private void testCase4() {
+		Process p1 = null;
+		String expectedErrorMessages[];
+		
+		runDestroyAllCaches();
+		
+		/* When older generation cache is not in use but current generation cache is in use */
+		if (isMVS() == false) {
+			try {
+				if (isWindows()) {
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC428I",/* Removed older generation of shared class cache "<cache name>" */
+						"JVMSHRC430I" /* Failed to remove current generation of shared class cache "<cache name>" */
+					};
+				} else {
+					/* Linux, AIX allow to destroy an active persistent cache */
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC428I",/* Removed older generation of shared class cache "<cache name>" */
+						"has been destroyed" /* Persistent shared cache "<cache name>" has been destroyed */
+					};
+				}
+				runSimpleJavaProgramWithPersistentCache(cacheName, "createOldGen");
+				if (realtimeTestsSelected()) {
+					/* Need to create realtime cache before it is used by InfiniteLoop. Otherwise, it won't be written to disk */
+					runSimpleJavaProgramWithPersistentCache(cacheName);
+				}
+				runInfiniteLoopJavaProgramWithPersistentCache(cacheName, infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (realtimeTestsSelected()) {
+					destroyPersistentCache(cacheName);
+				}
+			}
+		}
+		
+		if (realtimeTestsSelected() == false) {
+			try {
+				expectedErrorMessages = new String[] { 
+					"JVMSHRC428I",/* Removed older generation of shared class cache "<cache name>" */
+					"JVMSHRC430I" /* Failed to remove current generation of shared class cache "<cache name>" */
+				};
+				runSimpleJavaProgramWithNonPersistentCache(cacheName, "createOldGen");
+				runInfiniteLoopJavaProgramWithNonPersistentCache(cacheName, infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyNonPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+		
+		runDestroyAllCaches();
+	}
+	
+	private void testCase5() {
+		Process p1 = null;
+		String expectedErrorMessages[];		
+		
+		runDestroyAllCaches();
+		
+		/* When older generation is in use and current generation cache is not in use */
+		if (isMVS() == false) {
+			try {
+				if (isWindows()) {
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC429I",/* Failed to remove older generation of shared class cache "<cache name>" */
+						"has been destroyed" /* Persistent shared cache "<cache name>" has been destroyed */
+					};
+				} else {
+					/* Linux, AIX allow to destroy an active persistent cache */
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC428I",/* Removed older generation of shared class cache "<cache name>" */
+						"has been destroyed" /* Persistent shared cache "<cache name>" has been destroyed */
+					};
+				}
+				if (realtimeTestsSelected()) {
+					/* Need to create realtime cache before it is used by InfiniteLoop. Otherwise, it won't be written to disk */
+					runSimpleJavaProgramWithPersistentCache(cacheName, "createOldGen");
+				}
+				runInfiniteLoopJavaProgramWithPersistentCache(cacheName, "createOldGen", infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				runSimpleJavaProgramWithPersistentCache(cacheName);
+				RunCommand.execute(destroyPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (realtimeTestsSelected()) {
+					destroyPersistentCache(cacheName);
+				}
+			}
+		}
+		
+		if (realtimeTestsSelected() == false) {
+			try {
+				expectedErrorMessages = new String[] { 
+					"JVMSHRC429I",/* Failed to remove older generation of shared class cache "<cache name>" */
+					"is destroyed" /* Shared cache "<cache name>" is destroyed */
+				};
+				runInfiniteLoopJavaProgramWithNonPersistentCache(cacheName, "createOldGen", infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				runSimpleJavaProgramWithNonPersistentCache(cacheName);
+				RunCommand.execute(destroyNonPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+		
+		runDestroyAllCaches();
+	}
+	
+	private void testCase6() {
+		Process p1 = null;
+		Process p2 = null;
+		String expectedErrorMessages[];
+
+		runDestroyAllCaches();
+		
+		/* When both older generation cache and current generation cache are in use */
+		if (isMVS() == false) {
+			try {
+				if (isWindows()) {
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC429I",/* Failed to remove older generation of shared class cache "<cache name>" */
+						"JVMSHRC430I" /* Failed to remove current generation of shared class cache "<cache name>" */
+					};
+				} else {
+					/* Linux, AIX allow to destroy an active persistent cache */
+					expectedErrorMessages = new String[] { 
+						"JVMSHRC428I",/* Removed older generation of shared class cache "<cache name>" */
+						"has been destroyed" /* Persistent shared cache "<cache name>" has been destroyed */
+					};
+				}
+				if (realtimeTestsSelected()) {
+					/* Need to create realtime cache before it is used by InfiniteLoop. Otherwise, it won't be written to disk */
+					runSimpleJavaProgramWithPersistentCache(cacheName, "createOldGen");
+				}
+				runInfiniteLoopJavaProgramWithPersistentCache(cacheName, "createOldGen", infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				if (realtimeTestsSelected()) {
+					/* Need to create realtime cache before it is used by InfiniteLoop. Otherwise, it won't be written to disk */
+					runSimpleJavaProgramWithPersistentCache(cacheName);
+				}
+				runInfiniteLoopJavaProgramWithPersistentCache(cacheName, infiniteLoopOutput);
+				p2 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (null == p2) {
+					p2 = RunCommand.getLastProcess();
+				}
+				if (null != p2) {
+					p2.destroy();
+					try {
+						p2.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (realtimeTestsSelected()) {
+					destroyPersistentCache(cacheName);
+				}
+			}
+		}
+		
+		if (realtimeTestsSelected() == false) {
+			try {
+				expectedErrorMessages = new String[] { 
+					"JVMSHRC429I",/* Failed to remove older generation of shared class cache "<cache name>" */
+					"JVMSHRC430I" /* Failed to remove current generation of shared class cache "<cache name>" */
+				};
+				runInfiniteLoopJavaProgramWithNonPersistentCache(cacheName, "createOldGen", infiniteLoopOutput);
+				p1 = RunCommand.getLastProcess();
+				runInfiniteLoopJavaProgramWithNonPersistentCache(cacheName, infiniteLoopOutput);
+				p2 = RunCommand.getLastProcess();
+				RunCommand.execute(destroyNonPersistentCache, null, expectedErrorMessages, false, false, null);
+			} finally {
+				if (null == p1) {
+					p1 = RunCommand.getLastProcess();
+				}
+				if (null != p1) {
+					p1.destroy();
+					try {
+						p1.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+				if (null == p2) {
+					p2 = RunCommand.getLastProcess();
+				}
+				if (null != p2) {
+					p2.destroy();
+					try {
+						p2.waitFor();
+					} catch (java.lang.InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+		}
+		
+		runDestroyAllCaches();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyNonExistentCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyNonExistentCaches.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyNonExistentCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDestroyNonExistentCaches.java
@@ -1,0 +1,14 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Destroy caches that don't exist, checking for sensible message
+ */
+public class TestDestroyNonExistentCaches extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();   
+    destroyPersistentCache("DoesNotExist");
+    checkOutputContains("JVMSHRC023E", "Did not get expected message JVMSHRC023E saying the cache did not exist");
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDisableCorruptCacheDumps.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDisableCorruptCacheDumps.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDisableCorruptCacheDumps.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestDisableCorruptCacheDumps.java
@@ -1,0 +1,27 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a cache with testFakeCorruption, then read that cache with the option
+ * disablecorruptcachedumps and checks that no dumps are created
+ */
+public class TestDisableCorruptCacheDumps extends TestUtils {
+	public static void main(String[] args) {
+		runDestroyAllCaches();    
+
+		if (isMVS()) {
+			// disabling for ZOS ... it doesn't make sense to corrupt the file
+			return;
+		}
+    
+		createPersistentCache("Foo");
+		corruptCache("Foo", true, "truncate");
+		runSimpleJavaProgramWithPersistentCache("Foo", "disablecorruptcachedumps");
+		
+		checkOutputContains("JVMSHRC442E.*\"Foo\"",
+		"Did not get expected message JVMSHRC442E about the Foo cache being corrupted");
+		checkOutputForDump(false);
+		runDestroyAllCaches();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireAllWhenNoCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireAllWhenNoCaches.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireAllWhenNoCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireAllWhenNoCaches.java
@@ -1,0 +1,32 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * expire=0 when there are no caches - expect sensible message
+ */
+public class TestExpireAllWhenNoCaches extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();   
+    String tdir = createTemporaryDirectory("TestExpireAllWhenNoCaches");
+    String currentCacheDir = getCacheDir();
+    setCacheDir(tdir);
+    try {
+    	expireAllCaches();
+	    checkOutputContains("JVMSHRC005I", "Did not get expected message about there being no caches available");
+	    checkOutputDoesNotContain("JVMSHRC...E", "unexpected error received");
+	    if (isMVS())
+	    {
+	    	checkForSuccessfulNonPersistentCacheCreationMessage("");
+	    }
+	    else
+	    {
+	    	checkForSuccessfulPersistentCacheCreationMessage("");
+	    }
+    } finally {
+    	runDestroyAllCaches();
+    	setCacheDir(currentCacheDir);
+    	deleteTemporaryDirectory(tdir);
+    }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpireDestroyOnCorruptCache.java
@@ -1,0 +1,52 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a cache, corrput it by zero-ing out its pages, expire it using -Xshareclasses:expire=0 and -Xshareclasses:expire=n.
+ * Create a cache, corrupt it by zero-ing out its pages, destroy it using -Xshareclasses:destroy.
+ * Create a cache, corrupt it by zero-ing out its pages, destroy it using -Xshareclasses:destroyAll.
+ */
+public class TestExpireDestroyOnCorruptCache extends TestUtils {
+	public static void main(String[] args) {
+		if (isMVS()) {
+			/* we don't yet have a mechanism to corrupt a non-persistent cache */
+			return;
+		}
+		
+		destroyPersistentCache("Foo");
+		createPersistentCache("Foo");
+		checkFileExistsForPersistentCache("Foo");
+		corruptCache("Foo", true, "zeroFirstPage");
+		try {
+			Thread.sleep(1000);
+		} catch (Exception e) {
+		}
+		expireAllCaches();
+		/* expire does not delete caches detected as corrupt during oscache->startup() */
+		checkFileExistsForPersistentCache("Foo");
+
+		try {
+			/* sleep for 2 mins */
+			Thread.sleep(2000*60);
+		} catch (Exception e) {
+		}
+
+		/* expire all caches not used for past 1 min */
+		expireAllCachesWithTime(new Integer(1).toString());
+		/* expire does not delete caches detected as corrupt during oscache->startup() */
+		checkFileExistsForPersistentCache("Foo");
+		
+		destroyPersistentCache("Foo");
+		checkForSuccessfulPersistentCacheDestroyMessage("Foo");
+		checkNoFileForPersistentCache("Foo");
+		
+		createPersistentCache("Foo");
+		checkFileExistsForPersistentCache("Foo");
+		corruptCache("Foo", true, "zeroFirstPage");
+		runDestroyAllCaches();
+		checkForSuccessfulPersistentCacheDestroyMessage("Foo");
+		checkNoFileForPersistentCache("Foo");
+	}
+}
+	  

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpiringCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpiringCaches.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpiringCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestExpiringCaches.java
@@ -1,0 +1,85 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create the four caches (2 persistent, 2 non-persistent) and check they list OK
+ * then expire them, check they all go.
+ */
+public class TestExpiringCaches extends TestUtils {
+  public static void main(String[] args) {
+	  
+		if (isMVS()) {
+
+			destroyNonPersistentCache("Foo");
+			destroyNonPersistentCache("Bar");
+			checkNoFileForNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Bar");
+			
+			createNonPersistentCache("Bar");
+			createNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Bar");
+			
+			listAllCaches();
+			checkOutputContains("Foo.*(no|non-persistent)",
+					"Did not find a non-persistent cache called Foo");
+			checkOutputContains("Bar.*(no|non-persistent)",
+					"Did not find a non-persistent cache called Bar");
+			try {
+				Thread.sleep(1000);
+			} catch (Exception e) {
+			} // required???!?!?
+			expireAllCaches();
+			
+			checkForSuccessfulNonPersistentCacheDestoryMessage("Bar");
+			checkForSuccessfulNonPersistentCacheDestoryMessage("Foo");
+			checkNoFileForNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Bar");
+		} else {
+			destroyPersistentCache("Foo");
+			destroyPersistentCache("Bar");
+			destroyNonPersistentCache("Foo");
+			destroyNonPersistentCache("Bar");
+			checkNoFileForNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Bar");
+			checkNoFileForPersistentCache("Foo");
+			checkNoFileForPersistentCache("Bar");
+
+			createNonPersistentCache("Bar");
+			createNonPersistentCache("Foo");
+			createPersistentCache("Bar");
+			createPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Foo");
+			checkFileExistsForNonPersistentCache("Bar");
+			checkFileExistsForPersistentCache("Foo");
+			checkFileExistsForPersistentCache("Bar");
+
+			listAllCaches();
+			checkOutputContains("Foo.*(yes|persistent)",
+					"Did not find a persistent cache called Foo");
+			checkOutputContains("Foo.*(no|non-persistent)",
+					"Did not find a non-persistent cache called Foo");
+			checkOutputContains("Bar.*(yes|persistent)",
+					"Did not find a persistent cache called Bar");
+			checkOutputContains("Bar.*(no|non-persistent)",
+					"Did not find a non-persistent cache called Bar");
+
+			try {
+				Thread.sleep(1000);
+			} catch (Exception e) {
+			} // required???!?!?
+			expireAllCaches();
+
+			checkForSuccessfulPersistentCacheDestroyMessage("Bar");
+			checkForSuccessfulPersistentCacheDestroyMessage("Foo");
+			checkForSuccessfulNonPersistentCacheDestoryMessage("Bar");
+			checkForSuccessfulNonPersistentCacheDestoryMessage("Foo");
+
+			checkNoFileForNonPersistentCache("Foo");
+			checkNoFileForNonPersistentCache("Bar");
+			checkNoFileForPersistentCache("Foo");
+			checkNoFileForPersistentCache("Bar");
+		}
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches01.java
@@ -1,0 +1,27 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create some incompatible caches, check they appear in listAllCaches in the appropriate
+ * section.
+ */
+public class TestIncompatibleCaches01 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+	createIncompatibleCache("Foo5");
+	createIncompatibleCache("Foo");
+	createIncompatibleCache("Bar");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+
+	runDestroyAllCaches();
+	checkOutputContains("\"Bar\".*is destroyed", "Did not see expected message about cache Bar being destroyed");
+	checkOutputContains("\"Foo\".*is destroyed", "Did not see expected message about cache Foo being destroyed");
+	checkOutputContains("\"Foo5\".*is destroyed", "Did not see expected message about cache Foo5 being destroyed");
+	
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches02.java
@@ -1,0 +1,71 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible and incompatible caches, check they are reported in the right
+ * section on listAllCaches.
+ */
+public class TestIncompatibleCaches02 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+
+	createIncompatibleCache("Foo5");
+	createIncompatibleCache("Foo");
+	createIncompatibleCache("Bar");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+	
+	destroyNonPersistentCache("Foo");
+	checkNoFileForNonPersistentCache("Foo");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+
+	destroyNonPersistentCache("Bar");
+	checkNoFileForNonPersistentCache("Bar");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+
+	destroyPersistentCache("Foo");
+	checkNoFileForPersistentCache("Foo");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+
+	destroyPersistentCache("Bar");
+	checkNoFileForPersistentCache("Bar");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+
+	checkOutputForCompatiblePersistentCache("Foo",false);
+	checkOutputForCompatiblePersistentCache("Bar",false);
+	checkOutputForCompatibleNonPersistentCache("Foo",false);
+	checkOutputForCompatibleNonPersistentCache("Bar",false);
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches03.java
@@ -1,0 +1,44 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible and incompatible caches, check they are reported in the right
+ * section on listAllCaches - then destroyAll and check they *all* disappear.
+ */
+public class TestIncompatibleCaches03 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+
+	createIncompatibleCache("Foo5");
+	createIncompatibleCache("Foo");
+	createIncompatibleCache("Bar");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+	
+	runDestroyAllCaches();
+	
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",false);
+	checkOutputForIncompatibleCache("Foo",false);
+	checkOutputForIncompatibleCache("Bar",false);
+	checkOutputForCompatiblePersistentCache("Foo",false);
+	checkOutputForCompatiblePersistentCache("Bar",false);
+	checkOutputForCompatiblePersistentCache("Foo",false);
+	checkOutputForCompatiblePersistentCache("Bar",false);
+	
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestIncompatibleCaches04.java
@@ -1,0 +1,44 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible and incompatible caches, check they are reported in the right
+ * section on listAllCaches - then expire=0 and check they *all* disappear.
+ */
+public class TestIncompatibleCaches04 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+
+	createIncompatibleCache("Foo5");
+	createIncompatibleCache("Foo");
+	createIncompatibleCache("Bar");
+
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",true);
+	checkOutputForIncompatibleCache("Foo",true);
+	checkOutputForIncompatibleCache("Bar",true);
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+	checkOutputForCompatiblePersistentCache("Foo",true);
+	checkOutputForCompatiblePersistentCache("Bar",true);
+	
+	expireAllCaches();
+	
+	listAllCaches();
+	checkOutputForIncompatibleCache("Foo5",false);
+	checkOutputForIncompatibleCache("Foo",false);
+	checkOutputForIncompatibleCache("Bar",false);
+	checkOutputForCompatiblePersistentCache("Foo",false);
+	checkOutputForCompatiblePersistentCache("Bar",false);
+	checkOutputForCompatiblePersistentCache("Foo",false);
+	checkOutputForCompatiblePersistentCache("Bar",false);
+	
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestListAllWhenNoCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestListAllWhenNoCaches.java
@@ -1,0 +1,24 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * listAllCaches when there are no caches - expect sensible output
+ */
+public class TestListAllWhenNoCaches extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();   
+    String tdir = createTemporaryDirectory("TestListAllWhenNoCaches");
+    String currentCacheDir = getCacheDir();
+    
+    setCacheDir(tdir);
+    try {
+    	listAllCaches();
+	    checkOutputContains("JVMSHRC005I", "Did not get expected message about there being no caches available");
+	    checkOutputDoesNotContain("JVMSHRC...E", "unexpected error received");
+    } finally {
+    	setCacheDir(currentCacheDir);
+    	deleteTemporaryDirectory(tdir);
+    }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestListAllWhenNoCaches.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestListAllWhenNoCaches.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles01.java
@@ -1,0 +1,54 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create non-persistent cache, use it then move the control file, use it again (new one created), delete than one
+ * and return the original control file, use it then delete it.
+ */
+public class TestMovingControlFiles01 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  createNonPersistentCache("Foo");	  
+	  runSimpleJavaProgramWithNonPersistentCache("Foo");
+
+	  String fromdir = getCacheFileDirectory(false);
+	  String todir = createTemporaryDirectory("TestListAllWhenNoCaches");
+	  try {
+		  
+		  // move the control file to a temp directory
+		  moveControlFilesForNonPersistentCache("Foo",fromdir,todir);
+		  
+		  // shouldnt be able to find it now...
+		  listAllCaches();
+		  checkOutputForCompatibleCache("Foo",false,false);
+		  
+		  // recreated by this run
+		  runSimpleJavaProgramWithNonPersistentCache("Foo");
+		  checkForSuccessfulNonPersistentCacheCreationMessage("Foo");
+	
+		  destroyNonPersistentCache("Foo");
+		  
+		  // Copy the old control file back
+
+		  moveControlFilesForNonPersistentCache("Foo",todir,fromdir);
+		  // use it
+		  if (isWindows()) {
+			  runSimpleJavaProgramWithNonPersistentCache("Foo");
+			  checkForSuccessfulNonPersistentCacheOpenMessage("Foo");
+		  } else {
+			  // this may fail if our new file reuses inodes ...
+			  runSimpleJavaProgramWithNonPersistentCacheMayFail("Foo");
+		  }
+		  
+		  destroyNonPersistentCache("Foo");
+		  
+		  if (isWindows()) {
+			  checkForSuccessfulNonPersistentCacheDestoryMessage("Foo");
+		  }
+
+	  } finally {
+		  deleteTemporaryDirectory(todir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestMovingControlFiles02.java
@@ -1,0 +1,80 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+import java.io.*;
+
+/*
+ * Create non-persistent cache, rename the control file in the javasharedresources folder, try and delete it.
+ */
+public class TestMovingControlFiles02 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+	  createNonPersistentCache("Foo");	  
+	  runSimpleJavaProgramWithNonPersistentCache("Foo");
+	  
+	  String tmpdir = createTemporaryDirectory("TestMovingControlFiles02");
+	  
+	  File fHidden = null;
+	  try {
+		  // rename the control file, add '.hidden' suffix
+		  
+		  if (isWindows()) {
+			  String loc = getCacheFileLocationForNonPersistentCache("Foo");
+			  File f = new File(loc);
+			  fHidden = new File(loc+".hidden");
+			  fHidden.delete();
+			  if (!f.renameTo(fHidden)) fail("Could not rename the control file to be hidden");
+		  } else {
+			  // linux, two files to rename
+			  String loc = getCacheFileLocationForNonPersistentCache("Foo");
+			  File f= new File(loc);
+			  fHidden = new File(loc+".hidden");
+			  fHidden.delete();
+			  if (!f.renameTo(fHidden)) fail("Could not rename the 'memory' control file from "+f.getAbsolutePath()+" to "+fHidden.getAbsolutePath());
+			  loc = getCacheFileLocationForNonPersistentCache("Foo").replace("memory","semaphore");
+			  f= new File(loc);
+			  fHidden = new File(loc+".hidden");
+			  fHidden.delete();
+			  if (!f.renameTo(fHidden)) fail("Could not rename the 'semaphore' control file from "+f.getAbsolutePath()+" to "+fHidden.getAbsolutePath());
+			  
+		  }
+		  // shouldnt be able to find it now...
+		  listAllCaches();
+		  checkOutputForCompatibleCache("Foo",false,false);
+
+		  if (isWindows()) {
+			  runSimpleJavaProgramWithNonPersistentCache("Foo");
+			  checkForSuccessfulNonPersistentCacheCreationMessage("Foo");
+		  } else {
+			  // this may fail if our new file reuses inodes ...
+			  runSimpleJavaProgramWithNonPersistentCacheMayFail("Foo");
+		  }
+		  
+
+	  } finally {
+		  runDestroyAllCaches();
+		  // tidy up!
+		  if (isWindows()) {
+			  String loc = getCacheFileLocationForNonPersistentCache("Foo");
+			  File f = new File(loc);
+			  fHidden = new File(loc+".hidden");
+			  f.delete();
+			  if (!fHidden.renameTo(f)) fail("Could not rename the control file to its original name");
+		  } else {
+			  // linux, two files to rename
+			  String loc = getCacheFileLocationForNonPersistentCache("Foo");
+			  File f= new File(loc);
+			  fHidden = new File(loc+".hidden");
+			  f.delete();
+			  if (!fHidden.renameTo(f)) fail("Could not rename the 'memory' control file to its original name");
+			  loc = getCacheFileLocationForNonPersistentCache("Foo").replace("memory","semaphore");;
+			  f= new File(loc);
+			  fHidden = new File(loc+".hidden");
+			  f.delete();
+			  if (!fHidden.renameTo(f)) fail("Could not rename the 'semaphore' control file to its original name");
+		  }
+		  runDestroyAllCaches();
+		  deleteTemporaryDirectory(tmpdir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestOptionNone.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestOptionNone.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestOptionNone.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestOptionNone.java
@@ -1,0 +1,26 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the 'none' option - should switch off any class sharing
+ */
+public class TestOptionNone extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    runSimpleJavaProgramWithPersistentCache("plums","none");   
+    checkOutputDoesNotContain("JVMSHRC236I", "Did not expect a message about a cache being created");
+    
+    runSimpleJavaProgramWithPersistentCache("plums");
+    
+    if (isMVS())
+    {
+        checkForSuccessfulNonPersistentCacheCreationMessage("plums");
+    }
+    else
+    {
+    	checkForSuccessfulPersistentCacheCreationMessage("plums");
+    }
+    runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
@@ -1,0 +1,48 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+import java.io.*;
+
+/*
+ * Create a persistent cache, move the cache to another location, use cachedir to pick it up from the other 
+ * location and check no new classes are loaded.
+ */
+public class TestPersistentCacheMoving01 extends TestUtils {
+  public static void main(String[] args) {
+	  runDestroyAllCaches();
+
+	  if (isMVS())
+	  {
+		  // no support on ZOS for persistent caches ...
+		  return;
+	  }
+	  
+	  runSimpleJavaProgramWithPersistentCache("Foo,verboseIO");
+	  checkOutputContains("Stored class SimpleApp2", "Did not find expected message about the test class being stored in the cache");
+	  String currentCacheDir = getCacheDir();
+	  String tmpdir = createTemporaryDirectory("TestPersistentCacheMoving01");
+	  try {
+		  
+		  // move the cache file to the temp directory
+		  String loc = getCacheFileLocationForPersistentCache("Foo");
+		  File f = new File(loc);
+		  File fHidden = new File(tmpdir+File.separator+getCacheFileName("Foo", true));
+//		  System.out.println(loc);
+//		  System.out.println(fHidden);
+		  if (!f.renameTo(fHidden)) fail("Could not rename the control file to be hidden");
+		  
+		  setCacheDir(tmpdir);
+		  listAllCaches();
+		  checkOutputForCompatibleCache("Foo",true,true);
+		  
+		  runSimpleJavaProgramWithPersistentCache("Foo,verboseIO");
+		  checkOutputDoesNotContain("Stored class SimpleApp2", "Unexpectedly found message about storing the SimpleApp2 class in the cache, it should already be there!");
+		  checkOutputContains("Found class SimpleApp2", "Did not get expected message about looking for SimpleApp2 in the cache");
+
+		  runDestroyAllCaches();
+	  } finally {
+		  deleteTemporaryDirectory(tmpdir);
+		  setCacheDir(currentCacheDir);
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
@@ -27,10 +27,9 @@ public class TestPersistentCacheMoving01 extends TestUtils {
 		  String loc = getCacheFileLocationForPersistentCache("Foo");
 		  File f = new File(loc);
 		  File fHidden = new File(tmpdir+File.separator+getCacheFileName("Foo", true));
-//		  System.out.println(loc);
-//		  System.out.println(fHidden);
+		//  System.out.println(loc);
+		//  System.out.println(fHidden);
 		  if (!f.renameTo(fHidden)) fail("Could not rename the control file to be hidden");
-		  
 		  setCacheDir(tmpdir);
 		  listAllCaches();
 		  checkOutputForCompatibleCache("Foo",true,true);

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;
@@ -17,6 +39,7 @@ public class TestPersistentCacheMoving01 extends TestUtils {
 		  return;
 	  }
 	  String currentCacheDir = getCacheDir();
+
 	  if ( null == currentCacheDir && isOpenJ9() ) {
 		  // Persistent cachefile without groupaccess are generated under HOME directory
 		  // Current directory is under /tmp. Move a file from HOME directory to /tmp may not succeed on some platforms. 

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
@@ -16,10 +16,16 @@ public class TestPersistentCacheMoving01 extends TestUtils {
 		  // no support on ZOS for persistent caches ...
 		  return;
 	  }
+	  String currentCacheDir = getCacheDir();
+	  if ( null == currentCacheDir && isOpenJ9() ) {
+		  // Persistent cachefile without groupaccess are generated under HOME directory
+		  // Current directory is under /tmp. Move a file from HOME directory to /tmp may not succeed on some platforms. 
+		return;
+	  }
 	  
 	  runSimpleJavaProgramWithPersistentCache("Foo,verboseIO");
 	  checkOutputContains("Stored class SimpleApp2", "Did not find expected message about the test class being stored in the cache");
-	  String currentCacheDir = getCacheDir();
+
 	  String tmpdir = createTemporaryDirectory("TestPersistentCacheMoving01");
 	  try {
 		  
@@ -27,8 +33,7 @@ public class TestPersistentCacheMoving01 extends TestUtils {
 		  String loc = getCacheFileLocationForPersistentCache("Foo");
 		  File f = new File(loc);
 		  File fHidden = new File(tmpdir+File.separator+getCacheFileName("Foo", true));
-		//  System.out.println(loc);
-		//  System.out.println(fHidden);
+
 		  if (!f.renameTo(fHidden)) fail("Could not rename the control file to be hidden");
 		  setCacheDir(tmpdir);
 		  listAllCaches();

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving02.java
@@ -1,0 +1,102 @@
+package tests.sharedclasses.options;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a persistent cache by running an app and then move the app. Check that 
+ * classes are re-cached successfully.
+ */
+public class TestPersistentCacheMoving02 extends TestUtils {
+  public static void main(String[] args) {
+	  String mytestjar = "MySimpleApp.jar";
+	  runDestroyAllCaches();
+	  
+	  if (isMVS()) {
+		  // no support on ZOS for persistent caches ...
+		  return;
+	  }
+	  
+	  String tmpdir1 = createTemporaryDirectory("TestPersistentCacheMoving02Dir1");
+	  String tmpdir2 = createTemporaryDirectory("TestPersistentCacheMoving02Dir2");
+	  
+	  checkFileExists("SimpleApp.java");
+	  
+	  /*1.) Copy two files to tmp dir*/
+	  File javafile = new File("SimpleApp.java"); 
+	  checkFileExists(javafile.toString());
+	  File tmpfile1_dir1 = new File(tmpdir1+File.separator+"SimpleApp.java");
+	  File tmpfile1_dir2 = new File(tmpdir2+File.separator+"SimpleApp.java");
+	  
+	  if (!copyFile(javafile,tmpfile1_dir1)) {
+		  fail("Could not copy file '"+javafile+"' to '"+tmpfile1_dir1+"'");
+	  }
+
+	  File javafile2 = new File("SimpleApp2.java"); 
+	  checkFileExists(javafile2.toString());
+	  File tmpfile2_dir1 = new File(tmpdir1+File.separator+"SimpleApp2.java");
+	  File tmpfile2_dir2 = new File(tmpdir2+File.separator+"SimpleApp2.java");
+	  
+	  if (!copyFile(javafile2,tmpfile2_dir1)) {
+		  fail("Could not copy file '"+javafile+"' to '"+tmpfile2_dir1+"'");
+	  }
+	  
+	  /*2.) Compile two files*/
+	  checkFileExists(tmpfile1_dir1.toString());
+	  checkFileExists(tmpfile2_dir1.toString());
+	  
+	  String compileline = getCommand("runCompileSimpleApp",tmpdir1);
+	  //System.out.println(compileline);
+	  RunCommand.execute(compileline);
+	  
+	  compileline = getCommand("runCompileSimpleApp2",tmpdir1);
+	  //System.out.println(compileline);
+	  RunCommand.execute(compileline);
+	  
+	  /*3.) Jar the two class files*/
+	  checkFileExists(tmpdir1);
+	  String jarline = getCommand("runJarClassesInDir",tmpdir1);
+	  //System.out.println(jarline);
+	  RunCommand.execute(jarline);
+	  checkFileExists(mytestjar);
+	  
+	  /*4.) Copy new jar file into tmp directories*/
+	  File f = new File(mytestjar);
+	  File fNew = null;
+	  
+	  fNew = new File(tmpdir1+File.separator+mytestjar);
+	  if (!copyFile(f,fNew)) {
+		  fail("Could not copy file '"+f+"' to '"+fNew+"'");
+	  }
+	  checkFileExists(tmpdir1+File.separator+mytestjar);
+	  
+	  fNew = new File(tmpdir2+File.separator+mytestjar);
+	  if (!copyFile(f,fNew)) {
+		  fail("Could not copy file '"+f+"' to '"+fNew+"'");
+	  }
+	  checkFileExists(tmpdir2+File.separator+mytestjar);
+	  
+	  /*5.) Run sumple app*/
+	  String runProg1 = getCommand("runProgramSimpleApp","Foo,verboseIO",tmpdir1+File.separator+mytestjar);
+	  //System.out.println(runProg1);
+	  RunCommand.execute(runProg1);
+	  checkOutputContains("Failed to find class SimpleApp2 in shared cache for class-loader id 2", "Command 1a: Did not get expected message about looking for SimpleApp2 in the cache");
+	  checkOutputContains("Stored class SimpleApp2 in shared cache for class-loader id 2","Command 1b: Did not find expected message about the test class being stored in the cache : "+runProg1);
+	  
+	  /*6.) Re-run sumple app*/
+	  String runProg2 = getCommand("runProgramSimpleApp","Foo,verboseIO",tmpdir2+File.separator+mytestjar);
+	  //System.out.println(runProg2);
+	  RunCommand.execute(runProg2);
+	  checkOutputContains("Failed to find class SimpleApp2 in shared cache for class-loader id 2", "Command 2a: Did not get expected message about looking for SimpleApp2 in the cache");
+	  checkOutputContains("Stored class SimpleApp2 in shared cache for class-loader id 2","Command 2b: Did not find expected message about the test class being stored in the cache : " +runProg2);
+	  	  
+	  deleteTemporaryDirectory(tmpdir1);
+	  deleteTemporaryDirectory(tmpdir2);	  
+	  f.delete();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.BufferedWriter;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving03.java
@@ -1,0 +1,119 @@
+package tests.sharedclasses.options;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a persistent cache by running an app and then move the app and the cache. Check that 
+ * classes are re-cached successfully.
+ */
+public class TestPersistentCacheMoving03 extends TestUtils {
+	
+  public static void main(String[] args) 
+  {
+	  String mytestjar = "MySimpleApp.jar";
+	  String currentCacheDir = TestUtils.getCacheDir();
+	  runDestroyAllCaches();
+	  
+	  if (isMVS()) {
+		  // no support on ZOS for persistent caches ...
+		  return;
+	  }
+	  
+	  String tmpdir1 = createTemporaryDirectory("TestPersistentCacheMoving03");
+	  String tmpdir2 = createTemporaryDirectory("TestPersistentCacheMoving03");
+	  
+	  checkFileExists("SimpleApp.java");
+	  
+	  /*1.) Copy two files to tmp dir*/
+	  File javafile = new File("SimpleApp.java"); 
+	  checkFileExists(javafile.toString());
+	  File tmpfile1_dir1 = new File(tmpdir1+File.separator+"SimpleApp.java");
+	  File tmpfile1_dir2 = new File(tmpdir2+File.separator+"SimpleApp.java");
+	  
+	  if (!copyFile(javafile,tmpfile1_dir1)) {
+		  fail("Could not copy file '"+javafile+"' to '"+tmpfile1_dir1+"'");
+	  }
+
+	  File javafile2 = new File("SimpleApp2.java"); 
+	  checkFileExists(javafile2.toString());
+	  File tmpfile2_dir1 = new File(tmpdir1+File.separator+"SimpleApp2.java");
+	  File tmpfile2_dir2 = new File(tmpdir2+File.separator+"SimpleApp2.java");
+	  
+	  if (!copyFile(javafile2,tmpfile2_dir1)) {
+		  fail("Could not copy file '"+javafile+"' to '"+tmpfile2_dir1+"'");
+	  }
+	  
+	  /*2.) Compile two files*/
+	  checkFileExists(tmpfile1_dir1.toString());
+	  checkFileExists(tmpfile2_dir1.toString());
+	  
+	  String compileline = getCommand("runCompileSimpleApp",tmpdir1);
+	  //System.out.println(compileline);
+	  RunCommand.execute(compileline);
+	  
+	  compileline = getCommand("runCompileSimpleApp2",tmpdir1);
+	  //System.out.println(compileline);
+	  RunCommand.execute(compileline);
+	  
+	  /*3.) Jar the two class files*/
+	  checkFileExists(tmpdir1);
+	  String jarline = getCommand("runJarClassesInDir",tmpdir1);
+	  //System.out.println(jarline);
+	  RunCommand.execute(jarline);
+	  checkFileExists(mytestjar);
+	  
+	  /*4.) Copy new jar file into tmp directories*/
+	  File f = new File(mytestjar);
+	  File fNew = null;
+	  
+	  fNew = new File(tmpdir1+File.separator+mytestjar);
+	  if (!copyFile(f,fNew)) {
+		  fail("Could not copy file '"+f+"' to '"+fNew+"'");
+	  }
+	  checkFileExists(tmpdir1+File.separator+mytestjar);
+	  
+	  fNew = new File(tmpdir2+File.separator+mytestjar);
+	  if (!copyFile(f,fNew)) {
+		  fail("Could not copy file '"+f+"' to '"+fNew+"'");
+	  }
+	  checkFileExists(tmpdir2+File.separator+mytestjar);
+	  
+	  /*5.) Run sumple app*/
+	  String runProg1 = getCommand("runProgramSimpleApp","Foo,verboseIO",tmpdir1+File.separator+mytestjar);
+	  //System.out.println(runProg1);
+	  RunCommand.execute(runProg1);
+	  checkOutputContains("Failed to find class SimpleApp2 in shared cache for class-loader id 2", "Did not get expected message about looking for SimpleApp2 in the cache");
+	  checkOutputContains("Stored class SimpleApp2 in shared cache for class-loader id 2","Did not find expected message about the test class being stored in the cache");
+	  
+	  /*6.) Move cache file*/
+	  String loc = getCacheFileLocationForPersistentCache("Foo");
+	  File cachefile = new File(loc);
+	  File newcachefile = new File(tmpdir2 + File.separator + getCacheFileName("Foo", true));
+	  if (!copyFile(cachefile,newcachefile)) {
+		  fail("Could not copy file '"+cachefile+"' to '"+newcachefile+"'");
+	  } 
+	  checkFileExists(newcachefile.toString());
+	  setCacheDir(tmpdir2);
+	  
+	  /*7.) Re-run program*/
+	  String runProg2 = getCommand("runProgramSimpleApp","Foo,verboseIO",tmpdir2+File.separator+mytestjar);
+	  //System.out.println(runProg2);
+	  RunCommand.execute(runProg2);
+	  checkOutputContains("Failed to find class SimpleApp2 in shared cache for class-loader id 2", "Did not get expected message about looking for SimpleApp2 in the cache");
+	  checkOutputContains("Stored class SimpleApp2 in shared cache for class-loader id 2","Did not find expected message about the test class being stored in the cache");
+	  
+	  /*Set cache dir back to currentCacheDir ... or it will get created in test setup and tear down*/
+	  setCacheDir(currentCacheDir);
+	  
+	  deleteTemporaryDirectory(tmpdir1);
+	  deleteTemporaryDirectory(tmpdir2);	  
+	  f.delete();  
+  }
+  
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.BufferedWriter;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats01.java
@@ -1,0 +1,33 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible caches (persistent and non-persistent) and just run a simple
+ * printStats on each.
+ */
+public class TestPrintStats01 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+	
+	runPrintStats("Foo",true);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	
+	runPrintStats("Foo",false);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	
+	runPrintStats("Bar",true);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+
+	runPrintStats("Bar",false);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats02.java
@@ -1,0 +1,37 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible caches (persistent and non-persistent) and just run a simple
+ * printAllStats on each.
+ */
+public class TestPrintStats02 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    
+	createNonPersistentCache("Bar");
+	createNonPersistentCache("Foo");
+
+	createPersistentCache("Bar");
+	createPersistentCache("Foo");
+	
+	runPrintAllStats("Foo",true);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	checkOutputContains("1:.*CLASSPATH","Expected to find a line in the printAllStats output relating to CLASSPATH");
+	
+	runPrintAllStats("Foo",false);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	checkOutputContains("1:.*CLASSPATH","Expected to find a line in the printAllStats output relating to CLASSPATH");
+	
+	runPrintAllStats("Bar",true);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	checkOutputContains("1:.*CLASSPATH","Expected to find a line in the printAllStats output relating to CLASSPATH");
+
+	runPrintAllStats("Bar",false);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	checkOutputContains("1:.*CLASSPATH","Expected to find a line in the printAllStats output relating to CLASSPATH");
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats03.java
@@ -1,0 +1,32 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible and incompatible caches and just run a simple
+ * printStats on each. Should get errors for incompatible caches.
+ */
+public class TestPrintStats03 extends TestUtils {
+  public static void main(String[] args) {
+	//String cachenamefoo = TestUtils.getCacheFileName("Foo",false,false);
+    runDestroyAllCaches();
+    
+	createNonPersistentCache("Foo");
+
+	createPersistentCache("Foo");
+	
+	createIncompatibleCache("Foo5");
+	createIncompatibleCache("Foo");
+	
+	runPrintStats("Foo",true);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	
+	runPrintStats("Foo",false);
+	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+	
+	runPrintStats("Foo5",true);
+	checkOutputContains("incompatible", "Did not get expected message JVMSHRC278I about printStats cannot operate on incompatible cache Foo5");
+	
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats04.java
@@ -1,0 +1,16 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Running printStats on non-existent cache
+ */
+public class TestPrintStats04 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();	
+	runPrintStats("Foo",true);
+	checkOutputContains("JVMSHRC023E","Did not get expected message JVMSHRC023E about the cache not existing");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats05.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats05.java
@@ -1,0 +1,15 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Running printAllStats on non-existent cache
+ */
+public class TestPrintStats05 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+	
+	runPrintAllStats("Foo",true);
+	checkOutputContains("JVMSHRC023E","Did not get expected message JVMSHRC023E about the cache not existing");
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats06.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats06.java
@@ -1,0 +1,48 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create compatible non-persistent cache.
+ * Remove semaphore, run printStats, verify that it prints cache stats. It also creates a new semaphore.
+ * Using this cache again results in reporting cache corruption due to semaphore mismatch.
+ * 
+ * Remove shared memory, run printStats, verify that it reports cache does not exist.
+ */
+public class TestPrintStats06 extends TestUtils {
+	public static void main(String[] args) {
+		boolean rc;
+		
+		if (isWindows()) {
+			return;
+		}
+		runDestroyAllCaches();
+		
+		createNonPersistentCache("Foo");
+		checkFileExistsForNonPersistentCache("Foo");
+	
+		rc = removeSemaphoreForCache("Foo");
+		if (rc == false) {
+			fail("Failed to remove semaphore for cache Foo");
+		}
+		/* running printStats opens cache in read-only (since semaphore does not exist) and retrieves cache stats */
+		runPrintStats("Foo", false);
+		checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
+		
+		/* using nonpersistent cache now should result in cache corruption due to semaphore mismatch */
+		runSimpleJavaProgramWithNonPersistentCache("Foo", "disablecorruptcachedumps");
+		checkOutputContains("JVMSHRC508E", "Did not find expected message about mismatch semaphore");
+		checkOutputContains("JVMSHRC442E", "Did not find expected message about corrupt cache");
+		
+		rc = removeSharedMemoryForCache("Foo");
+		if (rc == false) {
+			fail("Failed to remove shared memory for cache Foo");
+		}
+		runPrintStats("Foo", false);
+		/* JVMSHRC023E Cache does not exist */
+		checkOutputContains("JVMSHRC023E", "Did not find expected line of output 'Cache does not exist'");
+		/* destroy control files */
+		destroyNonPersistentCache("Foo");
+		runDestroyAllCaches();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache.java
@@ -1,0 +1,24 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a new non-persistent cache using default options and then attempt to reuse it on
+ * a second run.
+ */
+public class TestReattachingToNonpersistentCache extends TestUtils {
+  public static void main(String[] args) {
+	destroyNonPersistentCache("Bar");
+	destroyPersistentCache("Bar");
+	checkNoFileForNonPersistentCache("Bar");
+	checkNoFileForPersistentCache("Bar");
+	
+	createNonPersistentCache("Bar");
+	checkForSuccessfulNonPersistentCacheCreationMessage("Bar");
+	
+	runSimpleJavaProgramWithNonPersistentCache("Bar");
+	checkOutputContains("JVMSHRC166I.*Bar","Expected message about successfully opening a shared class cache");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReattachingToNonpersistentCache02.java
@@ -1,0 +1,20 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a new non-persistent cache using default options and then attempt to reuse it on
+ * a second run.
+ */
+public class TestReattachingToNonpersistentCache02 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+	createNonPersistentCache("Bar");
+	checkForSuccessfulNonPersistentCacheCreationMessage("Bar");
+	
+	runSimpleJavaProgramWithNonPersistentCache("Bar");
+	checkOutputContains("JVMSHRC166I.*Bar","Expected message about successfully opening a shared class cache");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset01.java
@@ -1,0 +1,34 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create persistent cache, run something, check whats in there, then reset (as a standalone action) and check
+ * reset works.
+ */
+public class TestReset01 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+
+	if (isMVS())
+	{
+		  //this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		  return;
+	}
+    
+    createPersistentCache("Foo");
+	runSimpleJavaProgramWithPersistentCache("Foo");
+	
+	runPrintAllStats("Foo",true);
+	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runResetPersistentCache("Foo");
+	checkForSuccessfulPersistentCacheCreationMessage("Foo");
+	checkForSuccessfulPersistentCacheDestroyMessage("Foo");
+	
+	runPrintAllStats("Foo",true);
+	checkOutputDoesNotContain("ROMCLASS:.*SimpleApp", "Did not expect to see SimpleApp entries in the output now the cache has been reset");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset02.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset02.java
@@ -1,0 +1,30 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create non-persistent cache, run something, check whats in there, then reset (as a standalone action) and check
+ * reset works.
+ */
+public class TestReset02 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+	createNonPersistentCache("Foo");
+	runSimpleJavaProgramWithNonPersistentCache("Foo");
+	
+	runPrintAllStats("Foo",false);
+	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runResetNonPersistentCache("Foo");
+	
+	checkOutputContains("JVMSHRC159I","Expected message about the cache being opened: JVMSHRC159I");
+	checkOutputContains("is destroyed","Expected message about the cache being destroyed: is destroyed");
+	checkOutputContains("JVMSHRC158I","Expected message about the cache being created: JVMSHRC158I");
+	
+	
+	runPrintAllStats("Foo",false);
+	checkOutputDoesNotContain("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset03.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset03.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset03.java
@@ -1,0 +1,18 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Attempt to reset an incompatible cache.
+ */
+public class TestReset03 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();  
+	createIncompatibleCache("Foo");
+	runResetPersistentCache("Foo");
+	checkOutputContains("JVMSHRC278I.*\"reset\".*\"Foo\"",
+			"Did not get expected message JVMSHRC278I about reset not working on incompatible cache Foo");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset04.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset04.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset04.java
@@ -1,0 +1,33 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create persistent cache, run something, check whats in there, then run it again with a reset option.
+ */
+public class TestReset04 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+    
+	if (isMVS())
+	{
+		//this test checks persistent and non persistent cahces ... zos only has nonpersistent ... so we assume other tests cover this
+		return;
+	}
+    
+	createPersistentCache("Foo");
+	runSimpleJavaProgramWithPersistentCache("Foo");
+	
+	runPrintAllStats("Foo",true);
+	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runSimpleJavaProgramWithPersistentCacheAndReset("Foo");
+	checkForSuccessfulPersistentCacheDestroyMessage("Foo");
+	checkForSuccessfulPersistentCacheCreationMessage("Foo");
+	
+	runPrintAllStats("Foo",true);
+	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset05.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset05.java
@@ -1,0 +1,28 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create non-persistent cache, run something, check whats in there, then run it again with
+ * reset sub-option.
+ */
+public class TestReset05 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+	createNonPersistentCache("Foo");
+	runSimpleJavaProgramWithNonPersistentCache("Foo");
+	
+	runPrintAllStats("Foo",false);
+	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runSimpleJavaProgramWithNonPersistentCacheAndReset("Foo");
+	checkOutputContains("JVMSHRC159I","Expected message about the cache being opened: JVMSHRC159I");
+	checkOutputContains("is destroyed","Expected message about the cache being destroyed: is destroyed");
+	checkOutputContains("JVMSHRC158I","Expected message about the cache being created: JVMSHRC158I");
+	
+	runPrintAllStats("Foo",false);
+	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
+
+	runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset06.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset06.java
@@ -1,0 +1,16 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Attempt to reset an non existent cache
+ */
+public class TestReset06 extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();    
+    runResetPersistentCache("Foo");
+    checkOutputContains("JVMSHRC023E","Did not get expected message JVMSHRC023E about the cache not existing");
+	
+    runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset07.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset07.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset07.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset07.java
@@ -1,0 +1,24 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create an incompatible cache and a non-persistent cache, check reset warns us that we need to
+ * specify nonpersistent and not that it reports the incompatible one.
+ */
+public class TestReset07 extends TestUtils {
+  public static void main(String[] args) {
+	  try {
+	    runDestroyAllCaches();    
+	    createIncompatibleCache("Foo");
+	    createNonPersistentCache("Foo");
+	    runResetPersistentCache("Foo");
+	   // checkOutputContains("JVMSHRC278I.*Foo","Did not get expected message JVMSHRC273E about the incompatible form of Foo");
+	    
+	    showOutput();
+	    fail("What is the expected message here?  I think I expect the message 'did you mean the non-persistent cache Foo because you forgot to specify nonpersistent'");
+	  } finally {
+		  runDestroyAllCaches();
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSemaphoreMeddling01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSemaphoreMeddling01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSemaphoreMeddling01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSemaphoreMeddling01.java
@@ -1,0 +1,90 @@
+package tests.sharedclasses.options;
+
+import java.io.*;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a cache, discover the semaphore - wipe it with ipcrm, rerun and check a new semaphore is
+ * created for the existing cache.
+ */
+public class TestSemaphoreMeddling01 extends TestUtils {
+  public static void main(String[] args) throws Exception {
+	if (!isLinux()) {
+		System.err.println("Test 'TestSemaphoreMeddling01' not supported on os: "+getOS());
+		System.err.println("test skipped");
+		return;
+	}
+	runDestroyAllCaches();    
+    createNonPersistentCache("Oranges");
+    
+    // take the semaphore file to pieces
+    String semaphoreFile = getCacheFileLocationForNonPersistentCache("Oranges").replace("memory","semaphore");
+    SemaphoreFileContents semFile = new SemaphoreFileContents(semaphoreFile);
+    
+    // Delete the semaphore
+    // System.out.println("Semaphore id = "+semFile.semaphoreId);
+    int semIdBefore = semFile.semaphoreId;
+    RunCommand.execute("ipcrm -s "+semIdBefore);
+    checkOutputDoesNotContain("invalid id", 
+    		"Did not expect error about invalid semaphore id when calling ipcrm for semaphore "+semIdBefore);
+    
+    runSimpleJavaProgramWithNonPersistentCache("Oranges", "disablecorruptcachedumps");
+    checkOutputContains("JVMSHRC159I.*Oranges","Did not get expected message about attaching to cache 'Oranges'");
+
+    semFile = new SemaphoreFileContents(semaphoreFile);
+    // System.out.println("New semaphore id = "+semFile.semaphoreId);
+    
+    // chances of it being the same semaphore, 10zillion to one??
+    if (semFile.semaphoreId==semIdBefore) {
+    	fail("Really did not expect the new semaphore "+semFile.semaphoreId+" to be the same as the deleted one "+semIdBefore);
+    }
+   
+    runDestroyAllCaches();
+  }
+  
+  /**
+   * From j9shsem.h
+  typedef struct j9shsem_baseFileFormat {
+ 	I_32 version;
+ 	I_32 modlevel;
+ 	I_32 timeout;
+ 	I_32 proj_id;
+ 	key_t ftok_key;
+ 	I_32 semid;
+ 	I_32 creator_pid;
+ 	I_32 semsetSize;
+  } j9shsem_baseFileFormat;
+  */
+  static class SemaphoreFileContents {
+	  public int semaphoreId;
+	  
+	  public SemaphoreFileContents(String filename) throws Exception {
+
+		    File f = new File(filename);
+		    FileInputStream fis;
+			fis = new FileInputStream(f);
+		    DataInputStream dis = new DataInputStream(fis);
+		    int version = dis.readInt();
+		    int modlevel = dis.readInt();
+		    int timeout = dis.readInt();
+		    int projId = dis.readInt();
+		    int ftokKey = dis.readInt(); // vary in size on platforms?
+		    int b1 = dis.readUnsignedByte();
+		    int b2 = dis.readUnsignedByte();
+		    int b3 = dis.readUnsignedByte();
+		    int b4 = dis.readUnsignedByte();
+//		    System.out.println(b1+" "+b2+" "+b3+" "+b4);
+		    semaphoreId = b4<<24 | b3<<16 |b2<<8 |b1;
+//		    semaphoreId = dis.readInt();
+		    int creatorPid = dis.readInt();
+		    int semsetSize = dis.readInt();
+//		    System.out.println("SemaphoreFile[version="+version+",modlevel="+modlevel+",timeout="+timeout+
+//		    				   ",projId="+projId+",ftokKey="+ftokKey+",semaphoreId="+semaphoreId+
+//		    				   ",creatorPid="+creatorPid+",semsetSize="+semsetSize);
+		    dis.close();
+		    fis.close();
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheEnableBCI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheEnableBCI.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheEnableBCI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheEnableBCI.java
@@ -1,0 +1,526 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+import com.ibm.oti.shared.*;
+import java.util.*;
+import java.util.regex.*;
+
+/*
+ * Tests to check functionality of -Xshareclasses:enableBCI sub-option.
+ * To check the functionality, it needs an JVMTI agent that registers for JVMTI_EVENT_CLASS_FILE_LOAD_HOOK.
+ * This is achieved by using JVMTI agent present in com.ibm.jvmti.tests package.
+ * The JVMTI test used is ecflh001.c.
+ */
+public class TestSharedCacheEnableBCI extends TestUtils {
+	private final static String cacheName = "testSharedCacheEnableBCI";
+	private static final String BOOTSTRAP_CLASS = "openj9/internal/tools/attach/target/IPC";
+	private static final String NON_BOOTSTRAP_CLASS = "SimpleApp";
+	private static final String agentFailureMsg = "Invalid class file bytes for class";
+	private static final String jvmLevel = System.getProperty("java.specification.version");
+	
+	/*
+	 * Number of ROMClasses stored in cache during startup varies across VM
+	 * versions. However, this number is always comfortably more than 250. So,
+	 * it should be safe to assume atleast 250 classes are stored in the cache
+	 * during startup. If ever number of ROMClasses stored in cache during
+	 * startup goes below MIN_EXPECTED_ROMCLASSES, this constant would need to
+	 * be updated accordingly.
+	 */
+	private static final int MIN_EXPECTED_ROMCLASSES = 250;
+	private static int CLASSS_FILE_LOAD_HOOK_COUNT = 250;
+
+	public static void main(String args[]) {
+		String jvmLevel = System.getProperty("java.specification.version");
+		/* CLASSS_FILE_LOAD_HOOK_COUNT is different in Java8 and Java9 */
+		if (Double.parseDouble(jvmLevel) >= 9) {
+			CLASSS_FILE_LOAD_HOOK_COUNT = 20;
+		}
+		runDestroyAllCaches();
+		runTest1();
+		runTest2();
+		runTest3();
+		runTest4();
+		runTest5();
+		runDestroyAllCaches();
+	}
+
+	/**
+	 * 1. Create a cache without an agent and with disableBCI option.
+	 * <p>
+	 * 2. Create a cache without an agent and with enablBCI option.
+	 * <p>
+	 * 3. Create a cache with an agent that does not modify class file data and
+	 * with enableBCI option.
+	 * <p>
+	 * Verify that number of ROMClasses are same in all three cases.
+	 */
+	static void runTest1() {
+		String printStatsOutput[], output[];
+		int romClasses = 0, romClassesWithEnableBCI = 0;
+
+		/*
+		 * CMVC 186357 : This is to provide some leeway for number of ROMClasses
+		 * stored in shared cache by different invocations of JVM.
+		 */
+		int romClassNumberMargin = 10;
+
+		if (isMVS() == false) {
+			/* Create a cache without an agent and with disableBCI option. */
+			runHanoiProgramWithCache(cacheName,"disableBCI",null);
+			checkFileExistsForPersistentCache(cacheName);
+			runPrintStats(cacheName, true);
+
+			printStatsOutput = getLastCommandStderr();
+			if (printStatsOutput != null) {
+				for (int i = 0; i < printStatsOutput.length; i++) {
+					if (printStatsOutput[i].matches("# ROMClasses.*$")) {
+						String outputLine[] = printStatsOutput[i].split("=");
+						romClasses = Integer.parseInt(outputLine[1].trim());
+					}
+				}
+			}
+			if (romClasses == 0) {
+				fail("# ROMClasses statement not found in printStats output");
+			}
+
+			destroyPersistentCache(cacheName);
+			checkFileDoesNotExistForPersistentCache(cacheName);
+
+			if (romClasses < MIN_EXPECTED_ROMCLASSES) {
+				fail("Number of ROMClasses found: " + romClasses
+						+ ". Minimum expected ROMClasses: "
+						+ MIN_EXPECTED_ROMCLASSES);
+			}
+
+			/* Create a cache without an agent and with enablBCI option. */
+			runHanoiProgramWithCache(cacheName,"enableBCI",null);
+			checkFileExistsForPersistentCache(cacheName);
+			runPrintStats(cacheName, true);
+
+			printStatsOutput = getLastCommandStderr();
+			if (printStatsOutput != null) {
+				for (int i = 0; i < printStatsOutput.length; i++) {
+					if (printStatsOutput[i].matches("# ROMClasses.*$")) {
+						String outputLine[] = printStatsOutput[i].split("=");
+						romClassesWithEnableBCI = Integer
+								.parseInt(outputLine[1].trim());
+					}
+				}
+			}
+			if (romClassesWithEnableBCI == 0) {
+				fail("# ROMClasses statement not found in printStats output");
+			}
+
+			destroyPersistentCache(cacheName);
+			checkFileDoesNotExistForPersistentCache(cacheName);
+
+			if (romClassesWithEnableBCI < MIN_EXPECTED_ROMCLASSES) {
+				fail("Number of ROMClasses found: " + romClassesWithEnableBCI
+						+ ". Minimum expected ROMClasses: "
+						+ MIN_EXPECTED_ROMCLASSES);
+			}
+
+			if (Math.abs(romClasses - romClassesWithEnableBCI) > romClassNumberMargin) {
+				fail("Mismatch in number of ROMClasses. Without enableBCI, # ROMClasses: "
+						+ romClasses
+						+ "With enableBCI, # ROMClasses: "
+						+ romClassesWithEnableBCI
+						+ ".\nMaximum allowed difference is "
+						+ romClassNumberMargin);
+			}
+
+			/*
+			 * Create a cache with an agent that does not modify class file data
+			 * and with enableBCI option.
+			 */
+			runHanoiProgramWithCache(cacheName,"enableBCI","-agentlib:jvmtitest=test:ecflh001,args:noModify");
+			output = getLastCommandStderr();
+			checkAgentOutputForFailureMsg(output);
+			checkFileExistsForPersistentCache(cacheName);
+			runPrintStats(cacheName, true);
+
+			romClassesWithEnableBCI = 0;
+
+			printStatsOutput = getLastCommandStderr();
+			if (printStatsOutput != null) {
+				for (int i = 0; i < printStatsOutput.length; i++) {
+					if (printStatsOutput[i].matches("# ROMClasses.*$")) {
+						String outputLine[] = printStatsOutput[i].split("=");
+						romClassesWithEnableBCI = Integer
+								.parseInt(outputLine[1].trim());
+					}
+				}
+			}
+			if (romClassesWithEnableBCI == 0) {
+				fail("# ROMClasses statement not found in printStats output");
+			}
+
+			destroyPersistentCache(cacheName);
+			checkFileDoesNotExistForPersistentCache(cacheName);
+
+			if (romClassesWithEnableBCI < MIN_EXPECTED_ROMCLASSES) {
+				fail("Number of ROMClasses found: " + romClassesWithEnableBCI
+						+ ". Minimum expected ROMClasses: "
+						+ MIN_EXPECTED_ROMCLASSES);
+			}
+			if (Math.abs(romClasses - romClassesWithEnableBCI) > romClassNumberMargin) {
+				fail("Mismatch in number of ROMClasses. Without enableBCI, # ROMClasses: "
+						+ romClasses
+						+ "With enableBCI, # ROMClasses: "
+						+ romClassesWithEnableBCI
+						+ ".\nMaximum allowed difference is "
+						+ romClassNumberMargin);
+			}
+		}
+		
+		/* Create a cache without an agent and with disableBCI option. */
+		runHanoiProgramWithCache(cacheName,"nonpersistent,disableBCI",null);
+		checkFileExistsForNonPersistentCache(cacheName);
+		runPrintStats(cacheName, false);
+
+		printStatsOutput = getLastCommandStderr();
+		if (printStatsOutput != null) {
+			for (int i = 0; i < printStatsOutput.length; i++) {
+				if (printStatsOutput[i].matches("# ROMClasses.*$")) {
+					String outputLine[] = printStatsOutput[i].split("=");
+					romClasses = Integer.parseInt(outputLine[1].trim());
+				}
+			}
+		}
+		if (romClasses == 0) {
+			fail("# ROMClasses statement not found in printStats output");
+		}
+
+		destroyNonPersistentCache(cacheName);
+		checkFileDoesNotExistForNonPersistentCache(cacheName);
+
+		if (romClasses < MIN_EXPECTED_ROMCLASSES) {
+			fail("Number of ROMClasses found: " + romClasses
+					+ ". Minimum expected ROMClasses: "
+					+ MIN_EXPECTED_ROMCLASSES);
+		}
+
+		/* Create a cache without an agent and with enablBCI option. */
+		runHanoiProgramWithCache(cacheName,"nonpersistent,enableBCI",null);
+		checkFileExistsForNonPersistentCache(cacheName);
+		runPrintStats(cacheName, false);
+
+		romClassesWithEnableBCI = 0;
+
+		printStatsOutput = getLastCommandStderr();
+		if (printStatsOutput != null) {
+			for (int i = 0; i < printStatsOutput.length; i++) {
+				if (printStatsOutput[i].matches("# ROMClasses.*$")) {
+					String outputLine[] = printStatsOutput[i].split("=");
+					romClassesWithEnableBCI = Integer.parseInt(outputLine[1]
+							.trim());
+				}
+			}
+		}
+		if (romClassesWithEnableBCI == 0) {
+			fail("# ROMClasses statement not found in printStats output");
+		}
+
+		destroyNonPersistentCache(cacheName);
+		checkFileDoesNotExistForNonPersistentCache(cacheName);
+
+		if (romClassesWithEnableBCI < MIN_EXPECTED_ROMCLASSES) {
+			fail("Number of ROMClasses found: " + romClassesWithEnableBCI
+					+ ". Minimum expected ROMClasses: "
+					+ MIN_EXPECTED_ROMCLASSES);
+		}
+		if (Math.abs(romClasses - romClassesWithEnableBCI) > romClassNumberMargin) {
+			fail("Mismatch in number of ROMClasses. Without enableBCI, # ROMClasses: "
+					+ romClasses
+					+ "With enableBCI, # ROMClasses: "
+					+ romClassesWithEnableBCI
+					+ ".\nMaximum allowed difference is "
+					+ romClassNumberMargin);
+		}
+
+		/*
+		 * Create a cache wtih an agent that does not modify class file data and
+		 * with enableBCI option.
+		 */
+		runHanoiProgramWithCache(cacheName,"nonpersistent,enableBCI","-agentlib:jvmtitest=test:ecflh001,args:noModify");
+		output = getLastCommandStderr();
+		checkAgentOutputForFailureMsg(output);
+		checkFileExistsForNonPersistentCache(cacheName);
+		runPrintStats(cacheName, false);
+
+		romClassesWithEnableBCI = 0;
+
+		printStatsOutput = getLastCommandStderr();
+		if (printStatsOutput != null) {
+			for (int i = 0; i < printStatsOutput.length; i++) {
+				if (printStatsOutput[i].matches("# ROMClasses.*$")) {
+					String outputLine[] = printStatsOutput[i].split("=");
+					romClassesWithEnableBCI = Integer.parseInt(outputLine[1]
+							.trim());
+				}
+			}
+		}
+		if (romClassesWithEnableBCI == 0) {
+			fail("# ROMClasses statement not found in printStats output");
+		}
+
+		destroyNonPersistentCache(cacheName);
+		checkFileDoesNotExistForNonPersistentCache(cacheName);
+
+		if (romClassesWithEnableBCI < MIN_EXPECTED_ROMCLASSES) {
+			fail("Number of ROMClasses found: " + romClassesWithEnableBCI
+					+ ". Minimum expected ROMClasses: "
+					+ MIN_EXPECTED_ROMCLASSES);
+		}
+		if (Math.abs(romClasses - romClassesWithEnableBCI) > romClassNumberMargin) {
+			fail("Mismatch in number of ROMClasses. Without enableBCI, # ROMClasses: "
+					+ romClasses
+					+ "With enableBCI, # ROMClasses: "
+					+ romClassesWithEnableBCI
+					+ ".\nMaximum allowed difference is "
+					+ romClassNumberMargin);
+		}
+	}
+
+	/**
+	 * 1. Create a cache with enableBCI sub-option using an agent that modifies
+	 * java/lang/Class. Verify that it does not appear in printStats=romclass
+	 * output.
+	 * <p>
+	 * 2. Use same cache as in 1, but without an agent. Verify that
+	 * java/lang/Class is added in the cache.
+	 */
+	static void runTest2() {
+		testHelper(BOOTSTRAP_CLASS, "modifyBootstrap=" + BOOTSTRAP_CLASS);
+	}
+
+	/**
+	 * 1. Create a cache with enableBCI sub-option using an agent that modifies
+	 * non-bootstrap class like SimpleApp. Verify that it does not appear in
+	 * printStats=romclass output.
+	 * <p>
+	 * 2. Use same cache as in 1, but without an agent. Verify that SimpleApp is
+	 * added in the cache.
+	 */
+	static void runTest3() {
+		testHelper(NON_BOOTSTRAP_CLASS, "modifyNonBootstrap="
+				+ NON_BOOTSTRAP_CLASS);
+	}
+
+	/**
+	 * Create a cache with enableBCI sub-option using a JVMTI agent. JVMTI agent
+	 * prints a message on ClassFileLoadHook event. Verify that number of times
+	 * ClassFileLoadHook event message printed is close to number of classes
+	 * stored in the cache.
+	 */
+	static void runTest4() {
+		int romClassesWithEnableBCI = 0;
+		int classFileLoadHookCount = 0;
+		boolean found = false;
+		String output[];
+		int difference = 50;
+
+		if (isMVS() == false) {
+			runSimpleJavaProgramWithAgentWithPersistentCache(cacheName,
+					"enableBCI", "ecflh001", "noModify+printClassFileLoadMsg");
+			output = getLastCommandStderr();
+			checkAgentOutputForFailureMsg(output);
+			checkFileExistsForPersistentCache(cacheName);
+			/* Count number of times ClassFileLoadHook event was triggered */
+			if (output != null) {
+				classFileLoadHookCount = 0;
+				String expectedOutput = "ClassFileLoadHook event called for class:.*$";
+				for (int i = 0; i < output.length; i++) {
+					if (output[i].matches(expectedOutput)) {
+						classFileLoadHookCount += 1;
+					}
+				}
+			}
+
+			runPrintStats(cacheName, true, "romclass");
+			output = getLastCommandStderr();
+			if (output != null) {
+				found = false;
+				for (int i = 0; i < output.length; i++) {
+					if (output[i].matches("# ROMClasses.*$")) {
+						String romClassLine[] = output[i].split("=");
+						romClassesWithEnableBCI = Integer
+								.parseInt(romClassLine[1].trim());
+						found = true;
+						break;
+					}
+				}
+				if (false == found) {
+					fail("# ROMClasses statement not found in printStats output");
+				}
+			}
+
+			destroyPersistentCache(cacheName);
+			checkFileDoesNotExistForPersistentCache(cacheName);
+
+			if (romClassesWithEnableBCI < MIN_EXPECTED_ROMCLASSES) {
+				fail("Number of ROMClasses found: " + romClassesWithEnableBCI
+						+ ". Minimum expected ROMClasses: "
+						+ MIN_EXPECTED_ROMCLASSES);
+			}
+			if (classFileLoadHookCount < CLASSS_FILE_LOAD_HOOK_COUNT) {
+				fail("Number of times ClassFileLoadHook event triggered: "
+						+ classFileLoadHookCount + ". Expected it to be >= "
+						+ CLASSS_FILE_LOAD_HOOK_COUNT);
+			}
+			if (Double.parseDouble(jvmLevel) < 9) {
+				/*
+				 * For some classes like java.lang.J9VMInternals, ClassFileLoadHook
+				 * is not triggered. Some difference in number of ROMClasses in cache
+				 * and number of times ClassFileLoadHook gets triggered is expected.
+				 */
+				if (Math.abs(romClassesWithEnableBCI - classFileLoadHookCount) > difference) {
+					fail("Difference between number of ROMClasses ("
+							+ romClassesWithEnableBCI + ") in cache and "
+							+ "number of times ClassFileLoadHook event triggered ("
+							+ classFileLoadHookCount + ")is not as expected");
+				}
+			}
+		}
+
+		runSimpleJavaProgramWithAgentWithNonPersistentCache(cacheName,
+				"enableBCI", "ecflh001", "noModify+printClassFileLoadMsg");
+		output = getLastCommandStderr();
+		checkAgentOutputForFailureMsg(output);
+		checkFileExistsForNonPersistentCache(cacheName);
+		/* Count number of times ClassFileLoadHook event was triggered */
+		if (output != null) {
+			classFileLoadHookCount = 0;
+			String expectedOutput = "ClassFileLoadHook event called for class:.*$";
+			for (int i = 0; i < output.length; i++) {
+				if (output[i].matches(expectedOutput)) {
+					classFileLoadHookCount += 1;
+				}
+			}
+		}
+
+		runPrintStats(cacheName, false, "romclass");
+		output = getLastCommandStderr();
+		if (output != null) {
+			found = false;
+			for (int i = 0; i < output.length; i++) {
+				if (output[i].matches("# ROMClasses.*$")) {
+					String romClassLine[] = output[i].split("=");
+					romClassesWithEnableBCI = Integer.parseInt(romClassLine[1]
+							.trim());
+					found = true;
+					break;
+				}
+			}
+			if (false == found) {
+				fail("# ROMClasses statement not found in printStats output");
+			}
+		}
+
+		destroyNonPersistentCache(cacheName);
+		checkFileDoesNotExistForNonPersistentCache(cacheName);
+
+		if (romClassesWithEnableBCI < MIN_EXPECTED_ROMCLASSES) {
+			fail("Number of ROMClasses found: " + romClassesWithEnableBCI
+					+ ". Minimum expected ROMClasses: "
+					+ MIN_EXPECTED_ROMCLASSES);
+		}
+		if (classFileLoadHookCount < CLASSS_FILE_LOAD_HOOK_COUNT) {
+			fail("Number of times ClassFileLoadHook event triggered: "
+					+ classFileLoadHookCount + ". Expected it to be >= "
+					+ CLASSS_FILE_LOAD_HOOK_COUNT);
+		}
+		if (Double.parseDouble(jvmLevel) < 9) {
+		/*
+		 * For some classes like java.lang.J9VMInternals, ClassFileLoadHook is
+		 * not triggered Some difference in number of ROMClasses in cache and
+		 * number of times ClassFileLoadHook gets triggered is expected
+		 */
+			if (Math.abs(romClassesWithEnableBCI - classFileLoadHookCount) > difference) {
+				fail("Difference between number of ROMClasses ("
+						+ romClassesWithEnableBCI + ") in cache and "
+						+ "number of times ClassFileLoadHook event triggered ("
+						+ classFileLoadHookCount + ")is not as expected");
+			}
+		}
+	}
+
+	/**
+	 * Create a cache with 'enableBCI' sub-option but without using any jvmti
+	 * agent. Re-use the cache with jvmti agent that modifies the class files
+	 * and verifies that class file bytes passed to ClassFileLoadHoook event
+	 * callback represent valid class file.
+	 */
+	static void runTest5() {
+		String output[];
+
+		if (isMVS() == false) {
+			runSimpleJavaProgramWithPersistentCache(cacheName, "enableBCI");
+			checkFileExistsForPersistentCache(cacheName);
+			
+			runSimpleJavaProgramWithAgentWithPersistentCache(cacheName,
+					"enableBCI", "ecflh001", "modifyAll");
+			output = getLastCommandStderr();
+			checkAgentOutputForFailureMsg(output);
+			destroyPersistentCache(cacheName);
+			checkFileDoesNotExistForPersistentCache(cacheName);
+		}
+
+		runSimpleJavaProgramWithNonPersistentCache(cacheName, "enableBCI");
+		checkFileExistsForNonPersistentCache(cacheName);
+		
+		runSimpleJavaProgramWithAgentWithNonPersistentCache(cacheName,
+				"enableBCI", "ecflh001", "modifyAll");
+		output = getLastCommandStderr();
+		checkAgentOutputForFailureMsg(output);
+		destroyNonPersistentCache(cacheName);
+		checkFileDoesNotExistForNonPersistentCache(cacheName);
+	}
+	
+	static void testHelper(String classToModify, String modType) {
+		if (isMVS() == false) {
+			runSimpleJavaProgramWithAgentWithPersistentCache(cacheName,
+					"enableBCI", "ecflh001", modType);
+			checkFileExistsForPersistentCache(cacheName);
+			runPrintStats(cacheName, true, "romclass");
+			checkOutputDoesNotContain("^.*ROMCLASS: " + classToModify
+					+ " at.*$", "Did not expect " + classToModify
+					+ " in the cache.");
+
+			runSimpleJavaProgramWithPersistentCache(cacheName, "enableBCI");
+			checkFileExistsForPersistentCache(cacheName);
+			runPrintStats(cacheName, true, "romclass");
+			checkOutputContains("^.*ROMCLASS: " + classToModify + " at.*$",
+					classToModify + " not found in the cache");
+
+			destroyPersistentCache(cacheName);
+			checkFileDoesNotExistForPersistentCache(cacheName);
+		}
+
+		runSimpleJavaProgramWithAgentWithNonPersistentCache(cacheName,
+				"enableBCI", "ecflh001", modType);
+		checkFileExistsForNonPersistentCache(cacheName);
+		runPrintStats(cacheName, false, "romclass");
+		checkOutputDoesNotContain("^.*ROMCLASS: " + classToModify + " at.*$",
+				"Did not expect " + classToModify + " in the cache.");
+
+		runSimpleJavaProgramWithNonPersistentCache(cacheName, "enableBCI");
+		checkFileExistsForNonPersistentCache(cacheName);
+		runPrintStats(cacheName, false, "romclass");
+		checkOutputContains("^.*ROMCLASS: " + classToModify + " at.*$",
+				classToModify + " not found in the cache");
+
+		destroyNonPersistentCache(cacheName);
+		checkFileDoesNotExistForNonPersistentCache(cacheName);
+	}
+	
+	static void checkAgentOutputForFailureMsg(String output[]) {
+		if (output != null) {
+			for (int i = 0; i < output.length; i++) {
+				if (output[i].indexOf(agentFailureMsg) != -1) {
+					fail("ClassFileLoadHoook event callback: " + output[i]);
+				}
+			}
+		}
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
@@ -1,0 +1,296 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+import com.ibm.oti.shared.*;
+import java.util.*;
+
+public class TestSharedCacheJavaAPI extends TestUtils {
+	private final static int INVALID_CACHE_TYPE = 3;
+	/* Define SOFT_MAX_BYTES_VALUE to be equal to 16m. Caches used in this test are created with soft max size = 16m, 
+	 * see cmd.runSimpleJavaProgramWithPersistentCache/cmd.runSimpleJavaProgramWithNonPersistentCache in configs/config.defaults.
+	 */
+	private final static int SOFT_MAX_BYTES_VALUE = 16 * 1024 * 1024;
+	private final static int TEMP_JAVA10_JVMLEVEL = 6;
+	private static int persistentCount, nonpersistentCount, snapshotCount;
+	private static ArrayList<String> persistentList, nonpersistentList, snapshotList;
+		
+	static {
+		if (isMVS() == false) {
+			persistentList = new ArrayList<String>();
+			persistentList.add("cache1");
+			if (isWindows() == false) {
+				persistentList.add("cache1_groupaccess");
+			}
+		}
+    	if (realtimeTestsSelected() == false) {
+			nonpersistentList = new ArrayList<String>();
+			nonpersistentList.add("cache2");
+			if (isWindows() == false) {
+				nonpersistentList.add("cache2_groupaccess");
+				snapshotList = new ArrayList<String>();
+				snapshotList.add("cache2");
+			}
+    	}
+	}
+    public static void main(String args[]) {
+    	String dir = null;
+    	int oldCacheCount = 0;
+    	int newCacheCount = 0;
+    	String addrMode, jvmLevel;
+    	List<SharedClassCacheInfo> cacheList;
+    	int compressedRefMode = 0;
+    	
+    	if (TestUtils.isCompressedRefEnabled()) {
+    		compressedRefMode = 1;
+    	}
+    	runDestroyAllCaches();
+    	if (false == isWindows()) {
+    		runDestroyAllSnapshots();
+    	}
+    	addrMode = System.getProperty("com.ibm.vm.bitmode");
+		jvmLevel = System.getProperty("java.specification.version");
+		
+        try {
+        	dir = getCacheDir();
+	    	if (dir == null) {
+	    		dir = getControlDir();
+	    	}
+	    	
+	    	/* get cache count before creating any new cache */
+	    	cacheList = SharedClassUtilities.getSharedCacheInfo(dir, SharedClassUtilities.NO_FLAGS, false);
+	    	if (cacheList == null) {
+	    		oldCacheCount = 0;
+	    	} else {
+	    		oldCacheCount = cacheList.size();
+	    	}
+		    if (oldCacheCount == -1) {
+		    	fail("iterateSharedCacheFunction failed");
+		    }
+		    persistentCount = nonpersistentCount = snapshotCount = 0;
+	       	if (isMVS() == false) {
+	       		for(String cacheName: persistentList) {
+	       			if (cacheName.indexOf("groupaccess") != -1) {
+	       				runSimpleJavaProgramWithPersistentCache(cacheName, "groupAccess");
+	       			} else {
+	       				runSimpleJavaProgramWithPersistentCache(cacheName, null);
+	       			}
+	       			checkFileExistsForPersistentCache(cacheName);
+	       		}
+	       		persistentCount = persistentList.size();
+	    	}
+	       	if (realtimeTestsSelected() == false) {
+		       	for(String cacheName: nonpersistentList) {
+	       			if (cacheName.indexOf("groupaccess") != -1) {
+	       				runSimpleJavaProgramWithNonPersistentCache(cacheName, "groupAccess");
+	       			} else {
+	       				runSimpleJavaProgramWithNonPersistentCache(cacheName, null);
+	       			}
+	       			checkFileExistsForNonPersistentCache(cacheName);
+		    	}
+			    nonpersistentCount = nonpersistentList.size();
+			    
+			    if ((false == isWindows()) 
+			    	&& (nonpersistentCount > 0)
+			    ) {
+			    	for(String cacheName: snapshotList) {	
+		       			checkFileExistsForNonPersistentCache(cacheName);
+		       			createCacheSnapshot(cacheName);
+		       			checkFileExistsForCacheSnapshot(cacheName);
+			       	}
+			       	snapshotCount = snapshotList.size();
+			    }
+	       	}
+	       	
+		    cacheList = SharedClassUtilities.getSharedCacheInfo(dir, SharedClassUtilities.NO_FLAGS, false);
+		    if (cacheList == null) {
+		    	fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found");
+		    }
+		    newCacheCount = cacheList.size();
+		    if ((newCacheCount == -1) || (newCacheCount != (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount))) {
+		    	fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found\t" +
+		    			"expected: " + (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount) + "\tfound: " + newCacheCount);
+		    }
+		    if (isMVS() == false) {
+			    for(String cacheName: persistentList) {
+			    	for(SharedClassCacheInfo cacheInfo: cacheList) {
+			    		if (cacheInfo.getCacheName().equals(cacheName)) {
+			    			if ((cacheInfo.getCacheSize() <= 0) ||
+			    				(cacheInfo.getCacheSoftMaxBytes() != SOFT_MAX_BYTES_VALUE) ||
+			    				(cacheInfo.getCacheFreeBytes() <= 0) ||
+			    				(cacheInfo.isCacheCompatible() == false) ||
+			    				(cacheInfo.isCacheCorrupt() == true) ||
+			    				(cacheInfo.getCacheType() != SharedClassUtilities.PERSISTENT) ||
+			    				(cacheInfo.getOSshmid() != -1) ||
+			    				(cacheInfo.getOSsemid() != -1) ||
+			    				(cacheInfo.getLastDetach() == null) ||
+			    				(cacheInfo.getCacheCompressedRefsMode() != compressedRefMode) ||
+			    				(cacheInfo.getCacheLayer() != 0) ||
+			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() < 0) ||			/* if lastDetach is in future */
+			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() > (65*60*1000))	/* difference should not be more than 1 hr 5 mins */
+			    			) {
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: Cache information is not proper");
+	  		    			}	
+			    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
+			    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
+			    			) {
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: Address mode is not proper");
+			    			}
+			    			if ((jvmLevel.equals("1.6") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA6)) ||
+			    				(jvmLevel.equals("1.7") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA7)) ||
+			    				(jvmLevel.equals("1.8") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA8)) ||
+			    				((Double.parseDouble(jvmLevel) >= 10) && (cacheInfo.getCacheJVMLevel() != Integer.parseInt(jvmLevel)))
+			    			) {
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: JVM level is not proper");
+			    			}
+			    		}
+			    	}
+			    }
+		    }
+		    
+		    if (realtimeTestsSelected() == false) {
+		    	for(String cacheName: nonpersistentList) {
+			    	for(SharedClassCacheInfo cacheInfo: cacheList) {
+			    		if ((cacheInfo.getCacheName().equals(cacheName))
+			    			&& (cacheInfo.getCacheType() == SharedClassUtilities.NONPERSISTENT)
+			    		) {
+			    			if ((cacheInfo.getCacheSize() <= 0) ||
+			    				(cacheInfo.getCacheFreeBytes() <= 0) ||
+			    				(cacheInfo.isCacheCompatible() == false) ||
+			    				(cacheInfo.isCacheCorrupt() == true) ||
+			    				(cacheInfo.getLastDetach() == null) ||
+			    				(cacheInfo.getCacheSoftMaxBytes() != SOFT_MAX_BYTES_VALUE) ||
+			    				(cacheInfo.getCacheCompressedRefsMode() != compressedRefMode) ||
+			    				(cacheInfo.getCacheLayer() != 0) ||
+			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() < 0) ||			/* if lastDetach is in future */
+			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() > (65*60*1000))	/* difference should not be more than 1 hr 5 mins */
+			    			) {
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent cache: Cache information is not proper");
+			    			}	
+			    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
+			    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
+			    			) {
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent cache: Address mode is not proper");
+			    			}
+			    			if ((jvmLevel.equals("1.6") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA6)) ||
+			    				(jvmLevel.equals("1.7") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA7)) ||
+			    				(jvmLevel.equals("1.8") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA8)) ||
+			    				((Double.parseDouble(jvmLevel) >= 10) && (cacheInfo.getCacheJVMLevel() != Integer.parseInt(jvmLevel)))
+			    			) {
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent cache: JVM level is not proper");
+			    			}
+	
+		    				if ((isWindows()) && ((cacheInfo.getOSshmid() > 0) || (cacheInfo.getOSsemid() > 0))) {
+		    					fail("SharedClassUtilities.getSharedCacheInfo failed: Cache information is not proper\t" +
+		    							"os_shmid : " + cacheInfo.getOSshmid() + " os_semid : " + cacheInfo.getOSsemid());
+		    				} 
+		    				if ((isWindows() == false) && ((cacheInfo.getOSshmid() <= 0) || (cacheInfo.getOSsemid() <= 0))) {
+		    					fail("SharedClassUtilities.getSharedCacheInfo failed: Cache information is not proper\t" + 
+		    							"os_shmid : " + cacheInfo.getOSshmid() + " os_semid : " + cacheInfo.getOSsemid());
+		    				}
+			    		}
+			    	}
+		    	}
+		    	
+		    	if (false == isWindows()) {
+			    	for(String cacheName: snapshotList) {
+				    	for(SharedClassCacheInfo cacheInfo: cacheList) {
+				    		if ((cacheInfo.getCacheName().equals(cacheName))
+				    			&& (cacheInfo.getCacheType() == SharedClassUtilities.SNAPSHOT)
+				    		) {
+				    			if ((-1 != cacheInfo.getCacheSize()) ||
+				    				(-1 != cacheInfo.getCacheFreeBytes()) ||
+				    				(-1 != cacheInfo.getCacheSoftMaxBytes()) ||
+				    				(false == cacheInfo.isCacheCompatible()) ||
+				    				(true == cacheInfo.isCacheCorrupt()) ||
+				    				(null != cacheInfo.getLastDetach()) ||
+				    				(cacheInfo.getCacheCompressedRefsMode() != compressedRefMode) ||
+				    				(cacheInfo.getCacheLayer() != 0) ||
+				    				(-1 != cacheInfo.getOSshmid()) ||
+				    				(-1 != cacheInfo.getOSsemid())
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for cache snapshot: Cache information is not proper");
+				    			}	
+				    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
+				    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent cache: Address mode is not proper");
+				    			}
+				    			if ((jvmLevel.equals("1.8") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA8)) ||
+				    				((Double.parseDouble(jvmLevel) >= 10) && (cacheInfo.getCacheJVMLevel() != Integer.parseInt(jvmLevel)))
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for cache snapshot: JVM level is not proper");
+				    			}
+				    		}
+				    	}
+			    	}
+		    	}
+		    	
+		    }
+			    
+		    if (isMVS() == false) {
+		    	for(String cacheName: persistentList) {
+		    		int ret;
+		    		try {
+			        	SharedClassUtilities.destroySharedCache(dir, INVALID_CACHE_TYPE, cacheName, false);
+			        	fail("SharedClassUtilities.destroySharedCache (persistent)failed: should have thrown IllegalArgumentException");
+		    		} catch (IllegalArgumentException e) {
+		    			/* expected to reach here */
+		    		}
+			    	checkFileExistsForPersistentCache(cacheName);
+			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.NONPERSISTENT, cacheName, false);
+			    	if ((-1 != ret) && (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+			    		fail("SharedClassUtilities.destroySharedCache failed: trying to destroy persistent cache as a non-persistent cache");
+			    	}
+			    	checkFileExistsForPersistentCache(cacheName);
+			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.SNAPSHOT, cacheName, false);
+			    	if ((-1 != ret) && (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+			    		fail("SharedClassUtilities.destroySharedCache failed: trying to destroy persistent cache as a cache snapshot");
+			    	}
+			    	checkFileExistsForPersistentCache(cacheName);
+			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.PERSISTENT, cacheName, false);
+			    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+			    		fail("SharedClassUtilities.destroySharedCache failed (persistent)");
+			    	}
+			    	checkFileDoesNotExistForPersistentCache(cacheName);
+		    	}
+		    }
+		    if (realtimeTestsSelected() == false) {
+			    for(String cacheName: nonpersistentList) {
+			    	int ret;
+			    	try {
+			    		SharedClassUtilities.destroySharedCache(dir, INVALID_CACHE_TYPE, cacheName, false);
+			    		fail("SharedClassUtilities.destroySharedCache (non-persistent) failed: should have thrown IllegalArgumentException");
+			      	} catch (IllegalArgumentException e) {
+			      		/* expected to reach here */
+			      	}
+			    	checkFileExistsForNonPersistentCache(cacheName);
+			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.PERSISTENT, cacheName, false);
+			    	if ((-1 != ret) && (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+			    		fail("SharedClassUtilities.destroySharedCache failed: trying to destroy non-persistent cache as a persistent cache");
+			    	}
+			    	checkFileExistsForNonPersistentCache(cacheName);
+			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.NONPERSISTENT, cacheName, false);
+			    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+			    		fail("SharedClassUtilities.destroySharedCache failed (non-persistent)");
+			    	}
+				    checkFileDoesNotExistForNonPersistentCache(cacheName);
+				    
+				    if (false == isWindows() && snapshotList.contains(cacheName)) {
+				    	checkFileExistsForCacheSnapshot(cacheName);
+				    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.SNAPSHOT, cacheName, false);
+				    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+				    		fail("SharedClassUtilities.destroySharedCache failed (snapshot)");
+				    	}
+				    	checkFileDoesNotExistForCacheSnapshot(cacheName);
+				    }
+			    }
+		    }
+
+		} finally {
+			runDestroyAllCaches();
+			if (false == isWindows()) {
+				runDestroyAllSnapshots();
+			}
+		}
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
@@ -163,22 +163,16 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 		    newCacheCount = cacheList.size();
 		    
 		    if (dirGroupAccess != null) {
-		    	int tempGroupAccessCount = 0;
 		    	cacheGroupAccessList = SharedClassUtilities.getSharedCacheInfo(dirGroupAccess, SharedClassUtilities.NO_FLAGS, false);
 		    	if (cacheGroupAccessList == null) {
 		    		fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found with dir is " + dirGroupAccess);
 		    	}
-		    	tempGroupAccessCount = cacheGroupAccessList.size();
-		    	if (tempGroupAccessCount == -1) {
-		    		fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found with dir is " + dirGroupAccess);
-		    	}
+		    	
 		    	cacheGroupAccessNonPersistentList = SharedClassUtilities.getSharedCacheInfo(dirRemoveJavaSharedResources, SharedClassUtilities.NO_FLAGS, false);
 		    	if (cacheGroupAccessNonPersistentList == null) {
 			    	fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found with dir is " + dirRemoveJavaSharedResources);
 			    }
-		    	if (tempGroupAccessCount == -1) {
-		    		fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found with dir is " + dirRemoveJavaSharedResources);
-		    	}
+		    	
 		    	newCacheCount += cacheGroupAccessList.size() + cacheGroupAccessNonPersistentList.size();
 		    	if ((newCacheCount == -1) || (newCacheCount != 
 		    			(oldCacheCount + persistentGroupAccessCount + nonpersistentGroupAccessCount +

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
@@ -11,22 +11,33 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	 */
 	private final static int SOFT_MAX_BYTES_VALUE = 16 * 1024 * 1024;
 	private final static int TEMP_JAVA10_JVMLEVEL = 6;
-	private static int persistentCount, nonpersistentCount, snapshotCount;
-	private static ArrayList<String> persistentList, nonpersistentList, snapshotList;
+
+	private static int persistentCount, nonpersistentCount, snapshotCount, persistentGroupAccessCount, nonpersistentGroupAccessCount;
+	private static ArrayList<String> persistentList, nonpersistentList, snapshotList, persistentGroupAccessList, nonpersistentGroupAccessList;
 		
 	static {
 		if (isMVS() == false) {
 			persistentList = new ArrayList<String>();
 			persistentList.add("cache1");
 			if (isWindows() == false) {
-				persistentList.add("cache1_groupaccess");
+				if (isOpenJ9()) {
+					persistentGroupAccessList = new ArrayList<String>();
+					persistentGroupAccessList.add("cache1_groupaccess");
+				} else {
+					persistentList.add("cache1_groupaccess");
+				}
 			}
 		}
     	if (realtimeTestsSelected() == false) {
 			nonpersistentList = new ArrayList<String>();
 			nonpersistentList.add("cache2");
 			if (isWindows() == false) {
-				nonpersistentList.add("cache2_groupaccess");
+				if (isOpenJ9()) {
+					nonpersistentGroupAccessList = new ArrayList<String>();
+					nonpersistentGroupAccessList.add("cache2_groupaccess");
+				} else {
+					nonpersistentList.add("cache2_groupaccess");
+				}
 				snapshotList = new ArrayList<String>();
 				snapshotList.add("cache2");
 			}
@@ -34,18 +45,28 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	}
     public static void main(String args[]) {
     	String dir = null;
+    	String dirGroupAccess = null;
+    	String dirRemoveJavaSharedResources = null;
     	int oldCacheCount = 0;
+    	int oldCacheGroupAccessCount = 0;
+    	int oldCacheGroupAccessNonpersistentCount = 0;
     	int newCacheCount = 0;
+    	int newCacheGroupAccessCount = 0;
     	String addrMode, jvmLevel;
     	List<SharedClassCacheInfo> cacheList;
+    	List<SharedClassCacheInfo> cacheGroupAccessList = null;
+    	List<SharedClassCacheInfo> cacheGroupAccessNonPersistentList = null;
     	int compressedRefMode = 0;
-    	
+
     	if (TestUtils.isCompressedRefEnabled()) {
     		compressedRefMode = 1;
     	}
     	runDestroyAllCaches();
     	if (false == isWindows()) {
     		runDestroyAllSnapshots();
+        	if (isOpenJ9()) {
+        		runDestroyAllGroupAccessCaches();
+            }
     	}
     	addrMode = System.getProperty("com.ibm.vm.bitmode");
 		jvmLevel = System.getProperty("java.specification.version");
@@ -55,7 +76,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	    	if (dir == null) {
 	    		dir = getControlDir();
 	    	}
-	    	
+
 	    	/* get cache count before creating any new cache */
 	    	cacheList = SharedClassUtilities.getSharedCacheInfo(dir, SharedClassUtilities.NO_FLAGS, false);
 	    	if (cacheList == null) {
@@ -66,8 +87,35 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 		    if (oldCacheCount == -1) {
 		    	fail("iterateSharedCacheFunction failed");
 		    }
-		    persistentCount = nonpersistentCount = snapshotCount = 0;
+	    	
+	    	if (dir == null && false == isWindows() && false == isMVS() && isOpenJ9()) {
+	    		dirGroupAccess = getCacheDir("Foo_groupaccess", false);
+	    		dirRemoveJavaSharedResources = removeJavaSharedResourcesDir(dirGroupAccess);
+	    		cacheGroupAccessList = SharedClassUtilities.getSharedCacheInfo(dirGroupAccess, SharedClassUtilities.NO_FLAGS, false);
+		    	if (cacheGroupAccessList == null) {
+		    		oldCacheGroupAccessCount = 0;
+		    	} else {
+		    		oldCacheGroupAccessCount = cacheGroupAccessList.size();
+		    	}
+		    	cacheGroupAccessNonPersistentList = SharedClassUtilities.getSharedCacheInfo(dirRemoveJavaSharedResources, SharedClassUtilities.NO_FLAGS, false);
+		    	if (cacheGroupAccessNonPersistentList == null) {
+		    		oldCacheGroupAccessNonpersistentCount = 0;
+		    	} else {
+		    		oldCacheGroupAccessNonpersistentCount = cacheGroupAccessNonPersistentList.size();
+		    	}
+			    oldCacheCount = oldCacheCount + oldCacheGroupAccessCount + oldCacheGroupAccessNonpersistentCount;
+	    	}
+
+		    persistentCount = nonpersistentCount = snapshotCount = persistentGroupAccessCount = nonpersistentGroupAccessCount= 0;
 	       	if (isMVS() == false) {
+	       		if (dirGroupAccess != null) {
+		       		for(String cacheName: persistentGroupAccessList) {
+		       			runSimpleJavaProgramWithPersistentCache(cacheName, "groupAccess");
+		       			checkFileExistsForPersistentCache(cacheName);
+		       		}
+		       		persistentGroupAccessCount = persistentGroupAccessList.size();
+	       		}
+	       		
 	       		for(String cacheName: persistentList) {
 	       			if (cacheName.indexOf("groupaccess") != -1) {
 	       				runSimpleJavaProgramWithPersistentCache(cacheName, "groupAccess");
@@ -79,6 +127,13 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	       		persistentCount = persistentList.size();
 	    	}
 	       	if (realtimeTestsSelected() == false) {
+	       		if (dirGroupAccess != null) {
+		       		for(String cacheName: nonpersistentGroupAccessList) {
+		       			runSimpleJavaProgramWithNonPersistentCache(cacheName, "groupAccess");
+		       			checkFileExistsForNonPersistentCache(cacheName);
+		       		}
+		       		nonpersistentGroupAccessCount = nonpersistentGroupAccessList.size();
+	       		}
 		       	for(String cacheName: nonpersistentList) {
 	       			if (cacheName.indexOf("groupaccess") != -1) {
 	       				runSimpleJavaProgramWithNonPersistentCache(cacheName, "groupAccess");
@@ -103,12 +158,39 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	       	
 		    cacheList = SharedClassUtilities.getSharedCacheInfo(dir, SharedClassUtilities.NO_FLAGS, false);
 		    if (cacheList == null) {
-		    	fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found");
+		    	fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found with dir is " + dir);
 		    }
 		    newCacheCount = cacheList.size();
-		    if ((newCacheCount == -1) || (newCacheCount != (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount))) {
-		    	fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found\t" +
-		    			"expected: " + (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount) + "\tfound: " + newCacheCount);
+		    
+		    if (dirGroupAccess != null) {
+		    	int tempGroupAccessCount = 0;
+		    	cacheGroupAccessList = SharedClassUtilities.getSharedCacheInfo(dirGroupAccess, SharedClassUtilities.NO_FLAGS, false);
+		    	if (cacheGroupAccessList == null) {
+		    		fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found with dir is " + dirGroupAccess);
+		    	}
+		    	tempGroupAccessCount = cacheGroupAccessList.size();
+		    	if (tempGroupAccessCount == -1) {
+		    		fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found with dir is " + dirGroupAccess);
+		    	}
+		    	cacheGroupAccessNonPersistentList = SharedClassUtilities.getSharedCacheInfo(dirRemoveJavaSharedResources, SharedClassUtilities.NO_FLAGS, false);
+		    	if (cacheGroupAccessNonPersistentList == null) {
+			    	fail("SharedClassUtilities.getSharedCacheInfo failed: no cache found with dir is " + dirRemoveJavaSharedResources);
+			    }
+		    	if (tempGroupAccessCount == -1) {
+		    		fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found with dir is " + dirRemoveJavaSharedResources);
+		    	}
+		    	newCacheCount += cacheGroupAccessList.size() + cacheGroupAccessNonPersistentList.size();
+		    	if ((newCacheCount == -1) || (newCacheCount != 
+		    			(oldCacheCount + persistentGroupAccessCount + nonpersistentGroupAccessCount +
+		    					persistentCount + nonpersistentCount + snapshotCount))) {
+			    	fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found\t" +
+			    		"expected: " + (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount) + "\tfound: " + newCacheCount);
+			    }
+		    } else {
+			    if ((newCacheCount == -1) || (newCacheCount != (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount))) {
+			    	fail("SharedClassUtilities.getSharedCacheInfo failed: Invalid number of cache found\t" +
+			    			"expected: " + (oldCacheCount + persistentCount + nonpersistentCount + snapshotCount) + "\tfound: " + newCacheCount);
+			    }
 		    }
 		    if (isMVS() == false) {
 			    for(String cacheName: persistentList) {
@@ -124,16 +206,27 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    				(cacheInfo.getOSsemid() != -1) ||
 			    				(cacheInfo.getLastDetach() == null) ||
 			    				(cacheInfo.getCacheCompressedRefsMode() != compressedRefMode) ||
-			    				(cacheInfo.getCacheLayer() != 0) ||
 			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() < 0) ||			/* if lastDetach is in future */
 			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() > (65*60*1000))	/* difference should not be more than 1 hr 5 mins */
 			    			) {
-			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: Cache information is not proper");
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: Cache information is not proper" + 
+			    						"\n cacheName is " + cacheName + 
+			    						"\n cacheInfo.getCacheSize() is " +  cacheInfo.getCacheSize() + 
+			    						"\n cacheInfo.getCacheSoftMaxBytes() is " + cacheInfo.getCacheSoftMaxBytes() +
+			    						"\n cacheInfo.getCacheFreeBytes() is " + cacheInfo.getCacheFreeBytes() +
+			    						"\n cacheInfo.isCacheCompatible() is " + cacheInfo.isCacheCompatible() +
+			    						"\n cacheInfo.isCacheCorrupt() is " + cacheInfo.isCacheCorrupt() +
+			    						"\n cacheInfo.getOSshmid() is " + cacheInfo.getOSshmid() + 
+			    						"\n cacheInfo.getOSsemid() is " + cacheInfo.getLastDetach() + 
+			    						"\n cacheInfo.getCacheCompressedRefsMode() is " + cacheInfo.getCacheCompressedRefsMode() +
+			    						"\n cacheInfo.getCacheLayer() is " + cacheInfo.getCacheLayer() +
+			    						"\n System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() is " + ( System.currentTimeMillis() - cacheInfo.getLastDetach().getTime())) ;
 	  		    			}	
 			    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
 			    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
 			    			) {
-			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: Address mode is not proper");
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent cache: Address mode is not proper " + 
+			    						"\n cacheInfo.getCacheAddressMode() is " + cacheInfo.getCacheAddressMode());
 			    			}
 			    			if ((jvmLevel.equals("1.6") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA6)) ||
 			    				(jvmLevel.equals("1.7") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA7)) ||
@@ -144,6 +237,53 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    			}
 			    		}
 			    	}
+			    }
+			    if (dirGroupAccess != null){
+			    	for(String cacheName: persistentGroupAccessList) {
+				    	for(SharedClassCacheInfo cacheInfo: cacheGroupAccessList) {
+				    		if (cacheInfo.getCacheName().equals(cacheName)) {
+				    			if ((cacheInfo.getCacheSize() <= 0) ||
+				    				(cacheInfo.getCacheSoftMaxBytes() != SOFT_MAX_BYTES_VALUE) ||
+				    				(cacheInfo.getCacheFreeBytes() <= 0) ||
+				    				(cacheInfo.isCacheCompatible() == false) ||
+				    				(cacheInfo.isCacheCorrupt() == true) ||
+				    				(cacheInfo.getCacheType() != SharedClassUtilities.PERSISTENT) ||
+				    				(cacheInfo.getOSshmid() != -1) ||
+				    				(cacheInfo.getOSsemid() != -1) ||
+				    				(cacheInfo.getLastDetach() == null) ||
+				    				(cacheInfo.getCacheCompressedRefsMode() != compressedRefMode) ||
+				    				(cacheInfo.getCacheLayer() != 0) ||
+				    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() < 0) ||			/* if lastDetach is in future */
+				    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() > (65*60*1000))	/* difference should not be more than 1 hr 5 mins */
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent groupAccess cache: Cache information is not proper" + 
+				    						"\n cacheName is " + cacheName +
+				    						"\n cacheInfo.getCacheSize() is " +  cacheInfo.getCacheSize() + 
+				    						"\n cacheInfo.getCacheSoftMaxBytes() is " + cacheInfo.getCacheSoftMaxBytes() +
+				    						"\n cacheInfo.getCacheFreeBytes() is " + cacheInfo.getCacheFreeBytes() +
+				    						"\n cacheInfo.isCacheCompatible() is " + cacheInfo.isCacheCompatible() +
+				    						"\n cacheInfo.isCacheCorrupt() is " + cacheInfo.isCacheCorrupt() +
+				    						"\n cacheInfo.getOSshmid() is " + cacheInfo.getOSshmid() + 
+				    						"\n cacheInfo.getOSsemid() is " + cacheInfo.getLastDetach() + 
+				    						"\n cacheInfo.getCacheCompressedRefsMode() is " + cacheInfo.getCacheCompressedRefsMode() +
+				    						"\n cacheInfo.getCacheLayer() is " + cacheInfo.getCacheLayer() +
+				    						"\n System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() is " + ( System.currentTimeMillis() - cacheInfo.getLastDetach().getTime())) ;
+		  		    			}	
+				    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
+				    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent groupAccess cache: Address mode is not proper");
+				    			}
+				    			if ((jvmLevel.equals("1.6") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA6)) ||
+				    				(jvmLevel.equals("1.7") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA7)) ||
+				    				(jvmLevel.equals("1.8") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA8)) ||
+				    				((Double.parseDouble(jvmLevel) >= 10) && (cacheInfo.getCacheJVMLevel() != Integer.parseInt(jvmLevel)))
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for persistent groupAccess cache: JVM level is not proper");
+				    			}
+				    		}
+				    	}
+				    }
 			    }
 		    }
 		    
@@ -164,7 +304,16 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() < 0) ||			/* if lastDetach is in future */
 			    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() > (65*60*1000))	/* difference should not be more than 1 hr 5 mins */
 			    			) {
-			    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent cache: Cache information is not proper");
+			    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent cache: Cache information is not proper"+ 
+			    						"\n cacheName is " + cacheName + 
+			    						"\n cacheInfo.getCacheSize() is " +  cacheInfo.getCacheSize() + 
+			    						"\n cacheInfo.getCacheSoftMaxBytes() is " + cacheInfo.getCacheSoftMaxBytes() +
+			    						"\n cacheInfo.getCacheFreeBytes() is " + cacheInfo.getCacheFreeBytes() +
+			    						"\n cacheInfo.isCacheCompatible() is " + cacheInfo.isCacheCompatible() +
+			    						"\n cacheInfo.isCacheCorrupt() is " + cacheInfo.isCacheCorrupt() +
+			    						"\n cacheInfo.getCacheCompressedRefsMode() is " + cacheInfo.getCacheCompressedRefsMode() +
+			    						"\n cacheInfo.getCacheLayer() is " + cacheInfo.getCacheLayer() +
+			    						"\n System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() is " + ( System.currentTimeMillis() - cacheInfo.getLastDetach().getTime())) ;
 			    			}	
 			    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
 			    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
@@ -191,6 +340,60 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    	}
 		    	}
 		    	
+		    	if ( dirGroupAccess != null ) {
+			    	for(String cacheName: nonpersistentGroupAccessList) {
+				    	for(SharedClassCacheInfo cacheInfo: cacheGroupAccessNonPersistentList) {
+				    		if ((cacheInfo.getCacheName().equals(cacheName))
+				    			&& (cacheInfo.getCacheType() == SharedClassUtilities.NONPERSISTENT)
+				    		) {
+				    			if ((cacheInfo.getCacheSize() <= 0) ||
+				    				(cacheInfo.getCacheFreeBytes() <= 0) ||
+				    				(cacheInfo.isCacheCompatible() == false) ||
+				    				(cacheInfo.isCacheCorrupt() == true) ||
+				    				(cacheInfo.getLastDetach() == null) ||
+				    				(cacheInfo.getCacheSoftMaxBytes() != SOFT_MAX_BYTES_VALUE) ||
+				    				(cacheInfo.getCacheCompressedRefsMode() != compressedRefMode) ||
+				    				(cacheInfo.getCacheLayer() != 0) ||
+				    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() < 0) ||			/* if lastDetach is in future */
+				    				(System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() > (65*60*1000))	/* difference should not be more than 1 hr 5 mins */
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent groupAccess cache: Cache information is not proper Cache information is not proper " + 
+				    					"\n cacheName is " + cacheName + 
+				    					"\n cacheInfo.getCacheSize() is " +  cacheInfo.getCacheSize() + 
+			    						"\n cacheInfo.getCacheSoftMaxBytes() is " + cacheInfo.getCacheSoftMaxBytes() +
+			    						"\n cacheInfo.getCacheFreeBytes() is " + cacheInfo.getCacheFreeBytes() +
+			    						"\n cacheInfo.isCacheCompatible() is " + cacheInfo.isCacheCompatible() +
+			    						"\n cacheInfo.isCacheCorrupt() is " + cacheInfo.isCacheCorrupt() +
+			    						"\n cacheInfo.getCacheCompressedRefsMode() is " + cacheInfo.getCacheCompressedRefsMode() +
+			    						"\n cacheInfo.getCacheLayer() is " + cacheInfo.getCacheLayer() +
+			    						"\n System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() is " + ( System.currentTimeMillis() - cacheInfo.getLastDetach().getTime())) ;
+				    			}	
+				    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
+				    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent groupAccess cache: Address mode is not proper");
+				    			}
+				    			if ((jvmLevel.equals("1.6") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA6)) ||
+				    				(jvmLevel.equals("1.7") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA7)) ||
+				    				(jvmLevel.equals("1.8") && (cacheInfo.getCacheJVMLevel() != SharedClassCacheInfo.JVMLEVEL_JAVA8)) ||
+				    				((Double.parseDouble(jvmLevel) >= 10) && (cacheInfo.getCacheJVMLevel() != Integer.parseInt(jvmLevel)))
+				    			) {
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for non-persistent groupAccess cache: JVM level is not proper");
+				    			}
+		
+			    				if ((isWindows()) && ((cacheInfo.getOSshmid() > 0) || (cacheInfo.getOSsemid() > 0))) {
+			    					fail("SharedClassUtilities.getSharedCacheInfo failed: Cache information is not proper\t" +
+			    							"os_shmid : " + cacheInfo.getOSshmid() + " os_semid : " + cacheInfo.getOSsemid());
+			    				} 
+			    				if ((isWindows() == false) && ((cacheInfo.getOSshmid() <= 0) || (cacheInfo.getOSsemid() <= 0))) {
+			    					fail("SharedClassUtilities.getSharedCacheInfo failed: Cache information is not proper\t" + 
+			    							"os_shmid : " + cacheInfo.getOSshmid() + " os_semid : " + cacheInfo.getOSsemid());
+			    				}
+				    		}
+				    	}
+		    		}
+		    	}
+		    	
 		    	if (false == isWindows()) {
 			    	for(String cacheName: snapshotList) {
 				    	for(SharedClassCacheInfo cacheInfo: cacheList) {
@@ -208,7 +411,16 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 				    				(-1 != cacheInfo.getOSshmid()) ||
 				    				(-1 != cacheInfo.getOSsemid())
 				    			) {
-				    				fail("SharedClassUtilities.getSharedCacheInfo failed for cache snapshot: Cache information is not proper");
+				    				fail("SharedClassUtilities.getSharedCacheInfo failed for cache snapshot: Cache information is not proper Cache information is not proper " + 
+				    					"\n cacheName is " + cacheName + 
+				    					"\n cacheInfo.getCacheSize() is " +  cacheInfo.getCacheSize() + 
+			    						"\n cacheInfo.getCacheSoftMaxBytes() is " + cacheInfo.getCacheSoftMaxBytes() +
+			    						"\n cacheInfo.getCacheFreeBytes() is " + cacheInfo.getCacheFreeBytes() +
+			    						"\n cacheInfo.isCacheCompatible() is " + cacheInfo.isCacheCompatible() +
+			    						"\n cacheInfo.isCacheCorrupt() is " + cacheInfo.isCacheCorrupt() +
+			    						"\n cacheInfo.getCacheCompressedRefsMode() is " + cacheInfo.getCacheCompressedRefsMode() +
+			    						"\n cacheInfo.getCacheLayer() is " + cacheInfo.getCacheLayer() +
+			    						"\n System.currentTimeMillis() - cacheInfo.getLastDetach().getTime() is " + ( System.currentTimeMillis() - cacheInfo.getLastDetach().getTime())) ;
 				    			}	
 				    			if ((addrMode.equals("32") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_32)) ||
 				    				(addrMode.equals("64") && (cacheInfo.getCacheAddressMode() != SharedClassCacheInfo.ADDRESS_MODE_64))
@@ -229,6 +441,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    
 		    if (isMVS() == false) {
 		    	for(String cacheName: persistentList) {
+		    		System.out.println("javaapi destroy cache dir is " + dir);
 		    		int ret;
 		    		try {
 			        	SharedClassUtilities.destroySharedCache(dir, INVALID_CACHE_TYPE, cacheName, false);
@@ -249,14 +462,43 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    	checkFileExistsForPersistentCache(cacheName);
 			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.PERSISTENT, cacheName, false);
 			    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
-			    		fail("SharedClassUtilities.destroySharedCache failed (persistent)");
+			    		fail("SharedClassUtilities.destroySharedCache failed (persistent), Cache Name: " + cacheName);
 			    	}
 			    	checkFileDoesNotExistForPersistentCache(cacheName);
+		    	}
+		    	if (dirGroupAccess != null) {
+			    	for(String cacheName: persistentGroupAccessList) {
+			    		int ret;
+			    		try {
+				        	SharedClassUtilities.destroySharedCache(dirGroupAccess, INVALID_CACHE_TYPE, cacheName, false);
+				        	fail("SharedClassUtilities.destroySharedCache (persistent)failed: should have thrown IllegalArgumentException");
+			    		} catch (IllegalArgumentException e) {
+			    			/* expected to reach here */
+			    		}
+				    	checkFileExistsForPersistentCache(cacheName);
+				    	ret = SharedClassUtilities.destroySharedCache(dirGroupAccess, SharedClassUtilities.NONPERSISTENT, cacheName, false);
+				    	if ((-1 != ret) && (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+				    		fail("SharedClassUtilities.destroySharedCache failed: trying to destroy persistent cache as a non-persistent cache");
+				    	}
+				    	checkFileExistsForPersistentCache(cacheName);
+				    	ret = SharedClassUtilities.destroySharedCache(dirGroupAccess, SharedClassUtilities.SNAPSHOT, cacheName, false);
+				    	if ((-1 != ret) && (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+				    		fail("SharedClassUtilities.destroySharedCache failed: trying to destroy persistent cache as a cache snapshot");
+				    	}
+				    	checkFileExistsForPersistentCache(cacheName);
+				    	ret = SharedClassUtilities.destroySharedCache(dirGroupAccess, SharedClassUtilities.PERSISTENT, cacheName, false);
+				    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+				    		fail("SharedClassUtilities.destroySharedCache failed (persistent)");
+				    	}
+				    	checkFileDoesNotExistForPersistentCache(cacheName);
+			    	}
 		    	}
 		    }
 		    if (realtimeTestsSelected() == false) {
 			    for(String cacheName: nonpersistentList) {
 			    	int ret;
+			    	System.out.println("javaapi destroy nonpersistent cache dir is " + dir);
+		    		
 			    	try {
 			    		SharedClassUtilities.destroySharedCache(dir, INVALID_CACHE_TYPE, cacheName, false);
 			    		fail("SharedClassUtilities.destroySharedCache (non-persistent) failed: should have thrown IllegalArgumentException");
@@ -271,7 +513,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			    	checkFileExistsForNonPersistentCache(cacheName);
 			    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.NONPERSISTENT, cacheName, false);
 			    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
-			    		fail("SharedClassUtilities.destroySharedCache failed (non-persistent)");
+			    		fail("SharedClassUtilities.destroySharedCache failed (non-persistent), Cache Name: " + cacheName);
 			    	}
 				    checkFileDoesNotExistForNonPersistentCache(cacheName);
 				    
@@ -279,9 +521,31 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 				    	checkFileExistsForCacheSnapshot(cacheName);
 				    	ret = SharedClassUtilities.destroySharedCache(dir, SharedClassUtilities.SNAPSHOT, cacheName, false);
 				    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
-				    		fail("SharedClassUtilities.destroySharedCache failed (snapshot)");
+				    		fail("SharedClassUtilities.destroySharedCache failed (snapshot), Cache Name: " + cacheName);
 				    	}
 				    	checkFileDoesNotExistForCacheSnapshot(cacheName);
+				    }
+			    }
+			    if (dirGroupAccess != null) {
+				    for(String cacheName: nonpersistentGroupAccessList) {
+				    	int ret;
+				    	try {
+				    		SharedClassUtilities.destroySharedCache(dirRemoveJavaSharedResources, INVALID_CACHE_TYPE, cacheName, false);
+				    		fail("SharedClassUtilities.destroySharedCache (non-persistent) failed: should have thrown IllegalArgumentException");
+				      	} catch (IllegalArgumentException e) {
+				      		/* expected to reach here */
+				      	}
+				    	checkFileExistsForNonPersistentCache(cacheName);
+				    	ret = SharedClassUtilities.destroySharedCache(dirRemoveJavaSharedResources, SharedClassUtilities.PERSISTENT, cacheName, false);
+				    	if ((-1 != ret) && (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+				    		fail("SharedClassUtilities.destroySharedCache failed: trying to destroy non-persistent cache as a persistent cache");
+				    	}
+				    	checkFileExistsForNonPersistentCache(cacheName);
+				    	ret = SharedClassUtilities.destroySharedCache(dirRemoveJavaSharedResources, SharedClassUtilities.NONPERSISTENT, cacheName, false);
+				    	if ((-1 == ret) || (SharedClassUtilities.DESTROYED_ALL_CACHE != ret)) {
+				    		fail("SharedClassUtilities.destroySharedCache failed (non-persistent)");
+				    	}
+					    checkFileDoesNotExistForNonPersistentCache(cacheName);
 				    }
 			    }
 		    }
@@ -290,6 +554,9 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			runDestroyAllCaches();
 			if (false == isWindows()) {
 				runDestroyAllSnapshots();
+				if (isOpenJ9()) {
+					runDestroyAllGroupAccessCaches();
+				}
 			}
 		}
 	}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
@@ -1,0 +1,108 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+public class TestSharedCacheJvmtiAPI extends TestUtils {
+	private final static int NO_FLAGS = 0;
+	private final static int PERSISTENT = 1;
+	private final static int NONPERSISTENT = 2;
+	private final static int SNAPSHOT = 5;
+	private final static int INVALID_CACHE_TYPE = 3;
+	private static int cacheCount;
+	private static int snapshotCount = 0;
+		
+    public native static int iterateSharedCache(String cacheDir, int flags, boolean useCommandLineValues);
+    public native static boolean destroySharedCache(String cacheDir, String cacheName, int cacheType, boolean useCommandLineValues);
+
+    public static void main(String args[]) {
+    	boolean ret = true;
+    	String dir = null;
+    	int oldCacheCount = 0;
+    	int newCacheCount = 0;
+    	
+        runDestroyAllCaches();
+        if (false == isWindows()) {
+        	runDestroyAllSnapshots();
+        }
+        try {
+	    	dir = getCacheDir();
+	    	if (dir == null) {
+	    	}
+	    	
+	    	/* get cache count before creating any new cache */
+	    	oldCacheCount = iterateSharedCache(dir, NO_FLAGS, false);
+		    if (oldCacheCount == -1) {
+		    	fail("iterateSharedCacheFunction failed");
+		    }
+		    	    
+	    	cacheCount = 0;
+	    	if (isMVS() == false) {
+	    		createPersistentCache("cache1");
+	    		checkFileExistsForPersistentCache("cache1");
+	    		cacheCount++;
+	    		if (isWindows() == false) {
+			    	runSimpleJavaProgramWithPersistentCache("cache1_groupaccess", "groupAccess");
+					checkFileExistsForPersistentCache("cache1_groupaccess");
+					cacheCount++;
+				}
+	    	}
+	    	snapshotCount = 0;
+	    	if (realtimeTestsSelected() == false) {
+			    createNonPersistentCache("cache2");	  
+			    checkFileExistsForNonPersistentCache("cache2");
+			    cacheCount++;
+				if (isWindows() == false) {
+					runSimpleJavaProgramWithNonPersistentCache("cache2_groupaccess", "groupAccess");
+					checkFileExistsForNonPersistentCache("cache2_groupaccess");
+					cacheCount++;
+					
+					createCacheSnapshot("cache2");
+					checkFileExistsForCacheSnapshot("cache2");
+					snapshotCount++;
+				}
+	    	}
+		    
+		    newCacheCount = iterateSharedCache(dir, NO_FLAGS, false);
+		    if ((newCacheCount == -1) || (newCacheCount != oldCacheCount + cacheCount + snapshotCount)) {
+		    	fail("iterateSharedCacheFunction failed");
+		    }
+		    
+		    if (isMVS() == false) {
+		    	destroySharedCache(dir, "cache1", INVALID_CACHE_TYPE, false);
+		    	checkFileExistsForPersistentCache("cache1");
+		    	destroySharedCache(dir, "cache1", NONPERSISTENT, false);
+		    	checkFileExistsForPersistentCache("cache1");
+		    	destroySharedCache(dir, "cache1", SNAPSHOT, false);
+		    	checkFileExistsForPersistentCache("cache1");
+		    	destroySharedCache(dir, "cache1", PERSISTENT, false);
+		    	checkFileDoesNotExistForPersistentCache("cache1");
+				if (isWindows() == false) {
+			    	destroySharedCache(dir, "cache1_groupaccess", PERSISTENT, false);
+			    	checkFileDoesNotExistForPersistentCache("cache1_groupaccess");
+				}
+		    }
+		    if (realtimeTestsSelected() == false) {
+		    	destroySharedCache(dir, "cache2", INVALID_CACHE_TYPE, false);
+			    checkFileExistsForNonPersistentCache("cache2");
+		    	destroySharedCache(dir, "cache2", PERSISTENT, false);
+		    	checkFileExistsForNonPersistentCache("cache2");
+		    	destroySharedCache(dir, "cache2", NONPERSISTENT, false);
+			    checkFileDoesNotExistForNonPersistentCache("cache2");
+			    if (isWindows() == false) {
+			    	destroySharedCache(dir, "cache2_groupaccess", NONPERSISTENT, false);
+			    	checkFileDoesNotExistForNonPersistentCache("cache2_groupaccess");
+			    	
+			    	checkFileExistsForCacheSnapshot("cache2");
+			    	destroySharedCache(dir, "cache2", SNAPSHOT, false);
+			    	checkFileDoesNotExistForCacheSnapshot("cache2");
+				}
+		    }
+
+		} finally {
+			runDestroyAllCaches();
+			if (false == isWindows()) {
+				runDestroyAllSnapshots();
+			}
+		}
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedMemoryMeddling01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedMemoryMeddling01.java
@@ -1,0 +1,90 @@
+package tests.sharedclasses.options;
+
+import java.io.*;
+
+import tests.sharedclasses.RunCommand;
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Create a cache, discover the shared memory id - wipe it with ipcrm, rerun and we should get a new cache
+ */
+public class TestSharedMemoryMeddling01 extends TestUtils {
+  public static void main(String[] args) throws Exception {
+	if (!isLinux()) {
+		System.err.println("Test 'TestSemaphoreMeddling01' not supported on os: "+getOS());
+		System.err.println("test skipped");
+		return;
+	}
+	runDestroyAllCaches();    
+    createNonPersistentCache("Oranges");
+    
+    // take the semaphore file to pieces
+    String semaphoreFile = getCacheFileLocationForNonPersistentCache("Oranges");
+    CacheControlFile ctrlFile = new CacheControlFile(semaphoreFile);
+    
+    // Delete the shared memory
+    int shmIdBefore = ctrlFile.shmId;
+    // System.out.println("Shm id = "+shmIdBefore);
+    RunCommand.execute("ipcs");
+    
+    RunCommand.execute("ipcrm -m "+shmIdBefore);
+    checkOutputDoesNotContain("invalid id", 
+    		"Did not expect error about invalid shm id when calling ipcrm for shmid "+shmIdBefore);
+    RunCommand.execute("ipcs");
+    
+    runSimpleJavaProgramWithNonPersistentCache("Oranges");
+    checkOutputContains("JVMSHRC158I.*Oranges","Did not get expected message about creating cache 'Oranges'");
+
+    ctrlFile = new CacheControlFile(semaphoreFile);
+    // System.out.println("New shm id = "+ctrlFile.shmId);
+    
+    // chances of it being the same semaphore, 10zillion to one??
+    if (ctrlFile.shmId==shmIdBefore) {
+    	fail("Really did not expect the new shmid "+ctrlFile.shmId+" to be the same as the deleted one "+shmIdBefore);
+    }
+   
+    runDestroyAllCaches();
+  }
+  
+  /**
+   typedef struct j9shmem_controlFileFormat {
+	I_32 version;
+	I_32 modlevel;
+	key_t ftok_key;
+	I_32 proj_id;
+	I_32 shmid;
+	I_64 size;
+	I_32 uid;
+	I_32 gid;
+   } j9shmem_controlFileFormat;
+  */
+  static class CacheControlFile {
+	  public int shmId;
+	  
+	  public CacheControlFile(String filename) throws Exception {
+		    File f = new File(filename);
+		    FileInputStream fis;
+			fis = new FileInputStream(f);
+		    DataInputStream dis = new DataInputStream(fis);
+		    int version = dis.readInt();
+		    int modlevel = dis.readInt();
+		    int ftokKey = dis.readInt(); // vary in size on platforms?
+		    int projId = dis.readInt();
+		    int b1 = dis.readUnsignedByte();
+		    int b2 = dis.readUnsignedByte();
+		    int b3 = dis.readUnsignedByte();
+		    int b4 = dis.readUnsignedByte();
+//		    System.out.println(b1+" "+b2+" "+b3+" "+b4);
+		    shmId = b4<<24 | b3<<16 |b2<<8 |b1;
+//		    shmId = dis.readInt();
+		    long size = dis.readLong();
+		    int uid = dis.readInt();
+		    int gid = dis.readInt();
+		    System.out.println("ControlFile[version="+version+",modlevel="+modlevel+",ftokKey="+ftokKey+
+		    				   ",projId="+projId+",shmId="+shmId+",size="+size+
+		    				   ",uid="+uid+",gid="+gid);
+		    dis.close();
+		    fis.close();
+	  }
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedMemoryMeddling01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedMemoryMeddling01.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import java.io.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseAOT.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseAOT.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseAOT.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseAOT.java
@@ -1,0 +1,20 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the verboseAOT flag - just check for no crash.  AOT messages are intermittent so cannot rely on looking for them.
+ */
+public class TestVerboseAOT extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    runSimpleJavaProgramWithPersistentCache("plums","verboseAOT");
+    // actual message I saw in the output:
+    // "[-Xshareclasses AOT verbose output enabled]"
+    // may need to change test if that changes
+    checkOutputContains("-Xshareclasses AOT verbose output enabled", "Did not see expected verboseAOT activation message '-Xshareclasses AOT verbose output enabled'");
+    runSimpleJavaProgramWithNonPersistentCache("oranges","verboseAOT");
+    checkOutputContains("-Xshareclasses AOT verbose output enabled", "Did not see expected verboseAOT activation message '-Xshareclasses AOT verbose output enabled'");
+    runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseData.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseData.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseData.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseData.java
@@ -1,0 +1,20 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the verboseData flag - just check for no crash.
+ */
+public class TestVerboseData extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    runSimpleJavaProgramWithPersistentCache("plums","verboseData");
+    // actual message I saw in the output:
+    // "[-Xshareclasses byte data verbose output enabled]"
+    // may need to change test if that changes
+    checkOutputContains("-Xshareclasses byte data verbose output enabled", "Did not see expected verboseData activation message '-Xshareclasses byte data verbose output enabledd'");
+    runSimpleJavaProgramWithNonPersistentCache("oranges","verboseData");
+    checkOutputContains("-Xshareclasses byte data verbose output enabled", "Did not see expected verboseData activation message '-Xshareclasses byte data verbose output enabledd'");
+    runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseHelper.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseHelper.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseHelper.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseHelper.java
@@ -1,0 +1,21 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the verboseHelper flag - should be no crash and some sensible output
+ */
+public class TestVerboseHelper extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    runSimpleJavaProgramWithPersistentCache("plums","verboseHelper");
+    // actual line I saw:
+    // "Info for SharedClassURLClasspathHelper id 2: Created SharedClassURLClasspathHelper with id 2"
+    // may need to change test if that changes
+    checkOutputContains("Created SharedClassURLClasspathHelper", "Did not see expected verboseHelper text 'Created SharedClassURLClasspathHelper'");
+    
+    runSimpleJavaProgramWithNonPersistentCache("oranges","verboseHelper");
+    checkOutputContains("Created SharedClassURLClasspathHelper", "Did not see expected verboseHelper text 'Created SharedClassURLClasspathHelper'");
+    runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseIO.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseIO.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseIO.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestVerboseIO.java
@@ -1,0 +1,17 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+
+/*
+ * Check the verboseIO flag - should be no crash and some sensible output
+ */
+public class TestVerboseIO extends TestUtils {
+  public static void main(String[] args) {
+    runDestroyAllCaches();
+    runSimpleJavaProgramWithPersistentCache("plums","verboseIO");
+    checkOutputContains("Failed to find class SimpleApp ", "Did not see expected verboseIO text 'Failed to find class SimpleApp'");
+    runSimpleJavaProgramWithNonPersistentCache("oranges","verboseIO");
+    checkOutputContains("Failed to find class SimpleApp ", "Did not see expected verboseIO text 'Failed to find class SimpleApp'");
+    runDestroyAllCaches();
+  }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
@@ -1,0 +1,40 @@
+package tests.sharedclasses.options;
+
+import tests.sharedclasses.TestUtils;
+import java.io.File;
+
+/**
+ * This test checks for the content of the zipcache in the shared cache.
+ * It creates a persistent shared cache and runs
+ * java -Xshareclasses:printstats=zipcache
+ * on the shared cache.
+ * The list of boot strap jar is got from the system property sun.boot.class.path
+ * and we check that every file in the sun.boot.class.path is found in the
+ * shared cache
+ * 
+ * @author jeanpb
+ */
+public class TestZipCacheStoresAllBootstrapJar extends TestUtils {
+	public static void main(String[] args) {
+		runSimpleJavaProgramWithPersistentCache("TestZipCacheStoresAllBootstrapJar");
+		runPrintStats("TestZipCacheStoresAllBootstrapJar",true,"zipcache");
+
+		String bootClassPath = System.getProperty("sun.boot.class.path");
+		
+		// Assumimg that the sun.boot.class.path is of the following format:
+		// full_path_to_file1.jar;full_path_to_file2.jar
+		String[] bootClassPathSplit = bootClassPath.split(";");
+		
+		for (String bootClassPathEntry : bootClassPathSplit) {
+			// Not all files in the "sun.boot.class.path" have to exist, check if they do
+			if ((new File(bootClassPathEntry)).exists()) {
+				// get the file name, split for \ or /.
+				String[] bootClassPathEntryParts = bootClassPathEntry.split("[\\\\/]");
+	
+				String filename = bootClassPathEntryParts[bootClassPathEntryParts.length- 1];
+				checkOutputContains(filename, "The shared cache printstats output must contain the ZIPCACHE data for the file "+filename+".");
+			}
+		}
+		runDestroyAllCaches();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestZipCacheStoresAllBootstrapJar.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/AllTests.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/AllTests.java
@@ -1,0 +1,26 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.TestUtils;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class AllTests {
+
+	public static Test suite() {
+		TestSuite suite = new TestSuite(
+				"Testing design 467 changes to shared classes command line options");
+		//$JUnit-BEGIN$
+		if (TestUtils.realtimeTestsSelected()){
+			suite.addTestSuite(TestOptionsDefaultRealtime.class);
+			suite.addTestSuite(TestOptionsControlDirRealtime.class);
+			suite.addTestSuite(TestOptionsCacheDirRealtime.class);
+		} else {
+			suite.addTestSuite(TestOptionsDefault.class);
+			suite.addTestSuite(TestOptionsControlDir.class);
+			suite.addTestSuite(TestOptionsCacheDir.class);
+		}
+		//$JUnit-END$
+		return suite;
+	}
+
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/AllTests.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/AllTests.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBase.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBase.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.options.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBase.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBase.java
@@ -1,0 +1,111 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.options.*;
+
+/**
+ * Gather together all the tests into one testcase - see the subclasses for more info.
+ */
+public abstract class TestOptionsBase extends TestOptionsNonpersistent {
+
+	public void testCacheCreationListingDestroying01() {TestCacheCreationListingDestroying01.main(null);}
+
+	public void testCacheCreationListingDestroying02() {TestCacheCreationListingDestroying02.main(null);}
+
+	//public void testCacheGenerations01() { TestCacheGenerations01.main(null);}
+	//public void testCacheGenerations02() { TestCacheGenerations02.main(null);}
+	//public void testCacheGenerations03() { TestCacheGenerations03.main(null);}
+	//public void testCacheGenerations04() { TestCacheGenerations04.main(null);}
+	//public void testCacheGenerations05() { TestCacheGenerations01.main(null);}
+	//public void testCacheGenerations06() { TestCacheGenerations06.main(null);}
+	//public void testCacheGenerations07() { TestCacheGenerations07.main(null);}
+	//public void testCacheGenerations08() { TestCacheGenerations08.main(null);}
+
+	public void testCacheDir01() { TestCacheDir01.main(null);}
+
+//	public void testCacheDir02() { TestCacheDir02.main(null);}
+
+//	public void testCacheDir03() { TestCacheDir03.main(null);}
+	
+//	public void testCacheDir05() { TestCacheDir05.main(null);}
+	
+	public void testCacheDir06() { TestCacheDir06.main(null);}
+	
+	public void testCommandLineOptionXscmx01() { TestCommandLineOptionXscmx01.main(null); }
+
+	public void testComplexSequence() { TestComplexSequence.main(null);}
+
+	public void testControlDirCacheDir01() { TestControlDirCacheDir01.main(null);}
+
+	public void testControlDirCacheDir02() { TestControlDirCacheDir02.main(null);}
+
+	public void testCorruptedCaches01() { TestCorruptedCaches01.main(null);}
+
+	public void testCorruptedCaches02() { TestCorruptedCaches02.main(null);}
+
+	public void testCorruptedCaches03() { TestCorruptedCaches03.main(null);}
+
+	public void testCreatingNonpersistentCache() {TestCreatingNonpersistentCache.main(null);}
+
+	public void testCreationAndCompatibility() { TestCreationAndCompatibility.main(null);}
+
+	public void testDestroyNonExistentCaches() { TestDestroyNonExistentCaches.main(null);}
+	
+	public void testDisableCorruptCacheDumps() { TestDisableCorruptCacheDumps.main(null);}
+
+	public void testExpireAllWhenNoCaches() { TestExpireAllWhenNoCaches.main(null);}
+
+	public void testExpiringCaches() { TestExpiringCaches.main(null);}
+
+	//public void testIncompatibleCaches02() { TestIncompatibleCaches02.main(null);}
+
+	//public void testIncompatibleCaches03() { TestIncompatibleCaches03.main(null);}
+
+	//public void testIncompatibleCaches04() { TestIncompatibleCaches04.main(null);}
+
+	public void testListAllWhenNoCaches() { TestListAllWhenNoCaches.main(null);}
+	
+	public void testOptionNone() { TestOptionNone.main(null); }
+
+	public void testPersistentCacheMoving01() { TestPersistentCacheMoving01.main(null);}
+
+	public void testPersistentCacheMoving02() { TestPersistentCacheMoving02.main(null);}
+
+	public void testPersistentCacheMoving03() { TestPersistentCacheMoving03.main(null);}
+
+	public void testPrintStats01() { TestPrintStats01.main(null); }
+
+	public void testPrintStats02() { TestPrintStats02.main(null); }
+
+	//public void testPrintStats03() { TestPrintStats03.main(null); }
+
+	public void testReattachingToNonpersistentCache() {TestReattachingToNonpersistentCache.main(null);}
+
+	public void testReset01() { TestReset01.main(null); }
+
+	public void testReset02() { TestReset02.main(null); }
+
+	//public void testReset03() { TestReset03.main(null); }
+
+	public void testReset04() { TestReset04.main(null); }
+
+	public void testReset06() { TestReset06.main(null); }
+	
+	public void testVerboseIO() { TestVerboseIO.main(null); }
+	public void testVerboseData() { TestVerboseData.main(null); }
+	public void testVerboseHelper() { TestVerboseHelper.main(null); }
+	public void testVerboseAOT() { TestVerboseAOT.main(null); }
+	public void testSharedCacheJvmtiAPI() { TestSharedCacheJvmtiAPI.main(null); }
+	public void testSharedCacheJavaAPI() { TestSharedCacheJavaAPI.main(null); }
+	public void testDestroyCache() { TestDestroyCache.main(null); }
+	public void testExpireDestroyOnCorruptCache() { TestExpireDestroyOnCorruptCache.main(null); }
+
+	public void testZipCacheStoresAllBootstrapJar(){
+		String jvmLevel = System.getProperty("java.specification.version");
+		/* No bootstrap jars in Java 9, skip this test on Java 9 and later. */
+		if (Double.parseDouble(jvmLevel) < 9) {
+			TestZipCacheStoresAllBootstrapJar.main(null);
+		}
+	}
+	
+	public void testSharedCacheEnableBCI() { TestSharedCacheEnableBCI.main(null); }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBaseRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBaseRealtime.java
@@ -1,0 +1,41 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.options.*;
+
+/**
+ * Gather together all the tests into one testcase - see the subclasses for more info.
+ */
+public abstract class TestOptionsBaseRealtime extends TestOptionsNonpersistentRealtime {
+
+	public void testCacheDir06() { TestCacheDir06.main(null);}
+
+	public void testControlDirCacheDir01() { TestControlDirCacheDir01.main(null);}
+
+	public void testCorruptedCaches03() { TestCorruptedCaches03.main(null);}
+
+	public void testDestroyNonExistentCaches() { TestDestroyNonExistentCaches.main(null);}
+
+	public void testListAllWhenNoCaches() { TestListAllWhenNoCaches.main(null);}
+	
+	public void testOptionNone() { TestOptionNone.main(null); }
+
+	public void testPersistentCacheMoving01() { TestPersistentCacheMoving01.main(null);}
+
+	public void testPersistentCacheMoving02() { TestPersistentCacheMoving02.main(null);}
+
+	public void testPersistentCacheMoving03() { TestPersistentCacheMoving03.main(null);}
+
+	public void testReset01() { TestReset01.main(null); }
+
+	public void testReset04() { TestReset04.main(null); }
+
+	public void testReset06() { TestReset06.main(null); }
+	
+	public void testVerboseIO() { TestVerboseIO.main(null); }
+	public void testVerboseData() { TestVerboseData.main(null); }
+	public void testVerboseHelper() { TestVerboseHelper.main(null); }
+	public void testVerboseAOT() { TestVerboseAOT.main(null); }
+	public void testSharedCacheJvmtiAPI() { TestSharedCacheJvmtiAPI.main(null); }
+	public void testSharedCacheJavaAPI() { TestSharedCacheJavaAPI.main(null); }
+	public void testDestroyCache() { TestDestroyCache.main(null); }
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBaseRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsBaseRealtime.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.options.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDir.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDir.java
@@ -1,0 +1,28 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.TestUtils;
+
+/**
+ * For every testcase inherited from the superclass this will set the cacheDir.
+ */
+public class TestOptionsCacheDir extends TestOptionsBase {
+
+	String currentCacheDir;
+	String tmpdir;
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+		currentCacheDir = TestUtils.getCacheDir();
+		tmpdir= TestUtils.createTemporaryDirectory("TestOptionsCacheDir");
+		TestUtils.setCacheDir(tmpdir);
+		System.out.println("Running  :" + this.getName() + "  (Test suite : " + this.getClass().getSimpleName() + ")");
+	}
+	
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		TestUtils.runDestroyAllCaches();
+		TestUtils.setCacheDir(currentCacheDir);
+		TestUtils.deleteTemporaryDirectory(tmpdir);
+	}
+		
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDir.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDir.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDirRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDirRealtime.java
@@ -1,0 +1,28 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.TestUtils;
+
+/**
+ * For every testcase inherited from the superclass this will set the cacheDir.
+ */
+public class TestOptionsCacheDirRealtime extends TestOptionsBaseRealtime {
+
+	String currentCacheDir;
+	String tmpdir;
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+		currentCacheDir = TestUtils.getCacheDir();
+		tmpdir= TestUtils.createTemporaryDirectory("TestOptionsCacheDir");
+		TestUtils.setCacheDir(tmpdir);
+		System.out.println("Running  :" + this.getName() + "  (Test suite : " + this.getClass().getSimpleName() + ")");
+	}
+	
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		TestUtils.runDestroyAllCaches();
+		TestUtils.setCacheDir(currentCacheDir);
+		TestUtils.deleteTemporaryDirectory(tmpdir);
+	}
+		
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDirRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsCacheDirRealtime.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDir.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDir.java
@@ -1,0 +1,27 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.TestUtils;
+
+/**
+ * For every testcase inherited from the superclass this will set the controlDir.
+ */
+public class TestOptionsControlDir extends TestOptionsBase {
+
+	String currentCacheDir;
+	String tmpdir;
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+		currentCacheDir = TestUtils.getControlDir();
+		tmpdir= TestUtils.createTemporaryDirectory("TestOptionsControlDir");
+		TestUtils.setControlDir(tmpdir);
+		System.out.println("Running  :" + this.getName() + "  (Test suite : " + this.getClass().getSimpleName() + ")");
+	}
+	
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		TestUtils.runDestroyAllCaches();
+		TestUtils.setControlDir(currentCacheDir);
+		TestUtils.deleteTemporaryDirectory(tmpdir);
+	}	
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDir.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDir.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.TestUtils;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDirRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDirRealtime.java
@@ -1,0 +1,27 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.TestUtils;
+
+/**
+ * For every testcase inherited from the superclass this will set the controlDir.
+ */
+public class TestOptionsControlDirRealtime extends TestOptionsBaseRealtime {
+
+	String currentCacheDir;
+	String tmpdir;
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+		currentCacheDir = TestUtils.getControlDir();
+		tmpdir= TestUtils.createTemporaryDirectory("TestOptionsControlDir");
+		TestUtils.setControlDir(tmpdir);
+		System.out.println("Running  :" + this.getName() + "  (Test suite : " + this.getClass().getSimpleName() + ")");
+	}
+	
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		TestUtils.runDestroyAllCaches();
+		TestUtils.setControlDir(currentCacheDir);
+		TestUtils.deleteTemporaryDirectory(tmpdir);
+	}	
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDirRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsControlDirRealtime.java
@@ -1,4 +1,24 @@
-package tests.sharedclasses.options.junit;
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.TestUtils;
 

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefault.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefault.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import java.util.HashSet;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefault.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefault.java
@@ -1,0 +1,51 @@
+package tests.sharedclasses.options.junit;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import tests.sharedclasses.TestUtils;
+
+/**
+ * For every testcase inherited from the superclass this will just let the cache file location default.  It will
+ * also check for leaking memory/semaphores on unix platforms.
+ */
+public class TestOptionsDefault extends TestOptionsBase {
+
+	Set sharedMemorySegments;
+	Set sharedSemaphores;
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+		if (System.getProperty("check.shared.memory","no").toLowerCase().equals("yes")) {
+			if (!TestUtils.isWindows()  && !TestUtils.isMVS()) {
+				sharedMemorySegments = TestUtils.getSharedMemorySegments();
+				sharedSemaphores = TestUtils.getSharedSemaphores();	
+			}
+		}
+		System.out.println("Running  :" + this.getName() + "  (Test suite : " + this.getClass().getSimpleName() + ")");
+	}
+	
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		TestUtils.runDestroyAllCaches();
+		if (System.getProperty("check.shared.memory","no").toLowerCase().equals("yes")) {
+			if (!TestUtils.isWindows() && !TestUtils.isMVS()) {
+				Set after = TestUtils.getSharedMemorySegments();
+				Set difference = new HashSet();
+				difference.addAll(after);
+				difference.removeAll(sharedMemorySegments);
+				if (difference.size()!=0) {
+					throw new RuntimeException("Shared memory leaked: "+difference.size());
+				}
+				after = TestUtils.getSharedSemaphores();
+				difference = new HashSet();
+				difference.addAll(after);
+				difference.removeAll(sharedSemaphores);
+				if (difference.size()!=0) {
+					throw new RuntimeException("Shared semaphores leaked: "+difference.size());
+				}
+			}
+		}
+		TestUtils.runDestroyAllCaches();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefaultRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefaultRealtime.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import java.util.HashSet;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefaultRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsDefaultRealtime.java
@@ -1,0 +1,51 @@
+package tests.sharedclasses.options.junit;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import tests.sharedclasses.TestUtils;
+
+/**
+ * For every testcase inherited from the superclass this will just let the cache file location default.  It will
+ * also check for leaking memory/semaphores on unix platforms.
+ */
+public class TestOptionsDefaultRealtime extends TestOptionsBaseRealtime {
+
+	Set sharedMemorySegments;
+	Set sharedSemaphores;
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+		if (System.getProperty("check.shared.memory","no").toLowerCase().equals("yes")) {
+			if (!TestUtils.isWindows()  && !TestUtils.isMVS()) {
+				sharedMemorySegments = TestUtils.getSharedMemorySegments();
+				sharedSemaphores = TestUtils.getSharedSemaphores();	
+			}
+		}
+		System.out.println("Running  :" + this.getName() + "  (Test suite : " + this.getClass().getSimpleName() + ")");
+	}
+	
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		TestUtils.runDestroyAllCaches();
+		if (System.getProperty("check.shared.memory","no").toLowerCase().equals("yes")) {
+			if (!TestUtils.isWindows() && !TestUtils.isMVS()) {
+				Set after = TestUtils.getSharedMemorySegments();
+				Set difference = new HashSet();
+				difference.addAll(after);
+				difference.removeAll(sharedMemorySegments);
+				if (difference.size()!=0) {
+					throw new RuntimeException("Shared memory leaked: "+difference.size());
+				}
+				after = TestUtils.getSharedSemaphores();
+				difference = new HashSet();
+				difference.addAll(after);
+				difference.removeAll(sharedSemaphores);
+				if (difference.size()!=0) {
+					throw new RuntimeException("Shared semaphores leaked: "+difference.size());
+				}
+			}
+		}
+		TestUtils.runDestroyAllCaches();
+	}
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistent.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistent.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.options.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistent.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistent.java
@@ -1,0 +1,56 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.options.*;
+import junit.framework.TestCase;
+
+/**
+ * A subset of tests that don't rely on any persistent cache support
+ */
+public class TestOptionsNonpersistent extends TestCase {
+	public void testCacheCreationListingDestroying03() {TestCacheCreationListingDestroying03.main(null);}
+
+	public void testCacheCreationListingDestroying04() {TestCacheCreationListingDestroying04.main(null);}
+
+	public void testCacheDir04() {TestCacheDir04.main(null);}
+
+	public void testCacheDir07() {TestCacheDir07.main(null);}
+
+	public void testCommandLineOptionModified() { TestCommandLineOptionModified.main(null); }
+
+	public void testCommandLineOptionName01() { TestCommandLineOptionName01.main(null); }
+
+	public void testCommandLineOptionName02() { TestCommandLineOptionName02.main(null); }
+
+	public void testCommandLineOptionName03() { TestCommandLineOptionName03.main(null); }
+
+	public void testCommandLineOptionName04() { TestCommandLineOptionName04.main(null); }
+
+	public void testCommandLineOptionSilent01() { TestCommandLineOptionSilent01.main(null); }
+
+	public void testCommandLineOptionSilent02() { TestCommandLineOptionSilent02.main(null); }
+
+	public void testDestroyAllWhenNoCaches() { TestDestroyAllWhenNoCaches.main(null);}
+
+	//public void testIncompatibleCaches01() { TestIncompatibleCaches01.main(null);}
+
+	//CMVC 146158: these tests leave artifacts on the system so i am removing them
+	//public void testMovingControlFiles01() { TestMovingControlFiles01.main(null);}
+	//public void testMovingControlFiles02() { TestMovingControlFiles02.main(null);}
+
+	public void testPrintStats04() { TestPrintStats04.main(null); }
+	
+	public void testReattachingToNonpersistentCache02() { TestReattachingToNonpersistentCache02.main(null);}
+
+	public void testPrintStats05() { TestPrintStats05.main(null); }
+
+	public void testReset05() { TestReset05.main(null); }
+
+	public void testPrintStats06() {TestPrintStats06.main(null); }
+	
+	// little too unreliable - need to be more selective on what platform they run or
+	// support all unix flavours
+//	public void testSemaphoreMeddling01() throws Exception { TestSemaphoreMeddling01.main(null);}
+//
+//	public void testSharedMemoryMeddling01() throws Exception { TestSharedMemoryMeddling01.main(null);}
+
+}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistentRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistentRealtime.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 package tests.sharedclasses.options.junit;
 
 import tests.sharedclasses.options.*;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistentRealtime.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/junit/TestOptionsNonpersistentRealtime.java
@@ -1,0 +1,25 @@
+package tests.sharedclasses.options.junit;
+
+import tests.sharedclasses.options.*;
+import junit.framework.TestCase;
+
+/**
+ * A subset of tests that don't rely on any persistent cache support
+ */
+public class TestOptionsNonpersistentRealtime extends TestCase {
+
+	public void testCommandLineOptionName02() { TestCommandLineOptionName02.main(null); }
+
+	public void testCommandLineOptionName04() { TestCommandLineOptionName04.main(null); }
+
+	public void testCommandLineOptionSilent01() { TestCommandLineOptionSilent01.main(null); }
+
+	public void testCommandLineOptionSilent02() { TestCommandLineOptionSilent02.main(null); }
+
+	public void testDestroyAllWhenNoCaches() { TestDestroyAllWhenNoCaches.main(null);}
+
+	public void testPrintStats04() { TestPrintStats04.main(null); }
+
+	public void testPrintStats05() { TestPrintStats05.main(null); }
+
+}

--- a/test/functional/CacheManagement/testcode/InfiniteLoop.java
+++ b/test/functional/CacheManagement/testcode/InfiniteLoop.java
@@ -1,0 +1,13 @@
+/* This class is used by TestDestroyCache.java to keep a shared class cache active */
+public class InfiniteLoop {
+	public static void main(String args[]) throws Exception {
+		/* Do not change following print statement. 
+		 * It will break TestDestroyCache tests as it checks for it in the output.
+		 */
+		System.out.println("Running infinite loop");
+		Object lock = new Object();
+		synchronized (lock) {
+			lock.wait();
+		}
+	}
+}

--- a/test/functional/CacheManagement/testcode/InfiniteLoop.java
+++ b/test/functional/CacheManagement/testcode/InfiniteLoop.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 /* This class is used by TestDestroyCache.java to keep a shared class cache active */
 public class InfiniteLoop {
 	public static void main(String args[]) throws Exception {

--- a/test/functional/CacheManagement/testcode/ResetApp.java
+++ b/test/functional/CacheManagement/testcode/ResetApp.java
@@ -1,0 +1,5 @@
+public class ResetApp {
+  public static void main(String[] argv) {
+    // nop
+  }
+}

--- a/test/functional/CacheManagement/testcode/ResetApp.java
+++ b/test/functional/CacheManagement/testcode/ResetApp.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 public class ResetApp {
   public static void main(String[] argv) {
     // nop

--- a/test/functional/CacheManagement/testcode/SimpleApp.java
+++ b/test/functional/CacheManagement/testcode/SimpleApp.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 public class SimpleApp {
   public static void main(String []argv) {
     System.out.println("SimpleApp running");

--- a/test/functional/CacheManagement/testcode/SimpleApp.java
+++ b/test/functional/CacheManagement/testcode/SimpleApp.java
@@ -1,0 +1,6 @@
+public class SimpleApp {
+  public static void main(String []argv) {
+    System.out.println("SimpleApp running");
+    new SimpleApp2().call();
+  }
+}

--- a/test/functional/CacheManagement/testcode/SimpleApp2.java
+++ b/test/functional/CacheManagement/testcode/SimpleApp2.java
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 import java.util.regex.*;
 
 public class SimpleApp2 {

--- a/test/functional/CacheManagement/testcode/SimpleApp2.java
+++ b/test/functional/CacheManagement/testcode/SimpleApp2.java
@@ -1,0 +1,13 @@
+import java.util.regex.*;
+
+public class SimpleApp2 {
+	public void call() {
+		/*
+		 * CMVC 186357 : Use Pattern class to ensure classes in java.util.regex
+		 * package are loaded.
+		 */
+		boolean match = false;
+		String classNameRegex = "[a-zA-Z_][[\\w]|\\$]*";
+		match = Pattern.matches(classNameRegex, "SimpleApp2");
+	}
+}

--- a/test/functional/CacheManagement/testcode/readme.txt
+++ b/test/functional/CacheManagement/testcode/readme.txt
@@ -1,3 +1,25 @@
+<!--
+Copyright (c) 2010, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
 Code in here is built into the top level testcode.jar file
 
 javac *.java

--- a/test/functional/CacheManagement/testcode/readme.txt
+++ b/test/functional/CacheManagement/testcode/readme.txt
@@ -1,0 +1,4 @@
+Code in here is built into the top level testcode.jar file
+
+javac *.java
+jar -cvMf ../src/testcode.jar *


### PR DESCRIPTION
1. Migrate Cachemanagement test project
2. Update SharedCacheJavaAPI and SharedCacheJvmtiAPI tests to work with groupaccess option with OpenJ9
3. Disable TestPersistentCacheMoving01 with OpenJ9 if getCacheDir is null

