### PR TITLE
Override needRelocationsForLookupEvaluationData

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4712,6 +4712,11 @@ J9::CodeGenerator::needClassAndMethodPointerRelocations()
    return self()->fej9()->needClassAndMethodPointerRelocations();
    }
 
+bool
+J9::CodeGenerator::needRelocationsForLookupEvaluationData()
+   {
+   return self()->fej9()->needRelocationsForLookupEvaluationData();
+   }
 
 bool
 J9::CodeGenerator::needRelocationsForStatics()

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -171,6 +171,7 @@ public:
                                           TR::Node *node);
 
    bool needClassAndMethodPointerRelocations();
+   bool needRelocationsForLookupEvaluationData();
    bool needRelocationsForStatics();
    bool needRelocationsForHelpers();
 #if defined(JITSERVER_SUPPORT)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -286,6 +286,7 @@ public:
    virtual bool needRelocationsForStatics() { return false; }
    virtual bool needRelocationsForBodyInfoData() { return false; }
    virtual bool needRelocationsForPersistentInfoData() { return false; }
+   virtual bool needRelocationsForLookupEvaluationData() { return false; }
    virtual bool nopsAlsoProcessedByRelocations() { return false; }
 
    bool supportsContextSensitiveInlining () { return true; }
@@ -1146,6 +1147,7 @@ public:
    virtual bool               supportsEmbeddedHeapBounds()                    { return false; }
    virtual bool               supportsFastNanoTime()                          { return false; }
    virtual bool               needRelocationsForStatics()                     { return true; }
+   virtual bool               needRelocationsForLookupEvaluationData()        { return true; }
    virtual bool               needRelocationsForBodyInfoData()                { return true; }
    virtual bool               needRelocationsForPersistentInfoData()          { return true; }
    virtual bool               forceUnresolvedDispatch()                       { return true; }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -53,6 +53,7 @@ public:
    virtual bool canDevirtualizeDispatch() override                       { return true; }
    virtual bool needRelocationsForBodyInfoData() override                { return true; }
    virtual bool needRelocationsForPersistentInfoData() override          { return true; }
+   virtual bool needRelocationsForLookupEvaluationData() override        { return true; }
    virtual void markHotField(TR::Compilation *, TR::SymbolReference *, TR_OpaqueClassBlock *, bool) override { return; }
    virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT) override;
    virtual bool isClassLibraryClass(TR_OpaqueClassBlock *clazz) override;
@@ -218,6 +219,7 @@ public:
    virtual bool       supportsEmbeddedHeapBounds() override                    { return false; }
    virtual bool       supportsFastNanoTime() override                          { return false; }
    virtual bool       needRelocationsForStatics() override                     { return true; }
+   virtual bool       needRelocationsForLookupEvaluationData() override        { return true; }
    virtual bool       needRelocationsForBodyInfoData() override                { return true; }
    virtual bool       needRelocationsForPersistentInfoData() override          { return true; }
    virtual bool       forceUnresolvedDispatch() override                       { return true; }


### PR DESCRIPTION
This commit overrides the needRelocationsForLookupEvaluationData query found in the OMR codegenerator. The query is used to decide if a reloction record is needed when generating code for the lookup IL in power's code generator (it is needed for AOT and Remote compiles). Since OMR is not aware of remote compilations, overriding the query here will allow Openj9 to make a decision on whether a relocation record is needed.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>