### PR TITLE
Revert "Replace native libray unpack with awt in test_callNativesOnNewClassLoaders"

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -468,7 +468,7 @@ public class Test_ClassLoader {
 			 * not already loaded by another classloader. If it starts failing,
 			 * find another library to load.
 			 */
-			loader2.loadLibrary("awt");
+			loader2.loadLibrary("unpack");
 		} catch (UnsatisfiedLinkError e) {
 			e.printStackTrace();
 			Assert.fail("expected to find library");


### PR DESCRIPTION
Reverts eclipse/openj9#8057

I believe this change is causing a hang on Mac.
```
15:06:34  _RegisterApplication(), FAILED TO establish the default connection to the WindowServer, _CGSDefaultConnection() is NULL.
15:06:34  2019-12-11 15:06:34.057 java[66012:13593888] +[NSXPCSharedListener endpointForReply:withListenerName:]: an error occurred while attempting to obtain endpoint for listener 'ClientCallsAuxiliary': Connection interrupted
```