### PR TITLE
Replace J9InternalVMFunction table calls with direct calls

### DIFF
--- a/runtime/bcverify/CMakeLists.txt
+++ b/runtime/bcverify/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(j9bcv STATIC
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9bcverify.c
 )
 target_include_directories(j9bcv PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_compile_definitions(j9dyn PRIVATE J9_INTERNAL_TO_VM)
 
 target_link_libraries(j9bcv
 	PRIVATE

--- a/runtime/bcverify/clconstraints.c
+++ b/runtime/bcverify/clconstraints.c
@@ -383,7 +383,7 @@ constraintHashFn(void *key, void *userData)
 {
 	J9ClassLoadingConstraint *k = key;
 	J9JavaVM *vm = userData;
-	UDATA utf8Hash = vm->internalVMFunctions->computeHashForUTF8(k->name, k->nameLength);
+	UDATA utf8Hash = J9_VM_FUNCTION_VIA_JAVAVM(vm, computeHashForUTF8)(k->name, k->nameLength);
 
 	return (UDATA)k->classLoader ^ utf8Hash;
 }

--- a/runtime/bcverify/module.xml
+++ b/runtime/bcverify/module.xml
@@ -56,6 +56,7 @@
 				<include-if condition="spec.zos_390-64.*"/>
 				<include-if condition="spec.zos_390.*"/>
 			</flag>
+			<flag name="J9_INTERNAL_TO_VM"/>
 		</flags>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
Use the `J9_VM_FUNCTION_VIA_JAVAVM` macro to allow compiling
either as direct or indirect calls as some of these files are
used outside the core vm.

Also update the makefiles to ensure that the `J9_INTERNAL_TO_VM`
flag is set when building the bcverify static lib.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>