### PR TITLE
Ignore -XcompilationThreads0 option

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2626,14 +2626,14 @@ void TR::CompilationInfo::updateNumUsableCompThreads(int32_t &numUsableCompThrea
 #if defined(JITSERVER_SUPPORT)
    if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
-      numUsableCompThreads = ((numUsableCompThreads < 0) ||
+      numUsableCompThreads = ((numUsableCompThreads <= 0) ||
                               (numUsableCompThreads > MAX_SERVER_USABLE_COMP_THREADS)) ?
                                MAX_SERVER_USABLE_COMP_THREADS : numUsableCompThreads;
       }
    else
 #endif /* defined(JITSERVER_SUPPORT) */
       {
-      numUsableCompThreads = ((numUsableCompThreads < 0) ||
+      numUsableCompThreads = ((numUsableCompThreads <= 0) ||
                               (numUsableCompThreads > MAX_CLIENT_USABLE_COMP_THREADS)) ?
                                MAX_CLIENT_USABLE_COMP_THREADS : numUsableCompThreads;
       }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1849,7 +1849,7 @@ J9::Options::fePreProcess(void * base)
       UDATA numCompThreads;
       IDATA ret = GET_INTEGER_VALUE(argIndex, compThreadsOption, numCompThreads);
 
-      if (ret == OPTION_OK)
+      if (ret == OPTION_OK && numCompThreads > 0)
          {
          _numUsableCompilationThreads = numCompThreads;
          compInfo->updateNumUsableCompThreads(_numUsableCompilationThreads);


### PR DESCRIPTION
-XcompilationThreads<N> option can be used to specify the desired number
of compilation threads. The maximum valid number is 7 and the JIT will
silently ignore the option if a larger value is specified. If the user
specifies a value of 0, then the JIT will trigger a FATAL assert.
This commit modifies the code so that a value of 0 will too be silently
ignored, in which case the JIT will use its internal heuristics to determine
how many compilation threads to create.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>