### PR TITLE
Add fast JNI support for JDK9 Unsafe

### DIFF
--- a/runtime/vm/FastJNI.cpp
+++ b/runtime/vm/FastJNI.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,7 @@ J9_FAST_JNI_CLASS_TABLE(fastJNINatives)
 	J9_FAST_JNI_CLASS("java/lang/System", java_lang_System)
 	J9_FAST_JNI_CLASS("com/ibm/oti/vm/VM", com_ibm_oti_vm_VM)
 	J9_FAST_JNI_CLASS("sun/misc/Unsafe", sun_misc_Unsafe)
+	J9_FAST_JNI_CLASS("jdk/internal/misc/Unsafe", sun_misc_Unsafe)
 	J9_FAST_JNI_CLASS("java/lang/ClassLoader", java_lang_ClassLoader)
 	J9_FAST_JNI_CLASS("java/lang/ref/Reference", java_lang_ref_Reference)
 	J9_FAST_JNI_CLASS("java/lang/Thread", java_lang_Thread)


### PR DESCRIPTION
In JDK9 and later the Unsafe class moved from sun.misc to jdk.internal.
This change adds support for this change in the package name.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>