### PR TITLE
AArch64: Add call to setSupportsInliningOfTypeCoersionMethods

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -49,6 +49,7 @@ J9::ARM64::CodeGenerator::CodeGenerator() :
       initTreeEvaluatorTable = true;
       }
 
+   cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsDivCheck();
    }
 


### PR DESCRIPTION
This commit adds call to `setSupportsInliningOfTypeCoersionMethods`
to the constructor of `J9::ARM64::CodeGenerator`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>