### PR TITLE
Replaced all codegen/FrontEnd.hpp with env/FrontEnd.hpp

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -24,7 +24,7 @@
 #include "codegen/ARMAOTRelocation.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/Instruction.hpp"
 #include "compile/AOTClassInfo.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/arm/runtime/ARMRelocationTarget.cpp
+++ b/runtime/compiler/arm/runtime/ARMRelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@
 #include "j9cp.h"
 #include "j9protos.h"
 #include "rommeth.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PicHelpers.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"

--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -70,7 +70,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/CodeGenPrep.cpp \
     omr/compiler/codegen/CodeGenRA.cpp \
     omr/compiler/codegen/ELFGenerator.cpp \
-    omr/compiler/codegen/FrontEnd.cpp \
+    omr/compiler/env/FrontEnd.cpp \
     omr/compiler/codegen/LiveRegister.cpp \
     omr/compiler/codegen/NodeEvaluation.cpp \
     omr/compiler/codegen/OMRAheadOfTimeCompile.cpp \

--- a/runtime/compiler/codegen/CodeGenRA.cpp
+++ b/runtime/compiler/codegen/CodeGenRA.cpp
@@ -38,7 +38,7 @@
 #include "codegen/BackingStore.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/Linkage.hpp"

--- a/runtime/compiler/compile/AOTClassInfo.hpp
+++ b/runtime/compiler/compile/AOTClassInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef TR_AOTCLASSINFO_INCL
 #define TR_AOTCLASSINFO_INCL
 
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "env/jittypes.h"
 #include "env/VMJ9.h"

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -23,7 +23,7 @@
 #include "env/CHTable.hpp"
 
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "compile/CompilationTypes.hpp"

--- a/runtime/compiler/env/ClassTableCriticalSection.hpp
+++ b/runtime/compiler/env/ClassTableCriticalSection.hpp
@@ -23,7 +23,7 @@
 #ifndef TR_CLASSTABLECRITICALSECTION_INCL
 #define TR_CLASSTABLECRITICALSECTION_INCL
 
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/VMJ9.h"
 
 namespace TR

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -29,7 +29,7 @@
 #include "j9cp.h"
 #include "j9cfg.h"
 #include "rommeth.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/Method.hpp"

--- a/runtime/compiler/env/annotations/AnnotationBase.hpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 #define ANNOTATIONBASE_INCL
 
 #include "j9.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "infra/List.hpp"
 #include "env/VMJ9.h"
 

--- a/runtime/compiler/env/j9field.h
+++ b/runtime/compiler/env/j9field.h
@@ -27,7 +27,7 @@
 #include "j9protos.h"
 #include "j9consts.h"
 #include "j9comp.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/IO.hpp"
 
 class TR_VMField

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -23,7 +23,7 @@
 #ifndef j9method_h
 #define j9method_h
 
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -33,7 +33,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "env/TRMemory.hpp"

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/InlineBlock.hpp"

--- a/runtime/compiler/optimizer/AllocationSinking.cpp
+++ b/runtime/compiler/optimizer/AllocationSinking.cpp
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
 #include "control/Options.hpp"

--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
 #include "compile/SymbolReferenceTable.hpp"

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"

--- a/runtime/compiler/optimizer/EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.cpp
@@ -23,7 +23,7 @@
 #include "env/StackMemoryRegion.hpp"
 #include "optimizer/EstimateCodeSize.hpp"
 
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "il/ResolvedMethodSymbol.hpp"
 #include "infra/Assert.hpp"

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/TRMemory.hpp"

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.cpp
@@ -24,7 +24,7 @@
 #include "optimizer/OptimizationManager_inlines.hpp"
 
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/Method.hpp"

--- a/runtime/compiler/optimizer/J9SimplifierHandlers.cpp
+++ b/runtime/compiler/optimizer/J9SimplifierHandlers.cpp
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "codegen/TreeEvaluator.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/optimizer/JitProfiler.cpp
+++ b/runtime/compiler/optimizer/JitProfiler.cpp
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/SymbolReferenceTable.hpp"

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <algorithm>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/optimizer/NewInitialization.cpp
+++ b/runtime/compiler/optimizer/NewInitialization.cpp
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/optimizer/ProfileGenerator.cpp
+++ b/runtime/compiler/optimizer/ProfileGenerator.cpp
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/StorageInfo.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/SymbolReferenceTable.hpp"

--- a/runtime/compiler/optimizer/SignExtendLoads.cpp
+++ b/runtime/compiler/optimizer/SignExtendLoads.cpp
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"

--- a/runtime/compiler/optimizer/StaticFinalFieldFolding.cpp
+++ b/runtime/compiler/optimizer/StaticFinalFieldFolding.cpp
@@ -24,7 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"

--- a/runtime/compiler/optimizer/VPBCDConstraint.cpp
+++ b/runtime/compiler/optimizer/VPBCDConstraint.cpp
@@ -24,7 +24,7 @@
 
 #include <ctype.h>
 #include <stddef.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/VMJ9.h"

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -24,7 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/p/codegen/GenerateInstructions.cpp
+++ b/runtime/compiler/p/codegen/GenerateInstructions.cpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include "codegen/BackingStore.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/MemoryReference.hpp"

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -22,7 +22,7 @@
 
 #include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/Instruction.hpp"
 #include "compile/AOTClassInfo.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"

--- a/runtime/compiler/p/codegen/Trampoline.cpp
+++ b/runtime/compiler/p/codegen/Trampoline.cpp
@@ -23,7 +23,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/jittypes.h"

--- a/runtime/compiler/p/runtime/PPCHWProfiler.cpp
+++ b/runtime/compiler/p/runtime/PPCHWProfiler.cpp
@@ -25,7 +25,7 @@
 #include "j9cfg.h"
 #include "j9port_generated.h"
 #include "util_api.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/jittypes.h"

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -31,7 +31,7 @@
 #include "j9protos.h"
 #include "jvminit.h"
 #include "jitprotos.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PicHelpers.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"

--- a/runtime/compiler/ras/InternalFunctions.cpp
+++ b/runtime/compiler/ras/InternalFunctions.cpp
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "env/TRMemory.hpp"
 #include "env/defines.h"

--- a/runtime/compiler/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/runtime/CRuntimeImpl.cpp
@@ -31,7 +31,7 @@
 #endif
 
 #include "j9.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/IO.hpp"

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -38,7 +38,7 @@
 #include "infra/Monitor.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #ifdef CODECACHE_STATS
 #include "infra/Statistics.hpp"
 #endif

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -34,7 +34,7 @@
 #include "infra/Monitor.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/ut_j9jit.h"
 #include "infra/CriticalSection.hpp"
 #include "runtime/CodeCacheManager.hpp"

--- a/runtime/compiler/runtime/J9CodeCacheMemorySegment.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheMemorySegment.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@
 #include "infra/Monitor.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #ifdef CODECACHE_STATS
 #include "infra/Statistics.hpp"
 #endif

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -26,7 +26,7 @@
 #include <map>
 #include <stddef.h>
 #include <stdint.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -36,7 +36,7 @@
 #include "j9.h"
 #include "jitprotos.h"
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PrivateLinkage.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/Method.hpp"

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -31,7 +31,7 @@
 #include "j9protos.h"
 #include "rommeth.h"
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PicHelpers.hpp"
 #include "codegen/Relocation.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -49,7 +49,7 @@
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/ArtifactManager.hpp"
 #include "runtime/DataCache.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "infra/Monitor.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/VMAccessCriticalSection.hpp"

--- a/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
+++ b/runtime/compiler/runtime/RelocationRuntimeLogger.cpp
@@ -31,7 +31,7 @@
 #include "j9cp.h"
 #include "j9protos.h"
 #include "rommeth.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "runtime/MethodMetaData.h"

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -31,7 +31,7 @@
 #include "j9cp.h"
 #include "j9protos.h"
 #include "rommeth.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PicHelpers.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -37,7 +37,7 @@
 #include "jitprotos.h"
 #include "rommeth.h"
 #include "emfloat.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PreprologueConst.hpp"
 #include "codegen/PrivateLinkage.hpp"
 #include "control/Recompilation.hpp"

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -22,7 +22,7 @@
 
 #include "runtime/RuntimeAssumptions.hpp"
 
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CHTable.hpp"

--- a/runtime/compiler/runtime/Trampoline.cpp
+++ b/runtime/compiler/runtime/Trampoline.cpp
@@ -22,7 +22,7 @@
 
 #include "j9.h"
 #include "j9consts.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/PrivateLinkage.hpp"
 #include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"

--- a/runtime/compiler/runtime/ValueProfiler.cpp
+++ b/runtime/compiler/runtime/ValueProfiler.cpp
@@ -24,7 +24,7 @@
 #include <math.h>
 #include <stdint.h>
 #include "j9.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/jittypes.h"

--- a/runtime/compiler/x/codegen/GuardedDevirtualSnippet.cpp
+++ b/runtime/compiler/x/codegen/GuardedDevirtualSnippet.cpp
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/RegisterConstants.hpp"

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -21,7 +21,7 @@
  *******************************************************************************/
 
 #include "codegen/AheadOfTimeCompile.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/Instruction.hpp"
 #include "compile/AOTClassInfo.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/x/runtime/X86RelocationTarget.cpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.cpp
@@ -32,7 +32,7 @@
 #include "j9cp.h"
 #include "j9protos.h"
 #include "rommeth.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #if defined(JITSERVER_SUPPORT)

--- a/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.cpp
+++ b/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.cpp
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -26,7 +26,7 @@
 
 #include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "compile/AOTClassInfo.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -40,7 +40,7 @@
 #include <string.h>
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/ConstantDataSnippet.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/Linkage.hpp"

--- a/runtime/compiler/z/codegen/S390Register.cpp
+++ b/runtime/compiler/z/codegen/S390Register.cpp
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "codegen/Register.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "compile/Compilation.hpp"

--- a/runtime/compiler/z/runtime/S390RelocationTarget.cpp
+++ b/runtime/compiler/z/runtime/S390RelocationTarget.cpp
@@ -32,7 +32,7 @@
 #include "j9cp.h"
 #include "j9protos.h"
 #include "rommeth.h"
-#include "codegen/FrontEnd.hpp"
+#include "env/FrontEnd.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "runtime/J9Runtime.hpp"


### PR DESCRIPTION
Replace all `#include "codegen/FrontEnd.hpp"` with `#include "env/FrontEnd.hpp"`. 
Replace the `codegen/FrontEnd.cpp` with `env/FrontEnd.cpp` in `runtime/compiler/build/files/common.mk`

Issue: https://github.com/eclipse/omr/issues/4504

Signed-off-by: Yuehan-Lin <Yuehan.Lin@ibm.com>