### PR TITLE
Deprecate value assertions for NULLVALUE

### DIFF
--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -106,11 +106,7 @@ J9::ARM::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, bool 
 
       TR::Register    *targetRegister = cg->evaluate(reference);
 
-#if (NULLVALUE==0)
       generateSrc2Instruction(cg, ARMOp_tst, node, targetRegister, targetRegister);
-#else
-#error("NULL is not 0, must fix");
-#endif
 
       TR::SymbolReference *NULLCHKException = node->getSymbolReference();
       TR::Instruction *instr1 = generateImmSymInstruction(cg, ARMOp_bl, node, (uintptr_t)NULLCHKException->getMethodAddress(), NULL, NULLCHKException, NULL, NULL, ARMConditionCodeEQ);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -135,25 +135,14 @@ static TR::RegisterDependencyConditions *createConditionsAndPopulateVSXDeps(TR::
 
 static TR::Instruction *genNullTest(TR::Node *node, TR::Register *objectReg, TR::Register *crReg, TR::CodeGenerator *cg, TR::Instruction *cursor = NULL)
    {
-#if (NULLVALUE <= UPPER_IMMED && NULLVALUE >= LOWER_IMMED)
    cursor = generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, crReg, objectReg, NULLVALUE, cursor);
-#else
-#error "The NULL value cannot be contained in a 16-bit signed immediate."
-#endif
    return cursor;
    }
 
 static inline TR::Instruction *genNullTest(TR::Node *node, TR::Register *objectReg, TR::Register *crReg, TR::Register *scratchReg, TR::Instruction *cursor, TR::CodeGenerator *cg)
    {
    TR::Instruction *iRet;
-
-#if (NULLVALUE<=UPPER_IMMED && NULLVALUE>=LOWER_IMMED)
    iRet = generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, crReg, objectReg, NULLVALUE, cursor);
-#else
-   iRet = loadConstant(cg, node, NULLVALUE, scratchReg, cursor);
-   iRet = generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, crReg, objectReg,
-         scratchReg, (cursor==NULL)?NULL:iRet);
-#endif
    return (iRet);
    }
 
@@ -386,7 +375,6 @@ VMoutlinedHelperWrtbarEvaluator(
 
    if (!srcIsNonNull)
       {
-      TR_ASSERT(NULLVALUE <= UPPER_IMMED && NULLVALUE >= LOWER_IMMED, "Expecting NULLVALUE to fit in immediate field");
       srcNullCondReg = cg->allocateRegister(TR_CCR);
       generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, srcNullCondReg, srcObjectReg, NULLVALUE);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, doneWrtbarLabel, srcNullCondReg);
@@ -885,12 +873,7 @@ static void VMwrtbarEvaluator(TR::Node *node, TR::Register *srcReg, TR::Register
          }
       if (!srcNonNull && !TR::Options::getCmdLineOptions()->realTimeGC())
          {
-#if (NULLVALUE <= UPPER_IMMED && NULLVALUE >= LOWER_IMMED)
          generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpi, node, cr0, srcReg, NULLVALUE);
-#else
-         loadConstant(node, NULLVALUE, temp1Reg);
-         generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, cr0, srcReg, temp1Reg);
-#endif
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label, cr0);
          }
 
@@ -3393,7 +3376,6 @@ static void VMoutlinedHelperArrayStoreCHKEvaluator(TR::Node *node, TR::Register 
 
    if (!srcIsNonNull)
       {
-      TR_ASSERT(NULLVALUE <= UPPER_IMMED && NULLVALUE >= LOWER_IMMED, "Expecting NULLVALUE to fit in immediate field");
       srcNullCondReg = cg->allocateRegister(TR_CCR);
       generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, srcNullCondReg, srcReg, NULLVALUE);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, doneArrayStoreCHKLabel, srcNullCondReg);

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -1107,7 +1107,6 @@ void J9::Power::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          TR::RealRegister *nullValueRegister = gr0;
          int32_t            offset = atlas->getLocalBaseOffset();
 
-         // Note: gr0 will not be suitable if NULLVALUE is out of [LOWER, UPPER)
          cursor = loadConstant(cg(), firstNode, NULLVALUE, nullValueRegister, cursor);
 
          static bool disableUnrollPrologueInitLoop = (feGetEnv("TR_DisableUnrollPrologueInitLoop") != NULL);

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -450,7 +450,6 @@ static TR::Instruction *initializeLocals(TR::Instruction      *cursor,
       //    framePointer[offset + loopReg * pointerSize] = sourceReg;
       //
       TR_ASSERT(count > 0, "positive count required for dword RegImm instruction");
-      TR_ASSERT(NULLVALUE == 0, "sourceReg cannot be used as a base register for non-zero NULL values");
 
       cursor = new (cg->trHeapMemory()) TR::X86RegMemInstruction(
                   cursor,

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2027,7 +2027,6 @@ VMwrtbarEvaluator(
       if (srcNonNull == false)
          {
          // If object is NULL, done
-         static_assert(NULLVALUE == 0, "NULLVALUE is assumed to be zero here");
          generateRRInstruction(cg, TR::InstOpCode::getLoadTestRegOpCode(), node, srcReg, srcReg);
          generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneLabel);
          }
@@ -5605,7 +5604,6 @@ J9::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool n
                && reference->getOpCode().hasSymbolReference()
                && reference->getRegister() == NULL)
             {
-            TR_ASSERT( NULLVALUE == 0, "Can not generate ICM if NULL is not 0");
             bool isInternalPointer = reference->getSymbolReference()->getSymbol()->isInternalPointer();
             if ((reference->getOpCode().isLoadIndirect() || reference->getOpCodeValue() == TR::aload)
                   && !isInternalPointer)


### PR DESCRIPTION
The changes include :
- Code folding for #if directives for NULLVALUE value checks
- Removing assert statements
- Removing range checks for Power systems immediate range

Closes: #7870
Signed-off-by: Rohit Pandey <rohit.pandey.h@gmail.com>