### PR TITLE
CMake: add exports to j9ddr_misc

### DIFF
--- a/runtime/ddr/CMakeLists.txt
+++ b/runtime/ddr/CMakeLists.txt
@@ -46,3 +46,7 @@ endif()
 
 target_enable_ddr(j9ddr_misc)
 ddr_set_add_targets(j9ddr j9ddr_misc)
+
+# At least one symbol must be exported, but because this shared library
+# is only used by ddrgen it doesn't matter which name is exported.
+omr_add_exports(j9ddr_misc getAlgorithmVersionStructTable)


### PR DESCRIPTION
AIX emits an error when a shared library doesnt not export any symbols

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>