### PR TITLE
Dynamically load libssl in JITServer

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -367,7 +367,7 @@ target_link_libraries(j9jit
 )
 
 if(JITSERVER_SUPPORT)
-	target_link_libraries(j9jit PRIVATE ${PROTOBUF_LIBRARY} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+	target_link_libraries(j9jit PRIVATE ${PROTOBUF_LIBRARY})
 endif()
 
 # This is a bit hokey, but cmake can't track the fact that files are generated across directories.

--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -393,6 +393,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/VMJ9Server.cpp \
     compiler/net/ClientStream.cpp \
     compiler/net/CommunicationStream.cpp \
+    compiler/net/LoadSSLLibs.cpp \
     compiler/net/ProtobufTypeConvert.cpp \
     compiler/net/ServerStream.cpp \
     compiler/runtime/CompileService.cpp \

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -528,8 +528,6 @@ ifneq ($(JITSERVER_SUPPORT),)
     SOLINK_SLINK_STATIC=-l:libprotobuf.a
     CXX_DEFINES+=GOOGLE_PROTOBUF_NO_RTTI
 
-    SOLINK_SLINK+=ssl
-
     ifneq ($(OPENSSL_CFLAGS),)
         C_FLAGS+=$(OPENSSL_CFLAGS)
         CXX_FLAGS+=$(OPENSSL_CFLAGS)
@@ -537,11 +535,12 @@ ifneq ($(JITSERVER_SUPPORT),)
 
     # --with-openssl=fetched --enable-openssl-bundling
     ifneq ($(OPENSSL_BUNDLE_LIB_PATH),)
-        SOLINK_SLINK+=crypto
-        SOLINK_LIBPATH+=$(OPENSSL_BUNDLE_LIB_PATH)
         SOLINK_FLAGS+=-Wl,-rpath,\$$ORIGIN/..
+        C_INCLUDES+=$(OPENSSL_BUNDLE_LIB_PATH)
+        CXX_INCLUDES+=$(OPENSSL_BUNDLE_LIB_PATH)
     # --with-openssl=fetched only
     else ifneq ($(OPENSSL_DIR),)
-        SOLINK_LIBPATH+=$(OPENSSL_DIR)
+        C_INCLUDES+=$(OPENSSL_DIR)
+        CXX_INCLUDES+=$(OPENSSL_DIR)
     endif
 endif # JITSERVER_SUPPORT

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -110,6 +110,7 @@
 #include "env/JITServerPersistentCHTable.hpp"
 #include "net/CommunicationStream.hpp"
 #include "net/ClientStream.hpp"
+#include "net/LoadSSLLibs.hpp"
 #include "runtime/JITClientSession.hpp"
 #include "runtime/Listener.hpp"
 #include "runtime/JITServerStatisticsThread.hpp"
@@ -1634,6 +1635,12 @@ onLoadInternal(
    persistentMemory->getPersistentInfo()->setPersistentCHTable(chtable);
 
 #if defined(JITSERVER_SUPPORT)
+   if (JITServer::CommunicationStream::useSSL())
+      {
+      if (!JITServer::loadLibsslAndFindSymbols())
+         return -1;
+      }
+
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
       {
       JITServer::CommunicationStream::initVersion();

--- a/runtime/compiler/net/CMakeLists.txt
+++ b/runtime/compiler/net/CMakeLists.txt
@@ -23,6 +23,7 @@
 j9jit_files(
 	net/ClientStream.cpp
 	net/CommunicationStream.cpp
+	net/LoadSSLLibs.cpp
 	net/ProtobufTypeConvert.cpp
 	net/ServerStream.cpp
 )

--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -21,8 +21,10 @@
  *******************************************************************************/
 
 #include "ClientStream.hpp"
+#include "control/CompilationRuntime.hpp"
 #include "control/Options.hpp"
 #include "env/VerboseLog.hpp"
+#include "net/LoadSSLLibs.hpp"
 #include "net/SSLProtobufStream.hpp"
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -36,7 +38,6 @@
 #include <stdlib.h>
 #include <unistd.h> /// gethostname, read, write
 #include <openssl/err.h>
-#include "control/CompilationRuntime.hpp"
 
 namespace JITServer
 {
@@ -58,18 +59,18 @@ int ClientStream::static_init(TR::PersistentInfo *info)
 
    CommunicationStream::initSSL();
 
-   SSL_CTX *ctx = SSL_CTX_new(SSLv23_client_method());
+   SSL_CTX *ctx = (*OSSL_CTX_new)((*OSSLv23_client_method)());
    if (!ctx)
       {
       perror("can't create SSL context");
-      ERR_print_errors_fp(stderr);
+      (*OERR_print_errors_fp)(stderr);
       return -1;
       }
 
-   if (SSL_CTX_set_ecdh_auto(ctx, 1) != 1)
+   if ((*OSSL_CTX_set_ecdh_auto)(ctx, 1) != 1)
       {
       perror("failed to configure SSL ecdh");
-      ERR_print_errors_fp(stderr);
+      (*OERR_print_errors_fp)(stderr);
       return -1;
       }
 
@@ -83,45 +84,46 @@ int ClientStream::static_init(TR::PersistentInfo *info)
    TR_ASSERT_FATAL(sslKeys.size() == 0 && sslCerts.size() == 0, "client keypairs are not yet supported, use a root cert chain instead");
 
    // Parse and set certificate chain
-   BIO *certMem = BIO_new_mem_buf(&sslRootCerts[0], sslRootCerts.size());
+   BIO *certMem = (*OBIO_new_mem_buf)(&sslRootCerts[0], sslRootCerts.size());
    if (!certMem)
       {
       perror("cannot create memory buffer for cert (OOM?)");
-      ERR_print_errors_fp(stderr);
+      (*OERR_print_errors_fp)(stderr);
       return -1;
       }
-   STACK_OF(X509_INFO) *certificates = PEM_X509_INFO_read_bio(certMem, NULL, NULL, NULL);
+   STACK_OF(X509_INFO) *certificates = (*OPEM_X509_INFO_read_bio)(certMem, NULL, NULL, NULL);
    if (!certificates)
       {
       perror("cannot parse cert");
-      ERR_print_errors_fp(stderr);
+      (*OERR_print_errors_fp)(stderr);
       return -1;
       }
-   X509_STORE *certStore = SSL_CTX_get_cert_store(ctx);
+   X509_STORE *certStore = (*OSSL_CTX_get_cert_store)(ctx);
    if (!certStore)
       {
       perror("cannot get cert store");
-      ERR_print_errors_fp(stderr);
+      (*OERR_print_errors_fp)(stderr);
       return -1;
       }
+
    // add all certificates in the chain to the cert store
-   for (size_t i = 0; i < sk_X509_INFO_num(certificates); i++)
+   for (size_t i = 0; i < (*Osk_X509_INFO_num)(certificates); i++)
       {
-      X509_INFO *certInfo = sk_X509_INFO_value(certificates, i);
+      X509_INFO *certInfo = (*Osk_X509_INFO_value)(certificates, i);
       if (certInfo->x509)
-         X509_STORE_add_cert(certStore, certInfo->x509);
+         (*OX509_STORE_add_cert)(certStore, certInfo->x509);
       if (certInfo->crl)
-         X509_STORE_add_crl(certStore, certInfo->crl);
+         (*OX509_STORE_add_crl)(certStore, certInfo->crl);
       }
-   sk_X509_INFO_pop_free(certificates, X509_INFO_free);
+   (*Osk_X509_INFO_pop_free)(certificates, (*OX509_INFO_free));
 
    // verify server identity using standard method
-   SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+   (*OSSL_CTX_set_verify)(ctx, SSL_VERIFY_PEER, NULL);
 
    _sslCtx = ctx;
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context: OPENSSL_VERSION_NUMBER 0x%lx\n", OPENSSL_VERSION_NUMBER);
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Successfully initialized SSL context (%s) \n", (*OOpenSSL_version)(0));
    return 0;
    }
 
@@ -191,62 +193,63 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    if (!ctx)
       return NULL;
 
-   SSL *ssl = SSL_new(ctx);
+   SSL *ssl = (*OSSL_new)(ctx);
    if (!ssl)
       {
-      ERR_print_errors_fp(stderr);
+      (*OERR_print_errors_fp)(stderr);
       throw JITServer::StreamFailure("Failed to create new SSL connection");
       }
 
-   SSL_set_connect_state(ssl);
+   (*OSSL_set_connect_state)(ssl);
 
-   if (SSL_set_fd(ssl, connfd) != 1)
+   if ((*OSSL_set_fd)(ssl, connfd) != 1)
       {
-      ERR_print_errors_fp(stderr);
-      SSL_free(ssl);
+      (*OERR_print_errors_fp)(stderr);
+      (*OSSL_free)(ssl);
       throw JITServer::StreamFailure("Cannot set file descriptor for SSL");
       }
-   if (SSL_connect(ssl) != 1)
+   if ((*OSSL_connect)(ssl) != 1)
       {
-      ERR_print_errors_fp(stderr);
-      SSL_free(ssl);
+      (*OERR_print_errors_fp)(stderr);
+      (*OSSL_free)(ssl);
       throw JITServer::StreamFailure("Failed to SSL_connect");
       }
 
-   X509* cert = SSL_get_peer_certificate(ssl);
+   X509* cert = (*OSSL_get_peer_certificate)(ssl);
    if (!cert)
       {
-      ERR_print_errors_fp(stderr);
-      SSL_free(ssl);
+      (*OERR_print_errors_fp)(stderr);
+      (*OSSL_free)(ssl);
       throw JITServer::StreamFailure("Server certificate unspecified");
       }
-   X509_free(cert);
+   (*OX509_free)(cert);
 
-   if (X509_V_OK != SSL_get_verify_result(ssl))
+   if (X509_V_OK != (*OSSL_get_verify_result)(ssl))
       {
-      ERR_print_errors_fp(stderr);
-      SSL_free(ssl);
+      (*OERR_print_errors_fp)(stderr);
+      (*OSSL_free)(ssl);
       throw JITServer::StreamFailure("Server certificate verification failed");
       }
 
-   BIO *bio = BIO_new_ssl(ctx, true);
+   BIO *bio = (*OBIO_new_ssl)(ctx, true);
    if (!bio)
       {
-      ERR_print_errors_fp(stderr);
-      SSL_free(ssl);
+      (*OERR_print_errors_fp)(stderr);
+      (*OSSL_free)(ssl);
       throw JITServer::StreamFailure("Failed to make new BIO");
       }
-   if (BIO_set_ssl(bio, ssl, true) != 1)
+
+   if ((*OBIO_ctrl)(bio, BIO_C_SET_SSL, true, (char *)ssl) != 1) // BIO_set_ssl(bio, ssl, true)
       {
-      ERR_print_errors_fp(stderr);
-      BIO_free_all(bio);
-      SSL_free(ssl);
+      (*OERR_print_errors_fp)(stderr);
+      (*OBIO_free_all)(bio);
+      (*OSSL_free)(ssl);
       throw JITServer::StreamFailure("Failed to set BIO SSL");
       }
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "SSL connection on socket 0x%x, Version: %s, Cipher: %s\n",
-                                                      connfd, SSL_get_version(ssl), SSL_get_cipher(ssl));
+                                                      connfd, (*OSSL_get_version)(ssl), (*OSSL_get_cipher)(ssl));
    return bio;
    }
 

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -48,4 +48,13 @@ bool CommunicationStream::useSSL()
            compInfo->getJITServerSslCerts().size() ||
            compInfo->getJITServerSslRootCerts().size());
    }
+
+void CommunicationStream::initSSL()
+   {
+   (*OSSL_load_error_strings)();
+   (*OSSL_library_init)();
+   // OpenSSL_add_ssl_algorithms() is a synonym for SSL_library_init() and is implemented as a macro
+   // It's redundant, should be able to remove it later
+   // OpenSSL_add_ssl_algorithms();
+   }
 };

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -43,15 +43,9 @@ class CommunicationStream
    {
 public:
    static bool useSSL();
-   static void initSSL()
-      {
-      SSL_load_error_strings();
-      SSL_library_init();
-      OpenSSL_add_ssl_algorithms();
-      }
+   static void initSSL();
 
    static void initVersion();
-
 
    static uint64_t getJITServerVersion()
       {
@@ -107,7 +101,7 @@ protected:
          TR_Memory::jitPersistentFree(_sslInputStream);
          _sslOutputStream->~SSLOutputStream();
          TR_Memory::jitPersistentFree(_sslOutputStream);
-         BIO_free_all(_ssl);
+         (*OBIO_free_all)(_ssl);
          }
       if (_connfd != -1)
          {

--- a/runtime/compiler/net/LoadSSLLibs.cpp
+++ b/runtime/compiler/net/LoadSSLLibs.cpp
@@ -1,0 +1,527 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "LoadSSLLibs.hpp"
+
+#include <dlfcn.h>
+#include <string.h>
+
+#include "control/Options.hpp"
+
+#define OPENSSL_VERSION_1_0 "OpenSSL 1.0."
+#define OPENSSL_VERSION_1_1 "OpenSSL 1.1."
+
+OOpenSSL_version_t * OOpenSSL_version = NULL;
+
+OSSL_load_error_strings_t * OSSL_load_error_strings = NULL;
+OSSL_library_init_t * OSSL_library_init = NULL;
+OOPENSSL_init_ssl_t * OOPENSSL_init_ssl = NULL;
+
+OSSLv23_server_method_t * OSSLv23_server_method = NULL;
+OSSLv23_client_method_t * OSSLv23_client_method = NULL;
+
+OSSL_CTX_set_ecdh_auto_t * OSSL_CTX_set_ecdh_auto = NULL;
+OSSL_CTX_ctrl_t * OSSL_CTX_ctrl = NULL;
+
+OBIO_ctrl_t * OBIO_ctrl = NULL;
+
+OSSL_CIPHER_get_name_t * OSSL_CIPHER_get_name = NULL;
+OSSL_get_current_cipher_t * OSSL_get_current_cipher = NULL;
+OSSL_get_cipher_t * OSSL_get_cipher = NULL;
+
+OEVP_cleanup_t * OEVP_cleanup = NULL;
+
+Osk_num_t * Osk_num = NULL;
+Osk_value_t * Osk_value = NULL;
+Osk_pop_free_t * Osk_pop_free = NULL;
+
+Osk_X509_INFO_num_t * Osk_X509_INFO_num = NULL;
+Osk_X509_INFO_value_t * Osk_X509_INFO_value = NULL;
+Osk_X509_INFO_pop_free_t * Osk_X509_INFO_pop_free = NULL;
+
+OSSL_new_t * OSSL_new = NULL;
+OSSL_free_t * OSSL_free = NULL;
+OSSL_set_connect_state_t * OSSL_set_connect_state = NULL;
+OSSL_set_accept_state_t * OSSL_set_accept_state = NULL;
+OSSL_set_fd_t * OSSL_set_fd = NULL;
+OSSL_get_version_t * OSSL_get_version = NULL;
+OSSL_accept_t * OSSL_accept = NULL;
+OSSL_connect_t * OSSL_connect = NULL;
+OSSL_get_peer_certificate_t * OSSL_get_peer_certificate = NULL;
+OSSL_get_verify_result_t * OSSL_get_verify_result = NULL;
+
+OSSL_CTX_new_t * OSSL_CTX_new = NULL;
+OSSL_CTX_set_session_id_context_t * OSSL_CTX_set_session_id_context = NULL;
+OSSL_CTX_use_PrivateKey_t * OSSL_CTX_use_PrivateKey = NULL;
+OSSL_CTX_use_certificate_t * OSSL_CTX_use_certificate = NULL;
+OSSL_CTX_check_private_key_t * OSSL_CTX_check_private_key = NULL;
+OSSL_CTX_set_verify_t * OSSL_CTX_set_verify = NULL;
+OSSL_CTX_free_t * OSSL_CTX_free = NULL;
+OSSL_CTX_get_cert_store_t * OSSL_CTX_get_cert_store = NULL;
+
+OBIO_new_mem_buf_t * OBIO_new_mem_buf = NULL;
+OBIO_free_all_t * OBIO_free_all = NULL;
+OBIO_new_ssl_t * OBIO_new_ssl = NULL;
+OBIO_write_t * OBIO_write = NULL;
+OBIO_read_t * OBIO_read = NULL;
+
+OPEM_read_bio_PrivateKey_t * OPEM_read_bio_PrivateKey = NULL;
+OPEM_read_bio_X509_t * OPEM_read_bio_X509 = NULL;
+OPEM_X509_INFO_read_bio_t * OPEM_X509_INFO_read_bio = NULL;
+
+OX509_INFO_free_t * OX509_INFO_free = NULL;
+OX509_STORE_add_cert_t * OX509_STORE_add_cert = NULL;
+OX509_STORE_add_crl_t * OX509_STORE_add_crl = NULL;
+OX509_free_t * OX509_free = NULL;
+
+OERR_print_errors_fp_t * OERR_print_errors_fp = NULL;
+
+int OSSL102_OOPENSSL_init_ssl(uint64_t opts, const void * settings)
+   {
+   // Does not exist in 1.0.2. Should not be called directly outside this file
+   return 0;
+   }
+
+void OSSL110_load_error_strings(void)
+   {
+   // Do nothing here:
+   // SSL_load_error_strings() is deprecated in OpenSSL 1.1.0 by OPENSSL_init_ssl().
+   // CommunicationStream::initSSL() will call SSL_library_init. In 1.1.0 SSL_library_init
+   // is a macro of OPENSSL_init_ssl.
+   }
+
+int OSSL110_library_init(void)
+   {
+   return (*OOPENSSL_init_ssl)(0, NULL);
+   }
+
+#define OPENSSL102_SSL_CTRL_SET_ECDH_AUTO 94
+long OSSL102_CTX_set_ecdh_auto(SSL_CTX *ctx, int onoff)
+   {
+   return (*OSSL_CTX_ctrl)(ctx, OPENSSL102_SSL_CTRL_SET_ECDH_AUTO, onoff, NULL);
+   }
+
+long OSSL110_CTX_set_ecdh_auto(SSL_CTX *ctx, int onoff)
+   {
+   return ((onoff) != 0);
+   }
+
+const char * handle_SSL_get_cipher(const SSL *ssl)
+   {
+   return (*OSSL_CIPHER_get_name)((*OSSL_get_current_cipher)(ssl));
+   }
+
+void OEVP110_cleanup(void)
+   {
+   // In versions prior to 1.1.0 EVP_cleanup() removed all ciphers
+   // and digests from the table. It no longer has any effect in OpenSSL 1.1.0
+   }
+
+# define OPENSSL102_CHECKED_STACK_OF(type, p) \
+    ((_STACK*) (1 ? p : (STACK_OF(type)*)0))
+
+# define OPENSSL102_CHECKED_SK_FREE_FUNC(type, p) \
+    ((void (*)(void *)) ((1 ? p : (void (*)(type *))0)))
+
+typedef void (*OPENSSL110_sk_freefunc)(void *);
+
+int Osk102_X509_INFO_num(const STACK_OF(X509_INFO) *st)
+   {
+   //# define sk_X509_INFO_num(st) SKM_sk_num(X509_INFO, (st))
+   //# define SKM_sk_num(type, st) \
+   //  sk_num(CHECKED_STACK_OF(type, st))
+   return (*Osk_num)(OPENSSL102_CHECKED_STACK_OF(X509_INFO, st));
+   }
+
+int Osk110_X509_INFO_num(const STACK_OF(X509_INFO) *st)
+   {
+   // static ossl_inline int sk_##t1##_num(const STACK_OF(t1) *sk) \
+   // { \
+   //     return OPENSSL_sk_num((const OPENSSL_STACK *)sk); \
+   // }
+   return (*Osk_num)((const _STACK *)st);
+   }
+
+X509_INFO * Osk102_X509_INFO_value(const STACK_OF(X509_INFO) *st, int i)
+   {
+   //# define sk_X509_INFO_value(st, i) SKM_sk_value(X509_INFO, (st), (i))
+   //# define SKM_sk_value(type, st,i) \
+   //     ((type *)sk_value(CHECKED_STACK_OF(type, st), i))
+   return (X509_INFO *)(*Osk_value)(OPENSSL102_CHECKED_STACK_OF(X509_INFO, st), i);
+   }
+
+X509_INFO * Osk110_X509_INFO_value(const STACK_OF(X509_INFO) *st, int i)
+   {
+   // static ossl_inline t2 *sk_##t1##_value(const STACK_OF(t1) *sk, int idx) \
+   // { \
+   //     return (t2 *)OPENSSL_sk_value((const OPENSSL_STACK *)sk, idx); \
+   // }
+   return (X509_INFO *)(*Osk_value)((const _STACK *)st, i);
+   }
+
+void Osk102_X509_INFO_pop_free(STACK_OF(X509_INFO) *st, OX509_INFO_free_t *X509InfoFreeFunc)
+   {
+   //# define sk_X509_INFO_pop_free(st, free_func) SKM_sk_pop_free(X509_INFO, (st), (free_func))
+   //# define SKM_sk_pop_free(type, st, free_func) \
+   //     sk_pop_free(CHECKED_STACK_OF(type, st), CHECKED_SK_FREE_FUNC(type, free_func))
+   (*Osk_pop_free)(OPENSSL102_CHECKED_STACK_OF(X509_INFO, st), OPENSSL102_CHECKED_SK_FREE_FUNC(X509_INFO, X509InfoFreeFunc));
+   }
+
+void Osk110_X509_INFO_pop_free(STACK_OF(X509_INFO) *st, OX509_INFO_free_t *X509InfoFreeFunc)
+   {
+   // static ossl_inline void sk_##t1##_pop_free(STACK_OF(t1) *sk, sk_##t1##_freefunc freefunc) \
+   // { \
+   //     OPENSSL_sk_pop_free((OPENSSL_STACK *)sk, (OPENSSL_sk_freefunc)freefunc); \
+   // }
+   (*Osk_pop_free)((_STACK *)st, (OPENSSL110_sk_freefunc)X509InfoFreeFunc);
+   }
+
+namespace JITServer
+{
+void *loadLibssl()
+   {
+   void *result = NULL;
+
+   // Library names for OpenSSL 1.1.1, 1.1.0, 1.0.2 and symbolic links
+   static const char * const libNames[] =
+      {
+      "libssl.so.1.1",   // 1.1.x library name
+      "libssl.so.1.0.0", // 1.0.x library name
+      "libssl.so.10",    // 1.0.x library name on RHEL
+      "libssl.so"        // general symlink library name
+      };
+
+   int numOfLibraries = sizeof(libNames) / sizeof(libNames[0]);
+
+   for (int i = 0; i < numOfLibraries; ++i)
+      {
+      result = dlopen(libNames[i], RTLD_NOW);
+
+      if (result)
+         {
+         return result;
+         }
+      }
+   return result;
+   }
+
+void unloadLibssl(void *handle)
+   {
+   (void)dlclose(handle);
+   }
+
+void * findLibsslSymbol(void *handle, const char *symName)
+   {
+   return dlsym(handle, symName);
+   }
+
+int findLibsslVersion(void *handle)
+{
+   const char * openssl_version = NULL;
+   int ossl_ver = -1;
+
+   OOpenSSL_version = (OOpenSSL_version_t*)findLibsslSymbol(handle, "OpenSSL_version");
+
+   if (OOpenSSL_version)
+      {
+      openssl_version = (*OOpenSSL_version)(0);
+      if (0 == strncmp(openssl_version, OPENSSL_VERSION_1_1, strlen(OPENSSL_VERSION_1_1)))
+         {
+         ossl_ver = 1;
+         }
+      }
+   else
+      {
+      OOpenSSL_version = (OOpenSSL_version_t*)findLibsslSymbol(handle, "SSLeay_version");
+
+      if (OOpenSSL_version)
+         {
+         openssl_version = (*OOpenSSL_version)(0);
+         if (0 == strncmp(openssl_version, OPENSSL_VERSION_1_0, strlen(OPENSSL_VERSION_1_0)))
+            {
+            ossl_ver = 0;
+            }
+         }
+      }
+
+   return ossl_ver;
+}
+
+#if defined(DEBUG)
+void dbgPrintSymbols()
+   {
+   printf("=============================================================\n");
+
+   printf(" OpenSSL_version %p\n", OOpenSSL_version);
+
+   printf(" SSL_load_error_strings %p\n", OSSL_load_error_strings);
+   printf(" SSL_library_init %p\n", OSSL_library_init);
+   printf(" OPENSSL_init_ssl %p\n", OOPENSSL_init_ssl);
+
+   printf(" SSLv23_server_method %p\n", OSSLv23_server_method);
+   printf(" SSLv23_client_method %p\n", OSSLv23_client_method);
+
+   printf(" SSL_CTX_set_ecdh_auto %p\n", OSSL_CTX_set_ecdh_auto);
+   printf(" SSL_CTX_ctrl %p\n", OSSL_CTX_ctrl);
+
+   printf(" BIO_ctrl %p\n",  OBIO_ctrl);
+
+   printf(" SSL_CIPHER_get_name %p\n",  OSSL_CIPHER_get_name);
+   printf(" SSL_get_current_cipher %p\n",  OSSL_get_current_cipher);
+
+   printf(" EVP_cleanup %p\n",  OEVP_cleanup);
+
+   printf(" sk_num %p\n",  Osk_num);
+   printf(" sk_value %p\n",  Osk_value);
+   printf(" sk_pop_free %p\n",  Osk_pop_free);
+
+   printf(" X509_INFO_free %p\n",  OX509_INFO_free);
+   printf(" sk_X509_INFO_num %p\n",  Osk_X509_INFO_num);
+   printf(" sk_X509_INFO_value %p\n",  Osk_X509_INFO_value);
+   printf(" sk_X509_INFO_pop_free %p\n",  Osk_X509_INFO_pop_free);
+
+   printf(" SSL_new %p\n", OSSL_new);
+   printf(" SSL_free %p\n", OSSL_free);
+   printf(" SSL_set_connect_state %p\n", OSSL_set_connect_state);
+   printf(" SSL_set_accept_state %p\n", OSSL_set_accept_state);
+   printf(" SSL_set_fd %p\n", OSSL_set_fd);
+   printf(" SSL_get_version %p\n", OSSL_get_version);
+   printf(" SSL_accept %p\n", OSSL_accept);
+   printf(" SSL_connect %p\n", OSSL_connect);
+   printf(" SSL_get_peer_certificate %p\n", OSSL_get_peer_certificate);
+   printf(" SSL_get_verify_result %p\n", OSSL_get_verify_result);
+
+   printf(" SSL_CTX_new %p\n", OSSL_CTX_new);
+   printf(" SSL_CTX_set_session_id_context %p\n", OSSL_CTX_set_session_id_context);
+   printf(" SSL_CTX_use_PrivateKey %p\n", OSSL_CTX_use_PrivateKey);
+   printf(" SSL_CTX_use_certificate %p\n", OSSL_CTX_use_certificate);
+   printf(" SSL_CTX_check_private_key %p\n", OSSL_CTX_check_private_key);
+   printf(" SSL_CTX_set_verify %p\n", OSSL_CTX_set_verify);
+   printf(" SSL_CTX_free %p\n", OSSL_CTX_free);
+   printf(" SSL_CTX_get_cert_store %p\n", OSSL_CTX_get_cert_store);
+
+   printf(" BIO_new_mem_buf %p\n", OBIO_new_mem_buf);
+   printf(" BIO_free_all %p\n", OBIO_free_all);
+   printf(" BIO_new_ssl %p\n", OBIO_new_ssl);
+   printf(" BIO_write %p\n", OBIO_write);
+   printf(" BIO_read %p\n", OBIO_read);
+
+   printf(" PEM_read_bio_PrivateKey %p\n", OPEM_read_bio_PrivateKey);
+   printf(" PEM_read_bio_X509 %p\n", OPEM_read_bio_X509);
+   printf(" PEM_X509_INFO_read_bio %p\n", OPEM_X509_INFO_read_bio);
+
+   printf(" X509_STORE_add_cert %p\n", OX509_STORE_add_cert);
+   printf(" X509_STORE_add_crl %p\n", OX509_STORE_add_crl);
+   printf(" X509_free %p\n", OX509_free);
+
+   printf(" ERR_print_errors_fp %p\n", OERR_print_errors_fp);
+
+   printf("=============================================================\n\n");
+   }
+#endif /* defined(DEBUG) */
+
+bool loadLibsslAndFindSymbols()
+{
+   void *handle = NULL;
+
+   handle = loadLibssl();
+   if (!handle)
+      {
+      printf("#JITServer: Failed to load libssl\n");
+      return false;
+      }
+
+   int ossl_ver = findLibsslVersion(handle);
+   if (-1 == ossl_ver)
+      {
+      printf("#JITServer: Failed to find a correct version of libssl\n");
+      unloadLibssl(handle);
+      return false;
+      }
+
+
+   if (0 == ossl_ver)
+      {
+      OOPENSSL_init_ssl = &OSSL102_OOPENSSL_init_ssl;
+
+      OSSL_load_error_strings = (OSSL_load_error_strings_t *)findLibsslSymbol(handle, "SSL_load_error_strings");
+      OSSL_library_init = (OSSL_library_init_t *)findLibsslSymbol(handle, "SSL_library_init");
+
+      OSSLv23_server_method = (OSSLv23_server_method_t *)findLibsslSymbol(handle, "SSLv23_server_method");
+      OSSLv23_client_method = (OSSLv23_client_method_t *)findLibsslSymbol(handle, "SSLv23_client_method");
+
+      OSSL_CTX_set_ecdh_auto = &OSSL102_CTX_set_ecdh_auto;
+
+      OEVP_cleanup = (OEVP_cleanup_t *)findLibsslSymbol(handle, "EVP_cleanup");
+
+      Osk_num = (Osk_num_t *)findLibsslSymbol(handle, "sk_num");
+      Osk_value = (Osk_value_t *)findLibsslSymbol(handle, "sk_value");
+      Osk_pop_free = (Osk_pop_free_t *)findLibsslSymbol(handle, "sk_pop_free");
+
+      Osk_X509_INFO_num = &Osk102_X509_INFO_num;
+      Osk_X509_INFO_value = &Osk102_X509_INFO_value;
+      Osk_X509_INFO_pop_free = &Osk102_X509_INFO_pop_free;
+      }
+   else
+      {
+      OOPENSSL_init_ssl = (OOPENSSL_init_ssl_t *)findLibsslSymbol(handle, "OPENSSL_init_ssl");
+
+      OSSL_load_error_strings = &OSSL110_load_error_strings;
+      OSSL_library_init = &OSSL110_library_init;
+
+      OSSLv23_server_method = (OSSLv23_server_method_t *)findLibsslSymbol(handle, "TLS_server_method");
+      OSSLv23_client_method = (OSSLv23_client_method_t *)findLibsslSymbol(handle, "TLS_client_method");
+
+      OSSL_CTX_set_ecdh_auto = &OSSL110_CTX_set_ecdh_auto;
+
+      OEVP_cleanup = &OEVP110_cleanup;
+
+      Osk_num = (Osk_num_t *)findLibsslSymbol(handle, "OPENSSL_sk_num");
+      Osk_value = (Osk_value_t *)findLibsslSymbol(handle, "OPENSSL_sk_value");
+      Osk_pop_free = (Osk_pop_free_t *)findLibsslSymbol(handle, "OPENSSL_sk_pop_free");
+
+      Osk_X509_INFO_num = &Osk110_X509_INFO_num;
+      Osk_X509_INFO_value = &Osk110_X509_INFO_value;
+      Osk_X509_INFO_pop_free = &Osk110_X509_INFO_pop_free;
+      }
+
+   OSSL_CTX_ctrl = (OSSL_CTX_ctrl_t *)findLibsslSymbol(handle, "SSL_CTX_ctrl");
+   OBIO_ctrl = (OBIO_ctrl_t *)findLibsslSymbol(handle, "BIO_ctrl");
+
+   OSSL_CIPHER_get_name = (OSSL_CIPHER_get_name_t *)findLibsslSymbol(handle, "SSL_CIPHER_get_name");
+   OSSL_get_current_cipher = (OSSL_get_current_cipher_t *)findLibsslSymbol(handle, "SSL_get_current_cipher");
+   OSSL_get_cipher = &handle_SSL_get_cipher;
+
+
+   OSSL_new = (OSSL_new_t *)findLibsslSymbol(handle, "SSL_new");
+   OSSL_free = (OSSL_free_t *)findLibsslSymbol(handle, "SSL_free");
+   OSSL_set_connect_state = (OSSL_set_connect_state_t *)findLibsslSymbol(handle, "SSL_set_connect_state");
+   OSSL_set_accept_state = (OSSL_set_accept_state_t *)findLibsslSymbol(handle, "SSL_set_accept_state");
+   OSSL_set_fd = (OSSL_set_fd_t *)findLibsslSymbol(handle, "SSL_set_fd");
+   OSSL_get_version = (OSSL_get_version_t *)findLibsslSymbol(handle, "SSL_get_version");
+   OSSL_accept = (OSSL_accept_t *)findLibsslSymbol(handle, "SSL_accept");
+   OSSL_connect = (OSSL_connect_t *)findLibsslSymbol(handle, "SSL_connect");
+   OSSL_get_peer_certificate = (OSSL_get_peer_certificate_t *)findLibsslSymbol(handle, "SSL_get_peer_certificate");
+   OSSL_get_verify_result = (OSSL_get_verify_result_t *)findLibsslSymbol(handle, "SSL_get_verify_result");
+
+   OSSL_CTX_new = (OSSL_CTX_new_t *)findLibsslSymbol(handle, "SSL_CTX_new");
+   OSSL_CTX_set_session_id_context = (OSSL_CTX_set_session_id_context_t *)findLibsslSymbol(handle, "SSL_CTX_set_session_id_context");
+   OSSL_CTX_use_PrivateKey = (OSSL_CTX_use_PrivateKey_t *)findLibsslSymbol(handle, "SSL_CTX_use_PrivateKey");
+   OSSL_CTX_use_certificate = (OSSL_CTX_use_certificate_t *)findLibsslSymbol(handle, "SSL_CTX_use_certificate");
+   OSSL_CTX_check_private_key = (OSSL_CTX_check_private_key_t *)findLibsslSymbol(handle, "SSL_CTX_check_private_key");
+   OSSL_CTX_set_verify = (OSSL_CTX_set_verify_t *)findLibsslSymbol(handle, "SSL_CTX_set_verify");
+   OSSL_CTX_free = (OSSL_CTX_free_t *)findLibsslSymbol(handle, "SSL_CTX_free");
+   OSSL_CTX_get_cert_store = (OSSL_CTX_get_cert_store_t *)findLibsslSymbol(handle, "SSL_CTX_get_cert_store");
+
+   OBIO_new_mem_buf = (OBIO_new_mem_buf_t *)findLibsslSymbol(handle, "BIO_new_mem_buf");
+   OBIO_free_all = (OBIO_free_all_t *)findLibsslSymbol(handle, "BIO_free_all");
+   OBIO_new_ssl = (OBIO_new_ssl_t *)findLibsslSymbol(handle, "BIO_new_ssl");
+   OBIO_write = (OBIO_write_t *)findLibsslSymbol(handle, "BIO_write");
+   OBIO_read = (OBIO_read_t *)findLibsslSymbol(handle, "BIO_read");
+
+   OPEM_read_bio_PrivateKey = (OPEM_read_bio_PrivateKey_t *)findLibsslSymbol(handle, "PEM_read_bio_PrivateKey");
+   OPEM_read_bio_X509 = (OPEM_read_bio_X509_t *)findLibsslSymbol(handle, "PEM_read_bio_X509");
+   OPEM_X509_INFO_read_bio = (OPEM_X509_INFO_read_bio_t *)findLibsslSymbol(handle, "PEM_X509_INFO_read_bio");
+
+   OX509_INFO_free = (OX509_INFO_free_t *)findLibsslSymbol(handle, "X509_INFO_free");
+   OX509_STORE_add_cert = (OX509_STORE_add_cert_t *)findLibsslSymbol(handle, "X509_STORE_add_cert");
+   OX509_STORE_add_crl = (OX509_STORE_add_crl_t *)findLibsslSymbol(handle, "X509_STORE_add_crl");
+   OX509_free = (OX509_free_t *)findLibsslSymbol(handle, "X509_free");
+
+   OERR_print_errors_fp = (OERR_print_errors_fp_t *)findLibsslSymbol(handle, "ERR_print_errors_fp");
+
+   if (
+       (OOpenSSL_version == NULL) ||
+
+       (OSSL_load_error_strings == NULL) ||
+       (OSSL_library_init == NULL) ||
+       (OOPENSSL_init_ssl == NULL) ||
+
+       (OSSLv23_server_method == NULL) ||
+       (OSSLv23_client_method == NULL) ||
+
+       (OEVP_cleanup == NULL) ||
+
+       (OSSL_CTX_ctrl == NULL) ||
+       (OBIO_ctrl == NULL) ||
+
+       (Osk_num == NULL) ||
+       (Osk_value == NULL) ||
+       (Osk_pop_free == NULL) ||
+
+       (OSSL_CIPHER_get_name == NULL) ||
+       (OSSL_get_current_cipher == NULL) ||
+
+       (OSSL_new == NULL) ||
+       (OSSL_free == NULL) ||
+       (OSSL_set_connect_state == NULL) ||
+       (OSSL_set_accept_state == NULL) ||
+       (OSSL_set_fd == NULL) ||
+       (OSSL_get_version == NULL) ||
+       (OSSL_accept == NULL) ||
+       (OSSL_connect == NULL) ||
+       (OSSL_get_peer_certificate == NULL) ||
+       (OSSL_get_verify_result == NULL) ||
+
+       (OSSL_CTX_new == NULL) ||
+       (OSSL_CTX_set_session_id_context == NULL) ||
+       (OSSL_CTX_use_PrivateKey == NULL) ||
+       (OSSL_CTX_use_certificate == NULL) ||
+       (OSSL_CTX_check_private_key == NULL) ||
+       (OSSL_CTX_set_verify == NULL) ||
+       (OSSL_CTX_free == NULL) ||
+       (OSSL_CTX_get_cert_store == NULL) ||
+
+       (OBIO_new_mem_buf == NULL) ||
+       (OBIO_free_all == NULL) ||
+       (OBIO_new_ssl == NULL) ||
+       (OBIO_write == NULL) ||
+       (OBIO_read == NULL) ||
+
+       (OPEM_read_bio_PrivateKey == NULL) ||
+       (OPEM_read_bio_X509 == NULL) ||
+       (OPEM_X509_INFO_read_bio == NULL) ||
+
+       (OX509_INFO_free == NULL) ||
+       (OX509_STORE_add_cert == NULL) ||
+       (OX509_STORE_add_crl == NULL) ||
+       (OX509_free == NULL) ||
+
+       (OERR_print_errors_fp == NULL)
+      )
+      {
+      printf("#JITServer: Failed to load all the required OpenSSL symbols\n");
+#if defined(DEBUG)
+      dbgPrintSymbols();
+#endif /* defined(DEBUG) */
+      unloadLibssl(handle);
+      return false;
+      }
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Built against (%s); Loaded with (%s)\n",
+         OPENSSL_VERSION_TEXT, (*OOpenSSL_version)(0));
+
+   return true;
+}
+
+}; // JITServer

--- a/runtime/compiler/net/LoadSSLLibs.hpp
+++ b/runtime/compiler/net/LoadSSLLibs.hpp
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#ifndef LOAD_SSL_LIBS_H
+#define LOAD_SSL_LIBS_H
+
+#include <stdint.h>
+#include <openssl/ssl.h>
+
+typedef const char * OOpenSSL_version_t(int);
+
+typedef void OSSL_load_error_strings_t(void);
+typedef int OSSL_library_init_t(void);
+typedef int OOPENSSL_init_ssl_t(uint64_t opts, const void * settings);
+
+typedef const SSL_METHOD * OSSLv23_server_method_t(void);
+typedef const SSL_METHOD * OSSLv23_client_method_t(void);
+
+typedef long OSSL_CTX_set_ecdh_auto_t(SSL_CTX *ctx, int onoff);
+typedef long OSSL_CTX_ctrl_t(SSL_CTX *ctx, int cmd, long larg, void *parg);
+
+typedef long OBIO_ctrl_t(BIO *bp, int cmd, long larg, void *parg);
+
+typedef const char * OSSL_CIPHER_get_name_t(const SSL_CIPHER *c);
+typedef const SSL_CIPHER * OSSL_get_current_cipher_t(const SSL *s);
+typedef const char * OSSL_get_cipher_t(const SSL *s);
+
+typedef void OEVP_cleanup_t(void);
+
+typedef int Osk_num_t(const _STACK *);
+typedef void * Osk_value_t(const _STACK *, int);
+typedef void * Osk_pop_free_t(_STACK *st, void (*func) (void *));
+
+typedef void OX509_INFO_free_t(X509_INFO *a);
+typedef int Osk_X509_INFO_num_t(const STACK_OF(X509_INFO) *st);
+typedef X509_INFO * Osk_X509_INFO_value_t(const STACK_OF(X509_INFO) *st, int i);
+typedef void Osk_X509_INFO_pop_free_t(STACK_OF(X509_INFO) *st, OX509_INFO_free_t* X509InfoFreeFunc);
+
+typedef SSL * OSSL_new_t(SSL_CTX *ctx);
+typedef void OSSL_free_t(SSL *ssl);
+typedef void OSSL_set_connect_state_t(SSL *ssl);
+typedef void OSSL_set_accept_state_t(SSL *ssl);
+typedef int OSSL_set_fd_t(SSL *ssl, int fd);
+typedef const char * OSSL_get_version_t(const SSL *ssl);
+typedef int OSSL_accept_t(SSL *ssl);
+typedef int OSSL_connect_t(SSL *ssl);
+typedef X509 * OSSL_get_peer_certificate_t(const SSL *ssl);
+typedef long OSSL_get_verify_result_t(const SSL *ssl);
+
+typedef SSL_CTX * OSSL_CTX_new_t(const SSL_METHOD *method);
+typedef int OSSL_CTX_set_session_id_context_t(SSL_CTX *ctx, const unsigned char *sid_ctx, unsigned int sid_ctx_len);
+typedef int OSSL_CTX_use_PrivateKey_t(SSL_CTX *ctx, EVP_PKEY *pkey);
+typedef int OSSL_CTX_use_certificate_t(SSL_CTX *ctx, X509 *x);
+typedef int OSSL_CTX_check_private_key_t(const SSL_CTX *ctx);
+typedef void OSSL_CTX_set_verify_t(SSL_CTX *ctx, int mode, int (*verify_callback)(int, X509_STORE_CTX *));
+typedef void OSSL_CTX_free_t(SSL_CTX *ctx);
+typedef X509_STORE * OSSL_CTX_get_cert_store_t(const SSL_CTX *ctx);
+
+typedef BIO * OBIO_new_mem_buf_t(const void *buf, int len);
+typedef void OBIO_free_all_t(BIO *a);
+typedef BIO * OBIO_new_ssl_t(SSL_CTX *ctx, int client);
+typedef int OBIO_write_t(BIO *b, const void *data, int dlen);
+typedef int OBIO_read_t(BIO *b, void *data, int dlen);
+
+typedef EVP_PKEY * OPEM_read_bio_PrivateKey_t(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u);
+typedef X509 * OPEM_read_bio_X509_t(BIO *bp, X509 **x, pem_password_cb *cb, void *u);
+typedef STACK_OF(X509_INFO) *OPEM_X509_INFO_read_bio_t(BIO *bp, STACK_OF(X509_INFO) *sk, pem_password_cb *cb, void *u);
+
+typedef int OX509_STORE_add_cert_t(X509_STORE *ctx, X509 *x);
+typedef int OX509_STORE_add_crl_t(X509_STORE *ctx, X509_CRL *x);
+typedef void OX509_free_t(X509 *a);
+
+typedef void OERR_print_errors_fp_t(FILE *fp);
+
+extern "C" OOpenSSL_version_t * OOpenSSL_version;
+
+extern "C" OSSL_load_error_strings_t * OSSL_load_error_strings;
+extern "C" OSSL_library_init_t * OSSL_library_init;
+
+extern "C" OSSLv23_server_method_t * OSSLv23_server_method;
+extern "C" OSSLv23_client_method_t * OSSLv23_client_method;
+
+extern "C" OSSL_CTX_set_ecdh_auto_t * OSSL_CTX_set_ecdh_auto;
+
+extern "C" OBIO_ctrl_t * OBIO_ctrl;
+
+extern "C" OSSL_get_cipher_t * OSSL_get_cipher;
+
+extern "C" OEVP_cleanup_t * OEVP_cleanup;
+
+extern "C" OX509_INFO_free_t * OX509_INFO_free;
+extern "C" Osk_X509_INFO_num_t * Osk_X509_INFO_num;
+extern "C" Osk_X509_INFO_value_t * Osk_X509_INFO_value;
+extern "C" Osk_X509_INFO_pop_free_t * Osk_X509_INFO_pop_free;
+
+extern "C" OSSL_new_t * OSSL_new;
+extern "C" OSSL_free_t * OSSL_free;
+extern "C" OSSL_set_connect_state_t * OSSL_set_connect_state;
+extern "C" OSSL_set_accept_state_t * OSSL_set_accept_state;
+extern "C" OSSL_set_fd_t * OSSL_set_fd;
+extern "C" OSSL_get_version_t * OSSL_get_version;
+extern "C" OSSL_accept_t * OSSL_accept;
+extern "C" OSSL_connect_t * OSSL_connect;
+extern "C" OSSL_get_peer_certificate_t * OSSL_get_peer_certificate;
+extern "C" OSSL_get_verify_result_t * OSSL_get_verify_result;
+
+extern "C" OSSLv23_server_method_t * OSSLv23_server_method;
+extern "C" OSSLv23_client_method_t * OSSLv23_client_method;
+
+extern "C" OSSL_CTX_new_t * OSSL_CTX_new;
+extern "C" OSSL_CTX_set_session_id_context_t * OSSL_CTX_set_session_id_context;
+extern "C" OSSL_CTX_use_PrivateKey_t * OSSL_CTX_use_PrivateKey;
+extern "C" OSSL_CTX_use_certificate_t * OSSL_CTX_use_certificate;
+extern "C" OSSL_CTX_check_private_key_t * OSSL_CTX_check_private_key;
+extern "C" OSSL_CTX_set_verify_t * OSSL_CTX_set_verify;
+extern "C" OSSL_CTX_free_t * OSSL_CTX_free;
+extern "C" OSSL_CTX_get_cert_store_t * OSSL_CTX_get_cert_store;
+
+extern "C" OBIO_new_mem_buf_t * OBIO_new_mem_buf;
+extern "C" OBIO_free_all_t * OBIO_free_all;
+extern "C" OBIO_new_ssl_t * OBIO_new_ssl;
+extern "C" OBIO_write_t * OBIO_write;
+extern "C" OBIO_read_t * OBIO_read;
+
+extern "C" OPEM_read_bio_PrivateKey_t * OPEM_read_bio_PrivateKey;
+extern "C" OPEM_read_bio_X509_t * OPEM_read_bio_X509;
+extern "C" OPEM_X509_INFO_read_bio_t * OPEM_X509_INFO_read_bio;
+
+extern "C" OX509_STORE_add_cert_t * OX509_STORE_add_cert;
+extern "C" OX509_STORE_add_crl_t * OX509_STORE_add_crl;
+extern "C" OX509_free_t * OX509_free;
+
+extern "C" OEVP_cleanup_t * OEVP_cleanup;
+
+extern "C" OERR_print_errors_fp_t * OERR_print_errors_fp;
+
+namespace JITServer
+{
+void * loadLibssl();
+void   unloadLibssl(void * handle);
+void * findLibsslSymbol(void * handle, const char * symName);
+
+bool loadLibsslAndFindSymbols();
+};
+#endif // LOAD_SSL_LIBS_H

--- a/runtime/compiler/net/SSLProtobufStream.hpp
+++ b/runtime/compiler/net/SSLProtobufStream.hpp
@@ -26,6 +26,7 @@
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include "net/LoadSSLLibs.hpp"
 
 class SSLOutputStream : public google::protobuf::io::CopyingOutputStream
    {
@@ -40,16 +41,16 @@ public:
    virtual bool Write(const void *buffer, int size) override
       {
       TR_ASSERT(size > 0, "writing zero bytes is undefined behavior");
-      int n = BIO_write(_ssl, buffer, size);
+      int n = (*OBIO_write)(_ssl, buffer, size);
       if (n <= 0)
          {
-         ERR_print_errors_fp(stderr);
+         (*OERR_print_errors_fp)(stderr);
          return false;
          }
       /*if (BIO_flush(_ssl) != 1)
          {
          perror("flushing");
-         ERR_print_errors_fp(stderr);
+         (*OERR_print_errors_fp)(stderr);
          return false;
          }*/
       TR_ASSERT(n == size, "not expecting partial write");
@@ -73,10 +74,10 @@ public:
    virtual int Read(void *buffer, int size) override
       {
       TR_ASSERT(size > 0, "reading zero bytes is undefined behavior");
-      int n = BIO_read(_ssl, buffer, size);
+      int n = (*OBIO_read)(_ssl, buffer, size);
       if (n <= 0)
          {
-         ERR_print_errors_fp(stderr);
+         (*OERR_print_errors_fp)(stderr);
          }
       return n;
       }


### PR DESCRIPTION
Dynamically load `libssl` in JITServer using `dlopen` and load the OpenSSL libssl symbols required by JITServer. Replaced all the libssl APIs with function calls to the loaded symbols during the runtime.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>