### PR TITLE
Disabled VSTRS optimizations for `inlineVectorizedStringIndexOf`

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -261,7 +261,8 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
    const uint32_t elementSizeMask = isUTF16 ? 1 : 0;
    const int8_t vectorSize = cg->machine()->getVRFSize();
    const uintptrj_t headerSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
-   const bool supportsVSTRS = TR::Compiler->target.cpu.getSupportsVectorFacilityEnhancement2();
+   // TODO (#8274): Re-enable VSTRS support in inlineVectorizedStringIndexOf
+   const bool supportsVSTRS = TR::Compiler->target.cpu.getSupportsVectorFacilityEnhancement2() && feGetEnv("TR_EnableVectorStringSearch") != NULL;
    TR::Compilation* comp = cg->comp();
 
    if (comp->getOption(TR_TraceCG))


### PR DESCRIPTION
~~Compare and branch condition has been changed to greater than or equal~~
~~from greater than~~

~~This fix is based on @fjeremic's suggestion in https://github.com/eclipse/openj9/issues/8159#issuecomment-568795948~~

Fixes: #8159

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>