### PR TITLE
Disable garbage collection for value types test

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -31,13 +31,14 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xverify:none \
 		-Xint \
+		-Xgcpolicy:nogc \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		-XX:+EnableValhalla \
-	-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
-	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTests \
-	-groups $(TEST_GROUP) \
-	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS)</command>
+		-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTests \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
The garbage collector does not currently have support for value types.
It is only by chance that all tests are currently working. The initial
work to support value types will start causing the GC to runtime assert
when the policy does not support value types. As support for more GC
policies is added, we can update the policy used for this test.

cc @dmitripivkine @tajila 