### PR TITLE
Fix compilation failure in zLinux due to missing include

### DIFF
--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -28,6 +28,7 @@
 #include "env/jittypes.h"
 #include "env/VMJ9.h"
 #include "z/codegen/SystemLinkage.hpp"
+#include "control/CompilationRuntime.hpp"
 
 // Recompilation Support Runtime methods
 //


### PR DESCRIPTION
Include header file "control/CompilationRuntime.hpp" in
z/runtime/Recomp.cpp.

Fixes: #8174 

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>