### PR TITLE
Cache fileNameString on j.l.Class object during stacktrace generation & optimize Module lookup

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -166,6 +166,9 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	private transient ProtectionDomain protectionDomain;
 	private transient String classNameString;
 
+	/* Cache filename on Class to avoid repeated lookups / allocations in stack traces */
+	private transient String fileNameString;
+
 	private static final class AnnotationVars {
 		AnnotationVars() {}
 		static long annotationTypeOffset = -1;

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -91,7 +91,6 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 	J9MemoryManagerFunctions const * mmfns = vm->memoryManagerFunctions;
 	j9object_t element = NULL;
 	UDATA rc = TRUE;
-	J9Class* clazz = NULL;
 	const I_32 currentIndex = (I_32)userData->index;
 
 	/* If the stack trace is larger than the array, bail */
@@ -118,21 +117,36 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 		/* If there is a valid method at this frame, fill in the information for it in the StackTraceElement */
 
 		if (romMethod != NULL) {
+			J9UTF8 const * utfClassName = J9ROMCLASS_CLASSNAME(romClass);
 			J9UTF8 * utf = NULL;
 			j9object_t string = NULL;
 			UDATA j2seVersion = J2SE_VERSION(vm) & J2SE_VERSION_MASK;
+			J9Class* clazz = NULL;
 
 			PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, element);
+
+			/* Lookup the J9Class for this method if it can be found as it makes
+			 * a number of the remaining operations faster.  Code still needs to be
+			 * able to handle the case where the J9Class cannot be found
+			 */
+			if (NULL != classLoader) {
+				clazz = vmFuncs->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+				if (NULL != clazz) {
+					/* clazz can never be an array here as arrays can't define methods so we don't need to
+					* take them into account in the code below when writing the interned string back to
+					* the Class object.
+					*/
+					Assert_JCL_false(J9CLASS_IS_ARRAY(clazz));
+				}
+			}
 
 			/* Fill in module name and version */
 			if (j2seVersion >= J2SE_V11) {
 				J9Module *module = NULL;
-				U_8 *classNameUTF = NULL;
-				UDATA length = 0;
-				/* TODO: this can be null */
-				j9object_t classLoaderName = J9VMJAVALANGCLASSLOADER_CLASSLOADERNAME(vmThread, classLoader->classLoaderObject);
-
-				J9VMJAVALANGSTACKTRACEELEMENT_SET_CLASSLOADERNAME(vmThread, element, classLoaderName);
+				if (classLoader != NULL) {
+					j9object_t classLoaderName = J9VMJAVALANGCLASSLOADER_CLASSLOADERNAME(vmThread, classLoader->classLoaderObject);
+					J9VMJAVALANGSTACKTRACEELEMENT_SET_CLASSLOADERNAME(vmThread, element, classLoaderName);
+				}
 				if (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
 					string = mmfns->j9gc_createJavaLangString(vmThread, (U_8 *)JAVA_BASE_MODULE, LITERAL_STRLEN(JAVA_BASE_MODULE), J9_STR_XLAT);
 					if (string == NULL) {
@@ -152,11 +166,18 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 					element = PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0);
 					J9VMJAVALANGSTACKTRACEELEMENT_SET_MODULEVERSION(vmThread, element, string);
 				} else {
-					classNameUTF = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass));
-					length = packageNameLength(romClass);
-					omrthread_monitor_enter(vm->classLoaderModuleAndLocationMutex);
-					module = vmFuncs->findModuleForPackage(vmThread, classLoader, classNameUTF, (U_32) length);
-					omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
+					/* Fetch the J9Module from the j.l.Class->j.l.Module field if we have a class.
+					 * Otherwise the more painful package-based lookup must be performed
+					 */
+					if (clazz != NULL) {
+						j9object_t moduleObject = J9VMJAVALANGCLASS_MODULE(vmThread, clazz->classObject);
+						module = J9OBJECT_ADDRESS_LOAD(vmThread, moduleObject, vm->modulePointerOffset);
+					} else {
+						UDATA length = packageNameLength(romClass);
+						omrthread_monitor_enter(vm->classLoaderModuleAndLocationMutex);
+						module = vmFuncs->findModuleForPackage(vmThread, classLoader, J9UTF8_DATA(utfClassName), (U_32) length);
+						omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
+					}
 
 					if (NULL != module) {
 						J9VMJAVALANGSTACKTRACEELEMENT_SET_MODULENAME(vmThread, element, module->moduleName);
@@ -166,26 +187,17 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 			}
 
 			/* Fill in method class */
-			utf = J9ROMCLASS_CLASSNAME(romClass);
 			string = NULL;
 			{
-				if (NULL != classLoader) {
-					clazz = vmFuncs->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utf), J9UTF8_LENGTH(utf));
-					if (NULL != clazz) {
-						/* clazz can never be an array here as arrays can't define methods so we don't need to
-						 * take them into account in the code below when writing the interned string back to
-						 * the Class object.
-						 */
-						Assert_JCL_false(J9CLASS_IS_ARRAY(clazz));
-						string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
-					}
+				if (NULL != clazz) {
+					string = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 				}
 				if (NULL == string) {
 					UDATA flags = J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN;
 					if (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)) {
 						flags |= J9_STR_ANON_CLASS_NAME;
 					}
-					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), flags);
+					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utfClassName), (U_32) J9UTF8_LENGTH(utfClassName), flags);
 					if (NULL == string) {
 						rc = FALSE;
 						/* exception is pending from the call */

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -213,10 +213,9 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * r
 				J9VMJAVALANGSTACKTRACEELEMENT_SET_DECLARINGCLASS(vmThread, element, string);
 			}
 
-			/* Fill in method name */
-
+			/* Fill in method name - intern the string as it's also interned by the StackWalker API and by Reflection */
 			utf = J9ROMMETHOD_NAME(romMethod);
-			string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), 0);
+			string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utf), (U_32) J9UTF8_LENGTH(utf), J9_STR_TENURE | J9_STR_INTERN);
 			if (string == NULL) {
 				rc = FALSE;
 				/* exception is pending from the call */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -141,6 +141,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/Class" name="initializationLock" signature="Ljava/lang/J9VMInternals$ClassInitializationLock;"/>
 	<fieldref class="java/lang/Class" name="protectionDomain" signature="Ljava/security/ProtectionDomain;"/>
 	<fieldref class="java/lang/Class" name="classNameString" signature="Ljava/lang/String;"/>
+	<fieldref class="java/lang/Class" name="fileNameString" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/Class" name="annotationCache" signature="Ljava/lang/Class$AnnotationCache;"/>
 	<fieldref class="java/lang/Class" name="module" signature="Ljava/lang/Module;" flags="opt_module" versions="9-"/>
 	<fieldref class="java/lang/Class" name="methodHandleCache" signature="Ljava/lang/Object;" flags="opt_methodHandle"/>


### PR DESCRIPTION
When converting the array of saved PCs into a StackTraceElement[],
we spend a lot of time allocating filename strings.  The same string
may be allocated multiple times.

Previously, the code was optimized to avoid allocations when two
subsequent PCs were from the same file.

This change corrects some bugs in that code and further caches the
filename directly on the j.l.Class.  This catches both the case
where the class has already allocated a filename while still
reusing previously allocated filenames.

The later case is most relevant to multiple classes that have been
allocated in the same file.

related: #7776

This may increase heap pressure as strings are long lived

Also, re-arrange the code so the J9Class is looked up earlier and
can be used for more operations.  In particular, use it
to optimzie the j.l.Class->j.l.Module->J9Module lookup to
avoid the packageNameLength calculation and locking aroound
the module-related hashtable.

Also, fix the potential null dereference of the classlaoader.

Intern method names when generating StackTraceElements.

Method names are already interned by Reflection and by the
new StackWalker API (JDK11).  Match that behaviour here and
avoid repeated allocations of similar names.

Apply stacktrace generation opts to StackWalker 