### PR TITLE
Fix JVMTI getConstantPool and getBytecodes output

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -2607,7 +2607,7 @@ jvmtiGetConstantPool_addMethodHandle(jvmtiGcp_translation *translation, UDATA cp
 	entry.key = (void *) cpIndex;
 	entry.cpType = cpType;
 	entry.sunCpIndex = *sunCpIndex;
-	entry.type.methodHandle.methodOrFieldRefIndex = 0;
+	entry.type.methodHandle.methodOrFieldRefIndex = (*sunCpIndex) + 1;
 	entry.type.methodHandle.handleType = ref->handleTypeAndCpType >> J9DescriptionCpTypeShift;
 	if (NULL == (htEntry = hashTableAdd(translation->ht, &entry))) {
 		return JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -594,6 +594,7 @@ jvmtiGetBytecodes(jvmtiEnv* env,
 				case JBcheckcast:
 				case JBldcw:
 				case JBnew:
+				case JBnewdup:
 				case JBinvokehandle:
 				case JBinvokehandlegeneric:
 				case JBinvokestaticsplit:
@@ -606,6 +607,9 @@ jvmtiGetBytecodes(jvmtiEnv* env,
 						U_16 cpIndex = *(U_16 *) &bytecodes[index + 1];
 
 						switch (bc) {
+						case JBnewdup:
+							bytecodes[index] = CFR_BC_new;
+							break;
 						case JBinvokestaticsplit:
 							/* treat cpIndex as index into static split table */
 							cpIndex = *(U_16 *)(J9ROMCLASS_STATICSPLITMETHODREFINDEXES(class->romClass) + cpIndex);
@@ -722,10 +726,6 @@ readdWide:
 
 				case JBaload0getfield:
 					bytecodes[index] = JBaload0;
-					break;
-
-				case JBnewdup:
-					bytecodes[index] = JBnew;
 					break;
 
 				case JBinvokeinterface2:


### PR DESCRIPTION
In getConstantPool, fix MethodHandle's methodOrFieldRefIndex value so it's not always 0.
In getBytecodes, move newdup case with new case because it also needs to consider endianness

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes #7591 