### PR TITLE
Fix freemarker.jar path in Configure step

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -168,9 +168,8 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar
+bash configure --with-freemarker-jar=/root/freemarker.jar
 ```
-:warning: You must give an absolute path to freemarker.jar
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.
 


### PR DESCRIPTION
In OpenJDK11 build instructions we have:
`bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar`
while in OpenJD8 build instructions we have the more useful:
`bash configure --with-freemarker-jar=/root/freemarker.jar`
I fixed OpenJDK11 build instructions so that newbies using Docker
image for build will not think they need to download `freemaker.jar`

Signed-off-by: Alexandre Vermeerbergen <avermeerbergen@gmail.com>