### PR TITLE
Ability to set SCM_BRANCH and SCM_REFSPEC in personal builds

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -183,8 +183,6 @@ def cancel_running_builds(JOB_NAME, BUILD_IDENTIFIER) {
 
 def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SETUP_LABEL, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, CUSTOM_DESCRIPTION, ghprbPullId, ghprbCommentBody, ghprbTargetBranch, ARCHIVE_JAVADOC) {
     stage ("${BUILD_JOB_NAME}") {
-        SCM_BRANCH = (ghprbPullId && ghprbGhRepository == GHPRB_REPO_OPENJ9) ? "origin/pr/${ghprbPullId}/merge" : 'refs/heads/master'
-        SCM_REFSPEC = (ghprbPullId && ghprbGhRepository == GHPRB_REPO_OPENJ9) ? "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge" : ''
         return build_with_slack(BUILD_JOB_NAME, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER,
             [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
             string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH),
@@ -213,6 +211,7 @@ def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO
             string(name: 'ghprbTargetBranch', value: ghprbTargetBranch),
             string(name: 'SCM_BRANCH', value: SCM_BRANCH),
             string(name: 'SCM_REFSPEC', value: SCM_REFSPEC),
+            string(name: 'SCM_REPO', value: SCM_REPO),
             booleanParam(name: 'ARCHIVE_JAVADOC', value: ARCHIVE_JAVADOC)])
     }
 }
@@ -435,7 +434,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
             if (TEST_JOB_NAME.contains("special.system")){
                 IS_PARALLEL = true
             }
-            
+
             def EXTRA_OPTIONS = ""
             if (TEST_JOB_NAME.contains("jck")){
                 EXTRA_OPTIONS = "-Xfuture"
@@ -443,7 +442,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                     EXTRA_OPTIONS += " --enable-preview"
                 }
             }
-            
+
             testjobs["${TEST_JOB_NAME}"] = {
                 if (params.ghprbPullId) {
                     cancel_running_builds(TEST_JOB_NAME, BUILD_IDENTIFIER)

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -607,7 +607,6 @@ def set_job_variables(job_type) {
             set_slack_channel()
             set_restart_timeout()
             add_pr_to_description()
-            set_misc_variables()
             break
         case "wrapper":
             //set variable for pipeline all/personal
@@ -615,7 +614,6 @@ def set_job_variables(job_type) {
             set_build_extra_options(BUILD_SPECS)
             set_adoptopenjdk_tests_repository(get_build_releases(BUILD_SPECS))
             set_restart_timeout()
-            set_misc_variables()
             break
         default:
             error("Unknown Jenkins job type:'${job_type}'")
@@ -1052,10 +1050,6 @@ def create_job(JOB_NAME, SDK_VERSION, SPEC, downstreamJobType, id){
     pipelineFunctions.retry_and_delay({
         jobDsl targets: templatePath, ignoreExisting: false, additionalParameters: params}, 
         3, 120)
-}
-
-def set_misc_variables() {
-    GHPRB_REPO_OPENJ9 = VARIABLES.ghprbGhRepository_openj9
 }
 
 return this

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -161,6 +161,29 @@ echo "ghprbTargetBranch:'${ghprbTargetBranch}'"
 ghprbActualCommit = (params.ghprbActualCommit) ? params.ghprbActualCommit : ""
 echo "ghprbActualCommit:'${ghprbActualCommit}'"
 
+// If custom repo/branch/refspec is passed, use it,
+// elif build is OpenJ9 PR, use pr merge-ref/refspec,
+// else use eclipse/master/blank for defaults respectively.
+SCM_REPO = 'https://github.com/eclipse/openj9.git'
+if (params.SCM_REPO) {
+    SCM_REPO = params.SCM_REPO
+}
+echo "SCM_REPO:'${SCM_REPO}'"
+SCM_BRANCH = 'refs/heads/master'
+if (params.SCM_BRANCH) {
+    SCM_BRANCH = params.SCM_BRANCH
+} else if (ghprbPullId && ghprbGhRepository == 'eclipse/openj9') {
+    SCM_BRANCH = sha1
+}
+echo "SCM_BRANCH:'${SCM_BRANCH}'"
+SCM_REFSPEC = ''
+if (params.SCM_REFSPEC) {
+    SCM_REFSPEC = params.SCM_REFSPEC
+} else if (ghprbPullId && ghprbGhRepository == 'eclipse/openj9') {
+    SCM_REFSPEC = "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge"
+}
+echo "SCM_REFSPEC:'${SCM_REFSPEC}'"
+
 RELEASES = []
 
 OPENJDK_REPO = [:]
@@ -178,12 +201,7 @@ try {
                 try {
                     def gitConfig = scm.getUserRemoteConfigs().get(0)
                     def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
-                    def scmBranch = scm.branches[0].name
-                    if (ghprbGhRepository == 'eclipse/openj9') {
-                        // OpenJ9 PR build
-                        scmBranch = params.sha1
-                        remoteConfigParameters.put("refspec", "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge")
-                    }
+                    remoteConfigParameters.put("refspec", SCM_REFSPEC)
 
                     if (gitConfig.getCredentialsId()) {
                         remoteConfigParameters.put("credentialsId", "${gitConfig.getCredentialsId()}")
@@ -192,7 +210,7 @@ try {
                     checkout changelog: false,
                             poll: false,
                             scm: [$class: 'GitSCM',
-                            branches: [[name: "${scmBranch}"]],
+                            branches: [[name: SCM_BRANCH]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [[$class: 'CloneOption',
                                           reference: "${HOME}/openjdk_cache"]],
@@ -335,8 +353,6 @@ try {
 
 def build(JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, AUTOMATIC_GENERATION, CUSTOM_DESCRIPTION, ARCHIVE_JAVADOC) {
     stage ("${JOB_NAME}") {
-        SCM_BRANCH = (ghprbPullId && ghprbGhRepository == GHPRB_REPO_OPENJ9) ? "origin/pr/${ghprbPullId}/merge" : 'refs/heads/master'
-        SCM_REFSPEC = (ghprbPullId && ghprbGhRepository == GHPRB_REPO_OPENJ9) ? "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge" : ''
         JOB = build job: JOB_NAME,
                 parameters: [
                     string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
@@ -376,6 +392,7 @@ def build(JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRAN
                     string(name: 'ghprbActualCommit', value: ghprbActualCommit),
                     string(name: 'SCM_BRANCH', value: SCM_BRANCH),
                     string(name: 'SCM_REFSPEC', value: SCM_REFSPEC),
+                    string(name: 'SCM_REPO', value: SCM_REPO),
                     booleanParam(name: 'ARCHIVE_JAVADOC', value: ARCHIVE_JAVADOC)]
         return JOB
     }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
@@ -34,7 +34,7 @@ timestamps {
             currentBuild.description = "<a href=\"${RUN_DISPLAY_URL}\">Blue Ocean</a>"
 
             def gitConfig = scm.getUserRemoteConfigs().get(0)
-            def remoteConfigParameters = [url: "${gitConfig.getUrl()}"]
+            def remoteConfigParameters = [url: params.SCM_REPO]
             def scmBranch = params.SCM_BRANCH
             if (!scmBranch) {
                 scmBranch = scm.branches[0].name

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -27,7 +27,7 @@ if (!binding.hasVariable('VENDOR_REPO_DEFAULT')) VENDOR_REPO_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_BRANCH_DEFAULT')) VENDOR_BRANCH_DEFAULT = ''
 if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID_DEFAULT = ''
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
-if (!binding.hasVariable('SCM_URL')) SCM_URL = 'https://github.com/eclipse/openj9.git'
+if (!binding.hasVariable('SCM_REPO')) SCM_REPO = 'https://github.com/eclipse/openj9.git'
 if (!binding.hasVariable('SCM_BRANCH')) SCM_BRANCH = 'refs/heads/master'
 if (!binding.hasVariable('SCM_REFSPEC')) SCM_REFSPEC = 'refs/heads/*:refs/remotes/origin/*'
 
@@ -46,7 +46,7 @@ pipelineJob("$JOB_NAME") {
             scm {
                 git {
                     remote {
-                        url(SCM_URL)
+                        url('$SCM_REPO')
                         refspec('$SCM_REFSPEC')
                     }
                     branch('$SCM_BRANCH')
@@ -95,6 +95,7 @@ pipelineJob("$JOB_NAME") {
         stringParam('OPENJDK_CLONE_DIR')
         stringParam('PERSONAL_BUILD')
         stringParam('CUSTOM_DESCRIPTION')
+        stringParam('SCM_REPO', SCM_REPO)
         stringParam('SCM_BRANCH', SCM_BRANCH)
         stringParam('SCM_REFSPEC', SCM_REFSPEC)
         booleanParam('ARCHIVE_JAVADOC', false)

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -95,7 +95,6 @@ tests_targets:
     ? extended.system
     ? sanity.functional
     ? sanity.system
-ghprbGhRepository_openj9: 'eclipse/openj9'
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#


### PR DESCRIPTION
- Extending the functionality of testing Pipeline changes
  to personal builds instead of just PR builds.
  Currently one needs to do a few hacks to source as well
  as duplicate builds and extra params in order to test
  pipeline changes outside of a PR build. This allows
  SCM_BRANCH and SCM_REFSPEC to be set at the top level
  and be honoured at all 3 build levels (excluding test).

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>