### PR TITLE
DDR: Add workarounds for xlclang 16 on AIX

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -376,8 +376,8 @@ ppc64_aix:
     8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-openssl=fetched'
     11: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-openssl=fetched'
     12: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-openssl=fetched'
-    13: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-openssl=fetched --disable-ddr'
-    next: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-openssl=fetched --disable-ddr'
+    13: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-openssl=fetched'
+    next: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-openssl=fetched'
   build_env:
     vars:
       8: 'PATH+XLC=/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin'

--- a/runtime/ddr/CMakeLists.txt
+++ b/runtime/ddr/CMakeLists.txt
@@ -31,17 +31,23 @@ add_library(j9ddr_misc SHARED
 
 target_link_libraries(j9ddr_misc
 	PRIVATE
-	j9vm_interface
-	j9vm_gc_includes
+		j9vm_interface
+		j9vm_gc_includes
 )
 target_include_directories(j9ddr_misc
 	PRIVATE
-	${j9vm_SOURCE_DIR}/
-	${omr_SOURCE_DIR}/compiler
+		${j9vm_SOURCE_DIR}/
+		${j9vm_SOURCE_DIR}/bcutil
+		${j9vm_BINARY_DIR}/bcutil
+		${j9vm_SOURCE_DIR}/shared_common/include
+		${omr_SOURCE_DIR}/compiler
 )
 
+# remove all optimization options so needed debugging information is not suppressed
+omr_remove_flags(CMAKE_CXX_FLAGS -O -O1 -O2 -O3 /Ox)
+
 if(OMR_TOOLCONFIG STREQUAL "gnu")
-	target_compile_options(j9ddr_misc PRIVATE  -femit-class-debug-always)
+	target_compile_options(j9ddr_misc PRIVATE -femit-class-debug-always)
 endif()
 
 target_enable_ddr(j9ddr_misc)

--- a/runtime/ddr/blacklist
+++ b/runtime/ddr/blacklist
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,9 @@
 ###############################################################################
 
 file:<built-in>
+
+# Ignore types which exist only to coax compilers to describe other types.
+type:DDR_*
 
 # Ignore types which conflict with primitive or standard types.
 type:Byte

--- a/runtime/ddr/gcddr.cpp
+++ b/runtime/ddr/gcddr.cpp
@@ -22,6 +22,7 @@
 
 #include "AllocateDescription.hpp"
 #include "AllocationCategory.hpp"
+#include "CompactScheme.hpp"
 #include "ConcurrentCardTable.hpp"
 #include "CopyScanCacheStandard.hpp"
 #include "FreeHeapRegionList.hpp"
@@ -46,6 +47,7 @@
 #if defined(OMR_GC_SEGREGATED_HEAP)
 # include "MemoryPoolSegregated.hpp"
 # include "MemorySubSpaceSegregated.hpp"
+# include "ObjectHeapIteratorSegregated.hpp"
 # include "SegregatedGC.hpp"
 #endif /* OMR_GC_SEGREGATED_HEAP */
 
@@ -79,7 +81,108 @@ GC_DdrDebugLink(GC_FinalizeListManager)
 #endif /* J9VM_GC_FINALIZATION */
 
 #if defined(OMR_GC_SEGREGATED_HEAP)
+GC_DdrDebugLink(GC_ObjectHeapIteratorSegregated)
 GC_DdrDebugLink(MM_MemoryPoolSegregated)
 GC_DdrDebugLink(MM_MemorySubSpaceSegregated)
 GC_DdrDebugLink(MM_SegregatedGC)
+#endif /* OMR_GC_SEGREGATED_HEAP */
+
+/*
+ * Suggest to compilers that they include fuller descriptions of certain types.
+ */
+
+class DDR_MM_AllocateDescription : public MM_AllocateDescription
+{
+public:
+	MM_MemorySubSpace::AllocationType _ddrAllocationType;
+	MM_MemorySubSpace::AllocationType getAllocationType();
+};
+
+MM_MemorySubSpace::AllocationType
+DDR_MM_AllocateDescription::getAllocationType()
+{
+	return this->_ddrAllocationType;
+}
+
+class DDR_MM_HeapRegionDescriptor : public MM_HeapRegionDescriptor
+{
+public:
+	MM_HeapRegionDescriptor::RegionType _ddrRegionType;
+	MM_HeapRegionDescriptor::RegionType getRegionType();
+};
+
+MM_HeapRegionDescriptor::RegionType
+DDR_MM_HeapRegionDescriptor::getRegionType()
+{
+	return this->_ddrRegionType;
+}
+
+class DDR_MM_MemoryPoolHybrid : public MM_MemoryPoolHybrid
+{
+public:
+	const char * ddrHelper();
+};
+
+const char *
+DDR_MM_MemoryPoolHybrid::ddrHelper()
+{
+	return this->_typeId;
+}
+
+class DDR_MM_HeapRegionList : public MM_HeapRegionList
+{
+public:
+	MM_HeapRegionList::RegionListKind _ddrRegionListKind;
+	MM_HeapRegionList::RegionListKind getRegionListKind();
+};
+
+MM_HeapRegionList::RegionListKind
+DDR_MM_HeapRegionList::getRegionListKind()
+{
+	return this->_ddrRegionListKind;
+}
+
+#if defined(OMR_GC_MODRON_COMPACTION)
+
+class DDR_CompactMemoryPoolState : public MM_CompactMemoryPoolState
+{
+public:
+	const char * ddrHelper();
+};
+
+const char *
+DDR_CompactMemoryPoolState::ddrHelper()
+{
+	return this->_typeId;
+}
+
+#endif /* OMR_GC_MODRON_COMPACTION */
+
+#if defined(OMR_GC_SEGREGATED_HEAP)
+
+class DDR_GC_ObjectHeapIteratorSegregated : public GC_ObjectHeapIteratorSegregated
+{
+public:
+	MM_HeapRegionDescriptor::RegionType _ddrRegionType;
+	MM_HeapRegionDescriptor::RegionType getRegionType();
+};
+
+MM_HeapRegionDescriptor::RegionType
+DDR_GC_ObjectHeapIteratorSegregated::getRegionType()
+{
+	return this->_ddrRegionType;
+}
+
+class DDR_SegregatedGC : public MM_SegregatedGC
+{
+public:
+	MM_SegregatedMarkingScheme *getMarkingScheme();
+};
+
+MM_SegregatedMarkingScheme *
+DDR_SegregatedGC::getMarkingScheme()
+{
+	return this->_markingScheme;
+}
+
 #endif /* OMR_GC_SEGREGATED_HEAP */

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -400,6 +400,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<include path="$(OMR_DIR)/compiler" type="relativepath">
 				<include-if condition="spec.flags.J9VM_INTERP_NATIVE_SUPPORT"/>
 			</include>
+			<include path="bcutil" type="rootpath"/>
+			<include path="j9shr_include"/>
 		</includes>
 		<makefilestubs>
 			<makefilestub data="CFLAGS += -femit-class-debug-always">
@@ -412,6 +414,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.linux_ppc.*_gcc"/>
 				<include-if condition="spec.linux_x86.*"/>
 			</makefilestub>
+			<makefilestub data="UMA_DO_NOT_OPTIMIZE_CCODE = 1"/>
 			<makefilestub data="UMA_DLL_LINK_FLAGS += -bexpall">
 				<include-if condition="spec.aix_ppc.*"/>
 			</makefilestub>

--- a/runtime/ddr/overrides-gc
+++ b/runtime/ddr/overrides-gc
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-typeoverride.MM_EnvironmentVLHGC._depthStack=void*
+typeoverride.MM_AllocateDescription._allocationType=MM_MemorySubSpace$AllocationType 
 
 typeoverride.MM_MemoryPoolSplitAddressOrderedListBase._heapFreeLists=J9ModronFreeList*

--- a/runtime/ddr/run_omrddrgen.mk.ftl
+++ b/runtime/ddr/run_omrddrgen.mk.ftl
@@ -30,7 +30,7 @@ FindAllFiles = \
 	$(wildcard $1/$2) \
 	$(foreach i,$(wildcard $1/*),$(call FindAllFiles,$i,$2))
 
-DDR_INPUT_MODULES := j9ddr_misc j9gc j9jvmti j9prt j9shr j9thr j9trc j9vm jclse
+DDR_INPUT_MODULES := j9ddr_misc j9gc j9jvmti j9prt j9shr j9thr j9trc j9vm j9vrb jclse
 DDR_INPUT_DEPENDS := $(addprefix $(TOP_DIR)/,$(foreach module,$(DDR_INPUT_MODULES),$($(module)_depend)))
 
 <#if uma.spec.type.windows>

--- a/runtime/ddr/vmddr.cpp
+++ b/runtime/ddr/vmddr.cpp
@@ -28,6 +28,8 @@
 #include "shcdatatypes.h"
 #include "srphashtable_api.h"
 #include "stackwalk.h"
+#include "ComparingCursor.hpp"
+#include "ComparingCursorHelper.hpp"
 #include "ddrhelp.h"
 
 #define VM_DdrDebugLink(type) DdrDebugLink(vm, type)
@@ -35,6 +37,15 @@
 VM_DdrDebugLink(CacheletHints)
 VM_DdrDebugLink(CacheletWrapper)
 VM_DdrDebugLink(CharArrayWrapper)
+VM_DdrDebugLink(ComparingCursor)
+VM_DdrDebugLink(ComparingCursorHelper)
+
+const void *
+DDR_ComparingCursorHelper(ComparingCursorHelper * helper)
+{
+	return helper->getBaseAddress();
+}
+
 VM_DdrDebugLink(J9DbgROMClassBuilder)
 VM_DdrDebugLink(J9DbgStringInternTable)
 VM_DdrDebugLink(J9IndexableObject)
@@ -59,6 +70,20 @@ VM_DdrDebugLink(J9ROMConstantDynamicRef)
 VM_DdrDebugLink(J9SFStackFrame)
 VM_DdrDebugLink(J9SRPHashTable)
 VM_DdrDebugLink(J9VMPopFramesInterruptEvent)
+
+VM_DdrDebugLink(_jbooleanArray)
+VM_DdrDebugLink(_jbyteArray)
+VM_DdrDebugLink(_jcharArray)
+VM_DdrDebugLink(_jclass)
+VM_DdrDebugLink(_jdoubleArray)
+VM_DdrDebugLink(_jfloatArray)
+VM_DdrDebugLink(_jintArray)
+VM_DdrDebugLink(_jlongArray)
+VM_DdrDebugLink(_jobjectArray)
+VM_DdrDebugLink(_jshortArray)
+VM_DdrDebugLink(_jstring)
+VM_DdrDebugLink(_jthrowable)
+VM_DdrDebugLink(_jweak)
 
 /*
  * All builds now validate that DTFJ code is compatible with generating pointer

--- a/runtime/gc_base/StringTable.hpp
+++ b/runtime/gc_base/StringTable.hpp
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-
 /**
  * @file
  * @ingroup GC_Base
@@ -37,12 +36,12 @@ class MM_EnvironmentBase;
 
 class MM_StringTable : public MM_BaseVirtual {
 private:
-	UDATA _tableCount;				/**< count of hash sub-tables */
-	J9HashTable **_table;			/**< pointer to an array  of hash sub-tables */
-	omrthread_monitor_t *_mutex;		/**< pointer to an array  of monitors associated with each hash sub-table */
+	UDATA _tableCount;              /**< count of hash sub-tables */
+	J9HashTable **_table;           /**< pointer to an array of hash sub-tables */
+	omrthread_monitor_t *_mutex;    /**< pointer to an array of monitors associated with each hash sub-table */
 
-	enum { cacheSize = 511 };
-	j9object_t _cache[cacheSize];	/**< interned string table cash */
+    ddr_constant(cacheSize, 511);
+	j9object_t _cache[cacheSize];   /**< interned string table cash */
 public:
 
 private:
@@ -58,23 +57,23 @@ public:
 	/**
 	 * @return the address of cache (represented as an array)
 	 */
-	j9object_t *getStringInternCache() { return  _cache; }
+	j9object_t *getStringInternCache() { return _cache; }
 	/**
 	 * @param hash hash value of the string being cached
 	 * @return the address of an entry into the cache array
 	 */
-	j9object_t *getStringInternCache(UDATA hash) { return  &_cache[hash % cacheSize]; }
+	j9object_t *getStringInternCache(UDATA hash) { return &_cache[hash % cacheSize]; }
 
 	/**
 	 * @return hash sub-table count
 	 */
 	UDATA getTableCount() { return _tableCount; }
 
-	/* 
+	/*
 	 * @param hash value of a string
-	 * @return tableIndex given a hash value 
+	 * @return tableIndex given a hash value
 	 */
-	UDATA getTableIndex(UDATA  hash) {
+	UDATA getTableIndex(UDATA hash) {
 		return hash % _tableCount;
 	}
 	/**
@@ -131,7 +130,6 @@ public:
 
 	static MM_StringTable *newInstance(MM_EnvironmentBase *env, UDATA tableCount);
 	virtual void kill(MM_EnvironmentBase *env);
-	
 
 	MM_StringTable(MM_EnvironmentBase *env, UDATA tableCount) :
 		MM_BaseVirtual(),
@@ -141,8 +139,7 @@ public:
 	{
 		_typeId = __FUNCTION__;
 	}
-	
-};
 
+};
 
 #endif /* STRING_TABLE_HPP_ */

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -53,38 +53,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
 
-	<test>
-		<testCaseName>testDDRExt_General_openj9_jdk13+</testCaseName>
-		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
-	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
-	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
-	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-	</test>
-	
 	<test>
 		<testCaseName>testDDRExt_Callsites_ibm</testCaseName>
 		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -116,38 +89,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
 
-	<test>
-		<testCaseName>testDDRExt_Callsites_openj9_jdk13+</testCaseName>
-		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
-	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
-	-Dtest.list=$(Q)TestCallsites$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
-	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-	</test>
-	
 	<test>
 		<testCaseName>testDDRExt_JITExt_ibm</testCaseName>
 		<command>ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -164,7 +110,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<impl>ibm</impl>
 		</impls>
 	</test>
-	
+
 	<test>
 		<testCaseName>testDDRExt_JITExt_openj9</testCaseName>
 		<command>ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -179,38 +125,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
 
-	<test>
-		<testCaseName>testDDRExt_JITExt_openj9_JDK13+</testCaseName>
-		<command>ant -v -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
-	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
-	-Dtest.list=$(Q)TestJITExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -DEXTRADUMPOPT=$(Q)-Xjit:count=0$(Q) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
-	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-	</test>
-	
 	<test>
 		<testCaseName>testDDRExt_SharedClasses_ibm</testCaseName>
 		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
@@ -242,35 +161,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
 	</test>
-	
-	<test>
-		<testCaseName>testDDRExt_SharedClasses_openj9_JDK13+</testCaseName>
-		<command>ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DTEST_JDK_HOME=${TEST_JDK_HOME} -DJDK_VERSION=${JDK_VERSION} \
-	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) -DLIB_DIR=${LIB_DIR} \
-	-Dtest.list=$(Q)TestSharedClassesExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
-	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-	</test>
+
 </playlist>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -99,40 +99,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
-		<groups>
-			<group>functional</group>
-		</groups>
-	</test>
-	
-	<test>
-		<testCaseName>cmdLineTester_callsitedbgddrext_openj9_jdk13+</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
-	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
-	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
-	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
 		<groups>
 			<group>functional</group>
 		</groups>

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -71,51 +71,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
 	</test>
-	
-	<test>
-		<testCaseName>cmdLineTester_classesdbgddrext_jdk13+</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
-		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
-	-DRESJAR=$(CMDLINETESTER_RESJAR) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
-	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
-	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
-	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
-	${TEST_STATUS}</command>
-		<!-- j9ddr.jar is not supported on z/OS; OpenJ9 issue 1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
-	</test>
-
 	<test>
 		<testCaseName>cmdLineTester_classesdbgddrext_aix</testCaseName>
 		<variations>
@@ -140,10 +100,5 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -47,41 +47,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
-	</test>
-	
-	<test>
-		<testCaseName>cmdLineTester_modularityddrtests_jdk13+</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
-		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
-	-DRESJAR=$(CMDLINETESTER_RESJAR) \
-	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
-	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
-	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
-	${TEST_STATUS}</command>
-		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
+			<subset>9+</subset>
 		</subsets>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -47,46 +47,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
-	</test>
-
-	<test>
-		<testCaseName>cmdLineTester_shrcdbgddrext_jdk13+</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
-			<variation>Mode201</variation>
-		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	cp $(CMDLINETESTER_RESJAR) .; \
-	$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf cmdlinetestresources.jar; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
-	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
-	-DCONCAT=$(TEST_RESROOT)$(D)concatenate_dumps.sh \
-	-DJDMPVIEW_EXE=$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
-	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<!-- temporarily disable this test on JDK13+ aix; https://github.com/eclipse/openj9/issues/7612 -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>13+</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Note: this requires eclipse/omr#4661 which is not yet merged.

* add j9vrb to list of inputs for DDR
* use new macro, ddr_constant(name, value), to make constant declarations via anonymous enums available
* coax compiler to include debug information for
  - super types of _jbooleanArray, etc.
  - add override for MM_AllocateDescription._allocationType
  - MM_CompactMemoryPoolState
  - MM_SegregatedGC::_markingScheme
* disable optimization of j9ddr_misc
  a side-effect of enabling optimization is the elimination
  of certain pieces of debugging information we need
* blacklist types 'DDR_*' which are only for coaxing the compiler
* remove reference to field that no longer exists