### PR TITLE
Add AdoptOpenJDK/openjdk-tests repository to git repository cache

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
@@ -134,6 +134,12 @@ timeout(time: 6, unit: 'HOURS') {
 
                         // get Eclipse OpenJ9 extensions repositories from variables file
                         def repos = get_openjdk_repos(VARIABLES.openjdk, foundLabel)
+
+                        if (nodeLabels.contains('ci.role.test')) {
+                            // add AdoptOpenJDK/openjdk-tests repository
+                            repos.add([name: "adoptopenjdk", url: VARIABLES.adoptopenjdk.default.get('repoUrl')])
+                        }
+
                         if (jenkins.model.Jenkins.instance.getLabel(SETUP_LABEL).getNodes().contains(aNode)) {
                             // add OpenJ9 repo
                             repos.addAll(EXTENSIONS_REPOS)


### PR DESCRIPTION
Update test nodes git cache with AdoptOpenJDK/openjdk-tests repository.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>