### PR TITLE
Migrate TR_LinkageInfo from OMR to OpenJ9

### DIFF
--- a/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
@@ -29,6 +29,7 @@
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "arm/codegen/ARMSystemLinkage.hpp"
 #include "arm/codegen/ARMRecompilation.hpp"
 #include "env/OMRMemory.hpp"
@@ -289,7 +290,7 @@ void J9::ARM::CodeGenerator::doBinaryEncoding()
 
          if (recomp != NULL && recomp->couldBeCompiledAgain())
             {
-            TR_LinkageInfo *lkInfo = TR_LinkageInfo::get(self()->getCodeStart());
+            J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(self()->getCodeStart());
             if (recomp->useSampling())
                lkInfo->setSamplingMethodBody();
             else

--- a/runtime/compiler/arm/runtime/Recomp.cpp
+++ b/runtime/compiler/arm/runtime/Recomp.cpp
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/Machine.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/jittypes.h"
@@ -40,7 +41,7 @@ uint32_t encodeRuntimeHelperBranchAndLink(TR_RuntimeHelper helper, uint8_t *curs
 #define DEBUG_ARM_RECOMP false
 
 static uint32_t
-getJitEntryOffset(TR_LinkageInfo * linkageInfo)
+getJitEntryOffset(J9::PrivateLinkage::LinkageInfo * linkageInfo)
    {
    return linkageInfo->getReservedWord() & 0x0ffff;
    }
@@ -48,14 +49,14 @@ getJitEntryOffset(TR_LinkageInfo * linkageInfo)
 //
 TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *startPC)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    TR_PersistentJittedBodyInfo *info = linkageInfo->isRecompMethodBody() ? *(TR_PersistentJittedBodyInfo **)((uint8_t*)startPC + OFFSET_METHODINFO_FROM_STARTPC):0;
    return info;
    }
 
 bool J9::Recompilation::isAlreadyPreparedForRecompile(void *startPC)
    {
-   int32_t  jitEntryOffset = getJitEntryOffset(TR_LinkageInfo::get(startPC));
+   int32_t  jitEntryOffset = getJitEntryOffset(J9::PrivateLinkage::LinkageInfo::get(startPC));
    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
 
    if (DEBUG_ARM_RECOMP)
@@ -78,7 +79,7 @@ bool J9::Recompilation::isAlreadyPreparedForRecompile(void *startPC)
 //
 void J9::Recompilation::fixUpMethodCode(void *startPC)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC); //(TR_LinkageInfo *) (((uint8_t*)startPC) + PC_TO_LINKAGE_INFO);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    if (linkageInfo->isCountingMethodBody())
       {
       TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(startPC);
@@ -165,7 +166,7 @@ void J9::Recompilation::fixUpMethodCode(void *startPC)
 
 void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStartPC, TR_FrontEnd *fe)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    int32_t   bytesToSaveAtStart = 0;
    int32_t   *patchAddr, newInstr;
    intptrj_t distance;
@@ -252,7 +253,7 @@ uint32_t encodeRuntimeHelperBranchAndLink(TR_RuntimeHelper helper, uint8_t *curs
 
 void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *fe)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
    int32_t  *patchAddr, newInstr, distance;
    TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(oldStartPC);
@@ -336,7 +337,7 @@ void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
    // Pre-existence assumptions for this method have been violated. Make the
    // method no-longer runnable and schedule it for sync recompilation
    //
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    //linkageInfo->setInvalidated();
    TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
    bodyInfo->setIsInvalidated(); // bodyInfo must exist
@@ -361,7 +362,7 @@ void armIndirectCallPatching_unwrapper(void **argsPtr, void **resPtr)
 #if defined(TR_HOST_ARM)
 void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    int32_t  jitEntryOffset = getJitEntryOffset(linkageInfo);
    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
 

--- a/runtime/compiler/codegen/PrivateLinkage.hpp
+++ b/runtime/compiler/codegen/PrivateLinkage.hpp
@@ -24,6 +24,7 @@
 #define J9_PRIVATELINKAGE_INCL
 
 #include "codegen/Linkage.hpp"
+#include "infra/Assert.hpp"
 
 namespace TR { class CodeGenerator; }
 
@@ -38,6 +39,85 @@ public:
          TR::Linkage(cg)
       {
       }
+
+   /**
+    * @class LinkageInfo
+    *
+    * @brief Helper class for encoding and decoding the linkage info word that is
+    *    embedded in the code cache prior to the interpreter entry point in each
+    *    compiled method body.
+    *
+    * @details
+    *     Implementation restrictions:
+    *     * this is a non-instantiable abstract class
+    *     * this class cannot have any virtual methods
+    */
+   class LinkageInfo
+      {
+   public:
+      static LinkageInfo *get(void *startPC) { return reinterpret_cast<LinkageInfo *>(((uint32_t*)startPC)-1); }
+
+      void setCountingMethodBody() { _word |= CountingPrologue; }
+      void setSamplingMethodBody() { _word |= SamplingPrologue; }
+      void setHasBeenRecompiled()
+         {
+         TR_ASSERT((_word & HasFailedRecompilation)==0, "Cannot setHasBeenRecompiled because method has failed recompilation");
+         _word |= HasBeenRecompiled;
+         }
+
+      void setHasFailedRecompilation()
+         {
+         TR_ASSERT((_word & HasBeenRecompiled) == 0, "Cannot setHasFailedRecompilation because method has been recompiled");
+         _word |= HasFailedRecompilation;
+         }
+
+      void setIsBeingRecompiled() { _word |= IsBeingRecompiled; }
+      void resetIsBeingRecompiled() { _word &= ~IsBeingRecompiled; }
+
+      bool isCountingMethodBody() { return (_word & CountingPrologue) != 0; }
+      bool isSamplingMethodBody() { return (_word & SamplingPrologue) != 0; }
+      bool isRecompMethodBody() { return (_word & (SamplingPrologue | CountingPrologue)) != 0; }
+      bool hasBeenRecompiled() { return (_word & HasBeenRecompiled) != 0; }
+      bool hasFailedRecompilation() { return (_word & HasFailedRecompilation) != 0; }
+      bool recompilationAttempted() { return hasBeenRecompiled() || hasFailedRecompilation(); }
+      bool isBeingCompiled() { return (_word & IsBeingRecompiled) != 0; }
+
+      inline uint16_t getReservedWord() { return (_word & ReservedMask) >> 16; }
+      inline void setReservedWord(uint16_t w) { _word |= ((w << 16) & ReservedMask); }
+
+      int32_t getJitEntryOffset()
+         {
+#if defined(TR_TARGET_X86) && defined(TR_TARGET_32BIT)
+         return 0;
+#else
+         return getReservedWord();
+#endif
+         }
+
+      enum
+         {
+         ReturnInfoMask                     = 0x0000000F, // bottom 4 bits
+         // The VM depends on these four bits - word to the wise: don't mess
+
+         SamplingPrologue                   = 0x00000010,
+         CountingPrologue                   = 0x00000020,
+         // NOTE: flags have to be set under the compilation monitor or during compilation process
+         HasBeenRecompiled                  = 0x00000040,
+         HasFailedRecompilation             = 0x00000100,
+         IsBeingRecompiled                  = 0x00000200,
+
+         // RESERVED:
+         // non-ia32:                         0xffff0000 <---- jitEntryOffset
+         // ia32:                             0xffff0000 <---- Recomp/FSD save area
+
+         ReservedMask                       = 0xFFFF0000
+         };
+
+      uint32_t _word;
+
+   private:
+      LinkageInfo() {};
+      };
 
    };
 

--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -22,6 +22,7 @@
 
 #include "control/CompilationController.hpp"
 
+#include "codegen/PrivateLinkage.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "control/MethodToBeCompiled.hpp"
@@ -569,7 +570,7 @@ TR::DefaultCompilationStrategy::processJittedSample(TR_MethodEvent *event)
             }
          }
       }
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    TR_PersistentJittedBodyInfo *bodyInfo = NULL;
 
       compInfo->_stats._compiledMethodSamples++;
@@ -1535,7 +1536,7 @@ TR::ThresholdCompilationStrategy::processJittedSample(TR_MethodEvent *event)
    // here we may need to write into the vlog
 
 
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    TR_PersistentJittedBodyInfo *bodyInfo = NULL;
 
    if (linkageInfo->hasFailedRecompilation())

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -48,6 +48,7 @@
 #include "env/annotations/AnnotationBase.hpp"
 
 #define J9_EXTERNAL_TO_VM
+#include "codegen/PrivateLinkage.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
 #include "control/Recompilation.hpp"
@@ -107,7 +108,7 @@
 #include "env/exports.h"
 #if defined(JITSERVER_SUPPORT)
 #include "env/JITServerPersistentCHTable.hpp"
-#include "net/CommunicationStream.hpp" 
+#include "net/CommunicationStream.hpp"
 #include "net/ClientStream.hpp"
 #include "runtime/JITClientSession.hpp"
 #include "runtime/Listener.hpp"
@@ -274,7 +275,7 @@ j9jit_testarossa_err(
    if (oldStartPC)
       {
       // any recompilation attempt using fixUpMethodCode would go here
-      TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+      J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
       TR_PersistentJittedBodyInfo* jbi = TR::Recompilation::getJittedBodyInfoFromPC(oldStartPC);
 
       if (jbi)
@@ -425,7 +426,7 @@ retranslateWithPreparation(
       void *oldStartPC,
       UDATA reason)
    {
-   if (!TR::CompilationInfo::get()->asynchronousCompilation() && !TR_LinkageInfo::get(oldStartPC)->recompilationAttempted())
+   if (!TR::CompilationInfo::get()->asynchronousCompilation() && !J9::PrivateLinkage::LinkageInfo::get(oldStartPC)->recompilationAttempted())
       {
       TR::Recompilation::fixUpMethodCode(oldStartPC);
       }
@@ -1135,7 +1136,7 @@ onLoadInternal(
    // JITServer: persistentCHTable used to be inited here, but we have to move it after JITServer commandline opts
    // setting it to null here to catch anything that assumes it's set between here and the new init code.
    persistentMemory->getPersistentInfo()->setPersistentCHTable(NULL);
-   
+
    if (!TR::CompilationInfo::createCompilationInfo(jitConfig))
       return -1;
 

--- a/runtime/compiler/p/runtime/Recomp.cpp
+++ b/runtime/compiler/p/runtime/Recomp.cpp
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"
 #include "runtime/CodeCacheManager.hpp"
@@ -45,7 +46,7 @@ extern void ppcCodeSync(uint8_t *, uint32_t);
 //
 TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *startPC)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    int32_t  jitEntryOffset = getJitEntryOffset(linkageInfo);
    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
 
@@ -76,7 +77,7 @@ TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *st
 
 bool J9::Recompilation::isAlreadyPreparedForRecompile(void *startPC)
    {
-   int32_t  jitEntryOffset = getJitEntryOffset(TR_LinkageInfo::get(startPC));
+   int32_t  jitEntryOffset = getJitEntryOffset(J9::PrivateLinkage::LinkageInfo::get(startPC));
    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
 
    return ((*jitEntry & 0xff000000) == 0x4b000000);
@@ -93,7 +94,7 @@ bool J9::Recompilation::isAlreadyPreparedForRecompile(void *startPC)
 //
 void J9::Recompilation::fixUpMethodCode(void *startPC)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC); //(TR_LinkageInfo *) (((uint8_t*)startPC) + PC_TO_LINKAGE_INFO);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    if (linkageInfo->isCountingMethodBody())
       {
       TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(startPC);
@@ -127,7 +128,7 @@ void J9::Recompilation::fixUpMethodCode(void *startPC)
 
 void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStartPC, TR_FrontEnd *fe)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    int32_t   bytesToSaveAtStart = 0;
    int32_t   *patchAddr, newInstr;
 
@@ -194,7 +195,7 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
 
 void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *fe)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
    int32_t  *patchAddr, newInstr, distance;
    TR_ASSERT( linkageInfo->isSamplingMethodBody() && !linkageInfo->isCountingMethodBody() ||
@@ -269,7 +270,7 @@ void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
    // Pre-existence assumptions for this method have been violated. Make the
    // method no-longer runnable and schedule it for sync recompilation
    //
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    //linkageInfo->setInvalidated();
    TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
    bodyInfo->setIsInvalidated(); // bodyInfo must exist
@@ -295,7 +296,7 @@ void ppcIndirectCallPatching_unwrapper(void **argsPtr, void **resPtr)
 #if defined(TR_HOST_POWER)
 void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    int32_t  jitEntryOffset = getJitEntryOffset(linkageInfo);
    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
 

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -30,6 +30,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "codegen/Relocation.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
@@ -2395,10 +2396,10 @@ void TR_DebugExt::dxPrintMethodToBeCompiled(TR_MethodToBeCompiled *remoteCompEnt
    _dbgPrintf("\tbool                          _freeTag = %d\n",localCompEntry->_freeTag);
    _dbgPrintf("\tuint8_t                       _weight = %u\n",localCompEntry->_weight);
    _dbgPrintf("\tbool                          _hasIncrementedNumCompThreadsCompilingHotterMethods = %d\n",localCompEntry->_hasIncrementedNumCompThreadsCompilingHotterMethods);
-#if defined(JITSERVER_SUPPORT)   
+#if defined(JITSERVER_SUPPORT)
    _dbgPrintf("\tTR_Hotness                    _origOptLevel = 0x%p\n\n", localCompEntry->_origOptLevel);
 #endif
-   
+
    struct J9Method *ramMethod = (struct J9Method *)dxGetJ9MethodFromMethodToBeCompiled(remoteCompEntry);
    if (ramMethod)
       _dbgPrintf("\tAssociated J9Method = !trprint j9method 0x%p\n", ramMethod);
@@ -3228,7 +3229,7 @@ TR_DebugExt::dxPrintMethodName(char *p, int32_t searchLimit)
    if (hotness == -1)
       hotness = localMetadata->hotness;
 
-   TR_LinkageInfo *linkageInfo = (TR_LinkageInfo *) dxMallocAndRead(sizeof(TR_LinkageInfo), (void*)((char *)localMetadata->startPC - 4) );
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = (J9::PrivateLinkage::LinkageInfo *) dxMallocAndRead(sizeof(J9::PrivateLinkage::LinkageInfo), (void*)((char *)localMetadata->startPC - 4) );
 
    _dbgPrintf("\n\nMethod:\t%s.%s%s\n\n", className, methodName, methodSignature);
    dxPrintJ9RamAndRomMethod(localMetadata->ramMethod);

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -25,6 +25,7 @@
 
 #include "runtime/Runtime.hpp"
 #include "codegen/PreprologueConst.hpp"
+#include "codegen/PrivateLinkage.hpp"
 
 
 #if defined(TR_HOST_S390)
@@ -39,7 +40,7 @@ void saveJitEntryPoint(uint8_t* intEP, uint8_t* jitEP);
 inline uint16_t jitEntryOffset(void *startPC)
    {
 #if defined(TR_HOST_64BIT)
-   return TR_LinkageInfo::get(startPC)->getReservedWord();
+   return J9::PrivateLinkage::LinkageInfo::get(startPC)->getReservedWord();
 #else
    return 0;
 #endif
@@ -69,7 +70,7 @@ void replaceFirstTwoBytesWithData(void *startPC, int32_t startPCToData);
 #define  OFFSET_SAMPLING_METHODINFO_FROM_STARTPC         (-(8+sizeof(intptrj_t)))
 #define  OFFSET_SAMPLING_PRESERVED_FROM_STARTPC          (-8)
 
-inline uint32_t getJitEntryOffset(TR_LinkageInfo *linkageInfo)
+inline uint32_t getJitEntryOffset(J9::PrivateLinkage::LinkageInfo *linkageInfo)
    {
    return linkageInfo->getReservedWord() & 0x0ffff;
    }

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -37,6 +37,7 @@
 #include "jitprotos.h"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/FrontEnd.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/Method.hpp"
 #include "control/CompilationController.hpp"
@@ -244,7 +245,7 @@ J9::Recompilation::induceRecompilation(
       bool *queued,
       TR_OptimizationPlan *optimizationPlan)
    {
-   TR_LinkageInfo              *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    TR_PersistentMethodInfo     *methodInfo;
    TR_PersistentJittedBodyInfo *bodyInfo;
 
@@ -1329,12 +1330,12 @@ void platformUnlock(uint32_t *ptr)
 #if defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
 uint32_t *getLinkageInfo(void *startPC)
    {
-   return (uint32_t *)TR_LinkageInfo::get(startPC);
+   return (uint32_t *)J9::PrivateLinkage::LinkageInfo::get(startPC);
    }
 
 uint32_t isRecompMethBody(void *li)
    {
-   TR_LinkageInfo *linkageInfo = (TR_LinkageInfo *)li;
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = (J9::PrivateLinkage::LinkageInfo *)li;
    return linkageInfo->isRecompMethodBody();
    }
 
@@ -1699,7 +1700,7 @@ void *initialInvokeExactThunk(j9object_t methodHandle, J9VMThread *vmThread)
       uintptrj_t fieldOffset = fej9->getInstanceFieldOffset(fej9->getObjectClass(thunkTuple), "invokeExactThunk", "J");
 #if defined(TR_HOST_X86)
       bool success = fej9->compareAndSwapInt64Field(thunkTuple, "invokeExactThunk", (uint64_t)(uintptrj_t)initialInvokeExactThunkGlue, (uint64_t)(uintptrj_t)addressToDispatch);
-      
+
       if (details)
          TR_VerboseLog::writeLineLocked(TR_Vlog_MHD, "%p   %s updating ThunkTuple %p field %+d from %p to %p",
             vmThread, success? "Succeeded" : "Failed", thunkTuple, (int)fieldOffset, initialInvokeExactThunkGlue, addressToDispatch);

--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -23,6 +23,7 @@
 #include "j9.h"
 #include "j9consts.h"
 #include "codegen/FrontEnd.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"
 #include "runtime/CodeCacheManager.hpp"
@@ -130,7 +131,7 @@ void ppcCreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
    static TR_Processor proc = customP4 ? portLibCall_getProcessorType() :
       TR_DefaultPPCProcessor;
    uint8_t *buffer = (uint8_t *)trampPtr;
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    intptrj_t dispatcher = (intptrj_t)((uint8_t *)startPC + linkInfo->getReservedWord());
 
       // Take advantage of both gr0 and gr11 ...
@@ -306,7 +307,7 @@ static bool isInterfaceCallSite(uint8_t *callSite, int32_t& distanceToActualCall
 
 bool ppcCodePatching(void *method, void *callSite, void *currentPC, void *currentTramp, void *newPC, void *extra)
    {
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(newPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(newPC);
    uint8_t        *entryAddress = (uint8_t *)newPC + linkInfo->getReservedWord();
    intptrj_t       distance;
    uint8_t        *patchAddr;
@@ -547,7 +548,7 @@ void amd64CreateMethodTrampoline(void *trampPtr, void *startPC, TR_OpaqueMethodB
    {
    J9Method *ramMethod = reinterpret_cast<J9Method *>(method);
    uint8_t *buffer = (uint8_t *)trampPtr;
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    intptrj_t dispatcher = (intptrj_t)((uint8_t *)startPC + linkInfo->getReservedWord());
 
    // The code below is disabled because of a problem with direct call to JNI methods
@@ -608,7 +609,7 @@ int32_t amd64CodePatching(void *theMethod, void *callSite, void *currentPC, void
    J9Method *method = reinterpret_cast<J9Method *>(theMethod);
    // We already checked the call site for immediate call. No need to check again ...
    //
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(newPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(newPC);
    uint8_t        *entryAddress = (uint8_t *)newPC + linkInfo->getReservedWord();
    uint8_t        *patchAddr = (uint8_t *)callSite;
    intptrj_t       distance;
@@ -763,7 +764,7 @@ void armCreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
 void armCreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
    {
    uint32_t *buffer = (uint32_t *)trampPtr;
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    intptrj_t dispatcher = (intptrj_t)((uint8_t *)startPC + linkInfo->getReservedWord());
 
    // LDR  PC, [PC, #-4]
@@ -783,7 +784,7 @@ void armCreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
 
 bool armCodePatching(void *callee, void *callSite, void *currentPC, void *currentTramp, void *newAddrOfCallee, void *extra)
    {
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(newAddrOfCallee);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(newAddrOfCallee);
    uint8_t        *entryAddress = (uint8_t *)newAddrOfCallee + linkInfo->getReservedWord();
    intptrj_t       distance;
    int32_t         currentDistance;
@@ -873,7 +874,7 @@ void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
    for (int32_t i=1; i<numHelpers; i++)
       {
       *((int32_t *)buffer) = 0x58000050; //LDR R16 PC+8
-      buffer += 1; 
+      buffer += 1;
       *buffer = 0xD61F0200; //BR R16
       buffer += 1;
       *((intptrj_t *)buffer) = (intptrj_t)runtimeHelperValue((TR_RuntimeHelper)i);
@@ -884,11 +885,11 @@ void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
 void arm64CreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
    {
    uint32_t *buffer = (uint32_t *)trampPtr;
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    intptrj_t dispatcher = (intptrj_t)((uint8_t *)startPC + linkInfo->getReservedWord());
 
    *buffer = 0x58000050; //LDR R16 PC+8
-   buffer += 1; 
+   buffer += 1;
    *buffer = 0xD61F0200; //BR R16
    buffer += 1;
    *((intptrj_t *)buffer) = dispatcher;
@@ -896,7 +897,7 @@ void arm64CreateMethodTrampoline(void *trampPtr, void *startPC, void *method)
 
 bool arm64CodePatching(void *callee, void *callSite, void *currentPC, void *currentTramp, void *newAddrOfCallee, void *extra)
    {
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(newAddrOfCallee);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(newAddrOfCallee);
    uint8_t        *entryAddress = (uint8_t *)newAddrOfCallee + linkInfo->getReservedWord();
    intptrj_t       distance;
    int32_t         currentDistance;
@@ -906,7 +907,7 @@ bool arm64CodePatching(void *callee, void *callSite, void *currentPC, void *curr
    distance = entryAddress - (uint8_t *)callSite;
    currentDistance = (branchInstr << 6) >> 4;
    branchInstr &= 0xfc000000;
-   
+
    if (branchInstr != 0x94000000)
       {
       // This is not a 'bl' instruction -- Don't patch
@@ -914,12 +915,12 @@ bool arm64CodePatching(void *callee, void *callSite, void *currentPC, void *curr
       }
 
    if (TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines)
-            || distance>(intptrj_t)TR::Compiler->target.cpu.maxUnconditionalBranchImmediateForwardOffset() 
+            || distance>(intptrj_t)TR::Compiler->target.cpu.maxUnconditionalBranchImmediateForwardOffset()
             || distance<(intptrj_t)TR::Compiler->target.cpu.maxUnconditionalBranchImmediateBackwardOffset()
    )  {
       if (currentPC == newAddrOfCallee)
          {
-         newTramp = currentTramp; 
+         newTramp = currentTramp;
          }
       else
          {
@@ -1066,7 +1067,7 @@ void s390zOS64CreateMethodTrampoline(void *trampPtr, void *startPC, void *method
    uint8_t     *buffer = (uint8_t *)trampPtr;
    // Get the Entry Pointer (should be r15 for zOS64).
    uint16_t rEP = 15;
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    intptrj_t dispatcher = (intptrj_t)((uint8_t *)startPC + linkInfo->getReservedWord());
 
    // Trampoline Code:
@@ -1097,7 +1098,7 @@ void s390zOS64CreateMethodTrampoline(void *trampPtr, void *startPC, void *method
 // zOS64 Code Patching.
 bool s390zOS64CodePatching(void *method, void *callSite, void *currentPC, void *currentTramp, void *newPC, void *extra)
    {
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(newPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(newPC);
    // The location of the method call branch.
    uint8_t        *entryAddress = (uint8_t *)newPC + linkInfo->getReservedWord();
    // The location of the callsite.
@@ -1282,7 +1283,7 @@ void s390zLinux64CreateMethodTrampoline(void *trampPtr, void *startPC, void *met
    uint8_t     *buffer = (uint8_t *)trampPtr;
    // Get the Entry Pointer (should be r4 for zLinux64).
    uint16_t rEP = 4;  // Joran TODO: useEPRegNum instead.
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    intptrj_t dispatcher = (intptrj_t)((uint8_t *) startPC + linkInfo->getReservedWord());
 
    //Alternative Trampoline code
@@ -1313,7 +1314,7 @@ void s390zLinux64CreateMethodTrampoline(void *trampPtr, void *startPC, void *met
 // zLinux64 Code Patching.
 bool s390zLinux64CodePatching (void *method, void *callSite, void *currentPC, void *currentTramp, void *newPC, void *extra)
    {
-   TR_LinkageInfo *linkInfo = TR_LinkageInfo::get(newPC);
+   J9::PrivateLinkage::LinkageInfo *linkInfo = J9::PrivateLinkage::LinkageInfo::get(newPC);
    // The location of the method call branch.
    uint8_t        *entryAddress = (uint8_t *)newPC + linkInfo->getReservedWord();
    // The location of the callsite.

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -26,6 +26,7 @@
 #include "codegen/Machine.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "codegen/Snippet.hpp"
 #include "codegen/PreprologueConst.hpp"
 #include "compile/ResolvedMethod.hpp"
@@ -227,7 +228,7 @@ void TR_X86Recompilation::setMethodReturnInfoBits()
    //    instruction of the method (this is done by OMR::Recompilation::methodCannotBeRecompiled)
    //
    uint8_t  *startPC = _compilation->cg()->getCodeStart();
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
 
    if (useSampling())
       {

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -24,6 +24,7 @@
 
 #include <limits.h>
 #include <stdint.h>
+#include "codegen/PrivateLinkage.hpp"
 #include "env/jittypes.h"
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/J9Runtime.hpp"
@@ -121,7 +122,7 @@ TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *st
    // header-type bits in the linkage info fields to determine what kind of header
    // this is.
    //
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    return linkageInfo->isRecompMethodBody() ?
       *(TR_PersistentJittedBodyInfo **)((uint8_t*)startPC + START_PC_TO_METHOD_INFO_ADDRESS) :
       NULL;
@@ -147,7 +148,7 @@ bool J9::Recompilation::isAlreadyPreparedForRecompile(void *startPC)
 //
 void J9::Recompilation::fixUpMethodCode(void *startPC)
    {
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    if (linkageInfo->isCountingMethodBody())
       {
       TR_PersistentJittedBodyInfo   *bodyInfo = getJittedBodyInfoFromPC(startPC);
@@ -174,7 +175,7 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
    char *startByte = (char*)oldStartPC + jitEntryOffset(oldStartPC);
    char *p;
    int32_t offset, bytesToSaveAtStart;
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    if (linkageInfo->isCountingMethodBody())
       {
       // The start of the old method looks like on IA32:
@@ -283,7 +284,7 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
 void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *fe)
    {
    char *startByte = (char*)oldStartPC + jitEntryOffset(oldStartPC);
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
    TR_ASSERT( linkageInfo->isSamplingMethodBody() && !linkageInfo->isCountingMethodBody() ||
           !linkageInfo->isSamplingMethodBody() &&  linkageInfo->isCountingMethodBody(),
@@ -352,7 +353,7 @@ void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
    // Preexistence assumptions for this method have been violated.  Make the
    // method no-longer runnable and schedule it for a sync recompilation
    //
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    //linkageInfo->setInvalidated();
    TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
    bodyInfo->setIsInvalidated(); // bodyInfo must exist

--- a/runtime/compiler/z/codegen/S390Recompilation.cpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.cpp
@@ -25,6 +25,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
@@ -550,7 +551,7 @@ void TR_S390Recompilation::postCompilation()
    if(!couldBeCompiledAgain()) return;
 
    uint8_t  *startPC = _compilation->cg()->getCodeStart();
-   TR_LinkageInfo *linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    int32_t jitEntryOffset = linkageInfo->getReservedWord() & 0x0ffff;
    uint32_t * jitEntryPoint = (uint32_t*)(startPC + jitEntryOffset);
    uint32_t * saveLocn = (uint32_t*)(startPC + OFFSET_INTEP_JITEP_SAVE_RESTORE_LOCATION);

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -24,6 +24,7 @@
 
 #include <limits.h>
 #include <stdint.h>
+#include "codegen/PrivateLinkage.hpp"
 #include "env/jittypes.h"
 #include "env/VMJ9.h"
 #include "z/codegen/SystemLinkage.hpp"
@@ -72,7 +73,7 @@ s390compareAndExchange4(int32_t * addr, uint32_t oldInsn, uint32_t newInsn)
    }
 
 static uint32_t
-getJitEntryOffset(TR_LinkageInfo * linkageInfo)
+getJitEntryOffset(J9::PrivateLinkage::LinkageInfo * linkageInfo)
    {
    return linkageInfo->getReservedWord() & 0x0ffff;
    }
@@ -87,7 +88,7 @@ J9::Recompilation::getJittedBodyInfoFromPC(void * startPC)
 #endif
 
    TR_ASSERT(startPC, "startPC is null");
-   TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    if (!linkageInfo->isRecompMethodBody())
       {
       return NULL;
@@ -117,7 +118,7 @@ J9::Recompilation::getJittedBodyInfoFromPC(void * startPC)
 bool
 J9::Recompilation::isAlreadyPreparedForRecompile(void * startPC)
    {
-   TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    int32_t jitEntryOffset = getJitEntryOffset(linkageInfo);
    int32_t * jitEntry = (int32_t *) ((uint8_t *) startPC + jitEntryOffset);
    uint32_t startInsn = *jitEntry;
@@ -150,7 +151,7 @@ J9::Recompilation::fixUpMethodCode(void * startPC)
 #else
    const bool is64Bit = false;
 #endif
-   TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    if (DEBUGIT)
       {
       printf("fixup: 0x%p %s %s\n", linkageInfo, linkageInfo->isSamplingMethodBody() ? "samplingSet" : "",
@@ -209,7 +210,7 @@ J9::Recompilation::fixUpMethodCode(void * startPC)
 void
 J9::Recompilation::methodHasBeenRecompiled(void * oldStartPC, void * newStartPC, TR_FrontEnd * fe)
    {
-   TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    intptrj_t distance, * patchAddr, newInstr, * codePtrAddr;
    int32_t bytesToSaveAtStart;
    int32_t jitEntryOffset = getJitEntryOffset(linkageInfo);
@@ -335,7 +336,7 @@ J9::Recompilation::methodHasBeenRecompiled(void * oldStartPC, void * newStartPC,
 void
 J9::Recompilation::methodCannotBeRecompiled(void * oldStartPC, TR_FrontEnd * fe)
    {
-   TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(oldStartPC);
+   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
    int32_t * patchAddr, distance;
    TR_ASSERT( linkageInfo->isSamplingMethodBody() && !linkageInfo->isCountingMethodBody() ||
@@ -469,7 +470,7 @@ J9::Recompilation::invalidateMethodBody(void * startPC, TR_FrontEnd * fe)
    // Pre-existence assumptions for this method have been violated. Make the
    // method no-longer runnable and schedule it for sync recompilation
    //
-   TR_LinkageInfo * linkageInfo = TR_LinkageInfo::get(startPC);
+   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    //linkageInfo->setInvalidated();
    TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
    bodyInfo->setIsInvalidated(); // bodyInfo must exist


### PR DESCRIPTION
* Migrate TR_LinkageInfo from OMR to OpenJ9
* Reference LinkageInfo class within PrivateLinkage class

I added minimal documentation to the LinkageInfo class.  It should be safe for this version of LinkageInfo to co-exist with the TR_LinkageInfo class in OMR until the OMR version is removed.