### PR TITLE
Fast-path ASCII strings in j9gc_createJavaLangString

### DIFF
--- a/runtime/bcutil/ClassFileWriter.hpp
+++ b/runtime/bcutil/ClassFileWriter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
 #include "util_api.h"
 
 #include "BuildResult.hpp"
+#include "VMHelpers.hpp"
 
 class ClassFileWriter {
 /*
@@ -99,7 +100,7 @@ private:
 		case CFR_CONSTANT_Class:
 		case CFR_CONSTANT_Utf8: {
 			J9UTF8 *utf8 = (J9UTF8 *) e->address;
-			return computeHashForUTF8(J9UTF8_DATA(utf8), J9UTF8_LENGTH(utf8));
+			return VM_VMHelpers::computeHashForUTF8(J9UTF8_DATA(utf8), J9UTF8_LENGTH(utf8));
 		}
 		default:
 			/* Mix cpType into the 4th byte of the address, which is not likely to vary much within the ROM class */

--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -227,7 +227,6 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_getObjectHashCode,
 	j9gc_createJavaLangString,
 	j9gc_internString,
-	j9gc_allocStringWithSharedCharData,
 #if defined(J9VM_GC_FINALIZATION)
 	j9gc_runFinalizersOnExit,
 #endif /* J9VM_GC_FINALIZATION */

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -622,9 +622,8 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			if (J9_STR_UNICODE == (stringFlags & J9_STR_UNICODE)) {
 				unicodeLength = length / 2;
 			} else {
-				if (isCompressible) {
-					unicodeLength = length;
-				} else {
+				unicodeLength = length;
+				if (!isCompressible) {
 					unicodeLength = getUnicodeLength(data, length, NULL);
 				}
 			}

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -667,29 +667,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			if (IS_STRING_COMPRESSION_ENABLED_VM(vm) && isCompressible) {
 				VM_VMHelpers::copyUTF8ToCompressedUnicode(vmThread, data, length, stringFlags, charArray, 0);
 			} else {
-				if (isCompressible) {
-					if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-						for (UDATA i = 0; i < length; ++i) {
-							U_8 c = data[i];
-							J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, c != '/' ? c : '.');
-						}
-					} else {
-						for (UDATA i = 0; i < length; ++i) {
-							J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, data[i]);
-						}
-					}
-
-					if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
-						for (IDATA i = length - 1; i >= 0; --i) {
-							if ('.' == J9JAVAARRAYOFCHAR_LOAD(vmThread, charArray, i)) {
-								J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, '/');
-								break;
-							}
-						}
-					}
-				} else {
-					VM_VMHelpers::copyUTF8ToUnicode(vmThread, data, length, stringFlags, charArray, 0);
-				}
+				VM_VMHelpers::copyUTF8ToUnicode(vmThread, data, length, stringFlags, charArray, 0);
 			}
 		}
 

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -665,9 +665,9 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			}
 		} else {
 			if (IS_STRING_COMPRESSION_ENABLED_VM(vm) && isCompressible) {
-				VM_VMHelpers::copyUTF8ToCompressedUnicode(vmThread, data, length, stringFlags, charArray, 0);
+				VM_VMHelpers::copyUTF8ToASCII(vmThread, data, length, stringFlags, charArray, 0);
 			} else {
-				VM_VMHelpers::copyUTF8ToUnicode(vmThread, data, length, stringFlags, charArray, 0);
+				VM_VMHelpers::copyUTF8ToUTF16(vmThread, data, length, stringFlags, charArray, 0);
 			}
 		}
 
@@ -930,7 +930,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 		if (charArray == NULL) {
 			goto nomem;
 		}
-		VM_VMHelpers::copyUTF8ToCompressedUnicode(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
+		VM_VMHelpers::copyUTF8ToASCII(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
 	} else {
 		if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {
 			charArray = (J9IndexableObject*)J9AllocateIndexableObject(vmThread, vm->byteArrayClass, (U_32) unicodeLength * 2, allocateFlags);
@@ -942,7 +942,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 		if (charArray == NULL) {
 			goto nomem;
 		}
-		VM_VMHelpers::copyUTF8ToUnicode(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
+		VM_VMHelpers::copyUTF8ToUTF16(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
 	}
 
 	J9VMJAVALANGSTRING_SET_VALUE(vmThread, string, charArray);

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -600,13 +600,13 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			goto nomem;
 		}
 
-      if (J9_STR_UNICODE == (stringFlags & J9_STR_UNICODE)) {
+		if (J9_STR_UNICODE == (stringFlags & J9_STR_UNICODE)) {
 			unicodeLength = length / 2;
 		} else {
-         if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_ASCII)) {
-			   unicodeLength = length;
-		   } else {
-			   unicodeLength = VM_VMHelpers::getUTF8UnicodeLength(data, length);
+			if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_ASCII)) {
+				unicodeLength = length;
+			} else {
+				unicodeLength = VM_VMHelpers::getUTF8UnicodeLength(data, length);
 			}
 		}
 
@@ -647,9 +647,9 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			}
 		} else {
 			if (IS_STRING_COMPRESSION_ENABLED_VM(vm) && J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_ASCII)) {
-				VM_VMHelpers::copyUTF8ToASCII(vmThread, data, length, stringFlags, charArray, 0);
+				VM_VMHelpers::copyUTF8ToBackingArrayAsASCII(vmThread, data, length, stringFlags, charArray, 0);
 			} else {
-				VM_VMHelpers::copyUTF8ToUTF16(vmThread, data, length, stringFlags, charArray, 0);
+				VM_VMHelpers::copyUTF8ToBackingArrayAsUTF16(vmThread, data, length, stringFlags, charArray, 0);
 			}
 		}
 

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -31,6 +31,7 @@
 #include "GCExtensionsBase.hpp"
 #include "ScavengerForwardedHeader.hpp"
 #include "StringTable.hpp"
+#include "VMHelpers.hpp"
 
 /* the following is all ones except the least significant bit */
 #define TYPE_UTF8 ((UDATA)1)
@@ -583,11 +584,9 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 		UDATA hash = 0;
 
 		if (isCompressible) {
-			for (UDATA i = 0; i < length; ++i) {
-				hash = (hash << 5) - hash + data[i];
-			}
+			hash = VM_VMHelpers::computeHashForASCII(data, length);
 		} else {
-			hash = (U_32)vmFuncs->computeHashForUTF8(data, length);
+			hash = VM_VMHelpers::computeHashForUTF8(data, length);
 		}
 
 		UDATA tableIndex = stringTable->getTableIndex(hash);
@@ -912,7 +911,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 	UDATA unicodeLength;
 	bool isCompressible = false;
 
-	U_32 hash = (U_32) vmFuncs->computeHashForUTF8(data, length);
+	U_32 hash = (U_32)VM_VMHelpers::computeHashForUTF8(data, length);
 	UDATA tableIndex = stringTable->getTableIndex(hash);
 
 	/* see if the string is already in the table. Race condition where another thread may add the string

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -665,7 +665,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			}
 		} else {
 			if (IS_STRING_COMPRESSION_ENABLED_VM(vm) && isCompressible) {
-				vmFuncs->copyUTF8ToCompressedUnicode(vmThread, data, length, stringFlags, charArray, 0);
+				VM_VMHelpers::copyUTF8ToCompressedUnicode(vmThread, data, length, stringFlags, charArray, 0);
 			} else {
 				if (isCompressible) {
 					if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
@@ -688,7 +688,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 						}
 					}
 				} else {
-					vmFuncs->copyUTF8ToUnicode(vmThread, data, length, stringFlags, charArray, 0);
+					VM_VMHelpers::copyUTF8ToUnicode(vmThread, data, length, stringFlags, charArray, 0);
 				}
 			}
 		}
@@ -952,7 +952,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 		if (charArray == NULL) {
 			goto nomem;
 		}
-		vmFuncs->copyUTF8ToCompressedUnicode(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
+		VM_VMHelpers::copyUTF8ToCompressedUnicode(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
 	} else {
 		if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {
 			charArray = (J9IndexableObject*)J9AllocateIndexableObject(vmThread, vm->byteArrayClass, (U_32) unicodeLength * 2, allocateFlags);
@@ -964,7 +964,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 		if (charArray == NULL) {
 			goto nomem;
 		}
-		vmFuncs->copyUTF8ToUnicode(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
+		VM_VMHelpers::copyUTF8ToUnicode(vmThread, data, length, J9_STR_INTERN, (j9object_t)charArray, 0);
 	}
 
 	J9VMJAVALANGSTRING_SET_VALUE(vmThread, string, charArray);

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -580,7 +580,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 		UDATA tableIndex = stringTable->getTableIndex(hash);
 
 		stringTable->lockTable(tableIndex);
-		result = stringTable->hashAtUTF8(tableIndex, data, length, hash);
+		result = stringTable->hashAtUTF8(tableIndex, data, length, (U_32)hash);
 		stringTable->unlockTable(tableIndex);
 	}
 
@@ -606,7 +606,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
          if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_ASCII)) {
 			   unicodeLength = length;
 		   } else {
-			   unicodeLength = VM_VMHelpers::getUTF8UnicodeLength(data, length, stringFlags);
+			   unicodeLength = VM_VMHelpers::getUTF8UnicodeLength(data, length);
 			}
 		}
 
@@ -857,133 +857,6 @@ j9gc_internString(J9VMThread *vmThread, j9object_t sourceString)
 	*candidatePtr = internedString;
 	Trc_MM_stringTableCacheMiss(vmThread, internedString);
 	return internedString;
-}
-
-j9object_t
-j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA resolveFlags) {
-/* This option is disabled as its not supported by Tarok */
-	J9JavaVM *vm = vmThread->javaVM;
-	J9InternalVMFunctions * const vmFuncs = vm->internalVMFunctions;
-	MM_StringTable *stringTable = MM_GCExtensions::getExtensions(vm->omrVM)->getStringTable();
-	j9object_t string, internedString;
-	J9IndexableObject* charArray;
-	UDATA allocateFlags = J9_GC_ALLOCATE_OBJECT_TENURED | J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE;
-	UDATA unicodeLength = 0;
-	UDATA stringFlags = J9_STR_INTERN;
-
-	U_32 hash = (U_32)VM_VMHelpers::computeHashForUTF8(data, length);
-	UDATA tableIndex = stringTable->getTableIndex(hash);
-
-	/* see if the string is already in the table. Race condition where another thread may add the string
-	 * before this one is not fatal and is ignored.
-	 */
-	stringTable->lockTable(tableIndex);
-	internedString = stringTable->hashAtUTF8(tableIndex, data, length, hash);
-	stringTable->unlockTable(tableIndex);
-
-	if (internedString != NULL) {
-		return internedString;
-	}
-
-	J9Class * stringClass = J9VMJAVALANGSTRING_OR_NULL(vm);
-	string = J9AllocateObject(vmThread, stringClass, allocateFlags);
-	if (string == NULL) {
-		goto nomem;
-	}
-
-	unicodeLength = VM_VMHelpers::getUTF8UnicodeLength(data, length, stringFlags);
-
-	/* This option is disabled as its not supported by Tarok */
-	PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, string);
-
-	if (IS_STRING_COMPRESSION_ENABLED_VM(vm) && J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_ASCII)) {
-		if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {
-			charArray = (J9IndexableObject*)J9AllocateIndexableObject(vmThread, vm->byteArrayClass, (U_32) unicodeLength, allocateFlags);
-		} else {
-			charArray = (J9IndexableObject*)J9AllocateIndexableObject(vmThread, vm->charArrayClass, (U_32) (unicodeLength + 1) / 2, allocateFlags);
-		}
-
-		string = POP_OBJECT_IN_SPECIAL_FRAME(vmThread);
-		if (charArray == NULL) {
-			goto nomem;
-		}
-		VM_VMHelpers::copyUTF8ToASCII(vmThread, data, length, stringFlags, (j9object_t)charArray, 0);
-	} else {
-		if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_STRING_BYTE_ARRAY)) {
-			charArray = (J9IndexableObject*)J9AllocateIndexableObject(vmThread, vm->byteArrayClass, (U_32) unicodeLength * 2, allocateFlags);
-		} else {
-			charArray = (J9IndexableObject*)J9AllocateIndexableObject(vmThread, vm->charArrayClass, (U_32) unicodeLength, allocateFlags);
-		}
-
-		string = POP_OBJECT_IN_SPECIAL_FRAME(vmThread);
-		if (charArray == NULL) {
-			goto nomem;
-		}
-		VM_VMHelpers::copyUTF8ToUTF16(vmThread, data, length, stringFlags, (j9object_t)charArray, 0);
-	}
-
-	J9VMJAVALANGSTRING_SET_VALUE(vmThread, string, charArray);
-
-	if (IS_STRING_COMPRESSION_ENABLED_VM(vm)) {
-		if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_ASCII)) {
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
-				J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 0);
-			} else {
-				J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength);
-			}
-		} else {
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
-				J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 1);
-			} else {
-				J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength | (I_32)0x80000000);
-			}
-
-			if (IS_STRING_COMPRESSION_ENABLED_VM(vm) && J9VMJAVALANGSTRING_COMPRESSIONFLAG(vmThread, stringClass) == 0) {
-				/**
-				 * jitHookClassPreinitialize will process initialization events for String compression sideEffectGuards
-				 * so we must initialize the class if this is the first time we are loading it
-				 */
-				J9Class* flagClass = vmFuncs->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
-
-				if (NULL == flagClass) {
-					goto nomem;
-				} else {
-					j9object_t flag = J9AllocateObject(vmThread, flagClass, allocateFlags);
-
-					if (NULL == flag) {
-						goto nomem;
-					}
-
-					J9VMJAVALANGSTRING_SET_COMPRESSIONFLAG(vmThread, stringClass, flag);
-				}
-			}
-		}
-	} else {
-		if (J2SE_VERSION(vm) >= J2SE_V11) {
-			J9VMJAVALANGSTRING_SET_CODER(vmThread, string, 1);
-		} else {
-			J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32)unicodeLength);
-		}
-	}
-
-	MM_AtomicOperations::writeBarrier();
-
-	/* Intern the String */
-	internedString = stringTable->addStringToInternTable(vmThread, string);
-	if (NULL == internedString) {
-		goto nomem;
-	}
-	if (internedString != string) {
-		return internedString;
-	}
-
-/* This option is disabled as its not supported by Tarok */
-
-	return string;
-
-nomem:
-	vmFuncs->setHeapOutOfMemoryError(vmThread);
-	return NULL;
 }
 
 } /* end of extern "C" */

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -271,7 +271,6 @@ void j9mm_get_guaranteed_nursery_range(J9JavaVM* javaVM, void** start, void** en
 /* StringTable.cpp */
 extern J9_CFUNC j9object_t j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags);
 extern J9_CFUNC j9object_t j9gc_internString(J9VMThread *vmThread, j9object_t sourceString);
-extern J9_CFUNC j9object_t j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA resolveFlags);
 extern UDATA j9gc_stringHashFn (void *key, void *userData);
 extern UDATA j9gc_stringHashEqualFn (void *leftKey, void *rightKey, void *userData);
 

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -999,6 +999,49 @@ done:
 	}
 
 	/**
+	 * Computes the hash value for an input string using the hash algorithm defined by the java/lang/String.hashCode()I
+	 * method.
+	 *
+	 * @param data points to raw UTF8 bytes, assumed to be a valid (potentially multi-byte) encoding
+	 * @param length the number of bytes to hash
+	 *
+	 * @return hash code for the UTF8 string
+	 */
+	static VMINLINE UDATA
+	computeHashForUTF8(const U_8 *data, UDATA length)
+	{
+		UDATA hash = 0;
+		const U_8 * end = data + length;
+
+		while (data < end) {
+			U_16 c;
+
+			data += decodeUTF8Char(data, &c);
+			hash = (hash << 5) - hash + c;
+		}
+		return hash;
+	}
+
+	/**
+	 * Computes the hash value for an input string using the hash algorithm defined by the java/lang/String.hashCode()I
+	 * method.
+	 *
+	 * @param data points to raw UTF8 bytes, all of which are within the ASCII subset ord. [0, 127]
+	 * @param length the number of bytes to hash
+	 *
+	 * @return hash code for the UTF8 string
+	 */
+	static VMINLINE UDATA
+	computeHashForASCII(const U_8 *data, UDATA length)
+	{
+		UDATA hash = 0;
+		for (UDATA i = 0; i < length; ++i) {
+			hash = (hash << 5) - hash + data[i];
+		}
+		return hash;
+	}
+
+	/**
 	 * Determine the JIT to JIT start address by skipping over the interpreter
 	 * pre-prologue at the interpreter to JIT start address.
 	 *

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1158,6 +1158,42 @@ done:
 	}
 
 	/**
+	 * Determine the unicode length of a UTF8 string
+	 *
+	 * @param data[in] points to raw UTF8 bytes
+	 * @param length[in] the number of bytes representing characters in data
+	 * @param stringFlags[out] string flags corresponding to data which will be modified with the J9_STR_LATIN1 flag if
+	 * we determine all characters within data are within the Latin1 subset
+	 *
+	 * @return the length of the UTF8 string in unicode characters
+	 */
+	static UDATA
+	getUTF8UnicodeLength(U_8 *data, UDATA length, UDATA &stringFlags)
+	{
+		UDATA unicodeLength = 0;
+		bool isLatin1 = true;
+
+		while (length != 0) {
+			U_16 unicode = 0;
+			U_32 consumed = decodeUTF8CharN(data, &unicode, length);
+
+			if (unicode > 0xFF) {
+				isLatin1 = false;
+			}
+
+			data += consumed;
+			length -= consumed;
+			++unicodeLength;
+		}
+
+		if (isLatin1) {
+			stringFlags |= J9_STR_LATIN1;
+		}
+
+		return unicodeLength;
+	}
+
+	/**
 	 * Determine the JIT to JIT start address by skipping over the interpreter
 	 * pre-prologue at the interpreter to JIT start address.
 	 *

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1040,6 +1040,29 @@ done:
 		}
 		return hash;
 	}
+	
+	/**
+	 * Determines whether the UTF8 string is an ASCII string.
+	 *
+	 * @param data[in] points to raw UTF8 bytes
+	 * @param length[in] the number of bytes representing characters in data
+	 *
+	 * @return true if all of the characters in the UTF8 input string are ASCII; false otherwise
+	 */
+	static VMINLINE bool
+	isUTF8ASCII(const U_8 *data, UDATA length)
+	{
+		bool isASCII = true;
+
+		for (UDATA i = 0; i < length; ++i) {
+			if (data[i] > 0x7F) {
+				isASCII = false;
+				break;
+			}
+		}
+
+		return isASCII;
+	}
 
 	/**
 	 * Copies a UTF8 string into a UTF16 string at a specific index.

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1041,22 +1041,22 @@ done:
 		return hash;
 	}
 
-   /**
-    * Copies a UTF8 string into a UTF16 string at a specific index.
-    *
-    * @param vmThread[in] the current J9VMThread
-    * @param data[in] points to raw UTF8 bytes, some of which may be multi-byte UTF8 encoded Unicode characters
-    * @param length[in] the number of bytes representing characters in data
-    * @param stringFlags[in] string flags corresponding to data
-    * @param charArray[in] the character array (can be either byte[] or char[]) to copy the UTF8 string into
-    * @param startIndex the start index of charArray at which to begin the copy
-    */
+	/**
+	 * Copies a UTF8 string into a UTF16 string at a specific index.
+	 *
+	 * @param vmThread[in] the current J9VMThread
+	 * @param data[in] points to raw UTF8 bytes, some of which may be multi-byte UTF8 encoded Unicode characters
+	 * @param length[in] the number of bytes representing characters in data
+	 * @param stringFlags[in] string flags corresponding to data
+	 * @param charArray[in] the character array (can be either byte[] or char[]) to copy the UTF8 string into
+	 * @param startIndex the start index of charArray at which to begin the copy
+	 */
 	static VMINLINE void
 	copyUTF8ToUTF16(J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
 	{
 		UDATA originalLength = length;
 
-      if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ASCII)) {
+		if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ASCII)) {
 			if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
 				for (UDATA i = 0; i < length; ++i) {
 					U_8 c = data[i];
@@ -1068,20 +1068,20 @@ done:
 				}
 			}
 		} else {
-		   UDATA writeIndex = startIndex;
-		   while (length > 0) {
-			   U_16 unicode = 0;
-			   UDATA consumed = decodeUTF8Char(data, &unicode);
-			   if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-				   if ((U_16)'/' == unicode) {
-					   unicode = (U_16)'.';
-				   }
-			   }
-			   J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, writeIndex, unicode);
-			   writeIndex += 1;
-			   data += consumed;
-			   length -= consumed;
-		   }
+			UDATA writeIndex = startIndex;
+			while (length > 0) {
+				U_16 unicode = 0;
+				UDATA consumed = decodeUTF8Char(data, &unicode);
+				if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
+					if ((U_16)'/' == unicode) {
+						unicode = (U_16)'.';
+					}
+				}
+				J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, writeIndex, unicode);
+				writeIndex += 1;
+				data += consumed;
+				length -= consumed;
+			}
 		}
 
 		/* Anonymous classes have the following name format [className]/[ROMADDRESS], so we have to to fix up the name
@@ -1097,47 +1097,42 @@ done:
 		}
 	}
 
-   /**
-    * Copies a UTF8 string into a Latin1 compact string at a specific index.
-    *
-    * @param vmThread[in] the current J9VMThread
-    * @param data[in] points to raw UTF8 bytes, all of which are within the Latin1 subset ord. [0, 255]
-    * @param length[in] the number of bytes representing characters in data
-    * @param stringFlags[in] string flags corresponding to data
-    * @param charArray[in] the character array (can be either byte[] or char[]) to copy the UTF8 string into
-    * @param startIndex the start index of charArray at which to begin the copy
-    */
-   static VMINLINE void
-   copyUTF8ToASCII(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
-   {
-	   UDATA writeIndex = startIndex;
-	   UDATA originalLength = length;
-	   while (length > 0) {
-		   U_16 unicode = 0;
-		   UDATA consumed = VM_VMHelpers::decodeUTF8Char(data, &unicode);
-		   if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-			   if ((U_16)'/' == unicode) {
-				   unicode = (U_16)'.';
-			   }
-		   }
-		   J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, writeIndex, (U_8)unicode);
-		   writeIndex += 1;
-		   data += consumed;
-		   length -= consumed;
-	   }
+	/**
+	 * Copies a UTF8 string into a ASCII compact string at a specific index.
+	 *
+	 * @param vmThread[in] the current J9VMThread
+	 * @param data[in] points to raw UTF8 bytes, all of which are within the ASCII subset ord. [0, 127]
+	 * @param length[in] the number of bytes representing characters in data
+	 * @param stringFlags[in] string flags corresponding to data
+	 * @param charArray[in] the character array (can be either byte[] or char[]) to copy the UTF8 string into
+	 * @param startIndex the start index of charArray at which to begin the copy
+	 */
+	static VMINLINE void
+	copyUTF8ToASCII(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
+	{
+		if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
+			for (UDATA i = 0; i < length; ++i) {
+				U_8 c = data[i];
+				J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, c != '/' ? c : '.');
+			}
+		} else {
+			for (UDATA i = 0; i < length; ++i) {
+				J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, data[i]);
+			}
+		}
 
 		/* Anonymous classes have the following name format [className]/[ROMADDRESS], so we have to to fix up the name
 		 * because the previous loops have converted '/' to '.' already.
 		 */
-	   if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
-		   for (IDATA i = (IDATA) originalLength - 1; i >= 0; --i) {
-			   if ((U_8)'.' == J9JAVAARRAYOFBYTE_LOAD(vmThread, charArray, i)) {
-				   J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, (U_8)'/');
-				   break;
-			   }
-		   }
-	   }
-   }
+		if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
+			for (IDATA i = (IDATA)length - 1; i >= 0; --i) {
+				if ((U_8)'.' == J9JAVAARRAYOFBYTE_LOAD(vmThread, charArray, i)) {
+					J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, (U_8)'/');
+					break;
+				}
+			}
+		}
+	}
 
 	/**
 	 * Determine the JIT to JIT start address by skipping over the interpreter

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1162,8 +1162,8 @@ done:
 	 *
 	 * @param data[in] points to raw UTF8 bytes
 	 * @param length[in] the number of bytes representing characters in data
-	 * @param stringFlags[out] string flags corresponding to data which will be modified with the J9_STR_LATIN1 flag if
-	 * we determine all characters within data are within the Latin1 subset
+	 * @param stringFlags[out] string flags corresponding to data which will be modified with the J9_STR_ASCII flag if
+	 * we determine all characters within data are within the ASCII subset
 	 *
 	 * @return the length of the UTF8 string in unicode characters
 	 */
@@ -1171,14 +1171,14 @@ done:
 	getUTF8UnicodeLength(U_8 *data, UDATA length, UDATA &stringFlags)
 	{
 		UDATA unicodeLength = 0;
-		bool isLatin1 = true;
+		bool isASCII = true;
 
 		while (length != 0) {
 			U_16 unicode = 0;
 			U_32 consumed = decodeUTF8CharN(data, &unicode, length);
 
-			if (unicode > 0xFF) {
-				isLatin1 = false;
+			if (unicode > 0x7F) {
+				isASCII = false;
 			}
 
 			data += consumed;
@@ -1186,8 +1186,8 @@ done:
 			++unicodeLength;
 		}
 
-		if (isLatin1) {
-			stringFlags |= J9_STR_LATIN1;
+		if (isASCII) {
+			stringFlags |= J9_STR_ASCII;
 		}
 
 		return unicodeLength;

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1041,6 +1041,16 @@ done:
 		return hash;
 	}
 
+   /**
+    * Copies a UTF8 string into a UTF16 string at a specific index.
+    *
+    * @param vmThread[in] the current J9VMThread
+    * @param data[in] points to raw UTF8 bytes, some of which may be multi-byte UTF8 encoded Unicode characters
+    * @param length[in] the number of bytes representing characters in data
+    * @param stringFlags[in] string flags corresponding to data
+    * @param charArray[in] the character array (can be either byte[] or char[]) to copy the UTF8 string into
+    * @param startIndex the start index of charArray at which to begin the copy
+    */
 	static VMINLINE void
 	copyUTF8ToUTF16(J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
 	{
@@ -1088,13 +1098,14 @@ done:
 	}
 
    /**
-    * Compress the UTF8 string into compressed format into byteArray at offset
-    * @param *vmThread
-    * @param *data
-    * @param length
-    * @param stringFlags
-    * @param byteArray
-    * @param offset
+    * Copies a UTF8 string into a Latin1 compact string at a specific index.
+    *
+    * @param vmThread[in] the current J9VMThread
+    * @param data[in] points to raw UTF8 bytes, all of which are within the Latin1 subset ord. [0, 255]
+    * @param length[in] the number of bytes representing characters in data
+    * @param stringFlags[in] string flags corresponding to data
+    * @param charArray[in] the character array (can be either byte[] or char[]) to copy the UTF8 string into
+    * @param startIndex the start index of charArray at which to begin the copy
     */
    static VMINLINE void
    copyUTF8ToASCII(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1042,7 +1042,7 @@ done:
 	}
 
 	static VMINLINE void
-	copyUTF8ToUnicode(J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
+	copyUTF8ToUTF16(J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
 	{
 		UDATA originalLength = length;
 
@@ -1097,7 +1097,7 @@ done:
     * @param offset
     */
    static VMINLINE void
-   copyUTF8ToCompressedUnicode(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
+   copyUTF8ToASCII(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
    {
 	   UDATA writeIndex = startIndex;
 	   UDATA originalLength = length;

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1081,12 +1081,12 @@ done:
 
 		if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ASCII)) {
 			if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-				for (UDATA i = 0; i < length; ++i) {
+				for (UDATA i = startIndex; i < length; ++i) {
 					U_8 c = data[i];
 					J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, c != '/' ? c : '.');
 				}
 			} else {
-				for (UDATA i = 0; i < length; ++i) {
+				for (UDATA i = startIndex; i < length; ++i) {
 					J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, data[i]);
 				}
 			}
@@ -1134,12 +1134,12 @@ done:
 	copyUTF8ToASCII(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
 	{
 		if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-			for (UDATA i = 0; i < length; ++i) {
+			for (UDATA i = startIndex; i < length; ++i) {
 				U_8 c = data[i];
 				J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, c != '/' ? c : '.');
 			}
 		} else {
-			for (UDATA i = 0; i < length; ++i) {
+			for (UDATA i = startIndex; i < length; ++i) {
 				J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, data[i]);
 			}
 		}
@@ -1162,32 +1162,21 @@ done:
 	 *
 	 * @param data[in] points to raw UTF8 bytes
 	 * @param length[in] the number of bytes representing characters in data
-	 * @param stringFlags[out] string flags corresponding to data which will be modified with the J9_STR_ASCII flag if
-	 * we determine all characters within data are within the ASCII subset
 	 *
 	 * @return the length of the UTF8 string in unicode characters
 	 */
 	static UDATA
-	getUTF8UnicodeLength(U_8 *data, UDATA length, UDATA &stringFlags)
+	getUTF8UnicodeLength(U_8 *data, UDATA length)
 	{
 		UDATA unicodeLength = 0;
-		bool isASCII = true;
 
 		while (length != 0) {
 			U_16 unicode = 0;
-			U_32 consumed = decodeUTF8CharN(data, &unicode, length);
-
-			if (unicode > 0x7F) {
-				isASCII = false;
-			}
+			UDATA consumed = decodeUTF8CharN(data, &unicode, length);
 
 			data += consumed;
 			length -= consumed;
 			++unicodeLength;
-		}
-
-		if (isASCII) {
-			stringFlags |= J9_STR_ASCII;
 		}
 
 		return unicodeLength;

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1041,6 +1041,79 @@ done:
 		return hash;
 	}
 
+	static VMINLINE void
+	copyUTF8ToUnicode(J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
+	{
+		UDATA writeIndex = startIndex;
+		UDATA originalLength = length;
+		while (length > 0) {
+			U_16 unicode = 0;
+			UDATA consumed = decodeUTF8Char(data, &unicode);
+			if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
+				if ((U_16)'/' == unicode) {
+					unicode = (U_16)'.';
+				}
+			}
+			J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, writeIndex, unicode);
+			writeIndex += 1;
+			data += consumed;
+			length -= consumed;
+		}
+
+		/* anonClasses have the following name format [className]/[ROMADDRESS], we have to
+		 * to fix up the name because the previous functions automatically convert '/' to '.'
+		 */
+		if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
+			for (IDATA i = (IDATA) originalLength - 1; i >= 0; i--) {
+				if ((U_16)'.' == J9JAVAARRAYOFCHAR_LOAD(vmThread, charArray, i)) {
+					J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, (U_16) '/');
+					break;
+				}
+			}
+		}
+	}
+
+   /**
+    * Compress the UTF8 string into compressed format into byteArray at offset
+    * @param *vmThread
+    * @param *data
+    * @param length
+    * @param stringFlags
+    * @param byteArray
+    * @param offset
+    */
+   static VMINLINE void
+   copyUTF8ToCompressedUnicode(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
+   {
+	   UDATA writeIndex = startIndex;
+	   UDATA originalLength = length;
+	   while (length > 0) {
+		   U_16 unicode = 0;
+		   UDATA consumed = VM_VMHelpers::decodeUTF8Char(data, &unicode);
+		   if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
+			   if ((U_16)'/' == unicode) {
+				   unicode = (U_16)'.';
+			   }
+		   }
+		   J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, writeIndex, (U_8)unicode);
+		   writeIndex += 1;
+		   data += consumed;
+		   length -= consumed;
+	   }
+
+	   /* anonClasses have the following name format [className]/[ROMADDRESS], we have to
+	    * to fix up the name because the previous functions automatically convert '/' to '.'
+	    */
+	   if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
+		   for (IDATA i = (IDATA) originalLength - 1; i >= 0; i--) {
+			   if ((U_8)'.' == J9JAVAARRAYOFBYTE_LOAD(vmThread, charArray, i)) {
+				   J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, (U_8) '/');
+				   break;
+			   }
+		   }
+	   }
+   }
+
 	/**
 	 * Determine the JIT to JIT start address by skipping over the interpreter
 	 * pre-prologue at the interpreter to JIT start address.

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -568,7 +568,6 @@ extern "C" {
 #define J9_STR_NULL_TERMINATE_RESULT 0x40
 /* Determines whether the string contains only ASCII characters (ord <= 127) */
 #define J9_STR_ASCII 0x80
-#define J9_STR_COMPRESSION_THRESHOLD 0xFF
 
 #define J9_JCL_FLAG_REFERENCE_OBJECTS 0x1
 #define J9_JCL_FLAG_FINALIZATION 0x2

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -566,6 +566,7 @@ extern "C" {
 #define J9_STR_ANON_CLASS_NAME 0x20
 /* Determines whether a copied string result will be null terminated */
 #define J9_STR_NULL_TERMINATE_RESULT 0x40
+/* Determines whether the string contains only ASCII characters (ord <= 127) */
 #define J9_STR_ASCII 0x80
 #define J9_STR_COMPRESSION_THRESHOLD 0xFF
 

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -566,6 +566,7 @@ extern "C" {
 #define J9_STR_ANON_CLASS_NAME 0x20
 /* Determines whether a copied string result will be null terminated */
 #define J9_STR_NULL_TERMINATE_RESULT 0x40
+#define J9_STR_ASCII 0x80
 #define J9_STR_COMPRESSION_THRESHOLD 0xFF
 
 #define J9_JCL_FLAG_REFERENCE_OBJECTS 0x1

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4666,7 +4666,6 @@ typedef struct J9InternalVMFunctions {
 	UDATA  ( *compareStrings)(struct J9VMThread * vmThread, j9object_t string1, j9object_t string2) ;
 	UDATA  ( *compareStringToUTF8)(struct J9VMThread * vmThread, j9object_t stringObject, UDATA stringFlags, const U_8 * utfData, UDATA utfLength) ;
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
-	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
 	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, UDATA stringOffset, UDATA stringLength, U_8 *utf8Data, UDATA utf8DataLength);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext) ;
@@ -4737,7 +4736,6 @@ typedef struct J9InternalVMFunctions {
 	void  ( *clearHaltFlag)(struct J9VMThread * vmThread, UDATA flag) ;
 	void  ( *setHeapOutOfMemoryError)(struct J9VMThread * currentThread) ;
 	jint  ( *initializeHeapOOMMessage)(struct J9VMThread *currentThread) ;
-	void  ( *copyUTF8ToCompressedUnicode)(struct J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t byteArray, UDATA offset) ;
 	void  ( *threadAboutToStart)(struct J9VMThread *currentThread) ;
 	void  ( *mustHaveVMAccess)(struct J9VMThread * vmThread) ;
 #if defined(J9VM_PORT_ZOS_CEEHDLRSUPPORT)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4429,7 +4429,6 @@ typedef struct J9MemoryManagerFunctions {
 	I_32  ( *j9gc_objaccess_getObjectHashCode)(struct J9JavaVM *vm, J9Object* object) ;
 	j9object_t  ( *j9gc_createJavaLangString)(struct J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags) ;
 	j9object_t  ( *j9gc_internString)(struct J9VMThread *vmThread, j9object_t sourceString) ;
-	j9object_t  ( *j9gc_allocStringWithSharedCharData)(struct J9VMThread *vmThread, U_8 *data, UDATA length, UDATA resolveFlags) ;
 #if defined(J9VM_GC_FINALIZATION)
 	void  ( *j9gc_runFinalizersOnExit)(struct J9VMThread* vmThread, UDATA run) ;
 #endif /* J9VM_GC_FINALIZATION */

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1231,7 +1231,6 @@ extern J9_CFUNC UDATA  romImageLoad (J9VMThread *currentThread, void *segmentPoi
 /* J9VMStringSupport*/
 #ifndef _J9VMSTRINGSUPPORT_
 #define _J9VMSTRINGSUPPORT_
-extern J9_CFUNC void  copyUTF8ToUnicode (J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex);
 extern J9_CFUNC j9object_t  catUtfToString4 (J9VMThread * vmThread, const U_8 *data1, UDATA length1, const U_8 *data2, UDATA length2, const U_8 *data3, UDATA length3, const U_8 *data4, UDATA length4);
 extern J9_CFUNC j9object_t  methodToString (J9VMThread * vmThread, J9Method* method);
 #endif /* _J9VMSTRINGSUPPORT_ */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2822,18 +2822,6 @@ getStatistic (J9JavaVM* javaVM, U_8 * name);
 /* ---------------- stringhelpers.c ---------------- */
 
 /**
- * @brief
- * @param *vmThread
- * @param *data
- * @param length
- * @param stringFlags
- * @param byteArray
- * @param offset
- */
-void
-copyUTF8ToCompressedUnicode(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t byteArray, UDATA offset);
-
-/**
  * @brief Compare a java string to another java string for character equality.
  * @param *vmThread
  * @param *string1

--- a/runtime/util/utf8hash.c
+++ b/runtime/util/utf8hash.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,15 +23,14 @@
 #include "util_api.h"
 
 /**
- * Hash function for UTF8 strings which works from the front of the string to the back.  Mathematically equivalent to
- * computeJavaHashForExpandedString, which works back to front on Unicode.
+ * Computes the hash value for an input string using the hash algorithm defined by the java/lang/String.hashCode()I
+ * method.
  *
- * @param data points to raw UTF8 bytes, assumed to be a valid encoding
- * @param length is the number of bytes
+ * @param data points to raw UTF8 bytes, assumed to be a valid (potentially multi-byte) encoding
+ * @param length the number of bytes to hash
  *
  * @return hash code for the UTF8 string
  */
-
 UDATA
 computeHashForUTF8(const U_8 * data, UDATA length)
 {

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -236,7 +236,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	compareStrings,
 	compareStringToUTF8,
 	prepareForExceptionThrow,
-	copyUTF8ToUnicode,
 	verifyQualifiedName,
 	copyStringToUTF8Helper,
 	sendCompleteInitialization,
@@ -307,7 +306,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	clearHaltFlag,
 	setHeapOutOfMemoryError,
 	initializeHeapOOMMessage,
-	copyUTF8ToCompressedUnicode,
 	threadAboutToStart,
 	mustHaveVMAccess,
 #if defined(J9VM_PORT_ZOS_CEEHDLRSUPPORT)

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -168,8 +168,8 @@ resolveStringRef(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA cpIndex, UDA
 	
 	Trc_VM_resolveStringRef_utf8(vmStruct, &utf8Wrapper, J9UTF8_LENGTH(utf8Wrapper), J9UTF8_DATA(utf8Wrapper));
 
-	/* Create a new string with shared char[] data */
-	stringRef = vmStruct->javaVM->memoryManagerFunctions->j9gc_allocStringWithSharedCharData(vmStruct, J9UTF8_DATA(utf8Wrapper), J9UTF8_LENGTH(utf8Wrapper), resolveFlags);
+	/* Create a new string */
+	stringRef = vmStruct->javaVM->memoryManagerFunctions->j9gc_createJavaLangString(vmStruct, J9UTF8_DATA(utf8Wrapper), J9UTF8_LENGTH(utf8Wrapper), J9_STR_TENURE | J9_STR_INTERN);
 	
 	/* If stringRef is NULL, the exception has already been set. */
 	if (stringRef != NULL) {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -33,47 +33,6 @@
 extern "C" {
 
 /**
- * Compress the UTF8 string into compressed format into byteArray at offset
- * @param *vmThread
- * @param *data
- * @param length
- * @param stringFlags
- * @param byteArray
- * @param offset
- */
-void
-copyUTF8ToCompressedUnicode(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
-{
-	UDATA writeIndex = startIndex;
-	UDATA originalLength = length;
-	while (length > 0) {
-		U_16 unicode = 0;
-		UDATA consumed = VM_VMHelpers::decodeUTF8Char(data, &unicode);
-		if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-			if ((U_16)'/' == unicode) {
-				unicode = (U_16)'.';
-			}
-		}
-		J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, writeIndex, (U_8)unicode);
-		writeIndex += 1;
-		data += consumed;
-		length -= consumed;
-	}
-
-	/* anonClasses have the following name format [className]/[ROMADDRESS], we have to
-	 * to fix up the name because the previous functions automatically convert '/' to '.'
-	 */
-	if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
-		for (IDATA i = (IDATA) originalLength - 1; i >= 0; i--) {
-			if ((U_8)'.' == J9JAVAARRAYOFBYTE_LOAD(vmThread, charArray, i)) {
-				J9JAVAARRAYOFBYTE_STORE(vmThread, charArray, i, (U_8) '/');
-				break;
-			}
-		}
-	}
-}
-
-/**
  * Compare a uncompressed java unicode array to another uncompressed java unicode array for equality.
  * @param *vmThread
  * @param *unicodeBytes1
@@ -502,38 +461,6 @@ fixBadUtf8(const U_8 * original, U_8 *corrected, size_t length)
 		length -= consumed;
 	}
 	*corrected = '\0';
-}
-
-void
-copyUTF8ToUnicode(J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex)
-{
-	UDATA writeIndex = startIndex;
-	UDATA originalLength = length;
-	while (length > 0) {
-		U_16 unicode = 0;
-		UDATA consumed = VM_VMHelpers::decodeUTF8Char(data, &unicode);
-		if (J9_ARE_ANY_BITS_SET(stringFlags, J9_STR_XLAT)) {
-			if ((U_16)'/' == unicode) {
-				unicode = (U_16)'.';
-			}
-		}
-		J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, writeIndex, unicode);
-		writeIndex += 1;
-		data += consumed;
-		length -= consumed;
-	}
-
-	/* anonClasses have the following name format [className]/[ROMADDRESS], we have to
-	 * to fix up the name because the previous functions automatically convert '/' to '.'
-	 */
-	if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_ANON_CLASS_NAME)) {
-		for (IDATA i = (IDATA) originalLength - 1; i >= 0; i--) {
-			if ((U_16)'.' == J9JAVAARRAYOFCHAR_LOAD(vmThread, charArray, i)) {
-				J9JAVAARRAYOFCHAR_STORE(vmThread, charArray, i, (U_16) '/');
-				break;
-			}
-		}
-	}
 }
 
 j9object_t


### PR DESCRIPTION
Improve throughput performance of this API by introducing a forward
pass which identifies whether the entire UTF8 string is composed of
ASCII characters.

The idea is that most of the strings coming through this API are
indeed ASCII strings, typically strings relating to class, package,
and file names, in addition to some strings from the JCL. Profiling
tells us almost all of these strings are proper ASCII strings, and
as such we can take advantage of faster algorithms for translating
between UTF8 and UTF16.

Issue: #7776

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>