### PR TITLE
Remove references of deprecated const/compare Opcodes from OpenJ9

### DIFF
--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -285,11 +285,7 @@ bool TR_DynamicLiteralPool::transformLitPoolConst(TR::Node *grandParent, TR::Nod
       case TR::iconst:
       case TR::lconst:
       case TR::bconst:
-      case TR::cconst:
       case TR::sconst:
-      case TR::iuconst:
-      case TR::luconst:
-      case TR::buconst:
          if (transformNeeded(grandParent, parent, child))
             {
             if (performTransformation(comp(), "%s Large non-float Constant\n", optDetailString()))
@@ -372,22 +368,6 @@ bool TR_DynamicLiteralPool::transformNeeded(TR::Node *grandParent, TR::Node *par
       else
          {
          TR::ILOpCodes oldOpCode = child->getOpCodeValue();
-         if (oldOpCode == TR::iuconst &&
-             (parentOpCode.isAdd() || parentOpCode.isSub()))
-            {
-            TR::Node::recreate(child, TR::iconst);
-            }
-         else if (oldOpCode == TR::luconst &&
-             (parentOpCode.isAdd() || parentOpCode.isSub()))
-            {
-            TR::Node::recreate(child, TR::lconst);
-            }
-         else if (oldOpCode == TR::cconst &&
-             (parentOpCode.isAdd() || parentOpCode.isSub()))
-            {
-            TR::Node::recreate(child, TR::sconst);
-            }
-
          bool needs = (cg()->arithmeticNeedsLiteralFromPool(child));
          TR::Node::recreate(child, oldOpCode);
          return needs;

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -6594,7 +6594,6 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                switch(n->getOpcode())
                   {
                   case TR::ifbcmpeq:
-                  case TR::ifsucmpeq:
                   case TR::ificmpeq:
                      takenBV.empty();
                      ntakenBV = *bv[tID];
@@ -6605,7 +6604,6 @@ TR_CISCTransformer::analyzeBoolTable(TR_BitVector **bv, TR::TreeTop **retSameExi
                         }
                      break;
                   case TR::ifbcmpne:
-                  case TR::ifsucmpne:
                   case TR::ificmpne:
                      takenBV = *bv[tID];
                      ntakenBV.empty();

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1268,7 +1268,6 @@ TR_CISCGraph::addOpc2CISCNode(TR_CISCNode *n)
             if (!n->isValidOtherInfo()) break;
             // else fall through
          case TR_variable:
-         case TR::cconst:
          case TR::sconst:
          case TR::iconst:
          case TR::bconst:
@@ -2442,9 +2441,6 @@ TR_CISCTransformer::addAllSubNodes(TR_CISCGraph *const graph, TR::Block *const b
             {
             case TR::iconst:
                val = node->getInt();
-               break;
-            case TR::cconst:
-               val = node->getConst<uint16_t>();
                break;
             case TR::sconst:
                val = node->getShortInt();
@@ -6226,11 +6222,9 @@ TR_CISCTransformer::compareTrNodeTree(TR::Node *a, TR::Node *b)
       {
       switch(a->getOpCodeValue())
          {
-         case TR::iuconst:
          case TR::iconst:
             if (a->getUnsignedInt() != b->getUnsignedInt()) return false;
             break;
-         case TR::luconst:
          case TR::lconst:
             if (a->getUnsignedLongInt() != b->getUnsignedLongInt()) return false;
             break;
@@ -6244,14 +6238,10 @@ TR_CISCTransformer::compareTrNodeTree(TR::Node *a, TR::Node *b)
             if (a->getDouble() != b->getDouble()) return false;
             break;
          case TR::bconst:
-         case TR::buconst:
             if (a->getUnsignedByte() != b->getUnsignedByte()) return false;
             break;
          case TR::sconst:
             if (a->getShortInt() != b->getShortInt()) return false;
-            break;
-         case TR::cconst:
-            if (a->getConst<uint16_t>() != b->getConst<uint16_t>()) return false;
             break;
          default:
             return false;

--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -169,7 +169,6 @@ public:
          switch(_opcode)
             {
             case TR::iconst:
-            case TR::cconst:
             case TR::sconst:
             case TR::bconst:
             case TR::lconst:

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -9201,7 +9201,6 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       {
       case TR::ificmpne:
       case TR::ifbcmpne:
-      case TR::ifsucmpne:
       case TR::ifscmpne:
       case TR::iflcmpne:
       case TR::ifacmpne:

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -693,7 +693,6 @@ bool TR_ShiftedValueTree::process(TR::Node* loadNode)
       case TR::l2b: shift = true;  _valueSize = 8; shiftCode = TR::lushr; altShiftCode = TR::lshr; constCode = TR::iconst; break;
       case TR::bload:
       case TR::bconst:
-      case TR::cconst:
       case TR::sconst:
       case TR::iconst:
       case TR::lconst: shift = false; _valueSize = 1; _shiftValue = 0; break;
@@ -720,7 +719,6 @@ bool TR_ShiftedValueTree::process(TR::Node* loadNode)
          _valNode = loadNode->getFirstChild()->getFirstChild();
          switch(constCode)
             {
-            case TR::cconst: _shiftValue = shiftVal->getConst<uint16_t>(); break;
             case TR::sconst: _shiftValue = shiftVal->getShortInt(); break;
             case TR::iconst: _shiftValue = shiftVal->getInt(); break;
             case TR::lconst: _shiftValue = shiftVal->getLongInt(); break;
@@ -965,7 +963,6 @@ int64_t TR_arraycopySequentialStores::constVal()
       switch (_val[entry]->getValNode()->getOpCodeValue())
          {
          case TR::bconst: curVal = (uint64_t) (_val[entry]->getValNode()->getByte() & 0xFF); break;
-         case TR::cconst: curVal = (uint64_t) (_val[entry]->getValNode()->getConst<uint16_t>() & 0xFF); break;
          case TR::sconst: curVal = (uint64_t) (_val[entry]->getValNode()->getShortInt() & 0xFF); break;
          case TR::iconst: curVal = (uint64_t) (_val[entry]->getValNode()->getInt() & 0xFF); break;
          case TR::lconst: curVal = (uint64_t) (_val[entry]->getValNode()->getLongInt() & 0xFF); break;

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1771,7 +1771,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                   constValue = ((constValue << 8) | constValue);
                   }
 
-               constValueNode = TR::Node::cconst(istoreNode, constValue);
+               constValueNode = TR::Node::sconst(istoreNode, constValue);
                break;
                }
             case 4:


### PR DESCRIPTION
Remove all the references to deprecated unsigned ILOpcodes in `const`, `equality compare` and `equality compare and branch` categories.
*Note that: `Fatal Asserts` implemented in https://github.com/eclipse/omr/pull/4347 ensure the opcodes that are being removed in this PR are not generated anywhere in OMR/OpenJ9.*

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com