### PR TITLE
AArch64: Implement restoreJNICallOutFrame in JNILinkage

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
@@ -123,8 +123,9 @@ class JNILinkage : public PrivateLinkage
     * @param[in] tearDownJNIFrame : true if we need to clean up ref pool
     * @param[in] vmThreadReg : vm thread register
     * @param[in] javaStackReg : java stack register
+    * @param[in] scratchReg : scratch register
     */
-   void restoreJNICallOutFrame(TR::Node *callNode, bool tearDownJNIFrame, TR::Register *vmThreadReg, TR::Register *javaStackReg);
+   void restoreJNICallOutFrame(TR::Node *callNode, bool tearDownJNIFrame, TR::Register *vmThreadReg, TR::Register *javaStackReg, TR::Register *scratchReg);
 
    /**
     * @brief Builds JNI method arguments


### PR DESCRIPTION
Implement `restoreJNICallOutFrame` helper method in JNILinage for aarch64.

Depends on https://github.com/eclipse/openj9/pull/7971 and https://github.com/eclipse/openj9/pull/7972

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>