### PR TITLE
AArch64: Fix a build break with ARM64PrivateLinkage.cpp

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -44,7 +44,7 @@
 #include "infra/Assert.hpp"
 #include "infra/List.hpp"
 
-J9::ARM64::PrivateLinkage::ARM64PrivateLinkage(TR::CodeGenerator *cg)
+J9::ARM64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
    : J9::PrivateLinkage(cg),
    _interpretedMethodEntryPoint(NULL),
    _jittedMethodEntryPoint(NULL)


### PR DESCRIPTION
This commit fixes a build break with ARM64PrivateLinkage.cpp, which
was caused by the change from TR::ARM64PrivateLinkage to
J9::ARM64::PrivateLinkage.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>