### PR TITLE
Enable NextGenHCR during startup

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8167,8 +8167,21 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                      //   options->setTrivialInlinerMaxSize(40);
                      }
 
-                  // Disable NextGenHCR during Startup Phase
-                  if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP)
+                  // Disable NextGenHCR during Startup Phase, if any of the
+                  // following is true:
+                  //
+                  // - TR_DisableNextGenHCRDuringStartup has been specified, or
+                  // - this is a DLT compile, or
+                  // - optLevel is warm or lower, unless
+                  //   TR_EnableStartupNextGenHCRAtAllOpts has been specified
+                  //
+                  static char *disableNextGenHCRDuringStartup = feGetEnv("TR_DisableNextGenHCRDuringStartup");
+                  static char *enableStartupNextGenHCRAtAllOpts = feGetEnv("TR_EnableStartupNextGenHCRAtAllOpts");
+                  if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP
+                      && (disableNextGenHCRDuringStartup
+                          || that->_methodBeingCompiled->isDLTCompile()
+                          || options->getOptLevel() <= warm
+                             && !enableStartupNextGenHCRAtAllOpts))
                      {
                      options->setOption(TR_DisableNextGenHCR);
                      }


### PR DESCRIPTION
Methods that reach hot or higher optimization levels during start-up phase currently have NextGenCHR optimization disabled.  This reduces the potential performance improvements for such methods, even though the additional overhead for that optimization at start-up is not significant.

This change enables that optimization during start-up at optimization levels above warm, with support for an environment variable that will turn off the optimization during start-up, and another that will enable the optimization during start-up at lower optimization levels, for
experimental purposes.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>