### PR TITLE
Fix JITServer memory leak due to runtime assumptions

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4645,21 +4645,59 @@ J9::CodeGenerator::registerAssumptions()
       {
       TR_OpaqueMethodBlock *method = (*it)->getKey()->getPersistentIdentifier();
       TR::Instruction *i = (*it)->getValue();
-      TR_PatchJNICallSite::make(self()->fe(), self()->trPersistentMemory(), (uintptrj_t) method, i->getBinaryEncoding(), self()->comp()->getMetadataAssumptionList());
+#ifdef JITSERVER_SUPPORT
+      if (self()->comp()->isOutOfProcessCompilation())
+         {
+         // For JITServer we need to build a list of assumptions that will be sent to client at end of compilation
+         intptr_t offset = i->getBinaryEncoding() - self()->getCodeStart();
+         SerializedRuntimeAssumption* sar = 
+            new (self()->trHeapMemory()) SerializedRuntimeAssumption(RuntimeAssumptionOnRegisterNative, (uintptrj_t)method, offset);
+         self()->comp()->getSerializedRuntimeAssumptions().push_front(sar);
+         }
+      else
+#endif // JITSERVER_SUPPORT
+         {
+         TR_PatchJNICallSite::make(self()->fe(), self()->trPersistentMemory(), (uintptrj_t) method, i->getBinaryEncoding(), self()->comp()->getMetadataAssumptionList());
+         }
       }
    }
 
 void
 J9::CodeGenerator::jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched)
    {
-   createClassUnloadPicSite(classPointer, addressToBePatched, sizeof(uintptrj_t), self()->comp()->getMetadataAssumptionList());
-   self()->comp()->setHasClassUnloadAssumptions();
+#ifdef JITSERVER_SUPPORT
+   if (self()->comp()->isOutOfProcessCompilation())
+      {
+      intptr_t offset = (uint8_t*)addressToBePatched - self()->getCodeStart();
+      SerializedRuntimeAssumption* sar = 
+         new (self()->trHeapMemory()) SerializedRuntimeAssumption(RuntimeAssumptionOnClassUnload, (uintptrj_t)classPointer, offset, sizeof(uintptrj_t));
+      self()->comp()->getSerializedRuntimeAssumptions().push_front(sar);
+      }
+   else
+#endif // JITSERVER_SUPPORT
+      {
+      createClassUnloadPicSite(classPointer, addressToBePatched, sizeof(uintptrj_t), self()->comp()->getMetadataAssumptionList());
+      self()->comp()->setHasClassUnloadAssumptions();
+      }
    }
+
 void
 J9::CodeGenerator::jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched)
    {
-   createClassUnloadPicSite(classPointer, addressToBePatched,4, self()->comp()->getMetadataAssumptionList());
-   self()->comp()->setHasClassUnloadAssumptions();
+#ifdef JITSERVER_SUPPORT
+   if (self()->comp()->isOutOfProcessCompilation())
+      {
+      intptr_t offset = (uint8_t*)addressToBePatched - self()->getCodeStart();
+      SerializedRuntimeAssumption* sar = 
+         new (self()->trHeapMemory()) SerializedRuntimeAssumption(RuntimeAssumptionOnClassUnload, (uintptrj_t)classPointer, offset, 4);
+      self()->comp()->getSerializedRuntimeAssumptions().push_front(sar);
+      }
+   else
+#endif // JITSERVER_SUPPORT
+      {
+      createClassUnloadPicSite(classPointer, addressToBePatched,4, self()->comp()->getMetadataAssumptionList());
+      self()->comp()->setHasClassUnloadAssumptions();
+      }
    }
 
 void
@@ -4667,8 +4705,22 @@ J9::CodeGenerator::jitAddPicToPatchOnClassRedefinition(void *classPointer, void 
    {
     if (!self()->comp()->compileRelocatableCode())
       {
-      createClassRedefinitionPicSite(unresolved? (void*)-1 : classPointer, addressToBePatched, sizeof(uintptrj_t), unresolved, self()->comp()->getMetadataAssumptionList());
-      self()->comp()->setHasClassRedefinitionAssumptions();
+#ifdef JITSERVER_SUPPORT
+      if (self()->comp()->isOutOfProcessCompilation())
+         {
+         TR_RuntimeAssumptionKind kind = unresolved ? RuntimeAssumptionOnClassRedefinitionUPIC : RuntimeAssumptionOnClassRedefinitionPIC;
+         uintptrj_t key = unresolved ? (uintptrj_t)-1 : (uintptrj_t)classPointer;
+         intptr_t offset = (uint8_t*)addressToBePatched - self()->getCodeStart();
+         SerializedRuntimeAssumption* sar = 
+            new (self()->trHeapMemory()) SerializedRuntimeAssumption(kind, key, offset, sizeof(uintptrj_t));
+         self()->comp()->getSerializedRuntimeAssumptions().push_front(sar);
+         }
+      else
+#endif // JITSERVER_SUPPORT
+         {
+         createClassRedefinitionPicSite(unresolved? (void*)-1 : classPointer, addressToBePatched, sizeof(uintptrj_t), unresolved, self()->comp()->getMetadataAssumptionList());
+         self()->comp()->setHasClassRedefinitionAssumptions();
+         }
       }
    }
 
@@ -4677,10 +4729,25 @@ J9::CodeGenerator::jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, 
    {
    if (!self()->comp()->compileRelocatableCode())
       {
-      createClassRedefinitionPicSite(unresolved? (void*)-1 : classPointer, addressToBePatched, 4, unresolved, self()->comp()->getMetadataAssumptionList());
-      self()->comp()->setHasClassRedefinitionAssumptions();
+#ifdef JITSERVER_SUPPORT
+      if (self()->comp()->isOutOfProcessCompilation())
+         {
+         TR_RuntimeAssumptionKind kind = unresolved ? RuntimeAssumptionOnClassRedefinitionUPIC : RuntimeAssumptionOnClassRedefinitionPIC;
+         uintptrj_t key = unresolved ? (uintptrj_t)-1 : (uintptrj_t)classPointer;
+         intptr_t offset = (uint8_t*)addressToBePatched - self()->getCodeStart();
+         SerializedRuntimeAssumption* sar = 
+            new (self()->trHeapMemory()) SerializedRuntimeAssumption(kind, key, offset, 4);
+         self()->comp()->getSerializedRuntimeAssumptions().push_front(sar);
+         }
+      else
+#endif // JITSERVER_SUPPORT
+         {
+         createClassRedefinitionPicSite(unresolved? (void*)-1 : classPointer, addressToBePatched, 4, unresolved, self()->comp()->getMetadataAssumptionList());
+         self()->comp()->setHasClassRedefinitionAssumptions();
+         }
       }
    }
+
 
 void
 J9::CodeGenerator::createHWPRecords()

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -177,6 +177,7 @@ J9::Compilation::Compilation(int32_t id,
 #if defined(JITSERVER_SUPPORT)
    _outOfProcessCompilation(false),
    _remoteCompilation(false),
+   _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption>(self()->allocator())),
 #endif /* defined(JITSERVER_SUPPORT) */
    _osrProhibitedOverRangeOfTrees(false)
    {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -57,6 +57,9 @@ class TR_J9VM;
 class TR_AccessedProfileInfo;
 class TR_RelocationRuntime;
 namespace TR { class IlGenRequest; }
+#ifdef JITSERVER_SUPPORT
+struct SerializedRuntimeAssumption;
+#endif
 
 #define COMPILATION_AOT_HAS_INVOKEHANDLE -9
 #define COMPILATION_RESERVE_RESOLVED_TRAMPOLINE_FATAL_ERROR -10
@@ -318,6 +321,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void setOutOfProcessCompilation() { _outOfProcessCompilation = true; }
    bool isRemoteCompilation() const { return _remoteCompilation; } // client side
    void setRemoteCompilation() { _remoteCompilation = true; }
+   TR::list<SerializedRuntimeAssumption*>& getSerializedRuntimeAssumptions() { return _serializedRuntimeAssumptions; }
 #endif /* defined(JITSERVER_SUPPORT) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
@@ -410,6 +414,9 @@ private:
    TR_RelocationRuntime *_reloRuntime;
 
 #if defined(JITSERVER_SUPPORT)
+   // This list contains assumptions created during the compilation at the JITServer
+   // It needs to be sent to the client at the end of compilation
+   TR::list<SerializedRuntimeAssumption*> _serializedRuntimeAssumptions;
    // The following flag is set when this compilation is performed in a
    // VM that does not have the runtime part (server side in JITServer)
    bool _outOfProcessCompilation;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7845,6 +7845,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             TR_ASSERT(that->_methodBeingCompiled->isOutOfProcessCompReq(), "Options are already provided only for JITServer");
             options = TR::Options::unpackOptions(that->_methodBeingCompiled->_clientOptions, that->_methodBeingCompiled->_clientOptionsSize, that, vm, p->trMemory());
             options->setLogFileForClientOptions();
+            // The following is a hack to prevent the JITServer from allocating
+            // a sentinel entry for the list of runtime assumptions kept in the compiler object
+            options->setOption(TR_DisableFastAssumptionReclamation);
             }
          else
 #endif /* defined(JITSERVER_SUPPORT) */

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -287,4 +287,23 @@ class TR_UnloadedClassPicSite : public OMR::ValueModifyRuntimeAssumption
    uint32_t    _size;
    };
 
+#ifdef JITSERVER_SUPPORT
+// The following needs to have enough fields to cover any possible
+// runtime assumption that we may want to send from the server to the client
+struct SerializedRuntimeAssumption
+   {
+   SerializedRuntimeAssumption(TR_RuntimeAssumptionKind kind, uintptrj_t key, intptr_t offset, uint32_t size = 0)
+      : _kind(kind), _key(key), _offsetFromStartPC(offset), _size(size) {}
+   TR_RuntimeAssumptionKind getKind() const { return _kind; }
+   uintptrj_t getKey() const { return _key; }
+   intptr_t getOffsetFromStartPC() const { return _offsetFromStartPC; }
+   uint32_t getSize() const { return _size; }
+
+   TR_RuntimeAssumptionKind _kind;
+   uint32_t   _size;
+   uintptrj_t _key;
+   intptr_t  _offsetFromStartPC; // can be negative
+   };
+#endif // JITSERVER_SUPPORT
+
 #endif


### PR DESCRIPTION
While most runtime assumptions are generated at the client during
CHTable.commit, some of them are generated during compilation at
the JITServer. Examples include: TR_PatchJNICallSite and
TR_RedefinedClassRPicSite. Runtime assumptions stored at the
JITServer have no purpose, they only leak memory.

The solution is to buffer such runtime assumptions in a linked list
attached to the comp object (using scratch memory), send them to the
JITClient at the end of a compilation, deserialize them and instantiate
said runtime assumptions backed by persistent memory at the client.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>