### PR TITLE
AArch64: Enable directToJNI

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -50,6 +50,8 @@ J9::ARM64::CodeGenerator::CodeGenerator() :
       }
 
    cg->setSupportsDivCheck();
+   if (!comp()->getOption(TR_FullSpeedDebug))
+      cg->setSupportsDirectJNICalls();
    }
 
 TR::Linkage *

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1016,3 +1016,20 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
 
    return NULL;
    }
+
+TR::Register *J9::ARM64::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::SymbolReference *symRef = node->getSymbolReference();
+   TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
+   TR::Linkage *linkage;
+
+   if (callee->isJNI() && (node->isPreparedForDirectJNI() || callee->getResolvedMethodSymbol()->canDirectNativeCall()))
+      {
+      linkage = cg->getLinkage(TR_J9JNILinkage);
+      }
+   else
+      {
+      linkage = cg->getLinkage(callee->getLinkageConvention());
+      }
+   return linkage->buildDirectDispatch(node);
+   }

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -110,6 +110,14 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *NULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *resolveAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *evaluateNULLCHKWithPossibleResolve(TR::Node *node, bool needResolution, TR::CodeGenerator *cg);
+
+   /**
+    * @brief Handles direct call nodes
+    * @param[in] node : node
+    * @param[in] cg : CodeGenerator
+    * @return register containing result
+    */
+   static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    };
 
 } // ARM64


### PR DESCRIPTION
This commit enables directToJNI for aarch64.
- Add call to `setSupportsDirectToJNICalls` to constructor of `J9::ARM64::CodeGenerator`.
- <s>Implement `J9::ARM64::CodeGenerator::generateBinaryEncodingPrePrologue` to embed
 native method address into pre-prologue.</s> -> moved to https://github.com/eclipse/openj9/pull/8078
- Implement `J9::ARM64::CodeGenerator::directCallEvaluator` which calls
 `J9::ARM64::JNILinkage::buildDirectDispatch` for JNI method.

Depends on
- https://github.com/eclipse/openj9/pull/7972
- https://github.com/eclipse/openj9/pull/7993
- https://github.com/eclipse/openj9/pull/7994
- https://github.com/eclipse/openj9/pull/7996
- https://github.com/eclipse/openj9/pull/7997
- https://github.com/eclipse/openj9/pull/7998
- https://github.com/eclipse/openj9/pull/7999
- https://github.com/eclipse/openj9/pull/8000
- https://github.com/eclipse/openj9/pull/8001
- https://github.com/eclipse/openj9/pull/8002
- https://github.com/eclipse/openj9/pull/8003
- https://github.com/eclipse/openj9/pull/8078
- https://github.com/eclipse/omr/pull/4663 

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>