### PR TITLE
Revert "Don't exclude special.system testing on the 0.18 branch"

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -157,11 +157,19 @@ ppc64le_linux:
       12: 'CC=gcc-7 CXX=g++-7'
       13: 'CC=gcc-7 CXX=g++-7'
       next: 'CC=gcc-7 CXX=g++-7'
+  excluded_tests:
+    13:
+      - special.system
 #========================================#
 # Linux PPCLE 64bits Large Heap
 #========================================#
 ppc64le_linux_xl:
   extends: ['ppc64le_linux', 'largeheap']
+  excluded_tests:
+    8:
+      - special.system
+    11:
+      - special.system
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers /w JITSERVER
 #========================================#
@@ -206,6 +214,9 @@ ppc64le_linux_jit:
       12: 'CC=gcc-7 CXX=g++-7'
       13: 'CC=gcc-7 CXX=g++-7'
       next: 'CC=gcc-7 CXX=g++-7'
+  excluded_tests:
+    13:
+      ? special.system
   test_flags:
     8: 'JITAAS'
     11: 'JITAAS'
@@ -258,6 +269,11 @@ s390x_linux:
     12: '--with-openssl=fetched'
     13: '--with-openssl=fetched'
     next: '--with-openssl=fetched'
+  excluded_tests:
+    11:
+      - special.system
+    13:
+      - special.system
 #========================================#
 # Linux S390 64bits Large Heap
 # Note: boot_jdk 8 must use an Adopt JDK8 build rather than an
@@ -265,6 +281,9 @@ s390x_linux:
 #========================================#
 s390x_linux_xl:
   extends: ['s390x_linux', 'largeheap']
+  excluded_tests:
+    8:
+      - special.system
 #========================================#
 # Linux S390 64bits Compressed Pointers /w JITSERVER
 # Note: boot_jdk 8 must use an Adopt JDK8 build rather than an
@@ -366,6 +385,13 @@ ppc64_aix:
       12: 'PATH+XLC=/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin'
       13: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
       next: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
+  excluded_tests:
+    11:
+      - special.system
+    12:
+      - special.system
+    13:
+      - special.system
 #========================================#
 # Linux x86 64bits Compressed Pointers
 #========================================#
@@ -410,6 +436,13 @@ x86-64_linux:
       12: 'source /opt/rh/devtoolset-7/enable'
       13: 'source /opt/rh/devtoolset-7/enable'
       next: 'source /opt/rh/devtoolset-7/enable'
+  excluded_tests:
+    11:
+      - special.system
+    12:
+      - special.system
+    13:
+      - special.system
 #========================================#
 # Linux x86 64bits Compressed Pointers /w CMake
 #========================================#
@@ -477,6 +510,9 @@ x86-64_linux_jit:
 #========================================#
 x86-64_linux_xl:
   extends: ['x86-64_linux', 'largeheap']
+  excluded_tests:
+    8:
+      - special.system
 #========================================#
 # Linux Aarch 64bits Compressed Pointers
 #========================================#
@@ -533,6 +569,15 @@ x86-64_windows:
       12: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
       13: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
       next: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
+  excluded_tests:
+    8:
+      - special.system
+    11:
+      - special.system
+    12:
+      - special.system
+    13:
+      - special.system
 #========================================#
 # Windows x86 64bits Large Heap
 #========================================#
@@ -556,6 +601,15 @@ x86-32_windows:
   build_env:
     vars:
       8: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM32/bin:/cygdrive/c/openjdk/nasm-2.13.03'
+  excluded_tests:
+    8:
+      - special.system
+    11:
+      - special.system
+    12:
+      - special.system
+    13:
+      - special.system
 #========================================#
 # OSX x86 64bits Compressed Pointers
 #========================================#
@@ -596,8 +650,18 @@ x86-64_mac:
   build_env:
     vars:
       8: 'MACOSX_DEPLOYMENT_TARGET=10.9.0 SDKPATH=/Users/jenkins/Xcode4/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk'
+  excluded_tests:
+    11:
+      - special.system
+    12:
+      - special.system
+    13:
+      - special.system
 #========================================#
 # OSX x86 64bits Large Heap
 #========================================#
 x86-64_mac_xl:
   extends: ['x86-64_mac', 'largeheap']
+  excluded_tests:
+    8:
+      - special.system


### PR DESCRIPTION
Reverts eclipse/openj9#8118

I think this caused a problem launching builds #8123. I'm going to revert it and see.