### PR TITLE
CMake: Mark libffi assembly files on AIX

### DIFF
--- a/runtime/libffi/CMakeLists.txt
+++ b/runtime/libffi/CMakeLists.txt
@@ -117,6 +117,12 @@ elseif(OMR_ARCH_POWER)
 				powerpc/aix.S
 				powerpc/aix_closure.S
 		)
+		set_source_files_properties(
+			powerpc/aix.S
+			powerpc/aix_closure.S
+			PROPERTIES
+			LANGUAGE ASM
+		)
 		if(OMR_ENV_DATA64)
 			target_include_directories(ffi PUBLIC preconf/ap64)
 		else()


### PR DESCRIPTION
By default, cmake only recognizes '.s' files, not '.S', so we need to
explicity tell cmake that '.S' files are assembly so they get compiled.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>