### PR TITLE
Remove assignments from if statements when calling FIND_ARG_IN_VMARGS

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -40,7 +40,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 
 	if (vm->sharedCacheAPI == NULL) {
 
-		IDATA index;
+		IDATA index = FIND_ARG_IN_VMARGS( OPTIONAL_LIST_MATCH, OPT_XSHARECLASSES, NULL);
 
 		U_64 runtimeFlags = getDefaultRuntimeFlags();
 
@@ -57,7 +57,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 		vm->sharedCacheAPI->minJIT = -1;
 		vm->sharedCacheAPI->maxJIT = -1;
 		vm->sharedCacheAPI->layer = -1;
-		if ((index = FIND_ARG_IN_VMARGS( OPTIONAL_LIST_MATCH, OPT_XSHARECLASSES, NULL ))>=0) {
+		if (index >= 0) {
 			char optionsBuffer[SHR_SUBOPT_BUFLEN];
 			char* optionsBufferPtr = (char*)optionsBuffer;
 			IDATA parseRc = OPTION_OK;
@@ -282,8 +282,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 	/* This code detects "none" as part of Xshareclasses and unloads the DLL if it is found. Must therefore be in this stage or earlier */
 	case DLL_LOAD_TABLE_FINALIZED :
 	{
-		IDATA index;
-		if ((index = FIND_ARG_IN_VMARGS( OPTIONAL_LIST_MATCH, OPT_XSHARECLASSES, NULL ))>=0) {
+		IDATA index = FIND_ARG_IN_VMARGS( OPTIONAL_LIST_MATCH, OPT_XSHARECLASSES, NULL);
+		if (index >= 0) {
 			char optionsBuffer[SHR_SUBOPT_BUFLEN];
 			char* optionsBufferPtr = (char*)optionsBuffer;
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1996,7 +1996,8 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			}
 
 			/* Parse jcl options */
-			if ((argIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, VMOPT_XJCL_COLON, NULL)) >= 0) {
+			argIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, VMOPT_XJCL_COLON, NULL);
+			if (argIndex >= 0) {
 				loadInfo = FIND_DLL_TABLE_ENTRY( J9_DEFAULT_JCL_DLL_NAME );
 				/* we know there is a colon */
 				GET_OPTION_VALUE(argIndex, ':', &optionValue);


### PR DESCRIPTION
In some cases it could trigger undesirable code from the compiler.

Issue #7746

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>