### PR TITLE
Add options for workaround in case if Smart Address not reliable

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -464,6 +464,9 @@ enum INIT_STAGE {
 #define VMOPT_XXDEEP_SCAN "-XX:+GCDeepStructurePriorityScan"
 #define VMOPT_XXNODEEP_SCAN "-XX:-GCDeepStructurePriorityScan"
 
+#define VMOPT_XXFORCE_FULL_HEAP_ADDRESS_RANGE_SEARCH "-XX:+ForceFullHeapAddressRangeSearch"
+#define VMOPT_XXNOFORCE_FULL_HEAP_ADDRESS_RANGE_SEARCH "-XX:-ForceFullHeapAddressRangeSearch"
+
 #define VMOPT_XXCLASSRELATIONSHIPVERIFIER "-XX:+ClassRelationshipVerifier"
 #define VMOPT_XXNOCLASSRELATIONSHIPVERIFIER "-XX:-ClassRelationshipVerifier"
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1984,6 +1984,16 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				goto _memParseError;
 			}
 
+			/* workaround option in case if OMRPORT_VMEM_ALLOC_QUICK Smart Address feature still be not reliable  */
+			argIndex = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOFORCE_FULL_HEAP_ADDRESS_RANGE_SEARCH, NULL);
+			argIndex2 = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXFORCE_FULL_HEAP_ADDRESS_RANGE_SEARCH, NULL);
+
+			if (argIndex2 > argIndex) {
+				j9port_control(OMRPORT_CTLDATA_VMEM_PERFORM_FULL_MEMORY_SEARCH, 1);
+			} else {
+				j9port_control(OMRPORT_CTLDATA_VMEM_PERFORM_FULL_MEMORY_SEARCH, 0);
+			}
+
 			break;
 
 		case ALL_DEFAULT_LIBRARIES_LOADED :


### PR DESCRIPTION
If OMRPORT_VMEM_ALLOC_QUICK is used, memory search in maps file for
Smart Address is performed. In case is memory range with requested
parameters can not be discovered Smart Address is set to NULL. In the
past we use to have problem (but were not able to reproduce) when Smart
Address is set to NULL however full memory search able to find memory to
allocate. So currently full memory search performs always (maps file
search is not trusted). In some cases such full search might be a reason
for increased JVM startup time.
Smart Address is set to NULL not only if memory range is not available
but also if any error occur at the time of maps file reading/parsing. 
I separated this two cases and trust Smart Address is NULL (memory range
not found) only if no error occur and file has been read to the end.

However because an original problem has not been reproduced the option
-XX:+ForceFullHeapAddressRangeSearch can be used as workaround in case if
feature still be not reliable in some cases. Also I added
-XX:-ForceFullHeapAddressRangeSearch [default behaviour] for symmetry. I believe
these options should not be added to documentation because designed for
emergency only. Also I believe these options are temporary and can be
removed in a year or two if problem would not manifest back.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>