### PR TITLE
Runtime compressed refs work

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -293,12 +293,14 @@ JIT_HELPER(interpreterUnresolvedSpecialGlue);
 JIT_HELPER(interpreterUnresolvedStaticGlue);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
-JIT_HELPER(doAESInHardwareJit);
-JIT_HELPER(expandAESKeyInHardwareJit);
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+JIT_HELPER(doAESInHardwareJitFull);
+JIT_HELPER(expandAESKeyInHardwareJitFull);
+#endif /* defined(OMR_GC_FULL_POINTERS) */
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 JIT_HELPER(doAESInHardwareJitCompressed);
 JIT_HELPER(expandAESKeyInHardwareJitCompressed);
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 #endif
 
 JIT_HELPER(jitMonitorEnterReserved);
@@ -1101,17 +1103,19 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    //
 #if defined (TR_HOST_X86)
    SET(TR_isAESSupportedByHardware,    (void *) 0,                         TR_Helper);
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
    if (TR::Compiler->om.compressObjectReferences())
       {
       SET(TR_doAESInHardwareInner,        (void *) doAESInHardwareJitCompressed,        TR_Helper);
       SET(TR_expandAESKeyInHardwareInner, (void *) expandAESKeyInHardwareJitCompressed, TR_Helper);
       }
    else
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
       {
-      SET(TR_doAESInHardwareInner,        (void *) doAESInHardwareJit,        TR_Helper);
-      SET(TR_expandAESKeyInHardwareInner, (void *) expandAESKeyInHardwareJit, TR_Helper);
+#if defined(OMR_GC_FULL_POINTERS)
+      SET(TR_doAESInHardwareInner,        (void *) doAESInHardwareJitFull,        TR_Helper);
+      SET(TR_expandAESKeyInHardwareInner, (void *) expandAESKeyInHardwareJitFull, TR_Helper);
+#endif /* defined(OMR_GC_FULL_POINTERS) */
       }
 #elif defined (TR_HOST_POWER)
    SET(TR_PPCAESKeyExpansion, (void *) AESKeyExpansion_PPC, TR_Helper);


### PR DESCRIPTION
Use only the dedicated JIT compressed/full crypto helpers on X.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>