### PR TITLE
Remove initalize from ObjectScanner

### DIFF
--- a/runtime/gc_glue_java/HeadlessMixedObjectScanner.hpp
+++ b/runtime/gc_glue_java/HeadlessMixedObjectScanner.hpp
@@ -46,6 +46,9 @@ public:
 private:
 
 protected:
+
+public:
+
 	/**
 	 * @param env The scanning thread environment
 	 * @param[in] objectPtr the object to be processed
@@ -61,16 +64,7 @@ protected:
 #endif /* J9VM_GC_LEAF_BITS */
 	{
 		_typeId = __FUNCTION__;
-	}
 
-	/**
-	 * Subclasses must call this method to set up the instance description bits and description pointer.
-	 * @param[in] env The scanning thread environment
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
-	{
-		GC_ObjectScanner::initialize(env);
 
 		if (J9_IS_J9CLASS_FLATTENED(clazzPtr)) {
 			fprintf(stderr, "!!! Found flattened class\n");
@@ -101,7 +95,6 @@ protected:
 		}
 	}
 
-public:
 	/**
 	 * In-place instantiation and initialization for mixed object scanner.
 	 * @param[in] env The scanning thread environment
@@ -113,10 +106,7 @@ public:
 	MMINLINE static GC_HeadlessMixedObjectScanner *
 	newInstance(MM_EnvironmentBase *env, J9Class* clazzPtr, fomrobject_t* scanPtr, void *allocSpace, uintptr_t flags)
 	{
-		GC_HeadlessMixedObjectScanner *objectScanner = (GC_HeadlessMixedObjectScanner *)allocSpace;
-		new(objectScanner) GC_HeadlessMixedObjectScanner(env, clazzPtr, scanPtr, flags);
-		objectScanner->initialize(env, clazzPtr);
-		return objectScanner;
+		return new(allocSpace) GC_HeadlessMixedObjectScanner(env, clazzPtr, scanPtr, flags);
 	}
 	
 	MMINLINE uintptr_t getBytesRemaining() { return sizeof(fomrobject_t) * (_endPtr - _scanPtr); }

--- a/runtime/gc_glue_java/HeadlessMixedObjectScanner.hpp
+++ b/runtime/gc_glue_java/HeadlessMixedObjectScanner.hpp
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(HEADLESSMIXEDOBJECTSCANNER_HPP_)
+#define HEADLESSMIXEDOBJECTSCANNER_HPP_
+
+#include "j9.h"
+
+#include "ObjectScanner.hpp"
+
+class GC_HeadlessMixedObjectScanner : public GC_ObjectScanner
+{
+	/* Data Members */
+private:
+	fomrobject_t * const _endPtr;	/**< end scan pointer */
+	fomrobject_t *_mapPtr;			/**< pointer to first slot in current scan segment */
+	uintptr_t *_descriptionPtr;		/**< current description pointer */
+#if defined(J9VM_GC_LEAF_BITS)
+	uintptr_t *_leafPtr;			/**< current leaf description pointer */
+#endif /* J9VM_GC_LEAF_BITS */
+
+protected:
+
+public:
+
+	/* Member Functions */
+private:
+
+protected:
+	/**
+	 * @param env The scanning thread environment
+	 * @param[in] objectPtr the object to be processed
+	 * @param[in] flags Scanning context flags
+	 */
+	MMINLINE GC_HeadlessMixedObjectScanner(MM_EnvironmentBase *env, J9Class *clazzPtr, fomrobject_t *scanPtr, uintptr_t flags)
+		: GC_ObjectScanner(env, scanPtr, 0, flags)
+		, _endPtr((fomrobject_t *)((uint8_t*)_scanPtr + env->getExtensions()->mixedObjectModel.getSizeInBytesWithoutHeader(clazzPtr)))
+		, _mapPtr(_scanPtr)
+		, _descriptionPtr(NULL)
+#if defined(J9VM_GC_LEAF_BITS)
+		, _leafPtr(NULL)
+#endif /* J9VM_GC_LEAF_BITS */
+	{
+		_typeId = __FUNCTION__;
+	}
+
+	/**
+	 * Subclasses must call this method to set up the instance description bits and description pointer.
+	 * @param[in] env The scanning thread environment
+	 */
+	MMINLINE void
+	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
+	{
+		GC_ObjectScanner::initialize(env);
+
+		if (J9_IS_J9CLASS_FLATTENED(clazzPtr)) {
+			fprintf(stderr, "!!! Found flattened class\n");
+		}
+
+		/* Initialize the slot map from description bits */
+		_scanMap = (uintptr_t)clazzPtr->instanceDescription;
+#if defined(J9VM_GC_LEAF_BITS)
+		_leafMap = (uintptr_t)clazzPtr->instanceLeafDescription;
+#endif /* J9VM_GC_LEAF_BITS */
+		if (_scanMap & 1) {
+			_scanMap >>= 1;
+			_descriptionPtr = NULL;
+#if defined(J9VM_GC_LEAF_BITS)
+			_leafMap >>= 1;
+			_leafPtr = NULL;
+#endif /* J9VM_GC_LEAF_BITS */
+			setNoMoreSlots();
+		} else {
+			_descriptionPtr = (uintptr_t *)_scanMap;
+			_scanMap = *_descriptionPtr;
+			_descriptionPtr += 1;
+#if defined(J9VM_GC_LEAF_BITS)
+			_leafPtr = (uintptr_t *)_leafMap;
+			_leafMap = *_leafPtr;
+			_leafPtr += 1;
+#endif /* J9VM_GC_LEAF_BITS */
+		}
+	}
+
+public:
+	/**
+	 * In-place instantiation and initialization for mixed object scanner.
+	 * @param[in] env The scanning thread environment
+	 * @param[in] objectPtr The object to scan
+	 * @param[in] allocSpace Pointer to space for in-place instantiation (at least sizeof(GC_MixedObjectScanner) bytes)
+	 * @param[in] flags Scanning context flags
+	 * @return Pointer to GC_MixedObjectScanner instance in allocSpace
+	 */
+	MMINLINE static GC_HeadlessMixedObjectScanner *
+	newInstance(MM_EnvironmentBase *env, J9Class* clazzPtr, fomrobject_t* scanPtr, void *allocSpace, uintptr_t flags)
+	{
+		GC_HeadlessMixedObjectScanner *objectScanner = (GC_HeadlessMixedObjectScanner *)allocSpace;
+		new(objectScanner) GC_HeadlessMixedObjectScanner(env, clazzPtr, scanPtr, flags);
+		objectScanner->initialize(env, clazzPtr);
+		return objectScanner;
+	}
+	
+	MMINLINE uintptr_t getBytesRemaining() { return sizeof(fomrobject_t) * (_endPtr - _scanPtr); }
+
+	/**
+	 * Return base pointer and slot bit map for next block of contiguous slots to be scanned. The
+	 * base pointer must be fomrobject_t-aligned. Bits in the bit map are scanned in order of
+	 * increasing significance, and the least significant bit maps to the slot at the returned
+	 * base pointer.
+	 *
+	 * @param[out] scanMap the bit map for the slots contiguous with the returned base pointer
+	 * @param[out] hasNextSlotMap set this to true if this method should be called again, false if this map is known to be last
+	 * @return a pointer to the first slot mapped by the least significant bit of the map, or NULL if no more slots
+	 */
+	virtual fomrobject_t *
+	getNextSlotMap(uintptr_t *slotMap, bool *hasNextSlotMap)
+	{
+		fomrobject_t *result = NULL;
+		*slotMap = 0;
+		*hasNextSlotMap = false;
+		_mapPtr += _bitsPerScanMap;
+		while (_endPtr > _mapPtr) {
+			*slotMap = *_descriptionPtr;
+			_descriptionPtr += 1;
+			if (0 != *slotMap) {
+				*hasNextSlotMap = _bitsPerScanMap < (_endPtr - _mapPtr);
+				result = _mapPtr;
+				break;
+			}
+			_mapPtr += _bitsPerScanMap;
+		}
+		return result;
+	}
+
+#if defined(J9VM_GC_LEAF_BITS)
+	/**
+	 * Return base pointer and slot bit map for next block of contiguous slots to be scanned. The
+	 * base pointer must be fomrobject_t-aligned. Bits in the bit map are scanned in order of
+	 * increasing significance, and the least significant bit maps to the slot at the returned
+	 * base pointer.
+	 *
+	 * @param[out] scanMap the bit map for the slots contiguous with the returned base pointer
+	 * @param[out] leafMap the leaf bit map for the slots contiguous with the returned base pointer
+	 * @param[out] hasNextSlotMap set this to true if this method should be called again, false if this map is known to be last
+	 * @return a pointer to the first slot mapped by the least significant bit of the map, or NULL if no more slots
+	 */
+	virtual fomrobject_t *
+	getNextSlotMap(uintptr_t *slotMap, uintptr_t *leafMap, bool *hasNextSlotMap)
+	{
+		fomrobject_t *result = NULL;
+		*slotMap = 0;
+		*leafMap = 0;
+		*hasNextSlotMap = false;
+		_mapPtr += _bitsPerScanMap;
+		while (_endPtr > _mapPtr) {
+			*slotMap = *_descriptionPtr;
+			_descriptionPtr += 1;
+			*leafMap = *_leafPtr;
+			_leafPtr += 1;
+			if (0 != *slotMap) {
+				*hasNextSlotMap = _bitsPerScanMap < (_endPtr - _mapPtr);
+				result = _mapPtr;
+				break;
+			}
+			_mapPtr += _bitsPerScanMap;
+		}
+		return result;
+	}
+#endif /* J9VM_GC_LEAF_BITS */
+};
+
+#endif /* HEADLESSMIXEDOBJECTSCANNER_HPP_ */

--- a/runtime/gc_glue_java/MixedObjectScanner.hpp
+++ b/runtime/gc_glue_java/MixedObjectScanner.hpp
@@ -57,16 +57,6 @@ protected:
 		_typeId = __FUNCTION__;
 	}
 
-	/**
-	 * Subclasses must call this method to set up the instance description bits and description pointer.
-	 * @param[in] env The scanning thread environment
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
-	{
-		GC_HeadlessMixedObjectScanner::initialize(env, clazzPtr);
-	}
-
 public:
 	/**
 	 * In-place instantiation and initialization for mixed object scanner.
@@ -79,10 +69,7 @@ public:
 	MMINLINE static GC_MixedObjectScanner *
 	newInstance(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, void *allocSpace, uintptr_t flags)
 	{
-		GC_MixedObjectScanner *objectScanner = (GC_MixedObjectScanner *)allocSpace;
-		new(objectScanner) GC_MixedObjectScanner(env, objectPtr, flags);
-		objectScanner->initialize(env, J9GC_J9OBJECT_CLAZZ(objectPtr, env));
-		return objectScanner;
+		return new(allocSpace) GC_MixedObjectScanner(env, objectPtr, flags);
 	}
 };
 #endif /* MIXEDOBJECTSCANNER_HPP_ */

--- a/runtime/gc_glue_java/MixedObjectScanner.hpp
+++ b/runtime/gc_glue_java/MixedObjectScanner.hpp
@@ -34,28 +34,17 @@
 #include "objectdescription.h"
 #include "GCExtensions.hpp"
 #include "ObjectScanner.hpp"
+#include "HeadlessMixedObjectScanner.hpp"
+
+#include <stdio.h>
 
 /**
  * This class is used to iterate over the slots of a Java object.
  */
-class GC_MixedObjectScanner : public GC_ObjectScanner
+class GC_MixedObjectScanner : public GC_HeadlessMixedObjectScanner
 {
-	/* Data Members */
-private:
-	fomrobject_t * const _endPtr;	/**< end scan pointer */
-	fomrobject_t *_mapPtr;			/**< pointer to first slot in current scan segment */
-	uintptr_t *_descriptionPtr;		/**< current description pointer */
-#if defined(J9VM_GC_LEAF_BITS)
-	uintptr_t *_leafPtr;			/**< current leaf description pointer */
-#endif /* J9VM_GC_LEAF_BITS */
-
-protected:
-
-public:
-
 	/* Member Functions */
 private:
-
 protected:
 	/**
 	 * @param env The scanning thread environment
@@ -63,13 +52,7 @@ protected:
 	 * @param[in] flags Scanning context flags
 	 */
 	MMINLINE GC_MixedObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, uintptr_t flags)
-		: GC_ObjectScanner(env, env->getExtensions()->mixedObjectModel.getHeadlessObject(objectPtr), 0, flags)
-		, _endPtr((fomrobject_t *)((uint8_t*)_scanPtr + env->getExtensions()->mixedObjectModel.getSizeInBytesWithoutHeader(objectPtr)))
-		, _mapPtr(_scanPtr)
-		, _descriptionPtr(NULL)
-#if defined(J9VM_GC_LEAF_BITS)
-		, _leafPtr(NULL)
-#endif /* J9VM_GC_LEAF_BITS */
+		: GC_HeadlessMixedObjectScanner(env, J9GC_J9OBJECT_CLAZZ(objectPtr, env), env->getExtensions()->mixedObjectModel.getHeadlessObject(objectPtr), flags)
 	{
 		_typeId = __FUNCTION__;
 	}
@@ -81,31 +64,7 @@ protected:
 	MMINLINE void
 	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
 	{
-		GC_ObjectScanner::initialize(env);
-
-		/* Initialize the slot map from description bits */
-		_scanMap = (uintptr_t)clazzPtr->instanceDescription;
-#if defined(J9VM_GC_LEAF_BITS)
-		_leafMap = (uintptr_t)clazzPtr->instanceLeafDescription;
-#endif /* J9VM_GC_LEAF_BITS */
-		if (_scanMap & 1) {
-			_scanMap >>= 1;
-			_descriptionPtr = NULL;
-#if defined(J9VM_GC_LEAF_BITS)
-			_leafMap >>= 1;
-			_leafPtr = NULL;
-#endif /* J9VM_GC_LEAF_BITS */
-			setNoMoreSlots();
-		} else {
-			_descriptionPtr = (uintptr_t *)_scanMap;
-			_scanMap = *_descriptionPtr;
-			_descriptionPtr += 1;
-#if defined(J9VM_GC_LEAF_BITS)
-			_leafPtr = (uintptr_t *)_leafMap;
-			_leafMap = *_leafPtr;
-			_leafPtr += 1;
-#endif /* J9VM_GC_LEAF_BITS */
-		}
+		GC_HeadlessMixedObjectScanner::initialize(env, clazzPtr);
 	}
 
 public:
@@ -125,73 +84,5 @@ public:
 		objectScanner->initialize(env, J9GC_J9OBJECT_CLAZZ(objectPtr, env));
 		return objectScanner;
 	}
-	
-	MMINLINE uintptr_t getBytesRemaining() { return sizeof(fomrobject_t) * (_endPtr - _scanPtr); }
-
-	/**
-	 * Return base pointer and slot bit map for next block of contiguous slots to be scanned. The
-	 * base pointer must be fomrobject_t-aligned. Bits in the bit map are scanned in order of
-	 * increasing significance, and the least significant bit maps to the slot at the returned
-	 * base pointer.
-	 *
-	 * @param[out] scanMap the bit map for the slots contiguous with the returned base pointer
-	 * @param[out] hasNextSlotMap set this to true if this method should be called again, false if this map is known to be last
-	 * @return a pointer to the first slot mapped by the least significant bit of the map, or NULL if no more slots
-	 */
-	virtual fomrobject_t *
-	getNextSlotMap(uintptr_t *slotMap, bool *hasNextSlotMap)
-	{
-		fomrobject_t *result = NULL;
-		*slotMap = 0;
-		*hasNextSlotMap = false;
-		_mapPtr += _bitsPerScanMap;
-		while (_endPtr > _mapPtr) {
-			*slotMap = *_descriptionPtr;
-			_descriptionPtr += 1;
-			if (0 != *slotMap) {
-				*hasNextSlotMap = _bitsPerScanMap < (_endPtr - _mapPtr);
-				result = _mapPtr;
-				break;
-			}
-			_mapPtr += _bitsPerScanMap;
-		}
-		return result;
-	}
-
-#if defined(J9VM_GC_LEAF_BITS)
-	/**
-	 * Return base pointer and slot bit map for next block of contiguous slots to be scanned. The
-	 * base pointer must be fomrobject_t-aligned. Bits in the bit map are scanned in order of
-	 * increasing significance, and the least significant bit maps to the slot at the returned
-	 * base pointer.
-	 *
-	 * @param[out] scanMap the bit map for the slots contiguous with the returned base pointer
-	 * @param[out] leafMap the leaf bit map for the slots contiguous with the returned base pointer
-	 * @param[out] hasNextSlotMap set this to true if this method should be called again, false if this map is known to be last
-	 * @return a pointer to the first slot mapped by the least significant bit of the map, or NULL if no more slots
-	 */
-	virtual fomrobject_t *
-	getNextSlotMap(uintptr_t *slotMap, uintptr_t *leafMap, bool *hasNextSlotMap)
-	{
-		fomrobject_t *result = NULL;
-		*slotMap = 0;
-		*leafMap = 0;
-		*hasNextSlotMap = false;
-		_mapPtr += _bitsPerScanMap;
-		while (_endPtr > _mapPtr) {
-			*slotMap = *_descriptionPtr;
-			_descriptionPtr += 1;
-			*leafMap = *_leafPtr;
-			_leafPtr += 1;
-			if (0 != *slotMap) {
-				*hasNextSlotMap = _bitsPerScanMap < (_endPtr - _mapPtr);
-				result = _mapPtr;
-				break;
-			}
-			_mapPtr += _bitsPerScanMap;
-		}
-		return result;
-	}
-#endif /* J9VM_GC_LEAF_BITS */
 };
 #endif /* MIXEDOBJECTSCANNER_HPP_ */

--- a/runtime/gc_glue_java/PointerArrayObjectScanner.hpp
+++ b/runtime/gc_glue_java/PointerArrayObjectScanner.hpp
@@ -57,24 +57,33 @@ protected:
 	 * @param[in] endPtr pointer to the array cell where scanning will stop
 	 * @param[in] flags Scanning context flags
 	 */
-	MMINLINE GC_PointerArrayObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t arrayPtr, fomrobject_t *basePtr, fomrobject_t *limitPtr, fomrobject_t *scanPtr, fomrobject_t *endPtr, uintptr_t flags)
-		: GC_IndexableObjectScanner(env, arrayPtr, basePtr, limitPtr, scanPtr, endPtr, ((endPtr - scanPtr) < _bitsPerScanMap) ? (((uintptr_t)1 << (endPtr - scanPtr)) - 1) : UDATA_MAX, sizeof(fomrobject_t), flags)
-		, _mapPtr(_scanPtr)
+	MMINLINE GC_PointerArrayObjectScanner(
+		MM_EnvironmentBase *env
+		, omrobjectptr_t arrayPtr
+		, fomrobject_t *basePtr
+		, fomrobject_t *limitPtr
+		, fomrobject_t *scanPtr
+		, fomrobject_t *endPtr
+		, uintptr_t flags
+	)
+	: GC_IndexableObjectScanner(
+		env
+		, arrayPtr
+		, basePtr
+		, limitPtr
+		, scanPtr
+		, endPtr
+		, ((endPtr - scanPtr) < _bitsPerScanMap) ? (((uintptr_t)1 << (endPtr - scanPtr)) - 1) : UDATA_MAX
+		, sizeof(fomrobject_t)
+		, flags
+	)
+	, _mapPtr(_scanPtr)
 	{
 		_typeId = __FUNCTION__;
 	}
 
-	/**
-	 * Set up the scanner.
-	 * @param[in] env Current environment
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env)
-	{
-		GC_IndexableObjectScanner::initialize(env);
-	}
-
 public:
+
 	/**
 	 * @param[in] env The scanning thread environment
 	 * @param[in] objectPtr pointer to the array to be processed
@@ -104,7 +113,6 @@ public:
 			}
 
 			new(objectScanner) GC_PointerArrayObjectScanner(env, objectPtr, basePtr, limitPtr, scanPtr, endPtr, flags);
-			objectScanner->initialize(env);
 			if (0 != startIndex) {
 				objectScanner->clearHeadObjectScanner();
 			}
@@ -133,13 +141,9 @@ public:
 		}
 
 		Assert_MM_true(NULL != allocSpace);
-		/* If splitAmount is 0 the new scanner will return NULL on the first call to getNextSlot(). */
-		splitScanner = (GC_PointerArrayObjectScanner *)allocSpace;
-		/* Create new scanner for next chunk of array starting at the end of current chunk size splitAmount elements */
-		new(splitScanner) GC_PointerArrayObjectScanner(env, getArrayObject(), _basePtr, _limitPtr, _endPtr, _endPtr + splitAmount, _flags);
-		splitScanner->initialize(env);
 
-		return splitScanner;
+		/* Create new scanner for next chunk of array starting at the end of current chunk size splitAmount elements */
+		return new(allocSpace) GC_PointerArrayObjectScanner(env, getArrayObject(), _basePtr, _limitPtr, _endPtr, _endPtr + splitAmount, _flags);
 	}
 
 	/**

--- a/runtime/gc_glue_java/ReferenceObjectScanner.hpp
+++ b/runtime/gc_glue_java/ReferenceObjectScanner.hpp
@@ -76,17 +76,6 @@ protected:
 		, _referentSlotAddress(referentSlotAddress)
 	{
 		_typeId = __FUNCTION__;
-	}
-
-	/**
-	 * Subclasses must call this method to set up the instance description bits and description pointer.
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env, J9Class *clazzPtr)
-	{
-		GC_MixedObjectScanner::initialize(env, clazzPtr);
-
-		/* Skip over referent slot if required */
 		_scanMap = skipReferentSlot(_scanPtr, _scanMap);
 	}
 
@@ -106,7 +95,6 @@ public:
 	{
 		GC_ReferenceObjectScanner *objectScanner = (GC_ReferenceObjectScanner *)allocSpace;
 		new(objectScanner) GC_ReferenceObjectScanner(env, objectPtr, referentSlotAddress, flags);
-		objectScanner->initialize(env, J9GC_J9OBJECT_CLAZZ(objectPtr, env));
 		return objectScanner;
 	}
 


### PR DESCRIPTION
Move functionality of initialize() into the constructor.
Depends on #7895, look at only the head commit of this PR.
cc @dmitripivkine 