### PR TITLE
AArch64: Add initial implementation of JNILinkage

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -21,10 +21,240 @@
  *******************************************************************************/
 
 #include "codegen/ARM64JNILinkage.hpp"
+
+#include "codegen/ARM64HelperCallSnippet.hpp"
+#include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/RegisterDependency.hpp"
+#include "env/VMJ9.h"
+#include "il/Node.hpp"
+#include "il/SymbolReference.hpp"
+#include "infra/Assert.hpp"
 
 J9::ARM64::JNILinkage::JNILinkage(TR::CodeGenerator *cg)
    : J9::ARM64::PrivateLinkage(cg)
    {
+   _systemLinkage = cg->getLinkage(TR_System);
+   }
+
+int32_t J9::ARM64::JNILinkage::buildArgs(TR::Node *callNode,
+   TR::RegisterDependencyConditions *dependencies)
+   {
+   TR_ASSERT(0, "Should call J9::ARM64::JNILinkage::buildJNIArgs instead.");
+   return 0;
+   }
+
+TR::Register *J9::ARM64::JNILinkage::buildIndirectDispatch(TR::Node *callNode)
+   {
+   TR_ASSERT(0, "Calling J9::ARM64::JNILinkage::buildIndirectDispatch does not make sense.");
+   return NULL;
+   }
+
+void J9::ARM64::JNILinkage::buildVirtualDispatch(
+      TR::Node *callNode,
+      TR::RegisterDependencyConditions *dependencies,
+      uint32_t argSize)
+   {
+   TR_ASSERT(0, "Calling J9::ARM64::JNILinkage::buildVirtualDispatch does not make sense.");
+   }
+
+void J9::ARM64::JNILinkage::releaseVMAccess(TR::Node *callNode, TR::Register *vmThreadReg)
+   {
    TR_UNIMPLEMENTED();
+   }
+
+void J9::ARM64::JNILinkage::acquireVMAccess(TR::Node *callNode, TR::Register *vmThreadReg)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+#ifdef J9VM_INTERP_ATOMIC_FREE_JNI
+void J9::ARM64::JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode, TR::Register *vmThreadReg)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void J9::ARM64::JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode, TR::Register *vmThreadReg)
+   {
+   TR_UNIMPLEMENTED();
+   }
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+
+void J9::ARM64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, bool isWrapperForJNI, TR::LabelSymbol *returnAddrLabel,
+                                                 TR::Register *vmThreadReg, TR::Register *javaStackReg)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void J9::ARM64::JNILinkage::restoreJNICallOutFrame(TR::Node *callNode, bool tearDownJNIFrame, TR::Register *vmThreadReg, TR::Register *javaStackReg)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+size_t J9::ARM64::JNILinkage::buildJNIArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool passThread, bool passReceiver, bool killNonVolatileGPRs)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }
+
+TR::Register *J9::ARM64::JNILinkage::getReturnRegisterFromDeps(TR::Node *callNode, TR::RegisterDependencyConditions *deps)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+TR::Register *J9::ARM64::JNILinkage::pushJNIReferenceArg(TR::Node *child)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+void J9::ARM64::JNILinkage::adjustReturnValue(TR::Node *callNode, bool wrapRefs, TR::Register *returnRegister)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+void J9::ARM64::JNILinkage::checkForJNIExceptions(TR::Node *callNode, TR::Register *vmThreadReg)
+   {
+   TR_UNIMPLEMENTED();
+   }
+
+TR::Instruction *J9::ARM64::JNILinkage::generateMethodDispatch(TR::Node *callNode, bool isJNIGCPoint,
+                                                               TR::RegisterDependencyConditions *deps, uintptrj_t targetAddress)
+   {
+   TR_UNIMPLEMENTED();
+   return NULL;
+   }
+
+TR::Register *J9::ARM64::JNILinkage::buildDirectDispatch(TR::Node *callNode)
+   {
+   TR::LabelSymbol *returnLabel = generateLabelSymbol(cg());
+   TR::SymbolReference *callSymRef = callNode->getSymbolReference();
+   TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
+   TR::ResolvedMethodSymbol *resolvedMethodSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
+   TR_ResolvedMethod *resolvedMethod = resolvedMethodSymbol->getResolvedMethod();
+   uintptrj_t targetAddress = reinterpret_cast<uintptrj_t>(resolvedMethod->startAddressForJNIMethod(comp()));
+   TR_J9VMBase *fej9 = reinterpret_cast<TR_J9VMBase *>(fe());
+
+   bool dropVMAccess = !fej9->jniRetainVMAccess(resolvedMethod);
+   bool isJNIGCPoint = !fej9->jniNoGCPoint(resolvedMethod);
+   bool killNonVolatileGPRs = isJNIGCPoint;
+   bool checkExceptions = !fej9->jniNoExceptionsThrown(resolvedMethod);
+   bool createJNIFrame = !fej9->jniNoNativeMethodFrame(resolvedMethod);
+   bool tearDownJNIFrame = !fej9->jniNoSpecialTeardown(resolvedMethod);
+   bool wrapRefs = !fej9->jniDoNotWrapObjects(resolvedMethod);
+   bool passReceiver = !fej9->jniDoNotPassReceiver(resolvedMethod);
+   bool passThread = !fej9->jniDoNotPassThread(resolvedMethod);
+
+   if (resolvedMethodSymbol->canDirectNativeCall())
+      {
+      dropVMAccess = false;
+      killNonVolatileGPRs = false;
+      isJNIGCPoint = false;
+      checkExceptions = false;
+      createJNIFrame = false;
+      tearDownJNIFrame = false;
+      }
+   else if (resolvedMethodSymbol->isPureFunction())
+      {
+      dropVMAccess = false;
+      isJNIGCPoint = false;
+      checkExceptions = false;
+      }
+
+   cg()->machine()->setLinkRegisterKilled(true);
+
+   const int maxRegisters = getProperties()._numAllocatableIntegerRegisters + getProperties()._numAllocatableFloatRegisters;
+   TR::RegisterDependencyConditions *deps = new (trHeapMemory()) TR::RegisterDependencyConditions(maxRegisters, maxRegisters, trMemory());
+
+   size_t spSize = buildJNIArgs(callNode, deps, passThread, passReceiver, killNonVolatileGPRs);
+   TR::RealRegister *sp = machine()->getRealRegister(_systemLinkage->getProperties().getStackPointerRegister());
+
+   if (spSize > 0)
+      {
+      if (constantIsUnsignedImm12(spSize))
+         {
+         generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::subimmx, callNode, sp, sp, spSize);
+         }
+      else
+         {
+         TR_ASSERT_FATAL(false, "Too many arguments.");
+         }
+      }
+
+   TR::Register *returnRegister = getReturnRegisterFromDeps(callNode, deps);
+   auto postLabelDeps = deps->clonePost(cg());
+   TR::RealRegister *vmThreadReg = machine()->getRealRegister(getProperties().getMethodMetaDataRegister());   // x19
+   TR::RealRegister *javaStackReg = machine()->getRealRegister(getProperties().getStackPointerRegister());    // x20
+   TR::Register *x9Reg = deps->searchPreConditionRegister(TR::RealRegister::x9);
+   TR::Register *x10Reg = deps->searchPreConditionRegister(TR::RealRegister::x10);
+   TR::Register *x11Reg = deps->searchPreConditionRegister(TR::RealRegister::x11);
+   TR::Register *x12Reg = deps->searchPreConditionRegister(TR::RealRegister::x12);
+
+   if (createJNIFrame)
+      {
+      buildJNICallOutFrame(callNode, (resolvedMethod == comp()->getCurrentMethod()), returnLabel, vmThreadReg, javaStackReg);
+      }
+
+   if (passThread)
+      {
+      TR::RealRegister *vmThread = machine()->getRealRegister(getProperties().getMethodMetaDataRegister());
+      TR::Register *x0Reg = deps->searchPreConditionRegister(TR::RealRegister::x0);
+      generateMovInstruction(cg(), callNode, x0Reg, vmThread);
+      }
+
+   if (dropVMAccess)
+      {
+#ifdef J9VM_INTERP_ATOMIC_FREE_JNI
+      releaseVMAccessAtomicFree(callNode, vmThreadReg);
+#else
+      releaseVMAccess(callNode, vmThreadReg);
+#endif
+      }
+
+
+   TR::Instruction *callInstr = generateMethodDispatch(callNode, isJNIGCPoint, deps, targetAddress);
+   generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, returnLabel, deps, callInstr);
+
+   if (spSize > 0)
+      {
+      if (constantIsUnsignedImm12(spSize))
+         {
+         generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::addimmx, callNode, sp, sp, spSize);
+         }
+      else
+         {
+         TR_ASSERT_FATAL(false, "Too many arguments.");
+         }
+      }
+
+   if (dropVMAccess)
+      {
+#ifdef J9VM_INTERP_ATOMIC_FREE_JNI
+      acquireVMAccessAtomicFree(callNode, vmThreadReg);
+#else
+      acquireVMAccess(callNode, vmThreadReg);
+#endif
+      }
+
+   if (returnRegister != NULL)
+      {
+      adjustReturnValue(callNode, wrapRefs, returnRegister);
+      }
+
+   if (createJNIFrame)
+      {
+      restoreJNICallOutFrame(callNode, tearDownJNIFrame, vmThreadReg, javaStackReg);
+      }
+
+   if (checkExceptions)
+      {
+      checkForJNIExceptions(callNode, vmThreadReg);
+      }
+
+   TR::LabelSymbol *depLabel = generateLabelSymbol(cg());
+   generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, depLabel, postLabelDeps);
+
+   callNode->setRegister(returnRegister);
+   return returnRegister;
    }

--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
@@ -24,6 +24,7 @@
 #define ARM64_JNILINKAGE_INCL
 
 #include "codegen/ARM64PrivateLinkage.hpp"
+#include "codegen/Register.hpp"
 
 namespace J9
 {
@@ -36,6 +37,150 @@ class JNILinkage : public PrivateLinkage
    public:
 
    JNILinkage(TR::CodeGenerator *cg);
+
+   /**
+    * @brief Builds method arguments
+    * @param[in] callNode : caller node
+    * @param[in] dependencies : register dependency conditions
+    * @return size of arguments
+    */
+   virtual int32_t buildArgs(
+      TR::Node *callNode,
+      TR::RegisterDependencyConditions *dependencies);
+
+   /**
+    * @brief Builds direct dispatch to method
+    * @param[in] callNode : caller node
+    * @return register holding return value
+    */
+   virtual TR::Register *buildDirectDispatch(TR::Node *callNode);
+
+   /**
+    * @brief Builds indirect dispatch to method
+    * @param[in] callNode : caller node
+    * @return register holding return value
+    */
+   virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
+
+   /**
+    * @brief Builds virtual dispatch to method
+    * @param[in] callNode : caller node
+    * @param[in] dependencies : register dependency conditions
+    * @param[in] argSize : size of arguments
+    */
+   virtual void buildVirtualDispatch(
+      TR::Node *callNode,
+      TR::RegisterDependencyConditions *dependencies,
+      uint32_t argSize);
+
+   private:
+
+   /**
+    * @brief Releases VM access before calling into JNI method
+    * @param[in] callNode : caller node
+    * @param[in] vmThreadReg : vm thread register
+    */
+   void releaseVMAccess(TR::Node *callNode, TR::Register *vmThreadReg);
+
+   /**
+    * @brief Acquires VM access after returned from JNI method
+    * @param[in] callNode : caller node
+    * @param[in] vmThreadReg : vm thread register
+    */
+   void acquireVMAccess(TR::Node *callNode, TR::Register *vmThreadReg);
+
+#ifdef J9VM_INTERP_ATOMIC_FREE_JNI
+   /**
+    * @brief Releases VM access in a way described in OpenJ9 issue 2576
+    * @param[in] callNode : caller Node
+    * @param[in] vmThreadReg : vm thread register
+    */
+   void releaseVMAccessAtomicFree(TR::Node *callNode, TR::Register *vmThreadReg);
+
+   /**
+    * @brief Acquires VM access in a way described in OpenJ9 issue 2576
+    * @param[in] callNode : caller Node
+    * @param[in] vmThreadReg : vm thread register
+    */
+   void acquireVMAccessAtomicFree(TR::Node *callNode, TR::Register *vmThreadReg);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+
+   /**
+    * @brief Builds JNI call out frame
+    * @param[in] callNode : caller node
+    * @param[in] isWrapperForJNI : true if the current method is simply a wrapper for the JNI call
+    * @param[in] returnAddrLabel : label symbol of return address from JNI method
+    * @param[in] vmThreadReg : vm thread register
+    * @param[in] javaStackReg : java stack register
+    */
+   void buildJNICallOutFrame(TR::Node *callNode, bool isWrapperForJNI,
+                             TR::LabelSymbol *returnAddrLabel, TR::Register *vmThreadReg,
+                             TR::Register *javaStackReg);
+
+   /**
+    * @brief Restores JNI call out frame
+    * @param[in] callNode : caller node
+    * @param[in] tearDownJNIFrame : true if we need to clean up ref pool
+    * @param[in] vmThreadReg : vm thread register
+    * @param[in] javaStackReg : java stack register
+    */
+   void restoreJNICallOutFrame(TR::Node *callNode, bool tearDownJNIFrame, TR::Register *vmThreadReg, TR::Register *javaStackReg);
+
+   /**
+    * @brief Builds JNI method arguments
+    * @param[in] callNode : caller node
+    * @param[in] deps : register dependency conditions
+    * @param[in] passThread : true if we need to pass vm thread as first parameter
+    * @param[in] passReceiver : true if we need to pass receiver to the JNI method
+    * @param[in] killNonVolatileGPRs : true if we need to kill non-volatile GPRs
+    * @return the total size in bytes allocated on stack for parameter passing
+    */
+   size_t buildJNIArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool passThread, bool passReceiver, bool killNonVolatileGPRs);
+
+   /**
+    * @brief Returns register holding resturn value
+    * @param[in] callNode : caller node
+    * @param[in] deps : register dependency conditions
+    * @return register holding return value. Null if return type is void.
+    */
+   TR::Register *getReturnRegisterFromDeps(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
+
+   /**
+    * @brief Pushes a JNI reference argument
+    * @param[in] child : argument node
+    * @return register holding argument
+    */
+   TR::Register *pushJNIReferenceArg(TR::Node *child);
+
+   /**
+    * @brief Generates a JNI method dispatch instructions
+    * @param[in] callNode : caller node
+    * @param[in] isJNIGCPoint : true if the JNI method dispatch is GC point
+    * @param[in] deps : register dependency conditions
+    * @param[in] targetAddress : address of JNI method
+    * @return instruction of method dispatch
+    */
+   TR::Instruction *generateMethodDispatch(TR::Node *callNode, bool isJNIGCPoint, TR::RegisterDependencyConditions *deps, uintptrj_t targetAddress);
+
+   /**
+    * @brief Adjusts return value to java semantics
+    * @param[in] callNode : caller node
+    * @param[in] wrapRefs : true if the reference is wrapped
+    * @param[in] returnRegister : register that holds return value
+    */
+   void adjustReturnValue(TR::Node *callNode, bool wrapRefs, TR::Register *returnRegister);
+
+   /**
+    * @brief Throws exception if it is set in JNI method
+    * @param[in] callNode : caller node
+    * @param[in] vmThreadReg : vm thread register
+    */
+   void checkForJNIExceptions(TR::Node *callNode, TR::Register *vmThreadReg);
+
+   TR::Linkage *_systemLinkage;
+
+
+
    };
 
 }


### PR DESCRIPTION
- Add helper methods to JNILinkage class.
- Add `buildDirectDispatch` method and its initial implementation.

`buildDirectDispatch` builds direct dispatch using helper methods.
Those helper methods are unimplemented yet.

Depends on https://github.com/eclipse/omr/pull/4638

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>