### PR TITLE
Use existing sun.security.util.SecurityConstants

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/RuntimePermissions.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/RuntimePermissions.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.util;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,38 +24,14 @@ package com.ibm.oti.util;
  *******************************************************************************/
 
 /**
- * RuntimePermission objects represent access to runtime
- * support.
- *
- * @author		IBM
- * @version		initial
+ * RuntimePermission objects represent access to runtime support.
  */
 public class RuntimePermissions {
 
 	/**
-	 * RuntimePermission "accessDeclaredMembers"
-	 */
-	public static final RuntimePermission permissionAccessDeclaredMembers = new RuntimePermission("accessDeclaredMembers");	//$NON-NLS-1$ 
-	/**
 	 * RuntimePermission "enableContextClassLoaderOverride"
 	 */
 	public static final RuntimePermission permissionEnableContextClassLoaderOverride = new RuntimePermission("enableContextClassLoaderOverride");	//$NON-NLS-1$
-	/**
-	 * RuntimePermission "getClassLoader"
-	 */
-	public static final RuntimePermission permissionGetClassLoader = new RuntimePermission("getClassLoader");	//$NON-NLS-1$ 
-	/**
-	 * RuntimePermission "getProtectionDomain"
-	 */
-	public static final RuntimePermission permissionGetProtectionDomain = new RuntimePermission("getProtectionDomain");	//$NON-NLS-1$ 
-	/**
-	 * RuntimePermission "getStackTrace"
-	 */
-	public static final RuntimePermission permissionGetStackTrace = new RuntimePermission("getStackTrace");	//$NON-NLS-1$ 
-	/**
-	 * RuntimePermission "modifyThreadGroup"
-	 */
-	public static final RuntimePermission permissionModifyThreadGroup = new RuntimePermission("modifyThreadGroup");	//$NON-NLS-1$ 
 	/**
 	 * RuntimePermission "setContextClassLoader"
 	 */
@@ -72,10 +48,6 @@ public class RuntimePermissions {
 	 * RuntimePermission "setSecurityManager"
 	 */
 	public static final RuntimePermission permissionSetSecurityManager = new RuntimePermission("setSecurityManager");	//$NON-NLS-1$
-	/**
-	 * RuntimePermission "stopThread"
-	 */
-	public static final RuntimePermission permissionStopThread = new RuntimePermission("stopThread");	//$NON-NLS-1$
 	/**
 	 * RuntimePermission "loggerFinder"
 	 */

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -83,6 +83,7 @@ import java.lang.annotation.Repeatable;
 import java.lang.invoke.*;
 import com.ibm.oti.reflect.TypeAnnotationParser;
 import java.security.PrivilegedActionException;
+import sun.security.util.SecurityConstants;
 
 /**
  * An instance of class Class is the in-image representation
@@ -285,7 +286,7 @@ void checkMemberAccess(SecurityManager security, ClassLoader callerClassLoader, 
 		/*[PR CMVC 82311] Spec is incorrect before 1.5, RI has this behavior since 1.2 */
 		/*[PR CMVC 201490] To remove CheckPackageAccess call from more Class methods */
 		if (type == Member.DECLARED && callerClassLoader != loader) {
-			security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionAccessDeclaredMembers);
+			security.checkPermission(SecurityConstants.CHECK_MEMBER_ACCESS_PERMISSION);
 		}
 		/*[PR CMVC 195558, 197433, 198986] Various fixes. */
 		if (sun.reflect.misc.ReflectUtil.needsPackageAccessCheck(callerClassLoader, loader)) {	
@@ -314,7 +315,7 @@ private void checkNonSunProxyMemberAccess(SecurityManager security, ClassLoader 
 	if (callerClassLoader != ClassLoader.bootstrapClassLoader) {
 		ClassLoader loader = getClassLoaderImpl();
 		if (type == Member.DECLARED && callerClassLoader != loader) {
-			security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionAccessDeclaredMembers);
+			security.checkPermission(SecurityConstants.CHECK_MEMBER_ACCESS_PERMISSION);
 		}
 		String packageName = this.getPackageName();
 		if (!(Proxy.isProxyClass(this) && packageName.equals(sun.reflect.misc.ReflectUtil.PROXY_PACKAGE)) &&
@@ -468,7 +469,7 @@ public static Class<?> forName(String className, boolean initializeBoolean, Clas
 			ClassLoader callerClassLoader = caller.getClassLoaderImpl();
 			if (callerClassLoader != ClassLoader.bootstrapClassLoader) {
 				/* only allowed if caller has RuntimePermission("getClassLoader") permission */
-				sm.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+				sm.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
 		}
 	}
@@ -517,7 +518,7 @@ public static Class<?> forName(Module module, String name)
 	if (null != sm) {
 		/* If the caller is not the specified module and RuntimePermission("getClassLoader") permission is denied, throw SecurityException */
 		if ((null != caller) && (caller.getModule() != module)) {
-			sm.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+			sm.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 		classLoader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
 	        public ClassLoader run() {
@@ -626,7 +627,7 @@ public ClassLoader getClassLoader() {
 		if (null != security) {
 			ClassLoader callersClassLoader = ClassLoader.callerClassLoader();
 			if (ClassLoader.needsClassLoaderPermissionCheck(callersClassLoader, classLoader)) {
-				security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+				security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
 		}
 	}
@@ -1841,7 +1842,7 @@ public String getName() {
 public ProtectionDomain getProtectionDomain() {
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
-		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetProtectionDomain);
+		security.checkPermission(sun.security.util.SecurityConstants.GET_PD_PERMISSION);
 	}
 
 	ProtectionDomain result = getPDImpl();

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2019 IBM Corp. and others
  *
@@ -46,6 +46,7 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.*;
 import java.security.cert.Certificate;
+import sun.security.util.SecurityConstants;
 
 /*[IF Sidecar19-SE]
 import java.lang.reflect.Modifier;
@@ -814,7 +815,7 @@ public final ClassLoader getParent() {
 		ClassLoader callersClassLoader = callerClassLoader();
 		/*[PR JAZZ103 76960] permission check is needed against the parent instead of this classloader */
 		if (needsClassLoaderPermissionCheck(callersClassLoader, parent)) {
-			security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+			security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 	}
 	return parent;
@@ -1038,7 +1039,7 @@ public static ClassLoader getPlatformClassLoader() {
 	if (security != null) {
 		ClassLoader callersClassLoader = callerClassLoader();
 		if (needsClassLoaderPermissionCheck(callersClassLoader, platformClassLoader)) {
-			security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+			security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 	}
 	return platformClassLoader;
@@ -1117,7 +1118,7 @@ public static ClassLoader getSystemClassLoader () {
 	if (security != null) {	
 		ClassLoader callersClassLoader = callerClassLoader();
 		if (needsClassLoaderPermissionCheck(callersClassLoader, sysLoader)) {
-			security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+			security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 	}
 

--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import sun.security.util.SecurityConstants;
 /*[IF Java11]
 import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.reflect.CallerSensitive;
@@ -637,7 +638,7 @@ public ClassLoader getContextClassLoader() {
 	if (currentManager != null) {
 		ClassLoader callerClassLoader = ClassLoader.callerClassLoader();
 		if (ClassLoader.needsClassLoaderPermissionCheck(callerClassLoader, contextClassLoader)) {
-			currentManager.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+			currentManager.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}	
 	}	
 	return contextClassLoader;
@@ -1195,7 +1196,7 @@ private final synchronized void stopWithThrowable(Throwable throwable) {
 	if (currentThread() != this || !(throwable instanceof ThreadDeath)) {
 		SecurityManager currentManager = System.getSecurityManager();
 		if (currentManager != null)	{
-			currentManager.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionStopThread);
+			currentManager.checkPermission(SecurityConstants.STOP_THREAD_PERMISSION);
 		}
 	}
 
@@ -1334,7 +1335,7 @@ public StackTraceElement[] getStackTrace() {
 	if (Thread.currentThread() != this) {
 		SecurityManager security = System.getSecurityManager();
 		if (security != null)
-			security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetStackTrace); //$NON-NLS-1$
+			security.checkPermission(SecurityConstants.GET_STACK_TRACE_PERMISSION); //$NON-NLS-1$
 	}
 	Throwable t;
 
@@ -1361,8 +1362,8 @@ public StackTraceElement[] getStackTrace() {
 public static Map<Thread, StackTraceElement[]> getAllStackTraces() {
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
-		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetStackTrace);
-		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionModifyThreadGroup);
+		security.checkPermission(SecurityConstants.GET_STACK_TRACE_PERMISSION);
+		security.checkPermission(SecurityConstants.MODIFY_THREADGROUP_PERMISSION);
 	}
 	// Allow room for more Threads to be created before calling enumerate()
 	int count = systemThreadGroup.activeCount() + 20;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 2009, 2019 IBM Corp. and others
  *
@@ -1632,7 +1632,7 @@ public class MethodHandles {
 
 					if (!Modifier.isPublic(modifiers)) {
 						if (vma.getClassloader(definingClass) != vma.getClassloader(accessClass)) {
-							secmgr.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionAccessDeclaredMembers);
+							secmgr.checkPermission(sun.security.util.SecurityConstants.CHECK_MEMBER_ACCESS_PERMISSION);
 						}
 
 						/* third check */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 2009, 2019 IBM Corp. and others
  *
@@ -346,7 +346,7 @@ public final class MethodType implements Serializable
 			/*[IF Java14]*/
 			SecurityManager security = System.getSecurityManager();
 			if (security != null) {
-				security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionGetClassLoader);
+				security.checkPermission(sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
 			/*[ENDIF]*/
 			classLoader = ClassLoader.getSystemClassLoader();

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2019 IBM Corp. and others
  *
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 /*[IF Sidecar19-SE]*/
 import sun.security.util.FilePermCompat;
 /*[ENDIF] Sidecar19-SE*/
+import sun.security.util.SecurityConstants;
 
 /**
  * An AccessControlContext encapsulates the information which is needed
@@ -77,11 +78,6 @@ public final class AccessControlContext {
 	Permission[] limitedPerms; // the limited permissions when isLimitedContext is true
 	AccessControlContext nextStackAcc; // AccessControlContext in next call stack when isLimitedContext is true
 	private int debugHasCodebase; // Set to the value of DEBUG_UNINITIALIZED_HASCODEBASE be default. Cache the result of hasDebugCodeBase()
-
-	private static final SecurityPermission createAccessControlContext =
-		new SecurityPermission("createAccessControlContext"); //$NON-NLS-1$
-	private static final SecurityPermission getDomainCombiner =
-		new SecurityPermission("getDomainCombiner"); //$NON-NLS-1$
 
 	static final int DEBUG_ACCESS = 1;
 	static final int DEBUG_ACCESS_STACK = 2;
@@ -382,7 +378,7 @@ AccessControlContext(AccessControlContext acc, DomainCombiner combiner, boolean 
 	if (!preauthorized) {
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
-			security.checkPermission(createAccessControlContext);
+			security.checkPermission(SecurityConstants.CREATE_ACC_PERMISSION);
 			/*[PR JAZZ 78139] java.security.AccessController.checkPermission invokes untrusted DomainCombiner.combine method */
 		}
 	}
@@ -734,7 +730,7 @@ public void checkPermission(Permission perm) throws AccessControlException {
 	if (null != context && (STATE_AUTHORIZED != authorizeState) && containPrivilegedContext && null != System.getSecurityManager()) {
 		// only check SecurityPermission "createAccessControlContext" when context is not null, not authorized and containPrivilegedContext.
 		if (STATE_UNKNOWN == authorizeState) {
-			if (null == callerPD || callerPD.implies(createAccessControlContext)) {
+			if (null == callerPD || callerPD.implies(SecurityConstants.CREATE_ACC_PERMISSION)) {
 				authorizeState = STATE_AUTHORIZED;
 			} else {
 				authorizeState = STATE_NOT_AUTHORIZED;
@@ -743,7 +739,7 @@ public void checkPermission(Permission perm) throws AccessControlException {
 		}
 		if (STATE_NOT_AUTHORIZED == authorizeState) {
 			/*[MSG "K002d", "Access denied {0} due to untrusted AccessControlContext since {1} is denied"]*/
-			throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002d", perm, createAccessControlContext), perm); //$NON-NLS-1$
+			throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002d", perm, SecurityConstants.CREATE_ACC_PERMISSION), perm); //$NON-NLS-1$
 		}
 	}
 
@@ -900,7 +896,7 @@ public int hashCode() {
 public DomainCombiner getDomainCombiner() {
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
-		security.checkPermission(getDomainCombiner);
+		security.checkPermission(SecurityConstants.GET_COMBINER_PERMISSION);
 	return domainCombiner;
 }
 

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2019 IBM Corp. and others
  *
@@ -23,6 +23,7 @@
 package java.security;
 
 import java.security.AccessControlContext.AccessCache;
+import sun.security.util.SecurityConstants;
 
 /*[IF Sidecar19-SE]
 import jdk.internal.reflect.CallerSensitive;
@@ -50,8 +51,6 @@ public final class AccessController {
 	static final int OBJS_INDEX_PERMS_OR_CACHECHECKED = 2;
 
 private static native void initializeInternal();
-/*[PR CMVC 197399] Improve checking order */
-private static final SecurityPermission createAccessControlContext = new SecurityPermission("createAccessControlContext"); //$NON-NLS-1$
 
 /* [PR CMVC 188787] Enabling -Djava.security.debug option within WAS keeps JVM busy */
 static final class DebugRecursionDetection {
@@ -159,7 +158,7 @@ private static void throwACE(boolean debug, Permission perm, ProtectionDomain pD
 		DebugRecursionDetection.getTlDebug().set(""); //$NON-NLS-1$
 		AccessControlContext.debugPrintAccess();
 		if (createACCdenied) {
-			System.err.println("access denied " + perm + " due to untrusted AccessControlContext since " + createAccessControlContext + " is denied."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			System.err.println("access denied " + perm + " due to untrusted AccessControlContext since " + SecurityConstants.CREATE_ACC_PERMISSION + " is denied."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		} else {
 			System.err.println("access denied " + perm); //$NON-NLS-1$
 		}
@@ -169,7 +168,7 @@ private static void throwACE(boolean debug, Permission perm, ProtectionDomain pD
 		DebugRecursionDetection.getTlDebug().set(""); //$NON-NLS-1$
 		new Exception("Stack trace").printStackTrace(); //$NON-NLS-1$
 		if (createACCdenied) {
-			System.err.println("domain that failed " + createAccessControlContext + " check " + pDomain); //$NON-NLS-1$ //$NON-NLS-2$
+			System.err.println("domain that failed " + SecurityConstants.CREATE_ACC_PERMISSION + " check " + pDomain); //$NON-NLS-1$ //$NON-NLS-2$
 		} else {
 			System.err.println("domain that failed " + pDomain); //$NON-NLS-1$
 		}
@@ -177,7 +176,7 @@ private static void throwACE(boolean debug, Permission perm, ProtectionDomain pD
 	}
 	if (createACCdenied) {
 		/*[MSG "K002d", "Access denied {0} due to untrusted AccessControlContext since {1} is denied"]*/
-		throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002d", perm, createAccessControlContext), perm); //$NON-NLS-1$
+		throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002d", perm, SecurityConstants.CREATE_ACC_PERMISSION), perm); //$NON-NLS-1$
 	} else {
 		/*[MSG "K002c", "Access denied {0}"]*/
 		throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002c", perm), perm); //$NON-NLS-1$
@@ -228,7 +227,7 @@ private static boolean checkPermissionHelper(Permission perm, AccessControlConte
 		/*[PR JAZZ 72492] PMR 24367,001,866: Unexpected Security Permission "createAccessControlContext" exception thrown from 1.6SR14 onwards */
 		// startPos: 1 is JEP140 format, 2 is Pre-JEP140 format
 		ProtectionDomain callerPD = (ProtectionDomain) objPDomains[startPos - 1];
-		if (null != callerPD && !callerPD.implies(createAccessControlContext)) {
+		if (null != callerPD && !callerPD.implies(SecurityConstants.CREATE_ACC_PERMISSION)) {
 			/*[PR CMVC 197399] Improve checking order */
 			// new behavior introduced by this fix
 			// an ACE is thrown if there is a untrusted PD but without SecurityPermission createAccessControlContext
@@ -594,7 +593,7 @@ private static int getNewAuthorizedState(AccessControlContext acc, ProtectionDom
 		newAuthorizedState = acc.authorizeState;
 		if (AccessControlContext.STATE_UNKNOWN == newAuthorizedState) {
 			// only change AccessControlContext.authorizeState when it is unknown initially
-			if (null == callerPD || callerPD.implies(createAccessControlContext)) {
+			if (null == callerPD || callerPD.implies(SecurityConstants.CREATE_ACC_PERMISSION)) {
 				newAuthorizedState = AccessControlContext.STATE_AUTHORIZED;
 			} else {
 				newAuthorizedState = AccessControlContext.STATE_NOT_AUTHORIZED;


### PR DESCRIPTION
**Use existing sun.security.util.SecurityConstants**

Replaced duplicated `Permission` objects with those already defined within `sun.security.util.SecurityConstants`;
Minor refactoring in affected files.

Verified that `pConfig` still compile. 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>