### PR TITLE
Skip getNestMembers security check for array/primitive/void

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4588,15 +4588,21 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 	if (nestMembers == null) {
 		nestMembers = getNestMembersImpl();
 	}
-	SecurityManager securityManager = System.getSecurityManager();
-	if (securityManager != null) {
-		/* All classes in a nest must be in the same runtime package and therefore same classloader */
-		ClassLoader nestMemberClassLoader = this.internalGetClassLoader();
-		ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
-		if (!doesClassLoaderDescendFrom(nestMemberClassLoader, callerClassLoader)) {
-			String nestMemberPackageName = this.getPackageName();
-			if ((nestMemberPackageName != null) && (nestMemberPackageName != "")) {
-				securityManager.checkPackageAccess(nestMemberPackageName);
+	if (nestMembers.length == 1 && nestMembers[0] == this) {
+		/* This is a Class object that belongs to the nest consisting only of itself,
+		 * or a Class object representing array types, primitive types, or void.
+		 */
+	} else {
+		SecurityManager securityManager = System.getSecurityManager();
+		if (securityManager != null) {
+			/* All classes in a nest must be in the same runtime package and therefore same classloader */
+			ClassLoader nestMemberClassLoader = this.internalGetClassLoader();
+			ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
+			if (!doesClassLoaderDescendFrom(nestMemberClassLoader, callerClassLoader)) {
+				String nestMemberPackageName = this.getPackageName();
+				if ((nestMemberPackageName != null) && (nestMemberPackageName != "")) {
+					securityManager.checkPackageAccess(nestMemberPackageName);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Skip getNestMembers security check for array/primitive/void**

As per Java doc [1], each of the Class objects representing array types, primitive types, and void returns an array containing only this, and there is no need to perform further security check in such cases.

Verified that this PR fixes https://github.com/eclipse/openj9/issues/7715
The JTReg test in question can serve the regression test purpose.

[1] https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getNestMembers()

closes: #7715 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>