### PR TITLE
CMake: specify RUNTIME DESTINATION when installing shared libraries

### DIFF
--- a/runtime/tests/gp/CMakeLists.txt
+++ b/runtime/tests/gp/CMakeLists.txt
@@ -48,4 +48,5 @@ omr_add_exports(gptest
 install(
 	TARGETS gptest
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}
+	RUNTIME DESTINATION ${j9vm_SOURCE_DIR}
 )

--- a/runtime/tests/jniarg/CMakeLists.txt
+++ b/runtime/tests/jniarg/CMakeLists.txt
@@ -44,4 +44,5 @@ include("exports.cmake")
 install(
 	TARGETS jniargtests
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}
+	RUNTIME DESTINATION ${j9vm_SOURCE_DIR}
 )


### PR DESCRIPTION
This is required on windows

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>