### PR TITLE
Fix compact strings check to handle offsets correctly

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -253,8 +253,25 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 	}
 
-	static boolean compressible(char[] c, int start, int length) {
-		for (int i = start; i < length; ++i) {
+	/**
+	 * Determines whether the input character array can be encoded as a compact
+	 * Latin1 string.
+	 *
+	 * <p>This API implicitly assumes the following:
+	 * <blockquote><pre>
+	 *     - {@code length >= 0}
+	 *     - {@code start >= 0}
+	 *     - {@code start + length <= data.length}
+	 * <blockquote><pre>
+	 *
+	 * @param c      the array of characters to check
+	 * @param start  the starting offset in the character array
+	 * @param length the number of characters to check starting at {@code start}
+	 * @return       {@code true} if the input character array can be encoded
+	 *               using the Latin1 encoding; {@code false} otherwise
+	 */
+	static boolean canEncodeAsLatin1(char[] c, int start, int length) {
+		for (int i = start; i < start + length; ++i) {
 			if (c[i] > 255) {
 				return false;
 			}
@@ -703,7 +720,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *          a non-null array of characters
 	 */
 	String(char[] data, boolean ignore) {
-		if (enableCompression && compressible(data, 0, data.length)) {
+		if (enableCompression && canEncodeAsLatin1(data, 0, data.length)) {
 			value = new byte[data.length];
 			coder = LATIN1;
 
@@ -738,7 +755,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public String(char[] data, int start, int length) {
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
-			if (enableCompression && compressible(data, start, length)) {
+			if (enableCompression && canEncodeAsLatin1(data, start, length)) {
 				value = new byte[length];
 				coder = LATIN1;
 
@@ -4060,8 +4077,25 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 	}
 
-	static boolean compressible(char[] c, int start, int length) {
-		for (int i = start; i < length; ++i) {
+	/**
+	 * Determines whether the input character array can be encoded as a compact
+	 * Latin1 string.
+	 *
+	 * <p>This API implicitly assumes the following:
+	 * <blockquote><pre>
+	 *     - {@code length >= 0}
+	 *     - {@code start >= 0}
+	 *     - {@code start + length <= data.length}
+	 * <blockquote><pre>
+	 *
+	 * @param c      the array of characters to check
+	 * @param start  the starting offset in the character array
+	 * @param length the number of characters to check starting at {@code start}
+	 * @return       {@code true} if the input character array can be encoded
+	 *               using the Latin1 encoding; {@code false} otherwise
+	 */
+	static boolean canEncodeAsLatin1(char[] c, int start, int length) {
+		for (int i = start; i < start + length; ++i) {
 			if (c[i] > 255) {
 				return false;
 			}
@@ -4256,7 +4290,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			char[] buffer = StringCoding.decode(data, start, length);
 
 			if (enableCompression) {
-				if (compressible(buffer, 0, buffer.length)) {
+				if (canEncodeAsLatin1(buffer, 0, buffer.length)) {
 					value = new char[(buffer.length + 1) / 2];
 					count = buffer.length;
 
@@ -4376,7 +4410,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			char[] buffer = StringCoding.decode(encoding, data, start, length);
 
 			if (enableCompression) {
-				if (compressible(buffer, 0, buffer.length)) {
+				if (canEncodeAsLatin1(buffer, 0, buffer.length)) {
 					value = new char[(buffer.length + 1) / 2];
 					count = buffer.length;
 
@@ -4487,7 +4521,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	String(char[] data, boolean ignore) {
 		if (enableCompression) {
-			if (compressible(data, 0, data.length)) {
+			if (canEncodeAsLatin1(data, 0, data.length)) {
 				value = new char[(data.length + 1) / 2];
 				count = data.length;
 
@@ -4527,7 +4561,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String(char[] data, int start, int length) {
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
 			if (enableCompression) {
-				if (compressible(data, start, length)) {
+				if (canEncodeAsLatin1(data, start, length)) {
 					value = new char[(length + 1) / 2];
 					count = length;
 
@@ -7613,7 +7647,7 @@ written authorization of the copyright holder.
 			int size = 0;
 
 			// Optimistically assume we can compress data[]
-			boolean compressible = enableCompression;
+			boolean canEncodeAsLatin1 = enableCompression;
 
 			for (int i = start; i < start + length; ++i) {
 				int codePoint = data[i];
@@ -7621,20 +7655,20 @@ written authorization of the copyright holder.
 				if (codePoint < Character.MIN_CODE_POINT) {
 					throw new IllegalArgumentException();
 				} else if (codePoint < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
-					if (compressible && codePoint > 255) {
-						compressible = false;
+					if (canEncodeAsLatin1 && codePoint > 255) {
+						canEncodeAsLatin1 = false;
 					}
 
 					++size;
 				} else if (codePoint <= Character.MAX_CODE_POINT) {
-					if (compressible) {
+					if (canEncodeAsLatin1) {
 						codePoint -= Character.MIN_SUPPLEMENTARY_CODE_POINT;
 
 						int codePoint1 = Character.MIN_HIGH_SURROGATE + (codePoint >> 10);
 						int codePoint2 = Character.MIN_LOW_SURROGATE + (codePoint & 0x3FF);
 
 						if (codePoint1 > 255 || codePoint2 > 255) {
-							compressible = false;
+							canEncodeAsLatin1 = false;
 						}
 					}
 
@@ -7644,7 +7678,7 @@ written authorization of the copyright holder.
 				}
 			}
 
-			if (compressible) {
+			if (canEncodeAsLatin1) {
 				value = new char[(size + 1) / 2];
 				count = size;
 
@@ -8140,7 +8174,7 @@ written authorization of the copyright holder.
 			char[] chars = StringCoding.decode(charset, data, start, length);
 
 			if (enableCompression) {
-				if (compressible(chars, 0, chars.length)) {
+				if (canEncodeAsLatin1(chars, 0, chars.length)) {
 					value = new char[(chars.length + 1) / 2];
 					count = chars.length;
 

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -199,7 +199,7 @@ public synchronized StringBuffer append (char[] chars) {
 	
 	if (String.enableCompression) {
 		// Check if the StringBuffer is compressed
-		if (count >= 0 && String.compressible(chars, 0, chars.length)) {
+		if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 			if (newLength > currentCapacity) {
 				ensureCapacityImpl(newLength);
 			}
@@ -256,7 +256,7 @@ public synchronized StringBuffer append (char chars[], int start, int length) {
 		
 		if (String.enableCompression) {
 			// Check if the StringBuffer is compressed
-			if (count >= 0 && String.compressible(chars, start, length)) {
+			if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 				if (newLength > currentCapacity) {
 					ensureCapacityImpl(newLength);
 				}
@@ -840,7 +840,7 @@ public synchronized StringBuffer insert(int index, char[] chars) {
 		
 		if (String.enableCompression) {
 			// Check if the StringBuffer is compressed
-			if (count >= 0 && String.compressible(chars, 0, chars.length)) {
+			if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 				String.compress(chars, 0, value, index, chars.length);
 				
 				count = currentLength + chars.length;
@@ -894,7 +894,7 @@ public synchronized StringBuffer insert(int index, char[] chars, int start, int 
 			
 			if (String.enableCompression) {
 				// Check if the StringBuffer is compressed
-				if (count >= 0 && String.compressible(chars, start, length)) {
+				if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 					String.compress(chars, start, value, index, length);
 					
 					count = currentLength + length;
@@ -1788,7 +1788,7 @@ private void readObject(ObjectInputStream stream) throws IOException, ClassNotFo
 	} 
 	
 	if (String.enableCompression) {
-		if (String.compressible(streamValue, 0, streamValue.length)) {
+		if (String.canEncodeAsLatin1(streamValue, 0, streamValue.length)) {
 			if (streamValue.length == Integer.MAX_VALUE) {
 				value = new char[(streamValue.length / 2) + 1];
 			} else {

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -3,7 +3,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -198,7 +198,7 @@ public StringBuilder append (char[] chars) {
 	
 	if (String.enableCompression) {
 		// Check if the StringBuilder is compressed
-		if (count >= 0 && String.compressible(chars, 0, chars.length)) {
+		if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 			if (newLength > currentCapacity) {
 				ensureCapacityImpl(newLength);
 			}
@@ -255,7 +255,7 @@ public StringBuilder append (char chars[], int start, int length) {
 		
 		if (String.enableCompression) {
 			// Check if the StringBuilder is compressed
-			if (count >= 0 && String.compressible(chars, start, length)) {
+			if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 				if (newLength > currentCapacity) {
 					ensureCapacityImpl(newLength);
 				}
@@ -839,7 +839,7 @@ public StringBuilder insert(int index, char[] chars) {
 		
 		if (String.enableCompression) {
 			// Check if the StringBuilder is compressed
-			if (count >= 0 && String.compressible(chars, 0, chars.length)) {
+			if (count >= 0 && String.canEncodeAsLatin1(chars, 0, chars.length)) {
 				String.compress(chars, 0, value, index, chars.length);
 				
 				count = currentLength + chars.length;
@@ -893,7 +893,7 @@ public StringBuilder insert(int index, char[] chars, int start, int length) {
 			
 			if (String.enableCompression) {
 				// Check if the StringBuilder is compressed
-				if (count >= 0 && String.compressible(chars, start, length)) {
+				if (count >= 0 && String.canEncodeAsLatin1(chars, start, length)) {
 					String.compress(chars, start, value, index, length);
 					
 					count = currentLength + length;
@@ -1783,7 +1783,7 @@ private void readObject(ObjectInputStream stream) throws IOException, ClassNotFo
 	} 
 	
 	if (String.enableCompression) {
-		if (String.compressible(streamValue, 0, streamValue.length)) {
+		if (String.canEncodeAsLatin1(streamValue, 0, streamValue.length)) {
 			if (streamValue.length == Integer.MAX_VALUE) {
 				value = new char[(streamValue.length / 2) + 1];
 			} else {

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -985,6 +985,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
+			<variation>-XX:+CompactStrings</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
@@ -1041,7 +1042,7 @@
 		<testCaseName>JCL_Test_openj9_none_SCC</testCaseName>
 		<variations>
 			<variation>-Xshareclasses:none</variation>
-			<variation>-XX:RecreateClassfileOnload -Xshareclasses:none</variation>
+			<variation>-Xshareclasses:none -XX:RecreateClassfileOnload</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
@@ -1138,6 +1139,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
+			<variation>-XX:+CompactStrings</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
@@ -1255,7 +1257,7 @@
 	-Xbootclasspath/a:$(TEST_RESROOT)$(D)TestResources.jar \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-	-testnames  JCL_TEST_Java-Internals \
+	-testnames JCL_TEST_Java-Internals \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
@@ -1368,12 +1370,12 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-    <variations>
-      <variation>-Xjit:count=0 -XX:-CompactStrings</variation>
-      <variation>-Xjit:count=0 -XX:+CompactStrings</variation>
-      <variation>-Xjit:count=1,disableAsyncCompilation -XX:-CompactStrings</variation>
-      <variation>-Xjit:count=1,disableAsyncCompilation -XX:+CompactStrings</variation>
-    </variations>
+		<variations>
+			<variation>-Xjit:count=0 -XX:-CompactStrings</variation>
+			<variation>-Xjit:count=0 -XX:+CompactStrings</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -XX:-CompactStrings</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -XX:+CompactStrings</variation>
+		</variations>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -1398,12 +1400,12 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-    <variations>
-      <variation>-Xjit:count=0 -XX:-CompactStrings</variation>
-      <variation>-Xjit:count=0 -XX:+CompactStrings</variation>
-      <variation>-Xjit:count=1,disableAsyncCompilation -XX:-CompactStrings</variation>
-      <variation>-Xjit:count=1,disableAsyncCompilation -XX:+CompactStrings</variation>
-    </variations>
+		<variations>
+			<variation>-Xjit:count=0 -XX:-CompactStrings</variation>
+			<variation>-Xjit:count=0 -XX:+CompactStrings</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -XX:-CompactStrings</variation>
+			<variation>-Xjit:count=1,disableAsyncCompilation -XX:+CompactStrings</variation>
+		</variations>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -1736,7 +1738,7 @@
 			<variation>Mode351</variation>
 			<variation>Mode551</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)  \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames jniOnLoadExceptions \
@@ -1766,7 +1768,7 @@
 			<variation>Mode610</variation>
 			<variation>Mode551</variation>
 		</variations>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)  \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames badUTF8inJNI \
@@ -1791,7 +1793,7 @@
 
 	<test>
 		<testCaseName>pthreadDestructor</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)  \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames pthreadDestructor \
@@ -2086,7 +2088,7 @@
 
 	<test>
 		<testCaseName>hanoiTest</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump  \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames hanoiTest \
@@ -2111,7 +2113,7 @@
 	<test>
 		<testCaseName>hanoiTestTM_NATIVE</testCaseName>
 		<command>JAVA_THREAD_MODEL=NATIVE \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump  \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames hanoiTest \
@@ -2134,7 +2136,7 @@
 	<test>
 		<testCaseName>hanoiTestTM_MEDIUM</testCaseName>
 		<command>JAVA_THREAD_MODEL=MEDIUM \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump  \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames hanoiTest \
@@ -2157,7 +2159,7 @@
 	<test>
 		<testCaseName>hanoiTestTM_HEAVY</testCaseName>
 		<command>JAVA_THREAD_MODEL=HEAVY \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump  \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames hanoiTest \
@@ -2181,7 +2183,7 @@
 	<test>
 		<testCaseName>hanoiTestTM_SHOULDFAIL</testCaseName>
 		<command>JAVA_THREAD_MODEL=SHOULDFAIL \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump  \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames hanoiTest \
@@ -2226,7 +2228,7 @@
 
 	<test>
 		<testCaseName>fibTest</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -Xdump  \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint -Xdump \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames fibTest \
@@ -2301,7 +2303,7 @@
 			<variation>Mode110</variation>
 			<variation>Mode150</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS)  \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames floatSanityTests \
@@ -2392,7 +2394,7 @@
 
 	<test>
 		<testCaseName>loadLegacyLibrary</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)  \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 			-testnames loadLegacyLibrary \
@@ -2414,7 +2416,7 @@
 
 	<test>
 		<testCaseName>classRelationshipVerifierTests</testCaseName>
-		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)  \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-XX:+ClassRelationshipVerifier \
 			-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -162,9 +162,9 @@ public class Test_String {
 	 */
 	@Test
 	public void test_Constructor10() {
-		char[] buf = { 'H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd' };
-		String s = new String(buf, 0, buf.length);
-		AssertJUnit.assertTrue("Incorrect string created", hw1.equals(s));
+		char[] buf1 = { 'H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd' };
+		String s1 = new String(buf1, 0, buf1.length);
+		AssertJUnit.assertTrue("Incorrect string created", hw1.equals(s1));
 
 		boolean exception = false;
 		try {
@@ -173,6 +173,10 @@ public class Test_String {
 			exception = true;
 		}
 		AssertJUnit.assertTrue("Did not throw exception", exception);
+
+		char[] buf2 = { '\u201c', 'X', '\u201d', '\n', '\u201c', 'X', '\u201d' };
+		String s2 = new String(buf2, 4, 3);
+		AssertJUnit.assertTrue("Incorrect string created", s2.equals("\u201cX\u201d"));
 	}
 
 	/**


### PR DESCRIPTION
The `compressible` API in String is incorrectly implemented, as the loop termination should be `start + length`, not just `length`. This is evident when calling the `java.lang.String(char[],int,int)` constructor and passing non-zero values for start. In particular there is a bug when compact strings are enabled and the start offset is greater than the length passed in.

We add a test case as part of this PR to prevent such issues in the future and we fix the problem itself.

Fixes: #7639