### PR TITLE
Add JITServer-specific functional tests

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -117,7 +117,7 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
-	
+
 	<test>
 		<testCaseName>jit_compareAndBranch</testCaseName>
 		<variations>
@@ -490,6 +490,48 @@
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<!-- JITServer tests start here. -->
+	<test>
+		<testCaseName>testJITServer</testCaseName>
+		<!-- Variations are passed to the client via the CLIENT_PROGRAM property from $JVM_OPTIONS; neither the test harness nor the server care about these. -->
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>-Xshareclasses:none -Xjit:optLevel=hot</variation>
+		</variations>
+		<!-- Check if the JITServer launcher exists and if so start the test and
+			 - specify the executables for the client and server via the CLIENT_EXE and SERVER_EXE properties respectively,
+			 - specify what the client will run via the CLIENT_PROGRAM property.
+			 If the launcher doesn't exist we assume that the build doesn't support JITServer and trivially pass the test. -->
+		<command>if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
+	then \
+		$(JAVA_COMMAND) \
+		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+		-DSERVER_EXE=$(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) \
+		-DCLIENT_EXE=$(JAVA_COMMAND) \
+		-DCLIENT_PROGRAM=$(SQ)$(JVM_OPTIONS) -cp $(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar -DjarTesterArgs=$(TEST_RESROOT)$(D)jitt.jar org.testng.TestNG -d $(REPORTDIR)$(D)client $(TEST_RESROOT)$(D)testng.xml -testnames JarTesterTest -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE)$(SQ) \
+		org.testng.TestNG \
+		-d $(REPORTDIR) \
+		$(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+		-testnames JITServerTest \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+	else \
+		echo; \
+		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
+	fi; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
 		</impls>
 	</test>
 </playlist>

--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -1,0 +1,344 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package jit.test.jitserver;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.Scanner;
+import java.io.File;
+import java.io.IOException;
+import java.io.FileNotFoundException;
+
+import org.testng.AssertJUnit;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+@Test(groups={ "level.sanity", "component.jit" })
+public class JITServerTest {
+	private static Logger logger = Logger.getLogger(JITServerTest.class);
+
+	private static final int PROCESS_START_WAIT_TIME_MS = 2 * 1000;
+	private static final int SERVER_START_WAIT_TIME_MS = 5 * 1000;
+	private static final int CLIENT_TEST_TIME_MS = 45 * 1000;
+	private static final int SUCCESS_RETURN_VALUE = 0;
+
+	private final ProcessBuilder clientBuilder;
+	private final ProcessBuilder serverBuilder;
+
+	JITServerTest() {
+		AssertJUnit.assertEquals("Tests have only been validated on Linux. Other platforms are currently unsupported.", "Linux", System.getProperty("os.name"));
+
+		final String SERVER_PORT_ENV_VAR_NAME = "JITServerTest_SERVER_PORT";
+		final String SERVER_EXE = System.getProperty("SERVER_EXE");
+		final String CLIENT_EXE = System.getProperty("CLIENT_EXE");
+		final String CLIENT_PROGRAM = System.getProperty("CLIENT_PROGRAM");
+		// -Xjit options may already be on the command line so add extra JIT options via TR_Options instead to avoid one overriding the other.
+		final String JIT_LOG_ENV_OPTION = "verbose={compileEnd|JITServer|heartbeat}";
+		final String JITSERVER_PORT_OPTION_FORMAT_STRING = "-XX:JITServerPort=%0$d";
+		// Most systems have a specified ephemeral ports range. We're not bothering to find the actual range, just choosing a range that is outside the reserved area, reasonably large, and well-behaved.
+		// The range chosen here is within the actual ephemeral range on recent Linux systems and others (at the time of writing).
+		final int EPHEMERAL_PORTS_START = 33000, EPHEMERAL_PORTS_LAST = 60000;
+
+		// In order to run on multi-user systems we need to use a unique server port.
+		// We choose a random one in the ephemeral ports range here; the user can override via an env var if they want.
+		// This scheme is not perfect. We start many servers while executing this class using our random port so if someone else grabs the port
+		// in the middle of our test some of our servers will fail to start.
+		// The only way to avoid most of the races is to have the server choose a random port (and retry if it is busy) and for us read the port
+		// from the server log. We still need to worry about tests where we stop and restart the server, because we need to keep using the same
+		// port but someone may grab it in the interim.
+		String portOption;
+		final String userPort = System.getenv().get(SERVER_PORT_ENV_VAR_NAME);
+		if (userPort != null) {
+			portOption = String.format(JITSERVER_PORT_OPTION_FORMAT_STRING, Integer.parseInt(userPort));
+			logger.info("Using " + SERVER_PORT_ENV_VAR_NAME + "=" + userPort + " from env for server port.");
+		}
+		else {
+			final int randomPort = EPHEMERAL_PORTS_START + new Random().nextInt(EPHEMERAL_PORTS_LAST - EPHEMERAL_PORTS_START + 1);
+			portOption = String.format(JITSERVER_PORT_OPTION_FORMAT_STRING, randomPort);
+			logger.info("Chose random port for server: " + randomPort + ", set " + SERVER_PORT_ENV_VAR_NAME + " in your env to override.");
+		}
+
+		clientBuilder = new ProcessBuilder(String.join(" ", CLIENT_EXE, "-XX:+UseJITServer", portOption, CLIENT_PROGRAM).split(" +"));
+		serverBuilder = new ProcessBuilder(String.join(" ", SERVER_EXE, portOption).split(" +"));
+		// Redirect stderr to stdout, one log for each of the client and server is sufficient.
+		clientBuilder.redirectErrorStream(true);
+		serverBuilder.redirectErrorStream(true);
+		// Join our TR_Options with others if they exist, otherwise just set ours.
+		clientBuilder.environment().compute("TR_Options", (k, v) -> v != null && !v.isEmpty() ? String.join(",", v, JIT_LOG_ENV_OPTION) : JIT_LOG_ENV_OPTION);
+		serverBuilder.environment().compute("TR_Options", (k, v) -> v != null && !v.isEmpty() ? String.join(",", v, JIT_LOG_ENV_OPTION) : JIT_LOG_ENV_OPTION);
+	}
+
+	private static void dumpProcessLog(final ProcessBuilder b) {
+		File log = b.redirectOutput().file();
+		try {
+			Scanner s = new Scanner(log);
+			System.err.println("Dumping the contents of log file: " + log.getAbsolutePath() + "\n");
+			while (s.hasNextLine())
+				System.err.println(s.nextLine());
+			System.err.println("");
+		}
+		catch (FileNotFoundException e) {
+			System.err.println("Attempted to dump the log file '" + log.getAbsolutePath() + "' but it was not found.\n" + e.getMessage());
+		}
+	}
+
+	private static void destroyAndCheckProcess(final Process p, final ProcessBuilder builder) throws InterruptedException {
+		final int PROCESS_DESTROY_WAIT_TIME_MS = 5 * 1000;
+		// On *nix systems Process.destroy() sends SIGTERM to the process and (unless the process handles it and decides to return something else) the return value will be signum+128.
+		// SIGTERM is 15 on most *nix systems, but this can vary.
+		final int SIGTERM_RETURN_VALUE = 15 + 128;
+
+		p.destroy();
+
+		Thread.sleep(PROCESS_DESTROY_WAIT_TIME_MS);
+
+		final int exitValue = p.exitValue();
+
+		// The process may exit normally before we can destroy it so we have to accept two possible return values.
+		if ((exitValue != SUCCESS_RETURN_VALUE) && (exitValue != SIGTERM_RETURN_VALUE)) {
+			System.err.println("Expected a return value of " + SUCCESS_RETURN_VALUE + " or " + SIGTERM_RETURN_VALUE + ", got " + exitValue + " instead.");
+			dumpProcessLog(builder);
+			AssertJUnit.fail();
+		}
+	}
+
+	private static Process startProcess(final ProcessBuilder builder, final String name) throws IOException, InterruptedException {
+		logger.info("Starting " + name + " with command line:\n" + String.join(" ", builder.command()));
+		logger.info("With stdout/stderr redirected to:\n" + builder.redirectOutput().file().getAbsolutePath());
+		final Process p = builder.start();
+		// We expect these processes to be fairly long running; if they exit almost immediately abort the test.
+		if (p.waitFor(PROCESS_START_WAIT_TIME_MS, TimeUnit.MILLISECONDS)) {
+			System.err.println("Failed to start " + name);
+			dumpProcessLog(builder);
+			AssertJUnit.fail();
+		}
+		return p;
+	}
+
+	// `pkill` expects a regex pattern as the last argument. We need to pass in a JVM command line, but we don't want any regex-like patterns
+	// (e.g. certain -Xjit sub-options) on the command line to be interpreted as a regex by pkill so we need to escape any special chars.
+	private static String escapeCommandLineRegexChars(final String commandLine) { return commandLine.replaceAll("[{}|]", "\\\\$0"); }
+
+	// "Pause" and "resume" are implemented with SIGSTOP and SIGCONT; they should work on most *nix platforms, but YMMV. Windows would need another solution.
+	private static void pauseProcessWithCommandLine(final String commandLine) throws IOException, InterruptedException {
+		final String pkillCommandLine[] = {"pkill", "-STOP", "-f", "-x", escapeCommandLineRegexChars(commandLine)};
+		logger.debug("Running pkill with command line: " + Arrays.toString(pkillCommandLine));
+		AssertJUnit.assertEquals("Unable to pause target process, pkill failed or did not match any process.", SUCCESS_RETURN_VALUE, Runtime.getRuntime().exec(pkillCommandLine).waitFor());
+	}
+
+	private static void resumeProcessWithCommandLine(final String commandLine) throws IOException, InterruptedException {
+		final String pkillCommandLine[] = {"pkill", "-CONT", "-f", "-x", escapeCommandLineRegexChars(commandLine)};
+		logger.debug("Running pkill with command line: " + Arrays.toString(pkillCommandLine));
+		AssertJUnit.assertEquals("Unable to resume target process, pkill failed or did not match any process.", SUCCESS_RETURN_VALUE, Runtime.getRuntime().exec(pkillCommandLine).waitFor());
+	}
+
+	private static void redirectProcessOutputs(final ProcessBuilder builder, final String outputName) {
+		builder.redirectOutput(new File(outputName + ".out"));
+		// Add the vlog= option (or replace it if it was previously added) to TR_Options.
+		// Note: This code only handles vlog appearing at the end of TR_Options.
+		final String TR_Options = builder.environment().get("TR_Options").replaceFirst(",vlog=.+\\.jitverboselog\\.out$", "");
+		builder.environment().put("TR_Options", TR_Options + ",vlog=" + outputName + ".jitverboselog.out");
+	}
+
+	public void testServer() throws IOException, InterruptedException {
+		logger.info("running testServer: INFO and above level logging enabled");
+
+		redirectProcessOutputs(clientBuilder, "testServer.client");
+		redirectProcessOutputs(serverBuilder, "testServer.server");
+
+		final Process server = startProcess(serverBuilder, "server");
+
+		Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+		final Process client = startProcess(clientBuilder, "client");
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping client...");
+		destroyAndCheckProcess(client, clientBuilder);
+
+		logger.info("Stopping server...");
+		destroyAndCheckProcess(server, serverBuilder);
+	}
+
+	public void testServerGoesDown() throws IOException, InterruptedException {
+		logger.info("running testServerGoesDown: INFO and above level logging enabled");
+
+		redirectProcessOutputs(clientBuilder, "testServerGoesDown.client");
+		redirectProcessOutputs(serverBuilder, "testServerGoesDown.server");
+
+		final Process server = startProcess(serverBuilder, "server");
+
+		Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+		final Process client = startProcess(clientBuilder, "client");
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping server...");
+		destroyAndCheckProcess(server, serverBuilder);
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping client...");
+		destroyAndCheckProcess(client, clientBuilder);
+	}
+
+	public void testServerGoesDownAnotherComesUp() throws IOException, InterruptedException {
+		logger.info("running testServerGoesDownAnotherComesUp: INFO and above level logging enabled");
+
+		redirectProcessOutputs(clientBuilder, "testServerGoesDownAnotherComesUp.client");
+		redirectProcessOutputs(serverBuilder, "testServerGoesDownAnotherComesUp.server");
+
+		Process client = null;
+
+		{
+			final Process server = startProcess(serverBuilder, "server");
+
+			Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+			client = startProcess(clientBuilder, "client");
+
+			logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+			Thread.sleep(CLIENT_TEST_TIME_MS);
+
+			logger.info("Stopping server...");
+			destroyAndCheckProcess(server, serverBuilder);
+		}
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		redirectProcessOutputs(serverBuilder, "testServerGoesDownAnotherComesUp.secondServer");
+
+		{
+			final Process secondServer = startProcess(serverBuilder, "server");
+
+			Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+			logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+			Thread.sleep(CLIENT_TEST_TIME_MS);
+
+			logger.info("Stopping client...");
+			destroyAndCheckProcess(client, clientBuilder);
+
+			logger.info("Stopping server...");
+			destroyAndCheckProcess(secondServer, serverBuilder);
+		}
+	}
+
+	public void testServerUnreachableForAWhile() throws IOException, InterruptedException {
+		final int SERVER_UNREACHABLE_TIME_MS = 10 * 1000;
+
+		logger.info("running testServerUnreachableForAWhile: INFO and above level logging enabled");
+
+		redirectProcessOutputs(clientBuilder, "testServerUnreachableForAWhile.client");
+		redirectProcessOutputs(serverBuilder, "testServerUnreachableForAWhile.server");
+
+		final Process server = startProcess(serverBuilder, "server");
+
+		Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+		final Process client = startProcess(clientBuilder, "client");
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		final String serverCommandLine = String.join(" ", serverBuilder.command());
+		logger.info("Pausing server for " + SERVER_UNREACHABLE_TIME_MS + " millis.");
+		pauseProcessWithCommandLine(serverCommandLine);
+		Thread.sleep(SERVER_UNREACHABLE_TIME_MS);
+
+		logger.info("Resuming server...");
+		resumeProcessWithCommandLine(serverCommandLine);
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping server...");
+		destroyAndCheckProcess(server, serverBuilder);
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping client...");
+		destroyAndCheckProcess(client, clientBuilder);
+	}
+
+	public void testServerComesUpAfterClient() throws IOException, InterruptedException {
+		logger.info("running testServerComesUpAfterClient: INFO and above level logging enabled");
+
+		redirectProcessOutputs(clientBuilder, "testServerComesUpAfterClient.client");
+		redirectProcessOutputs(serverBuilder, "testServerComesUpAfterClient.server");
+
+		final Process client = startProcess(clientBuilder, "client");
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		final Process server = startProcess(serverBuilder, "server");
+
+		Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping client...");
+		destroyAndCheckProcess(client, clientBuilder);
+
+		logger.info("Stopping server...");
+		destroyAndCheckProcess(server, serverBuilder);
+	}
+
+	public void testServerComesUpAfterClientAndGoesDownAgain() throws IOException, InterruptedException {
+		logger.info("running testServerComesUpAfterClientAndGoesDownAgain: INFO and above level logging enabled");
+
+		redirectProcessOutputs(clientBuilder, "testServerComesUpAfterClientAndGoesDownAgain.client");
+		redirectProcessOutputs(serverBuilder, "testServerComesUpAfterClientAndGoesDownAgain.server");
+
+		final Process client = startProcess(clientBuilder, "client");
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		final Process server = startProcess(serverBuilder, "server");
+
+		Thread.sleep(SERVER_START_WAIT_TIME_MS);
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping server...");
+		destroyAndCheckProcess(server, serverBuilder);
+
+		logger.info("Waiting for " + CLIENT_TEST_TIME_MS + " millis.");
+		Thread.sleep(CLIENT_TEST_TIME_MS);
+
+		logger.info("Stopping client...");
+		destroyAndCheckProcess(client, clientBuilder);
+	}
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -561,5 +561,11 @@
       <class name="jit.test.recognizedMethod.TestJavaLangMath" />
     </classes>
   </test>
+
+  <test name="JITServerTest">
+    <classes>
+      <class name="jit.test.jitserver.JITServerTest"/>
+    </classes>
+  </test>
 </suite>
 <!-- Suite -->


### PR DESCRIPTION
This patch adds testing for a few basic JITServer scenarios.

The tests only excercise the compiler, not the compiled code (i.e. the compiled code is never executed). The tests are somewhat portable to other *nix platforms, but have only been validated on x86-64 Linux. A runtime assert makes sure to check that the tests only execute on Linux for now, in addition to the test having the following platform requirements at the playlist level: `os.linux,arch.x86,bits.64`.

Windows is not supported because (some of) the tests rely on `SIGSTOP` and `SIGCONT` to simulate unresponsiveness.

Testing is skipped at runtime if the build does not support JITServer (i.e. if `bin/jitserver` doesn't exist). When tests are skipped at runtime TKG will report them as failed. I've opened https://github.com/AdoptOpenJDK/TKG/pull/41 to fix this, after which they will be reported as passed.