### PR TITLE
CMake: Add windows macros

### DIFF
--- a/runtime/cmake/platform.cmake
+++ b/runtime/cmake/platform.cmake
@@ -21,6 +21,19 @@
 ################################################################################
 
 include(OmrPlatform)
+# Note: we need to inject WIN32 et al, as OMR no longer uses them
+if(OMR_OS_WINDOWS)
+    list(APPEND OMR_PLATFORM_DEFINITIONS
+        -DWIN32
+        -D_WIN32
+    )
+    if(OMR_ENV_DATA64)
+        list(APPEND OMR_PLATFORM_DEFINITIONS
+            -DWIN64
+            -D_WIN64
+        )
+    endif()
+endif()
 omr_platform_global_setup()
 
 if(OMR_TOOLCONFIG STREQUAL "gnu")


### PR DESCRIPTION
Add WIN32/64 macros definitions as they are no longer provided by omr

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>