### PR TITLE
Replace native library unpack with j9ben

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -986,7 +986,7 @@
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1028,9 +1028,12 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11+</subset>
 		</subsets>
 		<aot>nonapplicable</aot>
+		<types>
+			<type>native</type>
+		</types>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -1043,7 +1046,7 @@
 			<variation>-Xshareclasses:none</variation>
 			<variation>-XX:RecreateClassfileOnload -Xshareclasses:none</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules openj9.sharedclasses $(ADD_MODULE_JAVA_SE_EE) \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -1085,9 +1088,12 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11+</subset>
 		</subsets>
 		<aot>nonapplicable</aot>
+		<types>
+			<type>native</type>
+		</types>
 		<impls>
 			<impl>openj9</impl>
 		</impls>
@@ -1139,7 +1145,7 @@
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
@@ -1172,6 +1178,9 @@
 		<subsets>
 			<subset>8</subset>
 		</subsets>
+		<types>
+			<type>native</type>
+		</types>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
@@ -468,7 +468,7 @@ public class Test_ClassLoader {
 			 * not already loaded by another classloader. If it starts failing,
 			 * find another library to load.
 			 */
-			loader2.loadLibrary("jsound");
+			loader2.loadLibrary("j9ben");
 		} catch (UnsatisfiedLinkError e) {
 			e.printStackTrace();
 			Assert.fail("expected to find library");


### PR DESCRIPTION
**Replace native library unpack with j9ben**

`unpack` is removed in JDK 14+, replace it with `j9ben` instead.

Verified in platforms `x86-64_linux,ppc64_aix,ppc64le_linux,x86-64_mac,x86-64_windows`.

closes: #8049 

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>