### PR TITLE
Fix max size reporting issue for Large Object Area

### DIFF
--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -545,7 +545,7 @@ j9gc_pool_maxmemory(J9JavaVM *javaVM, UDATA poolID)
 			MM_MemorySubSpace *tenureMemorySubspace = defaultMemorySpace->getTenureMemorySubSpace();
 			MM_MemoryPoolLargeObjects *memoryPool = (MM_MemoryPoolLargeObjects *) tenureMemorySubspace->getMemoryPool();
 			UDATA loaSize = (UDATA) (memoryPool->getLOARatio() * extensions->maxOldSpaceSize);
-			loaSize = MM_Math::roundToFloor(extensions->heapAlignment, loaSize);
+			loaSize = MM_Math::roundToCeiling(extensions->heapAlignment, loaSize);
 			maxsize = extensions->maxOldSpaceSize - loaSize;
 		}
 		break;
@@ -555,7 +555,7 @@ j9gc_pool_maxmemory(J9JavaVM *javaVM, UDATA poolID)
 			MM_MemorySubSpace *tenureMemorySubspace = defaultMemorySpace->getTenureMemorySubSpace();
 			MM_MemoryPoolLargeObjects *memoryPool = (MM_MemoryPoolLargeObjects *) tenureMemorySubspace->getMemoryPool();
 			UDATA loaSize = (UDATA) (memoryPool->getLOARatio() * extensions->maxOldSpaceSize);
-			loaSize = MM_Math::roundToFloor(extensions->heapAlignment, loaSize);
+			loaSize = MM_Math::roundToCeiling(extensions->heapAlignment, loaSize);
 			maxsize = loaSize;
 		}
 		break;


### PR DESCRIPTION
	Update calculating max size for MemoryPool LOA, alignment
	the size with heapAlignment to ceiling instead of floor to match
	PR omr#4451
	The issue could potentially cause the Exception (in thread
	 "MemoryMXBean notification dispatcher"
	 java.lang.IllegalArgumentException: committed value cannot
	 be larger than the max value)

Signed-off-by: Lin Hu <linhu@ca.ibm.com>