### PR TITLE
AArch64: Handle TR_BodyInfoAddressLoad in initializeAOTRelocationHeader

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -219,6 +219,12 @@ uint8_t *J9::ARM64::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
          }
          break;
 
+      case TR_BodyInfoAddressLoad:
+         {
+         // Nothing to do
+         }
+         break;
+
       case TR_ConstantPoolOrderedPair:
          {
          *(uintptrj_t *)cursor = (uintptrj_t)relocation->getTargetAddress2(); // inlined site index


### PR DESCRIPTION
This commit changes `J9::ARM64::AheadOfTimeCompile::initializeAOTRelocationHeader`
to handle `TR_BodyInfoAddressLoad` relocation record.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>