### PR TITLE
Adding the J9ClassCanSupportFastSubstitutability flag

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -78,6 +78,7 @@
 #define J9ClassLargestAlignmentConstraintDouble 0x1000
 #define J9ClassIsExemptFromValidation 0x2000
 #define J9ClassContainsUnflattenedFlattenables 0x4000
+#define J9ClassCanSupportFastSubstitutability 0x8000
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 


### PR DESCRIPTION
This flag will be used to determine whether an optimization could be considered
for the acmp bytecode instruction given certain conditions.

Signed-off-by: Adithya Venkatarao <adi_101@live.com>