### PR TITLE
Add Linux ARM spec to DDR supersets cache file

### DIFF
--- a/debugtools/DDR_VM/generate.properties
+++ b/debugtools/DDR_VM/generate.properties
@@ -43,6 +43,7 @@ linux_x86-64_combo,linux_x86-64_cmprssptrs_combo,linux_x86-64_cmprssptrs_panama
 
 ddr.order=aix_ppc-64,aix_ppc-64_cmprssptrs,aix_ppc,\
 linux_390-64,linux_390-64_cmprssptrs,linux_390,\
+linux_arm,\
 linux_ppc-64,linux_ppc-64_cmprssptrs,linux_ppc,\
 linux_ppc-64_le,linux_ppc-64_cmprssptrs_le,\
 linux_ppc-64_le_gcc,linux_ppc-64_cmprssptrs_le_gcc,\


### PR DESCRIPTION
Add missing Linux ARM spec to cache file. It is required to
generate pointer classes when compiling DDR.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>