### PR TITLE
Couple of more checks to prevent local compilations in JITServer (0.1…

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -512,6 +512,13 @@ j9jit_createNewInstanceThunk_err(
       *compErrCode = compilationFailure;
       return 0;
       }
+
+#if defined(JITSERVER_SUPPORT)
+   // Do not allow local compilations in JITServer server mode
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      return 0;
+#endif
+
    bool queued = false;
 
    TR_MethodEvent event;

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1498,10 +1498,21 @@ uint8_t *compileMethodHandleThunk(j9object_t methodHandle, j9object_t arg, J9VMT
       TR_VerboseLog::vlogRelease();
       }
    bool disabled = false;
-   if (flags & TRANSLATE_METHODHANDLE_FLAG_CUSTOM)
-      disabled = cmdLineOptions->getOption(TR_DisableCustomMethodHandleThunks);
+#if defined(JITSERVER_SUPPORT)
+   // Do not allow local compilations in JITServer server mode
+   TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
+   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      disabled = true;
+      }
    else
-      disabled = cmdLineOptions->getOption(TR_DisableShareableMethodHandleThunks);
+#endif
+      {
+      if (flags & TRANSLATE_METHODHANDLE_FLAG_CUSTOM)
+         disabled = cmdLineOptions->getOption(TR_DisableCustomMethodHandleThunks);
+      else
+         disabled = cmdLineOptions->getOption(TR_DisableShareableMethodHandleThunks);
+      }
    if (disabled)
       {
       if (verbose)


### PR DESCRIPTION
…8.0)

Add checks to prevent local compilation in couple of code paths
that may get exercised during JVM startup when running JITServer.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>