### PR TITLE
AArch64: Add compensation code for PatchJNICallSite

### DIFF
--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -143,7 +143,7 @@ TR_PatchJNICallSite::compensate(
       bool isSMP,
       void *newAddress)
    {
-#if (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM))
+#if (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
    _patchJNICallSite((J9Method*)getKey(), getPc(), (uint8_t*) newAddress, fe, isSMP);
 #else
    TR_ASSERT(0, "Direct JNI support not present on this platform yet");


### PR DESCRIPTION
This commit adds compensation code for `PatchJNICallSite`.
`_patchJNICallSite` patches the code sequence generated by `J9::ARM64::JNILinkage::generateMethodDispatch`.

Depends on https://github.com/eclipse/openj9/pull/8000

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>