### PR TITLE
Fix call to static method Thread.yield() to compile on Java 14

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/util/SyncThread.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/util/SyncThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,13 +60,13 @@ public class SyncThread extends Thread
             lock.notify();
         }
         while(!isInterrupted() && work()) {
-        	yield();
+        	Thread.yield();
         }
     }
         
     protected boolean work() 
     {
-        yield();
+        Thread.yield();
         return true;
     }
 }


### PR DESCRIPTION
Fixes #7773

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>