### PR TITLE
Add tracepoint to aid debugging IProfiler unknown PC issues

### DIFF
--- a/runtime/compiler/env/j9jit.tdf
+++ b/runtime/compiler/env/j9jit.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2000, 2017 IBM Corp. and others
+// Copyright (c) 2000, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,4 +80,6 @@ TraceEvent=Trc_JIT_AotLoadEnd             Group=perfmon Overhead=1 Level=1 Test 
 TraceEvent=Trc_JIT_OverallCompCPU         Group=perfmon Overhead=1 Level=5 Test Template="JIT: compCPUPercent=%d"
 
 TraceEvent=Trc_JIT_SCCInfo                Group=perfmon Overhead=1 Level=5 Test Template="SCC: name=%s path=%s size=%u free=%u softMax=%u ROMClass=%u AOTCode=%u AOTData=%u JITHint=%u JITProfile=%u ROMClasses=%u AOTMethods=%u disabledReason=%d"
+
+TraceException=Trc_JIT_IProfiler_unrecognized Overhead=1 Level=1 Test Template="Unrecognized bytecode (pc=%p, bc=%u) cursor %p in buffer %p of size %zu"
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -4213,6 +4213,8 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
 #endif
                }
             TR_ASSERT(false, "Unrecognized bytecode in IProfiler buffer");
+            /* Template="Unrecognized bytecode (pc=%p, bc=%d) cursor %p in buffer %p of size %d" */
+            Trc_JIT_IProfiler_unrecognized(vmThread, pc, *pc, cursor, data, size);
             Assert_JIT_unreachable();
             return 0;
          }


### PR DESCRIPTION
The extra assert prints sufficient information that we can find
the iprofiler buffer, the current PC (which was unrecognized),
etc without having to find the pointers from the native crash.

Related to #7696 with the goal of making this easier to debug in the future.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>