### PR TITLE
Use sparse checkout path for Git-SCM

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -56,6 +56,15 @@ pipelineJob("$JOB_NAME") {
                         }
                         wipeOutWorkspace()
                     }
+                    configure { git ->
+                        git / 'extensions' / 'hudson.plugins.git.extensions.impl.SparseCheckoutPaths' / 'sparseCheckoutPaths' {
+                            [pipelineScript].each { mypath ->
+                                'hudson.plugins.git.extensions.impl.SparseCheckoutPath' {
+                                    path("${mypath}")
+                                }
+                            }
+                        }
+                    }
                 }
             }
             scriptPath(pipelineScript)


### PR DESCRIPTION
- Only the single pipeline file is required
  on master to start the build. Since we cannot
  do a lightweight checkout we can instead use
  sparse checkout to limit how many files we
  have to checkout on master. This should greatly
  reduce the load on master when many pipelines
  are running in parallel.

[skip ci]
https://bugs.eclipse.org/bugs/show_bug.cgi?id=553326

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>