### PR TITLE
Statically assert sizeof(J9Class) == sizeof(J9ArrayClass)

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3090,12 +3090,19 @@ typedef struct J9ArrayClass {
 	UDATA flattenedElementSize;
 } J9ArrayClass;
 
+
+#if defined(LINUX) && defined(J9VM_ARCH_X86) && !defined(OSX)
+/* Only enable the assert on linux x86 as not all the versions
+ * of the compilers we use (xlc) support static_asserts in on
+ * all the platforms.
+ */
 #if defined(__cplusplus)
 /* Hide the asserts from DDR */
 #if !defined(TYPESTUBS_H)
 static_assert(sizeof(J9Class) == sizeof(J9ArrayClass), "J9Class and J9ArrayClass must be the same size");
 #endif /* !TYPESTUBS_H */
 #endif /* __cplusplus */
+#endif /* LINUX && J9VM_ARCH_X86 */
 
 typedef struct J9HookedNative {
 	struct J9NativeLibrary* nativeLibrary;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3082,14 +3082,20 @@ typedef struct J9ArrayClass {
 	struct J9Method** specialSplitMethodTable;
 	struct J9JITExceptionTable* jitMetaDataList;
 	struct J9Class* gcLink;
+	struct J9Class* hostClass;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	struct J9Class* nestHost;
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	/* Added temporarily for consistency */
 	UDATA flattenedElementSize;
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 } J9ArrayClass;
+
+#if defined(__cplusplus)
+/* Hide the asserts from DDR */
+#if !defined(TYPESTUBS_H)
+static_assert(sizeof(J9Class) == sizeof(J9ArrayClass), "J9Class and J9ArrayClass must be the same size");
+#endif /* !TYPESTUBS_H */
+#endif /* __cplusplus */
 
 typedef struct J9HookedNative {
 	struct J9NativeLibrary* nativeLibrary;


### PR DESCRIPTION
After seeing https://github.com/eclipse/openj9/pull/7677, I tried adding a static assert for it and found a second problem.

This commit fixes the problem and adds the assert.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>