### PR TITLE
Populate cache corruption information for non-zero layer cache

### DIFF
--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -211,7 +211,7 @@ public:
 	virtual IDATA aotMethodOperation(J9VMThread* currentThread, char* methodSpecs, UDATA action);
 
 	/* @see CacheMapStats.hpp */
-	IDATA startupForStats(J9VMThread* currentThread, SH_OSCache * oscache, U_64 * runtimeflags);
+	IDATA startupForStats(J9VMThread* currentThread, const char* ctrlDirName, UDATA groupPerm, SH_OSCache * oscache, U_64 * runtimeflags, J9Pool **lowerLayerList);
 
 	/* @see CacheMapStats.hpp */
 	IDATA shutdownForStats(J9VMThread* currentThread);
@@ -519,6 +519,8 @@ private:
 	void printCacheStatsTopLayerSummaryStatsHelper(J9VMThread* currentThread, UDATA showFlags, U_64 runtimeFlags, J9SharedClassJavacoreDataDescriptor *javacoreData);
 	
 	void printCacheStatsAllLayersStatsHelper(J9VMThread* currentThread, UDATA showFlags, U_64 runtimeFlags, J9SharedClassJavacoreDataDescriptor *javacoreData, U_32 staleBytes);
+
+	IDATA startupLowerLayerForStats(J9VMThread* currentThread, const char* ctrlDirName, UDATA groupPerm, SH_OSCache *oscache, J9Pool** lowerLayerList);
 };
 
 #endif /* !defined(CACHEMAP_H_INCLUDED) */

--- a/runtime/shared_common/CacheMapStats.hpp
+++ b/runtime/shared_common/CacheMapStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@
 class SH_CacheMapStats
 {
 public:
-	virtual IDATA startupForStats(J9VMThread* currentThread, SH_OSCache * oscache, U_64 * runtimeflags) = 0;
+	virtual IDATA startupForStats(J9VMThread* currentThread, const char* ctrlDirName, UDATA groupPerm, SH_OSCache * oscache, U_64 * runtimeflags, J9Pool **lowerLayerList) = 0;
 
 	virtual IDATA shutdownForStats(J9VMThread* currentThread) = 0;
 

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -342,7 +342,11 @@ public:
 	void * getClassDebugDataStartAddress(void);
 
 	IDATA startupForStats(J9VMThread* currentThread, SH_OSCache * oscache, U_64 * runtimeFlags, UDATA verboseFlags);
-
+	
+	IDATA startupNonTopLayerForStats(J9VMThread* currentThread, const char* cacheDirName, const char* cacheName, U_32 cacheType, I_8 layer, U_64 * runtimeFlags, UDATA verboseFlags);
+	
+	IDATA getNonTopLayerCacheInfo(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, SH_OSCache_Info *cacheInfo);
+	
 	IDATA shutdownForStats(J9VMThread* currentThread);
 
 #if defined(J9SHR_CACHELET_SUPPORT)
@@ -431,6 +435,8 @@ public:
 	bool verifyCacheUniqueID(J9VMThread* currentThread, const char* expectedCacheUniqueID) const;
 	
 	void setMetadataMemorySegment(J9MemorySegment** segment);
+	
+	const char* getCacheNameWithVGen(void) const;
 
 private:
 	J9SharedClassConfig* _sharedClassConfig;

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -201,7 +201,10 @@ public:
 	static UDATA statCache(J9PortLibrary* portLibrary, const char* cacheDirName, const char* cacheNameWithVGen, bool displayNotFoundMsg);
 
 	static J9Pool* getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, bool includeOldGenerations, bool ignoreCompatible, UDATA reason, bool isCache);
-	static IDATA getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char* cacheNameWithVGen, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, SH_OSCache_Info* result, UDATA reason);
+
+	static IDATA getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char* cacheNameWithVGen, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, SH_OSCache_Info* result, UDATA reason, bool getLowerLayerStats, bool isTopLayer, J9Pool** lowerLayerList, SH_OSCache* oscache);
+	
+	static bool isTopLayerCache(J9JavaVM* vm, const char* ctrlDirName, char* nameWithVGen);
 	
 	static IDATA getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirName, char* buffer, UDATA bufferSize, const char* cacheNameWithVGen);
 	
@@ -212,8 +215,12 @@ public:
 	const char* getCacheUniqueID(J9VMThread* currentThread);
 
 	I_8 getLayer();
+	
+	const char* getCacheNameWithVGen();
 
 	bool isRunningReadOnly();
+	
+	U_32 getCacheType();
 
 	virtual bool startup(J9JavaVM* vm, const char* cacheDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, IDATA numLocks,
 			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* i, UDATA reason) = 0;
@@ -260,6 +267,8 @@ public:
 	virtual SH_CacheAccess isCacheAccessible(void) const { return J9SH_CACHE_ACCESS_ALLOWED; }
 
 	virtual void  dontNeedMetadata(J9VMThread* currentThread, const void* startAddress, size_t length);
+	
+	virtual IDATA detach(void) = 0;
 
 protected:	
 	/*This constructor should only be used by this class*/
@@ -289,7 +298,7 @@ protected:
 	
 	static U_64 getCacheVersionToU64(U_32 major, U_32 minor);
 
-	static bool getCacheStatsCommon(J9JavaVM* vm, SH_OSCache *cache, SH_OSCache_Info *cacheInfo);
+	static bool getCacheStatsCommon(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, SH_OSCache *cache, SH_OSCache_Info *cacheInfo, J9Pool **lowerLayerList);
 
 	char* _cacheName;
 	/* Align the U_64 so we don't have too many platform specific structure padding

--- a/runtime/shared_common/OSCachemmap.hpp
+++ b/runtime/shared_common/OSCachemmap.hpp
@@ -39,7 +39,9 @@
 class SH_OSCachemmap : public SH_OSCacheFile
 {
 public:
-	static IDATA getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char* filePath, SH_OSCache_Info* returnVal, UDATA reason);
+	static IDATA getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char *cacheNameWithVGen, SH_OSCache_Info *cacheInfo, UDATA reason, J9Pool** lowerLayerList);
+	
+	static IDATA getNonTopLayerCacheInfo(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char *cacheNameWithVGen, SH_OSCache_Info *cacheInfo, UDATA reason, SH_OSCachemmap* oscache);
 	  
 	SH_OSCachemmap(J9PortLibrary* portlib, J9JavaVM* vm, const char* cacheDirName, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
 			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer);
@@ -63,6 +65,8 @@ public:
 	virtual void cleanup();
 	
 	virtual void* attach(J9VMThread *currentThread, J9PortShcVersion* expectedVersionData);
+
+	virtual IDATA detach(void);
 	
 #if defined (J9SHR_MSYNC_SUPPORT)
 	virtual IDATA syncUpdates(void* start, UDATA length, U_32 flags);
@@ -114,7 +118,6 @@ private:
 	I_32 createCacheHeader(OSCachemmap_header_version_current *cacheHeader, J9PortShcVersion* versionData);
 	bool setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo);
 	I_32 initializeDataHeader(SH_OSCacheInitializer *initializer);
-	void detach();
 	
 	bool deleteCacheFile(LastErrorInfo *lastErrorInfo);
 	

--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -132,9 +132,13 @@ public:
 	IDATA acquireWriteLock(UDATA lockID);
 	IDATA releaseWriteLock(UDATA lockID);
   	
-	static IDATA getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char* filePath, SH_OSCache_Info* cacheInfo, UDATA reason);
+	static IDATA getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char* cacheNameWithVGen, SH_OSCache_Info* cacheInfo, UDATA reason, J9Pool** lowerLayerList);
+	
+	static IDATA getNonTopLayerCacheInfo(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char *cacheNameWithVGen, SH_OSCache_Info *cacheInfo, UDATA reason, SH_OSCachesysv* oscache);
 	
 	void *attach(J9VMThread *currentThread, J9PortShcVersion* expectedVersionData);
+	
+	virtual IDATA detach(void);
 	
 #if defined (J9SHR_MSYNC_SUPPORT)
 	IDATA syncUpdates(void* start, UDATA length, U_32 flags); 
@@ -206,8 +210,6 @@ private:
 	SH_SysvShmAccess _shmAccess;
 
 	J9ControlFileStatus _controlFileStatus;
-
-	IDATA detach(void);
 
 	IDATA openCache(const char* ctrlDirName, J9PortShcVersion* versionData, bool semCreated);
 

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2160,7 +2160,7 @@ TraceExit=Trc_SHR_OSC_Sysv_DestroySysVMemoryHelper_Exit NoEnv Overhead=1 Level=3
 TraceEntry=Trc_SHR_OSC_Sysv_getCacheStatsHelper_Entry NoEnv Overhead=1 Level=1 Template="SH_OSCachesysv::getCacheStatsHelper: Entered - cacheNameWithVGen=%s"
 TraceExit=Trc_SHR_OSC_Sysv_getCacheStatsHelper_removeCacheVersionAndGenFailed NoEnv Overhead=1 Level=1 Template="SH_OSCachesysv::getCacheStatsHelper: Exit - failed removeCacheVersionAndGen"
 TraceExit=Trc_SHR_OSC_Sysv_getCacheStatsHelper_cacheStatFailed NoEnv Overhead=1 Level=1 Template="SH_OSCachesysv::getCacheStatsHelper: Exit - failed j9shmem_stat"
-TraceExit=Trc_SHR_OSC_Sysv_getCacheStatsHelper_Exit NoEnv Overhead=1 Level=1 Template="SH_OSCachesysv::getCacheStatsHelper: Exit"
+TraceExit=Trc_SHR_OSC_Sysv_getCacheStatsHelper_Exit NoEnv Obsolete Overhead=1 Level=1 Template="SH_OSCachesysv::getCacheStatsHelper: Exit"
 
 TraceExit=Trc_SHR_OSC_getCacheDir_j9shmem_createDir_failed NoEnv Overhead=1 Level=1 Template="OSCache::getCacheDir: createDir failed"
 
@@ -2966,3 +2966,13 @@ TraceEvent=Trc_SHR_RRM_storeNew_existingEntryRemoved Overhead=1 Level=6 Template
 TraceExit-Exception=Trc_SHR_CM_updateROMClassResource_Exit8 Overhead=1 Level=1 Template="CM updateROMClassResource: Failed to allocate memory for ROMClass resource"
 
 TraceEvent=Trc_SHR_CM_updateROMSegmentList_NewHeapAlloc Overhead=1 Level=4 Template="CM updateROMSegmentList: Updated class segment list - currentSegment is %p, new heapAlloc=%p"
+
+TraceEntry=Trc_SHR_OSC_Sysv_getNonTopLayerCacheInfo_Entry NoEnv Overhead=1 Level=9 Template="SH_OSCachesysv::getNonTopLayerCacheInfo: Entering ctrlDirName is %s, groupPerm is %zu, cacheNameWithVGen is %s, reason is %zu"
+TraceExit=Trc_SHR_OSC_Sysv_getNonTopLayerCacheInfo_Exit NoEnv Overhead=1 Level=9 Template="SH_OSCachesysv::getNonTopLayerCacheInfo: Exit retval is %zd"
+TraceExit=Trc_SHR_OSC_Sysv_getCacheStatsHelper_Exit1 NoEnv Overhead=1 Level=1 Template="SH_OSCachesysv::getCacheStatsHelper: Exit. cacheInfo->name is %s, cacheInfo->os_shmid is %zu, cacheInfo->lastattach is %lld, cacheInfo->lastdetach is %lld, cacheInfo->nattach is %zd"
+TraceEntry=Trc_SHR_OSC_Mmap_getNonTopLayerCacheInfo_Entry NoEnv Overhead=1 Level=9 Template="SH_OSCachemmap::getNonTopLayerCacheInfo: Entering ctrlDirName is %s, groupPerm is %zu, cacheNameWithVGen is %s, reason is %zu"
+TraceExit=Trc_SHR_OSC_Mmap_getNonTopLayerCacheInfo_Exit NoEnv Overhead=1 Level=9 Template="SH_OSCachemmap::getNonTopLayerCacheInfo: Exit retval is %zd, cacheInfo->name is %s, cacheInfo->lastattach is %lld, cacheInfo->lastdetach is %lld, cacheInfo->createtime %lld"
+TraceEntry=Trc_SHR_CC_startupNonTopLayerForStats_Entry Overhead=1 Level=9 Template="CC::startupNonTopLayerForStats: Entering ctrlDirName is %s, cacheName is %s, cacheType %u, layer is %d, runtimeFlags is %llu, verboseFlags is %zu"
+TraceExit=Trc_SHR_CC_startupNonTopLayerForStats_Exit Overhead=1 Level=9 Template="CC::startupNonTopLayerForStats: Exit retVal is %zd"
+TraceException=Trc_SHR_OSC_getAllCacheStatistics_pool_newElement_failed NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache::getAllCacheStatistics: (%d) Failed to get a new pool element"
+TraceException=Trc_SHR_CM_startupForStats_pool_newElement_failed Overhead=1 Level=1 Template="SH_CacheMap::startupForStats: Failed to get a new pool element"


### PR DESCRIPTION
We read the cache metadata to detect whether a cache is corrupted and
populate such info to SH_OSCache_Info.isCorrupt. We do this only when
iterating the caches in a directory (reason==SHR_STATS_REASON_ITERATE).
Currently this is working on layer 0 cache only. 

This change extends this to non-zero layer cache. 
This change should only take effect when getting SH_OSCache_Info on a
compatible multi-layer cache when the reason to get cache statistics is
SHR_STATS_REASON_ITERATE.

issue #5480

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>