### PR TITLE
Handle circular chained exceptions

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -26,6 +26,8 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 import com.ibm.oti.util.Msg;
 import com.ibm.oti.util.Util;
@@ -301,14 +303,7 @@ StackTraceElement[] getInternalStackTrace() {
  *				The stream to write the walkback on.
  */
 public void printStackTrace (PrintStream err) {
-	StackTraceElement[] stack;
-	stack = printStackTrace(err, null, 0, false);
-
-	Throwable throwable = getCause();
-	while (throwable != null && stack != null) {
-        stack = throwable.printStackTrace(err, stack, 0, false);
-		throwable = throwable.getCause();
-	}
+	printStackTraceHelper(err);
 }
 
 /**
@@ -319,12 +314,31 @@ public void printStackTrace (PrintStream err) {
  *				The writer to write the walkback on.
  */
 public void printStackTrace(PrintWriter err) {
+	printStackTraceHelper(err);
+}
+
+/**
+ * Outputs representation of the receiver's
+ * walkback on the Appendable specified by the argument.
+ *
+ * @param	appendable Appendable 
+ *		The Appendable object to the walkback will be written.
+ */
+private void printStackTraceHelper(Appendable appendable) {
 	StackTraceElement[] stack;
-	stack = printStackTrace(err, null, 0, false);
+	Set<Throwable> exceptionChainSet = null;
+	try {
+		exceptionChainSet = Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>());
+	} catch(OutOfMemoryError e) {
+		/* If OOM is thrown when creating exception set, then we won't be able to check for circular exception chain,
+		 * which can cause OOM to be thrown again. This should be ok as we are already running out of heap memory.
+		 */
+	}
+	stack = printStackTrace(appendable, null, 0, false, exceptionChainSet);
 
 	Throwable throwable = getCause();
 	while (throwable != null && stack != null) {
-		stack = throwable.printStackTrace(err, stack, 0, false);
+		stack = throwable.printStackTrace(appendable, stack, 0, false, exceptionChainSet);
 		throwable = throwable.getCause();
 	}
 }
@@ -489,16 +503,45 @@ private void readObject(ObjectInputStream s)
  * 			number of indents (\t) to be printed
  * @param	suppressed	
  * 			if this is an exception suppressed
+ * @param	exceptionChainSet
+ * 			set of exceptions in the exception chain
  * 
  * @return	an array of stack trace elements printed 
  * 
  */
 private StackTraceElement[] printStackTrace(
-		Appendable err, StackTraceElement[] parentStack, int indents, boolean suppressed) {
+		Appendable err, StackTraceElement[] parentStack, int indents, boolean suppressed, Set<Throwable> exceptionChainSet) {
 	/*[PR 120593] CDC 1.0 and CDC 1.1 TCK fails in java.lang.. Exception tests */
 	if (err == null) throw new NullPointerException();
 	StackTraceElement[] stack;
 	boolean outOfMemory = this instanceof OutOfMemoryError;
+	if ((exceptionChainSet != null) && (exceptionChainSet.contains(this))) {
+		if (!outOfMemory) {
+			try {
+				appendTo(err, "\t[CIRCULAR REFERENCE:" + toString() + "]", 0); //$NON-NLS-1$
+			} catch(OutOfMemoryError e) {
+				outOfMemory = true;
+			}
+		}
+		if (outOfMemory) {
+			appendTo(err, "\t[CIRCULAR REFERENCE:"); //$NON-NLS-1$
+			try {
+				appendTo(err, getClass().getName());
+			} catch(OutOfMemoryError e) {
+				appendTo(err, "java.lang.OutOfMemoryError(?)");
+			}
+			appendTo(err, "]");
+		}
+		appendLnTo(err);
+		return null;
+	}
+	try {
+		exceptionChainSet.add(this);
+	} catch(OutOfMemoryError e) {
+		/* If OOM is thrown when adding Throwable to exception set, then we may not be able to identify circular exception chain,
+		 * which can cause OOM to be thrown again. This should be ok as we are already running out of heap memory.
+		 */
+	}
 	if (parentStack != null) {
 		if (suppressed) {
 			appendTo(err, "Suppressed: ", indents); //$NON-NLS-1$
@@ -506,14 +549,16 @@ private StackTraceElement[] printStackTrace(
 			appendTo(err, "Caused by: ", indents); //$NON-NLS-1$
 		}
 	}
-	if (!outOfMemory) try {
-		appendTo(err, toString());
-	} catch(OutOfMemoryError e) {
-		outOfMemory = true;
+	if (!outOfMemory) {
+		try {
+			appendTo(err, toString());
+		} catch(OutOfMemoryError e) {
+			outOfMemory = true;
+		}
 	}
 	if (outOfMemory) {
 		try {
-			appendTo(err, getClass().getName());		
+			appendTo(err, getClass().getName());
 		} catch(OutOfMemoryError e) {
 			outOfMemory = true;
 			appendTo(err, "java.lang.OutOfMemoryError(?)");			 //$NON-NLS-1$
@@ -538,7 +583,7 @@ private StackTraceElement[] printStackTrace(
 		if (parentStack != null) {
 			duplicates = countDuplicates(stack, parentStack);
 		}
-	} catch (OutOfMemoryError e) {
+	} catch(OutOfMemoryError e) {
 		appendTo(err, "\tat ?", indents); //$NON-NLS-1$
 		appendLnTo(err);
 		return null;
@@ -558,10 +603,12 @@ private StackTraceElement[] printStackTrace(
 		appendLnTo(err);		
 	}
 	if (duplicates > 0) {
-		if (!outOfMemory) try {
-			appendTo(err, "\t... " + duplicates + " more", indents); //$NON-NLS-1$ //$NON-NLS-2$
-		} catch(OutOfMemoryError e) {
-			outOfMemory = true;
+		if (!outOfMemory) {
+			try {
+				appendTo(err, "\t... " + duplicates + " more", indents); //$NON-NLS-1$ //$NON-NLS-2$
+			} catch(OutOfMemoryError e) {
+				outOfMemory = true;
+			}
 		}
 		if (outOfMemory) {
 			appendTo(err, "\t... ", indents); //$NON-NLS-1$
@@ -575,11 +622,11 @@ private StackTraceElement[] printStackTrace(
 		if (suppressedExceptions != null) {
 			for (Throwable t : suppressedExceptions) {
 				StackTraceElement[] stackSuppressed;
-				stackSuppressed = t.printStackTrace(err, stack, indents + 1, true);
+				stackSuppressed = t.printStackTrace(err, stack, indents + 1, true, exceptionChainSet);
 				
 				Throwable throwableSuppressed = t.getCause();
 				while (throwableSuppressed != null && stackSuppressed != null) {
-					stackSuppressed = throwableSuppressed.printStackTrace(err, stackSuppressed, indents + 1, false);
+					stackSuppressed = throwableSuppressed.printStackTrace(err, stackSuppressed, indents + 1, false, exceptionChainSet);
 					throwableSuppressed = throwableSuppressed.getCause();
 				}
 			}


### PR DESCRIPTION
Added code to identify cicular chained exceptions to avoid
OOM situations.

Fixes: #7669 

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>