### PR TITLE
Fix initialization of j9object_t object

### DIFF
--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1757,7 +1757,7 @@ storePDobjectsHelper(J9VMThread* vmThread, J9Class* arrayClass, J9StackWalkState
 		j9object_t lastPD = NULL;
 		I_32 resultIndex = startPos;
 		UDATA *cachePtr = walkState->cache;
-		j9object_t pd;
+		j9object_t pd = NULL;
 		for (i = framesWalked; i > 0; i--) {
 			pd = J9VMJAVALANGCLASS_PROTECTIONDOMAIN(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(J9_CLASS_FROM_CP(*cachePtr)));
 			cachePtr += 1;


### PR DESCRIPTION
When compiling openj9 code with debug options an warning treated
as a failure is triggered:
```
In file included from ../oti/vmhook.h:26:0,
                 from ../oti/vmhook_internal.h:10,
                 from ../oti/j9.h:48,
                 from ../oti/jcl.h:26,
                 from common/java_lang_Class.cpp:24:
../oti/j9accessbarrier.h: In function ‘J9Object* storePDobjectsHelper(J9VMThread*, J9Class*, J9StackWalkState*, j9object_t, U_32, UDATA, I_32, BOOLEAN)’:
../oti/j9accessbarrier.h:176:76: error: ‘pd’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  J9VMTHREAD_JAVAVM((vmThread))->memoryManagerFunctions->J9WriteBarrierStore((vmThread), (j9object_t)(object), (j9object_t)(value)) : \
                                                                            ^
common/java_lang_Class.cpp:1760:14: note: ‘pd’ was declared here
   j9object_t pd;
```
The `pd` object will be assigned a value in the `for` loop that follows
but the gcc compiler is not able to determine that, so in order
to keep the compiler happy it's better to initialize this local
variable with NULL

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>