### PR TITLE
Removed API within DAA for which Java implementations do not ex…

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -543,13 +543,6 @@
    com_ibm_dataaccess_ByteArrayUnmarshaller_readFloat,
    com_ibm_dataaccess_ByteArrayUnmarshaller_readDouble,
 
-   // Java wrapper method
-   com_ibm_dataaccess_ByteArrayUtils_trailingZeros,
-   // Java method
-   com_ibm_dataaccess_ByteArrayUtils_trailingZerosByteAtATime,
-   // recognized inline asm method
-   com_ibm_dataaccess_ByteArrayUtils_trailingZerosQuadWordAtATime_,
-
    //wrapper method
    com_ibm_dataaccess_DecimalData_convertIntegerToPackedDecimal,
    com_ibm_dataaccess_DecimalData_convertIntegerToPackedDecimal_ByteBuffer,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2794,13 +2794,6 @@ bool TR_J9VMBase::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, 
                dontInlineRecognizedMethod = true;
             break;
 
-         case TR::com_ibm_dataaccess_ByteArrayUtils_trailingZerosQuadWordAtATime_:
-            if (!comp->getOption(TR_DisablePackedDecimalIntrinsics) &&
-                    !comp->getOption(TR_DisableDAATrailingZero) &&
-                    !TR::Compiler->om.canGenerateArraylets())
-               dontInlineRecognizedMethod = true;
-            break;
-
          case TR::java_math_BigDecimal_noLLOverflowAdd:
          case TR::java_math_BigDecimal_noLLOverflowMul:
          case TR::java_math_BigDecimal_slowSubMulSetScale:

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2759,14 +2759,6 @@ void TR_ResolvedJ9Method::construct()
       { TR::unknownMethod}
    };
 
-   static X DataAccessByteArrayUtilMethods[] =
-      {
-       {x(TR::com_ibm_dataaccess_ByteArrayUtils_trailingZeros,           "trailingZeros"        ,    "([B)I")},
-       {x(TR::com_ibm_dataaccess_ByteArrayUtils_trailingZerosByteAtATime,"trailingZerosByteAtATime", "([BII)I")},
-       {x(TR::com_ibm_dataaccess_ByteArrayUtils_trailingZerosQuadWordAtATime_,   "trailingZerosQuadWordAtATime_", "([BI)I")},
-       { TR::unknownMethod}
-      };
-
    static X DataAccessDecimalDataMethods[] =
    {
       {x(TR::com_ibm_dataaccess_DecimalData_JITIntrinsicsEnabled, "JITIntrinsicsEnabled", "()Z")},
@@ -4360,7 +4352,6 @@ void TR_ResolvedJ9Method::construct()
 
    static Y class33[] =
       {
-      { "com/ibm/dataaccess/ByteArrayUtils", DataAccessByteArrayUtilMethods },
       { "java/util/stream/AbstractPipeline", JavaUtilStreamAbstractPipelineMethods },
       { "java/util/stream/IntPipeline$Head", JavaUtilStreamIntPipelineHeadMethods },
       { 0 }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3780,8 +3780,6 @@ break
       DAA_PRINT(TR::com_ibm_dataaccess_ByteArrayUnmarshaller_readFloat);
       DAA_PRINT(TR::com_ibm_dataaccess_ByteArrayUnmarshaller_readDouble);
 
-      DAA_PRINT(TR::com_ibm_dataaccess_ByteArrayUtils_trailingZeros);
-
       DAA_PRINT(TR::com_ibm_dataaccess_DecimalData_JITIntrinsicsEnabled);
 
       DAA_PRINT(TR::com_ibm_dataaccess_DecimalData_convertIntegerToPackedDecimal);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4013,12 +4013,6 @@ J9::Z::CodeGenerator::inlineDirectCall(
                                                                       : inlineUTF16BEEncode    (node, cg);
          break;
 
-      case TR::com_ibm_dataaccess_ByteArrayUtils_trailingZerosQuadWordAtATime_:
-         // TODO (Nigel): Is this deprecated? If so can we remove this?
-         if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableIntrinsics) && !comp->getOption(TR_DisableDAATrailingZero) && !TR::Compiler->om.canGenerateArraylets())
-            return resultReg = inlineTrailingZerosQuadWordAtATime(node, cg);
-         break;
-
       default:
          break;
 


### PR DESCRIPTION
- Removed reference to `TR::com_ibm_dataaccess_ByteArrayUtils_trailingZeros`
- Removed reference to `TR::com_ibm_dataaccess_ByteArrayUtils_trailingZerosByteAtATime`
- Removed reference to `TR::com_ibm_dataaccess_ByteArrayUtils_trailingZerosQuadWordAtATime_`

Closes: https://github.com/eclipse/openj9/issues/7318

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>