### PR TITLE
Fix JITServer memory leak due to runtime assumptions

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -177,6 +177,7 @@ J9::Compilation::Compilation(int32_t id,
 #if defined(JITSERVER_SUPPORT)
    _outOfProcessCompilation(false),
    _remoteCompilation(false),
+   _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption>(self()->allocator())),
 #endif /* defined(JITSERVER_SUPPORT) */
    _osrProhibitedOverRangeOfTrees(false)
    {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -57,6 +57,9 @@ class TR_J9VM;
 class TR_AccessedProfileInfo;
 class TR_RelocationRuntime;
 namespace TR { class IlGenRequest; }
+#ifdef JITSERVER_SUPPORT
+struct SerializedRuntimeAssumption;
+#endif
 
 #define COMPILATION_AOT_HAS_INVOKEHANDLE -9
 #define COMPILATION_RESERVE_RESOLVED_TRAMPOLINE_FATAL_ERROR -10
@@ -318,6 +321,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOutOfProcessCompilation() { _outOfProcessCompilation = true; }
    bool isRemoteCompilation() const { return _remoteCompilation; } // client side
    void setRemoteCompilation() { _remoteCompilation = true; }
+   TR::list<SerializedRuntimeAssumption*>& getSerializedRuntimeAssumptions() { return _serializedRuntimeAssumptions; }
 #endif /* defined(JITSERVER_SUPPORT) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -410,6 +414,9 @@ private:
    TR_RelocationRuntime *_reloRuntime;
 
 #if defined(JITSERVER_SUPPORT)
+   // This list contains assumptions created during the compilation at the JITServer
+   // It needs to be sent to the client at the end of compilation
+   TR::list<SerializedRuntimeAssumption*> _serializedRuntimeAssumptions;
    // The following flag is set when this compilation is performed in a
    // VM that does not have the runtime part (server side in JITServer)
    bool _outOfProcessCompilation;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7873,6 +7873,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             TR_ASSERT(that->_methodBeingCompiled->isOutOfProcessCompReq(), "Options are already provided only for JITServer");
             options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, that, vm, p->trMemory());
             options->setLogFileForClientOptions();
+            // The following is a hack to prevent the JITServer from allocating
+            // a sentinel entry for the list of runtime assumptions kept in the compiler object
+            options->setOption(TR_DisableFastAssumptionReclamation);
             }
          else
 #endif /* defined(JITSERVER_SUPPORT) */

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/PicHelpers.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
 #include "control/JITServerHelpers.hpp"
@@ -2750,6 +2751,7 @@ remoteCompile(
    std::string svmSymbolToIdStr;
    std::vector<TR_ResolvedJ9Method*> resolvedMirrorMethodsPersistIPInfo;
    TR_OptimizationPlan modifiedOptPlan;
+   std::vector<SerializedRuntimeAssumption> serializedRuntimeAssumptions;
    try
       {
       // Release VM access just before sending the compilation request
@@ -2777,7 +2779,8 @@ remoteCompile(
       if (JITServer::MessageType::compilationCode == response)
          {
          auto recv = client->getRecvData<std::string, std::string, CHTableCommitData, std::vector<TR_OpaqueClassBlock*>,
-                                      std::string, std::string, std::vector<TR_ResolvedJ9Method*>, TR_OptimizationPlan>();
+                                         std::string, std::string, std::vector<TR_ResolvedJ9Method*>, 
+                                         TR_OptimizationPlan, std::vector<SerializedRuntimeAssumption>>();
          statusCode = compilationOK;
          codeCacheStr = std::get<0>(recv);
          dataCacheStr = std::get<1>(recv);
@@ -2787,6 +2790,7 @@ remoteCompile(
          svmSymbolToIdStr = std::get<5>(recv);
          resolvedMirrorMethodsPersistIPInfo = std::get<6>(recv);
          modifiedOptPlan = std::get<7>(recv);
+         serializedRuntimeAssumptions = std::get<8>(recv);
          }
       else
          {
@@ -2863,6 +2867,45 @@ remoteCompile(
 
          // Relocate the received compiled code
          metaData = remoteCompilationEnd(vmThread, compiler, compilee, method, compInfoPT, codeCacheStr, dataCacheStr);
+         if (metaData)
+            {
+            // Must add the runtime assumptions received from the server to the RAT and
+            // update the list in the comp object with persistent entries. A pointer to
+            // this list will be copied into the metadata
+            for (auto& it : serializedRuntimeAssumptions)
+               {
+               uint8_t *addrToPatch = (uint8_t*)(metaData->startPC + it.getOffsetFromStartPC());
+               switch (it.getKind()) 
+                  {
+                  case RuntimeAssumptionOnRegisterNative:
+                     {
+                     TR_PatchJNICallSite::make(compiler->fej9vm(), compiler->trPersistentMemory(), it.getKey(), addrToPatch, compiler->getMetadataAssumptionList());
+                     break;
+                     }
+                  case RuntimeAssumptionOnClassRedefinitionPIC:
+                     {
+                     createClassRedefinitionPicSite((void*)it.getKey(), addrToPatch, it.getSize(), false, compiler->getMetadataAssumptionList());
+                     compiler->setHasClassRedefinitionAssumptions();
+                     break;
+                     }
+                  case RuntimeAssumptionOnClassRedefinitionUPIC:
+                     {
+                     createClassRedefinitionPicSite((void*)it.getKey(), addrToPatch, it.getSize(), true, compiler->getMetadataAssumptionList());
+                     compiler->setHasClassRedefinitionAssumptions();
+                     break;
+                     }
+                  case RuntimeAssumptionOnClassUnload:
+                     {
+                     createClassUnloadPicSite((void*)it.getKey(), addrToPatch, it.getSize(), compiler->getMetadataAssumptionList());
+                     compiler->setHasClassUnloadAssumptions();
+                     break;
+                     }
+                  default:
+                     TR_ASSERT_FATAL(false, "Runtime assumption of kind %d is not handled by JITClient\n", it.getKind());
+                  } // end switch (it->getKind()) 
+               }
+            metaData->runtimeAssumptionList = *(compiler->getMetadataAssumptionList());
+            }
 
          if (!compiler->getOption(TR_DisableCHOpts) && !useAotCompilation)
             {

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -286,4 +286,23 @@ class TR_UnloadedClassPicSite : public OMR::ValueModifyRuntimeAssumption
    uint32_t    _size;
    };
 
+#ifdef JITSERVER_SUPPORT
+// The following needs to have enough fields to cover any possible
+// runtime assumption that we may want to send from the server to the client
+struct SerializedRuntimeAssumption
+   {
+   SerializedRuntimeAssumption(TR_RuntimeAssumptionKind kind, uintptrj_t key, intptr_t offset, uint32_t size = 0)
+      : _kind(kind), _key(key), _offsetFromStartPC(offset), _size(size) {}
+   TR_RuntimeAssumptionKind getKind() const { return _kind; }
+   uintptrj_t getKey() const { return _key; }
+   intptr_t getOffsetFromStartPC() const { return _offsetFromStartPC; }
+   uint32_t getSize() const { return _size; }
+
+   TR_RuntimeAssumptionKind _kind;
+   uint32_t   _size;
+   uintptrj_t _key;
+   intptr_t  _offsetFromStartPC; // can be negative
+   };
+#endif // JITSERVER_SUPPORT
+
 #endif


### PR DESCRIPTION
While most runtime assumptions are generated at the client during
CHTable.commit, some of them are generated during compilation at
the JITServer. Examples include: TR_PatchJNICallSite and
TR_RedefinedClassRPicSite. Runtime assumptions stored at the
JITServer have no purpose, they only leak memory.

The solution is to buffer such runtime assumptions in a linked list
attached to the comp object (using scratch memory), send them to the
JITClient at the end of a compilation, deserialize them and instantiate
said runtime assumptions backed by persistent memory at the client.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>