### PR TITLE
Remove KEEP_REPORTDIR param to pickup default value true

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -233,7 +233,6 @@ def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, NO
             string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),
             string(name: 'USER_CREDENTIALS_ID', value: USER_CREDENTIALS_ID),
             string(name: 'TEST_FLAG', value: TEST_FLAG),
-            string(name: 'KEEP_REPORTDIR', value: 'false'),
             string(name: 'BUILD_IDENTIFIER', value: BUILD_IDENTIFIER),
             booleanParam(name: 'IS_PARALLEL', value: IS_PARALLEL),
             string(name: 'EXTRA_OPTIONS', value: EXTRA_OPTIONS)])
@@ -258,7 +257,6 @@ def build_with_artifactory(JOB_NAME, NODE, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SH
             string(name: 'CUSTOMIZED_SDK_URL', value: CUSTOMIZED_SDK_URL),
             string(name: 'CUSTOMIZED_SDK_URL_CREDENTIAL_ID', value: ARTIFACTORY_CREDS),
             string(name: 'TEST_FLAG', value: TEST_FLAG),
-            string(name: 'KEEP_REPORTDIR', value: 'false'),
             string(name: 'BUILD_IDENTIFIER', value: BUILD_IDENTIFIER),
             booleanParam(name: 'IS_PARALLEL', value: IS_PARALLEL),
             string(name: 'EXTRA_OPTIONS', value: EXTRA_OPTIONS)])


### PR DESCRIPTION
- Don't delete test reports in order for JUnit plugin
  to correctly report number of tests run.
- Test side defaults it to true so not passing the value
  will pickup the default value.
- The JUnit test results, used for the openjdk regression
  suite, reports an inaccurate total number of tests
  becasue we delete resuls as we go to conserve space.
  Setting this value back to true will avoid this
  deletion and allow the plugin to correctly calculate
  the number of tests run. The side effect is that when
  there are unstable tests and the files are archived,
  the resulting tarball will be much larger.

Reverses #3689
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>