### PR TITLE
Increase JITServer default timeout value (0.18.0)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1978,6 +1978,9 @@ J9::Options::fePreProcess(void * base)
          else // Server mode
             {
             compInfo->getPersistentInfo()->setRemoteCompilationMode(JITServer::SERVER);
+            // Increase the default timeout value for JITServer.
+            // It can be overridden with -XX:JITServerTimeout= option in JITServerParseCommonOptions().
+            compInfo->getPersistentInfo()->setSocketTimeout(30000);
             }
 
          JITServerParseCommonOptions(vm, compInfo);


### PR DESCRIPTION
The current timeout value for JITServer is 2000 ms (the same as
for the client JVM) which is too low. When the client is using
`-Xjit:enableJITServerHeuristics`  cheap compilations (those
performed at 'cold' and 'no-opt' optimization levels) are
performed locally in order to avoid network latency. If there is
a large stretch of such cheap compilations, the server may not
'hear' from the client for a long time and close the connection.
To avoid this scenario a larger timeout value at the server needs
to be used.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>