### PR TITLE
Fix the CacheUniqueID

### DIFF
--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -6877,3 +6877,13 @@ J9NLS_SHRC_SHRINIT_HELPTEXT_NO_TIMESTAMP_CHECKS_V1.system_action=
 J9NLS_SHRC_SHRINIT_HELPTEXT_NO_TIMESTAMP_CHECKS_V1.user_response=
 # END NON-TRANSLATABLE
 
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED=The top layer (layer %d) of the cache is destroyed. Modification to the layer %d of the shared cache has been detected. Expected Cache Unique ID is %s, current Cache Unique ID is %s.
+# START NON-TRANSLATABLE
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.sample_input_1=1
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.sample_input_2=0
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.sample_input_3=Cache_1
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.sample_input_4=Cache_2
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.explanation=An error has occurred in shared class processing. A lower layer shared cache should not be modified. Any modification to a lower layer shared cache invalidates all the higher layers shared caches built on top of it.
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.system_action=The JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes.
+J9NLS_SHRC_CM_NEW_LAYER_CACHE_DESTROYED.user_response=Use -Xshareclasses:name=<cacheName>,destroy to destroy all invalid layers (all the higher layers which are built on top of the modified layer) and retry.
+# END NON-TRANSLATABLE

--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -504,7 +504,9 @@ private:
 	IDATA startupCacheletForStats(J9VMThread* currentThread, SH_CompositeCache* cachelet);
 #endif /*J9SHR_CACHELET_SUPPORT*/
 
-	IDATA getPrereqCache(J9VMThread* currentThread, const char* cacheDir, SH_CompositeCacheImpl* ccToUse, bool startupForStats, const char** prereqCacheID, UDATA* idLen);
+	IDATA getPrereqCache(J9VMThread* currentThread, const char* cacheDir, SH_CompositeCacheImpl* ccToUse, bool startupForStats, const char** prereqCacheID, UDATA* idLen, bool *isCacheUniqueIdStored);
+
+	IDATA storeCacheUniqueID(J9VMThread* currentThread, const char* cacheDir, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes, const char** prereqCacheID, UDATA* idLen);
 
 	void handleStartupError(J9VMThread* currentThread, SH_CompositeCacheImpl* ccToUse, IDATA errorCode, U_64 runtimeFlags, UDATA verboseFlags, bool *doRetry, IDATA *deleteRC);
 	

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -187,6 +187,10 @@ public:
 	void getMinMaxBytes(U_32 *softmx, I_32 *minAOT, I_32 *maxAOT, I_32 *minJIT, I_32 *maxJIT);
 
 	UDATA getFreeBytes(void);
+
+	UDATA getMetadataBytes(void) const;
+
+	UDATA getClassesBytes(void) const;
 	
 	UDATA getFreeAvailableBytes(void);
 
@@ -198,9 +202,9 @@ public:
 
 	U_32 getFreeDebugSpaceBytes(void);
 
-	U_32 getLineNumberTableBytes(void);
+	U_32 getLineNumberTableBytes(void) const;
 
-	U_32 getLocalVariableTableBytes(void);
+	U_32 getLocalVariableTableBytes(void) const;
 
 	UDATA getFreeReadWriteBytes(void);
 	
@@ -431,6 +435,8 @@ public:
 	const char* getCacheName(void) const;
 	
 	I_8 getLayer(void) const;
+
+	U_64 getCreateTime(void) const;
 
 	bool verifyCacheUniqueID(J9VMThread* currentThread, const char* expectedCacheUniqueID) const;
 	

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -437,9 +437,6 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 		cachePathNameLen = strlen(fullPathName);
 		if ((_cachePathName = (char*)j9mem_allocate_memory(cachePathNameLen + 1, J9MEM_CATEGORY_CLASSES))) {
 			strcpy(_cachePathName, fullPathName);
-			if (NULL == getCacheUniqueID(vm->internalVMFunctions->currentVMThread(vm))) {
-				return -1;
-			}
 		} else {
 			Trc_SHR_OSC_commonStartup_nomem_cachePathName();
 			OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_ALLOC_FAILED);
@@ -997,7 +994,7 @@ SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char
 			rc = SH_OSCachemmap::getNonTopLayerCacheInfo(vm, ctrlDirName, groupPerm, cacheNameWithVGen, result, reason, (SH_OSCachemmap*)oscache);
 		} else {
 			Trc_SHR_OSC_getCacheStatistics_stattingMmap();
-			rc = SH_OSCachemmap::getCacheStats(vm, cacheDirName, groupPerm, cacheNameWithVGen, result, reason, lowerLayerList);
+			rc = SH_OSCachemmap::getCacheStats(vm, ctrlDirName, groupPerm, cacheNameWithVGen, result, reason, lowerLayerList);
 		}
 	} else if (result->versionData.cacheType == J9PORT_SHR_CACHE_TYPE_NONPERSISTENT) {
 		if (isCompatibleLowerLayer && getLowerLayerStats) {
@@ -1034,6 +1031,8 @@ void
 SH_OSCache::initOSCacheHeader(OSCache_header_version_current* header, J9PortShcVersion* versionData, UDATA headerLen)
 {
 	Trc_SHR_OSC_initOSCacheHeader_Entry(header, versionData, headerLen);
+	PORT_ACCESS_FROM_PORT(_portLibrary);
+	UDATA success = 0;
 
 	memcpy(&(header->versionData), versionData, sizeof(J9PortShcVersion));
 	header->size = (U_32)_cacheSize;
@@ -1042,6 +1041,7 @@ SH_OSCache::initOSCacheHeader(OSCache_header_version_current* header, J9PortShcV
 	header->generation = (U_32)_activeGeneration;
 	header->buildID = getOpenJ9Sha();
 	header->cacheInitComplete = 0;
+	header->createTime = j9time_current_time_nanos(&success);
 
 	Trc_SHR_OSC_initOSCacheHeader_Exit();
 }
@@ -1334,11 +1334,16 @@ SH_OSCache::getOSCacheStart() {
 /**
  * Get the unique ID of the current cache
  * @param[in] currentThread  The current VM thread.
+ * @param [in] createtime The cache create time which is stored in OSCache_header2.
+ * @param[in] metadataBytes  The size of the metadata section of current oscache.
+ * @param[in] classesBytes  The size of the classes section of current oscache.
+ * @param[in] lineNumTabBytes  The size of the line number table section of current oscache.
+ * @param[in] varTabBytes  The size of the variable table section of current oscache.
  *
  * @return the cache unique ID
  */
 const char*
-SH_OSCache::getCacheUniqueID(J9VMThread* currentThread)
+SH_OSCache::getCacheUniqueID(J9VMThread* currentThread, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	if (NULL != _cacheUniqueID) {
@@ -1348,13 +1353,13 @@ SH_OSCache::getCacheUniqueID(J9VMThread* currentThread)
 	Trc_SHR_Assert_True(NULL != _cacheName);
 
 	U_32 cacheType = J9_ARE_ALL_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_PERSISTENT_CACHE) ? J9PORT_SHR_CACHE_TYPE_PERSISTENT : J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
-	UDATA sizeRequired = generateCacheUniqueID(currentThread, _cacheDirName, _cacheName, _layer, cacheType, NULL, 0);
+	UDATA sizeRequired = generateCacheUniqueID(currentThread, _cacheDirName, _cacheName, _layer, cacheType, NULL, 0, createtime, metadataBytes, classesBytes, lineNumTabBytes,varTabBytes);
 
 	_cacheUniqueID = (char*)j9mem_allocate_memory(sizeRequired, J9MEM_CATEGORY_VM);
 	if (NULL == _cacheUniqueID) {
 		return NULL;
 	}
-	generateCacheUniqueID(currentThread, _cacheDirName, _cacheName, _layer, cacheType, _cacheUniqueID, sizeRequired);
+	generateCacheUniqueID(currentThread, _cacheDirName, _cacheName, _layer, cacheType, _cacheUniqueID, sizeRequired, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
 	return _cacheUniqueID;
 }
 
@@ -1367,12 +1372,17 @@ SH_OSCache::getCacheUniqueID(J9VMThread* currentThread)
  * @param[in] cacheType  The cache type
  * @param[out] buf  The buffer for the cache unique ID
  * @param[out] bufLen  The length of the buffer
+ * @param[in] createtime The cache create time which is stored in OSCache_header2.
+ * @param[in] metadataBytes  The size of the metadata section of current oscache.
+ * @param[in] classesBytes  The size of the classes section of current oscache.
+ * @param[in] lineNumTabBytes  The size of the line number table section of current oscache.
+ * @param[in] varTabBytes  The size of the variable table section of current oscache.
  *
  * @return If buf is not NULL, the number of characters printed into buf is returned , not including the NUL terminator.
  *          If buf is NULL, the size of the buffer required to print to the unique ID, including the NUL terminator is returned.
  */
 UDATA
-SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDirName, const char* cacheName, I_8 layer, U_32 cacheType, char* buf, UDATA bufLen)
+SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDirName, const char* cacheName, I_8 layer, U_32 cacheType, char* buf, UDATA bufLen, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes)
 {
 	char nameWithVGen[J9SH_MAXPATH];
 	char cacheFilePathName[J9SH_MAXPATH];
@@ -1386,15 +1396,17 @@ SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDi
 	getCacheVersionAndGen(PORTLIB, vm, nameWithVGen, J9SH_MAXPATH, cacheName, &versionData, OSCACHE_CURRENT_CACHE_GEN, true, layer);
 	/* Directory is included here, so if the cache directory is renamed, caches with layer > 0 becomes unusable */
 	getCachePathName(PORTLIB, cacheDirName, cacheFilePathName, J9SH_MAXPATH, nameWithVGen);
-	I_64 timeStamp = j9file_lastmod(cacheFilePathName);
 	I_64 fileSize = j9file_length(cacheFilePathName);
-	return j9str_printf(PORTLIB, buf, bufLen, "%s-%llx_%llx", cacheFilePathName, fileSize, timeStamp);
+	if (NULL != buf) {
+		UDATA bufLenrequired = j9str_printf(PORTLIB, NULL, 0, "%s-%llx_%llx_%zx_%zx_%zx_%zx", cacheFilePathName, fileSize, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
+		Trc_SHR_Assert_True(bufLenrequired <= bufLen);
+	}
+	return j9str_printf(PORTLIB, buf, bufLen, "%s-%llx_%llx_%zx_%zx_%zx_%zx", cacheFilePathName, fileSize, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
 }
 
 /**
  * Get the cache name and layer number from the unique cache ID.
  * @param[in] vm  The Java VM.
- * @param[in] cacheDirName  The cache directory
  * @param[in] uniqueID  The cache unique ID
  * @param[in] idLen  The length of the cache unique ID
  * @param[out] nameBuf  The buffer for the cache name
@@ -1402,13 +1414,16 @@ SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDi
  * @param[out] layer  The layer number in the cache unique ID
  */
 void
-SH_OSCache::getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* cacheDirName, const char* uniqueID, UDATA idLen, char* nameBuf, UDATA nameBuffLen, I_8* layer)
+SH_OSCache::getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* uniqueID, UDATA idLen, char* nameBuf, UDATA nameBuffLen, I_8* layer)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	UDATA dirLen = strlen(cacheDirName);
-	const char* cacheNameWithVGenStart = uniqueID + dirLen;
-	char* cacheNameWithVGenEnd = strnrchrHelper(cacheNameWithVGenStart, '-', idLen - dirLen);
-	if (NULL == cacheNameWithVGenEnd) {
+	char versionStr[J9SH_VERSION_STRING_LEN +3];
+	J9PortShcVersion versionData;
+	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
+	J9SH_GET_VERSION_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData.esVersionMajor, versionData.esVersionMinor), versionData.modlevel, versionData.feature, versionData.addrmode);
+	const char* cacheNameWithVGenStart = strstr(uniqueID, versionStr);
+	char* cacheNameWithVGenEnd = strnrchrHelper(cacheNameWithVGenStart, '-', idLen - (cacheNameWithVGenStart - uniqueID));
+	if (NULL == cacheNameWithVGenStart || NULL == cacheNameWithVGenEnd) {
 		Trc_SHR_Assert_ShouldNeverHappen();
 	}
 
@@ -1416,7 +1431,6 @@ SH_OSCache::getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* cacheDirN
 	memset(nameWithVGenCopy, 0, J9SH_MAXPATH);
 	strncpy(nameWithVGenCopy, cacheNameWithVGenStart, cacheNameWithVGenEnd - cacheNameWithVGenStart);
 
-	J9PortShcVersion versionData;
 	getValuesFromShcFilePrefix(PORTLIB, nameWithVGenCopy, &versionData);
 	UDATA prefixLen = J9SH_VERSION_STRING_LEN + 1;
 	/* 

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -139,7 +139,8 @@ typedef struct OSCache_header2 {
 	U_32 cacheInitComplete;
 	U_64 buildID;
 	U_32 unused32[5];
-	U_64 unused64[5];
+	U_64 createTime;
+	U_64 unused64[4];
 } OSCache_header2;
 
 typedef OSCache_header2 OSCache_header_version_current;
@@ -208,11 +209,11 @@ public:
 	
 	static IDATA getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirName, char* buffer, UDATA bufferSize, const char* cacheNameWithVGen);
 	
-	static void getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* cacheDirName, const char* uniqueID, UDATA idLen, char* nameBuf, UDATA nameBuffLen, I_8* layer);
+	static void getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* uniqueID, UDATA idLen, char* nameBuf, UDATA nameBuffLen, I_8* layer);
 	
-	static UDATA generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDir, const char* cacheName, I_8 layer, U_32 cacheType, char* buf, UDATA bufLen);
+	static UDATA generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDir, const char* cacheName, I_8 layer, U_32 cacheType, char* buf, UDATA bufLen, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes);
 	
-	const char* getCacheUniqueID(J9VMThread* currentThread);
+	const char* getCacheUniqueID(J9VMThread* currentThread, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes);
 
 	I_8 getLayer();
 	
@@ -233,6 +234,7 @@ public:
 	virtual IDATA getReadWriteLockID(void) = 0;
 	virtual IDATA acquireWriteLock(UDATA lockid) = 0;
 	virtual IDATA releaseWriteLock(UDATA lockid) = 0;
+	virtual U_64 getCreateTime(void) = 0;
   	
 	virtual void *attach(J9VMThread* currentThread, J9PortShcVersion* expectedVersionData) = 0;
 

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -837,6 +837,18 @@ SH_OSCachemmap::releaseWriteLock(UDATA lockID)
 }
 
 /**
+ * Get the createTime from the OSCache_header2
+ * 
+ * @return the createTime
+ */
+U_64
+SH_OSCachemmap::getCreateTime()
+{
+	OSCachemmap_header_version_current *cacheHeader = (OSCachemmap_header_version_current *)_headerStart;
+	return cacheHeader->oscHdr.createTime; 
+}
+
+/**
  * Method to acquire the read lock on the cache attach region
  *
  * Needs to be able to work with all generations

--- a/runtime/shared_common/OSCachemmap.hpp
+++ b/runtime/shared_common/OSCachemmap.hpp
@@ -76,6 +76,7 @@ public:
 	virtual IDATA getReadWriteLockID(void);
 	virtual IDATA acquireWriteLock(UDATA lockID);
 	virtual IDATA releaseWriteLock(UDATA lockID);
+	virtual U_64 getCreateTime(void);
   	
 	virtual void runExitCode();
 	

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -1252,6 +1252,17 @@ SH_OSCachesysv::releaseWriteLock(UDATA lockID)
 	return rc;
 }
 
+/**
+ * Get the createTime from the OSCache_header2
+ * 
+ * @return the createTime
+ */
+U_64
+SH_OSCachesysv::getCreateTime() {
+	OSCachesysv_header_version_current* header = (OSCachesysv_header_version_current*)_headerStart;
+	return header->oscHdr.createTime;
+}
+
 IDATA
 SH_OSCachesysv::enterHeaderMutex(LastErrorInfo *lastErrorInfo)
 {

--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -131,6 +131,7 @@ public:
 	IDATA getReadWriteLockID(void);
 	IDATA acquireWriteLock(UDATA lockID);
 	IDATA releaseWriteLock(UDATA lockID);
+	U_64 getCreateTime(void);
   	
 	static IDATA getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char* cacheNameWithVGen, SH_OSCache_Info* cacheInfo, UDATA reason, J9Pool** lowerLayerList);
 	

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2951,8 +2951,8 @@ TraceEvent=Trc_SHR_CM_getPrereqCache_Found Overhead=1 Level=6 Template="CM::getP
 TraceEvent=Trc_SHR_CM_getPrereqCache_NotFound Overhead=1 Level=1 Template="CM::getPrereqCache(): This shared cache does not have a prerequisite cache"
 TraceException=Trc_SHR_CM_getPrereqCache_Failed_To_Start_Manager Overhead=1 Level=1 Template="CM::getPrereqCache(): Failed to startup the corresponding manager"
 TraceException=Trc_SHR_CM_getPrereqCache_Failed_To_Add_ID Overhead=1 Level=1 Template="CM::getPrereqCache(): Failed to add unique ID of prerequisite cache"
-TraceException=Trc_SHR_CM_getPrereqCache_Failed_To_Get_Manager Overhead=1 Level=1 Template="CM::getPrereqCache(): Failed to get the corresponding manger"
-TraceException=Trc_SHR_CM_getPrereqCache_Failed_To_Store_Prereq_UniqueID Overhead=1 Level=1 Template="CM::getPrereqCache(): Failed to store the prerequisite cache unique ID %.*s"
+TraceException=Trc_SHR_CM_getPrereqCache_Failed_To_Get_Manager Obsolete Overhead=1 Level=1 Template="CM::getPrereqCache(): Failed to get the corresponding manger"
+TraceException=Trc_SHR_CM_getPrereqCache_Failed_To_Store_Prereq_UniqueID Obsolete Overhead=1 Level=1 Template="CM::getPrereqCache(): Failed to store the prerequisite cache unique ID %.*s"
 TraceException=Trc_SHR_CC_verifyCacheUniqueID_Failed Overhead=1 Level=1 Template="CC verify Cache Unique ID Failed. The Expected ID is %s, the current ID is %s"
 TraceExit-Exception=Trc_SHR_CM_startup_Exit8 Overhead=1 Level=1 Template="CM startup: Cache Unique ID Verification Failed"
 TraceExit-Exception=Trc_SHR_CM_startup_Exit9 Overhead=1 Level=1 Template="CM startup: Failed to get prerequisite unqiue cache ID, error is %d"
@@ -2976,3 +2976,11 @@ TraceEntry=Trc_SHR_CC_startupNonTopLayerForStats_Entry Overhead=1 Level=9 Templa
 TraceExit=Trc_SHR_CC_startupNonTopLayerForStats_Exit Overhead=1 Level=9 Template="CC::startupNonTopLayerForStats: Exit retVal is %zd"
 TraceException=Trc_SHR_OSC_getAllCacheStatistics_pool_newElement_failed NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache::getAllCacheStatistics: (%d) Failed to get a new pool element"
 TraceException=Trc_SHR_CM_startupForStats_pool_newElement_failed Overhead=1 Level=1 Template="SH_CacheMap::startupForStats: Failed to get a new pool element"
+
+TraceException=Trc_SHR_CM_storeCacheUniqueID_Failed_To_Get_Manager Overhead=1 Level=1 Template="CM::storeCacheUniqueID(): Failed to get the corresponding manger"
+TraceException=Trc_SHR_CM_storeCacheUniqueID_Failed_To_Store_Prereq_UniqueID Overhead=1 Level=1 Template="CM::storeCacheUniqueID(): Failed to store the prerequisite cache unique ID %.*s"
+TraceEvent=Trc_SHR_CM_storeCacheUniqueID_generateCacheUniqueID_before Overhead=1 Level=7 Template="CM::storeCacheUniqueID(): generateCacheUniqueID() - (createTime: %llx, metadataBytes: %zx, classesBytes: %zx, lineNumTabBytes: %zx, varTabBytes: %zx) "
+TraceEvent=Trc_SHR_CM_storeCacheUniqueID_generateCacheUniqueID_after Overhead=1 Level=7 Template="CM::storeCacheUniqueID(): generateCacheUniqueID() - the generated cache unique ID is %.*s"
+
+TraceEvent=Trc_SHR_CC_startup_getCacheUniqueID_before Overhead=1 Level=7 Template="CC::startup(): getCacheUniqueID() - (createTime: %llx, metadataBytes: %zx, classesBytes: %zx, lineNumTabBytes: %zx, varTabBytes: %zx) "
+TraceEvent=Trc_SHR_CC_startup_getCacheUniqueID_after Overhead=1 Level=7 Template="CC::startup(): getCacheUniqueID() - the cache unique ID is %s"


### PR DESCRIPTION
1. Add the creation time to the OSCache_header2
2. Fix the CacheUniqueID by adding creation time, metadatabytes, classesbytes, linenumbertablebytes and variabletablebytes at the end
3. Add new Trace Events j9shr.2326-2329 for the CacheUniqueID

Fixes https://github.com/eclipse/openj9/issues/8096

Signed-off-by: Jiahan Xi <doomerXe@gmail.com>