### PR TITLE
Fix issues highlighted by warnings from gcc 9

### DIFF
--- a/runtime/gc_verbose_old_events/VerboseEventMetronomeOutOfMemory.cpp
+++ b/runtime/gc_verbose_old_events/VerboseEventMetronomeOutOfMemory.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +49,12 @@ MM_VerboseEventMetronomeOutOfMemory::initialize(MM_OutOfMemoryEvent *event)
 {
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(_omrThread);
 	_timeInMilliSeconds = omrtime_current_time_millis();
-	strncpy(_memorySpaceString, event->memorySpaceString, 64);
+	size_t stringLength = strlen(event->memorySpaceString);
+	if (stringLength > sizeof(_memorySpaceString) - 1) {
+		stringLength = sizeof(_memorySpaceString) - 1;
+	}
+	memcpy(_memorySpaceString, event->memorySpaceString, stringLength);
+	_memorySpaceString[stringLength] = '\0';
 }
 
 /**
@@ -74,9 +78,9 @@ MM_VerboseEventMetronomeOutOfMemory::formattedOutput(MM_VerboseOutputAgent *agen
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(_omrThread->_vm);
 	MM_VerboseManagerBase *manager = extensions->verboseGCManager;
 	char timestamp[32];
-	
+
 	omrstr_ftime(timestamp, sizeof(timestamp), VERBOSEGC_DATE_FORMAT, _timeInMilliSeconds);
-	
+
 	agent->formatAndOutput(static_cast<J9VMThread*>(_omrThread->_language_vmthread), manager->getIndentLevel(), "<event details=\"out of memory\" timestamp=\"%s\" memoryspace=\"%s\" J9MemorySpace=\"0x%p\" />",
 		timestamp,
 		_memorySpaceString,

--- a/runtime/rasdump/j9dmp.tdf
+++ b/runtime/rasdump/j9dmp.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2008, 2017 IBM Corp. and others
+// Copyright (c) 2008, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,3 +37,5 @@ TraceEvent=Trc_dump_prepareForDump_Event1 NoEnv Overhead=1 Level=1 Template="Pre
 TraceEvent=Trc_dump_unwindAfterDump_Event1 NoEnv Overhead=1 Level=1 Template="Unwinding after dump, filename=%s"
 TraceEvent=Trc_dump_prepareForSilentDump_Event1 NoEnv Overhead=1 Level=4 Template="Preparing for silent dump"
 TraceEvent=Trc_dump_unwindAfterSilentDump_Event1 NoEnv Overhead=1 Level=4 Template="Unwinding after silent dump"
+
+TraceAssert=Assert_dump_true noEnv Overhead=1 Level=1 Assert="(P1)"

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -210,20 +210,23 @@ static J9RASdumpMatchResult
 matchesObjectAllocationFilter(J9RASdumpEventData *eventData, char *filter)
 {
 	char *message = eventData->detailData;
-	char* msgPtr;
-	UDATA msgValue;
+	char *msgPtr = NULL;
+	UDATA msgValue = 0;
 	char msgText[20];
-	char* fltPtr;
-	UDATA fltValueMin, fltValueMax;
+	char *fltPtr = NULL;
+	UDATA fltValueMin = 0;
+	UDATA fltValueMax = 0;
 	char fltText[20];
-	
+
 	if (!filter) {
 		/* Must have a filter for matching object allocation */
 		return J9RAS_DUMP_NO_MATCH;
 	}
-	
-	strncpy(msgText, message, sizeof(msgText));
-	strncpy(fltText, filter, sizeof(fltText));
+
+	strncpy(msgText, message, sizeof(msgText) - 1);
+	msgText[sizeof(msgText) - 1] = '\0';
+	strncpy(fltText, filter, sizeof(fltText) - 1);
+	fltText[sizeof(fltText) - 1] = '\0';
 
 	/* Convert the message to a number */
 	msgPtr = msgText;
@@ -250,15 +253,17 @@ static J9RASdumpMatchResult
 matchesSlowExclusiveEnterFilter(J9RASdumpEventData *eventData, char *filter)
 {
 	char *message = eventData->detailData;
-	char* msgPtr;
-	IDATA msgValue;
+	char *msgPtr = NULL;
+	IDATA msgValue = 0;
 	char msgText[20];
-	char* fltPtr;
-	IDATA fltValue;
+	char *fltPtr = NULL;
+	IDATA fltValue = 0;
 	char fltText[20];
 
-	strncpy(msgText, message, sizeof(msgText));
-	strncpy(fltText, filter, sizeof(fltText));
+	strncpy(msgText, message, sizeof(msgText) - 1);
+	msgText[sizeof(msgText) - 1] = '\0';
+	strncpy(fltText, filter, sizeof(fltText) - 1);
+	fltText[sizeof(fltText) - 1] = '\0';
 
 	/* convert the message value to a number */
 	msgPtr = msgText;

--- a/runtime/rastrace/trcoptions.c
+++ b/runtime/rastrace/trcoptions.c
@@ -31,7 +31,7 @@
 
 typedef omr_error_t (*uteOptionFunction)(UtThreadData **thr,const char * value, BOOLEAN atRuntime);
 
-/** 
+/**
  * Structure representing a UTE option such maximal or debug
  */
 struct uteOption {
@@ -67,37 +67,37 @@ static omr_error_t setFatalAssert(UtThreadData **thr, const char * spec, BOOLEAN
 static omr_error_t clearFatalAssert(UtThreadData **thr, const char * spec, BOOLEAN atRuntime);
 
 const struct uteOption UTE_OPTIONS[] = {
-/*		{ Keyword, Can be configured at runtime, Configuration function} */
-		
-		/* These four don't have any action */
-		{UT_DEBUG_KEYWORD, FALSE, NULL},
-		{UT_SUFFIX_KEYWORD, FALSE, NULL},
-		{UT_LIBPATH_KEYWORD, FALSE, NULL},
-		{UT_FORMAT_KEYWORD, FALSE, NULL},
-		
-		{UT_RESET_KEYWORD, FALSE, processResetOption},
-		{UT_PROPERTIES_KEYWORD, FALSE, processPropertiesOption},
-		{UT_MINIMAL_KEYWORD, TRUE, setMinimal},
-		{UT_MAXIMAL_KEYWORD, TRUE, setMaximal},
-		{UT_EXCEPTION_KEYWORD, TRUE, setException},
-		{UT_COUNT_KEYWORD, TRUE, setCount},
-		{UT_PRINT_KEYWORD, TRUE, setPrint},
-		{UT_NONE_KEYWORD, TRUE, setNone},
-		{UT_IPRINT_KEYWORD, TRUE, setIprint},
-		{UT_PLATFORM_KEYWORD, FALSE, setPlatform},
-		{UT_EXTERNAL_KEYWORD, TRUE, setExternal},
-		{UT_EXCEPT_OUT_KEYWORD, FALSE, setExceptOut},
-		{UT_STATE_OUT_KEYWORD, FALSE, setStateOut},
-		{UT_OUTPUT_KEYWORD, FALSE, setOutput},
-		{UT_BUFFERS_KEYWORD, TRUE, setBuffers}, /* Not all buffers functions are exposed - but are controlled in the set function*/
-		{UT_TRIGGER_KEYWORD, TRUE, setTrigger},
-		{UT_SUSPEND_KEYWORD, TRUE, processSuspendOption},
-		{UT_RESUME_KEYWORD, TRUE, processResumeOption},
-		{UT_RESUME_COUNT_KEYWORD, TRUE, processResumeOption},
-		{UT_SUSPEND_COUNT_KEYWORD, TRUE, processSuspendCountOption},
-		{UT_FATAL_ASSERT_KEYWORD, TRUE, setFatalAssert},
-		{UT_NO_FATAL_ASSERT_KEYWORD, TRUE, clearFatalAssert},
-		{UT_SLEEPTIME_KEYWORD, TRUE, setSleepTime},
+	/* { Keyword, Can be configured at runtime, Configuration function } */
+
+	/* These four don't have any action */
+	{UT_DEBUG_KEYWORD, FALSE, NULL},
+	{UT_SUFFIX_KEYWORD, FALSE, NULL},
+	{UT_LIBPATH_KEYWORD, FALSE, NULL},
+	{UT_FORMAT_KEYWORD, FALSE, NULL},
+
+	{UT_RESET_KEYWORD, FALSE, processResetOption},
+	{UT_PROPERTIES_KEYWORD, FALSE, processPropertiesOption},
+	{UT_MINIMAL_KEYWORD, TRUE, setMinimal},
+	{UT_MAXIMAL_KEYWORD, TRUE, setMaximal},
+	{UT_EXCEPTION_KEYWORD, TRUE, setException},
+	{UT_COUNT_KEYWORD, TRUE, setCount},
+	{UT_PRINT_KEYWORD, TRUE, setPrint},
+	{UT_NONE_KEYWORD, TRUE, setNone},
+	{UT_IPRINT_KEYWORD, TRUE, setIprint},
+	{UT_PLATFORM_KEYWORD, FALSE, setPlatform},
+	{UT_EXTERNAL_KEYWORD, TRUE, setExternal},
+	{UT_EXCEPT_OUT_KEYWORD, FALSE, setExceptOut},
+	{UT_STATE_OUT_KEYWORD, FALSE, setStateOut},
+	{UT_OUTPUT_KEYWORD, FALSE, setOutput},
+	{UT_BUFFERS_KEYWORD, TRUE, setBuffers}, /* Not all buffers functions are exposed - but are controlled in the set function*/
+	{UT_TRIGGER_KEYWORD, TRUE, setTrigger},
+	{UT_SUSPEND_KEYWORD, TRUE, processSuspendOption},
+	{UT_RESUME_KEYWORD, TRUE, processResumeOption},
+	{UT_RESUME_COUNT_KEYWORD, TRUE, processResumeOption},
+	{UT_SUSPEND_COUNT_KEYWORD, TRUE, processSuspendCountOption},
+	{UT_FATAL_ASSERT_KEYWORD, TRUE, setFatalAssert},
+	{UT_NO_FATAL_ASSERT_KEYWORD, TRUE, clearFatalAssert},
+	{UT_SLEEPTIME_KEYWORD, TRUE, setSleepTime},
 };
 
 #define NUMBER_OF_UTE_OPTIONS (sizeof(UTE_OPTIONS) / sizeof(struct uteOption))
@@ -111,16 +111,15 @@ const struct uteOption UTE_OPTIONS[] = {
 static omr_error_t
 addTraceCmd(UtThreadData **thr, const char *cmd, const char *value, BOOLEAN atRuntime)
 {
-	omr_error_t rc = OMR_ERROR_NONE;
-	char *str;
-
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
-	str = (char *)j9mem_allocate_memory(strlen(cmd) + (value == NULL ? 1 :
-												   strlen(value) + 2), OMRMEM_CATEGORY_TRACE);
-	if (str != NULL) {
+	omr_error_t rc = OMR_ERROR_NONE;
+	size_t valueLen = (NULL == value) ? 0 : strlen(value);
+	char * str = (char *)j9mem_allocate_memory(strlen(cmd) + valueLen + 2, OMRMEM_CATEGORY_TRACE);
+
+	if (NULL != str) {
 		strcpy(str, cmd);
-		if (value != NULL && strlen(value) > 0) {
+		if (valueLen > 0) {
 			strcat(str, "=");
 			strcat(str, value);
 		}
@@ -144,12 +143,12 @@ parseBufferSize(const char * const str, const int argSize, BOOLEAN atRuntime)
 	/* It's either invalid input or a number with an optional suffix
 	 * Find the position of the first digit and non-digit character.
 	 */
-	int32_t newBufferSize;
+	int32_t newBufferSize = 0;
 	intptr_t firstNonDigit = -1;
 	intptr_t firstDigit = -1;
 	const char * p = str;
-	
-	while( *p ) {
+
+	for (; '\0' != *p; ++p) {
 		if (isdigit(*p)) {
 			if (-1 == firstDigit) {
 				firstDigit = p - str;
@@ -159,13 +158,11 @@ parseBufferSize(const char * const str, const int argSize, BOOLEAN atRuntime)
 				firstNonDigit = p - str;
 			}
 		}
-		
-		p++;
 	}
-	
+
 	/* The only valid place for a non-digit is the final character */
 	if (firstNonDigit != -1) {
-		if (firstNonDigit == (argSize - 1) && firstDigit != -1) {
+		if ((firstNonDigit == (argSize - 1)) && (-1 != firstDigit)) {
 			int multiplier = 1;
 			switch (j9_cmdla_toupper(str[argSize - 1])) {
 			case 'K':
@@ -175,10 +172,10 @@ parseBufferSize(const char * const str, const int argSize, BOOLEAN atRuntime)
 				multiplier = 1024 * 1024;
 				break;
 			default:
-				reportCommandLineError(atRuntime, "Unrecognised suffix %c specified for buffer size",str[argSize - 1]);
+				reportCommandLineError(atRuntime, "Unrecognised suffix %c specified for buffer size", str[argSize - 1]);
 				return OMR_ERROR_ILLEGAL_ARGUMENT;
 			}
-			
+
 			newBufferSize = atoi(str) * multiplier;
 		} else {
 			/* Invalid */
@@ -189,14 +186,14 @@ parseBufferSize(const char * const str, const int argSize, BOOLEAN atRuntime)
 		/* The string contains no non-digits */
 		newBufferSize = atoi(str);
 	}
-	
+
 	if (newBufferSize < UT_MINIMUM_BUFFERSIZE) {
 		reportCommandLineError(atRuntime, "Specified buffer size %d bytes is too small. Minimum is %d bytes.", newBufferSize, UT_MINIMUM_BUFFERSIZE);
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	} else {
 		UT_GLOBAL(bufferSize) = newBufferSize;
 	}
-	
+
 	return OMR_ERROR_NONE;
 }
 
@@ -212,33 +209,33 @@ setBuffers(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	char * localBuffer = NULL;
 	omr_error_t rc = OMR_ERROR_NONE;
 	const int numberOfArgs = getParmNumber(value);
-	int i;
-	
+	int i = 0;
+
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	if (NULL == value) {
 		reportCommandLineError(atRuntime, "-Xtrace:buffers expects an argument.");
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	}
-    localBuffer = (char *)j9mem_allocate_memory(strlen(value) + 1, OMRMEM_CATEGORY_TRACE);
-    if (NULL == localBuffer) {
-    	UT_DBGOUT(1, ("<UT> Out of memory in setBuffers\n"));
+	localBuffer = (char *)j9mem_allocate_memory(strlen(value) + 1, OMRMEM_CATEGORY_TRACE);
+	if (NULL == localBuffer) {
+		UT_DBGOUT(1, ("<UT> Out of memory in setBuffers\n"));
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 	}
 
-	for (i=0;i<numberOfArgs;i++) {
-		int argSize;
-		const char * startOfThisArg = getPositionalParm(i+1,value,&argSize);
-		
-		if (argSize == 0) {
+	for (i = 0; i < numberOfArgs; ++i) {
+		int argSize = 0;
+		const char * startOfThisArg = getPositionalParm(i + 1, value, &argSize);
+
+		if (0 == argSize) {
 			reportCommandLineError(atRuntime, "Empty option passed to -Xtrace:buffers");
 			rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 			goto end;
 		}
-		
-		strncpy(localBuffer,startOfThisArg,argSize);
+
+		strncpy(localBuffer, startOfThisArg, argSize);
 		localBuffer[argSize] = '\0';
-		
+
 		if (j9_cmdla_stricmp(localBuffer, "DYNAMIC") == 0) {
 			UT_GLOBAL(dynamicBuffers) = TRUE;
 		} else if (j9_cmdla_stricmp(localBuffer, "NODYNAMIC") == 0) {
@@ -246,7 +243,7 @@ setBuffers(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 		} else {
 			if (!atRuntime) {
 				rc = parseBufferSize(localBuffer,argSize,atRuntime);
-			
+
 				if (rc != OMR_ERROR_NONE) {
 					goto end;
 				}
@@ -258,14 +255,14 @@ setBuffers(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 			}
 		}
 	}
-	
+
 	UT_DBGOUT(1, ("<UT> Trace buffer size: %d\n",UT_GLOBAL(bufferSize)));
-	
+
 end:
 	if (localBuffer != NULL) {
 		j9mem_free_memory(localBuffer);
 	}
-	
+
 	return rc;
 }
 
@@ -278,7 +275,7 @@ end:
 static omr_error_t
 setMinimal(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 {
-	return  addTraceCmd(thr, UT_MINIMAL_KEYWORD, value, atRuntime);
+	return addTraceCmd(thr, UT_MINIMAL_KEYWORD, value, atRuntime);
 }
 
 /*******************************************************************************
@@ -303,7 +300,7 @@ static omr_error_t
 setCount(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 {
 	UT_GLOBAL(traceCount) = TRUE;
-	return  addTraceCmd(thr, UT_COUNT_KEYWORD, value, atRuntime);
+	return addTraceCmd(thr, UT_COUNT_KEYWORD, value, atRuntime);
 }
 
 /*******************************************************************************
@@ -315,8 +312,8 @@ setCount(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 static omr_error_t
 setPrint(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 {
-	/* UT_GLOBAL(loadFormatFile) =  TRUE; */
-	return  addTraceCmd(thr, UT_PRINT_KEYWORD, value, atRuntime);
+	/* UT_GLOBAL(loadFormatFile) = TRUE; */
+	return addTraceCmd(thr, UT_PRINT_KEYWORD, value, atRuntime);
 }
 
 /*******************************************************************************
@@ -338,7 +335,7 @@ setNone(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 		clearAllTriggerActions();
 	}
 
-	return  rc;
+	return rc;
 }
 
 /*******************************************************************************
@@ -350,8 +347,8 @@ setNone(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 static omr_error_t
 setIprint(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 {
-	/* UT_GLOBAL(loadFormatFile) =  TRUE; */
-	return  addTraceCmd(thr, UT_IPRINT_KEYWORD, value, atRuntime);
+	/* UT_GLOBAL(loadFormatFile) = TRUE; */
+	return addTraceCmd(thr, UT_IPRINT_KEYWORD, value, atRuntime);
 }
 
 /*******************************************************************************
@@ -363,10 +360,10 @@ setIprint(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 static omr_error_t
 setPlatform(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 {
-  if (!UT_GLOBAL(platformTraceStarted)) {
-	  UT_GLOBAL(platformTraceStarted) = TRUE;
-  }
-  return  addTraceCmd(thr, UT_PLATFORM_KEYWORD, value, atRuntime);
+	if (!UT_GLOBAL(platformTraceStarted)) {
+		UT_GLOBAL(platformTraceStarted) = TRUE;
+	}
+	return addTraceCmd(thr, UT_PLATFORM_KEYWORD, value, atRuntime);
 }
 
 /*******************************************************************************
@@ -378,7 +375,7 @@ setPlatform(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 static omr_error_t
 setExternal(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 {
-	return  addTraceCmd(thr, UT_EXTERNAL_KEYWORD, value, atRuntime);
+	return addTraceCmd(thr, UT_EXTERNAL_KEYWORD, value, atRuntime);
 }
 
 /*******************************************************************************
@@ -413,7 +410,6 @@ setExceptOut(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	UT_GLOBAL(extExceptTrace) = TRUE;
-
 
 	/*
 	 * check for and expand %p or %p characters
@@ -462,7 +458,7 @@ setExceptOut(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 					str[length] = '\0';
 					UT_GLOBAL(exceptTraceWrap) = atoi(str) * multiplier;
 					UT_DBGOUT(1, ("<UT> Trace exception file wrap: %d\n",
-							   UT_GLOBAL(exceptTraceWrap)));
+								UT_GLOBAL(exceptTraceWrap)));
 				}
 			} else {
 				reportCommandLineError(atRuntime, "Length of wrap limit parameter invalid");
@@ -472,7 +468,7 @@ setExceptOut(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	}
 
 	/*
-	 *  That should be it
+	 * That should be it
 	 */
 
 	if (getParmNumber(instring) > 2) {
@@ -542,7 +538,7 @@ setStateOut(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	}
 
 	/*
-	 *  That should be it
+	 * That should be it
 	 */
 	if (getParmNumber(instring) > 2) {
 		reportCommandLineError(atRuntime, "Too many keywords in state.output specification");
@@ -575,7 +571,6 @@ setOutput(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 
 	UT_GLOBAL(externalTrace) = TRUE;
 
-
 	/*
 	 * check for and expand %p or %p characters
 	 */
@@ -592,7 +587,7 @@ setOutput(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 				memcpy(UT_GLOBAL(traceFilename), p, length);
 				UT_GLOBAL(traceFilename[length]) = '\0';
 				UT_DBGOUT(1, ("<UT> Output filename: %s\n",
-						   UT_GLOBAL(traceFilename)));
+							UT_GLOBAL(traceFilename)));
 
 			} else {
 				UT_DBGOUT(1, ("<UT> Out of memory handling output property\n"));
@@ -643,7 +638,7 @@ setOutput(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 				str[length] = '\0';
 				UT_GLOBAL(traceGenerations) = atoi(str);
 				UT_DBGOUT(1, ("<UT> Trace file generations: %d\n",
-						   UT_GLOBAL(traceGenerations)));
+							UT_GLOBAL(traceGenerations)));
 				if ((UT_GLOBAL(traceGenerations) < 2) ||
 					(UT_GLOBAL(traceGenerations) >36)) {
 					reportCommandLineError(atRuntime, "Invalid number of trace generations");
@@ -651,7 +646,7 @@ setOutput(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 				} else {
 					if ((UT_GLOBAL(generationChar) =
 						strchr(UT_GLOBAL(traceFilename), '#')) == NULL) {
-						reportCommandLineError(atRuntime, "Invalid filename for generation mode," 
+						reportCommandLineError(atRuntime, "Invalid filename for generation mode,"
 								" the filename must contain a \"#\"");
 						rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 					}
@@ -666,7 +661,7 @@ setOutput(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	}
 
 	/*
-	 *  That should be it
+	 * That should be it
 	 */
 	if (getParmNumber(instring) > 3) {
 		reportCommandLineError(atRuntime, "Too many keywords in output specification");
@@ -689,8 +684,8 @@ omr_error_t
 setTrigger(UtThreadData **thr, const char *triggerStr, BOOLEAN atRuntime)
 {
 	omr_error_t rc = OMR_ERROR_NONE;
-	char   *clause = NULL;
-	char   *str;
+	char *clause = NULL;
+	char *str = NULL;
 	const char *value = triggerStr;
 	int32_t done = FALSE;
 
@@ -700,17 +695,17 @@ setTrigger(UtThreadData **thr, const char *triggerStr, BOOLEAN atRuntime)
 	/*
 	 * Ignore empty value
 	 */
-	if(value == NULL || strlen(value) == 0) {
+	if (value == NULL || strlen(value) == 0) {
 		return rc;
 	}
 
 	/*
 	 * Keep calling getNextBracketedParm until done comes back TRUE
 	 */
-	for (;(OMR_ERROR_NONE == rc) && (!done);) {
+	for (; (OMR_ERROR_NONE == rc) && !done;) {
 		clause = getNextBracketedParm(value, &rc, &done, atRuntime);
-		if(OMR_ERROR_NONE == rc){
-			if(strlen(clause) == 0) {
+		if (OMR_ERROR_NONE == rc) {
+			if (strlen(clause) == 0) {
 				reportCommandLineError(atRuntime, "Empty clauses not allowed in trigger property.");
 				rc = OMR_ERROR_INTERNAL;
 			} else {
@@ -724,38 +719,36 @@ setTrigger(UtThreadData **thr, const char *triggerStr, BOOLEAN atRuntime)
 				} else {
 					workingClause = clause;
 				}
-				
+
 				/*
 				 * Tracepoint ID specified ?
 				 */
 				if (0 == j9_cmdla_strnicmp(workingClause, "tpnid{", strlen("tpnid{"))) {
-					
 					if (strchr(clause, ',') != NULL) {
 						str = strchr(clause, ',');
 						str[0] = '}';
 						str[1] = '\0';
 					}
-					
+
 					rc = addTraceCmd(thr, UT_TRIGGER_KEYWORD, clause, atRuntime);
 				}
 				/*
-				 * Group specified ?  =>  map to "all{name}"
+				 * Group specified ? => map to "all{name}"
 				 */
 				if (0 == j9_cmdla_strnicmp(workingClause, "group{", strlen("group{"))) {
-					
 					if (strchr(clause, ',') != NULL) {
 						str = strchr(clause, ',');
 						str[0] = '}';
 						str[1] = '\0';
 					}
-					
+
 					str = clause + 2;
 					if (disabling) {
-						strncpy(str, "!all", 4);
+						memcpy(str, "!all", 4);
 					} else {
-						strncpy(str, "all", 3);
+						memcpy(str, "all", 3);
 					}
-					
+
 					rc = addTraceCmd(thr, UT_TRIGGER_KEYWORD, str, atRuntime);
 				}
 			}
@@ -770,13 +763,12 @@ setTrigger(UtThreadData **thr, const char *triggerStr, BOOLEAN atRuntime)
 	 * Now we need to process the trigger actions so we can look up what to
 	 * do when one of those trace points fires.
 	 */
-	if( OMR_ERROR_NONE == rc ) {
+	if (OMR_ERROR_NONE == rc) {
 		rc = setTriggerActions(thr, triggerStr, atRuntime);
 	}
 
 	return rc;
 }
-
 
 /*******************************************************************************
  * name        - setFormat
@@ -816,28 +808,28 @@ setFormat(const char *value)
 omr_error_t
 setSuspendResumeCount(UtThreadData **thr, const char *value, int32_t resume, BOOLEAN atRuntime)
 {
-	omr_error_t     rc = OMR_ERROR_NONE;
-	const char    *p;
-	int     length;
-	int     maxLength=5;
+	omr_error_t rc = OMR_ERROR_NONE;
+	const char *p = NULL;
+	int length = 0;
+	int maxLength = 5;
 
 	/*
 	 * check for basic formatting errors
 	 */
 	p = getPositionalParm(1, value, &length);
 
-	if (getParmNumber(value) != 1) {  /* problem if not just the one parm */
+	if (getParmNumber(value) != 1) { /* problem if not just the one parm */
 		rc = OMR_ERROR_INTERNAL;
-	} else if (length == 0) {         /* first (only) parm must be non null */
+	} else if (length == 0) { /* first (only) parm must be non null */
 		rc = OMR_ERROR_INTERNAL;
 	}
 
-	if (OMR_ERROR_NONE == rc) {               /* max 5 chars long            */
-		if (*p == '+' || *p == '-') { /* but must allow 6 if signed  */
+	if (OMR_ERROR_NONE == rc) { /* max 5 chars long */
+		if (*p == '+' || *p == '-') { /* but must allow 6 if signed */
 			maxLength++;
 		}
-		if (length > maxLength){
-			rc=OMR_ERROR_INTERNAL;
+		if (length > maxLength) {
+			rc = OMR_ERROR_INTERNAL;
 		}
 	}
 
@@ -845,14 +837,14 @@ setSuspendResumeCount(UtThreadData **thr, const char *value, int32_t resume, BOO
 	 * If any of the above checks failed, issue message.
 	 */
 	if (OMR_ERROR_NONE != rc) {
-		if(resume) {
+		if (resume) {
 			reportCommandLineError(atRuntime, "resumecount takes a single integer value from -99999 to +99999");
 		} else {
 			reportCommandLineError(atRuntime, "suspendcount takes a single integer value from -99999 to +99999");
 		}
 	}
 
-	if(OMR_ERROR_NONE == rc) {
+	if (OMR_ERROR_NONE == rc) {
 		/*
 		 * Enforce that users may not use resumecount and suspendcount together !
 		 */
@@ -864,7 +856,7 @@ setSuspendResumeCount(UtThreadData **thr, const char *value, int32_t resume, BOO
 			int value = decimalString2Int(p, TRUE, &rc, atRuntime);
 
 			if (OMR_ERROR_NONE == rc) {
-				if(resume){
+				if (resume) {
 					UT_GLOBAL(initialSuspendResume) = (0 - value);
 				} else {
 					UT_GLOBAL(initialSuspendResume) = (value - 1);
@@ -888,23 +880,22 @@ setSuspendResumeCount(UtThreadData **thr, const char *value, int32_t resume, BOO
 static omr_error_t
 processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 {
-	intptr_t          propFile;
-	int64_t         size;
-	int            i;
-	omr_error_t            rc = OMR_ERROR_NONE;
-	char          *buffer = NULL;
-	char          *p;
-	char           name[MAX_IMAGE_PATH_LENGTH];
-	char          *separator = DIR_SEPARATOR_STR;
+	intptr_t propFile = 0;
+	int64_t size = 0;
+	int i = 0;
+	omr_error_t rc = OMR_ERROR_NONE;
+	char *buffer = NULL;
+	char *p = NULL;
+	char name[MAX_IMAGE_PATH_LENGTH];
+	char *separator = DIR_SEPARATOR_STR;
 
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	/*
-	 *  Process properties file, if any
+	 * Process properties file, if any
 	 */
 
 	if (filename == NULL || *filename == '\0') {
-
 		*name = '\0';
 
 		if (UT_GLOBAL(propertyFilePath) != NULL) {
@@ -923,7 +914,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 		reportCommandLineError(atRuntime, "Unable to open properties file %s", name);
 	} else {
 		/*
-		 *  Get the file size
+		 * Get the file size
 		 */
 		size = j9file_flength(propFile);
 		if ( 0 > size ) {
@@ -936,7 +927,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 			if (buffer == NULL) {
 				UT_DBGOUT(1, ("<UT> Cannot obtain memory to process %s\n", name));
 			} else {
-				if ((size = j9file_read(propFile, buffer, (int)size)) == 0){
+				if ((size = j9file_read(propFile, buffer, (int)size)) == 0) {
 					reportCommandLineError(atRuntime, "Error reading properties file %s", name);
 				} else {
 					buffer[size] = '\0';
@@ -948,7 +939,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 		j9file_close(propFile);
 	}
 	/*
-	 *  Transform all CR/LF's to binary zeroes and tabs to blanks
+	 * Transform all CR/LF's to binary zeroes and tabs to blanks
 	 */
 	if (rc == OMR_ERROR_NONE) {
 		*(buffer + size) = '\0';
@@ -962,7 +953,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 			}
 		}
 		/*
-		 *  Parse the file a line at a time
+		 * Parse the file a line at a time
 		 */
 		for (p = buffer;
 			 (rc == OMR_ERROR_NONE) && (p < (buffer + size));
@@ -974,7 +965,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 			if (0 == j9_cmdla_strnicmp(p, UT_PROPERTIES_COMMENT, strlen(UT_PROPERTIES_COMMENT))) {
 				continue;
 			}
-			if(0 == j9_cmdla_strnicmp(p, UT_DEBUG_KEYWORD, strlen(UT_DEBUG_KEYWORD))) {
+			if (0 == j9_cmdla_strnicmp(p, UT_DEBUG_KEYWORD, strlen(UT_DEBUG_KEYWORD))) {
 				if (strlen(p) > strlen(UT_DEBUG_KEYWORD)) {
 					p += strlen(UT_DEBUG_KEYWORD);
 					if (strlen(p) == 2 &&
@@ -1030,7 +1021,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 					   (*(p + strlen(UT_FORMAT_KEYWORD)) == '=')) {
 				char * tempSpec;
 				p += strlen(UT_FORMAT_KEYWORD) + 1;
-				tempSpec =  j9mem_allocate_memory(strlen(p) + 1, OMRMEM_CATEGORY_TRACE );
+				tempSpec = j9mem_allocate_memory(strlen(p) + 1, OMRMEM_CATEGORY_TRACE );
 				if (tempSpec != NULL) {
 					strcpy(tempSpec, p);
 					UT_GLOBAL(traceFormatSpec) = tempSpec;
@@ -1089,11 +1080,11 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 				rc = setSleepTime(thr, p, FALSE);
 			} else {
 				/*
-				 *  Check for options to quietly ignore
+				 * Check for options to quietly ignore
 				 */
 
 				if (UT_GLOBAL(ignore) != NULL) {
-					for(i = 0; UT_GLOBAL(ignore[i]) != NULL; i++) {
+					for (i = 0; UT_GLOBAL(ignore[i]) != NULL; i++) {
 						if (0 == j9_cmdla_strnicmp(p, UT_GLOBAL(ignore[i]), strlen(UT_GLOBAL(ignore[i])))) {
 							rc = propertyFileOption(p);
 							break;
@@ -1112,7 +1103,7 @@ processPropertyFile(UtThreadData **thr, const char *filename, BOOLEAN atRuntime)
 		j9mem_free_memory(buffer);
 	}
 	UT_DBGOUT(1, ("<UT> Properties file processing complete, RC=%d\n", rc));
-	
+
 	if (UT_GLOBAL(externalTrace) || UT_GLOBAL(extExceptTrace)) {
 		UT_GLOBAL(traceInCore) = FALSE;
 	}
@@ -1132,21 +1123,20 @@ processEarlyOptions(const char **opts)
 	omr_error_t rc = OMR_ERROR_NONE;
 
 	/*
-	 *  Process the options passed
+	 * Process the options passed
 	 */
-
 
 	/*
-	 *  Options are in name / value pairs, and terminate with a NULL
+	 * Options are in name / value pairs, and terminate with a NULL
 	 */
 
-	for(i = 0; opts[i] != NULL; i += 2) {
+	for (i = 0; opts[i] != NULL; i += 2) {
 		/* DEBUG is handled elsewhere, SUFFIX and LIBPATH are obsolete. */
-		if(j9_cmdla_stricmp((char *)opts[i], UT_DEBUG_KEYWORD) == 0) {
+		if (j9_cmdla_stricmp((char *)opts[i], UT_DEBUG_KEYWORD) == 0) {
 		} else if (j9_cmdla_stricmp((char *)opts[i], UT_SUFFIX_KEYWORD) == 0) {
 		} else if (j9_cmdla_stricmp((char *)opts[i], UT_LIBPATH_KEYWORD) == 0) {
 		} else if (j9_cmdla_stricmp((char *)opts[i], UT_FORMAT_KEYWORD) == 0) {
-			if ( opts[i+1] == NULL ){
+			if (opts[i + 1] == NULL) {
 				return OMR_ERROR_ILLEGAL_ARGUMENT;
 			}
 			rc = setFormat(opts[i + 1]);
@@ -1219,13 +1209,13 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	/*
-	 *  Check options for the debug switch. Options are in name / value pairs
-	 *  so only look at the first of each pair
+	 * Check options for the debug switch. Options are in name / value pairs
+	 * so only look at the first of each pair
 	 */
 
 	if (! atRuntime) {
-		for(i = 0; opts[i] != NULL; i += 2) {
-			if(j9_cmdla_stricmp((char *)opts[i], UT_DEBUG_KEYWORD) == 0) {
+		for (i = 0; opts[i] != NULL; i += 2) {
+			if (j9_cmdla_stricmp((char *)opts[i], UT_DEBUG_KEYWORD) == 0) {
 				if (opts[i + 1] != NULL &&
 						strlen(opts[i + 1]) == 1 &&
 						*opts[i + 1] >= '0' &&
@@ -1240,18 +1230,18 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 	}
 
 	/*
-	 *  Process the options passed
-	 *  Options are in name / value pairs, and terminate with a NULL
+	 * Process the options passed
+	 * Options are in name / value pairs, and terminate with a NULL
 	 */
 
-	for(i = 0; opts[i] != NULL; i += 2) {
+	for (i = 0; opts[i] != NULL; i += 2) {
 		int32_t found = 0;
 		const char *optName = opts[i];
 		char *optValue = (char*)opts[i+1];
 		size_t optNameLen = strlen(optName);
 		UT_DBGOUT(1, ("<UT> Processing option %s=%s\n", optName, (optValue == NULL)? "NULL" : optValue ));
-		
-		if( NULL != optValue ) {
+
+		if ( NULL != optValue ) {
 			size_t optValueLen = strlen(optValue);
 			/* Values enclosed in {...} should have the brackets removed */
 			if (optValue[0] == '{' && optValue[optValueLen-1] == '}') {
@@ -1268,21 +1258,21 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 		for (j=0; j < NUMBER_OF_UTE_OPTIONS; j++) {
 			if (optNameLen == strlen(UTE_OPTIONS[j].name) && 0 == j9_cmdla_stricmp((char *)optName,(char *)UTE_OPTIONS[j].name)) {
 				found = 1;
-				
+
 				if (atRuntime && ! UTE_OPTIONS[j].runtimeModifiable) {
 					reportCommandLineError(atRuntime, "Option \"%s\" cannot be set at run-time. Set it on the command line at start-up.", optName);
-					
+
 					rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 				} else {
 					if (NULL != UTE_OPTIONS[j].optionFunction) {
 						rc = UTE_OPTIONS[j].optionFunction(thr,optValue,atRuntime);
 					}
 				}
-				
+
 				break;
 			}
 		}
-		
+
 		/*
 		 * Handle any non-OMR options by calling back to the language layer.
 		 */
@@ -1291,13 +1281,13 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 				found = 1;
 			}
 		}
-		
+
 		/*
-		 *  Check for options to quietly ignore
+		 * Check for options to quietly ignore
 		 */
 		if (! found) {
 			if (UT_GLOBAL(ignore) != NULL) {
-				for(j = 0; UT_GLOBAL(ignore[j]) != NULL; j++) {
+				for (j = 0; UT_GLOBAL(ignore[j]) != NULL; j++) {
 					if (j9_cmdla_stricmp((char *)optName, (char *)UT_GLOBAL(ignore[j])) == 0) {
 						break;
 					}
@@ -1307,18 +1297,17 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 				}
 			}
 		}
-		
+
 		if (! found) {
 			if (!atRuntime) {
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_UNRECOGNISED_OPTION_STR, optName);
 			}
 			rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 		}
-		
-		
+
 		if (OMR_ERROR_NONE != rc) {
 			if (!atRuntime) {
-				if( optValue == NULL ) {
+				if ( optValue == NULL ) {
 					j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_ERROR_IN_OPTION_STR, optName);
 				} else {
 					j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_ERROR_IN_OPTION_WITH_ARG_STR, optName, optValue);
@@ -1329,9 +1318,9 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 			/* Add to trace config if the option was valid and actually set. */
 			addTraceConfigKeyValuePair(thr, optName, optValue);
 		}
-		
+
 		/* Check if we allocated a new string for optValue and free */
-		if( optValue != opts[i+1] ) {
+		if ( optValue != opts[i+1] ) {
 			j9mem_free_memory(optValue);
 		}
 	}
@@ -1339,9 +1328,9 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 	if (UT_GLOBAL(externalTrace) || UT_GLOBAL(extExceptTrace)) {
 		UT_GLOBAL(traceInCore) = FALSE;
 	}
-	
+
 	/*
-	 *  Set active flag
+	 * Set active flag
 	 */
 
 	UT_GLOBAL(traceActive) = TRUE;
@@ -1351,7 +1340,7 @@ processOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 /**************************************************************************
  * name        - reportCommandLineError
  * description - Report an error in a command line option and put the given
- * 			   - string in as detail in an NLS enabled message.
+ *             - string in as detail in an NLS enabled message.
  * parameters  - detailStr, args for formatting into detailStr.
  *             - suppressMessages, a flag that says whether messages should
  *               be displayed at the moment.
@@ -1372,7 +1361,7 @@ reportCommandLineError(BOOLEAN suppressMessages, const char* detailStr, ...)
 /**************************************************************************
  * name        - selectSpecial
  * description - Selects special option - provides argument parsing only to
- * 				 allow backwards command line compatibility.
+ *               allow backwards command line compatibility.
  * parameters  - Component name, component array,
  * returns     - size of the match
  *************************************************************************/
@@ -1393,10 +1382,10 @@ selectSpecial(const char *string)
 			(p[strlen(UT_BACKTRACE)] == '\0'))) {
 		UT_DBGOUT(3, ("<UT> Backtrace specifier found\n"));
 		p += strlen(UT_BACKTRACE);
-		if((*p == ',') && ((*(p+1) >= '0') && (*(p+1) <= '9'))) {
+		if ((*p == ',') && ((*(p+1) >= '0') && (*(p+1) <= '9'))) {
 			depth = 0;
 			p++;
-			while((*p != '\0') && (*p >= '0') && (*p <= '9')) {
+			while ((*p != '\0') && (*p >= '0') && (*p <= '9')) {
 				depth *= 10;
 				depth += (*p - '0');
 				p++;
@@ -1404,18 +1393,17 @@ selectSpecial(const char *string)
 		}
 		UT_DBGOUT(3, ("<UT> Depth set to %d\n", depth));
 	}
-	if(*p == ',') {
+	if (*p == ',') {
 		p++;
 	}
 	return((int)(p - string));
 }
 
-
 /*******************************************************************************
  * name        - selectComponent
  * description - Selects a component name
  * parameters  - Component name, component array, first time
-  *              through flag
+ *               through flag
  * returns     - size of the match
  ******************************************************************************/
 static int
@@ -1424,16 +1412,16 @@ selectComponent(const char *cmd, int32_t *first, char traceType, int32_t setActi
 	int length = 0;
 
 	/*
-	 *  If no component specified and first time through, default to all
+	 * If no component specified and first time through, default to all
 	 */
 	UT_DBGOUT(2, ("<UT> selectComponent: %s\n", cmd));
 	if (*cmd == '\0') {
 		if (*first) {
 			omr_error_t rc = OMR_ERROR_NONE;
-			
+
 			UT_DBGOUT(1, ("<UT> Defaulting to All components\n"));
 			/*
-			 *  Set all components and applications, but ignore groups
+			 * Set all components and applications, but ignore groups
 			 */
 			rc = setTracePointsTo((const char*) UT_ALL, UT_GLOBAL(componentList), TRUE, 0, 0, traceType, -1, NULL, atRuntime, setActive);
 			if (OMR_ERROR_NONE != rc) {
@@ -1441,12 +1429,12 @@ selectComponent(const char *cmd, int32_t *first, char traceType, int32_t setActi
 				return -1;
 			}
 		}
-		*first = FALSE;   
+		*first = FALSE;
 	} else {
 		omr_error_t rc = OMR_ERROR_NONE;
-		
+
 		*first = FALSE;
-		
+
 		UT_DBGOUT(2, ("<UT> Component %s selected\n", cmd));
 		rc = setTracePointsTo(cmd, UT_GLOBAL(componentList), TRUE, 0, 0, traceType, -1, NULL, atRuntime, setActive);
 		if (OMR_ERROR_NONE != rc) {
@@ -1472,22 +1460,21 @@ selectComponent(const char *cmd, int32_t *first, char traceType, int32_t setActi
 omr_error_t
 setTraceState(const char *cmd, BOOLEAN atRuntime)
 {
-	omr_error_t	rc = OMR_ERROR_NONE;
-	int	i;
-	int32_t	first = TRUE;
-	int	context = UT_CONTEXT_INITIAL;
-	char	traceType = UT_NONE;
-	int	length;
-	const char  *p;
-	int32_t	explicitClass;
-	int32_t	setActive = TRUE;
+	omr_error_t rc = OMR_ERROR_NONE;
+	int i = 0;
+	int32_t first = TRUE;
+	int context = UT_CONTEXT_INITIAL;
+	char traceType = UT_NONE;
+	int length = 0;
+	const char *p = NULL;
+	int32_t explicitClass = 0;
+	int32_t setActive = TRUE;
 
 	/*
-	 *  Initialize temporary boolean arrays to reflect whether a particular
-	 *  component or class is the target of this command
+	 * Initialize temporary boolean arrays to reflect whether a particular
+	 * component or class is the target of this command
 	 */
 	UT_DBGOUT(1, ("<UT> setTraceState %s\n", cmd));
-
 
 	/*
 	 * Parse the command using a finite state machine
@@ -1500,11 +1487,11 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 
 	p = cmd;
 	explicitClass = FALSE;
-	while((OMR_ERROR_NONE == rc)  &&
+	while ((OMR_ERROR_NONE == rc) &&
 		  (UT_CONTEXT_FINAL != context)) {
 		switch (context) {
 		/*
-		 *  Start of line
+		 * Start of line
 		 */
 		case UT_CONTEXT_INITIAL:
 			UT_DBGOUT(2, ("<UT> setTraceState: Initial\n"));
@@ -1560,10 +1547,10 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 				p += strlen(UT_EXCEPTION_KEYWORD);
 			} else {
 				/*
-				 *  Check for options to quietly ignore
+				 * Check for options to quietly ignore
 				 */
 				if (UT_GLOBAL(ignore) != NULL) {
-					for(i = 0; UT_GLOBAL(ignore[i]) != NULL; i++) {
+					for (i = 0; UT_GLOBAL(ignore[i]) != NULL; i++) {
 						if (0 == j9_cmdla_strnicmp(p, UT_GLOBAL(ignore[i]), strlen(UT_GLOBAL(ignore[i])))) {
 							p += strlen(p);
 							break;
@@ -1580,20 +1567,20 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 
 			if (*p == '=') {
 				p++;
-			} 
-			
+			}
+
 			if (*p == '\0' && traceType != UT_NONE) {
 				/* Only the keyword has been specified and the option isn't -Xtrace:none */
 				reportCommandLineError(atRuntime, "Option %s requires an argument.",cmd);
 				rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 			}
-			
+
 			context = UT_CONTEXT_COMPONENT;
 			UT_GLOBAL(traceDests) |= traceType;
 			break;
 
 		/*
-		 *  Looking for a component or TPID
+		 * Looking for a component or TPID
 		 */
 		case UT_CONTEXT_COMPONENT:
 			UT_DBGOUT(2, ("<UT> setTraceState: Component\n"));
@@ -1602,10 +1589,10 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 			if (*p == '!') {
 				UT_DBGOUT(2, ("<UT> Reset of tracepoints requested\n"));
 				p++;
-				setActive = FALSE;                
+				setActive = FALSE;
 			}
 			/* Parse deprecated option -Xtrace:maximal={backtrace[,depth]} */
-			if((length = selectSpecial(p)) != 0) {
+			if ((length = selectSpecial(p)) != 0) {
 				if (length < 0) {
 					rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 				} else {
@@ -1633,7 +1620,7 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 			}
 			break;
 		/*
-		 *  Looking for classes
+		 * Looking for classes
 		 */
 		case UT_CONTEXT_CLASS:
 			UT_DBGOUT(2, ("<UT> setTraceState: Class\n"));
@@ -1641,22 +1628,21 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 						context = UT_CONTEXT_PROCESS;
 			break;
 		/*
-		 *  Process the state so far.
+		 * Process the state so far.
 		 */
 		case UT_CONTEXT_PROCESS:
 			UT_DBGOUT(2, ("<UT> setTraceState: Process\n"));
-						if (*p == '\0'){
-							context = UT_CONTEXT_FINAL;
-						} else {
-							setActive = TRUE;
-							context = UT_CONTEXT_COMPONENT;
-						}
+			if (*p == '\0') {
+				context = UT_CONTEXT_FINAL;
+			} else {
+				setActive = TRUE;
+				context = UT_CONTEXT_COMPONENT;
+			}
 			break;
 		}
 
-
 		/*
-		 *  Check for more input
+		 * Check for more input
 		 */
 		if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
 			if (*p =='\0') {
@@ -1675,7 +1661,7 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
 	}
 
 	/*
-	 *  Expecting more input ?
+	 * Expecting more input ?
 	 */
 	if (explicitClass) {
 		rc = OMR_ERROR_ILLEGAL_ARGUMENT;
@@ -1698,17 +1684,16 @@ setTraceState(const char *cmd, BOOLEAN atRuntime)
  * parameters  - char **options, atRuntime
  * returns     - OMR return code
  ******************************************************************************/
-
-omr_error_t 
+omr_error_t
 setOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 {
-	omr_error_t	rc = OMR_ERROR_NONE;
+	omr_error_t rc = OMR_ERROR_NONE;
 
 	UT_DBGOUT(1, ("<UT> Initializing options \n"));
 
 	if (!atRuntime) {
 		/*
-		 *  Process any additional early options
+		 * Process any additional early options
 		 */
 		rc = processEarlyOptions(opts);
 		if (OMR_ERROR_NONE != rc) {
@@ -1718,7 +1703,7 @@ setOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
 	}
 
 	/*
-	 *  Process the rest of the options
+	 * Process the rest of the options
 	 */
 	rc = processOptions(thr, opts, atRuntime);
 	if (OMR_ERROR_NONE != rc) {
@@ -1736,7 +1721,7 @@ setOptions(UtThreadData **thr, const char **opts, BOOLEAN atRuntime)
  * parameters  - thread and option.
  * returns     - UTE error code
  *************************************************************************/
-static omr_error_t 
+static omr_error_t
 propertyFileOption(const char *value)
 {
 
@@ -1752,7 +1737,7 @@ propertyFileOption(const char *value)
 	if (!value) {
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	}
-	
+
 	if (NULL == optionCallback) {
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	}
@@ -1767,7 +1752,7 @@ propertyFileOption(const char *value)
 	/* If this is a name/value pair split it up. */
 	optName = tempStr;
 	optValue = strchr(tempStr, '=');
-	if( optValue != NULL ) {
+	if ( optValue != NULL ) {
 		size_t optValueLen = strlen(optValue);
 		*optValue = '\0';
 		optValue++;
@@ -1775,10 +1760,9 @@ propertyFileOption(const char *value)
 		/* Values enclosed in {...} should have the brackets removed */
 		if (optValue[0] == '{' && optValue[optValueLen-1] == '}') {
 			optValue++;
-			optValue[strlen(optValue)-1] = '\0';
+			optValue[strlen(optValue) - 1] = '\0';
 		}
 	}
-
 
 	/*
 	 * Handle any non-OMR options by calling back to the language layer.
@@ -1787,7 +1771,7 @@ propertyFileOption(const char *value)
 		j9mem_free_memory(tempStr);
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	}
-	
+
 	j9mem_free_memory(tempStr);
 	return OMR_ERROR_NONE;
 }

--- a/runtime/rastrace/trctrigger.c
+++ b/runtime/rastrace/trctrigger.c
@@ -99,7 +99,6 @@ static void doTriggerActionAbort(OMR_VMThread *);
 static void doTriggerActionSegv(OMR_VMThread *);
 static void doTriggerActionSleep(OMR_VMThread *thr);
 
-
 /**
  * Each possible trigger action has an entry in this array. The
  * order of the entries is not important. These are the default
@@ -129,7 +128,8 @@ static omr_error_t processTriggerTpnidClause(OMR_VMThread *, char *, BOOLEAN atR
  * Each possible trigger type has an entry in this array. The
  * order of the entries is not important.
  */
-static struct RasTriggerType defaultRasTriggerTypes[] = {
+static struct RasTriggerType defaultRasTriggerTypes[] =
+{
 	/* trigger clause, parse function, runtime configurable */
 	{ "group", processTriggerGroupClause, TRUE },
 	{ "tpnid", processTriggerTpnidClause, TRUE }
@@ -140,7 +140,6 @@ struct RasTriggerType* rasTriggerTypes = defaultRasTriggerTypes;
 #define NUM_DEFAULT_TRIGGER_TYPES (sizeof(defaultRasTriggerTypes) / sizeof(defaultRasTriggerTypes[0]))
 
 int numTriggerTypes = NUM_DEFAULT_TRIGGER_TYPES;
-
 
 /*The name passed to the dump trigger system describing this component - appears in Javacores and on the console*/
 #define DUMP_CALLER_NAME "-Xtrace:trigger"
@@ -171,7 +170,7 @@ getPositionalParm(int pos, const char *string, int *size)
 		}
 	}
 	/*
-	 *  Find its size
+	 * Find its size
 	 */
 
 	if (p != NULL) {
@@ -226,9 +225,9 @@ setSleepTime(UtThreadData **thr, const char * str, BOOLEAN atRuntime)
 	if (getParmNumber(str) != 1) {
 		goto err;
 	}
-	
+
 	param = getPositionalParm(1, str, &length);
-	
+
 	/* Max length of 12 because strlen(4294967295ms) = 12 */
 	if (length == 0 || length > 12) {
 		goto err;
@@ -240,14 +239,14 @@ setSleepTime(UtThreadData **thr, const char * str, BOOLEAN atRuntime)
 		suffix++;
 	}
 
-	if(suffix == param) {
+	if (suffix == param) {
 		/* First character isn't a number or the string is empty */
 		goto err;
 	}
 
-	if(*suffix != '\0') {
+	if (*suffix != '\0') {
 		/* A suffix has been specified, parse it */
-		if(j9_cmdla_stricmp((char *)suffix, "s") == 0) {
+		if (j9_cmdla_stricmp((char *)suffix, "s") == 0) {
 			unitsSeconds = TRUE;
 		} else if (j9_cmdla_stricmp((char *)suffix, "ms") == 0) {
 			/* Do nothing - milliseconds is the default */
@@ -266,16 +265,16 @@ setSleepTime(UtThreadData **thr, const char * str, BOOLEAN atRuntime)
 	}
 
 	/* If the value is larger than will fit in a 32 bit number, errno will be set to ERANGE */
-	if(errno == ERANGE) {
+	if (errno == ERANGE) {
 		goto err;
 	}
 
 	/* The value is stored in milliseconds */
-	if(unitsSeconds) {
+	if (unitsSeconds) {
 		value = value * 1000;
 	}
 
-	if(value > U_32_MAX) {
+	if (value > U_32_MAX) {
 		goto err;
 	}
 
@@ -286,7 +285,6 @@ err:
 	reportCommandLineError(atRuntime, "Sleeptime takes a positive integer value and, optionally, a suffix of s or ms. Maximum sleeptime is 4294967295 milliseconds.");
 	return OMR_ERROR_INTERNAL;
 }
-
 
 /**************************************************************************
  * name        - decimalString2Int
@@ -345,7 +343,7 @@ decimalString2Int(const char *decString, int32_t signedAllowed, omr_error_t *rc,
 		 */
 		if ((p - decString) < min_string_length || (p - decString) > max_string_length) {
 			*rc = OMR_ERROR_INTERNAL;
-			reportCommandLineError(atRuntime, "Number too long or too short \"%s\".", decString); 
+			reportCommandLineError(atRuntime, "Number too long or too short \"%s\".", decString);
 		} else {
 			sscanf(decString, "%d", &num);
 		}
@@ -361,15 +359,14 @@ decimalString2Int(const char *decString, int32_t signedAllowed, omr_error_t *rc,
  * parameters  - thr, a trigger name string.
  * returns     - Index into rasTriggerActions or -1 if the name is invalid
  *************************************************************************/
-
 static uint32_t
 parseTriggerIndex(OMR_VMThread *thr, const char * name, BOOLEAN atRuntime)
 {
 	int i;
-	
+
 	for (i = 0; i < numTriggerActions; i++) {
 		const struct RasTriggerAction *action = &rasTriggerActions[i];
-		
+
 		if (j9_cmdla_stricmp((char *)name, (char *)action->name) == 0) {
 			return i;
 		}
@@ -396,14 +393,14 @@ addTriggerAction(OMR_VMThread *thr, const struct RasTriggerAction *newAction)
 
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(thr);
 
-	if( NULL == newAction ||  NULL == newAction->name || NULL == newAction->fn ) {
+	if ( NULL == newAction || NULL == newAction->name || NULL == newAction->fn ) {
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	}
 
 	/* Append it to the existing list of options and update */
 	newRasTriggerActions = omrmem_allocate_memory(sizeof(struct RasTriggerAction) * (numTriggerActions + 1), OMRMEM_CATEGORY_TRACE);
 
-	if( NULL == newRasTriggerActions ) {
+	if ( NULL == newRasTriggerActions ) {
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 	}
 
@@ -413,7 +410,7 @@ addTriggerAction(OMR_VMThread *thr, const struct RasTriggerAction *newAction)
 	/* Add the new option as the final element. */
 	newRasTriggerActions[numTriggerActions] = *newAction;
 
-	if( defaultRasTriggerActions != rasTriggerActions ) {
+	if ( defaultRasTriggerActions != rasTriggerActions ) {
 		/* We have already allocated one new action, we need to free rasTriggerActions. */
 		omrmem_free_memory(rasTriggerActions);
 	}
@@ -434,7 +431,7 @@ const struct RasTriggerAction *
 parseTriggerAction(OMR_VMThread *thr, const char *name, BOOLEAN atRuntime)
 {
 	uint32_t index = parseTriggerIndex(thr,name,atRuntime);
-	
+
 	if (index != -1) {
 		return &rasTriggerActions[index];
 	} else {
@@ -481,9 +478,9 @@ processTriggerTpnidClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 	 * check doesn't have more than 4 args
 	 */
 	if (getParmNumber(clause) > 4 || /* may NOT have more than 4 parameters */
-			ptrName == NULL || /* but MUST have name                  */
-			ptrAction == NULL) { /* ...and action                       */
-		reportCommandLineError(atRuntime,  
+			ptrName == NULL || /* but MUST have name */
+			ptrAction == NULL) { /* ... and action */
+		reportCommandLineError(atRuntime,
 				"Invalid tpnid clause, usage:"
 				" tpnid{compname.offset[-offset2],action[,delaycount][,matchcount]}"
 				" clause is: tpnid{%s}", clause);
@@ -552,7 +549,7 @@ processTriggerTpnidClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 			}
 
 			/*
-			 * in "tpnid{component.x-y,...", y cannot be < x  (yes, it can be equal)
+			 * in "tpnid{component.x-y,...", y cannot be < x (yes, it can be equal)
 			 */
 			if ((OMR_ERROR_NONE == rc) && (tpidRangeEnd < tpidRangeStart)) {
 				reportCommandLineError(atRuntime, "Invalid tpnid range - start value cannot be higher than end value.");
@@ -681,8 +678,8 @@ processTriggerGroupClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 	 * if there's a third parameter, check that it is valid
 	 */
 	if (numParms >= 3 && ptrDelay != NULL && *ptrDelay != '\0') {
-		if (*ptrDelay == '+' || *ptrDelay == '-') { /* allow 6 chars if signed  */
-			maxLength++; /* or 5 if not              */
+		if (*ptrDelay == '+' || *ptrDelay == '-') { /* allow 6 chars if signed */
+			maxLength++; /* or 5 if not */
 		}
 		if (strlen(ptrDelay) > maxLength) {
 			reportCommandLineError(atRuntime, "Delay counts must be integer values from -99999 to +99999: group{%s,%s,%s,%s}",
@@ -698,11 +695,11 @@ processTriggerGroupClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 	 * if there's a fourth parameter, check that it is valid
 	 */
 	if (numParms == 4) {
-		if (*ptrMatch == '+' || *ptrMatch == '-') { /* allow 6 chars if signed  */
-			maxLength++; /* or 5 if not              */
+		if (*ptrMatch == '+' || *ptrMatch == '-') { /* allow 6 chars if signed */
+			maxLength++; /* or 5 if not */
 		}
 		if (strlen(ptrMatch) > maxLength) {
-			reportCommandLineError(atRuntime,  "Match counts must be integer values from -99999 to +99999: group{%s,%s,%s,%s}"
+			reportCommandLineError(atRuntime, "Match counts must be integer values from -99999 to +99999: group{%s,%s,%s,%s}"
 					, ptrGroupName, ptrAction, ptrDelay, ptrMatch);
 			rc = OMR_ERROR_INTERNAL;
 		} else {
@@ -725,12 +722,14 @@ processTriggerGroupClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 	 * create the group entry in the triggerOnGroups chain
 	 */
 	if (OMR_ERROR_NONE == rc) {
+		size_t groupNameLen = strlen(ptrGroupName);
+
 		RAS_DBGOUT((stderr, "<RAS> creating group entry in triggerOnGroups chain\n"));
 
 		/* allocate and populate a trigger Group structure */
 		newTriggerGroupP = (RasTriggerGroup *)omrmem_allocate_memory(sizeof(RasTriggerGroup), OMRMEM_CATEGORY_TRACE);
-		copyOfNameP = omrmem_allocate_memory(strlen(ptrGroupName) + 1, OMRMEM_CATEGORY_TRACE);
-		if (newTriggerGroupP == NULL || copyOfNameP == NULL) {
+		copyOfNameP = omrmem_allocate_memory(groupNameLen + 1, OMRMEM_CATEGORY_TRACE);
+		if ((NULL == newTriggerGroupP) || (NULL == copyOfNameP)) {
 			rc = OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 			UT_DBGOUT(1, ("<UT> Out of memory processing trigger property."));
 		}
@@ -739,20 +738,20 @@ processTriggerGroupClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 		if (OMR_ERROR_NONE == rc) {
 			/* header */
 			memcpy(newTriggerGroupP->header.eyecatcher, "RSGR", 4);
-			newTriggerGroupP->header.length = (int) (sizeof(RasTriggerGroup));
+			newTriggerGroupP->header.length = (int)sizeof(RasTriggerGroup);
 			/* body */
-			strncpy(copyOfNameP, ptrGroupName, strlen(ptrGroupName) + 1);
+			memcpy(copyOfNameP, ptrGroupName, groupNameLen + 1);
 			newTriggerGroupP->groupName = copyOfNameP;
 			newTriggerGroupP->next = NULL;
 			newTriggerGroupP->match = match;
 			newTriggerGroupP->delay = delay;
 			newTriggerGroupP->actionIndex = actionIndex;
-			
+
 			/*
 			 * add the new group range to the chain
 			 */
 			omrthread_monitor_enter(UT_GLOBAL(triggerOnGroupsWriteMutex));
-		
+
 			newTriggerGroupP->next = UT_GLOBAL(triggerOnGroups);
 			UT_GLOBAL(triggerOnGroups) = newTriggerGroupP;
 
@@ -785,14 +784,14 @@ addTriggerType(OMR_VMThread *thr, const struct RasTriggerType *newType)
 
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(thr);
 
-	if( NULL == newType) {
+	if ( NULL == newType) {
 		return OMR_ERROR_ILLEGAL_ARGUMENT;
 	}
 
 	/* Append it to the existing list of options and update */
 	newRasTriggerTypes = omrmem_allocate_memory(sizeof(struct RasTriggerType) * (numTriggerTypes + 1), OMRMEM_CATEGORY_TRACE);
 
-	if( NULL == newRasTriggerTypes ) {
+	if ( NULL == newRasTriggerTypes ) {
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 	}
 
@@ -802,7 +801,7 @@ addTriggerType(OMR_VMThread *thr, const struct RasTriggerType *newType)
 	/* Add the new option as the final element. */
 	newRasTriggerTypes[numTriggerTypes] = *newType;
 
-	if( defaultRasTriggerTypes != rasTriggerTypes ) {
+	if ( defaultRasTriggerTypes != rasTriggerTypes ) {
 		/* We have already allocated one new type, we need to free rasTriggerTypes. */
 		omrmem_free_memory(rasTriggerTypes);
 	}
@@ -818,14 +817,14 @@ freeTriggerOptions(J9PortLibrary *portLibrary) {
 
 	clearAllTriggerActions();
 
-	if( defaultRasTriggerTypes != rasTriggerTypes ) {
+	if ( defaultRasTriggerTypes != rasTriggerTypes ) {
 		/* We have allocated new types, we need to free rasTriggerTypes. */
 		j9mem_free_memory(rasTriggerTypes);
 		rasTriggerTypes = defaultRasTriggerTypes;
 		numTriggerTypes = NUM_DEFAULT_TRIGGER_TYPES;
 	}
 
-	if( defaultRasTriggerActions != rasTriggerActions ) {
+	if ( defaultRasTriggerActions != rasTriggerActions ) {
 		/* We have allocated new actions, we need to free rasTriggerActions. */
 		j9mem_free_memory(rasTriggerActions);
 		rasTriggerActions = defaultRasTriggerActions;
@@ -850,17 +849,17 @@ processTriggerClause(OMR_VMThread *thr, const char *clause, BOOLEAN atRuntime)
 	uintptr_t clauseLength = strlen(clause);
 	int i;
 	BOOLEAN disableSet = FALSE;
-	
+
 	if (clauseLength == 0) {
 		reportCommandLineError(atRuntime, "Zero length clause in trigger statement.");
 		return OMR_ERROR_INTERNAL;
 	}
-	
+
 	if (clause[clauseLength - 1] != '}') {
 		reportCommandLineError(atRuntime, "Trigger clause must end with '}'");
 		return OMR_ERROR_INTERNAL;
 	}
-	
+
 	if (*clause == '!') {
 		clause++;
 		disableSet = TRUE;
@@ -868,52 +867,52 @@ processTriggerClause(OMR_VMThread *thr, const char *clause, BOOLEAN atRuntime)
 
 	for (i = 0; i < numTriggerTypes; i++) {
 		const struct RasTriggerType *type = &rasTriggerTypes[i];
-		
+
 		if (j9_cmdla_strnicmp((char *)clause, (char *)type->name, strlen(type->name)) == 0) {
 			uintptr_t typeLength = strlen(type->name);
 			uintptr_t subClauseLength;
 			char *subClause;
 			int rc;
-			
+
 			if (atRuntime && !type->runtimeModifiable) {
 				UT_DBGOUT(1, ("<UT> Trigger clause %s cannot be modified at run time\n",type->name));
 				return OMR_ERROR_INTERNAL;
 			}
-			
+
 			if (disableSet) {
 				/* The trigger is being switched off. We have no processing to do
 				 * so return.
 				 */
 				return OMR_ERROR_NONE;
 			}
-			
+
 			if (clauseLength <= typeLength) {
 				reportCommandLineError(atRuntime, "Empty trigger clause \"%s\" not permitted.", clause);
 				return OMR_ERROR_INTERNAL;
 			}
-			
+
 			if (clause[typeLength] != '{') {
 				reportCommandLineError(atRuntime, "Trigger clause must begin with '{'.");
 				return OMR_ERROR_INTERNAL;
 			}
-			
+
 			subClauseLength = clauseLength - typeLength - 2;
-			
+
 			subClause = omrmem_allocate_memory(subClauseLength + 1, OMRMEM_CATEGORY_TRACE);
 			if (!subClause) {
 				UT_DBGOUT(1, ("<UT> Out of memory processing trigger property.\n"));
 				return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 			}
-			
+
 			strncpy(subClause, &clause[typeLength + 1], subClauseLength);
 			subClause[subClauseLength] = '\0';
-			
+
 			rc = type->parse(thr, subClause, atRuntime);
 			omrmem_free_memory(subClause);
 			return rc;
 		}
 	}
-	
+
 	reportCommandLineError(atRuntime, "Invalid trigger clause: \"%s\"", clause);
 	return OMR_ERROR_INTERNAL;
 }
@@ -1002,7 +1001,6 @@ getNextBracketedParm(const char *from, omr_error_t *rc, int32_t * done, BOOLEAN 
 	return returnClause;
 }
 
-
 /**************************************************************************
  * name        - setTriggerActions
  * description - Set Trigger property
@@ -1018,7 +1016,7 @@ setTriggerActions(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	int32_t done = FALSE;
 
 	if (value == NULL || strlen(value) == 0) {
-		reportCommandLineError(atRuntime, "Usage error: trigger={[method{args}],[tpnid{args}],[group{args}]...}"); 
+		reportCommandLineError(atRuntime, "Usage error: trigger={[method{args}],[tpnid{args}],[group{args}]...}");
 		return OMR_ERROR_INTERNAL;
 	}
 
@@ -1028,7 +1026,7 @@ setTriggerActions(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 	while ((OMR_ERROR_NONE == rc) && (!done)) {
 		clause = getNextBracketedParm(value, &rc, &done, atRuntime);
 		if ((OMR_ERROR_NONE == rc) && (0 == strlen(clause))) {
-			reportCommandLineError(atRuntime, "Empty clauses not allowed in trigger property."); 
+			reportCommandLineError(atRuntime, "Empty clauses not allowed in trigger property.");
 			rc = OMR_ERROR_INTERNAL;
 		}
 		if (OMR_ERROR_NONE == rc) {
@@ -1105,7 +1103,7 @@ doTriggerActionResumeThis(OMR_VMThread *thr)
 static void
 doTriggerActionAbort(OMR_VMThread *thr)
 {
-	 abort();
+	abort();
 }
 
 /**************************************************************************
@@ -1153,19 +1151,18 @@ checkTriggerGroupsForTpid(OMR_VMThread *thr, char *compName, int traceId, const 
 	int32_t *tracePts;
 	int32_t count, i;
 	intptr_t oldValue;
-	
+
 	/* Increment the reference count */
-	
+
 	do {
 		oldValue = UT_GLOBAL(triggerOnGroupsReferenceCount);
-		
+
 		if (oldValue < 0) {
 			/* The queue is being cleared - bail out */
 			return;
 		}
 	} while (compareAndSwapUDATA((uintptr_t *)&UT_GLOBAL(triggerOnGroupsReferenceCount),(uintptr_t)oldValue,(uintptr_t)oldValue+1) != (uintptr_t)oldValue);
 
-	
 	/*
 	 * we're in here because a tracepoint has been hit for which the trigger
 	 * bit was set in the active array and because the triggerOnGroups chain
@@ -1179,38 +1176,38 @@ checkTriggerGroupsForTpid(OMR_VMThread *thr, char *compName, int traceId, const 
 	for (groupPtr = UT_GLOBAL(triggerOnGroups); groupPtr != NULL; groupPtr = groupPtr->next) {
 
 		if (rasTriggerActions[groupPtr->actionIndex].phase == phase) {
-			
+
 			/*
 			 * Only need to look for groups inside this component
 			 */
 			getComponentGroup(compName, groupPtr->groupName, &count, &tracePts);
-			
+
 			/*
 			 * Check each tracepoint in the group
 			 */
 			for (i = 0; i < count; i++) {
 				if (traceId == tracePts[i]) {
 					uint32_t oldDelay;
-					
+
 					do {
 						oldDelay = groupPtr->delay;
-						
+
 						if (0 == oldDelay) {
 							break;
 						}
 					} while(compareAndSwapU32(&groupPtr->delay,oldDelay,oldDelay-1) != oldDelay);
-					
+
 					if (0 == oldDelay) {
 						int32_t oldMatch;
-						
+
 						do {
 							oldMatch = groupPtr->match;
-							
+
 							if (oldMatch <= 0) {
 								break;
 							}
 						} while(compareAndSwapU32((uint32_t*)&groupPtr->match,(uint32_t)oldMatch,(uint32_t)(oldMatch-1)) != oldMatch);
-						
+
 						if (oldMatch != 0) {
 							/*
 							 * Do a trigger action
@@ -1229,7 +1226,7 @@ checkTriggerGroupsForTpid(OMR_VMThread *thr, char *compName, int traceId, const 
 			}
 		}
 	}
-	
+
 	do {
 		oldValue = UT_GLOBAL(triggerOnGroupsReferenceCount);
 	} while (compareAndSwapUDATA((uintptr_t *)&UT_GLOBAL(triggerOnGroupsReferenceCount),(uintptr_t)oldValue,(uintptr_t)oldValue-1) != (uintptr_t)oldValue);
@@ -1249,17 +1246,16 @@ checkTriggerTpidForTpid(OMR_VMThread *thr, char *compName, unsigned int traceId,
 	intptr_t oldValue;
 
 	/* Increment the reference count */
-	
+
 	do {
 		oldValue = UT_GLOBAL(triggerOnTpidsReferenceCount);
-		
+
 		if (oldValue < 0) {
 			/* The queue is being cleared - bail out */
 			return;
 		}
 	} while (compareAndSwapUDATA((uintptr_t *)&UT_GLOBAL(triggerOnTpidsReferenceCount),(uintptr_t)oldValue,(uintptr_t)oldValue+1) != (uintptr_t)oldValue);
 
-	
 	/*
 	 * we're in here because a tracepoint has been hit for which the trigger
 	 * bit was set in the active array and because the triggerOnTpids chain
@@ -1273,28 +1269,28 @@ checkTriggerTpidForTpid(OMR_VMThread *thr, char *compName, unsigned int traceId,
 	for (ptr = UT_GLOBAL(triggerOnTpids); ptr != NULL; ptr = ptr->next) {
 		if (rasTriggerActions[ptr->actionIndex].phase == phase) {
 			if (strcmp(compName, ptr->compName) == 0 && traceId >= ptr->startTpid && traceId <= ptr->endTpid) {
-				
+
 				uint32_t oldDelay;
-				
+
 				do {
 					oldDelay = ptr->delay;
-					
+
 					if (0 == oldDelay) {
 						break;
 					}
 				} while(compareAndSwapU32(&ptr->delay,oldDelay,oldDelay-1) != oldDelay);
-				
+
 				if (0 == oldDelay) {
 					int32_t oldMatch;
-					
+
 					do {
 						oldMatch = ptr->match;
-						
+
 						if (oldMatch <= 0) {
 							break;
 						}
 					} while(compareAndSwapU32((uint32_t*)&ptr->match,(uint32_t)oldMatch,(uint32_t)(oldMatch-1)) != oldMatch);
-				
+
 					if (oldMatch != 0) {
 						/*
 						 * Do a trigger action
@@ -1306,7 +1302,8 @@ checkTriggerTpidForTpid(OMR_VMThread *thr, char *compName, unsigned int traceId,
 					}
 				} else {
 					RAS_DBGOUT((stderr, "tpnid %X matches tpnid range %s.%X-%X, "
-										"decrement delay\n", traceId, ptr->compName, ptr->startTpid, ptr->endTpid));				}
+										"decrement delay\n", traceId, ptr->compName, ptr->startTpid, ptr->endTpid));
+				}
 			}
 		}
 	}
@@ -1321,16 +1318,16 @@ void triggerHit(OMR_VMThread *thr, char *compName, uint32_t traceId, TriggerPhas
 	BOOLEAN *actionArray = NULL;
 	int i;
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
-	
+
 	actionArray = j9mem_allocate_memory( sizeof(BOOLEAN) * numTriggerActions, OMRMEM_CATEGORY_TRACE);
 	memset(actionArray,0,sizeof(BOOLEAN) * numTriggerActions);
-	
+
 	/* check for which trigger group clause(s) brought us here */
 	checkTriggerGroupsForTpid(thr, compName, traceId, phase,actionArray);
-	
+
 	/* check for which trigger tpnid clause(s) brought us here */
 	checkTriggerTpidForTpid(thr, compName, traceId, phase,actionArray);
-	
+
 	for (i=0;i!=numTriggerActions;i++) {
 		if (actionArray[i]) {
 			rasTriggerActions[i].fn(thr);
@@ -1347,16 +1344,16 @@ clearAllTriggerActions()
 	RasTriggerGroup *groupHead = NULL;
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 	intptr_t oldValue;
-	
+
 	/* tpid ranges */
 
 	/* Take the modification lock */
 	omrthread_monitor_enter(UT_GLOBAL(triggerOnTpidsWriteMutex));
-	
+
 	/* Decrement the reference count - to keep the readers out */
 	do {
 		oldValue = UT_GLOBAL(triggerOnTpidsReferenceCount);
-		
+
 		if (oldValue > 0) {
 			/* The queue is in use */
 			omrthread_yield();
@@ -1364,7 +1361,6 @@ clearAllTriggerActions()
 		}
 	} while (compareAndSwapUDATA((uintptr_t *)&UT_GLOBAL(triggerOnTpidsReferenceCount),(uintptr_t)oldValue,(uintptr_t)oldValue-1) != (uintptr_t)oldValue);
 
-	
 	tpidHead = UT_GLOBAL(triggerOnTpids);
 	UT_GLOBAL(triggerOnTpids) = NULL;
 
@@ -1372,28 +1368,28 @@ clearAllTriggerActions()
 	do {
 		oldValue = UT_GLOBAL(triggerOnTpidsReferenceCount);
 	} while (compareAndSwapUDATA((uintptr_t *)&UT_GLOBAL(triggerOnTpidsReferenceCount),(uintptr_t)oldValue,(uintptr_t)oldValue+1) != (uintptr_t)oldValue);
-	
+
 	omrthread_monitor_exit(UT_GLOBAL(triggerOnTpidsWriteMutex));
-	
+
 	if (tpidHead != NULL) {
 		RasTriggerTpidRange * current = tpidHead;
-		
+
 		do {
 			RasTriggerTpidRange * toFree = current;
 			current = current->next;
-			
+
 			j9mem_free_memory(toFree);
-			
+
 		} while(current != NULL);
 	}
-	
+
 	/* Take the modification lock */
 	omrthread_monitor_enter(UT_GLOBAL(triggerOnGroupsWriteMutex));
 
 	/* Decrement the reference count - to keep the readers out */
 	do {
 		oldValue = UT_GLOBAL(triggerOnGroupsReferenceCount);
-		
+
 		if (oldValue > 0) {
 			/* The queue is in use */
 			omrthread_yield();
@@ -1403,21 +1399,21 @@ clearAllTriggerActions()
 
 	groupHead = UT_GLOBAL(triggerOnGroups);
 	UT_GLOBAL(triggerOnGroups) = NULL;
-	
+
 	/* Increment the reference count again */
 	do {
 		oldValue = UT_GLOBAL(triggerOnGroupsReferenceCount);
 	} while (compareAndSwapUDATA((uintptr_t *)&UT_GLOBAL(triggerOnGroupsReferenceCount),(uintptr_t)oldValue,(uintptr_t)oldValue+1) != (uintptr_t)oldValue);
-	
+
 	omrthread_monitor_exit(UT_GLOBAL(triggerOnGroupsWriteMutex));
-	
+
 	if (groupHead != NULL) {
 		RasTriggerGroup * groupCurrent = groupHead;
-		
+
 		do {
 			RasTriggerGroup * groupToFree = groupCurrent;
 			groupCurrent = groupCurrent->next;
-			
+
 			j9mem_free_memory(groupToFree->groupName);
 			j9mem_free_memory(groupToFree);
 		} while(groupCurrent != NULL);

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -7972,7 +7972,7 @@ SH_CacheMap::getPrereqCache(J9VMThread* currentThread, const char* cacheDir, SH_
 
 		J9UTF8* utfKeyStruct = (J9UTF8*)utfKeyPtr;
 		J9UTF8_SET_LENGTH(utfKeyStruct, (U_16)keylen);
-		strncpy((char*)J9UTF8_DATA(utfKeyStruct), (char*)key, keylen);
+		memcpy((char*)J9UTF8_DATA(utfKeyStruct), key, keylen);
 
 		tokenKey = addScopeToCache(currentThread, utfKeyStruct, TYPE_PREREQ_CACHE);
 		if (NULL == tokenKey) {

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -47,7 +47,7 @@
  * Function which builds a cache filename from a cache name, version data and generation.
  * A cache file name is currently a composite of the cache name with a version prefix and generation postfix
  * Note that the function returns different results for Windows and Unix.
- * 
+ *
  * @param [in] portlib  A portLibrary
  * @param [out] buffer  The buffer to write the filename into
  * @param [in] bufferSize  The size of the buffer in bytes
@@ -64,9 +64,9 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 	char genString[7];
 	char versionStr[J9SH_VERSION_STRING_LEN+3];
 	UDATA versionStrLen = 0;
-	
+
 	PORT_ACCESS_FROM_PORT(portlib);
-	
+
 	Trc_SHR_OSC_getCacheVersionAndGen_Entry_V1(cacheName, generation, layer);
 
 	memset(versionStr, 0, J9SH_VERSION_STRING_LEN+1);
@@ -75,20 +75,20 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 	} else {
 		U_64 curVMVersion = 0;
 		U_64 oldVMVersion = 0;
-		
-		/* CMVC 163957: 
+
+		/* CMVC 163957:
 		 * There is overlap Java 6 cache file generations and Java 7. For example:
 		 * - Java 6 SR8: C240D2A64P_java6sr8_G08
 		 * - Java 7 CVS HEAD: C260M3A64P_cvshead_G08
-		 * 
+		 *
 		 * If we use any thing older than Major=2, and Minor=60 we must use J9SH_GET_VERSION_G07ANDLOWER_STRING to get the file name.
-		 * 
+		 *
 		 * When called b/c of '-Xshareclasses:listAllCaches' if the wrong cache name is used the cache will fail to be started, and will
 		 * not be listed.
 		 */
-		 oldVMVersion = SH_OSCache::getCacheVersionToU64(2, 60);
-		 curVMVersion = SH_OSCache::getCacheVersionToU64(versionData->esVersionMajor, versionData->esVersionMinor);
-		 
+		oldVMVersion = SH_OSCache::getCacheVersionToU64(2, 60);
+		curVMVersion = SH_OSCache::getCacheVersionToU64(versionData->esVersionMajor, versionData->esVersionMinor);
+
 		if ( curVMVersion >= oldVMVersion) {
 			if (generation <= J9SH_GENERATION_29) {
 				J9SH_GET_VERSION_G07TO29_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
@@ -97,7 +97,7 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 			} else {
 				J9SH_GET_VERSION_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->feature, versionData->addrmode);
 			}
-		} else {	
+		} else {
 			J9SH_GET_VERSION_G07ANDLOWER_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
 		}
 	}
@@ -129,7 +129,7 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 		j9str_printf(PORTLIB, buffer, bufferSize, "%s%c%s%c%s", versionStr, J9SH_PREFIX_SEPARATOR_CHAR, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
 	} else {
 		const char* identifier = isMemoryType ? J9SH_MEMORY_ID : J9SH_SEMAPHORE_ID;
-		
+
 		j9str_printf(PORTLIB, buffer, bufferSize, "%s%s%s%c%s", versionStr, identifier, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
 	}
 #endif
@@ -138,12 +138,12 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 
 /**
  * Extract the cache name from a filename of the format created by getCacheVersionAndGen
- * 
+ *
  * @param [out] buffer  Buffer to extract the cache name into
  * @param [in] bufferSize  The size of the buffer in bytes
  * @param [in] versionLen  Length of the version prefix (is variable for different types of cache)
  * @param [in] cacheNameWithVGen  The filename to extract the name from
- * 
+ *
  * @return 0 on success or -1 for failure
  */
 IDATA
@@ -152,7 +152,7 @@ SH_OSCache::removeCacheVersionAndGen(char* buffer, UDATA bufferSize, UDATA versi
 	char* nameStart;
 	UDATA lengthMinusGenAndLayer = 0;
 	UDATA generation = getGenerationFromName(cacheNameWithVGen);
-	
+
 	Trc_SHR_OSC_removeCacheVersionAndGen_Entry(versionLen, cacheNameWithVGen);
 
 	/*
@@ -185,15 +185,15 @@ SH_OSCache::removeCacheVersionAndGen(char* buffer, UDATA bufferSize, UDATA versi
 
 /**
  * Determine the directory to use for the cache file or control file(s)
- * 
+ *
  * @param [in] vm  A J9JavaVM
  * @param [in] ctrlDirName  The control dir name
  * @param [out] buffer  The buffer to write the result into
  * @param [in] bufferSize  The size of the buffer in bytes
  * @param [in] cacheType  The Type of cache
- * @param [in] allowVerbose Whether to allow verbose message.
+ * @param [in] allowVerbose  Whether to allow verbose message.
  *
- * @return 0 on success or -1 for failure  
+ * @return 0 on success or -1 for failure
  */
 IDATA
 SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType, bool allowVerbose)
@@ -264,9 +264,9 @@ SH_OSCache::getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDA
  * Create the directory to use for the cache file or control file(s)
  *
  * @param [in] portLibrary  A portLibrary
- * @param[in] cacheDirName The name of the cache directory
- * @param[in] cleanMemorySegments, set TRUE to call cleanSharedMemorySegments. It will clean sysv memory segments.
- * 				It should be set to TRUE if the ctrlDirName is NULL.
+ * @param[in] cacheDirName  The name of the cache directory
+ * @param[in] cleanMemorySegments  set TRUE to call cleanSharedMemorySegments. It will clean sysv memory segments.
+ *              It should be set to TRUE if the ctrlDirName is NULL.
  *
  * Returns -1 for error, >=0 for success
  */
@@ -288,38 +288,38 @@ IDATA
 SH_OSCache::getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirName, char* buffer, UDATA bufferSize, const char* cacheNameWithVGen)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	
+
 	Trc_SHR_OSC_getCachePathName_Entry(cacheNameWithVGen);
-	
+
 	j9str_printf(PORTLIB, buffer, bufferSize, "%s%s", cacheDirName, cacheNameWithVGen);
-	
+
 	Trc_SHR_OSC_getCachePathName_Exit();
 	return 0;
 }
 
 /**
  * Stat to see if a named cache exists
- *  
+ *
  * @param [in] portLibrary  A portLibrary
  * @param [in] cacheNameWithVGen  The cache filename
  * @param [in] displayNotFoundMsg  If true, message is displayed if the cache is not found
- * 
- * @return 1 if the cache exists and 0 otherwise 
+ *
+ * @return 1 if the cache exists and 0 otherwise
  */
 UDATA
 SH_OSCache::statCache(J9PortLibrary* portLibrary, const char* cacheDirName, const char* cacheNameWithVGen, bool displayNotFoundMsg)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
 	char fullPath[J9SH_MAXPATH];
-	
+
 	Trc_SHR_OSC_statCache_Entry(cacheNameWithVGen);
-	
+
 	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", cacheDirName, cacheNameWithVGen);
 	if (j9file_attr(fullPath) == EsIsFile) {
 		Trc_SHR_OSC_statCache_cacheFound();
 		return 1;
 	}
-	
+
 	if (displayNotFoundMsg) {
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_SHRC_OSCACHE_NOT_EXIST);
 	}
@@ -333,7 +333,7 @@ SH_OSCache::getGenerationFromName(const char* cacheNameWithVGen)
 {
 	char* cursor = (char*)cacheNameWithVGen;
 	UDATA genValue;
-	
+
 	if ((cursor = strrchr(cursor, J9SH_PREFIX_SEPARATOR_CHAR)) == NULL) {
 		return 0;
 	}
@@ -351,7 +351,9 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 
-	UDATA cacheNameLen=0, cachePathNameLen=0, versionStrLen=0;
+	UDATA cacheNameLen = 0;
+	UDATA cachePathNameLen = 0;
+	UDATA versionStrLen = 0;
 	char fullPathName[J9SH_MAXPATH];
 
 	Trc_SHR_OSC_commonStartup_Entry();
@@ -397,7 +399,7 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 	} else {
 		versionStrLen = J9SH_VERSION_STRING_LEN;
 	}
-	
+
 	if(J9_ARE_ANY_BITS_SET(_createFlags, J9SH_OSCACHE_CREATE | J9SH_OSCACHE_OPEXIST_DESTROY | J9SH_OSCACHE_OPEXIST_STATS | J9SH_OSCACHE_OPEXIST_DO_NOT_CREATE)) {
 		/* okay, one of the flags are set */
 	} else {
@@ -428,7 +430,7 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 	 */
 	Trc_SHR_Assert_True(_cacheNameWithVGen[OMR_MIN(cacheNameLen, CACHE_ROOT_MAXLEN) - 1] == '\0');
 	_cacheName = _cacheNameWithVGen + strlen(_cacheNameWithVGen) + 1;
-	strncpy(_cacheName, cacheName, strlen(cacheName));
+	memcpy(_cacheName, cacheName, strlen(cacheName) + 1);
 	setEnableVerbose(PORTLIB, vm, versionData, _cacheNameWithVGen);
 
 	if (getCachePathName(PORTLIB, _cacheDirName, fullPathName, J9SH_MAXPATH, _cacheNameWithVGen) == 0) {
@@ -446,9 +448,9 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 	}
 
 	_doCheckBuildID = ((openMode & J9OSCACHE_OPEN_MODE_CHECKBUILDID) != 0);
-		
+
 	Trc_SHR_OSC_commonStartup_copied_cachePathName(_cachePathName, cachePathNameLen);
-	
+
 	Trc_SHR_OSC_commonStartup_Exit();
 	return 0;
 }
@@ -474,7 +476,7 @@ SH_OSCache::commonInit(J9PortLibrary* portLibrary, UDATA generation, I_8 layer)
 	_cacheDirName = NULL;
 	_verboseFlags = 0;
 	_createFlags = 0;
-	_config = NULL;	
+	_config = NULL;
 	_openMode = 0;
 	_dataStart = NULL;
 	_dataLength = 0;
@@ -491,7 +493,7 @@ void
 SH_OSCache::commonCleanup()
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_commonCleanup_Entry();
 
 	if (_cacheNameWithVGen) {
@@ -509,14 +511,14 @@ SH_OSCache::commonCleanup()
 
 	/* If the cache is destroyed and then restarted, we still need portLibrary, versionData and generation */
 	commonInit(_portLibrary, _activeGeneration, _layer);
-	
+
 	Trc_SHR_OSC_commonCleanup_Exit();
 }
 
 /**
  * Static method to create a new OSCache instance
  *
- * @param [in] portLib The portlib
+ * @param [in] portLib  The portlib
  * @param [in] memForConstructor  Pointer to the memory to build the OSCache instance into
  * @param [in] cacheName  Name of the cache
  * @param [in] generation  Generation of the cache
@@ -524,7 +526,7 @@ SH_OSCache::commonCleanup()
  * @param [in] layer  The layer number of the cache
  *
  * @return A pointer to the new OSCache object (which will be the same as the memForConstructor parameter)
- * 			It never returns NULL.
+ *          It never returns NULL.
  */
 SH_OSCache*
 SH_OSCache::newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, const char* cacheName, UDATA generation, J9PortShcVersion* versionData, I_8 layer)
@@ -532,9 +534,9 @@ SH_OSCache::newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, c
 	SH_OSCache* newOSC = (SH_OSCache*)memForConstructor;
 
 	PORT_ACCESS_FROM_PORT(portlib);
-	
+
 	Trc_SHR_OSC_newInstance_Entry_V1(memForConstructor, cacheName, versionData->cacheType, layer);
-	
+
 	switch(versionData->cacheType) {
 	case J9PORT_SHR_CACHE_TYPE_PERSISTENT :
 		Trc_SHR_OSC_newInstance_creatingMmap(newOSC);
@@ -553,12 +555,12 @@ SH_OSCache::newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, c
 	}
 	Trc_SHR_OSC_newInstance_initializingNewObject();
 	newOSC->initialize(PORTLIB, ((char*)memForConstructor + SH_OSCache::getRequiredConstrBytes()), generation, layer);
-	
+
 	Trc_SHR_OSC_newInstance_Exit(newOSC);
 	return newOSC;
 }
 
-/** 
+/**
  * Static method to get the number of bytes required for an OSCache object
  *
  * @return The number of bytes required for an OSCache object
@@ -600,7 +602,7 @@ SH_OSCache::setEnableVerbose(J9PortLibrary* portLib, J9JavaVM* vm, J9PortShcVers
 
 /**
  * Return a list of all the caches/snapshots that can be found in the current cache directory
- * It is the responsibility of the caller to free the pool returned by this function 
+ * It is the responsibility of the caller to free the pool returned by this function
  * The function returns a semi-ordered pool with the compatible caches/snapshots first and incompatible ones last
  *
  * @param[in] vm  The Java VM
@@ -608,15 +610,14 @@ SH_OSCache::setEnableVerbose(J9PortLibrary* portLib, J9JavaVM* vm, J9PortShcVers
  * @param[in] groupPerm  Group permissions to open the cache directory
  * @param[in] localVerboseFlags  Flags indicating the level of verbose output in use
  * @param[in] j2seVersion  The j2se version that the VM is running
- * @param[in] includeOldGenerations  If true, include caches of older generations  
+ * @param[in] includeOldGenerations  If true, include caches of older generations
  * @param[in] ignoreCompatible  If true, only gets cache/snapshot statistics of incompatible caches
  * @param [in] reason Indicates the reason for getting cache/snapshot stats. Refer sharedconsts.h for valid values.
  * @param [in] isCache If true, get cache stats. If false, get snapshot stats.
- * 
- * @return a J9Pool that contains a semi-ordered list of caches/snapshots, NULL if no caches/snapshots are found
  *
+ * @return a J9Pool that contains a semi-ordered list of caches/snapshots, NULL if no caches/snapshots are found
  */
-J9Pool* 
+J9Pool*
 SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, bool includeOldGenerations, bool ignoreCompatible, UDATA reason, bool isCache)
 {
 	J9PortLibrary* portlib = vm->portLibrary;
@@ -624,9 +625,13 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 	UDATA snapshotFindHandle = (UDATA)-1;
 	UDATA shmemFindHandle = (UDATA)-1;
 	UDATA mmapFindHandle = (UDATA)-1;
-	char snapshotNameWithVGen[EsMaxPath];	/* Essential that this is EsMaxPath otherwise j9file_findX will overflow */
-	char shmemNameWithVGen[EsMaxPath];		/* Essential that this is EsMaxPath otherwise j9file_findX will overflow */
-	char mmapNameWithVGen[EsMaxPath];		/* Essential that this is EsMaxPath otherwise j9file_findX will overflow */
+	/*
+	 * It is essential that the length of these three arrays
+	 * is EsMaxPath otherwise j9file_findX will overflow.
+	 */
+	char snapshotNameWithVGen[EsMaxPath];
+	char shmemNameWithVGen[EsMaxPath];
+	char mmapNameWithVGen[EsMaxPath];
 	char persistentCacheDir[J9SH_MAXPATH];
 	char nonpersistentCacheDir[J9SH_MAXPATH];
 	char* nameWithVGen = NULL;
@@ -653,8 +658,8 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 		getShmDirVal = getCacheDir(vm, ctrlDirName, nonpersistentCacheDir, J9SH_MAXPATH, J9PORT_SHR_CACHE_TYPE_SNAPSHOT);
 		if (-1 != getShmDirVal) {
 			snapshotFindHandle = SH_OSCacheFile::findfirst(PORTLIB,
-								    nonpersistentCacheDir,
-								    snapshotNameWithVGen, J9PORT_SHR_CACHE_TYPE_SNAPSHOT);
+									nonpersistentCacheDir,
+									snapshotNameWithVGen, J9PORT_SHR_CACHE_TYPE_SNAPSHOT);
 			if ((UDATA)-1 == snapshotFindHandle) {
 				doneSnapshot = true;
 			} else {
@@ -672,8 +677,8 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 										J9SH_MAXPATH,
 										J9PORT_SHR_CACHE_TYPE_NONPERSISTENT)) != -1) {
 			shmemFindHandle = SH_OSCachesysv::findfirst(PORTLIB,
-								    nonpersistentCacheDir,
-								    shmemNameWithVGen);
+									nonpersistentCacheDir,
+									shmemNameWithVGen);
 			if (shmemFindHandle == (UDATA)-1) {
 				doneShmem = true;
 			} else {
@@ -714,7 +719,7 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 	}
 
 	if (!ignoreCompatible) {
-		cacheList = pool_new(sizeof(SH_OSCache_Info),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(PORTLIB));
+		cacheList = pool_new(sizeof(SH_OSCache_Info), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(PORTLIB));
 		if (cacheList == NULL) {
 			Trc_SHR_OSC_getAllCacheStatistics_Exit2();
 			rc = NULL;
@@ -724,7 +729,7 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 	}
 
 	/* Incompatible caches are added after the compatible caches so are initially created in a different pool */
-	incompatibleList = pool_new(sizeof(SH_OSCache_Info),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(PORTLIB));
+	incompatibleList = pool_new(sizeof(SH_OSCache_Info), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(PORTLIB));
 	if (incompatibleList == NULL) {
 		Trc_SHR_OSC_getAllCacheStatistics_Exit3();
 		rc = NULL;
@@ -778,7 +783,7 @@ SH_OSCache::getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA g
 		if (pool_numElements(incompatibleList)) {
 			pool_state poolState;
 			SH_OSCache_Info* anElement;
-			
+
 			anElement = (SH_OSCache_Info*)pool_startDo(incompatibleList, &poolState);
 			do {
 				newElement = (SH_OSCache_Info*) pool_newElement(cacheList);
@@ -820,10 +825,10 @@ cleanup:
  * @param[in] j2seVersion  The j2se version that the JVM is running
  * @param[out] result  A pointer to a SH_OSCache_Info should be provided, which is filled in with the results
  * @param [in] reason Indicates the reason for getting cache stats. Refer sharedconsts.h for valid values.
- * 
+ *
  * @return 0 if the operations has been successful, -1 if an error has occured
  */
-IDATA 
+IDATA
 SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char* cacheNameWithVGen, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, SH_OSCache_Info* result, UDATA reason)
 {
 	J9PortLibrary* portlib = vm->portLibrary;
@@ -834,9 +839,9 @@ SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char
 	U_64 fileVMVersion = 0;
 	U_64 curVMVersion = 0;
 	char cacheDirName[J9SH_MAXPATH];
-	
+
 	Trc_SHR_OSC_getCacheStatistics_Entry();
-	
+
 	if (NULL == result) {
 		Trc_SHR_OSC_getCacheStatistics_NullResult();
 		return -1;
@@ -872,14 +877,14 @@ SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char
 	}
 
 	setCurrentCacheVersion(vm, j2seVersion, &currentVersionData);
-	
+
 	fileVMVersion = SH_OSCache::getCacheVersionToU64(result->versionData.esVersionMajor, result->versionData.esVersionMinor);
 	curVMVersion = SH_OSCache::getCacheVersionToU64(currentVersionData.esVersionMajor, currentVersionData.esVersionMinor);
-	
+
 	if ( fileVMVersion <= curVMVersion ) {
 		/* The current JVM version can only see caches generated by:
 		 * - Equal or lower JVM versions
-		 * - Equal or lower JCL versions 
+		 * - Equal or lower JCL versions
 		 */
 		if (getShcModlevelForJCL(j2seVersion) < result->versionData.modlevel) {
 			Trc_SHR_OSC_getCacheStatistics_badModLevel_Exit(result->versionData.modlevel);
@@ -897,7 +902,7 @@ SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char
 	result->isCorrupt = 0;
 	result->isJavaCorePopulated = 0;
 	memset(&(result->javacoreData), 0, sizeof(J9SharedClassJavacoreDataDescriptor));
-	
+
 	result->javacoreData.feature = getJVMFeature(vm);
 	if (result->versionData.cacheType == J9PORT_SHR_CACHE_TYPE_PERSISTENT) {
 		Trc_SHR_OSC_getCacheStatistics_stattingMmap();
@@ -927,7 +932,7 @@ SH_OSCache::getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char
 }
 
 /* THREADING: Pre-req the cache header must be locked */
-void 
+void
 SH_OSCache::initOSCacheHeader(OSCache_header_version_current* header, J9PortShcVersion* versionData, UDATA headerLen)
 {
 	Trc_SHR_OSC_initOSCacheHeader_Entry(header, versionData, headerLen);
@@ -949,9 +954,9 @@ SH_OSCache::checkOSCacheHeader(OSCache_header_version_current* header, J9PortShc
 {
 	UDATA dataStartValue;
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_checkOSCacheHeader_Entry(header, versionData, headerLen);
-	
+
 	if (versionData == NULL) {
 		/* If it's not the current generation, the cache header will simply not look right and can't be verified */
 		if (header->generation != (U_32)_activeGeneration) {
@@ -960,8 +965,8 @@ SH_OSCache::checkOSCacheHeader(OSCache_header_version_current* header, J9PortShc
 		}
 	} else {
 		/* Check whether the version data contained in the header indeed matches the platform
- 		 * specifications of the current target.
- 		 */
+		 * specifications of the current target.
+		 */
 
 		if (memcmp(versionData, &(header->versionData), sizeof(J9PortShcVersion)) != 0) {
 			Trc_SHR_OSC_checkOSCacheHeader_wrongVersion();
@@ -983,13 +988,12 @@ SH_OSCache::checkOSCacheHeader(OSCache_header_version_current* header, J9PortShc
 		setCorruptionContext(CACHE_HEADER_INCORRECT_DATA_START_ADDRESS, dataStartValue);
 		return J9SH_OSCACHE_HEADER_CORRUPT;
 	}
-	
 
 	if ((J9_ARE_ALL_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_TEST_BAD_BUILDID))
 		&& (J9_ARE_NO_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_SNAPSHOT))
 	) {
 		Trc_SHR_OSC_checkOSCacheHeader_testBadBuildID();
-		/* The flag J9SHR_RUNTIMEFLAG_ENABLE_TEST_BAD_BUILDID is unset after 
+		/* The flag J9SHR_RUNTIMEFLAG_ENABLE_TEST_BAD_BUILDID is unset after
 		 * the first call to SH_OSCache:startup() in SH_CompositeCacheImpl::startup().
 		 * This ensures that this failure only occurs once. Running "snapshotCache"
 		 * with "badBuildID" means to write a bad build ID into the snapshot, rather than running
@@ -997,7 +1001,7 @@ SH_OSCache::checkOSCacheHeader(OSCache_header_version_current* header, J9PortShc
 		 */
 		return J9SH_OSCACHE_HEADER_DIFF_BUILDID;
 	}
-	
+
 	U_64 OpenJ9Sha = getOpenJ9Sha();
 	if (_doCheckBuildID && (header->buildID != OpenJ9Sha)) {
 		Trc_SHR_OSC_checkOSCacheHeader_wrongBuildID_3(OpenJ9Sha, header->buildID);
@@ -1017,7 +1021,7 @@ SH_OSCache::isRunningReadOnly() {
 }
 
 /* Used for connecting to legacy cache headers */
-void* 
+void*
 SH_OSCache::getHeaderFieldAddressForGen(void* header, UDATA headerGen, UDATA fieldID)
 {
 	return (U_8*)header + getHeaderFieldOffsetForGen(headerGen, fieldID);
@@ -1086,7 +1090,7 @@ SH_OSCache::getHeaderFieldOffsetForGen(UDATA headerGen, UDATA fieldID)
 
 /**
  * Returns the amount of bytes in the cache available for data
- * 
+ *
  * @return the bytes available for data
  */
 U_32
@@ -1097,7 +1101,7 @@ SH_OSCache::getDataSize()
 
 /**
  * Generate a U_64 from the major, and minor numbers from a cache file name
- * 
+ *
  * @return U_64
  */
 U_64
@@ -1116,7 +1120,7 @@ SH_OSCache::getCacheVersionToU64(U_32 major, U_32 minor)
  * @param[in] vm  The Java VM
  * @param[in] cache The OSCache to use
  * @param[in] cacheInfo Where to put statistics about this Cache
- * 
+ *
  * @return true if the operations has been successful, false if an error has occured
  */
 bool
@@ -1165,13 +1169,13 @@ SH_OSCache::getCacheStatsCommon(J9JavaVM* vm, SH_OSCache *cache, SH_OSCache_Info
 	if (cmStats->getJavacoreData(vm, &(cacheInfo->javacoreData)) == 1) {
 		cacheInfo->isJavaCorePopulated = 1;
 	}
-	
+
 done:
 	/*If startedForStats != CC_STARTUP_OK then shutdownForStats was already called by startupForStats in the failure condition*/
 	if ((cmStats != NULL) && (startedForStats == CC_STARTUP_OK)) {
 		cmStats->shutdownForStats(currentThread);
 	}
-	
+
 	if (cmPtr != NULL) {
 		j9mem_free_memory(cmPtr);
 	}
@@ -1201,8 +1205,8 @@ SH_OSCache::setCorruptionContext(IDATA corruptionCode, UDATA corruptValue)
  * if corruptionCode = ACQUIRE_HEADER_WRITE_LOCK_FAILED, corruptValue contains the error code for the failure to acquire lock.
  * if corruptionCode = CACHE_SIZE_INVALID, corruptValue contains invalid cache size.
  *
- * @param [out] corruptionCode	if non-null, it is populated with a code indicating corruption type.
- * @param [out] corruptValue	if non-null, it is populated with a value to be interpreted depending on corruptionCode.
+ * @param [out] corruptionCode  if non-null, it is populated with a code indicating corruption type.
+ * @param [out] corruptValue    if non-null, it is populated with a value to be interpreted depending on corruptionCode.
  *
  * @return void
  */
@@ -1264,7 +1268,7 @@ SH_OSCache::getCacheUniqueID(J9VMThread* currentThread)
  * @param[out] bufLen  The length of the buffer
  *
  * @return If buf is not NULL, the number of characters printed into buf is returned , not including the NUL terminator.
- * 			If buf is NULL, the size of the buffer required to print to the unique ID, including the NUL terminator is returned.
+ *          If buf is NULL, the size of the buffer required to print to the unique ID, including the NUL terminator is returned.
  */
 UDATA
 SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDirName, const char* cacheName, I_8 layer, U_32 cacheType, char* buf, UDATA bufLen)
@@ -1295,7 +1299,6 @@ SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDi
  * @param[out] nameBuf  The buffer for the cache name
  * @param[out] nameBuffLen  The length of cache name buffer
  * @param[out] layer  The layer number in the cache unique ID
- *
  */
 void
 SH_OSCache::getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* cacheDirName, const char* uniqueID, UDATA idLen, char* nameBuf, UDATA nameBuffLen, I_8* layer)
@@ -1313,18 +1316,17 @@ SH_OSCache::getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* cacheDirN
 
 	SH_OSCache::removeCacheVersionAndGen(nameBuf, nameBuffLen, J9SH_VERSION_STRING_LEN + 1, nameWithVGenCopy);
 	I_8 layerNo = getLayerFromName(nameWithVGenCopy);
-	Trc_SHR_Assert_True(((layerNo >= 0) 
+	Trc_SHR_Assert_True(((layerNo >= 0)
 						&& (layerNo <= J9SH_LAYER_NUM_MAX_VALUE))
 						);
 	*layer = layerNo;
 }
 
-/* 
- * Return the layer number 
+/*
+ * Return the layer number
  */
 I_8
 SH_OSCache::getLayer()
 {
 	return _layer;
 }
-

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -45,11 +45,10 @@
 #define RETRY_OBTAIN_WRITE_LOCK_MAX_MS 160
 #define NANOSECS_PER_MILLISEC (I_64)1000000
 
-
 /**
  * Multi-argument constructor
- * 
- * Constructs and initializes a SH_OSCachemmap object and calls startup to open/create 
+ *
+ * Constructs and initializes a SH_OSCachemmap object and calls startup to open/create
  * a shared classes cache.
  * This c'tor is currently used during unit testing only. Therefore we pass J9SH_DIRPERM_ABSENT as cacheDirPerm to startup().
  *
@@ -68,8 +67,8 @@
  * \args J9OSCACHE_OPEN_MODE_CHECK_NETWORK_CACHE - checks whether we are attempting to connect to a networked cache
  * @param [in]  versionData Version data of the cache to connect to
  * @param [in]  initializer Pointer to an initializer to be used to initialize the data
- * 				area of a new cache
- */ 
+ *              area of a new cache
+ */
 SH_OSCachemmap::SH_OSCachemmap(J9PortLibrary* portLibrary, J9JavaVM* vm, const char* cacheDirName, const char* cacheName, J9SharedClassPreinitConfig* piconfig,
 		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer)
 {
@@ -83,7 +82,7 @@ SH_OSCachemmap::SH_OSCachemmap(J9PortLibrary* portLibrary, J9JavaVM* vm, const c
  * Method to initialize object variables.  This is outside the constructor for
  * consistency with SH_OSCachesysv
  * Note:  This method is public as it is called by the factory method newInstance in SH_OSCache
- * 
+ *
  * @param [in]  portLibraryArg The Port library
  * @param [in]  memForConstructorArg Pointer to the memory to build the OSCachemmap into
  * @param [in]  generation The generation of this cache
@@ -115,7 +114,7 @@ void
 SH_OSCachemmap::finalise()
 {
 	Trc_SHR_OSC_Mmap_finalise_Entry();
-	
+
 	commonCleanup();
 	_fileHandle = -1;
 	_actualFileLength = 0;
@@ -132,15 +131,15 @@ SH_OSCachemmap::finalise()
 /**
  * Method to create or open a persistent shared classes cache
  * Should be able to successfully start up a cache on any version or generation
- * 
+ *
  * @param [in]  portLibrary The Port library
  * @param [in]  cacheName The name of the cache to be opened/created
  * @param [in]  cacheDirName The directory for the cache file
  * @param [in]  piconfig Pointer to a configuration structure
  * @param [in]  numLocks The number of locks to be initialized
  * @param [in]  createFlag Indicates whether cache is to be opened or created.
- * 				Included for consistency with SH_OSCachesysv, but need to open or create is
- * 				determined by logic within this class
+ *              Included for consistency with SH_OSCachesysv, but need to open or create is
+ *              determined by logic within this class
  * @param [in]  verboseFlags Verbose flags
  * @param [in]  openMode Mode to open the cache in. Any of the following flags:
  * \args J9OSCACHE_OPEN_MODE_DO_READONLY - open the cache readonly
@@ -149,9 +148,9 @@ SH_OSCachemmap::finalise()
  * \args J9OSCACHE_OPEN_MODE_CHECK_NETWORK_CACHE - checks whether we are attempting to connect to a networked cache
  * @param [in]  versionData Version data of the cache to connect to
  * @param [in]  initializer Pointer to an initializer to be used to initialize the data
- * 				area of a new cache
+ *              area of a new cache
  * @param [in]  reason Reason for starting up the cache. Used only when startup is called during destroy
- * 
+ *
  * @return true on success, false on failure
  */
 bool
@@ -175,13 +174,13 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	}
 #endif /* OPENJ9_BUILD */
 #endif /* J9VM_ENV_DATA64 */
-	
+
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 
 	Trc_SHR_OSC_Mmap_startup_Entry(cacheName, ctrlDirName,
 		(piconfig!= NULL)? piconfig->sharedClassCacheSize : defaultCacheSize,
 		numLocks, createFlag, verboseFlags, openMode);
-	
+
 	versionData->cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 	mmapCapabilities = j9mmap_capabilities();
 	if (!(mmapCapabilities & J9PORT_MMAP_CAPABILITY_WRITE) || !(mmapCapabilities & J9PORT_MMAP_CAPABILITY_MSYNC)) {
@@ -195,7 +194,7 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		goto _errorPreFileOpen;
 	}
 	Trc_SHR_OSC_Mmap_startup_commonStartupSuccess();
-	
+
 	/* Detect remote filesystem */
 	if (openMode & J9OSCACHE_OPEN_MODE_CHECK_NETWORK_CACHE) {
 		if (0 == j9file_stat(_cacheDirName, 0, &statBuf)) {
@@ -206,11 +205,11 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			}
 		}
 	}
-	
+
 	/* Open the file */
 	if (!openCacheFile(_createFlags & J9SH_OSCACHE_CREATE, &lastErrorInfo)) {
 		Trc_SHR_OSC_Mmap_startup_badfileopen(_cachePathName);
-		errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_FILEOPEN_ERROR, &lastErrorInfo);  /* TODO: ADD FILE NAME */
+		errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_FILEOPEN_ERROR, &lastErrorInfo); /* TODO: ADD FILE NAME */
 		goto _errorPostFileOpen;
 	}
 	Trc_SHR_OSC_Mmap_startup_goodfileopen(_cachePathName, _fileHandle);
@@ -219,7 +218,7 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	 * - user has specified a cache directory, or
 	 * - destroying an existing cache (if SHR_STARTUP_REASON_DESTROY or SHR_STARTUP_REASON_EXPIRE or J9SH_OSCACHE_OPEXIST_DESTROY is set)
 	 */
-	if (!_isUserSpecifiedCacheDir 
+	if (!_isUserSpecifiedCacheDir
 		&& (J9_ARE_NO_BITS_SET(_createFlags, J9SH_OSCACHE_OPEXIST_DESTROY))
 		&& (SHR_STARTUP_REASON_DESTROY != reason)
 		&& (SHR_STARTUP_REASON_EXPIRE != reason)
@@ -261,11 +260,11 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	for (UDATA i = 0; i < J9SH_OSCACHE_MMAP_LOCK_COUNT; i++) {
 		if (omrthread_monitor_init_with_name(&_lockMutex[i], 0, "Persistent shared classes lock mutex")) {
 			Trc_SHR_OSC_Mmap_startup_failed_mutex_init(i);
- 			goto _errorPostFileOpen;
+			goto _errorPostFileOpen;
 		}
 	}
 	Trc_SHR_OSC_Mmap_startup_initialized_mutexes();
-	
+
 	/* Get cache header write lock */
 	if (-1 == acquireHeaderWriteLock(_activeGeneration, &lastErrorInfo)) {
 		Trc_SHR_OSC_Mmap_startup_badAcquireHeaderWriteLock();
@@ -276,7 +275,7 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		goto _errorPostHeaderLock;
 	}
 	Trc_SHR_OSC_Mmap_startup_goodAcquireHeaderWriteLock();
-	
+
 	/* Check the length of the file */
 #if defined(WIN32) || defined(WIN64)
 	if ((_cacheSize = (U_32)j9file_blockingasync_flength(_fileHandle)) > 0) {
@@ -286,7 +285,7 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		IDATA rc;
 		/* We are opening an existing cache */
 		Trc_SHR_OSC_Mmap_startup_fileOpened();
-		
+
 		if (_cacheSize <= sizeof(OSCachemmap_header_version_current)) {
 			Trc_SHR_OSC_Mmap_startup_cacheTooSmall();
 			errorCode = J9SH_OSCACHE_CORRUPT;
@@ -300,9 +299,9 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		if (0 != rc) {
 			errorCode = rc;
 			Trc_SHR_OSC_Mmap_startup_badAttach();
- 			goto _errorPostAttach;
+			goto _errorPostAttach;
 		}
-		
+
 		if (_runningReadOnly) {
 			retryCntr = 0;
 			U_32* initCompleteAddr = (U_32*)getMmapHeaderFieldAddressForGen(_headerStart, _activeGeneration, OSCACHE_HEADER_FIELD_CACHE_INIT_COMPLETE);
@@ -315,10 +314,10 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			if (!*initCompleteAddr) {
 				errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_ERROR_READONLY_CACHE_NOTINITIALIZED, NULL);
 				Trc_SHR_OSC_Mmap_startup_cacheNotInitialized();
-	 			goto _errorPostAttach;
+				goto _errorPostAttach;
 			}
 		}
-				
+
 		if (_verboseFlags & J9SHR_VERBOSEFLAG_ENABLE_VERBOSE) {
 			if (_runningReadOnly) {
 				OSC_TRACE1(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_OPENED_READONLY, _cacheName);
@@ -330,31 +329,31 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	} else {
 		OSCachemmap_header_version_current *cacheHeader;
 		IDATA rc;
-		
+
 		creatingNewCache = true;
 
 		/* File is wrong length, so we are creating the cache */
 		Trc_SHR_OSC_Mmap_startup_fileCreated();
-		
+
 		/* We can't create the cache when we're running read-only */
 		if (_runningReadOnly) {
 			Trc_SHR_OSC_Mmap_startup_runningReadOnlyAndWrongLength();
 			errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_ERROR_OPENING_CACHE_READONLY, NULL);
- 			goto _errorPostHeaderLock;
+			goto _errorPostHeaderLock;
 		}
-		
+
 		/* Set cache to the correct length */
 		if (!setCacheLength((U_32)piconfig->sharedClassCacheSize, &lastErrorInfo)) {
 			Trc_SHR_OSC_Mmap_startup_badSetCacheLength(piconfig->sharedClassCacheSize);
 			errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_ERROR_SETTING_CACHE_LENGTH, &lastErrorInfo);
- 			goto _errorPostHeaderLock;
+			goto _errorPostHeaderLock;
 		}
 		Trc_SHR_OSC_Mmap_startup_goodSetCacheLength(piconfig->sharedClassCacheSize);
 
 		/* Verify if the group access has been set */
 		if (J9_ARE_ALL_BITS_SET(_openMode, J9OSCACHE_OPEN_MODE_GROUPACCESS)) {
 			I_32 groupAccessRc = verifyCacheFileGroupAccess(_portLibrary, _fileHandle, &lastErrorInfo);
-			
+
 			if (0 == groupAccessRc) {
 				Trc_SHR_OSC_Mmap_startup_setGroupAccessFailed(_cachePathName);
 				OSC_WARNING_TRACE(J9NLS_SHRC_OSCACHE_MMAP_SET_GROUPACCESS_FAILED);
@@ -370,16 +369,16 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		if (0 != rc) {
 			errorCode = rc;
 			Trc_SHR_OSC_Mmap_startup_badAttach();
- 			goto _errorPostAttach;
+			goto _errorPostAttach;
 		}
-				
+
 		cacheHeader = (OSCachemmap_header_version_current *)_headerStart;
 
 		/* Create the cache header */
 		if (!createCacheHeader(cacheHeader, versionData)) {
 			Trc_SHR_OSC_Mmap_startup_badCreateCacheHeader();
 			errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_ERROR_CREATING_CACHE_HEADER, NULL);
- 			goto _errorPostAttach;
+			goto _errorPostAttach;
 		}
 		Trc_SHR_OSC_Mmap_startup_goodCreateCacheHeader();
 
@@ -387,16 +386,16 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			if (!initializeDataHeader(initializer)) {
 				Trc_SHR_OSC_Mmap_startup_badInitializeDataHeader();
 				errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_ERROR_INITIALISING_DATA_HEADER, NULL);
-	 			goto _errorPostAttach;
+				goto _errorPostAttach;
 			}
-	 		Trc_SHR_OSC_Mmap_startup_goodInitializeDataHeader();
+			Trc_SHR_OSC_Mmap_startup_goodInitializeDataHeader();
 		}
-		
+
 		if (_verboseFlags & J9SHR_VERBOSEFLAG_ENABLE_VERBOSE) {
 			OSC_TRACE1(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_CREATED, _cacheName);
 		}
 	}
-	
+
 	if (creatingNewCache) {
 		OSCachemmap_header_version_current *cacheHeader = (OSCachemmap_header_version_current *)_headerStart;
 
@@ -417,10 +416,10 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 _exitForDestroy:
 	_finalised = 0;
 	_startupCompleted = true;
-	
+
 	Trc_SHR_OSC_Mmap_startup_Exit();
 	return true;
-	
+
 _errorPostAttach :
 	internalDetach(_activeGeneration);
 _errorPostHeaderLock :
@@ -464,16 +463,15 @@ SH_OSCachemmap::dontNeedMetadata(J9VMThread* currentThread, const void* startAdd
 #endif
 }
 
-
 /**
  * Destroy a persistent shared classes cache
- * 
+ *
  * @param[in] suppressVerbose suppresses verbose output
  * @param[in] isReset True if reset option is being used, false otherwise.
- * 
+ *
  * This method detaches from the cache, checks whether it is in use by any other
  * processes and if not, deletes it from the filesystem
- * 
+ *
  * @return 0 for success and -1 for failure
  */
 IDATA
@@ -481,26 +479,26 @@ SH_OSCachemmap::destroy(bool suppressVerbose, bool isReset)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	UDATA origVerboseFlags = _verboseFlags;
-	IDATA returnVal = -1; 		/* Assume failure */
+	IDATA returnVal = -1; /* Assume failure */
 	LastErrorInfo lastErrorInfo;
-	
+
 	Trc_SHR_OSC_Mmap_destroy_Entry();
-	
+
 	if (suppressVerbose) {
 		_verboseFlags = 0;
 	}
-	
+
 	if (_headerStart != NULL) {
 		detach();
 	}
-	
+
 	if (!closeCacheFile()) {
 		Trc_SHR_OSC_Mmap_destroy_closefilefailed();
 		goto _done;
 	}
 	_mapFileHandle = 0;
 	_actualFileLength = 0;
-	
+
 	Trc_SHR_OSC_Mmap_destroy_deletingfile(_cachePathName);
 	if (!deleteCacheFile(&lastErrorInfo)) {
 		Trc_SHR_OSC_Mmap_destroy_badunlink();
@@ -527,10 +525,10 @@ SH_OSCachemmap::destroy(bool suppressVerbose, bool isReset)
 			}
 		}
 	}
-	
+
 	Trc_SHR_OSC_Mmap_destroy_finalising();
 	finalise();
-	
+
 	returnVal = 0;
 	Trc_SHR_OSC_Mmap_destroy_Exit();
 
@@ -544,19 +542,19 @@ _done :
 
 /**
  * Method to update the cache's last detached time, detach it from the
- * process and clean up the object's resources.  It is called when the 
+ * process and clean up the object's resources.  It is called when the
  * cache is no longer required by the JVM.
  */
 void
 SH_OSCachemmap::cleanup()
-{	
+{
 	Trc_SHR_OSC_Mmap_cleanup_Entry();
-	
+
 	if (_finalised) {
 		Trc_SHR_OSC_Mmap_cleanup_alreadyfinalised();
 		return;
 	}
-	
+
 	if (_headerStart) {
 		if (acquireHeaderWriteLock(_activeGeneration, NULL) != -1) {
 			if (updateLastDetachedTime()) {
@@ -578,17 +576,17 @@ SH_OSCachemmap::cleanup()
 			Trc_SHR_Assert_ShouldNeverHappen();
 		}
 	}
-	
+
 	if (_headerStart) {
 		detach();
 	}
-	
+
 	if (_fileHandle != -1) {
 		closeCacheFile();
 	}
-	
+
 	finalise();
-	
+
 	Trc_SHR_OSC_Mmap_cleanup_Exit();
 	return;
 }
@@ -596,7 +594,7 @@ SH_OSCachemmap::cleanup()
 /*
  * TODO:
  * There follows a series methods for acquiring/releasing various read/write
- * locks on the cache.  These all contain very similar code and while they 
+ * locks on the cache.  These all contain very similar code and while they
  * do not present a problem in their current form, it would probably be better
  * to reduce them to a few basic methods and have them operate on an array of
  * lock words.
@@ -604,7 +602,7 @@ SH_OSCachemmap::cleanup()
 
 /**
  * Get an ID for a write area lock
- * 
+ *
  * @return a non-negative lockID on success
  */
 IDATA SH_OSCachemmap::getWriteLockID()
@@ -624,21 +622,21 @@ IDATA SH_OSCachemmap::getReadWriteLockID()
 
 /**
  * Method to acquire the write lock on the cache data region
- * 
+ *
  * @return 0 on success, -1 on failure
  */
 IDATA
 SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	I_32 lockFlags = J9PORT_FILE_WRITE_LOCK | J9PORT_FILE_WAIT_FOR_LOCK;
 	U_64 lockOffset, lockLength;
 	I_32 rc = 0;
 	I_64 startLoopTime = 0;
 	I_64 endLoopTime = 0;
 	UDATA loopCount = 0;
-	
+
 	Trc_SHR_OSC_Mmap_acquireWriteLock_Entry(lockID);
 
 	if ((lockID != J9SH_OSCACHE_MMAP_LOCKID_WRITELOCK) && (lockID != J9SH_OSCACHE_MMAP_LOCKID_READWRITELOCK)) {
@@ -648,7 +646,7 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 
 	lockOffset = offsetof(OSCachemmap_header_version_current, dataLocks) + (lockID * sizeof(I_32));
 	lockLength = sizeof(((OSCachemmap_header_version_current *)NULL)->dataLocks[0]);
-	
+
 	/* We enter a local mutex before acquiring the file lock. This is because file
 	 * locks only work between processes, whereas we need to lock between processes
 	 * AND THREADS. So we use a local mutex to lock between threads of the same JVM,
@@ -665,8 +663,8 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 	rc = j9file_blockingasync_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
 #else
 	rc = j9file_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
-#endif	
-	
+#endif
+
 	while ((rc == -1) && (j9error_last_error_number() == J9PORT_ERROR_FILE_LOCK_EDEADLK)) {
 		if (++loopCount > 1) {
 			/* We time the loop so it doesn't loop forever. Try the lock algorithm below
@@ -687,34 +685,33 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 		 * is to exit and let the caller retry.
 		 */
 		if (lockID == J9SH_OSCACHE_MMAP_LOCKID_READWRITELOCK && omrthread_monitor_owned_by_self(_lockMutex[J9SH_OSCACHE_MMAP_LOCKID_WRITELOCK]) == 1) {
-			/*	CMVC 153095: Case 1
+			/* CMVC 153095: Case 1
 			 * Current thread:
-			 *	- Owns W monitor, W lock, RW monitor, and gets EDADLK on RW lock
+			 *  - Owns W monitor, W lock, RW monitor, and gets EDADLK on RW lock
 			 *
 			 * Notes:
-			 *	- This means other JVMs caused EDEADLK because they are holding RW, and
-			 *	  waiting on W in a sequence that gives fcntl the impression of deadlock
-			 *	- If current thread owns the W monitor, it must also own the W lock 
-			 *	  if the call stack ended up here.
+			 *  - This means other JVMs caused EDEADLK because they are holding RW, and
+			 *    waiting on W in a sequence that gives fcntl the impression of deadlock
+			 *  - If current thread owns the W monitor, it must also own the W lock
+			 *    if the call stack ended up here.
 			 *
 			 * Recovery:
-			 *	- In this case we can't do anything but retry RW, because EDEADLK is caused by other JVMs.
-			 *
+			 *  - In this case we can't do anything but retry RW, because EDEADLK is caused by other JVMs.
 			 */
 			Trc_SHR_OSC_Mmap_acquireWriteLockDeadlockMsg("Case 1: Current thread owns W lock & monitor, and RW monitor, but EDEADLK'd on RW lock");
 #if defined(WIN32) || defined(WIN64)
 			rc = j9file_blockingasync_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
 #else
 			rc = j9file_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
-#endif			
+#endif
 
 		} else if (lockID == J9SH_OSCACHE_MMAP_LOCKID_READWRITELOCK) {
-			/*	CMVC 153095: Case 2
+			/* CMVC 153095: Case 2
 			 * Another thread:
-			 *	- Owns the W monitor, and is waiting on (or owns) the W lock
+			 *  - Owns the W monitor, and is waiting on (or owns) the W lock
 			 *
 			 * Current thread:
-			 *	- Current thread owns the RW monitor, and gets EDEADLK on RW lock
+			 *  - Current thread owns the RW monitor, and gets EDEADLK on RW lock
 			 *
 			 * Note:
 			 *  - Deadlock might caused by the order in which threads have taken taken locks, when compared to another JVM.
@@ -722,9 +719,9 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 			 *    can complete.
 			 *
 			 * Recovery
-			 *	- Recover by trying to take the W monitor, then RW monitor and lock. This will 
-			 *	  resolve any EDEADLK caused by this JVM, because it ensures no thread in this JVM will hold
-			 *	  the W lock.
+			 *  - Recover by trying to take the W monitor, then RW monitor and lock. This will
+			 *    resolve any EDEADLK caused by this JVM, because it ensures no thread in this JVM will hold
+			 *    the W lock.
 			 */
 			Trc_SHR_OSC_Mmap_acquireWriteLockDeadlockMsg("Case 2: Current thread owns RW mon, but EDEADLK'd on RW lock");
 			omrthread_monitor_exit(_lockMutex[J9SH_OSCACHE_MMAP_LOCKID_READWRITELOCK]);
@@ -743,27 +740,27 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 			rc = j9file_blockingasync_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
 #else
 			rc = j9file_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
-#endif	
+#endif
 
 			omrthread_monitor_exit(_lockMutex[J9SH_OSCACHE_MMAP_LOCKID_WRITELOCK]);
 
 		} else if (lockID == J9SH_OSCACHE_MMAP_LOCKID_WRITELOCK) {
-			/*	CMVC 153095: Case 3
+			/* CMVC 153095: Case 3
 			 * Another thread:
-			 *	- Owns RW monitor, and is waiting on (or owns) the RW lock.
-			 * 
+			 *  - Owns RW monitor, and is waiting on (or owns) the RW lock.
+			 *
 			 * Current thread:
-			 *	- Owns W monitor, and gets EDEADLK on W lock.
-			 *	
+			 *  - Owns W monitor, and gets EDEADLK on W lock.
+			 *
 			 * Note:
-			 *  - If the 'call stack' ends up here then it is known the current thread 
-			 *    does not own the ReadWrite lock. The shared classes code always 
+			 *  - If the 'call stack' ends up here then it is known the current thread
+			 *    does not own the ReadWrite lock. The shared classes code always
 			 *    takes the W lock, then RW lock, OR just the RW lock.
 			 *
 			 * Recovery:
-			 *	- In this case we recover by waiting on the RW monitor before taking the W lock. This will 
-			 *	  resolve any EDEADLK caused by this JVM, because it ensures no thread in this JVM will hold
-			 *	  the RW lock.
+			 *  - In this case we recover by waiting on the RW monitor before taking the W lock. This will
+			 *    resolve any EDEADLK caused by this JVM, because it ensures no thread in this JVM will hold
+			 *    the RW lock.
 			 */
 			Trc_SHR_OSC_Mmap_acquireWriteLockDeadlockMsg("Case 3: Current thread owns W mon, but EDEADLK'd on W lock");
 			if (omrthread_monitor_enter(_lockMutex[J9SH_OSCACHE_MMAP_LOCKID_READWRITELOCK]) != 0) {
@@ -788,24 +785,24 @@ SH_OSCachemmap::acquireWriteLock(UDATA lockID)
 	} else {
 		Trc_SHR_OSC_Mmap_acquireWriteLock_goodLock();
 	}
-	
+
 	Trc_SHR_OSC_Mmap_acquireWriteLock_Exit(rc);
 	return rc;
 }
 
 /**
  * Method to release the write lock on the cache data region
- * 
+ *
  * @return 0 on success, -1 on failure
  */
 IDATA
 SH_OSCachemmap::releaseWriteLock(UDATA lockID)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	U_64 lockOffset, lockLength;
 	I_32 rc = 0;
-	
+
 	Trc_SHR_OSC_Mmap_releaseWriteLock_Entry(lockID);
 
 	if (lockID >= J9SH_OSCACHE_MMAP_LOCK_COUNT) {
@@ -815,44 +812,44 @@ SH_OSCachemmap::releaseWriteLock(UDATA lockID)
 
 	lockOffset = offsetof(OSCachemmap_header_version_current, dataLocks) + (lockID * sizeof(I_32));
 	lockLength = sizeof(((OSCachemmap_header_version_current *)NULL)->dataLocks[0]);
-	
+
 	Trc_SHR_OSC_Mmap_releaseWriteLock_gettingLock(_fileHandle, lockOffset, lockLength);
-#if defined(WIN32) || defined(WIN64)	
+#if defined(WIN32) || defined(WIN64)
 	rc = j9file_blockingasync_unlock_bytes(_fileHandle, lockOffset, lockLength);
 #else
 	rc = j9file_unlock_bytes(_fileHandle, lockOffset, lockLength);
-#endif	
-	
+#endif
+
 	if (-1 == rc) {
 		Trc_SHR_OSC_Mmap_releaseWriteLock_badLock();
 	} else {
 		Trc_SHR_OSC_Mmap_releaseWriteLock_goodLock();
 	}
-	
+
 	Trc_SHR_OSC_Mmap_releaseWriteLock_exiting_monitor(lockID);
 	if (omrthread_monitor_exit(_lockMutex[lockID]) != 0) {
 		Trc_SHR_OSC_Mmap_releaseWriteLock_bad_monitor_exit(lockID);
 		rc = -1;
- 	}
-	
+	}
+
 	Trc_SHR_OSC_Mmap_releaseWriteLock_Exit(rc);
 	return rc;
 }
 
 /**
  * Method to acquire the read lock on the cache attach region
- * 
+ *
  * Needs to be able to work with all generations
- * 
+ *
  * @param [in] generation The generation of the cache header to use when calculating the lock offset
- * 
+ *
  * @return 0 on success, -1 on failure
  */
 IDATA
 SH_OSCachemmap::acquireAttachReadLock(UDATA generation, LastErrorInfo *lastErrorInfo)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	I_32 lockFlags = J9PORT_FILE_READ_LOCK | J9PORT_FILE_WAIT_FOR_LOCK;
 	U_64 lockOffset, lockLength;
 	I_32 rc = 0;
@@ -867,11 +864,11 @@ SH_OSCachemmap::acquireAttachReadLock(UDATA generation, LastErrorInfo *lastError
 	lockLength = sizeof(((OSCachemmap_header_version_current *)NULL)->attachLock);
 
 	Trc_SHR_OSC_Mmap_acquireAttachReadLock_gettingLock(_fileHandle, lockFlags, lockOffset, lockLength);
-#if defined(WIN32) || defined(WIN64)	
+#if defined(WIN32) || defined(WIN64)
 	rc = j9file_blockingasync_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
 #else
 	rc = j9file_lock_bytes(_fileHandle, lockFlags, lockOffset, lockLength);
-#endif	
+#endif
 	if (-1 == rc) {
 		if (NULL != lastErrorInfo) {
 			lastErrorInfo->lastErrorCode = j9error_last_error_number();
@@ -881,60 +878,60 @@ SH_OSCachemmap::acquireAttachReadLock(UDATA generation, LastErrorInfo *lastError
 	} else {
 		Trc_SHR_OSC_Mmap_acquireAttachReadLock_goodLock();
 	}
-	
+
 	Trc_SHR_OSC_Mmap_acquireAttachReadLock_Exit(rc);
 	return rc;
 }
 
 /**
  * Method to release the read lock on the cache attach region
- * 
+ *
  * Needs to be able to work with all generations
- * 
+ *
  * @param [in] generation The generation of the cache header to use when calculating the lock offset
- * 
+ *
  * @return 0 on success, -1 on failure
  */
 IDATA
 SH_OSCachemmap::releaseAttachReadLock(UDATA generation)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	U_64 lockOffset, lockLength;
 	I_32 rc = 0;
-	
+
 	Trc_SHR_OSC_Mmap_releaseAttachReadLock_Entry();
-	
+
 	lockOffset = (U_64)getMmapHeaderFieldOffsetForGen(generation, OSCACHEMMAP_HEADER_FIELD_ATTACH_LOCK);
 	lockLength = sizeof(((OSCachemmap_header_version_current *)NULL)->attachLock);
 
 	Trc_SHR_OSC_Mmap_releaseAttachReadLock_gettingLock(_fileHandle, lockOffset, lockLength);
-#if defined(WIN32) || defined(WIN64)	
+#if defined(WIN32) || defined(WIN64)
 	rc = j9file_blockingasync_unlock_bytes(_fileHandle, lockOffset, lockLength);
 #else
 	rc = j9file_unlock_bytes(_fileHandle, lockOffset, lockLength);
-#endif	
-	
+#endif
+
 	if (-1 == rc) {
 		Trc_SHR_OSC_Mmap_releaseAttachReadLock_badLock();
 	} else {
 		Trc_SHR_OSC_Mmap_releaseAttachReadLock_goodLock();
 	}
-	
+
 	Trc_SHR_OSC_Mmap_releaseAttachReadLock_Exit(rc);
 	return rc;
 }
 
 /*
- * This function performs enough of an attach to start the cache, but nothing more 
+ * This function performs enough of an attach to start the cache, but nothing more
  * The internalDetach function is the equivalent for detach
- * isNewCache should be true if we're attaching to a completely uninitialized cache, false otherwise 
+ * isNewCache should be true if we're attaching to a completely uninitialized cache, false otherwise
  * THREADING: Pre-req caller holds the cache header write lock
- * 
+ *
  * Needs to be able to work with all generations
- * 
+ *
  * @param [in] isNewCache true if the cache is new and we should calculate cache size using the file size;
- * 				false if the cache is pre-existing and we can read the size fields from the cache header 
+ *              false if the cache is pre-existing and we can read the size fields from the cache header
  * @param [in] generation The generation of the cache header to use when calculating the lock offset
  *
  * @return 0 on success, J9SH_OSCACHE_FAILURE on failure, J9SH_OSCACHE_CORRUPT for corrupt cache
@@ -946,12 +943,12 @@ SH_OSCachemmap::internalAttach(bool isNewCache, UDATA generation)
 	U_32 accessFlags = _runningReadOnly ? J9PORT_MMAP_FLAG_READ : J9PORT_MMAP_FLAG_WRITE;
 	LastErrorInfo lastErrorInfo;
 	IDATA rc = J9SH_OSCACHE_FAILURE;
-	
+
 	Trc_SHR_OSC_Mmap_internalAttach_Entry();
-	
+
 	/* Get current length of file */
 	accessFlags |= J9PORT_MMAP_FLAG_SHARED;
-	
+
 	_actualFileLength = _cacheSize;
 	Trc_SHR_Assert_True(_actualFileLength > 0);
 
@@ -991,7 +988,7 @@ SH_OSCachemmap::internalAttach(bool isNewCache, UDATA generation)
 	}
 	_headerStart = _mapFileHandle->pointer;
 	Trc_SHR_OSC_Mmap_internalAttach_goodmapfile(_headerStart);
-	
+
 	if (!isNewCache) {
 		J9SRP* dataStartField;
 		U_32* dataLengthField;
@@ -1015,23 +1012,23 @@ SH_OSCachemmap::internalAttach(bool isNewCache, UDATA generation)
 		_dataLength = (U_32)MMAP_CACHEDATASIZE(_actualFileLength);
 		_dataStart = (void*)((UDATA)_headerStart + MMAP_CACHEHEADERSIZE);
 	}
-	
+
 	Trc_SHR_OSC_Mmap_internalAttach_Exit(_dataStart, sizeof(OSCachemmap_header_version_current));
 	return 0;
 
 error:
 	internalDetach(generation);
 	return rc;
-} 
+}
 
 /**
  * Function to attach a persistent shared classes cache to the process
  * Function performs version checking on the cache if the version data is provided
- * 
+ *
  * @param [in] expectedVersionData  If not NULL, function checks the version data of the cache against the values in this struct
- * 
+ *
  * @return Pointer to the start of the cache data area on success, NULL on failure
- */ 
+ */
 void *
 SH_OSCachemmap::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVersionData)
 {
@@ -1042,23 +1039,23 @@ SH_OSCachemmap::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVers
 	J9JavaVM *vm = currentThread->javaVM;
 	bool doRelease = false;
 	IDATA rc;
-	
+
 	Trc_SHR_OSC_Mmap_attach_Entry1(UnitTest::unitTest);
-	
+
 	/* If we are already attached, just return */
 	if (_dataStart) {
 		Trc_SHR_OSC_Mmap_attach_alreadyattached(_headerStart, _dataStart, _dataLength);
 		return _dataStart;
 	}
-	
+
 	if (acquireHeaderWriteLock(_activeGeneration, &lastErrorInfo) == -1) {
 		Trc_SHR_OSC_Mmap_attach_acquireHeaderLockFailed();
 		errorHandler(J9NLS_SHRC_OSCACHE_MMAP_ATTACH_ACQUIREHEADERWRITELOCK_ERROR, &lastErrorInfo);
 		return NULL;
 	}
-	
+
 	doRelease = true;
-	
+
 	rc = internalAttach(false, _activeGeneration);
 	if (0 != rc) {
 		setError(rc);
@@ -1112,10 +1109,10 @@ SH_OSCachemmap::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVers
 	if ((_verboseFlags & J9SHR_VERBOSEFLAG_ENABLE_VERBOSE) && _startupCompleted) {
 		OSC_TRACE1(J9NLS_SHRC_OSCACHE_MMAP_ATTACH_ATTACHED, _cacheName);
 	}
-	
+
 	Trc_SHR_OSC_Mmap_attach_Exit(_dataStart);
 	return _dataStart;
-	
+
 detach:
 	internalDetach(_activeGeneration);
 release:
@@ -1125,13 +1122,13 @@ release:
 	}
 	Trc_SHR_OSC_Mmap_attach_ExitWithError();
 	return NULL;
-} 
+}
 
 /**
  * Method to update the last attached time in a cache's header
- * 
+ *
  * @param [in] headerArg  A pointer to the cache header
- * 
+ *
  * @return true on success, false on failure
  * THREADING: Pre-req caller holds the cache header write lock
  */
@@ -1139,25 +1136,25 @@ I_32
 SH_OSCachemmap::updateLastAttachedTime(OSCachemmap_header_version_current* header)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_Mmap_updateLastAttachedTime_Entry();
-	
+
 	if (_runningReadOnly) {
 		Trc_SHR_OSC_Mmap_updateLastAttachedTime_ReadOnly();
 		return true;
 	}
-	
+
 	I_64 newTime = j9time_current_time_millis();
 	Trc_SHR_OSC_Mmap_updateLastAttachedTime_time(newTime, header->lastAttachedTime);
 	header->lastAttachedTime = newTime;
-	
+
 	Trc_SHR_OSC_Mmap_updateLastAttachedTime_Exit();
 	return true;
 }
 
 /**
  * Method to update the last detached time in a cache's header
- * 
+ *
  * @return true on success, false on failure
  * THREADING: Pre-req caller holds the cache header write lock
  */
@@ -1165,12 +1162,12 @@ I_32
 SH_OSCachemmap::updateLastDetachedTime()
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	OSCachemmap_header_version_current* cacheHeader = (OSCachemmap_header_version_current*)_headerStart;
 	I_64 newTime;
-	
+
 	Trc_SHR_OSC_Mmap_updateLastDetachedTime_Entry();
-	
+
 	if (_runningReadOnly) {
 		Trc_SHR_OSC_Mmap_updateLastDetachedTime_ReadOnly();
 		return true;
@@ -1179,17 +1176,17 @@ SH_OSCachemmap::updateLastDetachedTime()
 	newTime = j9time_current_time_millis();
 	Trc_SHR_OSC_Mmap_updateLastDetachedTime_time(newTime, cacheHeader->lastDetachedTime);
 	cacheHeader->lastDetachedTime = newTime;
-	
+
 	Trc_SHR_OSC_Mmap_updateLastDetachedTime_Exit();
 	return true;
 }
 
 /**
  * Method to create the cache header for a new persistent cache
- * 
+ *
  * @param [in] cacheHeader  A pointer to the cache header
  * @param [in] versionData  The version data of the cache
- * 
+ *
  * @return true on success, false on failure
  * THREADING: Pre-req caller holds the cache header write lock
  */
@@ -1198,24 +1195,24 @@ SH_OSCachemmap::createCacheHeader(OSCachemmap_header_version_current *cacheHeade
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	U_32 headerLen = MMAP_CACHEHEADERSIZE;
-	
+
 	if(NULL == cacheHeader) {
 		return false;
 	}
 
 	Trc_SHR_OSC_Mmap_createCacheHeader_Entry(cacheHeader, headerLen, versionData);
-	
+
 	memset(cacheHeader, 0, headerLen);
-	strncpy(cacheHeader->eyecatcher, J9SH_OSCACHE_MMAP_EYECATCHER, J9SH_OSCACHE_MMAP_EYECATCHER_LENGTH);
-	
+	memcpy(cacheHeader->eyecatcher, J9SH_OSCACHE_MMAP_EYECATCHER, J9SH_OSCACHE_MMAP_EYECATCHER_LENGTH);
+
 	initOSCacheHeader(&(cacheHeader->oscHdr), versionData, headerLen);
 
 	cacheHeader->createTime = j9time_current_time_millis();
 	cacheHeader->lastAttachedTime = j9time_current_time_millis();
 	cacheHeader->lastDetachedTime = j9time_current_time_millis();
-	
-	Trc_SHR_OSC_Mmap_createCacheHeader_header(cacheHeader->eyecatcher, 
-													cacheHeader->oscHdr.size, 
+
+	Trc_SHR_OSC_Mmap_createCacheHeader_header(cacheHeader->eyecatcher,
+													cacheHeader->oscHdr.size,
 													cacheHeader->oscHdr.dataStart,
 													cacheHeader->oscHdr.dataLength,
 													cacheHeader->createTime,
@@ -1227,9 +1224,9 @@ SH_OSCachemmap::createCacheHeader(OSCachemmap_header_version_current *cacheHeade
 
 /**
  * Method to set the length of a new cache file
- * 
+ *
  * @param [in] cacheSize  The length of the cache in bytes
- * 
+ *
  * @return true on success, false on failure
  * THREADING: Pre-req caller holds the cache header write lock
  */
@@ -1239,7 +1236,7 @@ SH_OSCachemmap::setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo)
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 
 	Trc_SHR_OSC_Mmap_setCacheLength_Entry(cacheSize);
-	
+
 	if (NULL != lastErrorInfo) {
 		lastErrorInfo->lastErrorCode = 0;
 	}
@@ -1247,7 +1244,7 @@ SH_OSCachemmap::setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo)
 	if (cacheSize < sizeof(OSCachemmap_header_version_current)) {
 		return false;
 	}
-	
+
 #if defined(WIN32) || defined(WIN64)
 	if (0 != j9file_blockingasync_set_length(_fileHandle, cacheSize)) {
 #else
@@ -1264,9 +1261,9 @@ SH_OSCachemmap::setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo)
 		return false;
 	}
 	Trc_SHR_OSC_Mmap_setCacheLength_goodfilesetlength();
-	
+
 	_cacheSize = cacheSize;
-	
+
 	Trc_SHR_OSC_Mmap_setCacheLength_Exit();
 	return true;
 }
@@ -1274,9 +1271,9 @@ SH_OSCachemmap::setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo)
 /**
  * Method to run the initializer supplied to the multi argument constructor
  * or the startup method against the data area of a new cache
- * 
+ *
  * @param [in] initializer  Struct containing fields to initialize
- * 
+ *
  * @return true on success, false on failure
  * THREADING: Pre-req caller holds the cache header write lock
  */
@@ -1287,10 +1284,10 @@ SH_OSCachemmap::initializeDataHeader(SH_OSCacheInitializer *initializer)
 	U_32 softMaxBytes = (U_32)_config->sharedClassSoftMaxBytes;
 
 	Trc_SHR_OSC_Mmap_initializeDataHeader_Entry();
-	
+
 	Trc_SHR_OSC_Mmap_initializeDataHeader_callinginit3(_dataStart,
-															_dataLength, 
-															_config->sharedClassMinAOTSize, 
+															_dataLength,
+															_config->sharedClassMinAOTSize,
 															_config->sharedClassMaxAOTSize,
 															_config->sharedClassMinJITSize,
 															_config->sharedClassMaxJITSize,
@@ -1304,16 +1301,16 @@ SH_OSCachemmap::initializeDataHeader(SH_OSCacheInitializer *initializer)
 		Trc_SHR_OSC_Mmap_initializeDataHeader_softMaxBytesTooBig(softMaxBytes);
 	}
 
-	initializer->init((char*)_dataStart, 
-								_dataLength, 
-								(I_32)_config->sharedClassMinAOTSize, 
+	initializer->init((char*)_dataStart,
+								_dataLength,
+								(I_32)_config->sharedClassMinAOTSize,
 								(I_32)_config->sharedClassMaxAOTSize,
 								(I_32)_config->sharedClassMinJITSize,
 								(I_32)_config->sharedClassMaxJITSize,
 								readWriteBytes,
 								softMaxBytes);
 	Trc_SHR_OSC_Mmap_initializeDataHeader_initialized();
-	
+
 	Trc_SHR_OSC_Mmap_initializeDataHeader_Exit();
 	return true;
 }
@@ -1325,7 +1322,7 @@ void
 SH_OSCachemmap::detach()
 {
 	if (acquireHeaderWriteLock(_activeGeneration, NULL) != -1) {
-		updateLastDetachedTime();	
+		updateLastDetachedTime();
 		if (releaseHeaderWriteLock(_activeGeneration, NULL) == -1) {
 			PORT_ACCESS_FROM_PORT(_portLibrary);
 			I_32 myerror = j9error_last_error_number();
@@ -1346,19 +1343,19 @@ void
 SH_OSCachemmap::internalDetach(UDATA generation)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_Mmap_internalDetach_Entry();
-	
+
 	if (NULL == _headerStart) {
 		Trc_SHR_OSC_Mmap_internalDetach_notattached();
 		return;
 	}
-	
+
 	if (_mapFileHandle) {
 		j9mmap_unmap_file(_mapFileHandle);
 		_mapFileHandle = NULL;
 	}
-	
+
 	if (0 != releaseAttachReadLock(generation)) {
 		Trc_SHR_OSC_Mmap_internalDetach_badReleaseAttachReadLock();
 	}
@@ -1367,33 +1364,33 @@ SH_OSCachemmap::internalDetach(UDATA generation)
 	_headerStart = NULL;
 	_dataStart = NULL;
 	_dataLength = 0;
-	/* The member variable '_actualFileLength' is not set to zero b/c 
-	 * the cache size may be needed to reset the cache (e.g. in the 
-	 * case of a build id mismatch, the cache may be reset, and 
-	 * ::getTotalSize() may be called to ensure the new cache is the 
-	 * same size). 
+	/* The member variable '_actualFileLength' is not set to zero b/c
+	 * the cache size may be needed to reset the cache (e.g. in the
+	 * case of a build id mismatch, the cache may be reset, and
+	 * ::getTotalSize() may be called to ensure the new cache is the
+	 * same size).
 	 */
-	
+
 	Trc_SHR_OSC_Mmap_internalDetach_Exit(_headerStart, _dataStart, _dataLength);
 	return;
 }
 
 /**
  * Method to get the statistics for a shared classes cache
- * 
+ *
  * Needs to be able to get stats for all cache generations
- * 
+ *
  * This method returns the last attached, detached and created times,
  * whether the cache is in use and that it is a persistent cache.
- * 
+ *
  * Details of data held in the cache data area are not accessed here
- * 
+ *
  * @param [in] vm The Java VM
  * @param [in] ctrlDirName  Cache directory
  * @param [in] cacheNameWithVGen Filename of the cache to stat
- * @param [out]	cacheInfo Pointer to the structure to be completed with the cache's details
+ * @param [out] cacheInfo Pointer to the structure to be completed with the cache's details
  * @param [in] reason Indicates the reason for getting cache stats. Refer sharedconsts.h for valid values.
- * 
+ *
  * @return 0 on success and -1 for failure
  */
 IDATA
@@ -1413,16 +1410,16 @@ SH_OSCachemmap::getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char
 	J9SharedClassPreinitConfig piconfig;
 	J9PortShcVersion versionData;
 	UDATA reasonForStartup = SHR_STARTUP_REASON_NORMAL;
-	
+
 	Trc_SHR_OSC_Mmap_getCacheStats_Entry(cacheNameWithVGen, cacheInfo);
 
 	getValuesFromShcFilePrefix(portLibrary, cacheNameWithVGen, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
-	
+
 	if (removeCacheVersionAndGen(cacheInfo->name, CACHE_ROOT_MAXLEN, J9SH_VERSION_STRING_LEN+1, cacheNameWithVGen) != 0) {
 		return -1;
 	}
-	
+
 	if (SHR_STATS_REASON_DESTROY == reason) {
 		reasonForStartup = SHR_STARTUP_REASON_DESTROY;
 	} else if (SHR_STATS_REASON_EXPIRE == reason) {
@@ -1430,17 +1427,17 @@ SH_OSCachemmap::getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char
 	}
 
 	cache = (SH_OSCachemmap *) SH_OSCache::newInstance(PORTLIB, &cacheStruct, cacheInfo->name, cacheInfo->generation, &versionData, getLayerFromName(cacheNameWithVGen));
-	
+
 	/* We try to open the cache read/write */
 	if (!cache->startup(vm, cacheDirName, vm->sharedCacheAPI->cacheDirPerm, cacheInfo->name, &piconfig, SH_CompositeCacheImpl::getNumRequiredOSLocks(), J9SH_OSCACHE_OPEXIST_STATS, 0, 0/*runtime flags*/, 0, 0, &versionData, NULL, reasonForStartup)) {
-	
+
 		/* If that fails - try to open the cache read-only */
 		if (!cache->startup(vm, cacheDirName, vm->sharedCacheAPI->cacheDirPerm, cacheInfo->name, &piconfig, 0, J9SH_OSCACHE_OPEXIST_STATS, 0, 0/*runtime flags*/, J9OSCACHE_OPEN_MODE_DO_READONLY, 0, &versionData, NULL, reasonForStartup)) {
 			cache->cleanup();
 			return -1;
 		}
 		inUse = J9SH_OSCACHE_UNKNOWN; /* We can't determine whether there are JVMs attached to a read-only cache */
-	
+
 	} else {
 		/* Try to acquire the attach write lock. This will only succeed if noone else
 		 * has the attach read lock i.e. there is noone connected to the cache */
@@ -1461,10 +1458,10 @@ SH_OSCachemmap::getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char
 	cacheInfo->os_shmid = (UDATA)J9SH_OSCACHE_UNKNOWN;
 	cacheInfo->os_semid = (UDATA)J9SH_OSCACHE_UNKNOWN;
 	cacheInfo->nattach = inUse;
-	
+
 	/* CMVC 177634: Skip calling internalAttach() when destroying the cache */
 	if (SHR_STARTUP_REASON_DESTROY != reasonForStartup) {
-		/* The offset of fields createTime, lastAttachedTime, lastDetachedTime in struct OSCache_mmap_header2 are different on 32-bit and 64-bit caches. 
+		/* The offset of fields createTime, lastAttachedTime, lastDetachedTime in struct OSCache_mmap_header2 are different on 32-bit and 64-bit caches.
 		 * This depends on OSCachemmap_header_version_current and OSCache_header_version_current not changing in an incompatible way.
 		 */
 		if (J9SH_ADDRMODE == cacheInfo->versionData.addrmode) {
@@ -1494,7 +1491,7 @@ SH_OSCachemmap::getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char
 			cache->internalDetach(cacheInfo->generation);
 		}
 	}
-	
+
 	Trc_SHR_OSC_Mmap_getCacheStats_Exit(cacheInfo->os_shmid,
 											cacheInfo->os_semid,
 											cacheInfo->lastattach,
@@ -1510,7 +1507,7 @@ SH_OSCachemmap::getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char
 
 /**
  * Delete the cache file
- * 
+ *
  * @return true on success, false on failure
  */
 bool
@@ -1518,7 +1515,7 @@ SH_OSCachemmap::deleteCacheFile(LastErrorInfo *lastErrorInfo)
 {
 	bool result = true;
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_Mmap_deleteCacheFile_entry();
 
 	if (NULL != lastErrorInfo) {
@@ -1544,15 +1541,15 @@ SH_OSCachemmap::deleteCacheFile(LastErrorInfo *lastErrorInfo)
 
 /**
  * Method to perform processing required when the JVM is exiting
- * 
- * Note:  The JVM requires that memory should not be freed during
- * 			exit processing
+ *
+ * Note: The JVM requires that memory should not be freed during
+ *          exit processing
  */
 void
 SH_OSCachemmap::runExitCode()
 {
 	Trc_SHR_OSC_Mmap_runExitCode_Entry();
-	
+
 	if (acquireHeaderWriteLock(_activeGeneration, NULL) != -1) {
 		if (updateLastDetachedTime()) {
 			Trc_SHR_OSC_Mmap_runExitCode_goodUpdateLastDetachedTime();
@@ -1560,7 +1557,7 @@ SH_OSCachemmap::runExitCode()
 			Trc_SHR_OSC_Mmap_runExitCode_badUpdateLastDetachedTime();
 			errorHandler(J9NLS_SHRC_OSCACHE_MMAP_CLEANUP_ERROR_UPDATING_LAST_DETACHED_TIME, NULL);
 		}
-		releaseHeaderWriteLock(_activeGeneration, NULL);			/* No point checking return value - we're going down */
+		releaseHeaderWriteLock(_activeGeneration, NULL); /* No point checking return value - we're going down */
 	} else {
 		PORT_ACCESS_FROM_PORT(_portLibrary);
 		I_32 myerror = j9error_last_error_number();
@@ -1574,27 +1571,27 @@ SH_OSCachemmap::runExitCode()
 #if defined (J9SHR_MSYNC_SUPPORT)
 /**
  * Synchronise cache updates to disk
- * 
+ *
  * This function call j9mmap_msync to synchronise the cache to disk
- * 
+ *
  * @return 0 on success, -1 on failure
  */
 IDATA
 SH_OSCachemmap::syncUpdates(void* start, UDATA length, U_32 flags)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	IDATA rc;
-	
+
 	Trc_SHR_OSC_Mmap_syncUpdates_Entry(start, length, flags);
-	
+
 	rc = j9mmap_msync(start, length, flags);
 	if (-1 == rc) {
 		Trc_SHR_OSC_Mmap_syncUpdates_badmsync();
 		return -1;
 	}
 	Trc_SHR_OSC_Mmap_syncUpdates_goodmsync();
-	
+
 	Trc_SHR_OSC_Mmap_syncUpdates_Exit();
 	return 0;
 }
@@ -1602,10 +1599,10 @@ SH_OSCachemmap::syncUpdates(void* start, UDATA length, U_32 flags)
 
 /**
  * Return the locking capabilities of this shared classes cache implementation
- * 
+ *
  * Read and write locks are supported for this implementation
- * 
- * @return J9OSCACHE_DATA_WRITE_LOCK | J9OSCACHE_DATA_READ_LOCK 
+ *
+ * @return J9OSCACHE_DATA_WRITE_LOCK | J9OSCACHE_DATA_READ_LOCK
  */
 IDATA
 SH_OSCachemmap::getLockCapabilities()
@@ -1617,17 +1614,17 @@ SH_OSCachemmap::getLockCapabilities()
  * Sets the protection as specified by flags for the memory pages containing all or part of the interval address->(address+len)
  *
  * @param[in] portLibrary An instance of portLibrary
- * @param[in] address 	Pointer to the shared memory region.
- * @param[in] length	The size of memory in bytes spanning the region in which we want to set protection
- * @param[in] flags 	The specified protection to apply to the pages in the specified interval
- * 
+ * @param[in] address   Pointer to the shared memory region.
+ * @param[in] length    The size of memory in bytes spanning the region in which we want to set protection
+ * @param[in] flags     The specified protection to apply to the pages in the specified interval
+ *
  * @return 0 if the operations has been successful, -1 if an error has occured
  */
 IDATA
 SH_OSCachemmap::setRegionPermissions(J9PortLibrary* portLibrary, void *address, UDATA length, UDATA flags)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
-		
+
 	return j9mmap_protect(address, length, flags);
 }
 
@@ -1635,7 +1632,7 @@ SH_OSCachemmap::setRegionPermissions(J9PortLibrary* portLibrary, void *address, 
  * Returns the minimum sized region of a shared classes cache on which the process can set permissions, in the number of bytes.
  *
  * @param[in] portLibrary An instance of portLibrary
- * 
+ *
  * @return the minimum size of region on which we can control permissions size or 0 if this is unsupported
  */
 UDATA
@@ -1656,9 +1653,9 @@ SH_OSCachemmap::getPermissionsRegionGranularity(J9PortLibrary* portLibrary)
 
 /**
  * Returns the total size of the cache memory
- * 
+ *
  * This value is not derived from the cache header, so is reliable even if the cache is corrupted
- * 
+ *
  * @return size of cache memory
  */
 U_32
@@ -1667,7 +1664,7 @@ SH_OSCachemmap::getTotalSize()
 	return (U_32)_actualFileLength;
 }
 
-UDATA 
+UDATA
 SH_OSCachemmap::getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDescriptor* descriptor)
 {
 	descriptor->cacheGen = _activeGeneration;
@@ -1677,10 +1674,10 @@ SH_OSCachemmap::getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDescripto
 	return 1;
 }
 
-void * 
+void *
 SH_OSCachemmap::getAttachedMemory()
 {
-	/* This method should only be called between calls to 
+	/* This method should only be called between calls to
 	 * internalAttach and internalDetach
 	 */
 	return _dataStart;

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -43,7 +43,7 @@
 #define OSCACHESYSV_RESTART 4
 #define OSCACHESYSV_OPENED 3
 #define OSCACHESYSV_CREATED 2
-#define OSCACHESYSV_EXIST   1
+#define OSCACHESYSV_EXIST 1
 #define OSCACHESYSV_NOT_EXIST 0
 #define OSCACHESYSV_FAILURE -1
 
@@ -62,7 +62,7 @@
  *
  * This is a wrapper method for @ref SH_OSCache::startup
  * This c'tor is currently used during unit testing only. Therefore we pass J9SH_DIRPERM_ABSENT as cacheDirPerm to startup().
- * 
+ *
  * @param [in]  portLibrary The Port library
  * @param [in]  sharedClassConfig
  * @param [in]  cacheName The name of the cache to be opened/created
@@ -78,7 +78,7 @@
  * \args J9OSCACHE_OPEN_MODE_GROUPACCESS - creates a cache with group access
  * @param [in]  versionData Version data of the cache to connect to
  * @param [in]  i Pointer to an initializer to be used to initialize the data
- * 				area of a new cache
+ *              area of a new cache
  */
 SH_OSCachesysv::SH_OSCachesysv(J9PortLibrary* portLibrary, J9JavaVM* vm, const char* cachedirname, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
 		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitializer* i)
@@ -91,7 +91,7 @@ SH_OSCachesysv::SH_OSCachesysv(J9PortLibrary* portLibrary, J9JavaVM* vm, const c
 
 /**
  * Method to initialize object variables
- * 
+ *
  * @param [in]  portLib  The Port library
  * @param [in]  memForConstructor  Pointer to the memory to build the OSCachemmap into
  * @param [in]  generation  The generation of this cache
@@ -120,7 +120,7 @@ SH_OSCachesysv::initialize(J9PortLibrary* portLib, char* memForConstructor, UDAT
  * setup an OSCache Instance
  * This method will create necessary Operating System resources to support cross-process shared memory
  * If successful a memory area which can be attached by other process will be created
- * User can query the result of the setup operation using getError() method. If the startup has failed, 
+ * User can query the result of the setup operation using getError() method. If the startup has failed,
  * all further operation on the shared cache will be failed.
  *
  * @param [in]  cacheName The name of the cache to be opened/created
@@ -137,9 +137,9 @@ SH_OSCachesysv::initialize(J9PortLibrary* portLib, char* memForConstructor, UDAT
  * \args J9OSCACHE_OPEN_MODE_GROUPACCESS - creates a cache with group access
  * @param [in]  versionData Version data of the cache to connect to
  * @param [in]  i Pointer to an initializer to be used to initialize the data
- * 				area of a new cache
+ *              area of a new cache
  * @param [in]  reason Reason for starting up the cache. Not used for non-persistent cache startup
- * 
+ *
  * @return true on success, false on failure
  */
 bool
@@ -162,17 +162,17 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 #endif /* OPENJ9_BUILD */
 #endif /* J9VM_ENV_DATA64 */
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_startup_Entry(cacheName, (piconfig!= NULL)? piconfig->sharedClassCacheSize : defaultCacheSize, create);
 
 	if (openMode & J9OSCACHE_OPEN_MODE_GROUPACCESS) {
 		_groupPerm = 1;
 	}
-	
+
 	versionData->cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 	_cacheSize = (piconfig!= NULL) ? (U_32)piconfig->sharedClassCacheSize : (U_32)defaultCacheSize;
 	_initializer = i;
-	_totalNumSems = numLocks + 1;		/* +1 because of header mutex */
+	_totalNumSems = numLocks + 1; /* +1 because of header mutex */
 	_userSemCntr = 0;
 	retryCount=J9SH_OSCACHE_RETRYMAX;
 
@@ -193,7 +193,8 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 #else
 	semLength = strlen(_cacheNameWithVGen) + (strlen(J9SH_SEMAPHORE_ID) - strlen(J9SH_MEMORY_ID)) + 1;
 	/* Unfortunate case is that Java5 and early Java6 caches did not have _G append on the semaphore file,
-	 * so to connect with a generation 1 or 2 cache (Java5 was only ever G01), remove the _G01 from the semaphore file name */
+	 * so to connect with a generation 1 or 2 cache (Java5 was only ever G01), remove the _G01 from the semaphore file name
+	 */
 	if (_activeGeneration < 3) {
 		semLength -= strlen("_GXX");
 	}
@@ -204,10 +205,10 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	}
 	getCacheVersionAndGen(PORTLIB, vm, _semFileName, semLength, cacheName, versionData, _activeGeneration, false, _layer);
 #endif
-	
-	while(retryCount>0) {
+
+	while (retryCount>0) {
 		IDATA rc;
-		
+
 		if (_openMode & J9OSCACHE_OPEN_MODE_DO_READONLY) {
 			/* Try read-only mode only if shared memory control file exists
 			 * because we can't create a new control file when running in read-only mode.
@@ -239,17 +240,17 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			lastErrorInfo.lastErrorMsg = j9error_last_error_message();
 #endif
 		}
-	
+
 		if (shsemrc == J9PORT_INFO_SHSEM_PARTIAL) {
 			/*
 			 * J9PORT_INFO_SHSEM_PARTIAL indicates one of the following cases:
-			 * 	- j9shsem_deprecated_openDeprecated() was called and the control files for the semaphore does not exist, or
+			 *  - j9shsem_deprecated_openDeprecated() was called and the control files for the semaphore does not exist, or
 			 *  - j9shsem_deprecated_openDeprecated() was called and the sysv object matching the control file has been deleted, or
 			 *  - j9shsem_deprecated_open() failed and flag OPEXIST_STATS is set, or
 			 *  - j9shsem_deprecated_open() was called with flag OPEXIST_DESTROY and control files for the semaphore does not exist
-			 *  
+			 *
 			 * In such cases continue without the semaphore as readonly
-			 * 
+			 *
 			 * If we are starting up the cache for 'destroy' i.e. OPEXIST_DESTROY is set,
 			 * then do not set READONLY flag as it may prevent unlinking of control files in port library if required.
 			 */
@@ -260,8 +261,8 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			_semhandle = NULL;
 		}
 
-		switch(shsemrc) {
-	  
+		switch (shsemrc) {
+
 		case J9PORT_INFO_SHSEM_CREATED:
 #if !defined(WIN32)
 			if (J9_ARE_ALL_BITS_SET(_openMode, J9OSCACHE_OPEN_MODE_GROUPACCESS)) {
@@ -358,7 +359,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 				rc = OSCACHESYSV_FAILURE;
 			}
 			break;
-					 
+
 		case J9PORT_ERROR_SHSEM_OPFAILED:
 		case J9PORT_ERROR_SHSEM_OPFAILED_CONTROL_FILE_LOCK_FAILED:
 		case J9PORT_ERROR_SHSEM_OPFAILED_CONTROL_FILE_CORRUPT:
@@ -446,7 +447,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			rc=OSCACHESYSV_FAILURE;
 			break;
 		}
-		
+
 		switch (rc) {
 		case OSCACHESYSV_CREATED:
 			if (_verboseFlags & J9SHR_VERBOSEFLAG_ENABLE_VERBOSE) {
@@ -468,7 +469,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 					retryCount = 0;
 					continue;
 				}
-				
+
 				memset(&statBuf, 0, sizeof(statBuf));
 				if (0 == j9file_stat(_cachePathName, 0, &statBuf)) {
 					if (1 != statBuf.perm.isGroupReadable) {
@@ -491,7 +492,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			Trc_SHR_OSC_startup_Exit_Created(cacheName);
 			_startupCompleted=true;
 			return true;
-				
+
 		case OSCACHESYSV_OPENED:
 			if (_verboseFlags & J9SHR_VERBOSEFLAG_ENABLE_VERBOSE) {
 				if (_runningReadOnly) {
@@ -505,11 +506,11 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 			Trc_SHR_OSC_startup_Exit_Opened(cacheName);
 			_startupCompleted=true;
 			return true;
-			
+
 		case OSCACHESYSV_RESTART:
 			Trc_SHR_OSC_startup_attempt_Restart(cacheName);
 			break;
-		
+
 		case OSCACHESYSV_FAILURE:
 			retryCount = 0;
 			continue;
@@ -523,10 +524,10 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		default:
 			break;
 		}
-		
+
 		retryCount--;
-		
-	} /* END while(retryCount>0) */
+
+	} /* END while (retryCount>0) */
 
 	setError(J9SH_OSCACHE_FAILURE);
 	Trc_SHR_OSC_startup_Exit_Failed(cacheName);
@@ -534,7 +535,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 }
 
 /* The caller should hold the mutex */
-IDATA 
+IDATA
 SH_OSCachesysv::openCache(const char* cacheDirName, J9PortShcVersion* versionData, bool semCreated)
 {
 	/* we are attaching to existing cache! */
@@ -542,7 +543,7 @@ SH_OSCachesysv::openCache(const char* cacheDirName, J9PortShcVersion* versionDat
 	IDATA rc;
 	IDATA result = OSCACHESYSV_FAILURE;
 	LastErrorInfo lastErrorInfo;
-	   
+
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 
 	rc = shmemOpenWrapper(_shmFileName, &lastErrorInfo);
@@ -603,7 +604,7 @@ SH_OSCachesysv::openCache(const char* cacheDirName, J9PortShcVersion* versionDat
 		 * we should set it up, but don't need to init semaphore
 		 */
 		rc = initializeHeader(cacheDirName, versionData, lastErrorInfo);
-		if(rc == OSCACHESYSV_FAILURE) {
+		if (rc == OSCACHESYSV_FAILURE) {
 			Trc_SHR_OSC_openCache_Exit_CreatedHeaderInitFailed(_cacheName);
 			result = OSCACHESYSV_FAILURE;
 			break;
@@ -611,16 +612,16 @@ SH_OSCachesysv::openCache(const char* cacheDirName, J9PortShcVersion* versionDat
 		Trc_SHR_OSC_openCache_Exit_Created(_cacheName);
 		result = OSCACHESYSV_CREATED;
 		break;
-				
+
 	case J9PORT_ERROR_SHMEM_WAIT_FOR_CREATION_MUTEX_TIMEDOUT:
 		errorHandler(J9NLS_SHRC_OSCACHE_SHMEM_OPEN_WAIT_FOR_CREATION_MUTEX_TIMEDOUT, &lastErrorInfo);
 		Trc_SHR_OSC_openCache_Exit4();
 		result = OSCACHESYSV_FAILURE;
 		break;
-	
+
 	case J9PORT_INFO_SHMEM_PARTIAL:
 		/* If J9PORT_INFO_SHMEM_PARTIAL then ::startup() was called by j9shr_destroy_cache().
-		 * Returning OSCACHESYSV_OPENED will cause j9shr_destroy_cache() to call ::destroy(), 
+		 * Returning OSCACHESYSV_OPENED will cause j9shr_destroy_cache() to call ::destroy(),
 		 * which will cleanup any control files that have there SysV IPC objects del
 		 */
 		result = OSCACHESYSV_OPENED;
@@ -659,7 +660,7 @@ SH_OSCachesysv::openCache(const char* cacheDirName, J9PortShcVersion* versionDat
 				shmid = j9shmem_getid(_shmhandle);
 				j9mem_free_memory(_shmhandle);
 			}
-			
+
 			if ((J9PORT_ERROR_SHMEM_OPFAILED == rc) || (J9PORT_ERROR_SHMEM_OPFAILED_SHARED_MEMORY_NOT_FOUND == rc)) {
 				errorHandler(J9NLS_SHRC_OSCACHE_SHMEM_OPFAILED_V1, &lastErrorInfo);
 				if ((J9PORT_ERROR_SHMEM_OPFAILED == rc) && (0 != shmid)) {
@@ -719,11 +720,11 @@ SH_OSCachesysv::verifyCacheHeader(J9PortShcVersion* versionData)
 	IDATA rc = 0;
 
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	if (header == NULL) {
 		return J9SH_OSCACHE_HEADER_MISSING;
 	}
-	
+
 	/* In readonly, we can't get a header lock, so if the cache is mid-init, give it a chance to complete initialization */
 	if (_runningReadOnly) {
 		while ((!header->oscHdr.cacheInitComplete) && (retryCntr < J9SH_OSCACHE_READONLY_RETRY_COUNT)) {
@@ -734,20 +735,20 @@ SH_OSCachesysv::verifyCacheHeader(J9PortShcVersion* versionData)
 			return J9SH_OSCACHE_HEADER_MISSING;
 		}
 	}
-	
+
 	if (J9_ARE_NO_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_RESTORE | J9SHR_RUNTIMEFLAG_RESTORE_CHECK)) {
 		/* When running "restoreFromSnapshot" utility, headerMutex is already acquired */
 		rc = enterHeaderMutex(&lastErrorInfo);
 	}
 	if (0 == rc) {
 		/* First, check the eyecatcher */
-		if(strcmp(header->eyecatcher, J9PORT_SHMEM_EYECATCHER)) {
+		if (strcmp(header->eyecatcher, J9PORT_SHMEM_EYECATCHER)) {
 			OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_ERROR_WRONG_EYECATCHER);
 			Trc_SHR_OSC_recreateSemaphore_Exit1();
 			OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_CORRUPT_CACHE_HEADER_BAD_EYECATCHER, header->eyecatcher);
 			setCorruptionContext(CACHE_HEADER_BAD_EYECATCHER, (UDATA)(header->eyecatcher));
 			headerRc = J9SH_OSCACHE_HEADER_CORRUPT;
-		}		
+		}
 		if (J9SH_OSCACHE_HEADER_OK == headerRc) {
 			headerRc = checkOSCacheHeader(&(header->oscHdr), versionData, SHM_CACHEHEADERSIZE);
 		}
@@ -759,7 +760,7 @@ SH_OSCachesysv::verifyCacheHeader(J9PortShcVersion* versionData)
 				 * In both cases we ignore the below check.
 				 */
 				_semid = j9shsem_deprecated_getid(_semhandle);
-				if((_runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_SEMAPHORE_CHECK) && (header->attachedSemid != 0) && (header->attachedSemid != _semid)) {
+				if ((_runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_SEMAPHORE_CHECK) && (header->attachedSemid != 0) && (header->attachedSemid != _semid)) {
 					Trc_SHR_OSC_recreateSemaphore_Exit4(header->attachedSemid, _semid);
 					OSC_ERR_TRACE2(J9NLS_SHRC_OSCACHE_CORRUPT_CACHE_SEMAPHORE_MISMATCH, header->attachedSemid, _semid);
 					setCorruptionContext(CACHE_SEMAPHORE_MISMATCH, (UDATA)_semid);
@@ -767,7 +768,7 @@ SH_OSCachesysv::verifyCacheHeader(J9PortShcVersion* versionData)
 				}
 			}
 		}
-		
+
 		if (J9_ARE_NO_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_RESTORE | J9SHR_RUNTIMEFLAG_RESTORE_CHECK)) {
 			/* When running "restoreFromSnapshot" utility, do not release headerMutex here */
 			rc = exitHeaderMutex(&lastErrorInfo);
@@ -786,12 +787,12 @@ SH_OSCachesysv::verifyCacheHeader(J9PortShcVersion* versionData)
 	return headerRc;
 }
 
-IDATA 
+IDATA
 SH_OSCachesysv::detachRegion(void)
 {
 	IDATA rc = OSCACHESYSV_FAILURE;
 	PORT_ACCESS_FROM_PORT(_portLibrary);
-	
+
 	Trc_SHR_OSC_detachRegion_Entry();
 
 	if (_shmhandle != NULL) {
@@ -810,12 +811,12 @@ SH_OSCachesysv::detachRegion(void)
 		_headerStart = 0;
 	}
 
-	Trc_SHR_OSC_detachRegion_Exit();		
+	Trc_SHR_OSC_detachRegion_Exit();
 	return rc;
 }
 
 /**
- * This is the deconstructor routine. 
+ * This is the deconstructor routine.
  *
  * It will remove any memory allocated by this class.
  * However it will not remove any shared memory / mutex resources from the underlying OS.
@@ -829,10 +830,10 @@ SH_OSCachesysv::cleanup(void)
 	Trc_SHR_OSC_cleanup_Entry();
 	detachRegion();
 	/* now free the handles */
-	if(_shmhandle != NULL) {
+	if (_shmhandle != NULL) {
 		j9shmem_close(&_shmhandle);
 	}
-	if(_semhandle != NULL) {
+	if (_semhandle != NULL) {
 		j9shsem_deprecated_close(&_semhandle);
 	}
 	commonCleanup();
@@ -845,35 +846,34 @@ SH_OSCachesysv::cleanup(void)
 
 }
 
-IDATA 
+IDATA
 SH_OSCachesysv::detach(void)
 {
 	IDATA rc=OSCACHESYSV_FAILURE;
 	Trc_SHR_OSC_detach_Entry();
 
-	if(_shmhandle == NULL) {
+	if (_shmhandle == NULL) {
 		Trc_SHR_OSC_detach_Exit1();
 		return OSCACHESYSV_SUCCESS;
 	}
 
-	Trc_SHR_OSC_detach_Debug(_cacheName, _dataStart);    
+	Trc_SHR_OSC_detach_Debug(_cacheName, _dataStart);
 
 	_attach_count--;
-  
-	if(_attach_count == 0) {
+
+	if (_attach_count == 0) {
 		detachRegion();
 		rc=OSCACHESYSV_SUCCESS;
-	} 
-  
+	}
+
 	Trc_SHR_OSC_detach_Exit();
 	return rc;
 }
 
-
 /* The caller is responsible for locking the shared memory area */
-IDATA 
+IDATA
 SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* versionData, LastErrorInfo lastErrorInfo)
-{  
+{
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	void* region;
 	OSCachesysv_header_version_current* myHeader;
@@ -881,7 +881,7 @@ SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* ver
 	U_32 readWriteBytes = (U_32)((_config->sharedClassReadWriteBytes > 0) ? _config->sharedClassReadWriteBytes : 0);
 	U_32 totalSize = getTotalSize();
 	U_32 softMaxSize = (U_32)_config->sharedClassSoftMaxBytes;
-	
+
 	if (_config->sharedClassSoftMaxBytes < 0) {
 		softMaxSize = (U_32)-1;
 	} else if (softMaxSize > totalSize) {
@@ -889,7 +889,7 @@ SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* ver
 		softMaxSize = totalSize;
 	}
 
-	if(_cacheSize <= SHM_CACHEHEADERSIZE) {
+	if (_cacheSize <= SHM_CACHEHEADERSIZE) {
 		errorHandler(J9NLS_SHRC_OSCACHE_TOOSMALL, &lastErrorInfo);
 		return OSCACHESYSV_FAILURE;
 	} else {
@@ -898,7 +898,7 @@ SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* ver
 
 	region = j9shmem_attach(_shmhandle, J9MEM_CATEGORY_CLASSES_SHC_CACHE);
 
-	if(region == NULL) {
+	if (region == NULL) {
 		lastErrorInfo.lastErrorCode = j9error_last_error_number();
 		lastErrorInfo.lastErrorMsg = j9error_last_error_message();
 		errorHandler(J9NLS_SHRC_OSCACHE_SHMEM_ATTACH, &lastErrorInfo);
@@ -913,34 +913,34 @@ SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* ver
 	myHeader = (OSCachesysv_header_version_current*) region;
 
 	memset(myHeader, 0, SHM_CACHEHEADERSIZE);
-	strncpy(myHeader->eyecatcher, J9PORT_SHMEM_EYECATCHER, J9PORT_SHMEM_EYECATCHER_LENGTH);
-	
+	memcpy(myHeader->eyecatcher, J9PORT_SHMEM_EYECATCHER, J9PORT_SHMEM_EYECATCHER_LENGTH);
+
 	initOSCacheHeader(&(myHeader->oscHdr), versionData, SHM_CACHEHEADERSIZE);
-	
+
 	myHeader->attachedSemid = j9shsem_deprecated_getid(_semhandle);
 
 	/* If this is not being written into the default control file dir, mark it as such so that it cannot be auto-deleted */
 	myHeader->inDefaultControlDir = (cacheDirName == NULL);
-	
+
 	/* jump over to the data area*/
 	region = SHM_DATASTARTFROMHEADER(myHeader);
 
-	if(_initializer != NULL) { 
+	if (_initializer != NULL) {
 		_initializer->init((char*)region, dataLength, (I_32)_config->sharedClassMinAOTSize, (I_32)_config->sharedClassMaxAOTSize, (I_32)_config->sharedClassMinJITSize, (I_32)_config->sharedClassMaxJITSize, readWriteBytes, softMaxSize);
 	}
 
 	if (J9_ARE_NO_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_RESTORE)) {
-	/* Do not set oscHdr.cacheInitComplete to 1 if the cache is to be restored */
+		/* Do not set oscHdr.cacheInitComplete to 1 if the cache is to be restored */
 		myHeader->oscHdr.cacheInitComplete = 1;
 	}
 
 	/*ALL DONE */
-	
-	return OSCACHESYSV_SUCCESS; 
+
+	return OSCACHESYSV_SUCCESS;
 }
 
 /**
- * Attaches the shared memory into the process address space, and returns the address of the mapped 
+ * Attaches the shared memory into the process address space, and returns the address of the mapped
  * shared memory.
  *
  * This method send a request to the operating system to map the shared memory into the caller's address
@@ -948,12 +948,11 @@ SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* ver
  * if the region is being mapped for the first time.
  *
  * @param [in] expectedVersionData  If not NULL, function checks the version data of the cache against the values in this struct
- * 
+ *
  * @return The address of the memory mapped area for the caller's process - This is not guaranteed to be the same
  * for two different process.
- *
  */
-void * 
+void *
 SH_OSCachesysv::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVersionData)
 {
 	J9JavaVM *vm = currentThread->javaVM;
@@ -969,14 +968,14 @@ SH_OSCachesysv::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVers
 
 	if ((((_runtimeFlags & J9SHR_RUNTIMEFLAG_CREATE_OLD_GEN) == 0) && (_activeGeneration != getCurrentCacheGen())) ||
 		(((_runtimeFlags & J9SHR_RUNTIMEFLAG_CREATE_OLD_GEN) != 0) && (_activeGeneration != getCurrentCacheGen()-1))
-	){
+	) {
 		Trc_SHR_OSC_attach_ExitWrongGen();
 		return NULL;
 	}
 
-	/* Cache is opened attached, the call here will simply return the 
-	 * address memory already attached. 
-	 * 
+	/* Cache is opened attached, the call here will simply return the
+	 * address memory already attached.
+	 *
 	 * Note: Unless ::detach was called ... which I believe does not currently occur.
 	 */
 	Trc_SHR_OSC_attach_Try_Attach1(UnitTest::unitTest);
@@ -1018,7 +1017,7 @@ SH_OSCachesysv::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVers
 
 	/*_dataStart is set here, and possibly initializeHeader if its a new cache */
 	_dataStart = SHM_DATASTARTFROMHEADER(((OSCachesysv_header_version_current*)_headerStart));
-	
+
 	_dataLength = SHM_CACHEDATASIZE(((OSCachesysv_header_version_current*)_headerStart)->oscHdr.size);
 	_attach_count++;
 
@@ -1032,38 +1031,38 @@ SH_OSCachesysv::attach(J9VMThread *currentThread, J9PortShcVersion* expectedVers
 
 /**
  * Attempt to destroy the cache that is currently attached
- * 
+ *
  * @param[in] suppressVerbose suppresses verbose output
  * @param[in] True if reset option is being used, false otherwise.
- * 
+ *
  * This method will detach shared memory from the process address space, and attempt
- * to remove any operating system shared memory and mutex region. 
+ * to remove any operating system shared memory and mutex region.
  * When this call is complete you should consider the shared memory region will not be
  * available for use, and must be recreated.
- * 
+ *
  * @return 0 for success and -1 for failure
  */
-IDATA 
+IDATA
 SH_OSCachesysv::destroy(bool suppressVerbose, bool isReset)
 {
 	IDATA rc;
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	UDATA origVerboseFlags = _verboseFlags;
-	IDATA returnVal = -1;		/* Assume failure */
-	
+	IDATA returnVal = -1; /* Assume failure */
+
 	Trc_SHR_OSC_destroy_Entry();
-	
+
 	if (suppressVerbose) {
 		_verboseFlags = 0;
 	}
 
-	/* We will try our best and destroy the OSCache here */      
+	/* We will try our best and destroy the OSCache here */
 	detachRegion();
 
 #if !defined(WIN32)
 	/*If someone is still detached, don't do it, warn and exit*/
 	/* isCacheActive isn't really accurate for Win32, so can't check */
-	if(isCacheActive()) {
+	if (isCacheActive()) {
 		IDATA corruptionCode;
 		OSC_TRACE1(J9NLS_SHRC_OSCACHE_SHARED_CACHE_STILL_ATTACH, _cacheName);
 		/* Even if cache is active, we destroy the semaphore if the cache has been marked as corrupt due to CACHE_SEMAPHORE_MISMATCH. */
@@ -1077,7 +1076,7 @@ SH_OSCachesysv::destroy(bool suppressVerbose, bool isReset)
 		}
 		goto _done;
 	}
-#endif  
+#endif
 
 	/* Now try to remove the shared memory region */
 	if (_shmhandle != NULL) {
@@ -1086,19 +1085,19 @@ SH_OSCachesysv::destroy(bool suppressVerbose, bool isReset)
 #else
 		rc = j9shmem_destroy(_cacheDirName, _groupPerm, &_shmhandle);
 #endif
-		if(rc != 0) {
+		if (rc != 0) {
 			OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_SHARED_CACHE_MEMORY_REMOVE_FAILED, _cacheName);
 			goto _done;
 		}
 	}
-	
+
 	if (_semhandle != NULL) {
 #if !defined(WIN32)
 		rc = DestroySysVSemHelper();
 #else
 		rc = j9shsem_deprecated_destroy(&_semhandle);
 #endif
-		if(rc!=0) {
+		if (rc!=0) {
 			OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_SHARED_CACHE_SEMAPHORE_REMOVE_FAILED, _cacheName);
 			goto _done;
 		}
@@ -1136,7 +1135,7 @@ _done :
 
 /**
  * Get an ID for a new write lock
- * 
+ *
  * @return a non-negative lockID on success, -1 on failure
  */
 IDATA
@@ -1172,33 +1171,33 @@ SH_OSCachesysv::getReadWriteLockID() {
 /**
  * Obtain the exclusive access right for the shared cache
  *
- * If this method succeeds, the caller will own the exclusive access right to the lock specified 
+ * If this method succeeds, the caller will own the exclusive access right to the lock specified
  * and any other thread that attempts to call this method will be suspended.
- * If the process which owns the exclusive access right has crashed without relinquishing the access right, 
+ * If the process which owns the exclusive access right has crashed without relinquishing the access right,
  * it will automatically resume one of the waiting threads which will then own the access right.
  *
  * @param[in] lockID  The ID of the lock to acquire
- * 
+ *
  * @return 0 if the operation has been successful, -1 if an error has occured
  */
-IDATA 
-SH_OSCachesysv::acquireWriteLock(UDATA lockID) 
+IDATA
+SH_OSCachesysv::acquireWriteLock(UDATA lockID)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	IDATA rc;
 	Trc_SHR_OSC_enterMutex_Entry(_cacheName);
-	if(_semhandle == NULL) {
+	if (_semhandle == NULL) {
 		Trc_SHR_OSC_enterMutex_Exit1();
 		Trc_SHR_Assert_ShouldNeverHappen();
 		return -1;
 	}
-	
+
 	if (lockID > (_totalNumSems-1)) {
 		Trc_SHR_OSC_enterMutex_Exit2_V2(lockID, _totalNumSems-1);
 		Trc_SHR_Assert_ShouldNeverHappen();
 		return -1;
 	}
-	
+
 	rc = j9shsem_deprecated_wait(_semhandle, lockID, J9PORT_SHSEM_MODE_UNDO);
 	if (rc == -1) {
 		/* CMVC 97181 : Don't print error message because if JVM terminates with ^C signal, this function will return -1 and this is not an error*/
@@ -1221,21 +1220,21 @@ SH_OSCachesysv::acquireWriteLock(UDATA lockID)
 /**
  * Relinquish the exclusive access right
  *
- * If this method succeeds, the caller will return the exclusive access right to the lock specified. 
- * If there is one or more thread(s) suspended on the Mutex by calling @ref SH_OSCache::acquireWriteLock, 
+ * If this method succeeds, the caller will return the exclusive access right to the lock specified.
+ * If there is one or more thread(s) suspended on the Mutex by calling @ref SH_OSCache::acquireWriteLock,
  * then one of the threads will be resumed and become the new owner of the exclusive access rights for the lock
- * 
+ *
  * @param[in] lockID  The ID of the lock to release
  *
  * @return 0 if the operations has been successful, -1 if an error has occured
  */
-IDATA 
-SH_OSCachesysv::releaseWriteLock(UDATA lockID) 
+IDATA
+SH_OSCachesysv::releaseWriteLock(UDATA lockID)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	IDATA rc;
 	Trc_SHR_OSC_exitMutex_Entry(_cacheName);
-	if(_semhandle == NULL) {
+	if (_semhandle == NULL) {
 		Trc_SHR_OSC_exitMutex_Exit1();
 		Trc_SHR_Assert_ShouldNeverHappen();
 		return -1;
@@ -1277,7 +1276,7 @@ SH_OSCachesysv::enterHeaderMutex(LastErrorInfo *lastErrorInfo)
 
 IDATA
 SH_OSCachesysv::exitHeaderMutex(LastErrorInfo *lastErrorInfo)
-{	
+{
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	IDATA rc = 0;
 	if (NULL != lastErrorInfo) {
@@ -1307,17 +1306,17 @@ SH_OSCachesysv::isCacheActive(void)
 	if (-1 == rc) {
 		/* CMVC 143141: If shared memory can not be stat'd then it
 		 * doesn't exist.  In this case we return 0 because a cache
-		 * that does not exist on the system then it should not be active. 
+		 * that does not exist on the system then it should not be active.
 		 */
 		return 0;
 	}
 
-	if(statbuf.nattach > 0) {
+	if (statbuf.nattach > 0) {
 		return 1;
 	}
-		
+
 	return 0;
-	
+
 }
 
 void
@@ -1335,9 +1334,9 @@ SH_OSCachesysv::printErrorMessage(LastErrorInfo *lastErrorInfo)
 		Trc_SHR_Assert_True(errormsg != NULL);
 		OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_PORT_ERROR_MESSAGE, errormsg);
 	}
-	
+
 	/*Handle general errors*/
-	switch(errorCodeMasked) {
+	switch (errorCodeMasked) {
 		case J9PORT_ERROR_SHMEM_TOOBIG:
 		case J9PORT_ERROR_SYSV_IPC_ERRNO_E2BIG:
 #if defined(J9ZOS390)
@@ -1372,10 +1371,10 @@ SH_OSCachesysv::printErrorMessage(LastErrorInfo *lastErrorInfo)
 		case J9PORT_ERROR_SYSV_IPC_ERRNO_EMFILE:
 			OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_ERROR_MAX_OPEN_FILES_REACHED);
 			break;
-			
+
 		default:
-			break;			
-	}	
+			break;
+	}
 
 }
 
@@ -1398,7 +1397,7 @@ SH_OSCachesysv::cleanupSysvResources(void)
 #if !defined(WIN32)
 	/*If someone is still attached, don't destroy it*/
 	/* isCacheActive isn't really accurate for Win32, so can't check */
-	if(isCacheActive()) {
+	if (isCacheActive()) {
 		if (NULL != _semhandle) {
 			j9shsem_deprecated_close(&_semhandle);
 			OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_HANDLE_ERROR_ACTION_CLOSESEM);
@@ -1482,7 +1481,7 @@ SH_OSCachesysv::cleanupSysvResources(void)
 	}
 }
 
-void 
+void
 SH_OSCachesysv::errorHandler(U_32 module_name, U_32 message_num, LastErrorInfo *lastErrorInfo)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
@@ -1493,9 +1492,9 @@ SH_OSCachesysv::errorHandler(U_32 module_name, U_32 message_num, LastErrorInfo *
 			printErrorMessage(lastErrorInfo);
 		}
 	}
-	
+
 	setError(J9SH_OSCACHE_FAILURE);
-	if(!_startupCompleted && _openSharedMemory == false) {
+	if (!_startupCompleted && _openSharedMemory == false) {
 		cleanupSysvResources();
 	}
 }
@@ -1503,7 +1502,7 @@ SH_OSCachesysv::errorHandler(U_32 module_name, U_32 message_num, LastErrorInfo *
 void
 SH_OSCachesysv::setError(IDATA ec)
 {
-	_errorCode = ec;	
+	_errorCode = ec;
 }
 
 /**
@@ -1512,8 +1511,8 @@ SH_OSCachesysv::setError(IDATA ec)
  *
  * @return Error Code
  */
-IDATA 
-SH_OSCachesysv::getError(void) 
+IDATA
+SH_OSCachesysv::getError(void)
 {
 	return _errorCode;
 }
@@ -1568,7 +1567,7 @@ SH_OSCachesysv::shmemOpenWrapper(const char *cacheName, LastErrorInfo *lastError
 			}
 #if !defined(WIN32)
 		}
-#endif		
+#endif
 	}
 	if (((rc == J9PORT_INFO_SHMEM_OPENED) || (rc == J9PORT_INFO_SHMEM_OPENED_STALE)) && (perm == J9SH_SHMEM_PERM_READ)) {
 		Trc_SHR_OSC_Event_OpenReadOnly();
@@ -1590,9 +1589,9 @@ SH_OSCachesysv::runExitCode(void)
 #if defined (J9SHR_MSYNC_SUPPORT)
 /**
  * Synchronise cache updates to disk
- * 
+ *
  * This function is not supported for the shared memory cache
- * 
+ *
  * @return -1 as this function is not supported
  */
 IDATA
@@ -1604,9 +1603,9 @@ SH_OSCachesysv::syncUpdates(void* start, UDATA length, U_32 flags)
 
 /**
  * Return the locking capabilities of this shared classes cache implementation
- * 
+ *
  * Write locks (only) are supported for this implementation
- * 
+ *
  * @return J9OSCACHE_DATA_WRITE_LOCK
  */
 IDATA
@@ -1619,17 +1618,17 @@ SH_OSCachesysv::getLockCapabilities(void)
  * Sets the protection as specified by flags for the memory pages containing all or part of the interval address->(address+len)
  *
  * @param[in] portLibrary An instance of portLibrary
- * @param[in] address 	Pointer to the shared memory region.
- * @param[in] length	The size of memory in bytes spanning the region in which we want to set protection
- * @param[in] flags 	The specified protection to apply to the pages in the specified interval
- * 
+ * @param[in] address   Pointer to the shared memory region.
+ * @param[in] length    The size of memory in bytes spanning the region in which we want to set protection
+ * @param[in] flags     The specified protection to apply to the pages in the specified interval
+ *
  * @return 0 if the operations has been successful, -1 if an error has occured
  */
 IDATA
 SH_OSCachesysv::setRegionPermissions(struct J9PortLibrary* portLibrary, void *address, UDATA length, UDATA flags)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
-		
+
 	return j9shmem_protect(_cacheDirName, _groupPerm, address, length, flags);
 }
 
@@ -1637,7 +1636,7 @@ SH_OSCachesysv::setRegionPermissions(struct J9PortLibrary* portLibrary, void *ad
  * Returns the minimum sized region of a shared classes cache on which the process can set permissions, in the number of bytes.
  *
  * @param[in] portLibrary An instance of portLibrary
- * 
+ *
  * @return the minimum size of region on which we can control permissions size or 0 if unsupported
  *
  */
@@ -1650,9 +1649,9 @@ SH_OSCachesysv::getPermissionsRegionGranularity(struct J9PortLibrary* portLibrar
 
 /**
  * Returns the total size of the cache memory
- * 
+ *
  * This value is not derived from the cache header, so is reliable even if the cache is corrupted
- * 
+ *
  * @return size of cache memory
  */
 U_32
@@ -1666,17 +1665,16 @@ SH_OSCachesysv::getTotalSize()
 	}
 
 	if (j9shmem_stat(_cacheDirName, _groupPerm, _shmFileName, &statbuf) == (UDATA)-1) {
-		/* CMVC 143141: If shared memory can not be stat'd then it 
-		 * doesn't exist.  In this case we return 0 because a cache 
-		 * that does not exist on the system then it has zero size. 
+		/* CMVC 143141: If shared memory can not be stat'd then it
+		 * doesn't exist.  In this case we return 0 because a cache
+		 * that does not exist on the system then it has zero size.
 		 */
 		return 0;
 	}
-	
+
 	_actualCacheSize = (U_32)statbuf.size;
 	return _actualCacheSize;
 }
-
 
 UDATA
 SH_OSCachesysv::getHeaderSize(void)
@@ -1686,7 +1684,7 @@ SH_OSCachesysv::getHeaderSize(void)
 
 /**
  * Populates some of cacheInfo for 'SH_OSCachesysv::getCacheStats' and 'SH_OSCachesysv::getJavacoreData'
- * 
+ *
  * @param [in] vm  The Java VM
  * @param [in] ctrlDirName  Cache directory
  * @param [in] groupPerm  Group permissions to open the cache directory
@@ -1695,16 +1693,16 @@ SH_OSCachesysv::getHeaderSize(void)
  * @param [in] reason Indicates the reason for getting cache stats. Refer sharedconsts.h for valid values.
  * @return 0 on success
  */
-IDATA 
+IDATA
 SH_OSCachesysv::getCacheStatsHelper(J9JavaVM* vm, const char* cacheDirName, UDATA groupPerm, const char* cacheNameWithVGen, SH_OSCache_Info* cacheInfo, UDATA reason)
 {
 	PORT_ACCESS_FROM_PORT(vm->portLibrary);
 	J9PortShmemStatistic statbuf;
 	UDATA versionLen;
 	UDATA statrc = 0;
-	
+
 	Trc_SHR_OSC_Sysv_getCacheStatsHelper_Entry(cacheNameWithVGen);
-	
+
 #if defined(WIN32)
 	versionLen = J9SH_VERSION_STRING_LEN;
 #else
@@ -1720,7 +1718,7 @@ SH_OSCachesysv::getCacheStatsHelper(J9JavaVM* vm, const char* cacheDirName, UDAT
 #else
 	statrc = j9shmem_stat(cacheDirName, groupPerm, cacheNameWithVGen, &statbuf);
 #endif
-	
+
 	if (statrc == 0) {
 #if defined(J9ZOS390)
 		if ((J9SH_ADDRMODE != cacheInfo->versionData.addrmode) && (0 == statbuf.size)) {
@@ -1762,7 +1760,7 @@ SH_OSCachesysv::getCacheStatsHelper(J9JavaVM* vm, const char* cacheDirName, UDAT
 
 /**
  * Populates cacheInfo with cache statistics.
- * 
+ *
  * @param [in] vm  The Java VM
  * @param [in] ctrlDirName  Cache directory
  * @param [in] groupPerm  Group permissions to open the cache directory
@@ -1772,7 +1770,7 @@ SH_OSCachesysv::getCacheStatsHelper(J9JavaVM* vm, const char* cacheDirName, UDAT
  *
  * @return 0 on success
  */
-IDATA 
+IDATA
 SH_OSCachesysv::getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char* cacheNameWithVGen, SH_OSCache_Info* cacheInfo, UDATA reason)
 {
 	IDATA retval = 0;
@@ -1799,7 +1797,7 @@ SH_OSCachesysv::getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA group
 			if (!cache->startup(vm, ctrlDirName, vm->sharedCacheAPI->cacheDirPerm, cacheInfo->name, &piconfig, SH_CompositeCacheImpl::getNumRequiredOSLocks(), J9SH_OSCACHE_OPEXIST_STATS, 0, 0/*runtime flags*/, J9OSCACHE_OPEN_MODE_TRY_READONLY_ON_FAIL, vm->sharedCacheAPI->storageKeyTesting, &versionData, NULL, reason)) {
 				goto done;
 			}
-		
+
 			/* Avoid calling attach() for incompatible cache since its anyway going to fail.
 			 * But we can still get semid from _semhandle as it got populated during startup itself.
 			 */
@@ -1842,23 +1840,23 @@ done:
 /**
  * Find the first cache file in a given cacheDir
  * Follows the format of j9file_findfirst
- * 
+ *
  * @param [in] portLibrary  A port library
  * @param [in] sharedClassConfig
- * @param [out] resultbuf  The name of the file found 
- * 
+ * @param [out] resultbuf  The name of the file found
+ *
  * @return A handle to the first cache file found or -1 if the cache doesn't exist
- */ 
-UDATA 
+ */
+UDATA
 SH_OSCachesysv::findfirst(struct J9PortLibrary *portLibrary, char *cacheDir, char *resultbuf)
 {
 	UDATA rc;
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	
+
 	Trc_SHR_OSC_Sysv_findfirst_Entry();
-	
+
 	rc = j9shmem_findfirst(cacheDir, resultbuf);
-	
+
 	Trc_SHR_OSC_Sysv_findfirst_Exit(rc);
 	return rc;
 }
@@ -1866,23 +1864,23 @@ SH_OSCachesysv::findfirst(struct J9PortLibrary *portLibrary, char *cacheDir, cha
 /**
  * Find the next file in a given cacheDir
  * Follows the format of j9file_findnext
- * 
+ *
  * @param [in] portLibrary  A port library
  * @param [in] findHandle  The handle of the last file found
- * @param [out] resultbuf  The name of the file found 
- * 
+ * @param [out] resultbuf  The name of the file found
+ *
  * @return A handle to the cache file found or -1 if the cache doesn't exist
  */
-I_32 
+I_32
 SH_OSCachesysv::findnext(struct J9PortLibrary *portLibrary, UDATA findHandle, char *resultbuf)
 {
 	I_32 rc;
 	PORT_ACCESS_FROM_PORT(portLibrary);
-	
+
 	Trc_SHR_OSC_Sysv_findnext_Entry(findHandle);
-	
+
 	rc = j9shmem_findnext(findHandle, resultbuf);
-	
+
 	Trc_SHR_OSC_Sysv_findnext_Exit(rc);
 	return rc;
 }
@@ -1890,11 +1888,11 @@ SH_OSCachesysv::findnext(struct J9PortLibrary *portLibrary, UDATA findHandle, ch
 /**
  * Finish finding caches
  * Follows the format of j9file_findclose
- * 
+ *
  * @param [in] portLibrary  A port library
  * @param [in] findHandle  The handle of the last file found
  */
-void 
+void
 SH_OSCachesysv::findclose(struct J9PortLibrary *portLibrary, UDATA findhandle)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
@@ -1905,14 +1903,14 @@ SH_OSCachesysv::findclose(struct J9PortLibrary *portLibrary, UDATA findhandle)
 }
 
 /* Used for connecting to legacy cache headers */
-void* 
+void*
 SH_OSCachesysv::getSysvHeaderFieldAddressForGen(void* header, UDATA headerGen, UDATA fieldID)
 {
 	return (U_8*)header + getSysvHeaderFieldOffsetForGen(headerGen, fieldID);
 }
 
 /* Used for connecting to legacy cache headers */
-IDATA 
+IDATA
 SH_OSCachesysv::getSysvHeaderFieldOffsetForGen(UDATA headerGen, UDATA fieldID)
 {
 	if ((4 < headerGen) && (headerGen <= OSCACHE_CURRENT_CACHE_GEN)) {
@@ -1943,13 +1941,13 @@ SH_OSCachesysv::getSysvHeaderFieldOffsetForGen(UDATA headerGen, UDATA fieldID)
 	return 0;
 }
 
-UDATA 
+UDATA
 SH_OSCachesysv::getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDescriptor* descriptor)
 {
 #if !defined(WIN32)
 	SH_OSCache_Info cacheInfo;
 #endif
-	
+
 	descriptor->cacheGen = _activeGeneration;
 #if defined(WIN32)
 	descriptor->shmid = descriptor->semid = -2;
@@ -1971,7 +1969,7 @@ SH_OSCachesysv::getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDescripto
  * This method performs additional checks to catch scenarios that are not handled by permission and/or mode settings provided by operating system,
  * to avoid any unintended access to semaphore set.
  *
- * @param[in] lastErrorInfo	Pointer to store last portable error code and/or message
+ * @param[in] lastErrorInfo Pointer to store last portable error code and/or message
  *
  * @return enum SH_SysvSemAccess indicating if the process can access the semaphore set or not
  */
@@ -2081,7 +2079,7 @@ _end:
  * This method performs additional checks to catch scenarios that are not handled by permission and/or mode settings provided by operating system,
  * to avoid any unintended access to shared memory.
  *
- * @param[in] lastErrorInfo	Pointer to store last portable error code and/or message
+ * @param[in] lastErrorInfo Pointer to store last portable error code and/or message
  *
  * @return enum SH_SysvShmAccess indicating if the process can access the shared memory or not
  */
@@ -2236,7 +2234,7 @@ SH_OSCachesysv::OpenSysVSemaphoreHelper(J9PortShcVersion* versionData, LastError
 		flags |= J9SHSEM_OPEN_DO_NOT_CREATE;
 	}
 
-	switch(action){
+	switch (action) {
 		case J9SH_SYSV_REGULAR_CONTROL_FILE:
 			rc = j9shsem_deprecated_open(_cacheDirName, _groupPerm, &_semhandle, _semFileName, (int)_totalNumSems, 0, flags, &_controlFileStatus);
 			break;
@@ -2281,13 +2279,13 @@ SH_OSCachesysv::DestroySysVSemHelper()
 
 	action = SH_OSCachesysv::SysVCacheFileTypeHelper(cacheVMVersion, genVersion);
 
-	switch(action){
+	switch (action) {
 		case J9SH_SYSV_REGULAR_CONTROL_FILE:
 			rc = j9shsem_deprecated_destroy(&_semhandle);
 			break;
 		case J9SH_SYSV_OLDER_EMPTY_CONTROL_FILE:
 			rc = j9shsem_deprecated_destroyDeprecated(&_semhandle, J9SH_SYSV_OLDER_EMPTY_CONTROL_FILE);
-			break; 
+			break;
 		case J9SH_SYSV_OLDER_CONTROL_FILE:
 			rc = j9shsem_deprecated_destroyDeprecated(&_semhandle, J9SH_SYSV_OLDER_CONTROL_FILE);
 			break;
@@ -2306,7 +2304,7 @@ SH_OSCachesysv::DestroySysVSemHelper()
 			OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_SEMAPHORE_DESTROY_NOT_PERMITTED, j9shsem_deprecated_getid(_semhandle));
 		} else {
 			const char * errormsg = j9error_last_error_message();
-			
+
 			OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_DESTROYSEM_ERROR_WITH_SEMID, j9shsem_deprecated_getid(_semhandle));
 			OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_PORT_ERROR_NUMBER_SYSV_ERR, errorno);
 			Trc_SHR_Assert_True(errormsg != NULL);
@@ -2315,7 +2313,7 @@ SH_OSCachesysv::DestroySysVSemHelper()
 #else /* !defined(WIN32) */
 		I_32 errorno = j9error_last_error_number();
 		const char * errormsg = j9error_last_error_message();
-		
+
 		OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_DESTROYSEM_ERROR);
 		OSC_ERR_TRACE1(J9NLS_SHRC_OSCACHE_PORT_ERROR_NUMBER_SYSV_ERR, errorno);
 		Trc_SHR_Assert_True(errormsg != NULL);
@@ -2355,7 +2353,7 @@ SH_OSCachesysv::OpenSysVMemoryHelper(const char* cacheName, U_32 perm, LastError
 
 	action = SH_OSCachesysv::SysVCacheFileTypeHelper(cacheVMVersion, genVersion);
 
-	switch(action){
+	switch (action) {
 		case J9SH_SYSV_REGULAR_CONTROL_FILE:
 			if (J9_ARE_ANY_BITS_SET(_createFlags, J9SH_OSCACHE_OPEXIST_STATS)) {
 				flags |= J9SHMEM_OPEN_FOR_STATS;
@@ -2366,8 +2364,8 @@ SH_OSCachesysv::OpenSysVMemoryHelper(const char* cacheName, U_32 perm, LastError
 			}
 #if defined(J9ZOS390)
 			if (0 != (_runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_STORAGEKEY_TESTING)) {
-				flags |=  J9SHMEM_STORAGE_KEY_TESTING;
-				flags |=  _storageKeyTesting << J9SHMEM_STORAGE_KEY_TESTING_SHIFT;
+				flags |= J9SHMEM_STORAGE_KEY_TESTING;
+				flags |= _storageKeyTesting << J9SHMEM_STORAGE_KEY_TESTING_SHIFT;
 			}
 			flags |= J9SHMEM_PRINT_STORAGE_KEY_WARNING;
 #endif
@@ -2415,7 +2413,7 @@ SH_OSCachesysv::StatSysVMemoryHelper(J9PortLibrary* portLibrary, const char* cac
 
 	action = SH_OSCachesysv::SysVCacheFileTypeHelper(cacheVMVersion, genVersion);
 
-	switch(action){
+	switch (action) {
 		case J9SH_SYSV_REGULAR_CONTROL_FILE:
 			rc = j9shmem_stat(cacheDirName, groupPerm, cacheNameWithVGen, statbuf);
 			break;
@@ -2434,7 +2432,6 @@ SH_OSCachesysv::StatSysVMemoryHelper(J9PortLibrary* portLibrary, const char* cac
 	Trc_SHR_OSC_Sysv_StatSysVMemoryHelper_Exit(rc);
 	return rc;
 }
-
 
 IDATA
 SH_OSCachesysv::DestroySysVMemoryHelper()
@@ -2458,13 +2455,13 @@ SH_OSCachesysv::DestroySysVMemoryHelper()
 
 	action = SH_OSCachesysv::SysVCacheFileTypeHelper(cacheVMVersion, genVersion);
 
-	switch(action){
+	switch (action) {
 		case J9SH_SYSV_REGULAR_CONTROL_FILE:
 			rc = j9shmem_destroy(_cacheDirName, _groupPerm, &_shmhandle);
 			break;
 		case J9SH_SYSV_OLDER_EMPTY_CONTROL_FILE:
 			rc = j9shmem_destroyDeprecated(_cacheDirName, _groupPerm, &_shmhandle, J9SH_SYSV_OLDER_EMPTY_CONTROL_FILE);
-			break; 
+			break;
 		case J9SH_SYSV_OLDER_CONTROL_FILE:
 			rc = j9shmem_destroyDeprecated(_cacheDirName, _groupPerm, &_shmhandle, J9SH_SYSV_OLDER_CONTROL_FILE);
 			break;
@@ -2504,7 +2501,6 @@ done:
 
 }
 
-
 UDATA
 SH_OSCachesysv::SysVCacheFileTypeHelper(U_64 currentVersion, UDATA genVersion)
 {
@@ -2515,13 +2511,13 @@ SH_OSCachesysv::SysVCacheFileTypeHelper(U_64 currentVersion, UDATA genVersion)
 	 * C250 VM is used by Java 6 WRT and SRT
 	 * C260 VM is used by Java 7, possibly Java 6
 	 */
-	U_64 C230VMversion   = getCacheVersionToU64(2, 30);
-	U_64 C240VMversion   = getCacheVersionToU64(2, 40);
-	U_64 C250VMversion   = getCacheVersionToU64(2, 50);
-	U_64 C260VMversion   = getCacheVersionToU64(2, 60);
+	U_64 C230VMversion = getCacheVersionToU64(2, 30);
+	U_64 C240VMversion = getCacheVersionToU64(2, 40);
+	U_64 C250VMversion = getCacheVersionToU64(2, 50);
+	U_64 C260VMversion = getCacheVersionToU64(2, 60);
 
 	if (currentVersion >= C260VMversion) {
-		switch(genVersion) {
+		switch (genVersion) {
 			case 1:
 			case 2:
 			case 3:
@@ -2536,7 +2532,7 @@ SH_OSCachesysv::SysVCacheFileTypeHelper(U_64 currentVersion, UDATA genVersion)
 		}
 
 	} else if (currentVersion >= C250VMversion) {
-		switch(genVersion) {
+		switch (genVersion) {
 			case 1:
 			case 2:
 			case 3:
@@ -2548,7 +2544,7 @@ SH_OSCachesysv::SysVCacheFileTypeHelper(U_64 currentVersion, UDATA genVersion)
 		}
 
 	} else if (currentVersion >= C240VMversion) {
-		switch(genVersion) {
+		switch (genVersion) {
 			case 1:
 			case 2:
 			case 3:
@@ -2571,7 +2567,6 @@ SH_OSCachesysv::SysVCacheFileTypeHelper(U_64 currentVersion, UDATA genVersion)
 		Trc_SHR_Assert_ShouldNeverHappen();
 	}
 
-
 	Trc_SHR_OSC_Sysv_SysVCacheFileTypeHelper_Event(currentVersion, rc);
 	return rc;
 }
@@ -2581,7 +2576,7 @@ SH_OSCachesysv::SysVCacheFileTypeHelper(U_64 currentVersion, UDATA genVersion)
  *
  * @param [in] cacheDirName directory containing cache control file
  * @param [in] filename "semaphore" or "memory" depending on type of control file
- * @param [out]	isNotReadable true if the file cannot be read, false otherwise
+ * @param [out] isNotReadable true if the file cannot be read, false otherwise
  * @param [out] isReadOnly true if the file is read-only, false otherwise
  *
  * @return -1 if it fails to get file stats, 0 otherwise.
@@ -2629,7 +2624,7 @@ SH_OSCachesysv::getControlFilePerm(char *cacheDirName, char *filename, bool *isN
 
 #endif
 
-void * 
+void *
 SH_OSCachesysv::getAttachedMemory()
 {
 	/* This method should only be called between calls to attach and detach
@@ -2653,8 +2648,8 @@ SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA n
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	IDATA rc = 0;
-	char cacheDirName[J9SH_MAXPATH];		/* J9SH_MAXPATH defined to be EsMaxPath which is 1024 */
-	char nameWithVGen[CACHE_ROOT_MAXLEN];	/* CACHE_ROOT_MAXLEN defined to be 88 */
+	char cacheDirName[J9SH_MAXPATH];        /* J9SH_MAXPATH defined to be EsMaxPath which is 1024 */
+	char nameWithVGen[CACHE_ROOT_MAXLEN];   /* CACHE_ROOT_MAXLEN defined to be 88 */
 	char pathFileName[J9SH_MAXPATH];
 	J9PortShcVersion versionData;
 	IDATA fd = 0;
@@ -2791,7 +2786,7 @@ SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA n
 				bool cacheHasIntegrity = false;
 				I_32 semid = 0;
 				U_16 theVMCntr = 0;
-				OSCachesysv_header_version_current*  osCacheSysvHeader = NULL;
+				OSCachesysv_header_version_current* osCacheSysvHeader = NULL;
 				J9SharedCacheHeader* theca = (J9SharedCacheHeader *)attach(currentThread, &versionData);
 				IDATA nbytes = (IDATA)fileSize;
 				IDATA fileRc = 0;
@@ -2880,11 +2875,11 @@ done:
 /**
  * This method checks whether the group access of the semaphore is successfully set when a new cache is created with "groupAccess" suboption
  *
- * @param[in] lastErrorInfo	Pointer to store last portable error code and/or message.
+ * @param[in] lastErrorInfo Pointer to store last portable error code and/or message.
  *
  * @return -1 Failed to get the stats of the semaphore.
- * 			0 Group access is not set.
- * 			1 Group access is set.
+ *          0 Group access is not set.
+ *          1 Group access is set.
  */
 I_32
 SH_OSCachesysv::verifySemaphoreGroupAccess(LastErrorInfo *lastErrorInfo)
@@ -2913,11 +2908,11 @@ SH_OSCachesysv::verifySemaphoreGroupAccess(LastErrorInfo *lastErrorInfo)
 /**
  * This method checks whether the group access of the shared memory is successfully set when a new cache is created with "groupAccess" suboption
  *
- * @param[in] lastErrorInfo	Pointer to store last portable error code and/or message.
+ * @param[in] lastErrorInfo Pointer to store last portable error code and/or message.
  *
  * @return -1 Failed to get the stats of the shared memory.
- * 			0 Group access is not set.
- * 			1 Group access is set.
+ *          0 Group access is not set.
+ *          1 Group access is set.
  */
 I_32
 SH_OSCachesysv::verifySharedMemoryGroupAccess(LastErrorInfo *lastErrorInfo)

--- a/runtime/tests/shared/AttachedDataTest.cpp
+++ b/runtime/tests/shared/AttachedDataTest.cpp
@@ -147,13 +147,13 @@ AttachedDataTest::addMethodToCache(J9JavaVM *vm)
 
 	sizes.romClassSizeFullSize = romclassSize;
 	sizes.romClassMinimalSize = sizes.romClassSizeFullSize;
-	
+
 	if (transaction.allocateSharedClass((const J9RomClassRequirements *)&sizes) == false) {
 		ERRPRINTF("failure to alloc memory for ROMClass in shared cache\n");
 		return NULL;
 	} else {
 		romclassmem = transaction.getRomClass();
- 	}
+	}
 
 	if (romclassmem == NULL) {
 		ERRPRINTF(("romclassmem == NULL\n"));
@@ -163,10 +163,10 @@ AttachedDataTest::addMethodToCache(J9JavaVM *vm)
 	memcpy(newromclass,romclass,romclassSize);
 	romMethod = J9ROMCLASS_ROMMETHODS(newromclass);
 
-    if (transaction.updateSharedClassSize(newromclass->romSize) == -1) {
-    	ERRPRINTF(("failed to update shared class size\n"));
-    	return NULL;
-    }
+	if (transaction.updateSharedClassSize(newromclass->romSize) == -1) {
+		ERRPRINTF(("failed to update shared class size\n"));
+		return NULL;
+	}
 
 	return (romMethod);
  }
@@ -185,14 +185,14 @@ AttachedDataTest::openTestCache(J9JavaVM* vm, BlockPtr preallocatedCache, UDATA 
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-    classMemorySegments = vm->internalVMFunctions->allocateMemorySegmentListWithFlags(vm, 10, MEMORY_SEGMENT_LIST_FLAG_SORT, J9MEM_CATEGORY_CLASSES);
-    if (classMemorySegments == NULL) {
-            ERRPRINTF("openTestCache: failed to allocate memory segment list");
-            rc = FAIL;
-            goto done;
-    }
-    origClassMemorySegments = vm->classMemorySegments;
-    vm->classMemorySegments = classMemorySegments;
+	classMemorySegments = vm->internalVMFunctions->allocateMemorySegmentListWithFlags(vm, 10, MEMORY_SEGMENT_LIST_FLAG_SORT, J9MEM_CATEGORY_CLASSES);
+	if (classMemorySegments == NULL) {
+			ERRPRINTF("openTestCache: failed to allocate memory segment list");
+			rc = FAIL;
+			goto done;
+	}
+	origClassMemorySegments = vm->classMemorySegments;
+	vm->classMemorySegments = classMemorySegments;
 
 	piConfig = (J9SharedClassPreinitConfig *) j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES);
 	if (NULL == piConfig) {
@@ -248,7 +248,6 @@ AttachedDataTest::openTestCache(J9JavaVM* vm, BlockPtr preallocatedCache, UDATA 
 
 	sharedClassConfig->verboseFlags |= (J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_JITDATA | J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_DEFAULT);
 
-
 	/* populate AttachedData APIs */
 	sharedClassConfig->storeAttachedData = j9shr_storeAttachedData;
 	sharedClassConfig->findAttachedData = j9shr_findAttachedData;
@@ -287,7 +286,7 @@ AttachedDataTest::openTestCache(J9JavaVM* vm, BlockPtr preallocatedCache, UDATA 
 	}
 	UnitTest::cacheMemory = cacheMemory;
 	UnitTest::cacheSize = (U_32)piConfig->sharedClassCacheSize;
-	
+
 	cacheMapSize = SH_CacheMap::getRequiredConstrBytes(false);
 	memory = j9mem_allocate_memory(cacheMapSize, J9MEM_CATEGORY_CLASSES);
 	if (NULL == memory) {
@@ -336,11 +335,11 @@ done:
 			cacheAllocated = NULL;
 			cacheMemory = NULL;
 		}
-        if (NULL != classMemorySegments) {
-        	vm->internalVMFunctions->freeMemorySegmentList(vm, classMemorySegments);
-            vm->classMemorySegments = origClassMemorySegments;
-            classMemorySegments = NULL;
-        }
+		if (NULL != classMemorySegments) {
+			vm->internalVMFunctions->freeMemorySegmentList(vm, classMemorySegments);
+			vm->classMemorySegments = origClassMemorySegments;
+			classMemorySegments = NULL;
+		}
 	}
 	return rc;
 }
@@ -359,8 +358,8 @@ AttachedDataTest::closeTestCache(J9JavaVM *vm, bool freeCache)
 		cacheMap = NULL;
 	}
 
-	if ((true == freeCache) && (NULL != cacheAllocated)) {
-		/* Unprotect the cacheMemory before freeing. Otherwise it can cause crash on linux/ppc 64-bit machine when 
+	if (freeCache && (NULL != cacheAllocated)) {
+		/* Unprotect the cacheMemory before freeing. Otherwise it can cause crash on linux/ppc 64-bit machine when
 		 * the next call to allocate memory for cache returns same address as current cacheMemory.
 		 */
 		if (NULL != piConfig) {
@@ -381,11 +380,11 @@ AttachedDataTest::closeTestCache(J9JavaVM *vm, bool freeCache)
 		j9mem_free_memory(piConfig);
 		piConfig = NULL;
 	}
-    if (NULL != classMemorySegments) {
-    	vm->internalVMFunctions->freeMemorySegmentList(vm, classMemorySegments);
-        vm->classMemorySegments = origClassMemorySegments;
-        classMemorySegments = NULL;
-    }
+	if (NULL != classMemorySegments) {
+		vm->internalVMFunctions->freeMemorySegmentList(vm, classMemorySegments);
+		vm->classMemorySegments = origClassMemorySegments;
+		classMemorySegments = NULL;
+	}
 	return rc;
 }
 
@@ -481,7 +480,7 @@ AttachedDataTest::StoreAttachedDataSuccess(J9JavaVM *vm)
 			rc = PASS;
 		}
 #else
-		if (true == readOnlyCache) {
+		if (readOnlyCache) {
 			if (J9SHR_RESOURCE_STORE_ERROR != rV) {
 				ERRPRINTF2("j9shr_storeAttachedData returned incorrect code for read only cache, rV: %d for data index: %d\n", rV, i);
 				rc = FAIL;
@@ -549,7 +548,7 @@ AttachedDataTest::StoreAttachedDataFailure(J9JavaVM *vm)
 	attachedData.data.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
 
 	UDATA rv = vm->sharedClassConfig->storeAttachedData(currentThread, attachedData.keyAddress, &attachedData.data, false);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rv) {
 			ERRPRINTF2("j9shr_storeAttachedData did not return correct error code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rv);
 			rc = FAIL;
@@ -569,9 +568,9 @@ AttachedDataTest::StoreAttachedDataFailure(J9JavaVM *vm)
 	attachedData.data.length = strlen(junkData)+1;
 	attachedData.data.type = J9SHR_ATTACHED_DATA_TYPE_JITPROFILE;
 	attachedData.data.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
- 	j9tty_printf(PORTLIB, "\t");
+	j9tty_printf(PORTLIB, "\t");
 	rv = vm->sharedClassConfig->storeAttachedData(currentThread, attachedData.keyAddress, &attachedData.data, false);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rv) {
 			ERRPRINTF2("j9shr_storeAttachedData did not return correct error code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rv);
 			rc = FAIL;
@@ -595,7 +594,7 @@ AttachedDataTest::StoreAttachedDataFailure(J9JavaVM *vm)
 	attachedData.data.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
 
 	rv = vm->sharedClassConfig->storeAttachedData(currentThread, attachedData.keyAddress, &attachedData.data, false);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rv) {
 			ERRPRINTF2("j9shr_storeAttachedData did not return correct error code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rv);
 			rc = FAIL;
@@ -617,7 +616,7 @@ AttachedDataTest::StoreAttachedDataFailure(J9JavaVM *vm)
 	attachedData.data.flags = J9SHR_ATTACHED_DATA_NO_FLAGS + 100;
 
 	rv = vm->sharedClassConfig->storeAttachedData(currentThread, attachedData.keyAddress, &attachedData.data, false);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rv) {
 			ERRPRINTF2("j9shr_storeAttachedData did not return correct error code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rv);
 			rc = FAIL;
@@ -668,7 +667,7 @@ AttachedDataTest::FindAttachedData(J9JavaVM *vm, const void *addressInCache, J9S
 		rc = FAIL;
 		break;
 	default:
-		if (true == expectCorruptData) {
+		if (expectCorruptData) {
 			if (-1 != corruptOffset) {
 				if (NULL != (U_8 *)rc) {
 					ERRPRINTF1("%s: j9shr_findAttachedData successfully found corrupt data but did not return NULL", caller);
@@ -931,7 +930,7 @@ AttachedDataTest::ReplaceAttachedData(J9JavaVM *vm)
 
 	/* pass true to forceReplace parameter of j9shr_storeAttachedData */
 	rc = (IDATA) vm->sharedClassConfig->storeAttachedData(currentThread, attachedData.keyAddress, &attachedData.data, true);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF2("j9shr_storeAttachedData returned incorrect code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rc);
 			rc = FAIL;
@@ -1017,7 +1016,7 @@ AttachedDataTest::UpdateAttachedDataSuccess(J9JavaVM *vm)
 		rc = PASS;
 	}
 #else
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF2("j9shr_updateAttachedData returned incorrect code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rc);
 			rc = FAIL;
@@ -1102,7 +1101,7 @@ AttachedDataTest::UpdateJitHint(J9JavaVM *vm)
 		rc = PASS;
 	}
 #else
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF2("j9shr_updateAttachedData returned incorrect code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rc);
 			rc = FAIL;
@@ -1197,7 +1196,7 @@ AttachedDataTest::UpdateAttachedDataFailure(J9JavaVM *vm)
 	attachedData.data.type = dataList[1].data.type;
 	attachedData.data.flags = (UDATA)-1;
 	rc = (IDATA) vm->sharedClassConfig->updateAttachedData(currentThread, attachedData.keyAddress, 0, &attachedData.data);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF1("j9shr_storeAttachedData returned incorrect code for read only cache, rc: %d", rc);
 			rc = FAIL;
@@ -1223,7 +1222,7 @@ AttachedDataTest::UpdateAttachedDataFailure(J9JavaVM *vm)
 	attachedData.data.flags = dataList[1].data.flags;
 	j9tty_printf(PORTLIB, "\t");
 	rc = (IDATA) vm->sharedClassConfig->updateAttachedData(currentThread, attachedData.keyAddress, 0, &attachedData.data);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF1("j9shr_storeAttachedData returned incorrect code for read only cache, rc: %d", rc);
 			rc = FAIL;
@@ -1252,7 +1251,7 @@ AttachedDataTest::UpdateAttachedUDATASuccess(J9JavaVM *vm)
 	I_32 updateOffset;
 	UDATA updateData;
 	I_32 align = sizeof(UDATA);
-    const char* testName = "UpdateAttachedUDATASuccess";
+	const char* testName = "UpdateAttachedUDATASuccess";
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	currentThread = vm->internalVMFunctions->currentVMThread(vm);
@@ -1271,7 +1270,7 @@ AttachedDataTest::UpdateAttachedUDATASuccess(J9JavaVM *vm)
 		rc = PASS;
 	}
 #else
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF2("j9shr_updateAttachedUDATA returned incorrect code for read only cache, expected error code: %d, returned: %d", J9SHR_RESOURCE_STORE_ERROR, rc);
 			rc = FAIL;
@@ -1385,7 +1384,7 @@ AttachedDataTest::UpdateAttachedUDATAFailure(J9JavaVM *vm)
 	ca = cc->getCacheHeaderAddress();
 	j9tty_printf(PORTLIB, "\t");
 	rc = (IDATA) vm->sharedClassConfig->updateAttachedUDATA(currentThread, (U_8 *)ca, J9SHR_ATTACHED_DATA_TYPE_JITPROFILE, 0, updateData);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF1("j9shr_storeAttachedData returned incorrect code for read only cache, rc: %d", rc);
 			rc = FAIL;
@@ -1427,9 +1426,8 @@ AttachedDataTest::CorruptAttachedData(J9JavaVM *vm)
 		rc = FAIL;
 		goto _exit;
 	}
-	strncpy((char *)data.address, content, strlen(content));
-	data.address[strlen(content)] = '\0';
 	data.length = strlen(content) + 1;
+	memcpy((char *)data.address, content, data.length); /* copy NUL */
 	data.type = dataList[2].data.type;
 	data.flags = dataList[2].data.flags;
 	j9tty_printf(PORTLIB, "\t");
@@ -1437,7 +1435,7 @@ AttachedDataTest::CorruptAttachedData(J9JavaVM *vm)
 	UnitTest::unitTest = UnitTest::ATTACHED_DATA_TEST;
 
 	rc = (IDATA) vm->sharedClassConfig->updateAttachedData(currentThread, dataList[2].keyAddress, updateAtOffset, &data);
-	if (true == readOnlyCache) {
+	if (readOnlyCache) {
 		if (J9SHR_RESOURCE_STORE_ERROR != rc) {
 			ERRPRINTF1("j9shr_storeAttachedData returned incorrect code for read only cache, rc: %d", rc);
 			rc = FAIL;
@@ -1514,16 +1512,16 @@ startReader(void *entryArg) {
 	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 	/* writer thread must have failed, no need to proceed */
-	if (true == adt->cancelThread) {
+	if (adt->cancelThread) {
 		goto _exitCloseCache;
 	}
 
-    /* Reader thread needs to use same cache memory as writer thread */
-    rc = adt->openTestCache(vm, writerCacheMemory, writerCacheSize, J9PORT_SHR_CACHE_TYPE_PERSISTENT, J9SHR_RUNTIMEFLAG_ENABLE_READONLY, 0);
-    if (FAIL == rc) {
-    	ERRPRINTF("openTestCache failed");
-    	goto _exitCloseCache;
-    }
+	/* Reader thread needs to use same cache memory as writer thread */
+	rc = adt->openTestCache(vm, writerCacheMemory, writerCacheSize, J9PORT_SHR_CACHE_TYPE_PERSISTENT, J9SHR_RUNTIMEFLAG_ENABLE_READONLY, 0);
+	if (FAIL == rc) {
+		ERRPRINTF("openTestCache failed");
+		goto _exitCloseCache;
+	}
 
 	UnitTest::unitTest = UnitTest::ATTACHED_DATA_UPDATE_COUNT_TEST;
 
@@ -1569,13 +1567,13 @@ startWriter(void *entryArg) {
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
-    rc = adt->openTestCache(vm, NULL, 0, J9PORT_SHR_CACHE_TYPE_PERSISTENT, 0, 0);
-    if (FAIL == rc) {
-    	ERRPRINTF("openTestCache failed");
-    	goto _exitCloseCache;
-    }
-    writerCacheMemory = adt->cacheMemory;
-    writerCacheSize = adt->piConfig->sharedClassCacheSize;
+	rc = adt->openTestCache(vm, NULL, 0, J9PORT_SHR_CACHE_TYPE_PERSISTENT, 0, 0);
+	if (FAIL == rc) {
+		ERRPRINTF("openTestCache failed");
+		goto _exitCloseCache;
+	}
+	writerCacheMemory = adt->cacheMemory;
+	writerCacheSize = adt->piConfig->sharedClassCacheSize;
 
 	rc = adt->initializeAttachedData(vm);
 	if (FAIL == rc) {
@@ -1596,7 +1594,7 @@ startWriter(void *entryArg) {
 
 	omrthread_suspend();
 
-	if (true == adt->cancelThread) {
+	if (adt->cancelThread) {
 		/* reader thread must have failed, no need to proceed */
 		goto _exitCloseCache;
 	}
@@ -1609,7 +1607,7 @@ startWriter(void *entryArg) {
 	INFOPRINTF("Successfully updated data\n\t");
 	omrthread_suspend();
 
-	if (true == adt->cancelThread) {
+	if (adt->cancelThread) {
 		/* reader thread must have failed, no need to proceed */
 		goto _exitCloseCache;
 	}
@@ -1685,7 +1683,7 @@ testFindReadOnly(J9JavaVM *vm) {
 	/* Wait for writer thread to be suspended */
 	while (adtWriter.isThreadSuspended() == false) {
 		/* If writer thread exited without getting suspended, stop reader thread as well */
-		if (true == adtWriter.threadExited) {
+		if (adtWriter.threadExited) {
 			adtReader.cancelThread = true;
 			/* Give reader thread a chance to exit gracefully */
 			omrthread_resume(adtReader.osThread);
@@ -1703,7 +1701,7 @@ testFindReadOnly(J9JavaVM *vm) {
 		/* Wait for reader thread to be suspended */
 		while (adtReader.isThreadSuspended() == false) {
 			/* If reader thread exited without getting suspended, stop writer thread as well */
-			if (true == adtReader.threadExited) {
+			if (adtReader.threadExited) {
 				adtWriter.cancelThread = true;
 				/* Give writer thread a chance to exit gracefully */
 				omrthread_resume(adtWriter.osThread);
@@ -1719,7 +1717,7 @@ testFindReadOnly(J9JavaVM *vm) {
 		/* Wait for writer thread to be suspended */
 		while (adtWriter.isThreadSuspended() == false) {
 			/* If writer thread exited without getting suspended, stop reader thread as well */
-			if (true == adtWriter.threadExited) {
+			if (adtWriter.threadExited) {
 				adtReader.cancelThread = true;
 				/* Give reader thread a chance to exit gracefully.
 				 * Clear UnitTest::unitTest so that reader thread can exit without suspending itself again.
@@ -1743,7 +1741,7 @@ testFindReadOnly(J9JavaVM *vm) {
 	/* Wait for reader thread to be suspended */
 	while (adtReader.isThreadSuspended() == false) {
 		/* If reader thread exited without getting suspended, stop writer thread as well */
-		if (true == adtReader.threadExited) {
+		if (adtReader.threadExited) {
 			adtWriter.cancelThread = true;
 			/* Give writer thread a chance to exit gracefully */
 			omrthread_resume(adtWriter.osThread);
@@ -1759,7 +1757,7 @@ testFindReadOnly(J9JavaVM *vm) {
 	/* Wait for writer thread to be suspended */
 	while (adtWriter.isThreadSuspended() == false) {
 		/* If writer thread exited without getting suspended, stop reader thread as well */
-		if (true == adtWriter.threadExited) {
+		if (adtWriter.threadExited) {
 			adtReader.cancelThread = true;
 			/* Give reader thread a chance to exit gracefully.
 			 * Clear UnitTest::unitTest so that reader thread can exit without suspending itself again.
@@ -1869,7 +1867,7 @@ testAttachedData(J9JavaVM* vm)
 				goto _exitClearData;
 			}
 
-			if (true == readOnly) {
+			if (readOnly) {
 				/* close read-write cache and open it again as read-only */
 				adt.closeTestCache(vm, false);
 				extraRuntimeFlag |= J9SHR_RUNTIMEFLAG_ENABLE_READONLY;

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -44,20 +44,17 @@ extern "C"
 #include "j9.h"
 #include "hookhelpers.hpp"
 
-#define CACHE_SIZE (16*1024*1024)
-#define ROMCLASS_SIZE (4*1024)
+#define CACHE_SIZE (16 * 1024 * 1024)
+#define ROMCLASS_SIZE (4 * 1024)
 #define INVALID_EYECATCHER "XXXX"
 #define INVALID_EYECATCHER_LENGTH 4
 #define BROKEN_TEST_CACHE "BrokenTestCache"
 
 #define ERRPRINTF(args) \
 do { \
-	j9tty_printf(PORTLIB,"\t"); \
-	j9tty_printf(PORTLIB,"ERROR: %s",__FILE__); \
-	j9tty_printf(PORTLIB,"(%d)",__LINE__); \
-	j9tty_printf(PORTLIB," %s ",testName); \
-	j9tty_printf(PORTLIB,args); \
-}while(0) \
+	j9tty_printf(PORTLIB, "\tERROR: %s(%d) %s ", __FILE__, __LINE__, testName); \
+	j9tty_printf(PORTLIB, args); \
+} while (0)
 
 typedef enum CorruptionStage {
 	INVALID_STAGE,
@@ -97,32 +94,31 @@ struct CorruptionInfo {
 	CorruptionType corruptionType;
 	CorruptionStage corruptionStage;
 } corruptionInfo[] = {
-		{ INVALID_CORRUPTION, INVALID_STAGE },
-		{ CACHE_CRC_INVALID_TYPE, DURING_STARTUP },
-		{ WALK_ROMCLASS_CORRUPT_CASE1_TYPE, AFTER_STARTUP },
-		{ WALK_ROMCLASS_CORRUPT_CASE2_TYPE, AFTER_STARTUP },
-		{ ITEM_TYPE_CORRUPT_UNINITIALIZED_TYPE, AFTER_STARTUP },
-		{ ITEM_TYPE_CORRUPT_MAX_DATA_TYPES_TYPE, AFTER_STARTUP },
-		{ ITEM_LENGTH_CORRUPT_TYPE, AFTER_STARTUP },
-		{ ITEM_LENGTH_CORRUPT_TYPE_LEN2LONG, AFTER_STARTUP },
-		{ ITEM_LENGTH_CORRUPT_AFTER_STARTUP_TYPE, AFTER_STARTUP },
-		{ CACHE_HEADER_INCORRECT_DATA_LENGTH_TYPE, DURING_STARTUP },
-		{ CACHE_HEADER_INCORRECT_DATA_START_ADDRESS_TYPE, DURING_STARTUP },
-		{ CACHE_HEADER_BAD_EYECATCHER_TYPE, DURING_STARTUP },
-		{ CACHE_HEADER_INCORRECT_CACHE_SIZE_TYPE, DURING_STARTUP },
-		{ ACQUIRE_HEADER_WRITE_LOCK_FAILED_TYPE, DURING_STARTUP },
-		{ CACHE_SIZE_INVALID_TYPE, DURING_STARTUP },
-		{ BAD_FREESPACE_DEBUG_AREA, DURING_STARTUP },
-		{ BAD_FREESPACE_SIZE_DEBUG_AREA, DURING_STARTUP },
-		{ BAD_LVT_BOUNDS_DEBUG_AREA, DURING_STARTUP },
-		{ BAD_LNT_BOUNDS_DEBUG_AREA, DURING_STARTUP },
-		{ UPDATE_ROMCLASS_CORRUPT_CASE1_TYPE, AFTER_STARTUP },
-		{ UPDATE_ROMCLASS_CORRUPT_CASE2_TYPE, AFTER_STARTUP },
-		{ CACHE_DATA_NULL_TYPE, DURING_STARTUP },
-		{ CACHE_SEMAPHORE_MISMATCH_TYPE, DURING_STARTUP },
-		{ CACHE_CCINITCOMPLETE_UNINITIALIZED, DURING_STARTUP },
+	{ INVALID_CORRUPTION, INVALID_STAGE },
+	{ CACHE_CRC_INVALID_TYPE, DURING_STARTUP },
+	{ WALK_ROMCLASS_CORRUPT_CASE1_TYPE, AFTER_STARTUP },
+	{ WALK_ROMCLASS_CORRUPT_CASE2_TYPE, AFTER_STARTUP },
+	{ ITEM_TYPE_CORRUPT_UNINITIALIZED_TYPE, AFTER_STARTUP },
+	{ ITEM_TYPE_CORRUPT_MAX_DATA_TYPES_TYPE, AFTER_STARTUP },
+	{ ITEM_LENGTH_CORRUPT_TYPE, AFTER_STARTUP },
+	{ ITEM_LENGTH_CORRUPT_TYPE_LEN2LONG, AFTER_STARTUP },
+	{ ITEM_LENGTH_CORRUPT_AFTER_STARTUP_TYPE, AFTER_STARTUP },
+	{ CACHE_HEADER_INCORRECT_DATA_LENGTH_TYPE, DURING_STARTUP },
+	{ CACHE_HEADER_INCORRECT_DATA_START_ADDRESS_TYPE, DURING_STARTUP },
+	{ CACHE_HEADER_BAD_EYECATCHER_TYPE, DURING_STARTUP },
+	{ CACHE_HEADER_INCORRECT_CACHE_SIZE_TYPE, DURING_STARTUP },
+	{ ACQUIRE_HEADER_WRITE_LOCK_FAILED_TYPE, DURING_STARTUP },
+	{ CACHE_SIZE_INVALID_TYPE, DURING_STARTUP },
+	{ BAD_FREESPACE_DEBUG_AREA, DURING_STARTUP },
+	{ BAD_FREESPACE_SIZE_DEBUG_AREA, DURING_STARTUP },
+	{ BAD_LVT_BOUNDS_DEBUG_AREA, DURING_STARTUP },
+	{ BAD_LNT_BOUNDS_DEBUG_AREA, DURING_STARTUP },
+	{ UPDATE_ROMCLASS_CORRUPT_CASE1_TYPE, AFTER_STARTUP },
+	{ UPDATE_ROMCLASS_CORRUPT_CASE2_TYPE, AFTER_STARTUP },
+	{ CACHE_DATA_NULL_TYPE, DURING_STARTUP },
+	{ CACHE_SEMAPHORE_MISMATCH_TYPE, DURING_STARTUP },
+	{ CACHE_CCINITCOMPLETE_UNINITIALIZED, DURING_STARTUP },
 };
-
 
 /*Some strings to make the test output easier to read*/
 static const char * CorruptionTypeStrings[] = {
@@ -215,7 +211,7 @@ CorruptCacheTest::corruptCache(J9JavaVM *vm, I_32 cacheType, IDATA corruptionTyp
 		oscHeader = &((OSCachemmap_header_version_current *)header)->oscHdr;
 	}
 
-	switch(corruptionType) {
+	switch (corruptionType) {
 	case CACHE_HEADER_INCORRECT_DATA_LENGTH_TYPE:
 		/* set dataLength to invalid value */
 		oscHeader->dataLength = 0;
@@ -227,9 +223,9 @@ CorruptCacheTest::corruptCache(J9JavaVM *vm, I_32 cacheType, IDATA corruptionTyp
 	case CACHE_HEADER_BAD_EYECATCHER_TYPE:
 		/* set eye catcher to invalid value */
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
-			strncpy(((OSCachesysv_header_version_current *)header)->eyecatcher, INVALID_EYECATCHER, INVALID_EYECATCHER_LENGTH);
+			memcpy(((OSCachesysv_header_version_current *)header)->eyecatcher, INVALID_EYECATCHER, INVALID_EYECATCHER_LENGTH);
 		} else {
-			strncpy(((OSCachemmap_header_version_current *)header)->eyecatcher, INVALID_EYECATCHER, INVALID_EYECATCHER_LENGTH);
+			memcpy(((OSCachemmap_header_version_current *)header)->eyecatcher, INVALID_EYECATCHER, INVALID_EYECATCHER_LENGTH);
 		}
 		break;
 	case CACHE_HEADER_INCORRECT_CACHE_SIZE_TYPE:
@@ -309,7 +305,7 @@ CorruptCacheTest::corruptCache(J9JavaVM *vm, I_32 cacheType, IDATA corruptionTyp
 			 * Then call runEntryPointChecks() on original CacheMap to detect corruption.
 			 */
 			SH_CompositeCacheImpl *tempCC;
-			
+
 			tempCC = (SH_CompositeCacheImpl *)j9mem_allocate_memory(sizeof(SH_CompositeCacheImpl), J9MEM_CATEGORY_CLASSES);
 			if (NULL == tempCC) {
 				ERRPRINTF("failed to allocate memory for temporary CompositeCache\n");
@@ -469,7 +465,7 @@ CorruptCacheTest::openTestCache(J9JavaVM *vm, I_32 cacheType, I_32 cacheSize, U_
 	sharedClassConfig->sharedClassCache = (void*)cacheMap;
 
 	rc = cacheMap->startup(vm->mainThread, piConfig, BROKEN_TEST_CACHE, NULL, J9SH_DIRPERM_ABSENT, NULL, &cacheHasIntegrity);
-	if (true == startupWillFail) {
+	if (startupWillFail) {
 		if (0 == rc) {
 			ERRPRINTF("CacheMap.startup() passed when a fail was expected\n");
 			rc = FAIL;
@@ -484,7 +480,7 @@ CorruptCacheTest::openTestCache(J9JavaVM *vm, I_32 cacheType, I_32 cacheSize, U_
 	}
 
 done:
-	if ((FAIL == rc) && (true == doCleanupOnFail)) {
+	if ((FAIL == rc) && doCleanupOnFail) {
 		if (NULL != cacheMap) {
 			cacheMap->cleanup(vm->mainThread);
 			j9mem_free_memory(cacheMap);
@@ -538,7 +534,7 @@ CorruptCacheTest::closeTestCache(J9JavaVM *vm, I_32 cacheType, bool saveCRC)
 				/* When ::openTestCacheForStats() is called CacheMap::startup() may fail,
 				 * and cc->getCacheHeaderAddress() will return NULL because the cache was not started.
 				 */
-				if (true == saveCRC) {
+				if (saveCRC) {
 					/* need to explicitly call SH_CacheMap::runExitCode() to populate cache CRC */
 					cacheMap->runExitCode(vm->mainThread);
 					/* clear J9SHR_RUNTIMEFLAG_DENY_CACHE_UPDATES flag in runtimeFlags which is set in the call to SH_CompositeCacheImpl::runExitCode() above. */
@@ -584,7 +580,7 @@ CorruptCacheTest::openCorruptCache(J9JavaVM* vm, I_32 cacheType, bool readOnly, 
 		startupWillFail = true;
 	}
 
-	if (true == readOnly) {
+	if (readOnly) {
 		extraRuntimeFlags |= J9SHR_RUNTIMEFLAG_ENABLE_READONLY;
 		startupWillFail = true;
 	}
@@ -671,7 +667,7 @@ CorruptCacheTest::verifyCorruptionContext(J9JavaVM *vm, IDATA corruptionType) {
 	cc = (SH_CompositeCacheImpl *)cacheMap->getCompositeCacheAPI();
 	cc->getCorruptionContext(&corruptionCode, NULL);
 
-	switch(corruptionType) {
+	switch (corruptionType) {
 	case CACHE_CRC_INVALID_TYPE:
 		expectedCorruptionCode = CACHE_CRC_INVALID;
 		break;
@@ -785,13 +781,13 @@ CorruptCacheTest::findDummyROMClass(J9JavaVM *vm, const char *romClassName)
 	cpEntry.extraInfo = NULL;
 	cpEntry.pathLength = 1;
 	cpEntry.type = CPE_TYPE_DIRECTORY;
-	
+
 	cpi = createClasspath(vm->mainThread, &cpEntry, 1, 0, CP_TYPE_CLASSPATH, 0);
 	if (NULL == cpi) {
 		j9tty_printf(PORTLIB, "testCorruptCache: failed to create dummy classpath\n");
 		return FAIL;
 	}
-	
+
 	cacheMap = (SH_CacheMap *)vm->sharedClassConfig->sharedClassCache;
 	cacheMap->enterLocalMutex(vm->mainThread, vm->classMemorySegments->segmentMutex, "class segment mutex", "findDummyROMClass");
 	cacheMap->findROMClass(vm->mainThread, romClassName, cpi, NULL, NULL, -1, NULL);
@@ -838,9 +834,9 @@ zeroOutCache(J9JavaVM *vm, I_32 cacheType)
 
 	cacheSize = j9file_length(fullPath);
 	if (cacheSize <= 0) {
-                rc = FAIL;
-                ERRPRINTF("Failed to get cache file size\n");
-                goto done;
+				rc = FAIL;
+				ERRPRINTF("Failed to get cache file size\n");
+				goto done;
 	}
 	mapFileHandle = j9mmap_map_file(fd, 0, (UDATA)cacheSize, fullPath, J9PORT_MMAP_FLAG_WRITE, J9MEM_CATEGORY_CLASSES_SHC_CACHE);
 	if ((NULL == mapFileHandle) || (NULL == mapFileHandle->pointer)) {
@@ -1039,13 +1035,13 @@ testCorruptCache(J9JavaVM* vm)
 	UnitTest::unitTest = UnitTest::CORRUPT_CACHE_TEST;
 	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 
-	for(i = 0; i < 6; i++) {
+	for (i = 0; i < 6; i++) {
 		CorruptCacheTest corruptCacheTest;
 		U_64 extraRuntimeFlags = 0;
 		cacheType = 0;
 		IDATA semid = -1;
 
-		switch(i) {
+		switch (i) {
 		case 0:
 #if !defined(J9ZOS390)
 #if !defined(J9SHR_CACHELET_SUPPORT)
@@ -1109,7 +1105,7 @@ testCorruptCache(J9JavaVM* vm)
 		if (0 != cacheType) {
 			j9tty_printf(PORTLIB, "\nRunning tests with cacheType: %d(%s) and readOnly: %d with extraRuntimeFlags: 0x%llx\n", cacheType , cacheTypeString, readOnly, extraRuntimeFlags);
 
-			for(corruptionType = CACHE_CRC_INVALID_TYPE; corruptionType < NUM_CORRUPTION_TYPE; corruptionType++) {
+			for (corruptionType = CACHE_CRC_INVALID_TYPE; corruptionType < NUM_CORRUPTION_TYPE; corruptionType++) {
 				I_32 cacheSize = CACHE_SIZE;
 
 				j9tty_printf(PORTLIB, "\nCorrupt cache with corruption type: %d(%s)\n", corruptionType, CorruptionTypeStrings[corruptionType]);
@@ -1286,7 +1282,7 @@ testCorruptCache(J9JavaVM* vm)
 					}
 					if ((ITEM_LENGTH_CORRUPT_AFTER_STARTUP_TYPE == corruptionType) ||
 						(UPDATE_ROMCLASS_CORRUPT_CASE2_TYPE == corruptionType)
-					){
+					) {
 						rc = corruptCacheTest.verifyCorruptionContext(vm, corruptionType);
 						if (FAIL == rc) {
 							j9tty_printf(PORTLIB, "testCorruptCache: corruption context verification failed\n");
@@ -1305,24 +1301,24 @@ testCorruptCache(J9JavaVM* vm)
 				}
 
 				/*
-				 * Jazz 40220: Design: Don't destroy caches with bad CRCs during -Xshareclasses:printStats 
-				 * 
+				 * Jazz 40220: Design: Don't destroy caches with bad CRCs during -Xshareclasses:printStats
+				 *
 				 * Open the cache with J9SHR_RUNTIMEFLAG_ENABLE_STATS set to simulate using -Xshareclasses:printXXXStats.
 				 * If the cache is deleted incorrectly during this, then the below call to verifyCorruptionContext() will
 				 * not find the expected corruption context, because the cache was deleted.
-				 * 
-				 * It should also be noted that opening the cache with J9SHR_RUNTIMEFLAG_ENABLE_STATS from this test 
+				 *
+				 * It should also be noted that opening the cache with J9SHR_RUNTIMEFLAG_ENABLE_STATS from this test
 				 * will not set the cache header as corrupt.
 				 */
 
-				/* Set the flag to open the cache for stats so that cache is not recreated if corruption is detected during startup. 
+				/* Set the flag to open the cache for stats so that cache is not recreated if corruption is detected during startup.
 				 * This will ensure corruption context is preserved.
 				 * Opening the cache for stats does not detect CACHE_SEMAPHORE_MISMATCH_TYPE corruption.
 				 */
 				if (CACHE_SEMAPHORE_MISMATCH_TYPE != corruptionType) {
 #if defined(J9SHR_CACHELET_SUPPORT)
 					if ((WALK_ROMCLASS_CORRUPT_CASE1_TYPE == corruptionType) || (WALK_ROMCLASS_CORRUPT_CASE2_TYPE == corruptionType)) {
-						/* For realtime cache, cachelets are not started during startup. 
+						/* For realtime cache, cachelets are not started during startup.
 						 * As a result sanityWalkROMClassSegment() is not called during startup.
 						 * To startup a cachelet and perform sanity walk, we try to find a previously added dummy class
 						 * which should result in detecting cache as corrupt in sanityWalkROMClassSegment().

--- a/runtime/vm/jvminitcommon.c
+++ b/runtime/vm/jvminitcommon.c
@@ -24,34 +24,34 @@
 #include "ut_j9vm.h"
 
 /**
- *  Walks the J9VMDllLoadInfo table looking for the entry for a specific library name. 
- *  
- *  @param aPool the pool holding the DLL info
- *  @param dllName the name of the dll we are looking for
- *  @returns J9VMDllLoadInfo for the dll requested or NULL if not found
+ * Walks the J9VMDllLoadInfo table looking for the entry for a specific library name.
+ *
+ * @param aPool the pool holding the DLL info
+ * @param dllName the name of the dll we are looking for
+ * @returns J9VMDllLoadInfo for the dll requested or NULL if not found
  */
-J9VMDllLoadInfo *findDllLoadInfo(J9Pool* aPool, const char* dllName) {
-	J9VMDllLoadInfo *anElement;
+J9VMDllLoadInfo *
+findDllLoadInfo(J9Pool *aPool, const char *dllName)
+{
+	J9VMDllLoadInfo *anElement = NULL;
 	pool_state aState;
-	char key[SMALL_STRING_BUF_SIZE];			/* Plenty big enough. Needs to be at least DLLNAME_LEN + 4. */
 
-	strncpy(key, dllName, SMALL_STRING_BUF_SIZE);
-
-	anElement = (J9VMDllLoadInfo*)pool_startDo(aPool, &aState);
-	while (anElement && (strcmp(anElement->dllName, key)!=0)) {
-		anElement = (J9VMDllLoadInfo*)pool_nextDo(&aState);
+	anElement = (J9VMDllLoadInfo *)pool_startDo(aPool, &aState);
+	while ((NULL != anElement) && (0 != strcmp(anElement->dllName, dllName))) {
+		anElement = (J9VMDllLoadInfo *)pool_nextDo(&aState);
 	}
 
 	/* If library not found and name does not end in major/minor version, prepend j9 and append version */
-	if (anElement==NULL && strstr(dllName, J9_DLL_VERSION_STRING)==NULL) {
-		memset(key, 0, SMALL_STRING_BUF_SIZE);
+	if ((NULL == anElement) && (NULL == strstr(dllName, J9_DLL_VERSION_STRING))) {
+		char key[SMALL_STRING_BUF_SIZE]; /* Plenty big enough. Needs to be at least DLLNAME_LEN + 4. */
+
 		strcpy(key, "j9");
 		safeCat(key, dllName, SMALL_STRING_BUF_SIZE);
 		safeCat(key, J9_DLL_VERSION_STRING, SMALL_STRING_BUF_SIZE);
 
-		anElement = (J9VMDllLoadInfo*)pool_startDo(aPool, &aState);
-		while (anElement && (strcmp(anElement->dllName, key)!=0)) {
-			anElement = (J9VMDllLoadInfo*)pool_nextDo(&aState);
+		anElement = (J9VMDllLoadInfo *)pool_startDo(aPool, &aState);
+		while ((NULL != anElement) && (0 != strcmp(anElement->dllName, key))) {
+			anElement = (J9VMDllLoadInfo *)pool_nextDo(&aState);
 		}
 	}
 
@@ -60,28 +60,33 @@ J9VMDllLoadInfo *findDllLoadInfo(J9Pool* aPool, const char* dllName) {
 
 /**
  * Frees the dll load table
- * 
- * @param table the dll table to free 
+ *
+ * @param table the dll table to free
  */
-void freeDllLoadTable(J9Pool* table) {
-	if (table)
+void
+freeDllLoadTable(J9Pool *table)
+{
+	if (NULL != table) {
 		pool_kill(table);
+	}
 }
 
 /**
- *  Used as safe strcat 
- *  
- *  @param buffer holding existing string we should cat to
- *  @param text string to be added to existing string
- *  @param length length of the buffer
+ * Used as safe strcat
+ *
+ * @param buffer holding existing string we should cat to
+ * @param text string to be added to existing string
+ * @param length length of the buffer
  */
-IDATA safeCat(char* buffer, const char* text, IDATA length) {
+IDATA
+safeCat(char *buffer, const char *text, IDATA length)
+{
 	IDATA currentLength = strlen(buffer);
 	IDATA textLength = strlen(text);
 	IDATA availableChars = length - currentLength - 1;
 	if (availableChars > 0) {
 		strncat(buffer, text, availableChars);
-		buffer[length-1] = '\0';
+		buffer[length - 1] = '\0';
 	}
 	if (textLength > availableChars) {
 		return (textLength - availableChars);
@@ -90,33 +95,34 @@ IDATA safeCat(char* buffer, const char* text, IDATA length) {
 }
 
 /**
- *  Creates a J9VMDllLoadInfo as an element of the pool. 
- *   
- *  @param portLibrary port library that can be used in the function
- *  @param aPool the pool into which the load info for the dll should be added.  Pool must zero the elements.
- *  @param name Name of the DLL
- *  @param flags flags to be associated with the dll
- *  @param methodPointer to be associated with the library. Should be NULL unless the NOT_A_LIBRARY flag is set
- *  @param verboseFlags the verbose flags to be used for tracing
- *  
- *  @returns J9VMDllLoadInfo for the dll specified or NULL on failure
+ * Creates a J9VMDllLoadInfo as an element of the pool.
+ *
+ * @param portLibrary port library that can be used in the function
+ * @param aPool the pool into which the load info for the dll should be added. Pool must zero the elements.
+ * @param name Name of the DLL
+ * @param flags flags to be associated with the dll
+ * @param methodPointer to be associated with the library. Should be NULL unless the NOT_A_LIBRARY flag is set
+ * @param verboseFlags the verbose flags to be used for tracing
+ *
+ * @returns J9VMDllLoadInfo for the dll specified or NULL on failure
  */
-J9VMDllLoadInfo *createLoadInfo(J9PortLibrary* portLibrary, J9Pool* aPool, char* name, U_32 flags, void* methodPointer, UDATA verboseFlags) {
-	J9VMDllLoadInfo* returnVal = NULL;
+J9VMDllLoadInfo *
+createLoadInfo(J9PortLibrary *portLibrary, J9Pool *aPool, char *name, U_32 flags, void *methodPointer, UDATA verboseFlags)
+{
 	PORT_ACCESS_FROM_PORT(portLibrary);
 
 	/* Pool must return zero'd elements */
-	returnVal = (J9VMDllLoadInfo*) pool_newElement(aPool);
+	J9VMDllLoadInfo *returnVal = (J9VMDllLoadInfo *)pool_newElement(aPool);
 
-	if (!returnVal) {
+	if (NULL == returnVal) {
 		return NULL;
 	}
 	Assert_VM_notNull(name);
 	JVMINIT_VERBOSE_INIT_TRACE1(verboseFlags, "Creating table entry for %s\n", name);
 	returnVal->loadFlags = flags;
-	strncpy(returnVal->dllName, name, (DLLNAME_LEN - 1));
-	returnVal->dllName[(DLLNAME_LEN - 1)] = '\0';	/* Ensure last char is null as strncpy won't guarantee it */
-	returnVal->j9vmdllmain = (flags & (NOT_A_LIBRARY | BUNDLED_COMP)) ? (IDATA  (*)(struct J9JavaVM*, IDATA, void*))methodPointer : NULL;
+	strncpy(returnVal->dllName, name, DLLNAME_LEN - 1);
+	returnVal->dllName[DLLNAME_LEN - 1] = '\0'; /* Ensure last char is null as strncpy won't guarantee it */
+	returnVal->j9vmdllmain = (flags & (NOT_A_LIBRARY | BUNDLED_COMP)) ? (IDATA (*)(struct J9JavaVM *, IDATA, void *))methodPointer : NULL;
 	return returnVal;
 }
 
@@ -125,19 +131,19 @@ J9VMDllLoadInfo *createLoadInfo(J9PortLibrary* portLibrary, J9Pool* aPool, char*
  * @param jniVersion the version to be checked
  * @returns true if the version is valid
  */
-UDATA 
+UDATA
 jniVersionIsValid(UDATA jniVersion)
 {
-	return (jniVersion == JNI_VERSION_1_1) 
-		   || (jniVersion == JNI_VERSION_1_2) 
-		   || (jniVersion == JNI_VERSION_1_4) 
-		   || (jniVersion == JNI_VERSION_1_6) 
-		   || (jniVersion == JNI_VERSION_1_8)
+	return (jniVersion == JNI_VERSION_1_1)
+		|| (jniVersion == JNI_VERSION_1_2)
+		|| (jniVersion == JNI_VERSION_1_4)
+		|| (jniVersion == JNI_VERSION_1_6)
+		|| (jniVersion == JNI_VERSION_1_8)
 #if JAVA_SPEC_VERSION >= 9
-		   || (jniVersion == JNI_VERSION_9)
+		|| (jniVersion == JNI_VERSION_9)
 #endif /* JAVA_SPEC_VERSION >= 9 */
 #if JAVA_SPEC_VERSION >= 10
-		   || (jniVersion == JNI_VERSION_10)
+		|| (jniVersion == JNI_VERSION_10)
 #endif /* JAVA_SPEC_VERSION >= 10 */
-		   ;
+		;
 }


### PR DESCRIPTION
#### Ensure string is NUL-terminated in findDllLoadInfo()

strncpy() does not add a NUL-terminator if not part of the specified
segment of the source; use safeCat() instead.

Don't make a copy of the given dllName in the first pass.

#### Fix creation of UTF8 key in SH_CacheMap::getPrereqCache()

Using strncpy() here is inappropriate because the destination should
not be NUL-terminated: use memcpy() instead.

#### Fix cacheName calculation in SH_OSCache::commonStartup()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src));
which will never copy the NUL-termination from src.
This uses the following instead:
  memcpy(dst, src, strlen(src) + 1);

#### Fix eyecatcher initialization in SH_OSCachemmap::createCacheHeader()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src));
which will never copy the NUL-termination from src.
We can use the following instead
  memcpy(dst, src, strlen(src));
because the destination is in a block that has already been cleared.

#### Fix eyecatcher initialization in SH_OSCachesysv::initializeHeader()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src));
which will never copy the NUL-termination from src.
We can use the following instead
  memcpy(dst, src, strlen(src));
because the destination is in a block that has already been cleared.

#### Fix data initialization in AttachedDataTest::CorruptAttachedData()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src));
which will never copy the NUL-termination from src.
We can use the following instead
  memcpy(dst, src, strlen(src) + 1);
because the destination is in a block that has already been cleared.

Remove 'true ==' from boolean tests, for example,
  if (true == readOnly) ...
becomes
  if (readOnly) ...

  #### Fix eyecatcher initialization in CorruptCacheTest::corruptCache()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src));
which will never copy the NUL-termination from src.
We can use the following instead:
  memcpy(dst, src, strlen(src));

Remove 'true ==' from boolean tests, for example,
  if (true == readOnly) ...
becomes
  if (readOnly) ...

#### Fix _memorySpaceString in initialize()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, sizeof(dst));
which may leave the destination without a NUL-terminator.
This explicitly checks the length of the string and ensures
the destination is NUL-terminated.

#### Fix argument handling in dbgTrPrint()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, len);
where len <= strlen(src) which will leave the destination without a
NUL-terminator. Because we explicitly add the NUL-terminator, we can
use memcpy() instead of strncpy().

#### Avoid buffer overflow in expandString()

The test in the old code (formatCursor >= MAX_IMAGE_PATH_LENGTH - 1)
only ensured there was room for one more character (plus the
NUL-terminator) in any iteration of the loop and thus the expansion
of '%p', '%d' or '%t' might not fit.

#### Fix string handling in setTrigger()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src));
which does not copy the NUL-terminator. Because we don't need the
NUL-terminator, we can use memcpy() instead of strncpy().

#### Fix string handling in processTriggerGroupClause()

A warning was issued by gcc 9 about the pattern
  strncpy(dst, src, strlen(src) + 1);
which looks like it might overflow dst; we know otherwise here and can
use memcpy() instead of strncpy().

#### Avoid buffer overflows forming pathnames in runtime/cfdumper/main.c

#### Ensure buffer receiving eventString is properly NUL-terminated runtime/rasdump/dmpmap.c

Add assert tracepoint.

#### Ensure strings are NUL-terminated in runtime/rasdump/trigger.c

matchesObjectAllocationFilter()
matchesSlowExclusiveEnterFilter()