### PR TITLE
Replace native libray unpack with awt in test_callNativesOnNewClassLoaders

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -468,7 +468,7 @@ public class Test_ClassLoader {
 			 * not already loaded by another classloader. If it starts failing,
 			 * find another library to load.
 			 */
-			loader2.loadLibrary("unpack");
+			loader2.loadLibrary("awt");
 		} catch (UnsatisfiedLinkError e) {
 			e.printStackTrace();
 			Assert.fail("expected to find library");


### PR DESCRIPTION
**Replace native library unpack with `awt` in `test_callNativesOnNewClassLoaders`**

`unpack` is removed in `JDK 14+`, replace it with `awt` instead which is expected to be available in all existing Java levels.

Verified that JDK 11 still passes the test.

closes: #8049 

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>