### PR TITLE
Add support for zlinux large heap builds

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -39,6 +39,9 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - Linux on x86-64 with CMake
         - Spec: x86-64_linux_cm
         - Shortname: xlinuxcm or xlinuxcmake
+    - Linux on s390x largeheap/non-compressed references
+        - Spec: s390x_linux_xl
+        - Shortname: zlinuxlargeheap or zlinuxxl
     - Linux on s390x
         - Spec: s390x_linux
         - Shortname: zlinux
@@ -71,7 +74,7 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
         - Shortname: osxlargeheap or osxxl
     - ALL
         - Launches a subset of 'all' platforms
-        - ppc64le_linux, s390x_linux, x86-64_linux, x86-64_linux_xl, ppc64_aix, x86-64_windows, x86-32_windows, x86-64_mac
+        - ppc64le_linux, s390x_linux, s390x_linux_xl, x86-64_linux, x86-64_linux_xl, ppc64_aix, x86-64_windows, x86-32_windows, x86-64_mac
 
 - OpenJ9 committers can request builds by commenting in a pull request
     - Format: `Jenkins <build type> <level>.<group>[+<test_flag>] <platform>[,<platform>,...,<platform>] jdk<version>[,jdk<version>,...,jdk<version>]`

--- a/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
+++ b/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
@@ -36,7 +36,7 @@ Nightly:
             Java12: true
             Javanext: false
         string_parameters:
-            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,x86-64_windows,x86-32_windows,x86-64_mac"
+            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
             TEST_TARGETS: "sanity.functional,extended.functional,sanity.system,extended.system"
             RESTART_TIMEOUT: "12"
             TIMEOUT_TIME: "14"
@@ -71,7 +71,7 @@ OMR_Acceptance:
             Java12: false
             PROMOTE_OMR: true
         string_parameters:
-            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,x86-64_windows,x86-32_windows,x86-64_mac"
+            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
             TEST_TARGETS: "sanity.functional"
             RESTART_TIMEOUT: ""
         choice_parameters:
@@ -101,7 +101,7 @@ Release:
             OPENJDK12_BRANCH:
             OPENJ9_BRANCH:
             OMR_BRANCH:
-            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,ppc64le_linux,s390x_linux,x86-64_windows,x86-32_windows,x86-64_mac"
+            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,ppc64le_linux,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
             TEST_TARGETS: "sanity.functional,extended.functional,sanity.system,extended.system"
         choice_parameters:
             OPENJDK8_REPO:
@@ -160,7 +160,7 @@ PullRequest-OpenJDK:
 general:
     parameter_descriptions:
         TEST_TARGETS: "Use `none` for no testing.\nsanity.functional,extended.functional,sanity.system,extended.system"
-        PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,x86-64_windows,x86-32_windows,x86-64_mac"
+        PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
         RESTART_TIMEOUT: "Time allowed to restart a job"
         TIMEOUT_TIME: "Overall build timeout"
     repository_url: "https://github.com/eclipse/openj9.git"

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -34,6 +34,7 @@
  *              linux_x86-64,
  *              linux_x86-64_cmprssptrs,
  *              linux_ppc-64_cmprssptrs_le,
+ *              linux_390-64,
  *              linux_390-64_cmprssptrs,
  *              win_x86-64_cmprssptrs,
  *              win_x86 (Java 8 support only),
@@ -77,11 +78,12 @@
  *   OPENJDK<version>_SHA_<platform>: String - the last commit SHA
  */
 
-CURRENT_RELEASES = ['8', '11', '12', '13', 'next']
+CURRENT_RELEASES = ['8', '11', '13', 'next']
 
 SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
          'ppc64le_linux'  : CURRENT_RELEASES,
          's390x_linux'    : CURRENT_RELEASES,
+         's390x_linux_xl' : CURRENT_RELEASES,
          's390x_zos'      : ['11'],
          'x86-64_linux_xl': CURRENT_RELEASES,
          'x86-64_linux'   : CURRENT_RELEASES,
@@ -96,9 +98,11 @@ SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
 
 // SHORT_NAMES is used for PullRequest triggers
 // TODO Combine SHORT_NAMES and SPECS
-SHORT_NAMES = ['all' : ['ppc64le_linux','s390x_linux','x86-64_linux','x86-64_linux_xl','ppc64_aix','x86-64_windows','x86-32_windows','x86-64_mac'],
+SHORT_NAMES = ['all' : ['ppc64le_linux','s390x_linux','s390x_linux_xl','x86-64_linux','x86-64_linux_xl','ppc64_aix','x86-64_windows','x86-32_windows','x86-64_mac'],
             'aix' : ['ppc64_aix'],
             'zlinux' : ['s390x_linux'],
+            'zlinuxlargeheap' : ['s390x_linux_xl'],
+            'zlinuxxl' : ['s390x_linux_xl'],
             'plinux' : ['ppc64le_linux'],
             'xlinuxlargeheap' : ['x86-64_linux_xl'],
             'xlinuxxl' : ['x86-64_linux_xl'],

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -190,6 +190,61 @@ s390x_linux:
     13: '--with-openssl=fetched'
     next: '--with-openssl=fetched'
   excluded_tests:
+    11:
+      ? special.system
+    13:
+      ? special.system
+#========================================#
+# Linux S390 64bits Large Heap
+# Note: boot_jdk 8 must use an Adopt JDK8 build rather than an
+# IBM 7 for the bootJDK or compiling corba will fail to find Object.
+#========================================#
+s390x_linux_xl:
+  boot_jdk:
+    8: '/usr/lib/jvm/adoptojdk-java-s390x-80'
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+    12: '/usr/lib/jvm/adoptojdk-java-11'
+    13: '/usr/lib/jvm/adoptojdk-java-12'
+    next: '/usr/lib/jvm/adoptojdk-java-13'
+  release:
+    8: 'linux-s390x-normal-server-release'
+    11: 'linux-s390x-normal-server-release'
+    12: 'linux-s390x-server-release'
+    13: 'linux-s390x-server-release'
+    next: 'linux-s390x-server-release'
+  freemarker: '/home/jenkins/freemarker.jar'
+  openjdk_reference_repo: '/home/jenkins/openjdk_cache'
+  node_labels:
+    build:
+      8: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
+      11: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
+      12: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
+      13: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
+      next: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
+  build_env:
+    vars:
+      8: 'CC=gcc-7 CXX=g++-7'
+      11: 'CC=gcc-7 CXX=g++-7'
+      12: 'CC=gcc-7 CXX=g++-7'
+      13: 'CC=gcc-7 CXX=g++-7'
+      next: 'CC=gcc-7 CXX=g++-7'
+  extra_getsource_options:
+    8: '--openssl-version=1.1.1d'
+    11: '--openssl-version=1.1.1d'
+    12: '--openssl-version=1.1.1d'
+    13: '--openssl-version=1.1.1d'
+    next: '--openssl-version=1.1.1d'
+  extra_configure_options:
+    8: '--with-noncompressedrefs --with-openssl=fetched'
+    11: '--with-noncompressedrefs --with-openssl=fetched'
+    12: '--with-noncompressedrefs --with-openssl=fetched'
+    13: '--with-noncompressedrefs --with-openssl=fetched'
+    next: '--with-noncompressedrefs --with-openssl=fetched'
+  excluded_tests:
+    8:
+      ? special.system
+    11:
+      ? special.system
     13:
       ? special.system
 #========================================#

--- a/test/TestConfig/scripts/resultsSum.pl
+++ b/test/TestConfig/scripts/resultsSum.pl
@@ -43,6 +43,7 @@ my %spec2jenkinsFile = (
 	'linux_aarch64'                => 'openjdk_aarch64_linux_xl',
 	'linux_ppc-64_cmprssptrs_le'   => 'openjdk_ppc64le_linux',
 	'linux_390-64_cmprssptrs'      => 'openjdk_s390x_linux',
+	'linux_390-64'                 => 'openjdk_s390x_linux_xl',
 	'aix_ppc-64_cmprssptrs'        => 'openjdk_ppc64_aix',
 	'zos_390-64_cmprssptrs'        => 'openjdk_s390x_zos',
 	'osx_x86-64_cmprssptrs'        => 'openjdk_x86-64_mac',

--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1235,6 +1235,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
+		<platformRequirements>^spec.linux_390</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1263,6 +1264,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
+		<platformRequirements>^spec.linux_390</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Exclude testGuestOSMXBeanLocal and testGuestOSMXBeanRemote since they
fail on zlinux due to `Exception occurred while retrieving Guest memory
usage: -825: Failed retrieving GuestOS Memory Usage Info. (JVMPORT041E
HYPFS not mounted)`

Disable special.system testing for jdk11 to accommodate a large
heap build on the available machines. 

Issue #7856

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>