### PR TITLE
Add Linux PPC LE specs to DDR supersets cache file

### DIFF
--- a/debugtools/DDR_VM/generate.properties
+++ b/debugtools/DDR_VM/generate.properties
@@ -44,6 +44,8 @@ linux_x86-64_combo,linux_x86-64_cmprssptrs_combo,linux_x86-64_cmprssptrs_panama
 ddr.order=aix_ppc-64,aix_ppc-64_cmprssptrs,aix_ppc,\
 linux_390-64,linux_390-64_cmprssptrs,linux_390,\
 linux_ppc-64,linux_ppc-64_cmprssptrs,linux_ppc,\
+linux_ppc-64_le,linux_ppc-64_cmprssptrs_le,\
+linux_ppc-64_le_gcc,linux_ppc-64_cmprssptrs_le_gcc,\
 linux_x86-64,linux_x86-64_cmprssptrs,linux_x86-64_cmprssptrs_panama,\
 linux_x86,win_x86-64,win_x86-64_cmprssptrs,\
 win_x86,zos_390-64,zos_390-64_cmprssptrs,zos_390


### PR DESCRIPTION
Add missing Linux PPC LE specs to cache file. They are required to
generate pointer classes when compiling DDR.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>