### PR TITLE
Override CG query to decide when to emit data

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -123,7 +123,20 @@ J9::Power::CodeGenerator::CodeGenerator() :
 
    }
 
-
+bool
+J9::Power::CodeGenerator::canEmitDataForExternallyRelocatableInstructions()
+   {
+   // On Power, data cannot be emitted inside instructions that will be associated with an
+   // external relocation record (ex. AOT or Remote compiles in OpenJ9). This is because when the
+   // relocation is applied when a method is loaded, the new data in the instruction is OR'ed in (The reason
+   // for OR'ing is that sometimes usefule information such as flags and hints can be stored during compilation in these data fields).
+   // Hence, for the relocation to be applied correctly, we must ensure that the data fields inside the instruction
+   // initially are zero.
+#ifdef JITSERVER_SUPPORT
+   return !self()->comp()->compileRelocatableCode() && !self()->comp()->isOutOfProcessCompilation();
+#endif
+   return !self()->comp()->compileRelocatableCode();
+   }
 
 // Get or create the TR::Linkage object that corresponds to the given linkage
 // convention.

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -93,6 +93,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    int32_t getInternalPtrMapBit() { return 18;}
 
+   bool canEmitDataForExternallyRelocatableInstructions();
+
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    bool suppressInliningOfCryptoMethod(TR::RecognizedMethod method);
    bool inlineCryptoMethod(TR::Node *node, TR::Register *&resultReg);


### PR DESCRIPTION
This commit introduces overrides an OMR query,
canEmitDataForExternallyRelocatableInstructions, that
can be used to determine if data can be emitted safely
in an instruction that is the target of a relocation record.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>