### PR TITLE
Throw IllegalThreadStateException when thread is not suspended

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
@@ -354,8 +354,16 @@ public class Test_Thread {
 	 */
 	@Test
 	public void test_countStackFrames() {
-		if (org.openj9.test.util.VersionCheck.major() < 14) {
+		int versionMajor = org.openj9.test.util.VersionCheck.major();
+		if (versionMajor < 13) {
 			AssertJUnit.assertTrue("Test failed.", Thread.currentThread().countStackFrames() == 0);
+		} else if (versionMajor < 14) {
+			try {
+				Thread.currentThread().countStackFrames();
+				Assert.fail("Should thrown IllegalThreadStateException!");
+			} catch (IllegalThreadStateException itse) {
+				// pass with expected exception
+			}
 		} else {
 			try {
 				Thread.currentThread().countStackFrames();


### PR DESCRIPTION
**Throw IllegalThreadStateException when thread is not suspended**

For Java version before `JDK 14`, `j.l.Thread.countStackFrames()` should throw `IllegalThreadStateException()` if the thread has not been suspended;
Added a native `isSuspendedImpl()`;
Updated the test accordingly.

Note: this change is to meet specification compatibility requirement.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>