### PR TITLE
Fix memory leak due to caching of resolved methods

### DIFF
--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -741,6 +741,9 @@ TR_PersistentMethodInfo::setForSharedInfo(TR_PersistentProfileInfo** ptr, TR_Per
 TR_PersistentJittedBodyInfo *
 J9::Recompilation::persistentJittedBodyInfoFromString(const std::string &bodyInfoStr, const std::string &methodInfoStr, TR_Memory *trMemory)
    {
+   if (bodyInfoStr.empty())
+      return NULL;
+   TR_ASSERT_FATAL(!methodInfoStr.empty(), "If we have a persistentBodyInfo we must have a persistentMethodInfo too");
    auto bodyInfo = (TR_PersistentJittedBodyInfo*) trMemory->allocateHeapMemory(sizeof(TR_PersistentJittedBodyInfo), TR_MemoryBase::Recompilation);
    auto methodInfo = (TR_PersistentMethodInfo*) trMemory->allocateHeapMemory(sizeof(TR_PersistentMethodInfo), TR_MemoryBase::Recompilation);
 

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -60,7 +60,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
 
-   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedJ9JITServerMethodInfo &methodInfo);
+   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
    bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedJ9JITServerMethod *owningMethod, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
    TR_ResolvedMethodKey getResolvedMethodKey(TR_ResolvedMethodType type, TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_OpaqueClassBlock *classObject = NULL);
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -291,7 +291,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedPossiblyPrivateVirtualMethod(TR::Compil
          if (comp->getOption(TR_EnableAOTStats))
             aotStats = & (((TR_JitPrivateConfig *)_fe->_jitConfig->privateConfig)->aotStats->virtualMethods);
 
-         TR_ResolvedJ9JITServerMethodInfo methodInfo = std::get<3>(recv);
+         TR_ResolvedJ9JITServerMethodInfo &methodInfo = std::get<3>(recv);
          
          // call constructor without making a new query
          if (createResolvedMethod)
@@ -612,7 +612,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedStaticMethod(TR::Compilation * comp, I_
          }
       }
 
-   auto methodInfo = std::get<1>(recv);
+   auto &methodInfo = std::get<1>(recv);
    if (ramMethod && !skipForDebugging)
       {
       TR_AOTInliningStats *aotStats = NULL;
@@ -661,7 +661,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedSpecialMethod(TR::Compilation * comp, I
    _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedSpecialMethodAndMirror, _remoteMirror, cpIndex);
    auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITServerMethodInfo>();
    J9Method * ramMethod = std::get<0>(recv);
-   auto methodInfo = std::get<1>(recv);
+   auto &methodInfo = std::get<1>(recv);
 
    if (ramMethod)
       {
@@ -849,7 +849,7 @@ TR_ResolvedJ9JITServerMethod::getResolvedImproperInterfaceMethod(TR::Compilation
       _stream->write(JITServer::MessageType::ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror, _remoteMirror, cpIndex);
       auto recv = _stream->read<J9Method *, TR_ResolvedJ9JITServerMethodInfo, UDATA>();
       auto j9method = std::get<0>(recv);
-      auto methodInfo = std::get<1>(recv);
+      auto &methodInfo = std::get<1>(recv);
       auto vtableOffset = std::get<2>(recv);
 
       if (comp->getOption(TR_UseSymbolValidationManager) && j9method)
@@ -1606,7 +1606,7 @@ TR_ResolvedJ9JITServerMethod::packMethodInfo(TR_ResolvedJ9JITServerMethodInfo &m
 void
 TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, TR_FrontEnd * fe, TR_Memory * trMemory, uint32_t vTableSlot, TR::CompilationInfoPerThread *threadCompInfo, const TR_ResolvedJ9JITServerMethodInfo &methodInfo)
    {
-   auto methodInfoStruct = std::get<0>(methodInfo);
+   auto &methodInfoStruct = std::get<0>(methodInfo);
    
    
    _ramMethod = (J9Method *)aMethod;
@@ -1655,7 +1655,7 @@ TR_ResolvedJ9JITServerMethod::unpackMethodInfo(TR_OpaqueMethodBlock * aMethod, T
    setRecognizedMethod(rm);
 
    JITServerIProfiler *iProfiler = (JITServerIProfiler *) ((TR_J9VMBase *) fe)->getIProfiler();
-   const std::string entryStr = std::get<3>(methodInfo);
+   const std::string &entryStr = std::get<3>(methodInfo);
    const auto serialEntry = (TR_ContiguousIPMethodHashTableEntry*) &entryStr[0];
    _iProfilerMethodEntry = (iProfiler && !entryStr.empty()) ? iProfiler->deserializeMethodEntry(serialEntry, trMemory) : NULL; 
    }
@@ -2117,7 +2117,7 @@ TR_ResolvedRelocatableJ9JITServerMethod::createResolvedMethodFromJ9Method(TR::Co
    // Calling constructor would be simpler, but we would have to make another message to update stats
    _stream->write(JITServer::MessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, getRemoteMirror(), j9method, cpIndex, vTableSlot);
    auto recv = _stream->read<TR_ResolvedJ9JITServerMethodInfo, bool, bool, bool>();
-   auto methodInfo = std::get<0>(recv);
+   auto &methodInfo = std::get<0>(recv);
    // These parameters are only needed to update AOT stats. 
    // Maybe we shouldn't even track them, because another version of this method doesn't.
    bool isRomClassForMethodInSharedCache = std::get<1>(recv);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -23,6 +23,7 @@
 #ifndef J9METHODSERVER_H
 #define J9METHODSERVER_H
 
+#include "control/J9Recompilation.hpp"
 #include "env/j9method.h"
 #include "env/PersistentCollections.hpp"
 #include "runtime/JITServerIProfiler.hpp"
@@ -113,7 +114,10 @@ TR_ResolvedMethodCacheEntry
    {
    TR_OpaqueMethodBlock *method;
    uint32_t vTableSlot;
-   TR_ResolvedJ9JITServerMethodInfo methodInfo;
+   TR_ResolvedJ9JITServerMethodInfoStruct methodInfoStruct;
+   TR_PersistentJittedBodyInfo *persistentBodyInfo;
+   TR_PersistentMethodInfo *persistentMethodInfo;
+   TR_ContiguousIPMethodHashTableEntry *IPMethodInfo;
    };
 
 using TR_ResolvedMethodInfoCache = UnorderedMap<TR_ResolvedMethodKey, TR_ResolvedMethodCacheEntry>;


### PR DESCRIPTION
The JITServer keeps a cache with information that ease the creation
of new resolved methods. This information is sent by the JITClient
and includes three std::string blobs representing the bytes for
PersistentJittedBodyInfo, PersistentMethodInfo and a serialized version
of the IProfiler information related to the method in question.
Caching these three strings is wrong because they come directly from
the protobuf infrastructure which uses the system heap for memory
allocations. So even though our cache is created with scratch memory
the underlying buffers for these strings still use system heap memory.
These buffers will leak because we don't explicitly free memory, but
rather rely on freeing the entire backing scratch memory segments.

The solution adopted in this commit is to cache pointers to memory
allocated from the scratch segments with `allocateHeapMemory` and then
to recreate the strings when retrieving the required information from
the cache. Further efficiency can be achieved by not having to recreate
those strings, but doing so requires some code restructuring which is
better left for a separate PR.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>