### PR TITLE
Refactoring of TR::ternary opcodes to TR::select

### DIFF
--- a/runtime/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddRegStore
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::deRegStore
 
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deternary
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deselect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfexp
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddexp

--- a/runtime/compiler/arm/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/arm/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddRegStore
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::deRegStore
 
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deternary
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deselect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfexp
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddexp

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -447,13 +447,13 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::bRegStore
    NULL,          // TR::GlRegDeps
 
-   NULL,          // TR::iternary
-   NULL,          // TR::lternary
-   NULL,          // TR::bternary
-   NULL,          // TR::sternary
-   NULL,          // TR::aternary
-   NULL,          // TR::fternary
-   NULL,          // TR::dternary
+   NULL,          // TR::iselect
+   NULL,          // TR::lselect
+   NULL,          // TR::bselect
+   NULL,          // TR::sselect
+   NULL,          // TR::aselect
+   NULL,          // TR::fselect
+   NULL,          // TR::dselect
    NULL,          // TR::treetop
    NULL,          // TR::MethodEnterHook
    NULL,          // TR::MethodExitHook
@@ -491,7 +491,7 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::vicmpanyle
 
    NULL,          // TR::vnot
-   NULL,          // TR::vselect
+   NULL,          // TR::vbitselect
    NULL,          // TR::vperm
 
    NULL,          // TR::vsplats
@@ -564,7 +564,7 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::vreturn
    NULL,          // TR::vcall
    NULL,          // TR::vcalli
-   NULL,          // TR::vternary
+   NULL,          // TR::vselect
    NULL,          // TR::v2v
    NULL,          // TR::vl2vd
    NULL,          // TR::vconst
@@ -1072,9 +1072,9 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::ddRegStore
    NULL,          // TR::deRegStore
 
-   NULL,          // TR::dfternary
-   NULL,          // TR::ddternary
-   NULL,          // TR::deternary
+   NULL,          // TR::dfselect
+   NULL,          // TR::ddselect
+   NULL,          // TR::deselect
 
    NULL,          // TR::dfexp
    NULL,          // TR::ddexp

--- a/runtime/compiler/il/ILOpCodeProperties.hpp
+++ b/runtime/compiler/il/ILOpCodeProperties.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3293,10 +3293,10 @@
    },
 
    {
-   /* .opcode               = */ TR::dfternary,
-   /* .name                 = */ "dfternary",
+   /* .opcode               = */ TR::dfselect,
+   /* .name                 = */ "dfselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::DecimalFloat,
@@ -3309,10 +3309,10 @@
    },
 
    {
-   /* .opcode               = */ TR::ddternary,
-   /* .name                 = */ "ddternary",
+   /* .opcode               = */ TR::ddselect,
+   /* .name                 = */ "ddselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::DecimalDouble,
@@ -3325,10 +3325,10 @@
    },
 
    {
-   /* .opcode               = */ TR::deternary,
-   /* .name                 = */ "deternary",
+   /* .opcode               = */ TR::deselect,
+   /* .name                 = */ "deselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::DecimalLongDouble,

--- a/runtime/compiler/il/J9ILOpCodesEnum.hpp
+++ b/runtime/compiler/il/J9ILOpCodesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,10 +245,10 @@
    ddRegStore,  // Store decimal double global register
    deRegStore,  // Store decimal long double global register
 
-   dfternary,   // Ternary Operator:  Based on the result of the first child, take the value of the
+   dfselect,   // Select Operator:  Based on the result of the first child, take the value of the
                 // second or the third child.  Analogous to the "condition ? a : b" operations in C/Java.
-   ddternary,   //
-   deternary,   //
+   ddselect,   //
+   deselect,   //
 
    dfexp,       // decimal float exponent
    ddexp,       // decimal double exponent

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3278,10 +3278,10 @@ TR_J9ByteCodeIlGenerator::genOrFindAdjunct(TR::Node* node)
    else
       {
       // expect that adjunct part is third child of node
-      TR_ASSERT(node->isDualHigh() || node->isTernaryHigh(),
-             "this node should be a dual or ternary, where the adjunct part of the answer is in the third child");
+      TR_ASSERT(node->isDualHigh() || node->isSelectHigh(),
+             "this node should be a dual or select, where the adjunct part of the answer is in the third child");
       adjunct = node->getChild(2);
-      if (node->isTernaryHigh())
+      if (node->isSelectHigh())
          {
          adjunct = adjunct->getFirstChild();
          }
@@ -6519,14 +6519,14 @@ TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
 void
 TR_J9ByteCodeIlGenerator::storeDualAuto(TR::Node * storeValue, int32_t slot)
    {
-   TR_ASSERT(storeValue->isDualHigh() || storeValue->isTernaryHigh(), "Coerced types only happen when a dual or ternary operator is generated.");
+   TR_ASSERT(storeValue->isDualHigh() || storeValue->isSelectHigh(), "Coerced types only happen when a dual or select operator is generated.");
 
    // type may need to be coerced from TR::Address into the type of the value being stored
    TR::DataType type = storeValue->getDataType();
 
    // generate the two stores for the storeValue and its adjunct.
    TR::Node* adjunctValue = storeValue->getChild(2);
-   if (storeValue->isTernaryHigh())
+   if (storeValue->isSelectHigh())
       {
       adjunctValue = adjunctValue->getFirstChild();
       }
@@ -6554,7 +6554,7 @@ TR_J9ByteCodeIlGenerator::storeAuto(TR::DataType type, int32_t slot, bool isAdju
       }
 
    symRef = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, slot, type, true, false, true, isAdjunct);
-   if (storeValue->isDualHigh() || storeValue->isTernaryHigh() || isAdjunct)
+   if (storeValue->isDualHigh() || storeValue->isSelectHigh() || isAdjunct)
       symRef->setIsDual();
 
    bool isStatic = _methodSymbol->isStatic();

--- a/runtime/compiler/optimizer/AllocationSinking.cpp
+++ b/runtime/compiler/optimizer/AllocationSinking.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@ int32_t TR_AllocationSinking::perform()
    if (comp()->getOptions()->realTimeGC()) // memory area can be changed by the arg eval call, so better not disturb things
       return 0;
 
-   // Note: if the evaluation of constructor arguments contains control flow (ie. a ternary)
+   // Note: if the evaluation of constructor arguments contains control flow (ie. a select)
    // then the "new" and ctor call will be in different blocks, and this opt won't have the
    // desired effect.
 

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -475,49 +475,49 @@ class TR_EscapeAnalysis : public TR::Optimization
    bool     checkDefsAndUses(TR::Node *node, Candidate *candidate);
 
    /**
-    * Walk through trees looking for \c aternary operations.  For the
-    * value operands of an \c aternary, populate \ref _nodeUsesThroughAternary
+    * Walk through trees looking for \c aselect operations.  For the
+    * value operands of an \c aselect, populate \ref _nodeUsesThroughAselect
     * with an entry mapping from the operand to a list containing the
-    * \c aternary nodes that refer to it.
+    * \c aselect nodes that refer to it.
     *
-    * \see _nodeUsesThroughAternary
+    * \see _nodeUsesThroughAselect
     */
-   void     gatherUsesThroughAternary(void);
+   void     gatherUsesThroughAselect(void);
 
    /**
-    * Recursive implementation method for \ref gatherUsesThroughAternary
+    * Recursive implementation method for \ref gatherUsesThroughAselect
     *
     * \param[in] node The root of the subtree that is to be processed
     * \param[inout] visited A bit vector indicating whether a node has
     *                       already been visited
     */
-   void     gatherUsesThroughAternaryImpl(TR::Node *node, TR::NodeChecklist& visited);
+   void     gatherUsesThroughAselectImpl(TR::Node *node, TR::NodeChecklist& visited);
 
    /**
-    * Add an entry to \ref _nodeUsesThroughAternary mapping from the child node
-    * of \c aternaryNode at the specified index to the \c aternaryNode itself.
+    * Add an entry to \ref _nodeUsesThroughAselect mapping from the child node
+    * of \c aselectNode at the specified index to the \c aselectNode itself.
     *
-    * \param[in] aternaryNode A node whose opcode is an \c aternary operation
-    * \param[in] idx The index of a child of \c aternaryNode
+    * \param[in] aselectNode A node whose opcode is an \c aselect operation
+    * \param[in] idx The index of a child of \c aselectNode
     */
-   void     associateAternaryWithChild(TR::Node *aternaryNode, int32_t idx);
+   void     associateAselectWithChild(TR::Node *aselectNode, int32_t idx);
 
    /**
-    * Trace contents of \ref _nodeUsesThroughAternary
+    * Trace contents of \ref _nodeUsesThroughAselect
     */
-   void     printUsesThroughAternary(void);
+   void     printUsesThroughAselect(void);
 
    /**
     * Check whether \c node, which is a use of the candidate for stack
     * allocation, \c candidate, is itself used as one of the value operands
-    * in an \c aternary operation, as found in \ref _nodeUsesThroughAternary.
-    * If it is, the value number of any such \c aternary is added to the list
+    * in an \c aselect operation, as found in \ref _nodeUsesThroughAselect.
+    * If it is, the value number of any such \c aselect is added to the list
     * of value numbers associated with the candidate.
     *
     * \param[in] node The use of \c candidate that is under consideration
     * \param[in] candidate A candidate for stack allocation
     */
-   bool     checkUsesThroughAternary(TR::Node *node, Candidate *candidate);
+   bool     checkUsesThroughAselect(TR::Node *node, Candidate *candidate);
    bool     checkOtherDefsOfLoopAllocation(TR::Node *useNode, Candidate *candidate, bool isImmediateUse);
    bool     checkOverlappingLoopAllocation(TR::Node *useNode, Candidate *candidate);
    bool     checkOverlappingLoopAllocation(TR::Node *node, TR::Node *useNode, TR::Node *allocNode, rcount_t &numReferences);
@@ -737,10 +737,10 @@ class TR_EscapeAnalysis : public TR::Optimization
    typedef std::map<TR::Node*, NodeDeque*, NodeComparator, NodeToNodeDequeMapAllocator> NodeToNodeDequeMap;
 
    /**
-    * A mapping from nodes to a \c deque of \c aternary nodes that directly
+    * A mapping from nodes to a \c deque of \c aselect nodes that directly
     * reference them.
     */
-   NodeToNodeDequeMap *       _nodeUsesThroughAternary;
+   NodeToNodeDequeMap *       _nodeUsesThroughAselect;
 
    friend class TR_FlowSensitiveEscapeAnalysis;
    friend class TR_LocalFlushElimination;

--- a/runtime/compiler/optimizer/J9SimplifierTableEnum.hpp
+++ b/runtime/compiler/optimizer/J9SimplifierTableEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -243,9 +243,9 @@
    dftSimplifier,               // TR::ddRegStore
    dftSimplifier,               // TR::deRegStore
 
-   dftSimplifier,               // TR::dfternary
-   dftSimplifier,               // TR::ddternary
-   dftSimplifier,               // TR::deternary
+   dftSimplifier,               // TR::dfselect
+   dftSimplifier,               // TR::ddselect
+   dftSimplifier,               // TR::deselect
 
    dftSimplifier,               // TR::dfexp
    dftSimplifier,               // TR::ddexp

--- a/runtime/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddRegStore
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::deRegStore
 
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deternary
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deselect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfexp
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddexp

--- a/runtime/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddRegStore
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::deRegStore
 
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deternary
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deselect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfexp
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddexp

--- a/runtime/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddRegStore
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::deRegStore
 
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddternary
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deternary
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddselect
+   TR::TreeEvaluator::unImpOpEvaluator,          // TR::deselect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::dfexp
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::ddexp

--- a/runtime/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,9 +245,9 @@
    TR::TreeEvaluator::dRegStoreEvaluator,   // TR::ddRegStore
    TR::TreeEvaluator::deRegStoreEvaluator,  // TR::deRegStore
 
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::dfternary
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::ddternary
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::deternary
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::dfselect
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::ddselect
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::deselect
 
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::dfexp
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::ddexp


### PR DESCRIPTION
Refactoring of TR::ternary opcodes to TR::select

Replacing of the ternary OpCodes such as TR::bternary etc. to
TR::bselect etc. respectively.

Replaced the ternary OpCodes such as TR::aternary etc. to
TR::aselect etc. respectively.

Related OMR PR: eclipse/omr#4578

Partially Resolves: Issue eclipse/omr#681

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>