### PR TITLE
Add jdk test natives to test-images.tar.gz archive

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -281,7 +281,7 @@ def build() {
 def archive_sdk() {
     stage('Archive') {
         def buildDir = "build/${RELEASE}/images/"
-        def testDir = "test/openj9"
+        def testDir = "test"
 
         dir(OPENJDK_CLONE_DIR) {
             sh "tar -C ${buildDir} -zcvf ${SDK_FILENAME} ${JDK_FOLDER}"
@@ -289,9 +289,9 @@ def archive_sdk() {
             if (fileExists("${buildDir}${testDir}")) {
                 if (SPEC.contains('zos')) {
                     // Note: to preserve the files ACLs set _OS390_USTAR=Y env variable (see variable files)
-                    sh "pax  -wvz -s#${buildDir}${testDir}#native-test-libs#g -f ${TEST_FILENAME} ${buildDir}${testDir}"
+                    sh "pax  -wvz -s#${buildDir}${testDir}#test-images#g -f ${TEST_FILENAME} ${buildDir}${testDir}"
                 } else {
-                    sh "tar -C ${buildDir} -zcvf ${TEST_FILENAME} ${testDir} --transform 's,${testDir},native-test-libs,'"
+                    sh "tar -C ${buildDir} -zcvf ${TEST_FILENAME} ${testDir} --transform 's,${testDir},test-images,'"
                 }
             }
             if (ARTIFACTORY_SERVER) {

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -436,7 +436,7 @@ def set_build_variables() {
 def set_sdk_variables() {
     DATESTAMP = get_date()
     SDK_FILENAME = "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}.tar.gz"
-    TEST_FILENAME = "native-test-libs.tar.gz"
+    TEST_FILENAME = "test-images.tar.gz"
     echo "Using SDK_FILENAME = ${SDK_FILENAME}"
     echo "Using TEST_FILENAME = ${TEST_FILENAME}"
     DIAGNOSTICS_FILENAME = "${JOB_NAME}-${BUILD_NUMBER}-${DATESTAMP}-diagnostics.tar.gz"


### PR DESCRIPTION
* rename native-test-libs.tar.gz -> test-images.tar.gz to match
    what openjdk test framework is looking for
* eclipse/openj9#7521
* [skip ci]

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>