### PR TITLE
AArch64: Add ConstantDataSnippet.cpp to the source list in makefile

### DIFF
--- a/runtime/compiler/build/files/target/aarch64.mk
+++ b/runtime/compiler/build/files/target/aarch64.mk
@@ -26,6 +26,7 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp \
     omr/compiler/aarch64/codegen/ARM64SystemLinkage.cpp \
     omr/compiler/aarch64/codegen/BinaryEvaluator.cpp \
+    omr/compiler/aarch64/codegen/ConstantDataSnippet.cpp \
     omr/compiler/aarch64/codegen/ControlFlowEvaluator.cpp \
     omr/compiler/aarch64/codegen/FPTreeEvaluator.cpp \
     omr/compiler/aarch64/codegen/GenerateInstructions.cpp \


### PR DESCRIPTION
Add ConstantDataSnippet.cpp to the source list in makefile.

Depends on https://github.com/eclipse/omr/pull/4588

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>