### PR TITLE
Add support for terabytes in -X options

### DIFF
--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1369,7 +1369,19 @@ scan_udata_memory_size_helper(J9JavaVM *javaVM, char **cursor, UDATA *value, con
 		return false;
 	}
 	
-	if(try_scan(cursor, "G") || try_scan(cursor, "g")) {
+	if(try_scan(cursor, "T") || try_scan(cursor, "t")) {
+		if (0 != *value) {
+#if defined(J9VM_ENV_DATA64)
+			if (*value <= (((UDATA)-1) >> 40)) {
+				*value <<= 40;
+			} else
+#endif /* defined(J9VM_ENV_DATA64) */
+			{
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_VALUE_OVERFLOWED, argName);
+				return false;
+			}
+		}
+	} else if(try_scan(cursor, "G") || try_scan(cursor, "g")) {
 		if (*value <= (((UDATA)-1) >> 30)) {
 			*value <<= 30;
 		} else {

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -608,6 +608,21 @@ optionValueOperations(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA
 							}
 							cursor++;
 							break;
+						case 't':
+						case 'T':
+#if defined(J9VM_ENV_DATA64)
+							if (value <= (((UDATA)-1) >> 40)) {
+								value <<= 40;
+							} else {
+								return OPTION_OVERFLOW;
+							}
+#else /* defined(J9VM_ENV_DATA64) */
+							if (0 != value) {
+								return OPTION_OVERFLOW;
+							}
+#endif /* defined(J9VM_ENV_DATA64) */
+							cursor++;
+							break;
 						default:
 							return OPTION_MALFORMED;
 					}

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5175,6 +5175,50 @@ static void testOptionValueOps(J9JavaVM* vm) {
 	TEST_INT(uResult, (1024*1024*1024));
 	TEST_INT(intResult, OPTION_OK);
 
+#if defined(J9VM_ENV_DATA64)
+	SET_TO(1, "-Xfog16777215T");			/* (2^24-1)*2^40 */
+	optName = "-Xfog";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+	TEST_INT(uResult, (16777215UL*1024UL*1024UL*1024UL*1024UL));
+	TEST_INT(intResult, OPTION_OK);
+
+	SET_TO(1, "-Xfoh1t");
+	optName = "-Xfoh";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+	TEST_INT(uResult, (1024*1024*1024*1024L));
+	TEST_INT(intResult, OPTION_OK);
+
+	SET_TO(1, "-Xfoi16777216T");			/* 2^64 */
+	optName = "-Xfoi";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+	TEST_INT(intResult, OPTION_OVERFLOW);
+
+	SET_TO(1, "-Xfoj16777216t");			/* 2^64 */
+	optName = "-Xfoj";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+	TEST_INT(intResult, OPTION_OVERFLOW);
+#else	/* defined(J9VM_ENV_DATA64) */
+	SET_TO(1, "-Xfog1T");
+	optName = "-Xfog";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+	TEST_INT(intResult, OPTION_OVERFLOW);
+
+	SET_TO(1, "-Xfoh1t");
+	optName = "-Xfoh";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+	TEST_INT(intResult, OPTION_OVERFLOW);
+
+	SET_TO(1, "-Xfoi0T");
+	optName = "-Xfoi";
+	TEST_INT(uResult, 0);
+	TEST_INT(intResult, OPTION_OK);
+
+	SET_TO(1, "-Xfoj0t");
+	optName = "-Xfoj";
+	TEST_INT(uResult, 0);
+	TEST_INT(intResult, OPTION_OK);
+#endif /* defined(J9VM_ENV_DATA64) */
+
 	SET_TO(1, "-Xfoz0.1");
 	optName = "-Xfoz";
 	intResult = GET_MEMORY_VALUE(1, optName, uResult);


### PR DESCRIPTION
This fix adds support for 'T' and 't' suffix (indicating terabytes) to -X options that take a `<size>` parameter.

Fixes: #7427
