### PR TITLE
Add NOP Calls (Bits.keepAlive & Reference.reachabilityFence) to pure function list

### DIFF
--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -144,8 +144,8 @@ J9::MethodSymbol::functionCallDoesNotYieldOSR()
       case TR::java_lang_ref_Reference_reachabilityFence:
       case TR::java_nio_Bits_keepAlive:
          return true;
-      default: 
-         return false;
+      default:
+         return OMR::MethodSymbolConnector::functionCallDoesNotYieldOSR(); 
       }
    return false;
    }

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,6 +80,7 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_lang_Math_sqrt:
       case TR::java_lang_Math_tan:
       case TR::java_lang_Math_tanh:
+      case TR::java_lang_ref_Reference_reachabilityFence:
       case TR::java_lang_StrictMath_acos:
       case TR::java_lang_StrictMath_asin:
       case TR::java_lang_StrictMath_atan:
@@ -112,6 +113,7 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_lang_StrictMath_sqrt:
       case TR::java_lang_StrictMath_tan:
       case TR::java_lang_StrictMath_tanh:
+      case TR::java_nio_Bits_keepAlive:
          /*
       case TR::java_math_BigDecimal_valueOf:
       case TR::java_math_BigDecimal_add:
@@ -121,13 +123,32 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_math_BigInteger_subtract:
       case TR::java_math_BigInteger_multiply:
          */
-      return true;
+         return true;
       default:
          return false;
       }
    return false;
    }
 
+/**
+ * Returns true if the function call will not yield to OSR point.
+ * 
+ * An example of kind of function which can go in the list would be recognized calls with
+ * NOP calls or the one that are guaranteed to be inlined by codegenerator. 
+ */
+bool 
+J9::MethodSymbol::functionCallDoesNotYieldOSR()
+   {
+   switch(self()->getRecognizedMethod())
+      {
+      case TR::java_lang_ref_Reference_reachabilityFence:
+      case TR::java_nio_Bits_keepAlive:
+         return true;
+      default: 
+         return false;
+      }
+   return false;
+   }
 
 // Which recognized methods are known to have no valid null checks
 //

--- a/runtime/compiler/il/J9MethodSymbol.hpp
+++ b/runtime/compiler/il/J9MethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,7 +57,7 @@ protected:
       OMR::MethodSymbolConnector(lc, m) { }
 
 public:
-
+   bool functionCallDoesNotYieldOSR();
    bool isPureFunction();
 
    TR_RuntimeHelper getVMCallHelper() { return TR_j2iTransition; } // deprecated


### PR DESCRIPTION
Calls to java/lang/ref/Reference.reachabilityFence and java/nio/Bits.keepAlive are NOP functions inserted into NIO libraries. As these are NOP functions, these calls can not cause GC or throw exception or catch OSR. Adding this function calls to list of Pure Functions as well as list of functions that does not yield OSR point.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>