### PR TITLE
AArch64: Fix jitNewValue helpers

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -246,8 +246,8 @@ END_PROC($1)
 
 dnl Runtime helpers
 
-DUAL_MODE_HELPER(jitNewValue,1)
-DUAL_MODE_HELPER(jitNewValueNoZeroInit,1)
+NEW_DUAL_MODE_HELPER(jitNewValue,1)
+NEW_DUAL_MODE_HELPER(jitNewValueNoZeroInit,1)
 DUAL_MODE_HELPER(jitNewObject,1)
 DUAL_MODE_HELPER(jitNewObjectNoZeroInit,1)
 DUAL_MODE_HELPER(jitANewArray,2)


### PR DESCRIPTION
This commit fixes jitNewValue helpers for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>