### PR TITLE
Provide PrivateLinkage implementations for method entry inquiries

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -266,6 +266,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/codegen/J9WatchedInstanceFieldSnippet.cpp \
     compiler/codegen/J9WatchedStaticFieldSnippet.cpp \
     compiler/codegen/MonitorState.cpp \
+    compiler/codegen/PrivateLinkage.cpp \
     compiler/compile/J9AliasBuilder.cpp \
     compiler/compile/J9Compilation.cpp \
     compiler/compile/J9Method.cpp \

--- a/runtime/compiler/codegen/CMakeLists.txt
+++ b/runtime/compiler/codegen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@ j9jit_files(
 	codegen/CodeGenGPU.cpp
 	codegen/CodeGenRA.cpp
 	codegen/MonitorState.cpp
+	codegen/PrivateLinkage.cpp
 	codegen/J9AheadOfTimeCompile.cpp
 	codegen/J9CodeGenerator.cpp
 	codegen/J9CodeGenPhase.cpp

--- a/runtime/compiler/codegen/PrivateLinkage.cpp
+++ b/runtime/compiler/codegen/PrivateLinkage.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage_inlines.hpp"
+#include "codegen/PrivateLinkage.hpp"
+#include "env/jittypes.h"
+
+intptr_t
+J9::PrivateLinkage::entryPointFromCompiledMethod()
+   {
+   uint8_t *methodEntry = cg()->getCodeStart();
+   methodEntry += J9::PrivateLinkage::LinkageInfo::get(methodEntry)->getReservedWord();
+   return reinterpret_cast<intptr_t>(methodEntry);
+   }
+
+intptr_t
+J9::PrivateLinkage::entryPointFromInterpretedMethod()
+   {
+   return reinterpret_cast<intptr_t>(cg()->getCodeStart());
+   }

--- a/runtime/compiler/codegen/PrivateLinkage.hpp
+++ b/runtime/compiler/codegen/PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 #define J9_PRIVATELINKAGE_INCL
 
 #include "codegen/Linkage.hpp"
+#include "env/jittypes.h"
 #include "infra/Assert.hpp"
 
 namespace TR { class CodeGenerator; }
@@ -118,6 +119,16 @@ public:
    private:
       LinkageInfo() {};
       };
+
+   /**
+    * @brief J9 private linkage override of OMR function
+    */
+   virtual intptr_t entryPointFromCompiledMethod();
+
+   /**
+    * @brief J9 private linkage override of OMR function
+    */
+   virtual intptr_t entryPointFromInterpretedMethod();
 
    };
 

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -720,3 +720,8 @@ void J9::X86::I386::PrivateLinkage::buildVirtualOrComputedCall(
       }
    }
 
+intptr_t
+J9::X86::I386::PrivateLinkage::entryPointFromCompiledMethod()
+   {
+   return reinterpret_cast<intptr_t>(cg()->getCodeStart());
+   }

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.hpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 #define IA32LINKAGE_INCL
 
 #include "codegen/X86PrivateLinkage.hpp"
+#include "env/jittypes.h"
 
 namespace TR { class UnresolvedDataSnippet; }
 
@@ -46,6 +47,16 @@ class PrivateLinkage : public J9::X86::PrivateLinkage
    TR::Register *pushIntegerWordArg(TR::Node *child);
 
    TR::UnresolvedDataSnippet *generateX86UnresolvedDataSnippetWithCPIndex(TR::Node *child, TR::SymbolReference *symRef, int32_t cpIndex);
+
+   /**
+    * @brief J9 private linkage override of OMR function
+    */
+   virtual intptr_t entryPointFromCompiledMethod();
+
+   /**
+    * @brief J9 private linkage override of OMR function
+    */
+   virtual intptr_t entryPointFromInterpretedMethod();
 
    protected:
 


### PR DESCRIPTION
* `entryPointFromCompiledMethod` will answer the question using the LinkageInfo word
* `entryPointFromInterpretedMethod` will answer using the start of the code buffer

Signed-off-by: Daryl Maier <maier@ca.ibm.com>