### PR TITLE
Move SPEC suffixes to BUILD_IDENTIFIER for test jobs

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -575,7 +575,7 @@ def set_build_variables() {
     set_repos_variables()
 
     def buildspec = buildspec_manager.getSpec(SPEC)
-   
+
     // fetch values per spec and Java version from the variables file
     BOOT_JDK = buildspec.getScalarField("boot_jdk", SDK_VERSION)
     FREEMARKER = buildspec.getScalarField("freemarker", SDK_VERSION)
@@ -586,7 +586,7 @@ def set_build_variables() {
 
     // set variables for the build environment configuration
     // check job parameters, if not provided default to variables file
-    BUILD_ENV_VARS = params.BUILD_ENV_VARS 
+    BUILD_ENV_VARS = params.BUILD_ENV_VARS
     if (!BUILD_ENV_VARS) {
         BUILD_ENV_VARS = buildspec.getVectorField("build_env.vars", SDK_VERSION).join(" ")
     }


### PR DESCRIPTION
Spec suffixes like cm (cmake) and jit (JITServer) are
not recognized as unique specs to test jobs but rather
they are the same as the regular specs. In order to have
seprate test jobs for these specs we must move the spec
suffix (eg. '_cm') from the spec variable to the identifier
variable. This allows us to maintain the same test job name
and format. Having separate test jobs is necessary in order
to avoid a) Missing Github PR status updates. Since two
jobs would have been updating the same satus line. b) Avoid
cancelling test jobs (cancel_running_builds) if two
different test runs had the same name but originated
from separate specs.

[skip ci]
Follows #7860
Issue #7782
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>