### PR TITLE
Enable OpenSSL build in JITServer

### DIFF
--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -35,10 +35,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h> /// gethostname, read, write
-#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/err.h>
 #include "control/CompilationRuntime.hpp"
-#endif
 
 namespace JITServer
 {
@@ -55,7 +53,6 @@ const int ClientStream::INCOMPATIBILITY_COUNT_LIMIT = 5;
 // This is called during startup from rossa.cpp
 int ClientStream::static_init(TR::PersistentInfo *info)
    {
-#if defined(JITSERVER_ENABLE_SSL)
    if (!CommunicationStream::useSSL())
       return 0;
 
@@ -125,13 +122,10 @@ int ClientStream::static_init(TR::PersistentInfo *info)
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
-#endif
    return 0;
    }
 
-#if defined(JITSERVER_ENABLE_SSL)
 SSL_CTX *ClientStream::_sslCtx = NULL;
-#endif
 
 int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs)
    {
@@ -192,7 +186,6 @@ int openConnection(const std::string &address, uint32_t port, uint32_t timeoutMs
    return sockfd;
    }
 
-#if defined(JITSERVER_ENABLE_SSL)
 BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    {
    if (!ctx)
@@ -265,14 +258,4 @@ ClientStream::ClientStream(TR::PersistentInfo *info)
    initStream(connfd, ssl);
    _numConnectionsOpened++;
    }
-#else // JITSERVER_ENABLE_SSL
-ClientStream::ClientStream(TR::PersistentInfo *info)
-   : CommunicationStream(), _versionCheckStatus(NOT_DONE)
-   {
-   int connfd = openConnection(info->getJITServerAddress(), info->getJITServerPort(), info->getSocketTimeout());
-   initStream(connfd);
-   _numConnectionsOpened++;
-   }
-#endif
-
 };

--- a/runtime/compiler/net/ClientStream.hpp
+++ b/runtime/compiler/net/ClientStream.hpp
@@ -29,11 +29,9 @@
 #include "net/ProtobufTypeConvert.hpp"
 #include "net/CommunicationStream.hpp"
 
-#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/ssl.h>
 class SSLOutputStream;
 class SSLInputStream;
-#endif
 
 namespace JITServer
 {
@@ -214,9 +212,7 @@ private:
    static const uint64_t RETRY_COMPATIBILITY_INTERVAL_MS; // (ms) When we should perform again a version compatibilty check
    static const int INCOMPATIBILITY_COUNT_LIMIT;
 
-#if defined(JITSERVER_ENABLE_SSL)
    static SSL_CTX *_sslCtx;
-#endif
    };
 
 }

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -41,7 +41,6 @@ void CommunicationStream::initVersion()
    CONFIGURATION_FLAGS |= JAVA_SPEC_VERSION & JITServerJavaVersionMask;
    }
 
-#if defined(JITSERVER_ENABLE_SSL)
 bool CommunicationStream::useSSL()
    {
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
@@ -49,5 +48,4 @@ bool CommunicationStream::useSSL()
            compInfo->getJITServerSslCerts().size() ||
            compInfo->getJITServerSslRootCerts().size());
    }
-#endif
 };

--- a/runtime/compiler/net/SSLProtobufStream.hpp
+++ b/runtime/compiler/net/SSLProtobufStream.hpp
@@ -23,7 +23,6 @@
 #ifndef SSL_PROTOBUF_STREAM_HPP
 #define SSL_PROTOBUF_STREAM_HPP
 
-#if defined(JITSERVER_ENABLE_SSL)
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -86,5 +85,4 @@ private:
    BIO *_ssl;
    };
 
-#endif // JITSERVER_ENABLE_SSL
 #endif // SSL_PROTOBUF_STREAM_HPP

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -29,11 +29,9 @@
 #include "env/VerboseLog.hpp"
 #include "control/Options.hpp"
 
-#if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/ssl.h>
 class SSLOutputStream;
 class SSLInputStream;
-#endif
 
 namespace JITServer
 {
@@ -73,11 +71,7 @@ public:
       @param ssl  BIO for the SSL enabled stream
       @param timeout timeout value (ms) to be set for connfd
    */
-#if defined(JITSERVER_ENABLE_SSL)
    explicit ServerStream(int connfd, BIO *ssl);
-#else
-   explicit ServerStream(int connfd);
-#endif
    virtual ~ServerStream()
       {
       _numConnectionsClosed++;


### PR DESCRIPTION
Remove `JITSERVER_ENABLE_SSL` flag so that `JITServer` is built
with `OpenSSL` by default, related to ibmruntimes/openj9-openjdk-jdk8#303
and #7846.

Fixes #6327

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>