### PR TITLE
Handle NoRecompilationRecoverableILGenException

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -10981,6 +10981,10 @@ TR::CompilationInfoPerThreadBase::processException(
       _methodBeingCompiled->_compErrCode = compilationAotHasInvokeVarHandle;
       }
    catch (const J9::FSDHasInvokeHandle &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationRestrictedMethod;
+      }
+   catch (const TR::NoRecompilationRecoverableILGenException &e)
       {
       _methodBeingCompiled->_compErrCode = compilationRestrictedMethod;
       }


### PR DESCRIPTION
Do not recompile the method if the exception is NoRecompilationRecoverableILGenException

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>