### PR TITLE
Remove always on ifdef code

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1529,7 +1529,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          I_32 cpIndex = std::get<1>(recv);
          TR::VMAccessCriticalSection getResolvedHandleMethod(fe);
 
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
          bool unresolvedInCP = mirror->isUnresolvedMethodTypeTableEntry(cpIndex);
          TR_OpaqueMethodBlock *dummyInvokeExact = fe->getMethodFromName("java/lang/invoke/MethodHandle",
                "invokeExact", "([Ljava/lang/Object;)Ljava/lang/Object;");
@@ -1537,18 +1536,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          J9ROMNameAndSignature *nameAndSig = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
          int32_t signatureLength;
          char   *signature = utf8Data(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig), signatureLength);
-#else
-         bool unresolvedInCP = mirror->isUnresolvedMethodType(cpIndex);
-         TR_OpaqueMethodBlock *dummyInvokeExact = fe->getMethodFromName("java/lang/invoke/MethodHandle",
-               "invokeExact", "([Ljava/lang/Object;)Ljava/lang/Object;");
-         J9ROMMethodTypeRef *romMethodTypeRef = (J9ROMMethodTypeRef *)(mirror->cp()->romConstantPool + cpIndex);
-         int32_t signatureLength;
-         char   *signature = utf8Data(J9ROMMETHODTYPEREF_SIGNATURE(romMethodTypeRef), signatureLength);
-#endif
          client->write(response, dummyInvokeExact, std::string(signature, signatureLength), unresolvedInCP);
          }
          break;
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
       case MessageType::ResolvedMethod_methodTypeTableEntryAddress:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method*, I_32>();
@@ -1565,7 +1555,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, mirror->isUnresolvedMethodTypeTableEntry(cpIndex));
          }
          break;
-#endif
       case MessageType::ResolvedMethod_isUnresolvedCallSiteTableEntry:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method*, int32_t>();

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1086,10 +1086,6 @@ onLoadInternal(
    ((TR_JitPrivateConfig*)jitConfig->privateConfig)->j9jitrt_lock_log = j9jitrt_lock_log;
    ((TR_JitPrivateConfig*)jitConfig->privateConfig)->j9jitrt_unlock_log = j9jitrt_unlock_log;
 
-   #ifndef J9VM_ENV_DIRECT_FUNCTION_POINTERS
-      jitConfig->jitTranslateMethod = jitTranslateMethod;
-   #endif
-
    // set up the entryPoints for compiling and for support of the
    // java.lang.Compiler class.
    jitConfig->entryPoint = j9jit_testarossa;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4876,11 +4876,7 @@ uintptrj_t TR_J9VMBase::mutableCallSiteCookie(uintptrj_t mutableCallSite, uintpt
 bool
 TR_J9VMBase::hasMethodTypesSideTable()
    {
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
    return true;
-#else
-   return false;
-#endif
    }
 
 void *

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6164,7 +6164,6 @@ TR_ResolvedJ9Method::isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex)
    return *(j9object_t*)varHandleMethodTypeTableEntryAddress(cpIndex) == NULL;
    }
 
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
 void *
 TR_ResolvedJ9Method::methodTypeTableEntryAddress(int32_t cpIndex)
    {
@@ -6179,7 +6178,6 @@ TR_ResolvedJ9Method::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
    {
    return *(j9object_t*)methodTypeTableEntryAddress(cpIndex) == NULL;
    }
-#endif
 
 TR_OpaqueClassBlock *
 TR_ResolvedJ9Method::getClassFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, TR::Compilation *comp, uint32_t cpIndex)
@@ -6759,7 +6757,6 @@ TR_ResolvedJ9Method::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpInde
       {
       TR::VMAccessCriticalSection getResolvedHandleMethod(fej9());
 
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
       if (unresolvedInCP)
          *unresolvedInCP = isUnresolvedMethodTypeTableEntry(cpIndex);
       TR_OpaqueMethodBlock *dummyInvokeExact = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "invokeExact", JSR292_invokeExactSig);
@@ -6767,14 +6764,6 @@ TR_ResolvedJ9Method::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpInde
       J9ROMNameAndSignature *nameAndSig = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
       int32_t signatureLength;
       char   *signature = utf8Data(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig), signatureLength);
-#else
-      if (unresolvedInCP)
-         *unresolvedInCP = isUnresolvedMethodType(cpIndex);
-      TR_OpaqueMethodBlock *dummyInvokeExact = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "invokeExact", JSR292_invokeExactSig, getNonPersistentIdentifier());
-      J9ROMMethodTypeRef *romMethodTypeRef = (J9ROMMethodTypeRef *)(cp()->romConstantPool + cpIndex);
-      int32_t signatureLength;
-      char   *signature = utf8Data(J9ROMMETHODTYPEREF_SIGNATURE(romMethodTypeRef), signatureLength);
-#endif
       result = _fe->createResolvedMethodWithSignature(comp->trMemory(), dummyInvokeExact, NULL, signature, signatureLength, this);
       }
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -408,11 +408,8 @@ public:
 
    virtual bool                    isUnresolvedCallSiteTableEntry(int32_t callSiteIndex);
    virtual void *                  callSiteTableEntryAddress(int32_t callSiteIndex);
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
    virtual bool                    isUnresolvedMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  methodTypeTableEntryAddress(int32_t cpIndex);
-#endif
-   // J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING is always true and is planed to be cleaned up, always assume it's true
    virtual bool                    isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  varHandleMethodTypeTableEntryAddress(int32_t cpIndex);
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1209,7 +1209,6 @@ TR_ResolvedJ9JITServerMethod::getResolvedHandleMethod(TR::Compilation * comp, I_
 #endif
    }
 
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
 void *
 TR_ResolvedJ9JITServerMethod::methodTypeTableEntryAddress(int32_t cpIndex)
    {
@@ -1223,7 +1222,6 @@ TR_ResolvedJ9JITServerMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex)
    _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedMethodTypeTableEntry, _remoteMirror, cpIndex);
    return std::get<0>(_stream->read<bool>());
    }
-#endif
 
 bool
 TR_ResolvedJ9JITServerMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex)

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -186,10 +186,8 @@ public:
    virtual bool isSubjectToPhaseChange(TR::Compilation *comp) override;
    virtual void * stringConstant(int32_t cpIndex) override;
    virtual TR_ResolvedMethod *getResolvedHandleMethod( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP) override;
-#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)
    virtual bool isUnresolvedMethodTypeTableEntry(int32_t cpIndex) override;
    virtual void * methodTypeTableEntryAddress(int32_t cpIndex) override;
-#endif
    virtual bool isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) override;
    virtual void * callSiteTableEntryAddress(int32_t callSiteIndex) override;
    virtual bool isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex) override;

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -59,10 +59,8 @@ extern "C" {
 
 extern void init_codert_vm_fntbl(J9JavaVM * vm);
 
-#ifdef J9VM_ENV_DIRECT_FUNCTION_POINTERS
-   #ifndef J9SW_NEEDS_JIT_2_INTERP_THUNKS
-      extern void * jit2InterpreterSendTargetTable;
-   #endif
+#ifndef J9SW_NEEDS_JIT_2_INTERP_THUNKS
+   extern void * jit2InterpreterSendTargetTable;
 #endif
 
 
@@ -487,11 +485,7 @@ void codert_init_helpers_and_targets(J9JITConfig * jitConfig, char isSMP)
    initializeCodertFunctionTable(javaVM);
 
    #ifndef J9SW_NEEDS_JIT_2_INTERP_THUNKS
-      #ifdef J9VM_ENV_DIRECT_FUNCTION_POINTERS
-         jitConfig->jitSendTargetTable = &jit2InterpreterSendTargetTable;
-      #else
-         jitConfig->jitSendTargetTable = jitConfig->javaVM->internalVMLabels->jit2InterpreterSendTargetTable;
-      #endif
+      jitConfig->jitSendTargetTable = &jit2InterpreterSendTargetTable;
    #endif
 
    #if defined(J9VM_PORT_SIGNAL_SUPPORT) && defined(J9VM_INTERP_NATIVE_SUPPORT)
@@ -529,11 +523,7 @@ UDATA lookupSendTargetForThunk(J9JavaVM * javaVM, int thunkNumber)
 #if defined(J9ZOS390)
    #define VIRTUAL_TARGET(x) TOC_UNWRAP_ADDRESS(x)
 #else
-#ifdef J9VM_ENV_DIRECT_FUNCTION_POINTERS
    #define VIRTUAL_TARGET(x) (x)
-#else
-   #define VIRTUAL_TARGET(x) javaVM->internalVMLabels->x
-#endif
 #endif
 
    /* Use the internal function table which knows how to reference the code part of an intermodule reference */

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/ConstantPoolStream.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/ConstantPoolStream.java
@@ -304,11 +304,7 @@ public class ConstantPoolStream {
 
 	private void writeFooter() {
 		out.println("\t},");
-		out.println("#if defined(J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING)");
 		writeUnsplitDescription();
-		out.println("#else");
-		writeDescription();
-		out.println("#endif");
 		out.println("};");
 		out.println();
 		out.println("const J9ROMClass * jclROMClass = &_jclROMClass.romClass;");
@@ -356,14 +352,6 @@ public class ConstantPoolStream {
 				}
 			}
 			out.print("0x" + Integer.toHexString(descriptionWord) + ", ");
-		}
-		out.println("}");
-	}
-
-	private void writeDescription() {
-		out.print("\t{");
-		for (int i = 0; i < cpDescription.length; i++) {
-			out.print("0x" + Integer.toHexString(cpDescription[i]) + ", ");
 		}
 		out.println("}");
 	}


### PR DESCRIPTION
J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING and
J9VM_ENV_DIRECT_FUNCTION_POINTERS are always defined.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>