### PR TITLE
JIT Support for getCallerClass in recent JDK versions

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -7457,10 +7457,9 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
             }
 
          // char *caseName = (methodID == TR::sun_reflect_Reflection_getCallerClass) ? "s/r/R.getCallerClass" : "j/l/CL.getStackClassLoader";
-         TR::Node *iconstNode = callNode->getFirstChild();
-         if (iconstNode->getOpCodeValue() == TR::iconst)
+         if (callNode->getNumChildren() == 0 || callNode->getFirstChild()->getOpCodeValue() == TR::iconst)
             {
-            int32_t stackDepth = iconstNode->getInt();
+            int32_t stackDepth = callNode->getNumChildren() == 0 ? -1 : callNode->getFirstChild()->getInt();
             if (stackDepth <= 0)
                return 0;   // getCallerClass is meaningless when invoked with depth <= 0
             int32_t callerIndex = callNode->getByteCodeInfo().getCallerIndex();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3595,6 +3595,7 @@ void TR_ResolvedJ9Method::construct()
    static X ReflectionMethods[] =
       {
       {x(TR::sun_reflect_Reflection_getCallerClass, "getCallerClass", "(I)Ljava/lang/Class;")},
+      {x(TR::sun_reflect_Reflection_getCallerClass, "getCallerClass", "()Ljava/lang/Class;")},
       {x(TR::sun_reflect_Reflection_getClassAccessFlags, "getClassAccessFlags", "(Ljava/lang/Class;)I")},
       {  TR::unknownMethod}
       };
@@ -4340,6 +4341,7 @@ void TR_ResolvedJ9Method::construct()
    static Y class31[] =
       {
       { "com/ibm/jit/DecimalFormatHelper", DecimalFormatHelperMethods},
+      { "jdk/internal/reflect/Reflection", ReflectionMethods },
       { 0 }
       };
    static Y class32[] =


### PR DESCRIPTION
In recent versions of the JDK the getCallerClass taking an int argument has
been dropped with an argument-less version remaining. The behaviour of this
API is equivalent to getCallerClass with an argument of -1. This change adds
support for this second version of getCallerClass and for the renamed package
of the class this method is found in.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>