### PR TITLE
Add removal of content in /cores on osx

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
@@ -165,13 +165,16 @@ timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNITS) {
                                     // cleanup test results
                                     sh "rm -fr ${cleanDirsStr}"
 
-                                    // Cleanup OSX shared memory
+                                    // Cleanup OSX shared memory and content in /cores
                                     if (nodeLabels.contains('sw.os.osx')) {
                                         retry(2) {
                                             sh """
                                                 ipcs -ma
                                                 ipcs -ma | awk '/^m / { if (\$9 == 0) { print \$2 }}' | xargs -n 1 ipcrm -m
                                                 ipcs -ma
+						du -sh /cores
+						rm -rf /cores/*
+						du -sh /cores
                                             """
                                         }
                                     }


### PR DESCRIPTION
* jobs often leave content in /cores which over time cause all free
    space to be consumed
* [skip ci]

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>