### PR TITLE
Command Line DDR tests for ValueTypes

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/DDRValueTypeTest.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/DDRValueTypeTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.lworld;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Array;
+
+public class DDRValueTypeTest {
+    public static void main(String[] args) {
+        try {
+            createAndCheckValueType();
+        } catch (Throwable e) {
+            System.out.println("Exception caught!");
+            e.printStackTrace();
+        }
+    }
+
+    private static void createAndCheckValueType() throws Throwable {
+        // Setup required classes
+        ValueTypeTests.testCreateValueInt();
+        ValueTypeTests.testCreateValueFloat();
+        ValueTypeTests.testCreatePoint2D();
+        ValueTypeTests.testCreateFlattenedLine2D();
+        ValueTypeTests.testCreateTriangle2D();
+        
+        // Create value types and check object
+        Class assortedValueWithSingleAlignmentClass = ValueTypeGenerator.generateValueClass("AssortedValueWithSingleAlignment", ValueTypeTests.typeWithSingleAlignmentFields);
+
+        MethodHandle makeAssortedValueWithSingleAlignment = MethodHandles.lookup().findStatic(assortedValueWithSingleAlignmentClass,
+            "makeValueGeneric", MethodType.methodType(assortedValueWithSingleAlignmentClass, Object.class,
+                        Object.class, Object.class, Object.class, Object.class, Object.class));
+
+        Object[] altFields = {
+            ValueTypeTests.defaultTrianglePositionsNew, 
+            ValueTypeTests.defaultPointPositions2, 
+            ValueTypeTests.defaultLinePositions2, 
+            ValueTypeTests.defaultIntNew, 
+            ValueTypeTests.defaultFloatNew, 
+            ValueTypeTests.defaultTrianglePositionsNew
+        };
+        Object assortedValueWithSingleAlignment = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields);
+        Object assortedValueWithSingleAlignmentAlt = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields, altFields);
+    
+        Object valArray = Array.newInstance(assortedValueWithSingleAlignmentClass, 2);
+        Array.set(valArray, 0, assortedValueWithSingleAlignment);
+        Array.set(valArray, 1, assortedValueWithSingleAlignmentAlt);
+
+        ValueTypeTests.checkObject(assortedValueWithSingleAlignment, assortedValueWithSingleAlignmentAlt, valArray);
+    }
+}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1720,37 +1720,41 @@ public class ValueTypeTests {
 	}
 
 	static Object createAssorted(MethodHandle makeMethod, String[] fields) throws Throwable {
+		return createAssorted(makeMethod, fields, null);
+	}
+	static Object createAssorted(MethodHandle makeMethod, String[] fields, Object[] initFields) throws Throwable {
 		Object[] args = new Object[fields.length];
+		boolean useInitFields = initFields != null;
 		for (int i = 0; i < fields.length; i++) {
 			String nameAndSigValue[] = fields[i].split(":");
 			String signature = nameAndSigValue[1];
 			switch (signature) {
 			case "QPoint2D;":
-				args[i] = createPoint2D(defaultPointPositions1);
+				args[i] = createPoint2D(useInitFields ? (int[])initFields[i] : defaultPointPositions1);
 				break;
 			case "QFlattenedLine2D;":
-				args[i] = createFlattenedLine2D(defaultLinePositions1);
+				args[i] = createFlattenedLine2D(useInitFields ? (int[][])initFields[i] : defaultLinePositions1);
 				break;
 			case "QTriangle2D;":
-				args[i] = createTriangle2D(defaultTrianglePositions);
+				args[i] = createTriangle2D(useInitFields ? (int[][][])initFields[i] : defaultTrianglePositions);
 				break;
 			case "QValueInt;":
-				args[i] = makeValueInt.invoke(defaultInt);
+				args[i] = makeValueInt.invoke(useInitFields ? (int)initFields[i] : defaultInt);
 				break;
 			case "QValueFloat;":
-				args[i] = makeValueFloat.invoke(defaultFloat);
+				args[i] = makeValueFloat.invoke(useInitFields ? (float)initFields[i] : defaultFloat);
 				break;
 			case "QValueDouble;":
-				args[i] = makeValueDouble.invoke(defaultDouble);
+				args[i] = makeValueDouble.invoke(useInitFields ? (double)initFields[i] : defaultDouble);
 				break;
 			case "QValueObject;":
-				args[i] = makeValueObject.invoke(defaultObject);
+				args[i] = makeValueObject.invoke(useInitFields ? (Object)initFields[i] : defaultObject);
 				break;
 			case "QValueLong;":
-				args[i] = makeValueLong.invoke(defaultLong);
+				args[i] = makeValueLong.invoke(useInitFields ? (long)initFields[i] : defaultLong);
 				break;
 			case "QLargeObject;":
-				args[i] = createLargeObject(defaultObject);
+				args[i] = createLargeObject(useInitFields ? (Object)initFields[i] : defaultObject);
 				break;
 			default:
 				args[i] = null;

--- a/test/functional/cmdLineTests/valuetypeddrtests/build.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/build.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build valuetype ddr tests
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/valuetypeddrtests" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml,*.mk,*.sh"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<if>
+			<equals arg1="${JDK_VERSION}" arg2="Valhalla"/>
+			<then>
+				<antcall target="dist" inheritall="true" />
+			</then>
+		</if>
+	</target>
+</project>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
+	<variable name="ARGS" value="-Xint -XX:+EnableValhalla -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="JARS" value="-cp $ASMJAR$:$JCOMMANDERJAR$:$TESTNGJAR$:$VALUETYPEJAR$" />
+	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
+	<variable name="DUMPFILE" value="j9core.dmp" />
+
+	<test id="Create core file">
+		<exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+		<exec command="rm -f $DUMPFILE$" />
+		<exec command="rm -f core*" />
+		<command showMatch="yes">$EXE$ $ARGS$ $JARS$ $PROGRAM$</command>
+		<output regex="no" type="success" showMatch="yes">System dump written</output>
+		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
+		<output regex="no" type="failure">Exception caught!</output>
+	</test>
+
+ 	<test id="Run !threads">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!threads</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!stack 0x</output>
+		<saveoutput regex="no" type="required" saveName="mainThreadId" splitIndex="1" splitBy="!stack ">!stack 0x</saveoutput>
+		<output regex="no" type="failure">DDR is not enabled for this core file</output>
+ 	</test>
+
+	<test id="Run !stackslots $mainThreadId$">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!stackslots $mainThreadId$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $objectAddr$ to display container array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $objectAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr$ to show the fields of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">tri (offset = 0) (Triangle2D)</output>
+		<output regex="no" type="success" showMatch="yes">line (offset = 56) (FlattenedLine2D)</output>
+		<output regex="no" type="success" showMatch="yes">i (offset = 72) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr$ i to show the int contents of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr$ i</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x7FFFFFFF (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayAddr$ to display flattened array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="arrayIndex1Addr" splitIndex="1" splitBy="!j9object " showMatch="yes">[0] = !j9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayIndex2Addr" splitIndex="1" splitBy="!j9object " showMatch="yes">[1] = !j9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayIndex1Addr$.i to show value of the variable i">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayIndex1Addr$.i</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x7FFFFFFF (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayIndex2Addr$.i to show the value of the variable i">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayIndex2Addr$.i</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0xB670C61E (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $arrayIndex1Addr$ to recursively show the contents of the object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $arrayIndex1Addr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x7FFFFFFF</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $arrayIndex2Addr$ to recursively show the contents of the object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $arrayIndex2Addr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0xB670C61E</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_flattenedvaluetypeddrtests</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>
+			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -XX:+EnableValhalla -Xverify:none \
+			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+			-DRESJAR=$(CMDLINETESTER_RESJAR) \
+			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+			-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+			-DASMJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)asm-all.jar$(Q) \
+			-DJCOMMANDERJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)jcommander.jar$(Q) \
+			-DTESTNGJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)testng.jar$(Q) \
+			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
+			-jar $(CMDLINETESTER_JAR) \
+			-config $(Q)$(TEST_RESROOT)$(D)flattenedvaluetypeddrtests.xml$(Q) \
+			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
+			${TEST_STATUS}
+		</command>
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<platformRequirements>^os.zos</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>Valhalla</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_unflattenedvaluetypeddrtests</testCaseName>
+		<variations>
+			<variation>-XX:ValueTypeFlatteningThreshold=1</variation>
+		</variations>
+		<command>
+			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+			$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -XX:+EnableValhalla -Xverify:none \
+			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+			-DRESJAR=$(CMDLINETESTER_RESJAR) \
+			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+			-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+			-DASMJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)asm-all.jar$(Q) \
+			-DJCOMMANDERJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)jcommander.jar$(Q) \
+			-DTESTNGJAR=$(Q)$(JVM_TEST_ROOT)$(D)TKG$(D)lib$(D)testng.jar$(Q) \
+			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
+			-jar $(CMDLINETESTER_JAR) \
+			-config $(Q)$(TEST_RESROOT)$(D)unflattenedvaluetypeddrtests.xml$(Q) \
+			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
+			${TEST_STATUS}
+		</command>
+		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<platformRequirements>^os.zos</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>Valhalla</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Value Type ddr test with flattening disabled" timeout="600">
+	<variable name="ARGS" value="-Xint -XX:+EnableValhalla -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="JARS" value="-cp $ASMJAR$:$JCOMMANDERJAR$:$TESTNGJAR$:$VALUETYPEJAR$" />
+	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
+	<variable name="DUMPFILE" value="j9core.dmp" />
+
+	<test id="Create core file">
+		<exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+		<exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+		<exec command="rm -f $DUMPFILE$" />
+		<exec command="rm -f core*" />
+		<command showMatch="yes">$EXE$ $ARGS$ $JARS$ $PROGRAM$</command>
+		<output regex="no" type="success" showMatch="yes">System dump written</output>
+		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
+		<output regex="no" type="failure">Exception caught!</output>
+	</test>
+
+ 	<test id="Run !threads">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!threads</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!stack 0x</output>
+		<saveoutput regex="no" type="required" saveName="mainThreadId" splitIndex="1" splitBy="!stack ">!stack 0x</saveoutput>
+		<output regex="no" type="failure">DDR is not enabled for this core file</output>
+ 	</test>
+
+	<test id="Run !stackslots $mainThreadId$">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!stackslots $mainThreadId$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I-Slot: a0[0x</output>
+		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $objectAddr$ to display container array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $objectAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!J9IndexableObject 0x</output>
+		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="valueAddr2" splitIndex="1" splitBy="= !j9object " showMatch="yes">[1] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr1$ to show the contents of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">QValueInt; i = !fj9object 0x</output>
+		<saveoutput regex="no" type="required" saveName="intAddr1" splitIndex="4" splitBy=" " showMatch="yes">QValueInt; i = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !fj9object $intAddr1$ to show the int contents of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!fj9object $intAddr1$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0x7FFFFFFF (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $valueAddr2$ to show the contents of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $valueAddr2$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">QValueInt; i = !fj9object 0x</output>
+		<saveoutput regex="no" type="required" saveName="intAddr2" splitIndex="4" splitBy=" " showMatch="yes">QValueInt; i = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !fj9object $intAddr2$ to show the int contents of the reference object">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!fj9object $intAddr2$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">I i = 0xB670C61E (offset = 0) (ValueInt)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $arrayAddr$ to display array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $arrayAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">!j9object $valueAddr1$</output>
+		<output regex="no" type="success" showMatch="yes">!j9object $valueAddr2$</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $arrayAddr$ to display array contents">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $arrayAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">QTriangle2D; tri = !fj9object</output>
+		<output regex="no" type="success" showMatch="yes">QValueInt; i = !fj9object</output>
+		<output regex="no" type="success" showMatch="yes">QTriangle2D; tri2 = !fj9object</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+</suite>


### PR DESCRIPTION
This commits adds tests coverage for ddr commands that can be used to inspect valuetypes with flattening both enabled and disabled.

Signed-off-by: Adithya Venkatarao <adi_101@live.com>