### PR TITLE
WIP: Improve performance of DirectByteBuffer.put

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4115,6 +4115,8 @@ static bool foldFinalFieldsIn(const char *className, int32_t classNameLength, TR
       return true;
    else if (classNameLength >= 38 && !strncmp(className, "java/util/concurrent/ThreadLocalRandom", 38))
       return true;
+   else if (classNameLength >= 25 && !strncmp(className, "java/nio/DirectByteBuffer", 25))
+      return true;
    else
       return false;
    }

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -80,6 +80,7 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_lang_Math_sqrt:
       case TR::java_lang_Math_tan:
       case TR::java_lang_Math_tanh:
+      case TR::java_lang_ref_Reference_reachabilityFence:
       case TR::java_lang_StrictMath_acos:
       case TR::java_lang_StrictMath_asin:
       case TR::java_lang_StrictMath_atan:
@@ -112,6 +113,7 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_lang_StrictMath_sqrt:
       case TR::java_lang_StrictMath_tan:
       case TR::java_lang_StrictMath_tanh:
+      case TR::java_nio_Bits_keepAlive:
          /*
       case TR::java_math_BigDecimal_valueOf:
       case TR::java_math_BigDecimal_add:

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -441,6 +441,8 @@ bool J9::TransformUtil::foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, const char
       return true;
    else if (classNameLength >= 17 && !strncmp(className, "java/util/EnumMap", 17))
       return true;
+   else if (classNameLength >= 25 && !strncmp(className, "java/nio/DirectByteBuffer", 25))
+      return true;
 
    if (classNameLength == 16 && !strncmp(className, "java/lang/System", 16))
       return false;


### PR DESCRIPTION
Loop Unroller was restricted in unrolling loop that contains inlined implementation of DirectByteBuffer.put. This commits adds following changes to make sure if loop is candidate for unrolling, it is unrolled.
1. Add java/nio/DirectByteBuffer class to list of classes with foldable final fields.
2. Calls to java/lang/ref/Reference.reachabilityFence and java/nio/Bits.keepAlive are NOP functions inserted into NIO libraries. As these are NOP functions, these calls can not cause GC or throw exception. Adding this function calls to Pure functions list.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>