### PR TITLE
Set refc to VarHandle when creating a VarHandleInvokeHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInvokeHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInvokeHandle.java
@@ -41,8 +41,7 @@ abstract class VarHandleInvokeHandle extends PrimitiveHandle {
 		/* Prepend a VarHandle receiver argument to match the how this MethodHandle will be invoked
 		 * Note: the modifiers are specific to the access mode methods in VarHandle.
 		 */
-		super(accessModeType.insertParameterTypes(0, VarHandle.class), null, accessMode.methodName(), kind, PUBLIC_FINAL_NATIVE, null);
-		this.defc = VarHandle.class;
+		super(accessModeType.insertParameterTypes(0, VarHandle.class), VarHandle.class, accessMode.methodName(), kind, PUBLIC_FINAL_NATIVE, null);
 		this.operation = accessMode.ordinal();
 		// Append a VarHandle argument to match the VarHandle's internal method signature
 		this.accessModeType = accessModeType.appendParameterTypes(VarHandle.class);


### PR DESCRIPTION
The referring class should be the VarHandle class instead of null.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse/openj9/issues/7172
since reference class won't be null anymore when creating a MethodHandle for the VarHandle and thus won't throw a NullPointerException in `MethodHandles.checkSecurity`.