### PR TITLE
Add caching in iterateStackTrace

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5484,6 +5484,8 @@ typedef struct J9JavaVM {
 	UDATA valueFlatteningThreshold;
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	UDATA dCacheLineSize;
+	void* methodPCCache;
+	omrthread_monitor_t methodPCCacheMutex;
 } J9JavaVM;
 
 #define J9VM_PHASE_NOT_STARTUP  2

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -80,6 +80,8 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 
 		omrthread_monitor_init_with_name(&vm->constantDynamicMutex, 0, "Wait mutex for constantDynamic during resolve") ||
 
+		omrthread_monitor_init_with_name(&vm->methodPCCacheMutex, 0, "Method PC cache mutex") ||
+
 		initializeMonitorTable(vm)
 	)
 	{
@@ -156,6 +158,7 @@ void terminateVMThreading(J9JavaVM *vm)
 	if (vm->nativeLibraryMonitor) omrthread_monitor_destroy(vm->nativeLibraryMonitor);
 	if (vm->vmRuntimeStateListener.runtimeStateListenerMutex) omrthread_monitor_destroy(vm->vmRuntimeStateListener.runtimeStateListenerMutex);
 	if (vm->constantDynamicMutex) omrthread_monitor_destroy(vm->constantDynamicMutex);
+	if (vm->methodPCCacheMutex) omrthread_monitor_destroy(vm->methodPCCacheMutex);
 
 	destroyMonitorTable(vm);
 }


### PR DESCRIPTION
Add a global (VM thread shared) cache mapping JIT method PCs to data needed for the callback in `iterateStackTrace`. Since this cache is global and multiple VM threads can be reading/writing we also add locking around the cache.

Issue: #7776

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>