### PR TITLE
Java 14 j.l.Thread.countStackFrames() throws UOE

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -528,13 +528,17 @@ public final void checkAccess() {
  *
  * @deprecated	The semantics of this method are poorly defined and it uses the deprecated suspend() method.
  */
-/*[IF Sidecar19-SE]*/
+/*[IF Java11]*/
 @Deprecated(forRemoval=true, since="1.2")
 /*[ELSE]*/
 @Deprecated
 /*[ENDIF]*/
 public int countStackFrames() {
+/*[IF Java14]*/
+	throw new UnsupportedOperationException();
+/*[ELSE]*/
 	return 0;
+/*[ENDIF]*/
 }
 
 /**

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
@@ -354,7 +354,16 @@ public class Test_Thread {
 	 */
 	@Test
 	public void test_countStackFrames() {
-		AssertJUnit.assertTrue("Test failed.", Thread.currentThread().countStackFrames() == 0);
+		if (org.openj9.test.util.VersionCheck.major() < 14) {
+			AssertJUnit.assertTrue("Test failed.", Thread.currentThread().countStackFrames() == 0);
+		} else {
+			try {
+				Thread.currentThread().countStackFrames();
+				Assert.fail("Should thrown UnsupportedOperationException!");
+			} catch (UnsupportedOperationException uoe) {
+				// pass with expected exception
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
**Java 14 j.l.Thread.countStackFrames() throws UOE**

`Java 14 java.lang.Thread.countStackFrames()` throws `UnsupportedOperationException`;
Updated the test accordingly.

Verified that `pConfig` still compiles.

Note: no NLS message specified just like https://github.com/eclipse/openj9/blob/52d8b53ebd00e3724cf663137ab0391dcaadb264/jcl/src/java.base/share/classes/java/lang/Thread.java#L1152.

closes: #7818

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>