### PR TITLE
AArch64: Add generateBinaryEncodingPrePrologue in J9CodeGenerator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -78,6 +78,11 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
    
+   /**
+    * @brief Generates pre-prologue
+    * @param[in] data : binary encoding data
+    */
+   void generateBinaryEncodingPrePrologue(TR_ARM64BinaryEncodingData &data);
    };
 
 }


### PR DESCRIPTION
This commit implements `J9::ARM64::CodeGenerator::generateBinaryEncodingPrePrologue`
 to embed native method address into pre-prologue.

Depends on https://github.com/eclipse/omr/pull/4663

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>