### PR TITLE
Add maxDays to Artifactory buildInfo

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -330,7 +330,7 @@ def archive_sdk() {
 * When crash occurs in java, there will be an output in the log: IEATDUMP success for DSN='JENKINS.JVM.JENKIN*.*.*.X&DS'.
 * The X&DS is a macro that is passed to the IEATDUMP service on z/OS.
 * The dump is split into multiple files by the macro if the address space is large.
-* Each dataset is named in a similar way but there is a distinct suffix to specify the order. 
+* Each dataset is named in a similar way but there is a distinct suffix to specify the order.
 * For example, JVM.*.*.*.001, JVM.*.*.*.002, and JVM.*.*.*.003.
 * The function fetchFile moves each dataset into the current directory of the machine, and appends the data to the core.xxx.dmp at the same time.
 * The file core.xxx.dmp is uploaded to artifactory for triage.
@@ -342,7 +342,7 @@ def fetchFile(src, dest) {
     // append the dataset to core.xxx.dmp file
     sh "cat '//${fileToMove}' >> ${dest}"
     // remove the dataset
-    sh "tso DELETE ${fileToMove}"   
+    sh "tso DELETE ${fileToMove}"
 }
 
 def archive_diagnostics() {
@@ -360,14 +360,14 @@ def archive_diagnostics() {
             def numFiles = num.trim().toInteger()
             for (i = 1; i <= numFiles; i++) {
                 switch (i) {
-                    case 1..9: 
+                    case 1..9:
                         src = filename + '.' + 'X00' + i;
                         break;
-                    case 10..99: 
+                    case 10..99:
                         src = filename + '.' + 'X0' + i;
                         break;
-                    case 100..999: 
-                        src = filename + '.' + 'X' + i;          
+                    case 100..999:
+                        src = filename + '.' + 'X' + i;
                         break;
                 }
                 dest = 'core' + '.' + filename + '.' + 'dmp'
@@ -403,15 +403,15 @@ def upload_artifactory(uploadSpec) {
     server.connection.timeout = 600
 
     def buildInfo = Artifactory.newBuildInfo()
-    buildInfo.retention maxBuilds: ARTIFACTORY_NUM_ARTIFACTS, deleteBuildArtifacts: true
+    buildInfo.retention maxBuilds: ARTIFACTORY_NUM_ARTIFACTS, maxDays: ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS, deleteBuildArtifacts: true
     // Add BUILD_IDENTIFIER to the buildInfo. The UploadSpec adds it to the Artifact info
     buildInfo.env.filter.addInclude("BUILD_IDENTIFIER")
     buildInfo.env.capture = true
 
     //Retry uploading to Artifactory if errors occur
     pipelineFunctions.retry_and_delay({
-        server.upload spec: uploadSpec, buildInfo: buildInfo; 
-        server.publishBuildInfo buildInfo}, 
+        server.upload spec: uploadSpec, buildInfo: buildInfo;
+        server.publishBuildInfo buildInfo},
         3, 300)
 
     // Write URL to env so that we can pull it from the upstream pipeline job

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -494,11 +494,12 @@ def set_artifactory_config() {
         env.ARTIFACTORY_SERVER = ARTIFACTORY_SERVER
         env.ARTIFACTORY_REPO = VARIABLES.artifactory_repo
         env.ARTIFACTORY_NUM_ARTIFACTS = VARIABLES.artifactory_num_artifacts
-        env.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS = VARIABLES.artifactory_days_to_keep_artifacts // This is being used by the cleanup script
+        env.ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS = VARIABLES.artifactory_days_to_keep_artifacts
         env.ARTIFACTORY_MANUAL_CLEANUP = VARIABLES.artifactory_manual_cleanup // This is being used by the cleanup script
         env.ARTIFACTORY_UPLOAD_DIR = "${ARTIFACTORY_REPO}/${JOB_NAME}/${BUILD_ID}/"
         echo "Using artifactory server/repo: ${ARTIFACTORY_SERVER} / ${ARTIFACTORY_REPO}"
         echo "Keeping '${ARTIFACTORY_NUM_ARTIFACTS}' artifacts"
+        echo "Keeping artifacts for '${ARTIFACTORY_DAYS_TO_KEEP_ARTIFACTS}' days"
         echo "Artifactory Manual Cleanup: ${env.ARTIFACTORY_MANUAL_CLEANUP}"
     }
 }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -55,7 +55,6 @@ adoptopenjdk:
 artifactory_server: 'ci-eclipse-openj9'
 artifactory_repo: 'ci-eclipse-openj9'
 artifactory_num_artifacts: 30
-# This is being used for the cleanup script
 artifactory_days_to_keep_artifacts: 50
 artifactory_manual_cleanup: true
 #========================================#


### PR DESCRIPTION
- This allows builds to be automatically deleted by
  the server after they expire (when supported).
- Whitespace cleanup.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>