### PR TITLE
Remove static declaration for ARM evaluateNULLCHKWithPossibleResolve

### DIFF
--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -65,7 +65,7 @@ J9::ARM::TreeEvaluator::resolveAndNULLCHKEvaluator(TR::Node *node, TR::CodeGener
    return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, true, cg);
    }
 
-static TR::Register *
+TR::Register *
 J9::ARM::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, bool needsResolve, TR::CodeGenerator *cg)
    {
    // NOTE:


### PR DESCRIPTION
Fixes #7917

Signed-off-by: Daryl Maier <maier@ca.ibm.com>