### PR TITLE
Handle unsupported scanner types in ObjectIterator

### DIFF
--- a/runtime/gc_glue_java/ObjectIterator.hpp
+++ b/runtime/gc_glue_java/ObjectIterator.hpp
@@ -132,6 +132,8 @@ public:
 			return _pointerContiguousArrayIterator.restore(objectIteratorState);
 		case GC_ObjectModel::SCAN_PRIMITIVE_ARRAY_OBJECT:
 			return;
+		default:
+			Assert_MM_unreachable();
 		}
 	}
 
@@ -157,6 +159,8 @@ public:
 			return _pointerContiguousArrayIterator.save(objectIteratorState);
 		case GC_ObjectModel::SCAN_PRIMITIVE_ARRAY_OBJECT:
 			return;
+		default:
+			Assert_MM_unreachable();
 		}
 	}
 


### PR DESCRIPTION
There are two switch statements regarding the scanner type which are missing the default case. This results in the following warning:
```
In file included from HeapWalker.cpp:36:0:
../../../../gc_glue_java/ObjectIterator.hpp: In member function 'void GC_ObjectIterator::restore(GC_ObjectIteratorState*)':
../../../../gc_glue_java/ObjectIterator.hpp:120:10: error: enumeration value 'SCAN_FLATTENED_ARRAY_OBJECT' not handled in switch [-Werror=switch
   switch (_type) {
         ^
./../../../gc_glue_java/ObjectIterator.hpp: In member function 'void GC_ObjectIterator::save(GC_ObjectIteratorState*)':
../../../../gc_glue_java/ObjectIterator.hpp:145:10: error: enumeration value 'SCAN_FLATTENED_ARRAY_OBJECT[m[K' not handled in switch [-Werror=switch]
   switch (_type) {
          ^
```
This was introduced in #7916 
cc @dmitripivkine

Fixes #7960