### PR TITLE
Fix JNI performance regression

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -85,6 +85,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
 
+   TR::Linkage *deriveCallingLinkage(TR::Node *node, bool isIndirect);
+
    bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
    bool enableAESInHardwareTransformations();


### PR DESCRIPTION
This is to check in OpenJ9 side refactoring first before OMR side fix can be check
in.

It was caused by changes committed for OpenJ9 issue #4893. When JNILinkage is not
set on the method symbol anymore, OutOfLine performCall eventully evaluated it
through PrivateLinkage and stuck in interpreter. The fundamental reason is that
a new node is created for performCall but the isPreparedForJNI flag is not copied
over and performCall doesn't get the linkage right.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>