### PR TITLE
Use buildspec manager for JDK Image Dir

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -543,8 +543,7 @@ def set_node(job_type) {
 
     if (!NODE) {
         // fetch from variables file
-        def spec = buildspec_manager.getSpec(SPEC)
-        NODE = spec.getScalarField("node_labels.${job_type}", SDK_VERSION)
+        NODE = buildspec_manager.getSpec(SPEC).getScalarField("node_labels.${job_type}", SDK_VERSION)
         if (!NODE) {
             error("Missing ${job_type} NODE!")
         }
@@ -556,15 +555,14 @@ def set_node(job_type) {
 * Set the RELEASE variable with the value provided in the variables file.
 */
 def set_release() {
-    def spec = buildspec_manager.getSpec(SPEC)
-    RELEASE = spec.getScalarField("release", SDK_VERSION)
+    RELEASE = buildspec_manager.getSpec(SPEC).getScalarField("release", SDK_VERSION)
 }
 
 /*
 * Set the JDK_FOLDER variable with the value provided in the variables file.
 */
 def set_jdk_folder() {
-    JDK_FOLDER = get_value(VARIABLES.jdk_image_dir, SDK_VERSION)
+    JDK_FOLDER = buildspec_manager.getSpec('misc').getScalarField("jdk_image_dir", SDK_VERSION)
 }
 
 /*

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -60,12 +60,10 @@ artifactory_manual_cleanup: true
 #========================================#
 # Miscellaneous settings
 #========================================#
-jdk_image_dir:
-  8: 'j2sdk-image'
-  11: 'jdk'
-  13: 'jdk'
-  14: 'jdk'
-  next: 'jdk'
+misc:
+  jdk_image_dir:
+    all: 'jdk'
+    8: 'j2sdk-image'
 credentials:
   github: 'b6987280-6402-458f-bdd6-7affc2e360d4'
 test_dependencies_job_name: 'test.getDependency'


### PR DESCRIPTION
- This allows us to take advantage of buildspec
  inheritance.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>