### PR TITLE
Use FrontEnd implementations of instanceOfOrCheckCast routines (0.18.0)

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -573,7 +573,7 @@ void traceInstanceOfOrCheckCastProfilingInfo(TR::CodeGenerator *cg, TR::Node *no
          continue;
          }
 
-      bool isInstanceOf = instanceOfOrCheckCastNoCacheUpdate((J9Class *)profiledClass, (J9Class *)castClass);
+      bool isInstanceOf = fej9->instanceOfOrCheckCast((J9Class *)profiledClass, (J9Class *)castClass);
       traceMsg(comp, "%s:\tProfiled class [" POINTER_PRINTF_FORMAT "] is %san instance of cast class\n",
                node->getOpCode().getName(), profiledClass, isInstanceOf ? "" : "not ");
       }
@@ -646,7 +646,7 @@ uint32_t getInstanceOfOrCheckCastTopProfiledClass(TR::CodeGenerator *cg, TR::Nod
       // For checkcast, skip classes that will fail the cast, not much value in optimizing for those cases.
       // We also don't want to pollute the cast class cache with a failing class for the same reason.
       //
-      bool isInstanceOf = instanceOfOrCheckCastNoCacheUpdate((J9Class *)tempProfiledClass, (J9Class *)castClass);
+      bool isInstanceOf = fej9->instanceOfOrCheckCast((J9Class *)tempProfiledClass, (J9Class *)castClass);
       if (node->getOpCode().isCheckCast() && !isInstanceOf)
          {
          if (comp->getOption(TR_TraceCG))

--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -573,7 +573,7 @@ void traceInstanceOfOrCheckCastProfilingInfo(TR::CodeGenerator *cg, TR::Node *no
          continue;
          }
 
-      bool isInstanceOf = fej9->instanceOfOrCheckCast((J9Class *)profiledClass, (J9Class *)castClass);
+      bool isInstanceOf = fej9->instanceOfOrCheckCastNoCacheUpdate((J9Class *)profiledClass, (J9Class *)castClass);
       traceMsg(comp, "%s:\tProfiled class [" POINTER_PRINTF_FORMAT "] is %san instance of cast class\n",
                node->getOpCode().getName(), profiledClass, isInstanceOf ? "" : "not ");
       }
@@ -646,7 +646,7 @@ uint32_t getInstanceOfOrCheckCastTopProfiledClass(TR::CodeGenerator *cg, TR::Nod
       // For checkcast, skip classes that will fail the cast, not much value in optimizing for those cases.
       // We also don't want to pollute the cast class cache with a failing class for the same reason.
       //
-      bool isInstanceOf = fej9->instanceOfOrCheckCast((J9Class *)tempProfiledClass, (J9Class *)castClass);
+      bool isInstanceOf = fej9->instanceOfOrCheckCastNoCacheUpdate((J9Class *)tempProfiledClass, (J9Class *)castClass);
       if (node->getOpCode().isCheckCast() && !isInstanceOf)
          {
          if (comp->getOption(TR_TraceCG))

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1073,6 +1073,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->instanceOfOrCheckCast(clazz1, clazz2));
          }
          break;
+      case MessageType::VM_instanceOfOrCheckCastNoCacheUpdate:
+         {
+         auto recv = client->getRecvData<J9Class*, J9Class*>();
+         auto clazz1 = std::get<0>(recv);
+         auto clazz2 = std::get<1>(recv);
+         client->write(response, fe->instanceOfOrCheckCastNoCacheUpdate(clazz1, clazz2));
+         }
+         break;
       case MessageType::VM_transformJlrMethodInvoke:
          {
          auto recv = client->getRecvData<J9Method*, J9Class*>();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -259,6 +259,12 @@ TR_J9VMBase::instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass)
    return ::instanceOfOrCheckCast(instanceClass, castClass);
    }
 
+bool
+TR_J9VMBase::instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass)
+   {
+   return ::instanceOfOrCheckCastNoCacheUpdate(instanceClass, castClass);
+   }
+
 // Points to address: what if vmThread is not the compilation thread.
 // What if the compilation thread does not have the classUnloadMonitor.
 // What if jitConfig does not exist.

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1039,6 +1039,7 @@ public:
    virtual bool isMethodBreakpointed(TR_OpaqueMethodBlock *method);
 
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass);
+   virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass);
    virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) { return false; }
    virtual bool isStringCompressionEnabledVM();
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1466,7 +1466,7 @@ TR_J9ServerVM::isClassArray(TR_OpaqueClassBlock *klass)
 bool
 TR_J9ServerVM::instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate)
    {
-      if (instanceClass == castClass)
+   if (instanceClass == castClass)
       return true;
 
    // When castClass is an ancestor/interface of class instanceClass, can avoid a remote message,
@@ -1490,8 +1490,7 @@ TR_J9ServerVM::instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* cast
             auto interfaces = it->second._interfaces;
             return std::find(interfaces->begin(), interfaces->end(), castClassOffset) != interfaces->end();
             }
-
-         if (isClassArray(instanceClassOffset) && isClassArray(castClassOffset))
+         else if (isClassArray(instanceClassOffset) && isClassArray(castClassOffset))
             {
             int instanceNumDims = 0, castNumDims = 0;
             // these are the leaf classes of the arrays, unless the leaf class is primitive.
@@ -1505,23 +1504,21 @@ TR_J9ServerVM::instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* cast
             if (instanceNumDims != 0 && instanceNumDims == castNumDims)
                return instanceOfOrCheckCast((J9Class *) instanceClassOffset, (J9Class *) castClassOffset);
 
-            // reached when (instanceNumDims > castNumDims), or when one of the arrays contains primitive values.
-            // to correctly deal with these cases on the server, need to call
+            // We reach the end of this block when instanceNumDims > castNumDims, or when one of the arrays contains primitive values.
+            // To correctly deal with these cases on the server, we need to call
             // getComponentFromArrayClass multiple times, or getLeafComponentTypeFromArrayClass.
-            // each call requires a remote message, faster and easier to call instanceOfOrCheckCast on the client
-            JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-            if (cacheUpdate)
-               stream->write(JITServer::MessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);
-            else
-               stream->write(JITServer::MessageType::VM_instanceOfOrCheckCastNoCacheUpdate, instanceClass, castClass);
-            return std::get<0>(stream->read<bool>());
+            // Each of these calls requires a remote message. It's faster and easier to just call instanceOfOrCheckCast
+            // on the client. So we exit out of the critical section here and do the remote call.
             }
-         // instance class is cached, and all of the checks failed, cast is invalid
-         return false;
+         else
+            {
+            // instance class is cached, and all of the checks failed, cast is invalid
+            return false;
+            }
          }
       }
 
-   // instance class is not cached, make a remote call
+   // instance class is not cached or isClassArray(instanceClassOffset) && isClassArray(castClassOffset). So make a remote call.
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    if (cacheUpdate)
       stream->write(JITServer::MessageType::VM_instanceOfOrCheckCast, instanceClass, castClass);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -170,6 +170,8 @@ public:
    virtual uintptrj_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
    virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) { return false; } // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
+   virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass) override;
+   virtual bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
    using TR_J9VM :: isAnonymousClass;
    virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -171,7 +171,6 @@ public:
    virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) { return false; } // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass) override;
-   virtual bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
    using TR_J9VM :: isAnonymousClass;
    virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;
@@ -185,6 +184,9 @@ public:
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
    virtual bool getReportByteCodeInfoAtCatchBlock() override;
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType) override;
+
+private:
+   bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -228,6 +228,7 @@ enum MessageType
    VM_getReferenceFieldAt = 306;
    VM_getJ2IThunk = 307;
    VM_needsInvokeExactJ2IThunk = 308;
+   VM_instanceOfOrCheckCastNoCacheUpdate = 309;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1581,7 +1581,7 @@ static bool generateInlineTest(TR::CodeGenerator * cg, TR::Node * node, TR::Node
          {
          for (i = 0; i < numberOfGuessClasses; i++)
             {
-            if (instanceOfOrCheckCast((J9Class*)tempGuessClassArray[i], (J9Class*)castClassAddr))
+            if (fej9->instanceOfOrCheckCast((J9Class*)tempGuessClassArray[i], (J9Class*)castClassAddr))
                {
                guessClassArray[num_PICs++] = tempGuessClassArray[i];
                if (maxNum_PICS == num_PICs) break;
@@ -1617,7 +1617,7 @@ static bool generateInlineTest(TR::CodeGenerator * cg, TR::Node * node, TR::Node
       if (cg->wantToPatchClassPointer(guessClassArray[i], node))
          comp->getStaticHCRPICSites()->push_front(unloadableConstInstr[i]);
 
-      result_bool = instanceOfOrCheckCast((J9Class*)(guessClassArray[i]), (J9Class*)castClassAddr);
+      result_bool = fej9->instanceOfOrCheckCast((J9Class*)(guessClassArray[i]), (J9Class*)castClassAddr);
       result_label = (falseLabel != trueLabel ) ? (result_bool ? trueLabel : falseLabel) : doneLabel;
 
       if (needsResult)


### PR DESCRIPTION
This is a cherry pick for commits in PR #8117 which basically replaces the calls to `instanceOfOrCheckCast()` with front-end equivalent routines.