### PR TITLE
Set JITServer Compilations Options on the client instead

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7922,7 +7922,18 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   that->getCompThreadId());
             // JITServer TODO determine if we care to support annotations
             if (that->_methodBeingCompiled->isRemoteCompReq())
+               {
                options->setOption(TR_EnableAnnotations,false);
+
+               // This option is used to generate SIMD instructions on Z. Currently the infrastructure
+               // to support the relocation of some of those instructions is not available. Thus we disable
+               // this option for remote compilations.
+               options->setOption(TR_DisableSIMDArrayTranslate);
+
+               // Infrastructure to support the TOC is currently not available for Remote Compilations. We disable the feature
+               // here so that the codegen doesn't generate TOC enabled code as it won't be valid on the client JVM.
+               options->setOption(TR_DisableTOC);
+               }
             // Determine if known annotations exist and if so, keep annotations enabled
             if (!that->_methodBeingCompiled->isAotLoad() && !vm->isAOT_DEPRECATED_DO_NOT_USE() && options->getOption(TR_EnableAnnotations))
                {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2064,15 +2064,6 @@ J9::Options::setupJITServerOptions()
          // IProfiler thread is not needed at JITServer because
          // no IProfiler info is collected at the server itself
          self()->setOption(TR_DisableIProfilerThread);
-
-         // This option is used to generate SIMD instructions on Z. Currently the infrastructure
-         // to support the relocation of some of those instructions is not available. Thus we disable
-         // this option for remote compilations.
-         self()->setOption(TR_DisableSIMDArrayTranslate);
-
-         // Infrastructure to support the TOC is currently not available for Remote Compilations. We disable the feature
-         // here so that the codegen doesn't generate TOC enabled code as it won't be valid on the client JVM.
-         self()->setOption(TR_DisableTOC);
          }
 
       // In the JITServer world, expensive compilations are performed remotely so there is no risk of blowing the footprint limit on the JVM


### PR DESCRIPTION
Previously, these options were being set as global options on the server side during startup. This is incorrect, as options set on the server are overwritten by the client options when the server receives a compilation request from a client.

This commit now sets the options on the client, right before a remote
compilation request is sent to the server.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>