### PR TITLE
Add protobuf 3.7.1 to x86 and 390 docker containers

### DIFF
--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu18/Dockerfile
@@ -57,6 +57,23 @@ RUN apt-get update \
     xvfb \
   && rm -rf /var/lib/apt/lists/*
 
+# Install Protobuf 3.7.1
+RUN cd /tmp \
+  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-cpp-3.7.1.tar.gz \
+  && tar -xzf protobuf-cpp-3.7.1.tar.gz \
+  && rm -f protobuf-cpp-3.7.1.tar.gz \
+  && cd ./protobuf-3.7.1 \
+  && ./configure --disable-shared --with-pic \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -rf /tmp/protobuf-3.7.1
+
+# Edit ldconfig to connect the new libstdc++.so* library
+RUN echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && echo "/usr/local/lib" >> /etc/ld.so.conf.d/usr-local.conf \
+  && ldconfig
+
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \
   && mkdir /home/${USER}/.ssh/

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -259,18 +259,17 @@ RUN cd /tmp \
   && echo "/usr/local/openssl-1.1.1b/lib" > /etc/ld.so.conf.d/openssl-1.1.1b.conf \
   && echo "PATH=/usr/local/openssl-1.1.1b/bin:\$PATH" > /etc/profile.d/openssl.sh
 
-# Install Protobuf v3.5.1
-# Required for JITServer
+# Install Protobuf v3.7.1
 RUN cd /tmp \
-  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
-  && tar -xzf protobuf-cpp-3.5.1.tar.gz \
-  && rm -f protobuf-cpp-3.5.1.tar.gz \
-  && cd /tmp/protobuf-3.5.1 \
+  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-cpp-3.7.1.tar.gz \
+  && tar -xzf protobuf-cpp-3.7.1.tar.gz \
+  && rm -f protobuf-cpp-3.7.1.tar.gz \
+  && cd ./protobuf-3.7.1 \
   && ./configure --disable-shared --with-pic \
   && make \
   && make install \
   && cd .. \
-  && rm -rf protobuf-3.5.1
+  && rm -rf /tmp/protobuf-3.7.1
 
 # Run ldconfig to create necessary links and cache to protobuf libraries
 # Both OpenSSL and Protobuf rely on this step to work properly

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
@@ -115,18 +115,17 @@ RUN cd /tmp \
   && echo "/usr/local/openssl-1.1.1b/lib" > /etc/ld.so.conf.d/openssl-1.1.1b.conf \
   && echo "PATH=/usr/local/openssl-1.1.1b/bin:$PATH" > /etc/environment
 
-# Install Protobuf v3.5.1
-# Required for JITServer
+# Install Protobuf v3.7.1
 RUN cd /tmp \
-  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
-  && tar -xzf protobuf-cpp-3.5.1.tar.gz \
-  && rm -f protobuf-cpp-3.5.1.tar.gz \
-  && cd /tmp/protobuf-3.5.1 \
+  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-cpp-3.7.1.tar.gz \
+  && tar -xzf protobuf-cpp-3.7.1.tar.gz \
+  && rm -f protobuf-cpp-3.7.1.tar.gz \
+  && cd ./protobuf-3.7.1 \
   && ./configure --disable-shared --with-pic \
   && make \
   && make install \
   && cd .. \
-  && rm -rf protobuf-3.5.1
+  && rm -rf /tmp/protobuf-3.7.1
 
 # Run ldconfig to create necessary links and cache to shared libraries
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
@@ -91,18 +91,17 @@ RUN cd /tmp \
   && echo "/usr/local/openssl-1.1.1b/lib" > /etc/ld.so.conf.d/openssl-1.1.1b.conf \
   && echo "PATH=/usr/local/openssl-1.1.1b/bin:$PATH" > /etc/environment
 
-# Install Protobuf v3.5.1
-# Required for JITServer
+# Install Protobuf v3.7.1
 RUN cd /tmp \
-  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz \
-  && tar -xzf protobuf-cpp-3.5.1.tar.gz \
-  && rm -f protobuf-cpp-3.5.1.tar.gz \
-  && cd /tmp/protobuf-3.5.1 \
+  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-cpp-3.7.1.tar.gz \
+  && tar -xzf protobuf-cpp-3.7.1.tar.gz \
+  && rm -f protobuf-cpp-3.7.1.tar.gz \
+  && cd ./protobuf-3.7.1 \
   && ./configure --disable-shared --with-pic \
   && make \
   && make install \
   && cd .. \
-  && rm -rf protobuf-3.5.1
+  && rm -rf /tmp/protobuf-3.7.1
 
 # Run ldconfig to create necessary links and cache to shared libraries
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \


### PR DESCRIPTION
* [skip ci]
* addition to eclipse/openj9#6863
* supporting eclipse/openj9#7099

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>