### PR TITLE
Add missing barriers to jProfiling helpers

### DIFF
--- a/runtime/compiler/runtime/ValueProfiler.cpp
+++ b/runtime/compiler/runtime/ValueProfiler.cpp
@@ -229,7 +229,15 @@ TR_AbstractHashTableProfilerInfo::tryLock(bool disableJITAccess)
    MetaData unlocked = _metaData;
    unlocked.lock = 0;
 
-   return unlocked.rawData == VM_AtomicSupport::lockCompareExchangeU32((uint32_t*) &_metaData, unlocked.rawData, locked.rawData);
+   if (unlocked.rawData == VM_AtomicSupport::lockCompareExchangeU32((uint32_t*) &_metaData, unlocked.rawData, locked.rawData))
+      {
+      VM_AtomicSupport::readBarrier();
+      return true;
+      }
+   else
+      {
+      return false;
+      }
    }
 
 /**
@@ -242,6 +250,8 @@ TR_AbstractHashTableProfilerInfo::unlock(bool enableJITAccess)
    {
    MetaData locked = _metaData;
    MetaData unlocked = _metaData;
+
+   VM_AtomicSupport::writeBarrier();
 
    do {
       locked.rawData = _metaData.rawData;


### PR DESCRIPTION
Previously, the tryLock and unlock methods on the jProfiling hash table
implementation did not contain any read or write barriers. While this is
fine on architectures such as x86-64, this causes problems with the weak
memory model used in Power. Failing to include the barriers could allow
reordering of memory accesses to cause incorrect behaviour with
unpredictable results.

Signed-off-by: Ben Thomas <ben@benthomas.ca>