### PR TITLE
Stop caching nestMembers[] on j.l.Class

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -259,7 +259,6 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	}
 	
 /*[IF Java11]*/
-	/* Store the results of getNestHostImpl() and getNestMembersImpl() respectively */
 	private Class<?> nestHost;
 /*[ENDIF] Java11*/
 	

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -261,7 +261,6 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 /*[IF Java11]*/
 	/* Store the results of getNestHostImpl() and getNestMembersImpl() respectively */
 	private Class<?> nestHost;
-	private Class<?>[] nestMembers;
 /*[ENDIF] Java11*/
 	
 /**
@@ -4585,28 +4584,26 @@ public boolean isNestmateOf(Class<?> that) {
  */
 @CallerSensitive
 public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
-	if (nestMembers == null) {
-		nestMembers = getNestMembersImpl();
-	}
-	if (nestMembers.length == 1 && nestMembers[0] == this) {
-		/* This is a Class object that belongs to the nest consisting only of itself,
-		 * or a Class object representing array types, primitive types, or void.
+	if (isArray() || isPrimitive()) {
+		/* By spec, Class objects representing array types or primitive types
+		 * belong to the nest consisting only of itself.
 		 */
-	} else {
-		SecurityManager securityManager = System.getSecurityManager();
-		if (securityManager != null) {
-			/* All classes in a nest must be in the same runtime package and therefore same classloader */
-			ClassLoader nestMemberClassLoader = this.internalGetClassLoader();
-			ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
-			if (!doesClassLoaderDescendFrom(nestMemberClassLoader, callerClassLoader)) {
-				String nestMemberPackageName = this.getPackageName();
-				if ((nestMemberPackageName != null) && (nestMemberPackageName != "")) {
-					securityManager.checkPackageAccess(nestMemberPackageName);
-				}
+		return new Class<?>[] { this };
+	}
+	SecurityManager securityManager = System.getSecurityManager();
+	if (securityManager != null) {
+		/* All classes in a nest must be in the same runtime package and therefore same classloader */
+		ClassLoader nestMemberClassLoader = this.internalGetClassLoader();
+		ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
+		if (!doesClassLoaderDescendFrom(nestMemberClassLoader, callerClassLoader)) {
+			String nestMemberPackageName = this.getPackageName();
+			if ((nestMemberPackageName != null) && (nestMemberPackageName != "")) {
+				securityManager.checkPackageAccess(nestMemberPackageName);
 			}
 		}
 	}
-	return nestMembers;
+
+	return getNestMembersImpl();
 }
 /*[ENDIF] Java11 */
 

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1838,7 +1838,6 @@ Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv)
 	U_16 nestMemberCount = 0;
 	J9Class *jlClass = NULL;
 	J9Class *arrayClass = NULL;
-	J9Class *nestMember = NULL;
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
@@ -1882,7 +1881,7 @@ Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv)
 			J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8 *);
 
 			PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, resultObject);
-			nestMember = vmFuncs->internalFindClassUTF8(currentThread, J9UTF8_DATA(nestMemberName), J9UTF8_LENGTH(nestMemberName), classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+			J9Class *nestMember = vmFuncs->internalFindClassUTF8(currentThread, J9UTF8_DATA(nestMemberName), J9UTF8_LENGTH(nestMemberName), classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 			resultObject = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 
 			if (NULL == nestMember) {

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1847,7 +1847,6 @@ Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv)
 
 	if (NULL == nestHost) {
 		if (J9_VISIBILITY_ALLOWED != vmFuncs->loadAndVerifyNestHost(currentThread, clazz, 0)) {
-			nestMember = clazz;
 			goto _done;
 		}
 		nestHost = clazz->nestHost;


### PR DESCRIPTION
The code originally cached the nestMembers[] on the Class
object to avoid calling the JNI native to fetch them.

The code should have been clone()ing the array before handing
it out to users otherwise they can modify it.  Rather than
adding the clone call here, I've removed the caching of the
array as there are no callers of nestMembers() in the JDK.

From an access perspective, the nestHost is the interesting
value and the one worth caching.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>