### PR TITLE
Move arithmeticNeedsLiteralFromPool from OMR for Z codegen

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -129,6 +129,7 @@ public:
    bool enableAESInHardwareTransformations() {return false;}
 
    bool isMethodInAtomicLongGroup(TR::RecognizedMethod rm);
+   bool arithmeticNeedsLiteralFromPool(TR::Node *node) { return false; }
 
    // OSR
    //

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4211,3 +4211,13 @@ J9::Z::CodeGenerator::inlineDirectCall(
    resultReg = NULL;
    return false;
    }
+
+/**
+* Check if arithmetic operations with a constant requires entry in the literal pool.
+*/
+bool
+J9::Z::CodeGenerator::arithmeticNeedsLiteralFromPool(TR::Node *node)
+   {
+   int64_t value = getIntegralValue(node);
+   return value > GE_MAX_IMMEDIATE_VAL || value < GE_MIN_IMMEDIATE_VAL;
+   }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -325,6 +325,9 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
       return _ignoreDecimalOverflowException;
       }
 
+   // LL: move to .cpp
+   bool arithmeticNeedsLiteralFromPool(TR::Node *node);
+
    private:
 
    /** \brief


### PR DESCRIPTION
Move arithmeticNeedsLiteralFromPool from OMR for Z codegen

This commit moves arithmeticNeedsLiteralFromPool function
from OMR to OpenJ9 for Z codegen implementation.

Related OMR PR: eclipse/omr#4616

Issue: eclipse/omr#1870
Signed-off-by: Md. Ariful Haque <mhaque5@unb.ca>