### PR TITLE
Fix serialization of entire CHTable

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2398,12 +2398,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          {
          client->getRecvData<JITServer::Void>();
          auto table = (JITClientPersistentCHTable*)comp->getPersistentInfo()->getPersistentCHTable();
-         TR_OpaqueClassBlock *rootClass = fe->TR_J9VM::getSystemClassFromClassName("java/lang/Object", 16);
-         TR_PersistentClassInfo* result = table->findClassInfoAfterLocking(
-                                                   rootClass,
-                                                   comp,
-                                                   true);
-         std::string encoded = FlatPersistentClassInfo::serializeHierarchy(result);
+         std::string encoded = FlatPersistentClassInfo::serializeHierarchy(table);
          client->write(response, encoded);
          }
          break;

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -112,7 +112,12 @@ public:
    virtual void removeClass(TR_FrontEnd *, TR_OpaqueClassBlock *classId, TR_PersistentClassInfo *info, bool removeInfo) override;
    virtual bool classGotExtended(TR_FrontEnd *vm, TR_PersistentMemory *, TR_OpaqueClassBlock *superClassId, TR_OpaqueClassBlock *subClassId) override;
 
-  
+   /** 
+    * @brief Collect entire class hierarchy into a vector
+    * @param[out] out : The vector that gets populated with pointers to all existing TR_PersistentClassInfo
+    * @return Returns the amount of space needed to serialize the entire hierarchy
+    */
+   size_t collectEntireHierarchy(std::vector<TR_PersistentClassInfo*> &out) const;
    void markForRemoval(TR_OpaqueClassBlock *clazz);
    void markDirty(TR_OpaqueClassBlock *clazz);
 #ifdef COLLECT_CHTABLE_STATS
@@ -146,8 +151,8 @@ private:
 class FlatPersistentClassInfo
    {
 public:
-   static std::string serializeHierarchy(TR_PersistentClassInfo *orig);
-   static std::vector<TR_PersistentClassInfo*> deserializeHierarchy(std::string& data);
+   static std::string serializeHierarchy(const JITClientPersistentCHTable *chTable);
+   static std::vector<TR_PersistentClassInfo*> deserializeHierarchy(const std::string& data);
    static size_t classSize(TR_PersistentClassInfo *clazz);
    static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info);
    static size_t deserializeClassSimple(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo *info);

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -90,7 +90,7 @@ class TR_PersistentCHTable
 
    protected:
    void removeAssumptionFromRAT(OMR::RuntimeAssumption *assumption);
-   TR_LinkHead<TR_PersistentClassInfo> *getClasses() { return _classes; }
+   TR_LinkHead<TR_PersistentClassInfo> *getClasses() const { return _classes; }
 
    private:
    uint8_t _buffer[sizeof(TR_LinkHead<TR_PersistentClassInfo>) * (CLASSHASHTABLE_SIZE + 1)];


### PR DESCRIPTION
The JITClient needs to send the entire CHTable to the JITServer during
the first compilation when connecting to a new JITServer. Currently
the hierarchy is collected starting from the java/lang/Object class
and recursively finding all the subclasses. However, this approach
does not catch the interfaces. In the end all is well due to a quirk
of the implementation that sends CHTable updates, but it's better to
do the right thing and correctly send the entire CHTable when the
JITServer asks for it.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>