### PR TITLE
Update IProfiler to handle invokePrivateMethod

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6559,8 +6559,6 @@ TR_ResolvedJ9Method::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpInd
    J9Method * ramMethod;
    if (unresolvedInCP != NULL)
       {
-      //we init the CP with a special magic method, which has no bytecodes (hence bytecode start is NULL)
-      //i.e. the CP will always contain a method for special and static methods
       *unresolvedInCP = true;
       }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6557,10 +6557,8 @@ TR_ResolvedJ9Method::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpInd
    // See if the constant pool entry is already resolved or not
    //
    J9Method * ramMethod;
-   if (unresolvedInCP)
+   if (unresolvedInCP != NULL)
       {
-      ramMethod = jitGetJ9MethodUsingIndex(_fe->vmThread(), cp(), cpIndex);
-      //*unresolvedInCP = !ramMethod || !J9_BYTECODE_START_FROM_RAM_METHOD(ramMethod);
       //we init the CP with a special magic method, which has no bytecodes (hence bytecode start is NULL)
       //i.e. the CP will always contain a method for special and static methods
       *unresolvedInCP = true;
@@ -6572,7 +6570,7 @@ TR_ResolvedJ9Method::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpInd
       {
       TR::VMAccessCriticalSection resolveSpecialMethodRef(fej9());
 
-      ramMethod = jitResolveSpecialMethodRef(_fe->vmThread(), cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
+      J9Method * ramMethod = jitResolveSpecialMethodRef(_fe->vmThread(), cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
       if (ramMethod)
          {
          bool createResolvedMethod = true;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6554,9 +6554,6 @@ TR_ResolvedJ9Method::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpInd
 
 #if !TURN_OFF_INLINING
 
-   // See if the constant pool entry is already resolved or not
-   //
-   J9Method * ramMethod;
    if (unresolvedInCP != NULL)
       {
       *unresolvedInCP = true;
@@ -6619,7 +6616,7 @@ TR_ResolvedJ9Method::getResolvedPossiblyPrivateVirtualMethod(TR::Compilation * c
          performTransformation(comp, "Setting as unresolved virtual call cpIndex=%d\n",cpIndex) ) || ignoreRtResolve)
       {
       // only call the resolve if unresolved
-      UDATA vTableOffset;
+      UDATA vTableOffset = 0;
       J9Method * ramMethod = (J9Method *)getVirtualMethod(_fe, cp(), cpIndex, &vTableOffset, unresolvedInCP);
       bool createResolvedMethod = true;
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -4128,8 +4128,7 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
                cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
             J9Method * callee = jitGetJ9MethodUsingIndex(vmThread, ramCP, cpIndex);
 
-            if ((javaVM->initialMethods.initialStaticMethod == callee) ||
-                (javaVM->initialMethods.initialSpecialMethod == callee))
+            if (callee == NULL)
                {
                break;
                }
@@ -4156,8 +4155,10 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
             callee = *(J9Method**)cursor;
             cursor += sizeof(J9Method *);
 
-            if (callee && javaVM->initialMethods.initialVirtualMethod != callee &&
-               !fanInDisabled)
+            if (callee
+               && (javaVM->initialMethods.initialVirtualMethod != callee)
+               && (javaVM->initialMethods.invokePrivateMethod != callee)
+               && !fanInDisabled)
                {
                uint32_t offset = (uint32_t) (pc - caller->bytecodes);
                findOrCreateMethodEntry(caller, callee , true , offset);

--- a/runtime/jit_vm/ctsupport.c
+++ b/runtime/jit_vm/ctsupport.c
@@ -609,7 +609,7 @@ jitGetRealCPIndex(J9VMThread *currentThread, J9ROMClass *romClass, UDATA cpOrSpl
  * @param constantPool		Constant pool of the class that 'owns' the 'cpOrSplitIndex'
  * @param cpOrSplitIndex	Index of a method. Either an index into constant pool or into split table
  *
- * @return 				J9Method represented by 'cpOrSplitIndex'
+ * @return J9Method represented by 'cpOrSplitIndex' or NULL if the method is one of the "special" initialMethods or invokePrivateMethod
  */
 J9Method *
 jitGetJ9MethodUsingIndex(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpOrSplitIndex)
@@ -622,17 +622,18 @@ jitGetJ9MethodUsingIndex(J9VMThread *currentThread, J9ConstantPool *constantPool
 
 		if (J9_IS_STATIC_SPLIT_TABLE_INDEX(cpOrSplitIndex)) {
 			method = clazz->staticSplitMethodTable[splitTableIndex];
-			if (method == (J9Method*)currentThread->javaVM->initialMethods.initialStaticMethod) {
-				method = NULL;
-			}
 		} else {
 			method = clazz->specialSplitMethodTable[splitTableIndex];
-			if (method == (J9Method*)currentThread->javaVM->initialMethods.initialSpecialMethod) {
-				method = NULL;
-			}
 		}
 	} else {
 		method = ((J9RAMStaticMethodRef*)(constantPool + cpOrSplitIndex))->method;
+	}
+	if ((method == (J9Method*)currentThread->javaVM->initialMethods.initialStaticMethod)
+	|| (method == (J9Method*)currentThread->javaVM->initialMethods.initialSpecialMethod)
+	|| (method == (J9Method*)currentThread->javaVM->initialMethods.initialVirtualMethod)
+	|| (method == (J9Method*)currentThread->javaVM->initialMethods.invokePrivateMethod)
+	) {
+		method = NULL;
 	}
 	return method;
 }


### PR DESCRIPTION
IProfiler already was aware of the initialVirtualMethod due to
how the profiles are collected - the VM just writes the J9Method*
that corresponds to the vtable index without doing additional
processing.

Previously, only the initialVirtualMethod would show up in that
case.  Now the invokePrivateMethod can as well and will more
often with #7666, which stops doing the invokevirtual ->
invokespecial mapping for private methods.

Further improvements are needed to get profiling for the "real"
method being called in the invokeprivate case but that will
have to be done in a separate PR.

As part of this, I've also modified jitGetJ9MethodUsingIndex()
to consistently return NULL for the initial*Method and
invokePrivateMethod cases.  Though there is some very strange
code in one case that I believe was, and still is, incorrect.

fixes: #7696

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>