### PR TITLE
Add support for single level peeking in EA under HCR

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -26,6 +26,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/optimizer/DataAccessAccelerator.cpp \
     compiler/optimizer/DynamicLiteralPool.cpp \
     compiler/optimizer/EscapeAnalysis.cpp \
+    compiler/optimizer/EscapeAnalysisTools.cpp \
     compiler/optimizer/PreEscapeAnalysis.cpp \
     compiler/optimizer/PostEscapeAnalysis.cpp \
     compiler/optimizer/FearPointAnalysis.cpp \

--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -26,6 +26,7 @@ j9jit_files(
 	optimizer/DataAccessAccelerator.cpp
 	optimizer/DynamicLiteralPool.cpp
 	optimizer/EscapeAnalysis.cpp
+	optimizer/EscapeAnalysisTools.cpp
 	optimizer/EstimateCodeSize.cpp
 	optimizer/FearPointAnalysis.cpp
 	optimizer/HCRGuardAnalysis.cpp

--- a/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.cpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "optimizer/EscapeAnalysisTools.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/AutomaticSymbol.hpp"
+
+TR_EscapeAnalysisTools::TR_EscapeAnalysisTools(TR::Compilation *comp)
+  {
+  _loads = NULL;
+  _comp = comp;
+  }
+
+void TR_EscapeAnalysisTools::insertFakeEscapeForLoads(TR::Block *block, TR::Node *node, NodeDeque *loads)
+   {
+   //TR::Node *fakePrepare = TR::Node::createWithSymRef(node, TR::call, loads->size(), _comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_prepareForOSR, false, false, true));
+   TR::Node *fakePrepare = TR::Node::createEAEscapeHelperCall(node, loads->size());
+   int idx = 0;
+   for (auto itr = loads->begin(), end = loads->end(); itr != end; ++itr)
+       {
+       (*itr)->setByteCodeInfo(node->getByteCodeInfo());
+       fakePrepare->setAndIncChild(idx++, *itr);
+       }
+   dumpOptDetails(_comp, " Adding fake prepare n%dn to OSR induction block_%d\n", fakePrepare->getGlobalIndex(), block->getNumber());
+   block->getLastRealTreeTop()->insertBefore(
+      TR::TreeTop::create(_comp, TR::Node::create(node, TR::treetop, 1, fakePrepare)));
+   }
+
+void TR_EscapeAnalysisTools::insertFakeEscapeForOSR(TR::Block *block, TR::Node *induceCall)
+   {
+   if (_loads == NULL)
+      _loads = new (_comp->trMemory()->currentStackRegion()) NodeDeque(NodeDequeAllocator(_comp->trMemory()->currentStackRegion()));
+   else   
+      _loads->clear();
+
+   TR_ByteCodeInfo &bci = induceCall->getByteCodeInfo();
+
+   int32_t inlinedIndex = bci.getCallerIndex();
+   int32_t byteCodeIndex = bci.getByteCodeIndex();
+   TR_OSRCompilationData *osrCompilationData = _comp->getOSRCompilationData();
+
+   // Gather all live autos and pending pushes at this point for inlined methods in _loads
+   // This ensures objects that EA can stack allocate will be heapified if OSR is induced
+   while (inlinedIndex > -1)
+      {
+      TR::ResolvedMethodSymbol *rms = _comp->getInlinedResolvedMethodSymbol(inlinedIndex);
+      TR_ASSERT_FATAL(rms, "Unknwon resolved method during escapetools");
+      TR_OSRMethodData *methodData = osrCompilationData->findOSRMethodData(inlinedIndex, rms);
+      processAutosAndPendingPushes(rms, methodData, byteCodeIndex);
+      byteCodeIndex = _comp->getInlinedCallSite(inlinedIndex)._byteCodeInfo.getByteCodeIndex();
+      inlinedIndex = _comp->getInlinedCallSite(inlinedIndex)._byteCodeInfo.getCallerIndex();
+      }
+
+   // handle the outter most method
+      {
+      TR_OSRMethodData *methodData = osrCompilationData->findOSRMethodData(-1, _comp->getMethodSymbol());
+      processAutosAndPendingPushes(_comp->getMethodSymbol(), methodData, byteCodeIndex);
+      }
+   insertFakeEscapeForLoads(block, induceCall, _loads);
+   }
+
+void TR_EscapeAnalysisTools::processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex)
+   {
+   processSymbolReferences(rms->getAutoSymRefs(), methodData->getLiveRangeInfo(byteCodeIndex));
+   processSymbolReferences(rms->getPendingPushSymRefs(), methodData->getPendingPushLivenessInfo(byteCodeIndex));
+   }
+
+void TR_EscapeAnalysisTools::processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs)
+   {
+   for (int i = 0; symbolReferences && i < symbolReferences->size(); i++)
+      {
+      List<TR::SymbolReference> autosList = (*symbolReferences)[i];
+      ListIterator<TR::SymbolReference> autosIt(&autosList);
+      for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext())
+         {
+         TR::AutomaticSymbol *p = symRef->getSymbol()->getAutoSymbol();
+         if (p && p->getDataType() == TR::Address && (deadSymRefs == NULL || !deadSymRefs->isSet(symRef->getReferenceNumber())))
+            {
+            _loads->push_back(TR::Node::createWithSymRef(TR::aload, 0, symRef));
+            }
+         }
+      }
+   }

--- a/runtime/compiler/optimizer/EscapeAnalysisTools.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.hpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ESCAPEANALYSISTOOLS_INCL
+#define ESCAPEANALYSISTOOLS_INCL
+
+#include <stdint.h>                           // for int32_t
+#include "optimizer/Optimization.hpp"         // for Optimization
+#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "optimizer/EscapeAnalysis.hpp"
+#include "il/SymbolReference.hpp"
+
+namespace TR { class Block; class Node; }
+
+//typedef TR::typed_allocator<TR::Node *, TR::Region &> NodeDequeAllocator;
+//typedef std::deque<TR::Node *, NodeDequeAllocator> NodeDeque;
+
+class TR_EscapeAnalysisTools
+   {
+   public:
+   TR_EscapeAnalysisTools(TR::Compilation *comp);
+
+// TODO:  Bring Doxygen comments up to date
+   /**
+    * Create a "fake" call to the \c escapeHelper gathering references to all
+    * live autos and pending pushes.
+    *
+    * \param[in] block An OSR induce block containing the call represented by
+    *            \c induceCall.  The fake \c escapeHelper call that is
+    *            generated will be added at the end of this block.
+    * \param[in] induceCall The call to the OSR induction helper in \c block.
+    *            Used as the source of byte code info for the fake
+    *            \c escapeHelper
+    */
+   void insertFakeEscapeForOSR(TR::Block *block, TR::Node *induceCall);
+
+
+   void insertFakeEscapeForLoads(TR::Block *block, TR::Node *node, NodeDeque *loads);
+   //static bool isFakeEscape(TR::Node *node) { return node->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR;}
+   static bool isFakeEscape(TR::Node *node) { return node->isEAEscapeHelperCall(); }
+   private:
+   TR::Compilation *_comp;
+
+   /**
+    * Used by \ref insertFakePrepareForOSR to gather \c aloads of autos and
+    * pending pushes.
+    */
+   NodeDeque *_loads;
+
+   /**
+    * Gather live autos and pending pushes at the point of a call to the OSR
+    * induction helper in the context of an inlined method or the outermost
+    * method.  Create an \c aload reference to each such auto or pending push.
+    *
+    * \c aloads are gathered in \ref _loads.
+    *
+    * \param[in] rms The method whose live autos and pending pushes are to be
+    *                processed
+    * \param[in] methodData \ref TR_OSRMethodData at this point in the
+    *                relevant method
+    * \param[in] byteCodeIndex The bytecode index at this point inside the
+    *                relevant method
+    */
+   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
+
+   /**
+    * Create \c aload references to each live symbol reference among those
+    * listed in the \c symbolReferences argument.
+    *
+    * \c aloads are gathered in \ref _loads.
+    *
+    * \param[in] symbolReferences \ref TR_Array<> of symbol references for
+    *               autos or pending pushes
+    * \param[in] deadSymRefs Liveness info for \c symbolReferences - a
+    *               \ref TR_BitVector of symbols that are not live at the
+    *               relevant point
+    */
+   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs);
+   };
+
+#endif
+

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.hpp
@@ -28,9 +28,7 @@
 
 namespace TR { class Block; class Node; }
 
-typedef TR::typed_allocator<TR::Node *, TR::Region &> NodeDequeAllocator;
-typedef std::deque<TR::Node *, NodeDequeAllocator> NodeDeque;
-
+// TODO:  Bring Doxygen comments up to date
 /**
  * The \c TR_PreEscapeAnalysis optimization looks for calls to
  * \c OSRInductionHelper and adds a fake \c prepareForOSR call
@@ -61,57 +59,6 @@ class TR_PreEscapeAnalysis : public TR::Optimization
 
    virtual int32_t perform();
    virtual const char * optDetailString() const throw();
-
-   private:
-
-   /**
-    * Used by \ref insertFakePrepareForOSR to gather \c aloads of autos and
-    * pending pushes.
-    */
-   NodeDeque *_loads;
-
-   /**
-    * Create a "fake" \c prepareForOSR call that gathers references to all
-    * live autos and pending pushes.
-    *
-    * \param[in] block An OSR induce block containing the call represented by
-    *            \c induceCall.  The fake \c prepareForOSR call that is
-    *            generated will be added at the end of this block.
-    * \param[in] induceCall The call to the OSR induction helper in \c block.
-    *            Used as the source of byte code info for the fake
-    *            \c prepareForOSR
-    */
-   void insertFakePrepareForOSR(TR::Block *block, TR::Node *induceCall);
-
-   /**
-    * Gather live autos and pending pushes at the point of a call to the OSR
-    * induction helper in the context of an inlined method or the outermost
-    * method.  Create an \c aload reference to each such auto or pending push.
-    *
-    * \c aloads are gathered in \ref _loads.
-    *
-    * \param[in] rms The method whose live autos and pending pushes are to be
-    *                processed
-    * \param[in] methodData \ref TR_OSRMethodData at this point in the
-    *                relevant method
-    * \param[in] byteCodeIndex The bytecode index at this point inside the
-    *                relevant method
-    */
-   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
-
-   /**
-    * Create \c aload references to each live symbol reference among those
-    * listed in the \c symbolReferences argument.
-    *
-    * \c aloads are gathered in \ref _loads.
-    *
-    * \param[in] symbolReferences \ref TR_Array<> of symbol references for
-    *               autos or pending pushes
-    * \param[in] deadSymRefs Liveness info for \c symbolReferences - a
-    *               \ref TR_BitVector of symbols that are not live at the
-    *               relevant point
-    */
-   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs);
    };
 
 #endif


### PR DESCRIPTION
Currently EA does not support peaking under HCR. This change supports adding peeking of
depth 1 under HCR by creating HCR guards which force heapficiation of potentially stack
allocated candidates ahead of peeked calls to ensure accidental escape does not happen
 at runtime even if peeking results are trusted.

The nature of this change relies on OSR to retrieve the live local information. Peeking
under HCR with OSR off is NOT supported. A protected call will be proceeded by an HCR
guard with heapificaitons on the taken side of the guard (if needed) to ensure that
stack allocated objects are heapified ahead of the call if the peeked method is
redefined and could potentially lead to an escape at runtime.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>