### PR TITLE
AArch64: Implement checkForJNIExceptions in JNILinkage

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.hpp
@@ -174,8 +174,9 @@ class JNILinkage : public PrivateLinkage
     * @brief Throws exception if it is set in JNI method
     * @param[in] callNode : caller node
     * @param[in] vmThreadReg : vm thread register
+    * @param[in] scratchReg : scratch register
     */
-   void checkForJNIExceptions(TR::Node *callNode, TR::Register *vmThreadReg);
+   void checkForJNIExceptions(TR::Node *callNode, TR::Register *vmThreadReg, TR::Register *scratchReg);
 
    TR::Linkage *_systemLinkage;
 


### PR DESCRIPTION
Implement `checkForJNIExceptions` helper method in JNILinkage for aarch64.

Depends on https://github.com/eclipse/openj9/pull/7972

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>