### PR TITLE
Implement findOr{Create,Fabricate}ShadowSymbol functions

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -786,6 +786,14 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
    bool sharesSymbol = false;
 
    TR_OpaqueClassBlock *containingClass = NULL;
+   TR::Symbol::RecognizedField recognizedField = TR::Symbol::searchRecognizedField(comp(), owningMethod, cpIndex, false);
+
+   if (isStore && isPrivate && !comp()->getOptions()->realTimeGC() &&
+       owningMethodSymbol->getResolvedMethod()->getRecognizedMethod() == TR::java_lang_ref_SoftReference_get &&
+       recognizedField == TR::Symbol::Java_lang_ref_SoftReference_age)
+      {
+      isVolatile = false;
+      }
 
    if (resolved)
       {
@@ -809,7 +817,6 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
 
    TR::Symbol * sym = 0;
 
-   TR::Symbol::RecognizedField recognizedField = TR::Symbol::searchRecognizedField(comp(), owningMethod, cpIndex, false);
    TR::SymbolReference * symRef = findShadowSymbol(owningMethod, cpIndex, type, &recognizedField);
    if (symRef)
       {

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -52,6 +52,12 @@
 #include "env/PersistentCHTable.hpp"
 #include "optimizer/J9TransformUtil.hpp"
 
+#include <stdio.h>
+
+#if defined (_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
+
 namespace J9
 {
 enum NonUserMethod
@@ -76,7 +82,10 @@ J9::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation 
      _unsafeJavaStaticVolatileSymRefs(NULL),
      _currentThreadDebugEventDataSymbol(0),
      _currentThreadDebugEventDataSymbolRefs(c->trMemory()),
-     _constantPoolAddressSymbolRefs(c->trMemory())
+     _constantPoolAddressSymbolRefs(c->trMemory()),
+     _resolvedFieldShadows(
+        std::less<ResolvedFieldShadowKey>(),
+        getTypedAllocator<ResolvedFieldShadowsEntry>(c->allocator()))
    {
    for (uint32_t i = 0; i < _numImmutableClasses; i++)
       _immutableSymRefNumbers[i] = new (trHeapMemory()) TR_BitVector(sizeHint, c->trMemory(), heapAlloc, growable);
@@ -608,43 +617,195 @@ J9::SymbolReferenceTable::findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol *
       return symRef;
    else
       {
-      sym = TR::Symbol::createRecognizedShadow(trHeapMemory(),type, recognizedField);
-      if (name)
-         {
-         sym->setNamedShadowSymbol();
-         sym->setName(name);
-         }
-
-      if (isVolatile)
-         sym->setVolatile();
-      if (isFinal)
-         sym->setFinal();
-      if (isPrivate)
-         sym->setPrivate();
-      static char *dontAliasShadowsToEarlierGIS = feGetEnv("TR_dontAliasShadowsToEarlierGIS");
-      if (aliasBuilder.mutableGenericIntShadowHasBeenCreated() && !dontAliasShadowsToEarlierGIS)
-         {
-         // Some previously-created GIS might actually refer to this shadow
-         aliasBuilder.setConservativeGenericIntShadowAliasing(true);
-         }
-
+      sym = createShadowSymbol(
+         type,
+         isVolatile,
+         isPrivate,
+         isFinal,
+         name,
+         recognizedField);
       }
+
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1);
    // isResolved = true, isUnresolvedInCP = false
    initShadowSymbol(owningMethod, symRef, true, type, offset, false);
    return symRef;
    }
 
+TR::SymbolReference *
+J9::SymbolReferenceTable::findResolvedFieldShadow(
+   ResolvedFieldShadowKey key,
+   bool isVolatile,
+   bool isPrivate,
+   bool isFinal)
+   {
+   const auto entry = _resolvedFieldShadows.find(key);
+   if (entry == _resolvedFieldShadows.end())
+      return NULL;
+
+   TR::SymbolReference *symRef = entry->second;
+   int32_t refNum = symRef->getReferenceNumber();
+   TR::Symbol *sym = symRef->getSymbol();
+
+   // The following asserts enforce restrictions on certain symbols properties.
+   //
+   // Taking volatility as an example, it is possible to find a symref in _resolvedFieldShadows
+   // whose symbols is marked isVolatile but that is for a non-volatile field. Consider a scenario
+   // where, during compilation, an unresolved field reference is encountered. We will create a
+   // symbol and conservatively mark is volatile. Later, a resolved reference for the same field is
+   // encountered (note that it need not have the same cpIndex as the first field ref). Being
+   // resolved, we determine that it is non-volatile. Because a symref for the field
+   // already exists but has a different resolution state, a new *symref* is created but the found
+   // *symbol* is reused. Since volatility is a property of the symbol, the new symref will share
+   // the volatility of the first symref (which was unresolved and must therefore be conservatively
+   // considered volatile). The new symref is then added to _resolvedFieldShadows. The next time
+   // the same field reference is encountered, the symref for it is found in _resolvedFieldShadows
+   // and once again its symbol is marked as volatile despite the field being non-volatile.
+   //
+   // The inverse condition, however, is not currently possible (i.e. finding a non-volatile symbol
+   // for a volatile field). Still, it's possible that could change in the future (for accesses
+   // with different memory ordering effects). If so, it should be made part of the key, and the
+   // two symRefs differing only in isVolatile should be considered to possibly alias.
+   //
+   // Similar restrictions apply to the isPrivate and isFinal symbol properties, although the truth
+   // conditions are reversed.
+   TR_ASSERT_FATAL(sym->isVolatile() || !isVolatile, "expecting volatile symref but found non-volatile symref #%d\n", refNum);
+   TR_ASSERT_FATAL(!sym->isPrivate() || isPrivate, "expecting non-private symref but found private symref #%d\n", refNum);
+   TR_ASSERT_FATAL(!sym->isFinal() || isFinal, "expecting non-final symref but found final symref #%d\n", refNum);
+
+   return symRef;
+   }
+
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrFabricateShadowSymbol(
+   TR_OpaqueClassBlock *containingClass,
+   TR::DataType type,
+   uint32_t offset,
+   bool isVolatile,
+   bool isPrivate,
+   bool isFinal,
+   const char *name,
+   const char *signature)
+   {
+   ResolvedFieldShadowKey key(containingClass, offset, type);
+   TR::SymbolReference *symRef = findResolvedFieldShadow(key, isVolatile, isPrivate, isFinal);
+   if (symRef != NULL)
+      return symRef;
+
+   int32_t classNameLen = 0;
+   const char *className =
+      TR::Compiler->cls.classNameChars(comp(), containingClass, classNameLen);
+
+   int qualifiedFieldNameSize = classNameLen + 1 + strlen(name) + 1 + strlen(signature) + 1;
+   char *qualifiedFieldName = (char*)trHeapMemory().allocate(qualifiedFieldNameSize);
+   snprintf(
+      qualifiedFieldName,
+      qualifiedFieldNameSize,
+      "%.*s.%s %s",
+      classNameLen,
+      className,
+      name,
+      signature);
+
+   TR::Symbol *sym = createShadowSymbol(
+      type,
+      isVolatile,
+      isPrivate,
+      isFinal,
+      qualifiedFieldName,
+      TR::Symbol::UnknownField);
+
+   mcount_t methodIndex = mcount_t::valueOf(0);
+   int32_t cpIndex = -1;
+   symRef = new (trHeapMemory()) TR::SymbolReference(
+      self(),
+      sym,
+      methodIndex,
+      cpIndex);
+
+   bool isResolved = true;
+   bool isUnresolvedInCP = false;
+   initShadowSymbol(NULL, symRef, isResolved, type, offset, isUnresolvedInCP);
+
+   _resolvedFieldShadows.insert(std::make_pair(key, symRef));
+   return symRef;
+   }
+
+TR::Symbol *
+J9::SymbolReferenceTable::createShadowSymbol(
+   TR::DataType type,
+   bool isVolatile,
+   bool isPrivate,
+   bool isFinal,
+   const char *name,
+   TR::Symbol::RecognizedField recognizedField)
+   {
+   TR::Symbol *sym = NULL;
+   if (recognizedField != TR::Symbol::UnknownField)
+      sym = TR::Symbol::createRecognizedShadow(trHeapMemory(), type, recognizedField);
+   else
+      sym = TR::Symbol::createShadow(trHeapMemory(), type);
+
+   if (name != NULL)
+      {
+      sym->setNamedShadowSymbol();
+      sym->setName(name);
+      }
+
+   if (isVolatile)
+      sym->setVolatile();
+
+   if (isPrivate)
+      sym->setPrivate();
+
+   if (isFinal)
+      sym->setFinal();
+
+   static char *dontAliasShadowsToEarlierGISEnv = feGetEnv("TR_dontAliasShadowsToEarlierGIS");
+   bool dontAliasShadowsToEarlierGIS = dontAliasShadowsToEarlierGISEnv != NULL;
+
+   if (aliasBuilder.mutableGenericIntShadowHasBeenCreated() && !dontAliasShadowsToEarlierGIS)
+      {
+      // Some previously-created GIS might actually refer to this shadow
+      aliasBuilder.setConservativeGenericIntShadowAliasing(true);
+      }
+
+   return sym;
+   }
 
 TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore)
    {
-   TR_ResolvedMethod * owningMethod = owningMethodSymbol->getResolvedMethod();
+   TR_ResolvedJ9Method * owningMethod =
+      static_cast<TR_ResolvedJ9Method*>(owningMethodSymbol->getResolvedMethod());
+
    bool isVolatile = true, isFinal = false, isPrivate = false, isUnresolvedInCP;
    TR::DataType type = TR::NoType;
    uint32_t offset = 0;
    bool resolved = owningMethod->fieldAttributes(comp(), cpIndex, &offset, &type, &isVolatile, &isFinal, &isPrivate, isStore, &isUnresolvedInCP, true);
    bool sharesSymbol = false;
+
+   TR_OpaqueClassBlock *containingClass = NULL;
+
+   if (resolved)
+      {
+      bool isStatic = false;
+      containingClass =
+         owningMethod->definingClassFromCPFieldRef(comp(), cpIndex, isStatic);
+
+      TR_ASSERT_FATAL(
+         containingClass != NULL,
+         "failed to get defining class of field ref cpIndex=%d in owning method J9Method=%p",
+         cpIndex,
+         owningMethod->getNonPersistentIdentifier());
+
+      ResolvedFieldShadowKey key(containingClass, offset, type);
+      TR::SymbolReference *symRef =
+         findResolvedFieldShadow(key, isVolatile, isPrivate, isFinal);
+
+      if (symRef != NULL)
+         return symRef;
+      }
 
    TR::Symbol * sym = 0;
 
@@ -660,22 +821,13 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
       }
    else
       {
-      if (recognizedField != TR::Symbol::UnknownField)
-         sym = TR::Symbol::createRecognizedShadow(trHeapMemory(),type, recognizedField);
-      else
-         sym = TR::Symbol::createShadow(trHeapMemory(),type);
-      if (isVolatile)
-         sym->setVolatile();
-      if (isFinal)
-         sym->setFinal();
-      if (isPrivate)
-         sym->setPrivate();
-      static char *dontAliasShadowsToEarlierGIS = feGetEnv("TR_dontAliasShadowsToEarlierGIS");
-      if (aliasBuilder.mutableGenericIntShadowHasBeenCreated() && !dontAliasShadowsToEarlierGIS)
-         {
-         // Some previously-created GIS might actually refer to this shadow
-         aliasBuilder.setConservativeGenericIntShadowAliasing(true);
-         }
+      sym = createShadowSymbol(
+         type,
+         isVolatile,
+         isPrivate,
+         isFinal,
+         NULL,
+         recognizedField);
       }
 
    int32_t unresolvedIndex = resolved ? 0 : _numUnresolvedSymbols++;
@@ -693,6 +845,12 @@ J9::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * ow
 
    if (cpIndex > 0)
       aliasBuilder.cpSymRefs().set(symRef->getReferenceNumber());
+
+   if (containingClass != NULL)
+      {
+      ResolvedFieldShadowKey key(containingClass, offset, type);
+      _resolvedFieldShadows.insert(std::make_pair(key, symRef));
+      }
 
    return symRef;
    }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1835,7 +1835,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          J9Class *clazz = (J9Class *) J9_CLASS_FROM_METHOD(ramMethod);
          if (!definingClass)
             {
-            definingClass = (J9Class *) compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), constantPool, cpIndex, isStatic);
+            definingClass = (J9Class *) TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, isStatic);
             }
          UDATA *classChain = NULL;
          if (definingClass)
@@ -1866,7 +1866,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          bool result = method->fieldAttributes(comp, cpIndex, &fieldOffset, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
-         TR_OpaqueClassBlock *definingClass = compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), constantPool, cpIndex, false);
+         TR_OpaqueClassBlock *definingClass = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, false);
 
          TR_J9MethodFieldAttributes attrs(static_cast<uintptr_t>(fieldOffset), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result, definingClass);
 
@@ -1886,7 +1886,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          bool result = method->staticAttributes(comp, cpIndex, &address, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
-         TR_OpaqueClassBlock *definingClass = compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), constantPool, cpIndex, true);
+         TR_OpaqueClassBlock *definingClass = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, true);
 
          TR_J9MethodFieldAttributes attrs(reinterpret_cast<uintptr_t>(address), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result, definingClass);
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1711,7 +1711,7 @@ TR_ResolvedRelocatableJ9Method::storeValidationRecordIfNecessary(TR::Compilation
 
    if (!definingClass)
       {
-      definingClass = (J9Class *) reloRuntime->getClassFromCP(fej9->vmThread(), constantPool, cpIndex, isStatic);
+      definingClass = (J9Class *) TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, isStatic);
       traceMsg(comp, "\tdefiningClass recomputed from cp as %p\n", definingClass);
       }
 
@@ -1835,7 +1835,7 @@ TR_ResolvedRelocatableJ9Method::fieldAttributes(TR::Compilation * comp, int32_t 
                else
                   reloRuntime = compInfo->getCompInfoForThread(fej9->vmThread())->reloRuntime();
 
-               TR_OpaqueClassBlock *clazz = reloRuntime->getClassFromCP(fej9->vmThread(), constantPool, cpIndex, false);
+               TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, false);
 
                fieldInfoCanBeUsed = comp->getSymbolValidationManager()->addDefiningClassFromCPRecord(clazz, constantPool, cpIndex);
                }
@@ -1960,7 +1960,7 @@ TR_ResolvedRelocatableJ9Method::staticAttributes(TR::Compilation * comp,
          else
             reloRuntime = compInfo->getCompInfoForThread(fej9->vmThread())->reloRuntime();
 
-         TR_OpaqueClassBlock *clazz = reloRuntime->getClassFromCP(fej9->vmThread(), constantPool, cpIndex, true);
+         TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, true);
 
          fieldInfoCanBeUsed = comp->getSymbolValidationManager()->addDefiningClassFromCPRecord(clazz, constantPool, cpIndex, true);
          }
@@ -7087,7 +7087,6 @@ TR_ResolvedJ9Method::definingClassFromCPFieldRef(
    /* Get the class.  Stop immediately if an exception occurs. */
    J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&constantPool->romConstantPool[cpIndex];
 
-   // TODO: J9_RESOLVE_FLAG_JIT_COMPILE_TIME vs. J9_RESOLVE_FLAG_AOT_LOAD_TIME
    J9Class *resolvedClass = javaVM->internalVMFunctions->resolveClassRef(vmThread, constantPool, romFieldRef->classRefCPIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
 
    if (resolvedClass == NULL)

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2024,7 +2024,18 @@ TR_ResolvedRelocatableJ9Method::definingClassFromCPFieldRef(
    I_32 cpIndex,
    bool isStatic)
    {
-   return TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+   TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, cp(), cpIndex, isStatic);
+
+   bool valid = false;
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      valid = comp->getSymbolValidationManager()->addDefiningClassFromCPRecord(clazz , cp(), cpIndex, isStatic);
+   else
+      valid = storeValidationRecordIfNecessary(comp, cp(), cpIndex, isStatic ? TR_ValidateStaticField : TR_ValidateInstanceField, ramMethod());
+
+   if (!valid)
+      clazz = NULL;
+
+   return clazz;
    }
 
 char *

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -426,6 +426,9 @@ public:
 
    virtual bool                    staticAttributes( TR::Compilation *, int32_t cpIndex, void * *, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOValidation);
 
+   static TR_OpaqueClassBlock  * definingClassFromCPFieldRef(TR::Compilation *comp, J9ConstantPool *constantPool, int32_t cpIndex, bool isStatic);
+   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
+
    virtual char *                  fieldNameChars(int32_t cpIndex, int32_t & len);
    virtual char *                  staticNameChars(int32_t cpIndex, int32_t & len);
    virtual char *                  fieldSignatureChars(int32_t cpIndex, int32_t & len);
@@ -571,6 +574,8 @@ public:
    virtual bool                    fieldAttributes ( TR::Compilation *, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
 
    virtual bool                    staticAttributes( TR::Compilation *, int32_t cpIndex, void * *, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
+
+   virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic);
 
    virtual int32_t                 virtualCallSelector(uint32_t cpIndex);
    virtual char *                  fieldSignatureChars(int32_t cpIndex, int32_t & len);

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -162,6 +162,7 @@ private:
    // GenLoadStore
    //
    void         loadInstance(int32_t);
+   void         loadInstance(TR::SymbolReference *, int32_t);
    void         loadStatic(int32_t);
    void         loadAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);
    TR::Node     *loadSymbol(TR::ILOpCodes, TR::SymbolReference *);
@@ -183,6 +184,7 @@ private:
    void         loadMonitorArg();
 
    void         storeInstance(int32_t);
+   void         storeInstance(TR::SymbolReference *symRef);
    void         storeStatic(int32_t);
    void         storeAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);
    void         storeArrayElement(TR::DataType dt){ storeArrayElement(dt, comp()->il.opCodeForIndirectArrayStore(dt)); }
@@ -225,6 +227,9 @@ private:
    int32_t      genAThrow();
    void         genMonitorEnter();
    void         genMonitorExit(bool);
+   TR_OpaqueClassBlock *loadValueClass(int32_t classCpIndex);
+   void         genDefaultValue(uint16_t classCpIndex);
+   void         genWithField(uint16_t fieldCpIndex);
    void         genFlush(int32_t nargs);
    void         genFullFence(TR::Node *node);
    void         handlePendingPushSaveSideEffects(TR::Node *, int32_t stackSize = -1);

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -602,6 +602,10 @@ const uint8_t TR_J9ByteCodeIterator::_byteCodeFlags[] =
                              0x01, // J9BCmonitorenter
                              0x01, // J9BCmonitorexit
                              0x00, // J9BCwide
+                             0x01, // J9BCasyncCheck --- TODO: Is this the right size?
+                             0x03, // J9BCdefaultvalue
+                             0x03, // J9BCwithfield
+                             0x01, // J9BCbreakpoint --- TODO: Is this the right size?
                              0x01, // BCunknown
    };
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6363,7 +6363,6 @@ TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
          TR::Node *secondChild = node->getChild(1);
          if (secondChild && secondChild->getOpCodeValue() == TR::iconst && secondChild->getInt() == 0)
             {
-            symbol->resetVolatile();
             handleSideEffect(node);
             genTreeTop(node);
             genFullFence(node);

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3168,8 +3168,7 @@ TR_RelocationRecordValidateInstanceField::getClassFromCP(TR_RelocationRuntime *r
    TR_OpaqueClassBlock *definingClass = NULL;
    if (void_cp)
       {
-      J9JavaVM *javaVM = reloRuntime->javaVM();
-      definingClass = reloRuntime->getClassFromCP(javaVM->internalVMFunctions->currentVMThread(javaVM), (J9ConstantPool *) void_cp, cpIndex(reloTarget), false);
+      definingClass = TR_ResolvedJ9Method::definingClassFromCPFieldRef(reloRuntime->comp(), (J9ConstantPool *) void_cp, cpIndex(reloTarget), false);
       }
 
    return definingClass;
@@ -3221,8 +3220,7 @@ TR_RelocationRecordValidateStaticField::getClass(TR_RelocationRuntime *reloRunti
    TR_OpaqueClassBlock *definingClass = NULL;
    if (void_cp)
       {
-      J9JavaVM *javaVM = reloRuntime->javaVM();
-      definingClass = reloRuntime->getClassFromCP(javaVM->internalVMFunctions->currentVMThread(javaVM), (J9ConstantPool *) void_cp, cpIndex(reloTarget), true);
+      definingClass = TR_ResolvedJ9Method::definingClassFromCPFieldRef(reloRuntime->comp(), (J9ConstantPool *) void_cp, cpIndex(reloTarget), true); 
       }
 
    return definingClass;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -181,8 +181,6 @@ class TR_RelocationRuntime {
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
 
-      virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
-
       static uintptr_t    getGlobalValue(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
@@ -350,8 +348,6 @@ public:
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
 
-      virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic);
-
 private:
       uint32_t getCurrentLockwordOptionHashValue(J9JavaVM *vm) const;
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize);
@@ -384,7 +380,6 @@ public:
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0;}
 
-      virtual TR_OpaqueClassBlock *getClassFromCP(J9VMThread *vmThread, J9ConstantPool *constantPool, I_32 cpIndex, bool isStatic)  override { TR_ASSERT(0, "Should not be called in this RelocationRuntime!"); return 0; }
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 
 private:

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1057,7 +1057,7 @@ TR::SymbolValidationManager::validateDefiningClassFromCPRecord(uint16_t classID,
 
    J9Class *beholder = getJ9ClassFromID(beholderID);
    J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
-   return validateSymbol(classID, reloRuntime->getClassFromCP(_vmThread, beholderCP, cpIndex, isStatic));
+   return validateSymbol(classID, TR_ResolvedJ9Method::definingClassFromCPFieldRef(_comp, beholderCP, cpIndex, isStatic));
    }
 
 bool


### PR DESCRIPTION
Implement findOrCreateShadowSymbol and findOrFabricateShadowSymbol functions that accept a TR_OpaqueClassBlock. These will be needed for supporting value types.

Also `TR_SharedCacheRelocationRuntime::getClassFromCP()` is removed in favor of `TR_ResolvedJ9Method::definingClassFromCPFieldRef()`