### PR TITLE
Fix assertions in debug build

### DIFF
--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -505,7 +505,7 @@ InterpreterEmulator::visitInvokedynamic()
 
       TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
                                                                         callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                        (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                        -1, cpIndex, resolvedMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
 
@@ -580,7 +580,7 @@ InterpreterEmulator::visitInvokevirtual()
          {
          callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
                                                                         callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-                                                                        (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+                                                                        -1, cpIndex, resolvedMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
          }
@@ -691,7 +691,7 @@ InterpreterEmulator::visitInvokestatic()
          {
          callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite( _calltarget->_calleeMethod, callNodeTreeTop,   parent,
                callNode, interfaceMethod, resolvedMethod->classOfMethod(),
-               (int32_t) resolvedMethod->virtualCallSelector(cpIndex), cpIndex, resolvedMethod,
+               -1, cpIndex, resolvedMethod,
                resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                _recursionDepth, allconsts);
          }

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -397,7 +397,14 @@ public:
    void * operator new (size_t size) throw();
    void * operator new (size_t size, void * placement) {return placement;}
 
+#ifdef OMR_GC_COMPRESSED_POINTERS
+   // Set the higher 32 bits to zero under compressedref to avoid assertion in
+   // CallSiteProfileInfo::setClazz, which is called by setInvalid with IPROFILING_INVALID
+   //
+   static const uintptrj_t IPROFILING_INVALID = 0x00000000FFFFFFFF;
+#else
    static const uintptrj_t IPROFILING_INVALID = ~0;
+#endif
 
    virtual uintptrj_t getData(TR::Compilation *comp = NULL);
    virtual CallSiteProfileInfo* getCGData() { return &_csInfo; } // overloaded


### PR DESCRIPTION
Archetype specimen doesn't have valid vft slot, calling
`virtualCallSelector` will hit an assertion, thus pass -1 when creating
a MethodHandle call site.

Also, assign IPROFILING_INVALID a value that won't trigger the assert in
`CallSiteProfileInfo::setClazz` called by
`TR_IPBCDataCallGraph::setInvalid` with `IPROFILING_INVALID`.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>