### PR TITLE
Jenkins: Fix handling of default test targets

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -668,8 +668,7 @@ def set_test_targets() {
 
 def get_default_test_targets() {
     if (VARIABLES.tests_targets && VARIABLES.tests_targets.default) {
-        // VARIABLES.tests_targets.default is a map where all values are null
-        return VARIABLES.tests_targets.default.keySet().join(',')
+        return VARIABLES.tests_targets.default.join(',')
     }
 
     return ''


### PR DESCRIPTION
Test targets are no longer stored as a map, so there is no need to call
keySet() on it.

Fixes #8123

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>