### PR TITLE
Use sparse checkout path for clones on workers

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Build-Any-Platform.groovy
@@ -52,8 +52,8 @@ timeout(time: 10, unit: 'HOURS') {
                         branches: [[name: "${scmBranch}"]],
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [[$class: 'CloneOption',
-                                      reference: "${HOME}/openjdk_cache"]],
-                        submoduleCfg: [],
+                                      reference: "${HOME}/openjdk_cache"],
+                                    [$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: 'buildenv/jenkins']]]],
                         userRemoteConfigs: [remoteConfigParameters]]
 
                 variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -225,8 +225,8 @@ try {
                             branches: [[name: SCM_BRANCH]],
                             doGenerateSubmoduleConfigurations: false,
                             extensions: [[$class: 'CloneOption',
-                                          reference: "${HOME}/openjdk_cache"]],
-                            submoduleCfg: [],
+                                          reference: "${HOME}/openjdk_cache"],
+                                        [$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: 'buildenv/jenkins']]]],
                             userRemoteConfigs: [remoteConfigParameters]]
 
                     variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
@@ -54,8 +54,8 @@ timestamps {
                     branches: [[name: "${scmBranch}"]],
                     doGenerateSubmoduleConfigurations: false,
                     extensions: [[$class: 'CloneOption',
-                                  reference: "${HOME}/openjdk_cache"]],
-                    submoduleCfg: [],
+                                  reference: "${HOME}/openjdk_cache"],
+                                [$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: 'buildenv/jenkins']]]],
                     userRemoteConfigs: [remoteConfigParameters]]
 
             variableFile = load 'buildenv/jenkins/common/variables-functions.groovy'


### PR DESCRIPTION
- Since we only need to load pipeline code we
  can limit the checkout to be buildenv/jenkins.
- This will save disk space and time as well as
  memory consumption on the workers.
- Remove submodule config line since it is empty.

[skip ci]
Related #7992
https://bugs.eclipse.org/bugs/show_bug.cgi?id=553326

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>