### PR TITLE
Optimize stacktraces and resolve using peekClassHashTable

### DIFF
--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -165,7 +165,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 			/* Fill in method class */
 			utf = J9ROMCLASS_CLASSNAME(romClass);
 			{
-				J9Class* clazz = peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
+				J9Class* clazz = vmfns->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
 				string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 				if (string == NULL) {
 					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN);

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -174,7 +174,11 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 					}
 				}
 				if (NULL == string) {
-					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN);
+					UDATA flags = J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN;
+					if (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)) {
+						flags |= J9_STR_ANON_CLASS_NAME;
+					}
+					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), flags);
 					if (NULL == string) {
 						rc = FALSE;
 						/* exception is pending from the call */

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -29,6 +29,7 @@
 #include "omrgcconsts.h"
 #include "rommeth.h"
 #include "vm_api.h"
+#include "ut_j9jcl.h"
 
 static UDATA getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader);
 
@@ -170,6 +171,11 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 				if (NULL != classLoader) {
 					clazz = vmfns->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
 					if (NULL != clazz) {
+						/* clazz can never be an array here as arrays can't define methods so we don't need to
+						 * take them into account in the code below when writing the interned string back to
+						 * the Class object.
+						 */
+						Assert_JCL_false(J9CLASS_IS_ARRAY(clazz));
 						string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 					}
 				}

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -164,18 +164,23 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 
 			/* Fill in method class */
 			utf = J9ROMCLASS_CLASSNAME(romClass);
+			string = NULL;
 			{
 				J9Class* clazz = vmfns->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
-				string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
-				if (string == NULL) {
+				if (NULL != clazz) {
+					string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
+				}
+				if (NULL == string) {
 					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN);
-					if (string == NULL) {
+					if (NULL == string) {
 						rc = FALSE;
 						/* exception is pending from the call */
 						goto done;
 					} else {
-						/* Class name was interned so it's safe to write it back to the Class Object */
-						J9VMJAVALANGCLASS_SET_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz), string);
+						if (NULL != clazz) {
+							/* Class name was interned so it's safe to write it back to the Class Object */
+							J9VMJAVALANGCLASS_SET_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz), string);
+						}
 					}
 				}
 				element = PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0);

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -166,9 +166,12 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 			utf = J9ROMCLASS_CLASSNAME(romClass);
 			string = NULL;
 			{
-				J9Class* clazz = vmfns->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
-				if (NULL != clazz) {
-					string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
+				J9Class* clazz = NULL;
+				if (NULL != classLoader) {
+					clazz = vmfns->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
+					if (NULL != clazz) {
+						string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
+					}
 				}
 				if (NULL == string) {
 					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN);
@@ -190,7 +193,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 			/* Fill in method name */
 
 			utf = J9ROMMETHOD_NAME(romMethod);
-			string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_XLAT);
+			string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), 0);
 			if (string == NULL) {
 				rc = FALSE;
 				/* exception is pending from the call */
@@ -211,7 +214,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 				 * provided the utf8 interning is hitting on common strings
 				 */
 				if ((NULL != previousFileName) && (previousFileName == fileName)) {
-					j9array_t result = (j9array_t) PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 1);
+					j9array_t result = (j9array_t) PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 2);
 					element = J9JAVAARRAYOFOBJECT_LOAD(vmThread, result, (I_32)userData->index - 1);
 					string = J9VMJAVALANGSTACKTRACEELEMENT_FILENAME(vmThread, element);
 				} else {

--- a/runtime/jcl/common/jclexception.h
+++ b/runtime/jcl/common/jclexception.h
@@ -28,9 +28,10 @@ typedef struct J9GetStackTraceUserData {
 	J9Class * elementClass;
 	UDATA index;
 	UDATA maxFrames;
+	J9UTF8 *previousFileName;
 } J9GetStackTraceUserData;
 
-J9IndexableObject *   getStackTrace(J9VMThread * vmThread, j9object_t* exceptionAddr, UDATA pruneConstructors);
+J9IndexableObject * getStackTrace(J9VMThread * vmThread, j9object_t* exceptionAddr, UDATA pruneConstructors);
 
 
 #endif

--- a/runtime/jcl/common/jclexception.h
+++ b/runtime/jcl/common/jclexception.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4793,6 +4793,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *setNestmatesError)(struct J9VMThread *vmThread, struct J9Class *nestMember, struct J9Class *nestHost, IDATA errorCode);
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	BOOLEAN ( *areValueTypesEnabled)(struct J9JavaVM *vm);
+	J9Class* ( *peekClassHashTable)(struct J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* className, UDATA classNameLength);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -327,6 +327,16 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 UDATA
 calculateArity(J9VMThread* vmThread, U_8* name, UDATA length);
 
+/**
+* @brief
+* @param currentThread
+* @param classLoader
+* @param className
+* @param classNameLength
+* @return UDATA
+*/
+J9Class*
+peekClassHashTable(J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* className, UDATA classNameLength);
 
 /**
 * @brief

--- a/runtime/tests/vm/module.xml
+++ b/runtime/tests/vm/module.xml
@@ -48,7 +48,6 @@
 			<vpath path="j9vm" pattern="KeyHashTable.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ModularityHashTables.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="resolvefield.cpp" augmentObjects="true"/>
-			<vpath path="j9vm" pattern="classsupport.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ObjectFieldInfo.cpp" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="segment.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ut_j9vm.c" augmentObjects="true"/>

--- a/runtime/tests/vm/module.xml
+++ b/runtime/tests/vm/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2017 IBM Corp. and others
+  Copyright (c) 2001, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,7 @@
 			<vpath path="j9vm" pattern="KeyHashTable.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ModularityHashTables.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="resolvefield.cpp" augmentObjects="true"/>
+			<vpath path="j9vm" pattern="classsupport.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ObjectFieldInfo.cpp" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="segment.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ut_j9vm.c" augmentObjects="true"/>

--- a/runtime/tests/vm/vmstubs.c
+++ b/runtime/tests/vm/vmstubs.c
@@ -35,6 +35,21 @@ setCurrentExceptionUTF(J9VMThread * vmThread, UDATA exceptionNumber, const char 
 	/* NOTE: Stub function. */
 }
 
+struct J9Class *
+internalFindClassUTF8(J9VMThread *currentThread, U_8 *className, UDATA classNameLength, J9ClassLoader *classLoader, UDATA options)
+{
+	/* NOTE: Stub function. */
+	return NULL;
+}
+
+struct J9Class*
+peekClassHashTable(J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* className, UDATA classNameLength)
+{
+	/* NOTE: Stub function. */
+	return NULL;
+}
+
+
 J9VMThread *
 currentVMThread(J9JavaVM * vm)
 {

--- a/runtime/tests/vm/vmstubs.c
+++ b/runtime/tests/vm/vmstubs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,13 +33,6 @@ void
 setCurrentExceptionUTF(J9VMThread * vmThread, UDATA exceptionNumber, const char * detailUTF)
 {
 	/* NOTE: Stub function. */
-}
-
-struct J9Class *
-internalFindClassUTF8(J9VMThread *currentThread, U_8 *className, UDATA classNameLength, J9ClassLoader *classLoader, UDATA options)
-{
-	/* NOTE: Stub function. */
-	return NULL;
 }
 
 J9VMThread *

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -167,29 +167,21 @@ findPrimitiveArrayClass(J9JavaVM* vm, jchar sigChar)
 	switch (sigChar) {
 	case 'B':
 		return vm->byteArrayClass;
-		break;
 	case 'C':
 		return vm->charArrayClass;
-		break;
 	case 'I':
 		return vm->intArrayClass;
-		break;
 	case 'J':
 		return vm->longArrayClass;
-		break;
 	case 'S':
 		return vm->shortArrayClass;
-		break;
 	case 'Z':
 		return vm->booleanArrayClass;
-		break;
 #ifdef J9VM_INTERP_FLOAT_SUPPORT
 	case 'D':
 		return vm->doubleArrayClass;
-		break;
 	case 'F':
 		return vm->floatArrayClass;
-		break;
 #endif
 	default:
 		return NULL;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -372,4 +372,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	setNestmatesError,
 #endif
 	areValueTypesEnabled,
+	peekClassHashTable,
 };

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -115,25 +115,20 @@ findField(J9VMThread *vmStruct, J9Class *clazz, U_8 *fieldName, UDATA fieldNameL
 			 */
 			J9UTF8 * interfaceName = NNSRP_PTR_GET(interfaces, J9UTF8 *);
 			J9Class* interfaceClass = peekClassHashTable(vmStruct, currentClass->classLoader, J9UTF8_DATA(interfaceName), J9UTF8_LENGTH(interfaceName));
-
-			if (J9_EXPECTED(interfaceClass != NULL)) { /* shouldn't be NULL, but be safe */
-				J9ITable* iTable = NULL;
-				for(;;) {
-					field = findFieldInClass(vmStruct,
-						interfaceClass, 
-						fieldName, fieldNameLength, 
-						signature, signatureLength, 
-						offsetOrAddress, definingClass);
-					if (field != NULL) {
-						return field;
-					}
-					iTable = iTable ? iTable->next : (J9ITable *)interfaceClass->iTable;
-					if (iTable == NULL) break;
-					interfaceClass = iTable->interfaceClass;
+			J9ITable* iTable = NULL;
+			Assert_VM_notNull(interfaceClass);
+			for(;;) {
+				field = findFieldInClass(vmStruct,
+					interfaceClass,
+					fieldName, fieldNameLength,
+					signature, signatureLength,
+					offsetOrAddress, definingClass);
+				if (field != NULL) {
+					return field;
 				}
-			} else {
-				/* This should never happen as the interfaces need to have already been loaded */
-				Assert_VM_unreachable();
+				iTable = iTable ? iTable->next : (J9ITable *)interfaceClass->iTable;
+				if (iTable == NULL) break;
+				interfaceClass = iTable->interfaceClass;
 			}
 		}
 


### PR DESCRIPTION
**Add new peekClassHashTable api**
It's often useful to peek the class hashtable - especially
if it can be done without taking the classHashTableMutex.

This patch adds a peeking api and uses it as part of the
resolution path where we know the interfaces must have
already been loaded.

**Optimize the object allocation in stack traces**
Stack traces create a string for the class name.  This patch
attempts to reuse the string that has already been allocated
in the class->classNameString field.  If the string hasn't
been allocated, we allocate an interned tenure string and
write it back to the class->classNameString field effectively
caching it for future access.

This may result in a footprint growth due to more strings being
held by the class.

This patch uses the new peekClassHashTable() api to get the
class without needing to change the iterateStackFrames call.

We also attempt to optimize the fileName string allocation by
reusing the previously allocated string in the case where
adjacent stack frames are from the same file.

Note, there is some subtlety around how the J9UTF8 * are
compared as we can't do a string comparison and must rely on
utf8 interning as previous J9UTF8's may have been unloaded
between processing this frame and preceeding ones.