### PR TITLE
Fix JITServer cmdLineTester_fieldwatchtests_0 failure

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -77,7 +77,7 @@ J9::TreeEvaluator::rdWrtbarHelperForFieldWatch(TR::Node *node, TR::CodeGenerator
    // If unresolved, then we generate instructions to populate the data snippet's fields correctly at runtime.
    // Note: We also call the VM Helper routine to fill in the data snippet's fields if this is an AOT compilation.
    // Once the infrastructure to support AOT during fieldwatch is enabled and functionally correct, we can remove is check.
-   if (isUnresolved || cg->comp()->compileRelocatableCode() /* isAOTCompile */)
+   if (isUnresolved || cg->needClassAndMethodPointerRelocations())
       {
       // Resolve and populate dataSnippet fields.
       TR::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(cg, node, dataSnippet, isWrite, sideEffectRegister, dataSnippetRegister);

--- a/runtime/compiler/codegen/J9WatchedStaticFieldSnippet.cpp
+++ b/runtime/compiler/codegen/J9WatchedStaticFieldSnippet.cpp
@@ -88,7 +88,9 @@ uint8_t *TR::J9WatchedStaticFieldSnippet::emitSnippetBody()
             __LINE__,
             node);
          }
-      else
+      // relocations for TR_ClassAddress are needed for AOT/AOTaaS compiles and not needed for regular JIT and JITServer compiles. 
+      // cg->needClassAndMethodPointerRelocations() tells us whether a relocation is needed depending on the type of compile being performed.
+      else if (cg()->needClassAndMethodPointerRelocations())
          {
          // As things currently stand, this will not work on Power because TR_ClassAddress is used to a generate a 5 instruction sequence that materializes the address into a register. Meanwhile we are using TR_ClassAddress here to represent a contiguous word.
          // A short-term solution would be to use TR_ClassPointer. However this is hacky because TR_ClassPointer expects an aconst node (so we would have to create a dummy node). The proper solution would be to implement the functionality in the power

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1305,9 +1305,9 @@ J9::Power::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::CodeGe
    else if (!(node->getSymbolReference()->isUnresolved()))
       {
       fieldClassReg = cg->allocateRegister();
-      // During Non-AOT compilation the fieldClass has been populated inside the dataSnippet during compilation.
+      // During Non-AOT (JIT and JITServer) compilation the fieldClass has been populated inside the dataSnippet during compilation.
       // During AOT compilation the fieldClass must be loaded from the snippet. The fieldClass in an AOT body is invalid.
-      if (cg->comp()->compileRelocatableCode())
+      if (cg->needClassAndMethodPointerRelocations())
          {
          // Load FieldClass from snippet
          generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, fieldClassReg,

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3968,9 +3968,9 @@ J9::Z::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::CodeGenera
       if (isResolved)
          {
          fieldClassReg = cg->allocateRegister();
-         if (!(cg->comp()->compileRelocatableCode()))
+         if (!(cg->needClassAndMethodPointerRelocations()))
             {
-            // For non-AOT compiles we don't need to use sideEffectRegister here as the class information is available to us at compile time.
+            // For non-AOT (JIT and JITServer) compiles we don't need to use sideEffectRegister here as the class information is available to us at compile time.
             J9Class *fieldClass = static_cast<TR::J9WatchedStaticFieldSnippet *>(dataSnippet)->getFieldClass();
             TR_ASSERT_FATAL(fieldClass != NULL, "A valid J9Class must be provided for direct rdbar/wrtbar opcodes %p\n", node);
             generateRILInstruction(cg, TR::InstOpCode::LARL, node, fieldClassReg, static_cast<void *>(fieldClass));


### PR DESCRIPTION
Replace `cg->comp()->compileRelocatableCode()` queries
with `cg->needClassAndMethodPointerRelocations()` as
`cg->needClassAndMethodPointerRelocations()` takes JITServer
into consideration.
Add an additional check when creating relo record for
`TR_ClassAddress`, we want to prevent JITServer mode from
creating a relo record. Relocations for `TR_ClassAddress` are
needed for AOT/AOTaaS compiles and not needed for JIT/JITServer
compiles.

Issue: #7674
Signed-off-by: Harry Yu <harryyu1994@gmail.com>