### PR TITLE
Added the -Xshareclasses:none option tests

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -119,6 +119,53 @@
 	</test>
 
 	<test>
+		<testCaseName>jit_jitt_openj9_none_SCC</testCaseName>
+		<variations>
+			<variation>-Xjit:noJitUntilMain,count=0,assumeStrictFP,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>
+			<variation>-Xrs -Xjit:noJitUntilMain,count=0,assumeStrictFP,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>
+			<variation>-Xrs:sync -Xjit:noJitUntilMain,count=0,assumeStrictFP,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>
+			<variation>-Xrs:async -Xjit:noJitUntilMain,count=0,assumeStrictFP,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	arrayTest,\
+	assemblerTest,\
+	castingTest,\
+	cfgTest,\
+	crashesTest,\
+	ctresolvesTest,\
+	exceptionsTest,\
+	fieldsTest,\
+	floatsTest,\
+	gcTest,\
+	geCastingTest,\
+	immedOpTest,\
+	invokeTest,\
+	mathTest,\
+	math2Test,\
+	miscTest,\
+	os390LinkageTest,\
+	promotionTest,\
+	resolvesTest,\
+	sieveTest,\
+	transitionsTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+
+	<test>
 		<testCaseName>jit_jitt_XCEEHDLR</testCaseName>
 		<variations>
 			<variation>-XCEEHDLR -Xjit:noJitUntilMain,count=0,assumeStrictFP,optlevel=warm,gcOnResolve,rtResolve -verbose:stackwalk=0 -Xdump</variation>

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1038,6 +1038,62 @@
 	</test>
 
 	<test>
+		<testCaseName>JCL_Test_openj9_none_SCC</testCaseName>
+		<variations>
+			<variation>-Xshareclasses:none</variation>
+			<variation>-XX:RecreateClassfileOnload -Xshareclasses:none</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
+	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
+	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED $(ADD_EXPORTS_JDK_INTERNAL_REFLECT) \
+	--add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
+	--add-exports java.base/sun.net.www.protocol.jrt=ALL-UNNAMED \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	--add-opens=java.base/java.security=ALL-UNNAMED \
+	$(ADD_EXPORTS_JDK_INTERNAL_ACCESS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(JAXB_API_JAR)$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	JCL_TEST_Test-TypeAnnotation,\
+	JCL_TEST_Test-Annotation,\
+	JCL_TEST_Test-Annotation-Identity,\
+	JCL_TEST_Test-Annotation-ClassLoader,\
+	JCL_TEST_Java-Lang_ClassLoader,\
+	JCL_TEST_Test-Annotation-Package,\
+	JCL_TEST_Test-Defects,\
+	JCL_TEST_Test-UnsafeFence,\
+	JCL_TEST_IBM-VM,\
+	JCL_TEST_Java-Lang,\
+	JCL_TEST_Java-Lang-Invoke,\
+	JCL_TEST_Java-Lang-Ref,\
+	JCL_TEST_Java-Lang-Reflect,\
+	JCL_TEST_Java-Math,\
+	JCL_TEST_Test-RunLast \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^vm.hrt</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>9+</subset>
+		</subsets>
+		<aot>nonapplicable</aot>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+
+	<test>
 		<testCaseName>JCL_Test_OutOfMemoryError</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1547,6 +1603,33 @@
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>TestArrayCopy_openj9_none_SCC</testCaseName>
+		<variations>
+			<variation>Mode100</variation>
+			<variation>Mode101</variation>
+			<variation>Mode600</variation>
+			<variation>Mode619</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames TestArrayCopy \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
 		</impls>
 	</test>
 

--- a/test/functional/Jsr335/playlist.xml
+++ b/test/functional/Jsr335/playlist.xml
@@ -90,6 +90,38 @@
 	</test>
 
 	<test>
+		<testCaseName>jsr335tests_openj9_none_SCC</testCaseName>
+		<variations>
+			<variation>Mode100</variation>
+			<variation>Mode600</variation>
+			<variation>Mode101</variation>
+			<variation>Mode601</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+			<variation>Mode301</variation>
+			<variation>Mode501</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)junit4.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(P)$(TEST_RESROOT)$(D)Jsr335.jar$(P).$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames jsr335 \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>9+</subset>
+		</subsets>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+
+	<test>
 		<testCaseName>jsr335tests_defendersupersends_SE80</testCaseName>
 		<variations>
 			<variation>Mode100</variation>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -149,6 +149,50 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_jvmtitests_hcr_openi9_none_SCC</testCaseName>
+		<variations>
+			<variation>Mode100</variation>
+			<variation>Mode101</variation>
+			<variation>Mode110</variation>
+			<variation>Mode112</variation>
+			<variation>Mode148</variation>
+			<variation>Mode201</variation>
+			<variation>Mode301</variation>
+			<variation>Mode351</variation>
+			<variation>Mode551</variation>
+			<variation>Mode501</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+	-DTEST_ROOT=$(Q)$(TEST_RESROOT)$(Q) \
+	-DJAR=$(Q)$(TEST_RESROOT)$(D)jvmtitest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump $(SQ) \
+	-DEXTRA_Add_OPEN_OPTION=$(SQ)--add-opens=java.base/java.lang.reflect=ALL-UNNAMED$(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)jvmtitests_hcr.xml$(Q) \
+	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>^arch.390</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+
 	<test>
 		<testCaseName>cmdLineTester_jvmtitests_debug</testCaseName>
 		<variations>
@@ -189,6 +233,47 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_jvmtitests_debug_openj9_none_SCC</testCaseName>
+		<variations>
+			<variation>Mode100</variation>
+			<variation>Mode107</variation>
+			<variation>Mode108</variation>
+			<variation>Mode154</variation>
+			<variation>Mode307</variation>
+			<variation>Mode357</variation>
+			<variation>Mode507</variation>
+			<variation>Mode557</variation>
+			<variation>Mode607</variation>
+			<variation>Mode608</variation>
+			<variation>Mode107-OSR</variation>
+			<variation>Mode607-OSR</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xshareclasses:none \
+	-DTEST_ROOT=$(Q)$(TEST_RESROOT)$(Q) \
+	-DJAR=$(Q)$(TEST_RESROOT)$(D)jvmtitest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump $(SQ) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)jvmtitests_extended.xml$(Q) \
+	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>^arch.390</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+
 	<test>
 		<testCaseName>cmdLineTester_jvmtitests_nongold</testCaseName>
 		<variations>


### PR DESCRIPTION
Added the tests with -Xshareclasses:none option for the following tests:

JCL_Test
TestArrayCopy
cmdLineTester_jvmtitests
cmdLineTester_jvmtitests_hcr
cmdLineTester_jvmtitests_debug
jsr335tests
jit_jitt

Fixes: #3945

Signed-off-by: Jiahan Xi <doomerXe@gmail.com>