### PR TITLE
Initialize header of stack allocated object

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -6377,34 +6377,11 @@ void TR_EscapeAnalysis::makeLocalObject(Candidate *candidate)
       traceMsg(comp(), " }\n");
       }
 
-   //bool insertInitAtStart = false;
-   //if (referenceSlots)
-   //   {
-   //   for (i = 0; referenceSlots[i]; i++)
-   //      {
-   //      insertInitAtStart = true;
-   //      break;
-   //      }
-   //   }
-
-   TR::TreeTop *insertionPoint;
-   TR::Node *nodeToUseInInit;
-   //if (insertInitAtStart)
-   if (  referenceSlots
-      || (candidate->_kind != TR::New) // 174954: array size field must be initialized in the first block until we put a sumref on TR::arraylength
-      || candidate->isInsideALoop())
-      {
-      nodeToUseInInit = allocationNode->duplicateTree();
-      insertionPoint = comp()->getStartTree();
-      }
-   else
-      {
-      nodeToUseInInit = allocationNode;
-      insertionPoint = candidate->_treeTop;
-      }
-
    // Initialize the header of the local object
    //
+   TR::Node *nodeToUseInInit = allocationNode->duplicateTree();
+   TR::TreeTop *insertionPoint = comp()->getStartTree();
+
    if (candidate->_kind == TR::New)
       comp()->fej9()->initializeLocalObjectHeader(comp(), nodeToUseInInit, insertionPoint);
    else


### PR DESCRIPTION
Beause a stack allocated object is always collected in GC's point of
view and we treat them live everywhere in the program for simplicity,
the header of the stack allocated object should be initialized at the
method entry even when there is no reference field in it.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>