### PR TITLE
setSecurityManager() always initialize the protection domain

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2019 IBM Corp. and others
  *
@@ -1855,7 +1855,7 @@ public ProtectionDomain getProtectionDomain() {
 
 private void allocateAllPermissionsPD() {
 	Permissions collection = new Permissions();
-	collection.add(new AllPermission());
+	collection.add(sun.security.util.SecurityConstants.ALL_PERMISSION);
 	AllPermissionsPD = new ProtectionDomain(null, collection);
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2019 IBM Corp. and others
  *
@@ -860,13 +860,11 @@ public static void setSecurityManager(final SecurityManager s) {
 						// also load security sensitive classes 
 						com.ibm.oti.util.Msg.getString("K002c"); //$NON-NLS-1$
 					}
-					ProtectionDomain oldDomain = currentSecurity == null ?
-						System.class.getPDImpl() : currentSecurity.getClass().getPDImpl();
-					ProtectionDomain newDomain = s.getClass().getPDImpl();
-					if (oldDomain != newDomain) {
+					ProtectionDomain pd = s.getClass().getPDImpl();
+					if (pd != null) {
 						// initialize the protection domain, which may include preloading the
 						// dynamic permissions from the policy before installing
-						newDomain.implies(new AllPermission());
+						pd.implies(sun.security.util.SecurityConstants.ALL_PERMISSION);
 					}
 					return null;
 				}});


### PR DESCRIPTION
**j.l.System.setSecurityManager() always initialize the protection domain**

There is a case that current `SecurityManager` has same `ProtectionDomain` with incoming `SecurityManager` which still need to initialize the protection domain otherwise `java.lang.StackOverflowError` might occur;
Always invoke `pd.implies(ALL_PERMISSION)` for new `SecurityManager`;
Minor code refactoring.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>