### PR TITLE
Temporarily launch 2 OMR abuilds

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
@@ -61,6 +61,7 @@ timestamps {
                             echo "Previous SHA:${previous.omr_sha}\nCurrent SHA:${current_sha}"
                             if ( previous.omr_sha != current_sha ) {
                                 build job: 'Pipeline-OMR-Acceptance', propagate: false, wait: false
+                                build job: 'Pipeline-OMR-Acceptance-11', propagate: false, wait: false
                                 writeFile file: "${ARCHIVE_FILE}", text: "omr_sha=${current_sha}"
                             }
                             archiveArtifacts "${ARCHIVE_FILE}"


### PR DESCRIPTION
- One for Java8 and one for Java11
- Java11 is delayed to start via quiet period.
- Due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=553326

Fixes #7854
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>