### PR TITLE
Fix findROMClassFromPC() when romClass is in the shared cache.

### DIFF
--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -381,7 +381,7 @@ private:
 
 	const U_8* findAttachedData(J9VMThread* currentThread, const void* addressInCache, J9SharedDataDescriptor* data, IDATA *corruptOffset, const char** p_subcstr) ;
 
-	void updateROMSegmentList(J9VMThread* currentThread, bool hasClassSegmentMutex);
+	void updateROMSegmentList(J9VMThread* currentThread, bool hasClassSegmentMutex, bool topLayerOnly = true);
 
 	void updateROMSegmentListForCache(J9VMThread* currentThread, SH_CompositeCacheImpl* forCache);
 

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2964,3 +2964,5 @@ TraceExit-Exception=Trc_SHR_CM_updateROMClassResource_Exit7 Overhead=1 Level=1 T
 TraceException=Trc_SHR_CM_storeSharedData_OverwriteExisting_NotInTopLayer Overhead=1 Level=2 Template="CM storeSharedData: Existing data in the shared cache (data->address %p, foundDatalen %zu) is not in top layer cache."
 TraceEvent=Trc_SHR_RRM_storeNew_existingEntryRemoved Overhead=1 Level=6 Template="RRM storeNew: removed existing item 0x%p from the hashTable"
 TraceExit-Exception=Trc_SHR_CM_updateROMClassResource_Exit8 Overhead=1 Level=1 Template="CM updateROMClassResource: Failed to allocate memory for ROMClass resource"
+
+TraceEvent=Trc_SHR_CM_updateROMSegmentList_NewHeapAlloc Overhead=1 Level=4 Template="CM updateROMSegmentList: Updated class segment list - currentSegment is %p, new heapAlloc=%p"


### PR DESCRIPTION
1. Check for potential romClass segment update regardless of the return
value of readCacheUpdates()
2. Issue write barrier after updating the romClass segment list
3. Check for potential romClass segment update before returning a class
from SH_CacheMap::findROMClass()

Fixes #7641

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>