### PR TITLE
master: Apply #311 to Java 8

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -3836,16 +3836,8 @@ private class MethodInfo {
 
 static boolean methodAOverridesMethodB(Class<?> methodAClass,	boolean methodAIsAbstract, boolean methodAClassIsInterface,
 		Class<?> methodBClass, boolean methodBIsAbstract, boolean methodBClassIsInterface) {
-	return (methodBIsAbstract && methodBClassIsInterface && !methodAIsAbstract && !methodAClassIsInterface) ||
-			(methodBClass.isAssignableFrom(methodAClass)
-					/*[IF !Sidecar19-SE]*/
-					/*
-					 * In Java 8, abstract methods in subinterfaces do not hide abstract methods in superinterfaces.
-					 * This is fixed in Java 9.
-					 */
-					&& (!methodAClassIsInterface || !methodAIsAbstract)
-					/*[ENDIF]*/
-					);
+	return (methodBIsAbstract && methodBClassIsInterface && !methodAIsAbstract && !methodAClassIsInterface) 
+		|| (methodBClass.isAssignableFrom(methodAClass));
 }
 
 /*[PR 125873] Improve reflection cache */

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetMethodsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetMethodsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,6 @@ public class GetMethodsTests {
 	private static final String EXAMPLE_CLASS = "org.openj9.test.reflect.ExampleClass."; //$NON-NLS-1$
 	
 	public static final Logger logger = Logger.getLogger(GetMethodsTests.class);
-	private final static boolean isJava8 = System.getProperty("java.specification.version").equals("1.8");  //$NON-NLS-1$//$NON-NLS-2$
 
 	private AsmLoader loader;
 
@@ -119,21 +118,9 @@ public class GetMethodsTests {
 	static HashMap<String, String[]> makeMethodLists() {
 		/* 
 		 * Class.getMethods() erroneously included methods in superinterfaces which are
-		 * overridden in subinterfaces.  This has been corrected in Java 9.
+		 * overridden in subinterfaces.  This has been corrected as of Java 8 151.
 		 */
-		String[] methodList_C_I_SupDuperSupA = isJava8? new String[] {
-				"org.openj9.test.reflect.SuperA.abstractInSuperA_abstractInSuperDuper()void",
-				"org.openj9.test.reflect.SuperA.abstractInSuperA_defaultInSuperDuper()void",
-				"org.openj9.test.reflect.SuperA.defaultInSuperA_abstractInSuperDuper()void",
-				"org.openj9.test.reflect.SuperA.defaultInSuperA_defaultInSuperDuper()void",
-				/* 
-				 * include these because of a known issue in Java 8:
-				 * JDK-8029459 (reflect) getMethods returns methods that are not members of the class
-				 */
-				"org.openj9.test.reflect.SuperDuper.abstractInSuperA_abstractInSuperDuper()void",
-				"org.openj9.test.reflect.SuperDuper.abstractInSuperA_defaultInSuperDuper()void" 
-				}:
-			new String[] {
+		String[] methodList_C_I_SupDuperSupA = new String[] {
 					"org.openj9.test.reflect.SuperA.abstractInSuperA_abstractInSuperDuper()void",
 					"org.openj9.test.reflect.SuperA.abstractInSuperA_defaultInSuperDuper()void",
 					"org.openj9.test.reflect.SuperA.defaultInSuperA_abstractInSuperDuper()void",

--- a/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -296,7 +296,6 @@ public class Test_Class {
 		String[] expected_CD = new String[] {
 				"CD.method_N(java.lang.String)",
 				"IA.method_M(java.lang.String)",
-				"IA.method_L(java.lang.String)",
 				"IC.method_L(java.lang.String)",
 				"IB.method_M(java.lang.String)" };
 		Method[] methodNames_CD = CD.class.getMethods();
@@ -313,7 +312,6 @@ public class Test_Class {
 		}
 
 		String[] expected_CF = new String[] {
-				"IA.method_L(java.lang.String)",
 				"IA.method_M(java.lang.String)",
 				"CF.method_N(java.lang.String)",
 				"IC.method_L(java.lang.String)",
@@ -527,6 +525,21 @@ public class Test_Class {
 				InterfaceTestClasses.SuperClass.class,
 				InterfaceTestClasses.SubClass.class };
 		HashMap<Class, String[]> expectedMethods = new HashMap<>();
+		/*
+		* As of Java 8 151, method declarations in subinterfaces hide declarations of the same method in superinterfaces.
+		* This means that the following methods are not inherited by implementors of M3:
+		* InterfaceTestClasses$I1.m1
+		* InterfaceTestClasses$I1.m2
+		* InterfaceTestClasses$I1.m3
+		* InterfaceTestClasses$I2.m1
+		* InterfaceTestClasses$I2.m2
+		* InterfaceTestClasses$I2.m3
+		*/
+		final String[] interfaceMethodList = concatenateObjectMethods(new String [] {
+			specimenPackage+".InterfaceTestClasses$I3.m1()void",
+			specimenPackage+".InterfaceTestClasses$I3.m2()void",
+			specimenPackage+".InterfaceTestClasses$I3.m3()void"
+		});
 		expectedMethods.put(testClasses[0],
 				new String[] {
 						specimenPackage + ".InterfaceTestClasses$I1.m1()void",
@@ -543,38 +556,11 @@ public class Test_Class {
 						specimenPackage + ".InterfaceTestClasses$I3.m2()void",
 						specimenPackage + ".InterfaceTestClasses$I3.m3()void" });
 		expectedMethods.put(testClasses[3],
-				concatenateObjectMethods(new String[] {
-						specimenPackage + ".InterfaceTestClasses$I1.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I1.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I1.m3()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m3()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m3()void" }));
+				interfaceMethodList);
 		expectedMethods.put(testClasses[4],
-				concatenateObjectMethods(new String[] {
-						specimenPackage + ".InterfaceTestClasses$I1.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I1.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I1.m3()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m3()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m3()void" }));
+				interfaceMethodList);
 		expectedMethods.put(testClasses[5],
-				concatenateObjectMethods(new String[] {
-						specimenPackage + ".InterfaceTestClasses$I1.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I1.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I1.m3()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I2.m3()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m1()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m2()void",
-						specimenPackage + ".InterfaceTestClasses$I3.m3()void" }));
+				interfaceMethodList);
 		compareMethods(testClasses, expectedMethods);
 	}
 
@@ -588,22 +574,19 @@ public class Test_Class {
 				SuperA.class,
 				SuperDuper.class };
 		HashMap<Class, String[]> expectedMethods = new HashMap<>();
-		expectedMethods.put(testClasses[0],
-				concatenateObjectMethods(new String[] {
-						specimenPackage + ".SuperA.abstractInSuperA_abstractInSuperDuper()void",
-						specimenPackage + ".SuperA.abstractInSuperA_defaultInSuperDuper()void",
-						specimenPackage + ".SuperA.defaultInSuperA_abstractInSuperDuper()void",
-						specimenPackage + ".SuperA.defaultInSuperA_defaultInSuperDuper()void",
-						specimenPackage + ".SuperDuper.abstractInSuperA_abstractInSuperDuper()void",
-						specimenPackage + ".SuperDuper.abstractInSuperA_defaultInSuperDuper()void" }));
-		expectedMethods.put(testClasses[1],
-				concatenateObjectMethods(new String[] {
-						specimenPackage + ".SuperA.abstractInSuperA_abstractInSuperDuper()void",
-						specimenPackage + ".SuperA.abstractInSuperA_defaultInSuperDuper()void",
-						specimenPackage + ".SuperA.defaultInSuperA_abstractInSuperDuper()void",
-						specimenPackage + ".SuperA.defaultInSuperA_defaultInSuperDuper()void",
-						specimenPackage + ".SuperDuper.abstractInSuperA_abstractInSuperDuper()void",
-						specimenPackage + ".SuperDuper.abstractInSuperA_defaultInSuperDuper()void" }));
+		/*
+		* As of Java 8 151, method declarations in subinterfaces hide declarations of the same method in superinterfaces.
+		* This means that the following methods are now hidden in implementors of SuperA:
+		* SuperDuper.abstractInSuperA_abstractInSuperDuper()
+		* SuperDuper.abstractInSuperA_defaultInSuperDuper()
+		*/
+		final String[] interfaceMethodList = concatenateObjectMethods(new String [] {
+			specimenPackage+".SuperA.abstractInSuperA_abstractInSuperDuper()void",
+			specimenPackage+".SuperA.abstractInSuperA_defaultInSuperDuper()void",
+			specimenPackage+".SuperA.defaultInSuperA_abstractInSuperDuper()void",
+			specimenPackage+".SuperA.defaultInSuperA_defaultInSuperDuper()void"});
+		expectedMethods.put(testClasses[0], interfaceMethodList);
+		expectedMethods.put(testClasses[1], interfaceMethodList);
 		expectedMethods.put(testClasses[2],
 				concatenateObjectMethods(new String[] {
 						specimenPackage + ".SuperA.abstractInSuperA_abstractInSuperDuper()void",

--- a/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
@@ -273,7 +273,7 @@ public void test_getMethods_subtest1() {
 		AssertJUnit.assertTrue("Expected method " + expected_IC[i] + " not found.", match);
 	}
 
-	/* as of Java 9, IC.method_L() masks IA.method_L() */
+	/* as of Java 8 151, IC.method_L() masks IA.method_L() */
 	String[]	expected_CD = new String[] {
 			"CD.method_N(java.lang.String)",
 			"IA.method_M(java.lang.String)",
@@ -444,7 +444,7 @@ public void testInterfaceMethodInheritance() {
 	HashMap<Class, String[]> expectedMethods = new HashMap<>();
 	
 	/*
-	 * As of Java 9, method declarations in subinterfaces hide declarations of the same method in superinterfaces.
+	 * As of Java 8 151, method declarations in subinterfaces hide declarations of the same method in superinterfaces.
 	 * This means that the following methods are not inherited by implementers of M3:
 	 * InterfaceTestClasses$I1.m1
 	 * InterfaceTestClasses$I1.m2
@@ -501,7 +501,7 @@ public void testDefaultMethodInheritance() {
 	Class testClasses[] = new Class[] {C_CSuperA_SuperDuper.class, C_I_SupDuperSupA.class, C_SuperA.class, I_SupDuper_SupA.class, SuperA.class, SuperDuper.class};
 	HashMap<Class, String[]> expectedMethods = new HashMap<>();
 	/*
-	 * As of Java 9, method declarations in subinterfaces hide declarations of the same method in superinterfaces.
+	 * As of Java 8 151, method declarations in subinterfaces hide declarations of the same method in superinterfaces.
 	 * This means that the following methods are now hidden in implementers of SuperA:
 	 * SuperDuper.abstractInSuperA_abstractInSuperDuper()
 	 * SuperDuper.abstractInSuperA_defaultInSuperDuper()


### PR DESCRIPTION
Part 1 for: https://github.com/eclipse/openj9/issues/7623
Applies https://github.com/eclipse/openj9/pull/311 to Java 8

- Ensure interface abstract method are overridden by subinterface for Java 8, this Java language spec change started for Java 8 151.
- Update functional tests

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>