### PR TITLE
CMake: Add flag for double mapped arraylets

### DIFF
--- a/runtime/cmake/caches/linux.cmake
+++ b/runtime/cmake/caches/linux.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,20 +20,4 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-set(J9VM_ARCH_X86 ON CACHE BOOL "")
-set(J9VM_ENV_DATA64 ON CACHE BOOL "")
-set(J9VM_ENV_HAS_FPU ON CACHE BOOL "")
-set(J9VM_ENV_LITTLE_ENDIAN ON CACHE BOOL "")
-
-set(OMR_GC_IDLE_HEAP_MANAGER ON CACHE BOOL "")
-set(OMR_GC_TLH_PREFETCH_FTA ON CACHE BOOL "")
-set(J9VM_PORT_RUNTIME_INSTRUMENTATION OFF CACHE BOOL "")
-set(J9VM_MODULE_CODEGEN_IA32 ON CACHE BOOL "")
-set(J9VM_MODULE_CODERT_IA32 ON CACHE BOOL "")
-set(J9VM_MODULE_JIT_IA32 ON CACHE BOOL "")
-set(J9VM_MODULE_JITRT_IA32 ON CACHE BOOL "")
-set(J9VM_MODULE_MASM2GAS ON CACHE BOOL "")
-set(J9VM_GC_IDLE_HEAP_MANAGER ON CACHE BOOL "")
-set(J9VM_OPT_SWITCH_STACKS_FOR_SIGNAL_HANDLER ON CACHE BOOL "")
-
-include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
+set(J9VM_GC_ENABLE_DOUBLE_MAP ON CACHE BOOL "")

--- a/runtime/cmake/caches/linux_ppc-64_le_gcc.cmake
+++ b/runtime/cmake/caches/linux_ppc-64_le_gcc.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 1991, 2019 IBM Corp. and others
+# Copyright (c) 1991, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,4 +38,5 @@ set(J9VM_GC_IDLE_HEAP_MANAGER OFF CACHE BOOL "")
 set(J9VM_OPT_SWITCH_STACKS_FOR_SIGNAL_HANDLER OFF CACHE BOOL "")
 set(J9VM_PORT_RUNTIME_INSTRUMENTATION ON CACHE BOOL "")
 
+include("${CMAKE_CURRENT_LIST_DIR}/linux.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")

--- a/runtime/cmake/caches/linux_x86-64.cmake
+++ b/runtime/cmake/caches/linux_x86-64.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 1991, 2019 IBM Corp. and others
+# Copyright (c) 1991, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,4 +37,5 @@ set(J9VM_MODULE_MASM2GAS ON CACHE BOOL "")
 set(J9VM_GC_IDLE_HEAP_MANAGER ON CACHE BOOL "")
 set(J9VM_OPT_SWITCH_STACKS_FOR_SIGNAL_HANDLER ON CACHE BOOL "")
 
+include("${CMAKE_CURRENT_LIST_DIR}/linux.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")

--- a/runtime/cmake/caches/win_x86-64.cmake
+++ b/runtime/cmake/caches/win_x86-64.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,10 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(J9VM_ARCH_X86 ON CACHE BOOL "")
+set(J9VM_ENV_DATA64 ON CACHE BOOL "")
+set(J9VM_ENV_LITTLE_ENDIAN ON CACHE BOOL "")
+
 set(J9VM_ENV_HAS_FPU OFF CACHE INTERNAL "")
 set(OMR_GC_IDLE_HEAP_MANAGER OFF CACHE BOOL "")
 set(J9VM_GC_IDLE_HEAP_MANAGER OFF CACHE BOOL "")
@@ -31,4 +35,13 @@ set(J9VM_MODULE_WINDBG ON CACHE BOOL "")
 set(OMR_THR_YIELD_ALG OFF CACHE BOOL "")
 #OPT_NATIVE_CHARACTER_CONVERTER
 
-include(${CMAKE_CURRENT_LIST_DIR}/linux_x86-64_cmprssptrs.cmake)
+set(OMR_GC_TLH_PREFETCH_FTA ON CACHE BOOL "")
+set(J9VM_PORT_RUNTIME_INSTRUMENTATION OFF CACHE BOOL "")
+set(J9VM_MODULE_CODEGEN_IA32 ON CACHE BOOL "")
+set(J9VM_MODULE_CODERT_IA32 ON CACHE BOOL "")
+set(J9VM_MODULE_JIT_IA32 ON CACHE BOOL "")
+set(J9VM_MODULE_JITRT_IA32 ON CACHE BOOL "")
+set(J9VM_MODULE_MASM2GAS ON CACHE BOOL "")
+set(J9VM_OPT_SWITCH_STACK_FOR_SIGNAL_HANDLER ON CACHE BOOL "")
+
+include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")

--- a/runtime/cmake/options.cmake
+++ b/runtime/cmake/options.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,12 @@ j9vm_shadowed_option(J9VM_GC_BATCH_CLEAR_TLH "Zero any TLH allocated")
 j9vm_shadowed_option(J9VM_GC_COMBINATION_SPEC "Set on specs which implement LIR 16325:  reduce memory footprint by combining multiple sidecars into the same set of libraries.")
 j9vm_shadowed_option(J9VM_GC_CONCURRENT_SWEEP "Enable concurrent sweep in Modron")
 j9vm_shadowed_option(J9VM_GC_DEBUG_ASSERTS "Specialized GC assertions are used instead of standard trace asserts for GC assertions")
+
+# When enabled, a contiguous block of memory is created for each array in which data surpasses the size of a region. This contiguous block represents the array as
+# if the data was stored in a contiguous region of memory. All of the array data is stored in a unique region (not with spine); hence, all arraylets
+# become discontiguous whenever this flag is enabled. Since there won’t be any empty arraylet leaves, then arrayoid NULL pointers are no longer required since
+# all data is stored in a unique region. It additionaly reduces footprint, mainly for JNI primitive array critical.
+j9vm_shadowed_option(J9VM_GC_ENABLE_DOUBLE_MAP OMR_GC_DOUBLE_MAP_ARRAYLETS "Allows LINUX systems to double map arrays that are stored as arraylets.")
 j9vm_shadowed_option(J9VM_GC_IDLE_HEAP_MANAGER  "Enable VM idle java heap management(decommit excess free java heap pages)")
 j9vm_shadowed_option(J9VM_GC_LARGE_OBJECT_AREA "Enable large object area (LOA) support")
 j9vm_shadowed_option(J9VM_GC_LEAF_BITS "Add leaf bit instance descriptions to classes")

--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,6 +111,7 @@ extern "C" {
 #cmakedefine J9VM_GC_DEBUG_ASSERTS
 #cmakedefine J9VM_GC_DYNAMIC_CLASS_UNLOADING
 #cmakedefine J9VM_GC_DYNAMIC_NEW_SPACE_SIZING
+#cmakedefine J9VM_GC_ENABLE_DOUBLE_MAP
 #cmakedefine J9VM_GC_FINALIZATION
 #cmakedefine J9VM_GC_FRAGMENTED_HEAP
 #cmakedefine J9VM_GC_GENERATIONAL


### PR DESCRIPTION
- Introduce new "linux.cmake" for holding options common to linux configs
- Stop using linux_x86-64 as a base for osx and windows builds

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>