### PR TITLE
AArch64: Enable DirectToJNI on AOT compilation

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -83,6 +83,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     * @param[in] data : binary encoding data
     */
    void generateBinaryEncodingPrePrologue(TR_ARM64BinaryEncodingData &data);
+
+   bool supportsDirectJNICallsForAOT() { return true;}
    };
 
 }

--- a/runtime/compiler/aarch64/runtime/ARM64RelocationTarget.hpp
+++ b/runtime/compiler/aarch64/runtime/ARM64RelocationTarget.hpp
@@ -52,6 +52,10 @@ class TR_ARM64RelocationTarget : public TR_RelocationTarget
 
       virtual uint8_t *arrayCopyHelperAddress(J9JavaVM *javaVM);
       virtual void flushCache(uint8_t *codeStart, unsigned long size);
+      virtual void storeAddressRAM(uint8_t *address, uint8_t *reloLocation)
+         {
+         storeAddressSequence(address, reloLocation, 0);
+         }
    };
 
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1504,7 +1504,7 @@ TR_ResolvedRelocatableJ9Method::startAddressForJittedMethod()
 void *
 TR_ResolvedRelocatableJ9Method::startAddressForJNIMethod(TR::Compilation * comp)
    {
-#if defined(TR_TARGET_S390)  || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER)
+#if defined(TR_TARGET_S390)  || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER) || defined(TR_TARGET_ARM64)
    return TR_ResolvedJ9Method::startAddressForJNIMethod(comp);
 #else
    return NULL;


### PR DESCRIPTION
This commit enables `DirectToJNI` on AOT compilation.

Depends on https://github.com/eclipse/omr/pull/4589

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>