### PR TITLE
Exclude DDR tests for JDK13+ AIX

### DIFF
--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -53,11 +53,38 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
 
+	<test>
+		<testCaseName>testDDRExt_General_openj9_jdk13+</testCaseName>
+		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	
 	<test>
 		<testCaseName>testDDRExt_Callsites_ibm</testCaseName>
 		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -89,11 +116,38 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
 
+	<test>
+		<testCaseName>testDDRExt_Callsites_openj9_jdk13+</testCaseName>
+		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestCallsites$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	
 	<test>
 		<testCaseName>testDDRExt_JITExt_ibm</testCaseName>
 		<command>ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -125,11 +179,38 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
 
+	<test>
+		<testCaseName>testDDRExt_JITExt_openj9_JDK13+</testCaseName>
+		<command>ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestJITExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -DEXTRADUMPOPT=$(Q)-Xjit:count=0$(Q) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	
 	<test>
 		<testCaseName>testDDRExt_SharedClasses_ibm</testCaseName>
 		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -161,6 +242,33 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	
+	<test>
+		<testCaseName>testDDRExt_SharedClasses_openj9_JDK13+</testCaseName>
+		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestSharedClassesExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -99,6 +99,40 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
+		<groups>
+			<group>functional</group>
+		</groups>
+	</test>
+	
+	<test>
+		<testCaseName>cmdLineTester_callsitedbgddrext_openj9_jdk13+</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
 		<groups>
 			<group>functional</group>
 		</groups>

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -71,11 +71,51 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	
+	<test>
+		<testCaseName>cmdLineTester_classesdbgddrext_jdk13+</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
+	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
+	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<!-- j9ddr.jar is not supported on z/OS; OpenJ9 issue 1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
 	<test>
 		<testCaseName>cmdLineTester_classesdbgddrext_aix</testCaseName>
 		<variations>
@@ -100,5 +140,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -47,7 +47,41 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	
+	<test>
+		<testCaseName>cmdLineTester_modularityddrtests_jdk13+</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
+	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
 		</subsets>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -47,6 +47,46 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_shrcdbgddrext_jdk13+</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+			<variation>Mode201</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
+	cp $(CMDLINETESTER_RESJAR) .; \
+	$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf cmdlinetestresources.jar; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-DCONCAT=$(TEST_RESROOT)$(D)concatenate_dumps.sh \
+	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>13+</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Exclude DDR tests for JDK13+ AIX

As per https://github.com/eclipse/openj9/issues/7612

Verified that this PR still works with JDK 11 at AIX.

Reviewer: @llxia 

FYI: @pshipton @keithc-ca 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>