### PR TITLE
Fix initialization of J9::Compilation::_isOutOfProcessCompilation (0.…

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -123,6 +123,9 @@ const char * callingContextNames[] = {
    "LAST_CONTEXT"
 };
 
+#if defined(JITSERVER_SUPPORT)
+bool J9::Compilation::_outOfProcessCompilation = false;
+#endif  /* defined(JITSERVER_SUPPORT) */
 
 J9::Compilation::Compilation(int32_t id,
       J9VMThread *j9vmThread,
@@ -175,7 +178,6 @@ J9::Compilation::Compilation(int32_t id,
    _skippedJProfilingBlock(false),
    _reloRuntime(reloRuntime),
 #if defined(JITSERVER_SUPPORT)
-   _outOfProcessCompilation(false),
    _remoteCompilation(false),
    _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption>(self()->allocator())),
 #endif /* defined(JITSERVER_SUPPORT) */

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -317,8 +317,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    bool incompleteOptimizerSupportForReadWriteBarriers();
 
 #if defined(JITSERVER_SUPPORT)
-   bool isOutOfProcessCompilation() const { return _outOfProcessCompilation; } // server side
-   void setOutOfProcessCompilation() { _outOfProcessCompilation = true; }
+   static bool isOutOfProcessCompilation() { return _outOfProcessCompilation; } // server side
+   static void setOutOfProcessCompilation() { _outOfProcessCompilation = true; }
    bool isRemoteCompilation() const { return _remoteCompilation; } // client side
    void setRemoteCompilation() { _remoteCompilation = true; }
    TR::list<SerializedRuntimeAssumption*>& getSerializedRuntimeAssumptions() { return _serializedRuntimeAssumptions; }
@@ -419,7 +419,7 @@ private:
    TR::list<SerializedRuntimeAssumption*> _serializedRuntimeAssumptions;
    // The following flag is set when this compilation is performed in a
    // VM that does not have the runtime part (server side in JITServer)
-   bool _outOfProcessCompilation;
+   static bool _outOfProcessCompilation;
    // The following flag is set when a request to complete this compilation
    // has been sent to a remote VM (client side in JITServer)
    bool _remoteCompilation;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2064,12 +2064,12 @@ J9::Options::setupJITServerOptions()
          // IProfiler thread is not needed at JITServer because
          // no IProfiler info is collected at the server itself
          self()->setOption(TR_DisableIProfilerThread);
+         J9::Compilation::setOutOfProcessCompilation();
          }
 
       // In the JITServer world, expensive compilations are performed remotely so there is no risk of blowing the footprint limit on the JVM
       // Setting _expensiveCompWeight to a large value so that JSR292/hot/scorching compilation are allowed to be executed concurrently
       TR::Options::_expensiveCompWeight = TR::CompilationInfo::MAX_WEIGHT;
-
       }
 
    if (TR::Options::getVerboseOption(TR_VerboseJITServer))


### PR DESCRIPTION
…18.0)

The field `J9::Compilation::_isOutOfProcessCompilation` is used by the compiler
to determine whether this is a compilation performed at the JITServer. The
problem is that during the construction of the compiler object many other
objects are instantiated and during these operations we enquire the status
of the _isOutOfProcessCompilation field which might be unset. According to the
C++ standard fields are initialized in the order of their declaration. In order
to have `_isOutOfProcessCompilation` initialized before anything else we might
need to declare it at the omr level as the first field in OMR::Compilation and
to pass some information about being an out-of-process compilation to the
constructor of J9::Compilation.

This commit implements a simpler solution: since the JITServer can perform only
out-of-process compilations and nothing else, we can make `_isOutOfProcessCompilation`
a static field that is set once as soon as we learn that this process is a
JITServer.

Fixes #8150

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>