### PR TITLE
Call getROMString() to retrieve the signature at the server

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1262,7 +1262,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto literals = std::get<1>(recv);
          J9ConstantPool *cp = (J9ConstantPool*)literals;
          I_32 cpIndex = std::get<2>(recv);
-         bool resolvedInCP = false;
+         bool unresolvedInCP = true;
 
          // Only call the resolve if unresolved
          J9Method * ramMethod = 0;
@@ -1280,7 +1280,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             uint32_t classIndex = ((J9ROMMethodRef *) cp->romConstantPool)[cpIndex].classRefCPIndex;
             J9Class * classObject = (((J9RAMClassRef*) literals)[classIndex]).value;
             ramMethod = *(J9Method **)((char *)classObject + vTableIndex);
-            resolvedInCP = true;
+            unresolvedInCP = false;
             }
 
          if(TR_ResolvedJ9Method::isInvokePrivateVTableOffset(vTableIndex))
@@ -1294,11 +1294,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             TR_ResolvedJ9JITServerMethodInfo methodInfo;
             TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) ramMethod, (uint32_t) vTableIndex, owningMethod, fe, trMemory);
 
-            client->write(response, ramMethod, vTableIndex, resolvedInCP, methodInfo);
+            client->write(response, ramMethod, vTableIndex, unresolvedInCP, methodInfo);
             }
          else
             {
-            client->write(response, ramMethod, vTableIndex, resolvedInCP, TR_ResolvedJ9JITServerMethodInfo());
+            client->write(response, ramMethod, vTableIndex, unresolvedInCP, TR_ResolvedJ9JITServerMethodInfo());
             }
          }
          break;
@@ -1426,7 +1426,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          if (j9method)
             TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) j9method, (uint32_t)vtableOffset, mirror, fe, trMemory);
 
-         client->write(response, j9method, methodInfo);
+         client->write(response, j9method, methodInfo, vtableOffset);
          }
          break;
       case MessageType::ResolvedMethod_startAddressForJNIMethod:

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6580,7 +6580,7 @@ TR_ResolvedJ9Method::getResolvedSpecialMethod(TR::Compilation * comp, I_32 cpInd
    if (resolvedMethod == NULL)
       {
       if (unresolvedInCP)
-         handleUnresolvedVirtualMethodInCP(cpIndex, unresolvedInCP);
+         handleUnresolvedSpecialMethodInCP(cpIndex, unresolvedInCP);
       }
 
 #endif


### PR DESCRIPTION
When `setSignature()` is called at the `JITServer` in
`TR_ResolvedJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod()`,
the signature might not have been stored in `romMethodRef` at the
server. `getROMString()` should be called to retrieve the signature
and it takes care of querying the client side if it hasn't been cached.
Otherwise, `jitParseSignature()` will be triggered with an empty
signature string. It doesn’t handle the case of signature length
being `0` and ends up going into an infinite loop and causing stack overflow.

Also made the change to call `handleUnresolvedSpecialMethodInCP`
instead of `handleUnresolvedVirtualMethodInCP` in
`TR_ResolvedJ9Method::getResolvedSpecialMethod()`.

Issue: #7567

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>