### PR TITLE
Initialize MM_GCExtensions::classLoaderManager field

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -300,6 +300,7 @@ public:
 		, finalizeMasterPriority(J9THREAD_PRIORITY_NORMAL)
 		, finalizeSlavePriority(J9THREAD_PRIORITY_NORMAL)
 #endif /* J9VM_GC_FINALIZATION */
+		, classLoaderManager(NULL)
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 		, deadClassLoaderCacheSize(1024 * 1024) /* default is one MiB */
 #endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */


### PR DESCRIPTION
MM_GCExtensions::classLoaderManager is not initialized in the constructor,
but much later, which can cause problems if the GC decides to terminate
the JVM early due to bad options: during the tear down process the GC
does a test against MM_GCExtensions::classLoaderManager and if it's not
NULL, it tries to free the block it points to, which can be any value.

Closes #8104

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>