### PR TITLE
Limit CacheManagement compile job to JDK_IMPL=openj9 | IBM

### DIFF
--- a/test/functional/CacheManagement/build.xml
+++ b/test/functional/CacheManagement/build.xml
@@ -84,7 +84,15 @@
        <delete dir="${build}"/>
     </target>
 	
-    <target name="build">
-		<antcall target="clean" inheritall="true" />	
-    </target>
+	<target name="build" >
+		<if>
+			<or>
+				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
+				<equals arg1="${JDK_IMPL}" arg2="openj9" />
+			</or>
+			<then>
+				<antcall target="clean" inheritall="true" />
+			</then>
+		</if>
+	</target>
 </project>


### PR DESCRIPTION
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>