### PR TITLE
Relocate getMonClass and addMonClass to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -294,6 +294,16 @@ public:
    TR_BitVector *getLiveMonitors() {return _liveMonitors;}
    TR_BitVector *setLiveMonitors(TR_BitVector *v) {return (_liveMonitors = v);}
 
+public:
+
+TR_OpaqueClassBlock* getMonClass(TR::Node* monNode);
+
+protected:
+
+TR_Array<void *> _monitorMapping;
+
+void addMonClass(TR::Node* monNode, TR_OpaqueClassBlock* clazz);
+
 private:
 
    TR_HashTabInt _uncommonedNodes;               // uncommoned nodes keyed by the original nodes


### PR DESCRIPTION
Relocate getMonClass and addMonClass to OpenJ9

The OMR::CodeGenerator functions- getMonClass and addMonClass are
relocated to OpenJ9 CodeGenerator and removed from OMR.

The changes also include the array- _monitorMapping moving from OMR
to OpenJ9.

Related OMR PR: eclipse/omr#4592

Closes: GitHub issue eclipse/omr#1869

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>