### PR TITLE
Add launcher for JITServer (0.18.0)

### DIFF
--- a/buildspecs/core.feature
+++ b/buildspecs/core.feature
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<project id="runtime"/>
 	</source>
 	<flags>
+		<flag id="build_jitserver" value="false"/>
 		<flag id="build_stage_ottawa_vmlab" value="true"/>
 		<flag id="build_uma" value="true"/>
 		<flag id="compiler_promotion" value="true"/>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2019 IBM Corp. and others
+Copyright (c) 2006, 2020 IBM Corp. and others
  
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -184,6 +184,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	</flag>
 	<flag id="build_java9">
 		<description>BuildSpec represents a Java 9x configuration.</description>
+		<ifRemoved></ifRemoved>
+	</flag>
+	<flag id="build_jitserver">
+		<description>JITServer support is enabled in the buildspec.</description>
 		<ifRemoved></ifRemoved>
 	</flag>
 	<flag id="build_openj9">

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,6 +104,9 @@ include(cmake/omr_config.cmake)
 
 if(OPENJ9_BUILD)
 	add_definitions(-DOPENJ9_BUILD)
+endif()
+if (JITSERVER_SUPPORT)
+	add_definitions(-DJITSERVER_SUPPORT)
 endif()
 
 # clean up the variables we used
@@ -591,3 +594,7 @@ endif()
 
 # NOTE this is not conditional in the UMA module.xml
 add_subdirectory(tests)
+
+if (JITSERVER_SUPPORT)
+	add_subdirectory(jitserver_launcher)
+endif()

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1942,27 +1942,31 @@ J9::Options::fePreProcess(void * base)
       self()->setOption(TR_DisableAOTBytesCompression);
 
 #if defined(JITSERVER_SUPPORT)
-   // Check option -XX:+UseJITServer and/or -XX:StartAsJITServer
-   // -XX:-UseJITServer disables JITServer at the client
    static bool JITServerAlreadyParsed = false;
    if (!JITServerAlreadyParsed) // Avoid processing twice for AOT and JIT and produce duplicate messages
       {
       JITServerAlreadyParsed = true;
-
-      const char *xxUseJITServerOption = "-XX:+UseJITServer";
-      const char *xxDisableUseJITServerOption = "-XX:-UseJITServer";
-      const char *xxStartAsJITServerOption = "-XX:StartAsJITServer";
-
-      int32_t xxUseJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxUseJITServerOption, 0);
-      int32_t xxDisableUseJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxDisableUseJITServerOption, 0);
-      int32_t xxStartAsJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxStartAsJITServerOption, 0);
-
-      // Check if option is at all specified
-      if ((xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex) ||
-          (xxStartAsJITServerArgIndex >= 0))
+      if (vm->internalVMFunctions->isJITServerEnabled(vm))
          {
-         if (xxUseJITServerArgIndex > xxStartAsJITServerArgIndex) // Client mode
+         compInfo->getPersistentInfo()->setRemoteCompilationMode(JITServer::SERVER);
+         // Increase the default timeout value for JITServer.
+         // It can be overridden with -XX:JITServerTimeout= option in JITServerParseCommonOptions().
+         compInfo->getPersistentInfo()->setSocketTimeout(30000);
+         }
+      else
+         {
+         // Check option -XX:+UseJITServer
+         // -XX:-UseJITServer disables JITServer at the client
+         const char *xxUseJITServerOption = "-XX:+UseJITServer";
+         const char *xxDisableUseJITServerOption = "-XX:-UseJITServer";
+
+         int32_t xxUseJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxUseJITServerOption, 0);
+         int32_t xxDisableUseJITServerArgIndex = FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, xxDisableUseJITServerOption, 0);
+
+         // Check if option is at all specified
+         if (xxUseJITServerArgIndex > xxDisableUseJITServerArgIndex)
             {
+            j9tty_printf(PORTLIB, "JITServer is currently a technology preview. Its use is not yet supported\n");
             compInfo->getPersistentInfo()->setRemoteCompilationMode(JITServer::CLIENT);
 
             const char *xxJITServerAddressOption = "-XX:JITServerAddress=";
@@ -1975,16 +1979,8 @@ J9::Options::fePreProcess(void * base)
                compInfo->getPersistentInfo()->setJITServerAddress(address);
                }
             }
-         else // Server mode
-            {
-            compInfo->getPersistentInfo()->setRemoteCompilationMode(JITServer::SERVER);
-            // Increase the default timeout value for JITServer.
-            // It can be overridden with -XX:JITServerTimeout= option in JITServerParseCommonOptions().
-            compInfo->getPersistentInfo()->setSocketTimeout(30000);
-            }
-
-         JITServerParseCommonOptions(vm, compInfo);
          }
+      JITServerParseCommonOptions(vm, compInfo);
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
          {
          // Generate a random identifier for this JITServer instance.
@@ -1994,13 +1990,10 @@ J9::Options::fePreProcess(void * base)
          std::mt19937_64 rng(rd());
          std::uniform_int_distribution<uint64_t> dist;
          compInfo->getPersistentInfo()->setClientUID(dist(rng));
+         // _safeReservePhysicalMemoryValue is set as 0 for the JITClient because compilations
+         // are done remotely. The user can still override it with a command line option
+         J9::Options::_safeReservePhysicalMemoryValue = 0;
          }
-      }
-   // _safeReservePhysicalMemoryValue is set as 0 for the JITClient because compilations
-   // are done remotely. The user can still override it with a command line option
-   if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-      {
-      J9::Options::_safeReservePhysicalMemoryValue = 0;
       }
 #endif /* defined(JITSERVER_SUPPORT) */
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -244,6 +244,8 @@ launchGPU(J9VMThread *vmThread, jobject invokeObject,
 extern "C" void promoteGPUCompile(J9VMThread *vmThread);
 
 extern "C" int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm);
+extern "C" int32_t startJITServer(J9JITConfig *jitConfig);
+extern "C" int32_t waitJITServerTermination(J9JITConfig *jitConfig);
 
 char *AOTcgDiagOn="1";
 
@@ -1132,6 +1134,11 @@ onLoadInternal(
    TR_VerboseLog::initialize(jitConfig);
    initializePersistentMemory(jitConfig);
 
+   // set up entry point for starting JITServer
+#if defined(JITSERVER_SUPPORT)
+   jitConfig->startJITServer = startJITServer;
+   jitConfig->waitJITServerTermination = waitJITServerTermination;
+#endif /* JITSERVER_SUPPORT */
 
    TR_PersistentMemory * persistentMemory = (TR_PersistentMemory *)jitConfig->scratchSegment;
    if (persistentMemory == NULL)

--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,8 @@ void TR_Listener::startListenerThread(J9JavaVM *javaVM)
       {
       // create the thread for listening to a Client compilation request
       const UDATA defaultOSStackSize = javaVM->defaultOSStackSize; //256KB stack size
-      if (javaVM->internalVMFunctions->createThreadWithCategory(&_listenerOSThread, 
+
+      if (J9THREAD_SUCCESS != javaVM->internalVMFunctions->createJoinableThreadWithCategory(&_listenerOSThread,
                                                                defaultOSStackSize,
                                                                priority,
                                                                0,
@@ -120,4 +121,12 @@ void TR_Listener::startListenerThread(J9JavaVM *javaVM)
       {
       j9tty_printf(PORTLIB, "Error: Unable to create JITServer Listener Monitor\n");
       }
+   }
+
+int32_t TR_Listener::waitForListenerThreadExit(J9JavaVM *javaVM)
+   {
+   if (NULL != _listenerOSThread)
+      return omrthread_join(_listenerOSThread);
+   else
+      return 0;
    }

--- a/runtime/compiler/runtime/Listener.hpp
+++ b/runtime/compiler/runtime/Listener.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,7 @@ public:
    TR_Listener();
    static TR_Listener* allocate();
    void startListenerThread(J9JavaVM *javaVM);
+   int32_t waitForListenerThreadExit(J9JavaVM *javaVM);
    void setAttachAttempted(bool b) { _listenerThreadAttachAttempted = b; }
    bool getAttachAttempted() const { return _listenerThreadAttachAttempted; }
 

--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,12 @@ extern "C" {
 
 #if defined(J9VM_ENV_DATA64)
 #define J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
+#endif
+
+#if defined(J9VM_BUILD_JITSERVER)
+#ifndef JITSERVER_SUPPORT
+#define JITSERVER_SUPPORT
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -348,5 +348,11 @@ if(NOT JAVA_SPEC_VERSION LESS 14)
 	jvm_add_exports(jvm
 		# Additions for Java 14 (General)
 		JVM_GetExtendedNPEMessage
+	)
+endif()
+
+if(JITSERVER_SUPPORT)
+	jvm_add_exports(jvm
+		JITServer_CreateServer
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2007, 2019 IBM Corp. and others
+Copyright (c) 2007, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JNI_CreateJavaVM" />
 		<export name="JNI_GetCreatedJavaVMs" />
 		<export name="JNI_GetDefaultJavaVMInitArgs" />
+		<export name="JITServer_CreateServer">
+			<include-if condition="spec.flags.build_jitserver"/>
+		</export>
 	</exports>
 
 	<exports group="j9vmnatives">

--- a/runtime/jitserver_launcher/CMakeLists.txt
+++ b/runtime/jitserver_launcher/CMakeLists.txt
@@ -1,0 +1,36 @@
+################################################################################
+# Copyright (c) 2019, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
+
+add_executable(jitserver
+	jitserver.c
+)
+
+target_link_libraries(jitserver
+	PRIVATE
+		j9vm_interface
+		${CMAKE_DL_LIBS}
+)
+
+install(
+	TARGETS jitserver
+	RUNTIME DESTINATION ${j9vm_SOURCE_DIR}
+)

--- a/runtime/jitserver_launcher/jitserver.c
+++ b/runtime/jitserver_launcher/jitserver.c
@@ -1,0 +1,368 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(LINUX) || defined(J9ZTPF) || defined(J9ARM) || defined(J9AARCH64)
+#error "jitserver is only supported on Linux OS, excluding ARM and ZTPF archs"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <inttypes.h>
+#include <linux/limits.h>
+#include "j9cfg.h"
+#include "j9arch.h"
+#include "jitserver_api.h"
+#include "jitserver_error.h"
+
+#undef JITSERVER_LAUNCHER_DEBUG
+
+#define DIR_SEPARATOR_CHAR '/'
+
+#define PATH_BUFFER_LEN 512
+#define SELF_EXE "/proc/self/exe"
+
+typedef int32_t (*createJITServer)(JITServer **jitServer, void *vm_args);
+
+static void truncateOneLevel(char *path);
+static int32_t append(char **buffer, uint32_t bufLen, char *str);
+static int32_t isDir(const char *path);
+static int32_t isRegularFile(const char *path);
+static int32_t getJvmPath(char *pathBuffer, int32_t pathBufLen);
+static char * getJvmLibPath(void);
+
+static const char *jvmOptions[] = {	"-Xms8m",
+					"-Xmx8m",
+					"-Xgcthreads1",
+				};
+
+static void
+truncateOneLevel(char *path)
+{
+	char *lastLevel = NULL;
+	uint32_t index = strlen(path) - 1;
+
+#if defined(JITSERVER_LAUNCHER_DEBUG)
+	fprintf(stdout, "truncateOneLevel> on entry, path: %s\n", path);
+#endif
+
+	/* Consume any trailing '/' */
+	while (path[index] == DIR_SEPARATOR_CHAR) {
+		path[index] = '\0';
+		index -= 1;
+	}
+
+	/* Now consume the last directory if present */
+	lastLevel = strrchr(path, DIR_SEPARATOR_CHAR);
+	if (NULL != lastLevel) {
+		*lastLevel = '\0';
+	}
+
+#if defined(JITSERVER_LAUNCHER_DEBUG)
+	fprintf(stdout, "truncateOneLevel> on exit, path: %s\n", path);
+#endif
+}
+
+static int32_t
+append(char **buffer, uint32_t bufLen, char *str)
+{
+	uint32_t strLen = strlen(str);
+
+	if (strlen(*buffer) + strLen >= bufLen) {
+		uint32_t newBufLen = bufLen + strLen + PATH_BUFFER_LEN;
+		char *newBuf = realloc(*buffer, newBufLen);
+		if (NULL == newBuf) {
+			return -1;
+		}
+		strcat(newBuf, str);
+		*buffer = newBuf;
+		return 0;
+	} else {
+		strcat(*buffer, str);
+		return 0;
+	}
+}
+
+static int32_t
+isDir(const char *path)
+{
+	int32_t rc = 0;
+	struct stat statBuf = {0};
+
+	rc = stat(path, &statBuf);
+	if ((0 == rc) && (S_ISDIR(statBuf.st_mode))) {
+		return 1;
+	}
+	return 0;
+}
+
+static int32_t
+isRegularFile(const char *path)
+{
+	int32_t rc = 0;
+	struct stat statBuf = {0};
+
+	rc = stat(path, &statBuf);
+	if ((0 == rc) && (S_ISREG(statBuf.st_mode))) {
+		return 1;
+	}
+	return 0;
+}
+
+static int32_t
+getJvmPath(char *pathBuffer, int32_t pathBufLen)
+{
+	int32_t rc = 0;
+
+#if JAVA_SPEC_VERSION == 8
+	/* pathBuffer can be either <jdk_home> or <jdk_home>/jre or <jre_home> */
+	char *lastLevel = strrchr(pathBuffer, DIR_SEPARATOR_CHAR);
+
+	if ((NULL != lastLevel) && (strcmp(lastLevel + 1, "jre") == 0)) {
+		/* pathBuffer is at <jdk_home>/jre */
+		rc = append(&pathBuffer, pathBufLen, "/lib/" OPENJ9_ARCH_DIR);
+	} else {
+		/* pathBuffer is at <jdk_home> or <jre_home> */
+		rc = append(&pathBuffer, pathBufLen, "/jre");
+		if (0 != rc) {
+			fprintf(stderr, "Failed to allocated memory for path buffer\n");
+			goto _end;
+		}
+		if (isDir(pathBuffer)) {
+			/* pathBuffer is at <jdk_home>/jre */
+			rc = append(&pathBuffer, pathBufLen, "/lib/" OPENJ9_ARCH_DIR);
+		} else {
+			/* pathBuffer is at <jre_home> */
+			truncateOneLevel(pathBuffer);
+			rc = append(&pathBuffer, pathBufLen, "/lib/" OPENJ9_ARCH_DIR);
+		}
+	}
+#else
+	rc = append(&pathBuffer, pathBufLen, "/lib");
+#endif /* JAVA_SPEC_VERSION */
+	if (0 != rc) {
+		fprintf(stderr, "Failed to allocated memory for path buffer\n");
+		goto _end;
+	}
+
+	/* try "compressedrefs" first */
+	rc = append(&pathBuffer, pathBufLen, "/" OPENJ9_CR_JVM_DIR);
+	if (0 != rc) {
+		fprintf(stderr, "Failed to allocated memory for path buffer\n");
+		goto _end;
+	}
+	rc = isDir(pathBuffer);
+	if (0 == rc) {
+		/* "compressedrefs" is not present, try "noncr" now */
+		truncateOneLevel(pathBuffer);
+#if defined(JITSERVER_LAUNCHER_DEBUG)
+		fprintf(stdout, "getJvmPath> failed to find \"compressedrefs\" dir, looking for \"default\" dir now\n");
+#endif /* JITSERVER_LAUNCHER_DEBUG */
+		rc = append(&pathBuffer, pathBufLen, "/" OPENJ9_NOCR_JVM_DIR);
+		if (0 != rc) {
+			fprintf(stderr, "Failed to allocated memory for path buffer\n");
+			goto _end;
+		}
+		rc = isDir(pathBuffer);
+		if (0 == rc) {
+			fprintf(stderr, "Failed to find any recognized JVM\n");
+			rc = -1;
+			goto _end;
+		}
+	}
+#if defined(JITSERVER_LAUNCHER_DEBUG)
+	fprintf(stdout, "getJvmPath> path: %s\n", pathBuffer);
+#endif
+	rc = 0; /* success */
+
+_end:
+	return rc;
+}
+
+static char *
+getJvmLibPath(void)
+{
+	char *jvmLibPath = NULL;
+	uint32_t jvmLibPathLen = 0;
+	int32_t rc = 0;
+
+	do {
+		jvmLibPathLen += PATH_BUFFER_LEN;
+		jvmLibPath = malloc(jvmLibPathLen);
+		if (NULL == jvmLibPath) {
+			fprintf(stderr, "Failed to allocate memory for jvm library\n");
+			goto _end;
+		}
+		rc = readlink(SELF_EXE, jvmLibPath, jvmLibPathLen);
+		if (-1 == rc) {
+			free(jvmLibPath);
+			jvmLibPath = NULL;
+			goto _end;
+		} else if (jvmLibPathLen == rc) {
+			/* path is probably truncated, try again with larger buffer */
+			free(jvmLibPath);
+		}
+	} while (jvmLibPathLen == rc);
+
+	jvmLibPath[rc] = '\0';
+
+	/* selfPath could be one of the following:
+	 *  - <jdk_home>/bin/jitserver for Java 9+
+	 *  - <jdk_home>/jre/bin/jitserver for Java 8
+	 *  - <jdk_home>/bin/jitserver for Java 8
+	 *  - <jre_home>/bin/jitserver for Java 8
+	 *
+	 * libjvm.so can be at the following locations:
+	 *  - <jdk_home>/lib/<jvm_type>/libjvm.so for Java 9+
+	 *  - <jdk_home>/jre/lib/amd64/<jvm_type>/libjvm.so for Java 8
+	 *  - <jre_home>/lib/amd64/<jvm_type>/libjvm.so for Java 8
+	 * where <jvm_type> can be "compressedrefs" or "default"
+	 */
+
+	/* Remove at least two entries from the path. */
+	truncateOneLevel(jvmLibPath);
+	truncateOneLevel(jvmLibPath);
+	/* Now jvmLibPath is either <jdk_home> (Java 9+, Java 8) or <jdk_home>/jre (Java 8) or <jre_home> (Java 8) */
+
+	rc = getJvmPath(jvmLibPath, jvmLibPathLen);
+	if (0 != rc) {
+		goto _end;
+	}
+
+	rc = append(&jvmLibPath, jvmLibPathLen, "/libjvm.so");
+	if (0 != rc) {
+		fprintf(stderr, "Failed to allocated memory for path buffer\n");
+		free(jvmLibPath);
+		jvmLibPath = NULL;
+		goto _end;
+	}
+
+#if defined(JITSERVER_LAUNCHER_DEBUG)
+	fprintf(stdout, "getJvmLibPath> jvmLibPath: %s\n", jvmLibPath);
+#endif
+
+	/* Final check for libjvm.so */
+	rc = isRegularFile(jvmLibPath);
+	if (1 != rc) {
+		fprintf(stderr, "Failed to find JVM library libjvm.so at expected location %s\n", jvmLibPath);
+		goto _end;
+	}
+	rc = 0; /* success */
+
+_end:
+	if ((0 != rc) && (NULL != jvmLibPath)) {
+		free(jvmLibPath);
+		jvmLibPath = NULL;
+	}
+	return jvmLibPath;
+}
+
+int
+main(int argc, char *argv[])
+{
+	JavaVM *jvm = NULL;
+	JNIEnv *env = NULL;
+	JITServer *server = NULL;
+	JavaVMOption *options = NULL;
+	JavaVMInitArgs vmArgs = {0};
+	void *libHandle = NULL;
+	char *jvmLibPath = NULL;
+	int32_t rc = 0;
+	int32_t i = 0;
+	int32_t argIndex = 0;
+	int32_t numJvmOptions = 0;
+	createJITServer createServer = NULL;
+
+	fprintf(stderr, "JITServer is currently a technology preview. Its use is not yet supported\n");
+
+	jvmLibPath = getJvmLibPath();
+	if (NULL == jvmLibPath) {
+		fprintf(stderr, "Failed to find libjvm.so\n");
+		rc = -1;
+		goto _end;
+	}
+	dlerror(); /* clear any old error conditions */
+	libHandle = (void*)dlopen(jvmLibPath, RTLD_NOW);
+	if (NULL == libHandle) {
+		fprintf(stderr, "%s\n", dlerror());
+		rc = -1;
+		goto _end;
+	}
+
+	createServer = (createJITServer) dlsym(libHandle, "JITServer_CreateServer");
+	if (NULL == createServer) {
+		fprintf(stderr, "%s\n", dlerror());
+		rc = -1;
+		goto _end;
+	}
+
+	vmArgs.version = JNI_VERSION_1_6;
+	vmArgs.nOptions = 0;
+	vmArgs.ignoreUnrecognized = JNI_TRUE;
+	vmArgs.options = NULL;
+
+	numJvmOptions = (argc - 1) + (sizeof(jvmOptions) / sizeof(char *));
+	options = malloc(sizeof(JavaVMOption) * numJvmOptions);
+	if (NULL == options) {
+		fprintf(stderr, "Insufficient memory to allocate JavaVMOption\n");
+		rc = -1;
+		goto _end;
+	}
+	vmArgs.options = options;
+
+	for (i = 0, argIndex = 0; i < (sizeof(jvmOptions) / sizeof(char *)); i++, argIndex++) {
+		options[argIndex].optionString = (char *)jvmOptions[i];
+	}
+	for (i = 1; i < argc; i++, argIndex++) {
+		options[argIndex].optionString = argv[i];
+	}
+	vmArgs.nOptions = argIndex;
+
+	rc = createServer(&server, &vmArgs);
+	if (JITSERVER_OK != rc) {
+		fprintf(stderr, "JITServer_CreateServer failed, error code=%d\n", rc);
+		goto _end;
+	}
+
+	rc = server->startJITServer(server);
+	if (JITSERVER_OK != rc) {
+		fprintf(stderr, "startJITServer failed, error code=%d\n", rc);
+		goto _end;
+	}
+	fprintf(stderr, "\nJITServer is ready to accept incoming requests\n");
+
+	rc = server->waitForJITServerTermination(server);
+	if (JITSERVER_OK != rc) {
+		fprintf(stderr, "waitForJITServerTermination failed, error code=%d\n", rc);
+		goto _end;
+	}
+
+	free(jvmLibPath);
+	free(options);
+
+_end:
+	return rc;
+}

--- a/runtime/jitserver_launcher/module.xml
+++ b/runtime/jitserver_launcher/module.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2019, 2020 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<module xmlns:xi="http://www.w3.org/2001/XInclude">
+	<artifact type="executable" name="jitserver">
+		<include-if condition="spec.flags.build_jitserver"/>
+		<options>
+			<option name="doesNotRequireCMAIN"/>
+		</options>
+
+		<phase>core quick j2se</phase>
+		<includes>
+			<include path="j9include"/>
+			<include path="j9oti"/>
+		</includes>
+		<makefilestubs>
+			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+		</makefilestubs>
+		<objects>
+			<object name="jitserver"/>
+		</objects>
+		<libraries>
+			<library name="dl" type="system"/>
+		</libraries>
+	</artifact>
+
+</module>

--- a/runtime/oti/j9arch.h
+++ b/runtime/oti/j9arch.h
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef j9arch_h
+#define j9arch_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#if defined(RS6000) || defined(LINUXPPC)
+#ifdef PPC64
+#ifdef J9VM_ENV_LITTLE_ENDIAN
+#define OPENJ9_ARCH_DIR "ppc64le"
+#else /* J9VM_ENV_LITTLE_ENDIAN */
+#define OPENJ9_ARCH_DIR "ppc64"
+#endif /* J9VM_ENV_LITTLE_ENDIAN */
+#else
+#define OPENJ9_ARCH_DIR "ppc"
+#endif /* PPC64*/
+#elif defined(J9X86) || defined(WIN32)
+#define OPENJ9_ARCH_DIR "i386"
+#elif defined(S390) || defined(J9ZOS390)
+#if defined(S39064) || defined(J9ZOS39064)
+#define OPENJ9_ARCH_DIR "s390x"
+#else
+#define OPENJ9_ARCH_DIR "s390"
+#endif /* S39064 || J9ZOS39064 */
+#elif defined(J9HAMMER)
+#define OPENJ9_ARCH_DIR "amd64"
+#elif defined(J9ARM)
+#define OPENJ9_ARCH_DIR "arm"
+#elif defined(J9AARCH64)
+#define OPENJ9_ARCH_DIR "aarch64"
+#else
+#error "Must define an architecture"
+#endif
+
+#define OPENJ9_CR_JVM_DIR "compressedrefs"
+#define OPENJ9_NOCR_JVM_DIR "default"
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* j9arch_h */

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -330,6 +330,7 @@ extern "C" {
 #define J9_EXTENDED_RUNTIME2_LOAD_AGENT_MODULE 0x8
 #define J9_EXTENDED_RUNTIME2_ENABLE_DEEPSCAN 0x10
 #define J9_EXTENDED_RUNTIME2_ENABLE_CLASS_RELATIONSHIP_VERIFIER 0x20
+#define J9_EXTENDED_RUNTIME2_ENABLE_START_JITSERVER 0x40
 
 
 /* TODO: Define this until the JIT removes it */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
@@ -3757,6 +3757,10 @@ typedef struct J9JITConfig {
 	void ( *jitIllegalFinalFieldModification)(struct J9VMThread *currentThread, struct J9Class *fieldClass);
 	U_8* (*codeCacheWarmAlloc)(void *codeCache);
 	U_8* (*codeCacheColdAlloc)(void *codeCache);
+#if defined(JITSERVER_SUPPORT)
+	int32_t (*startJITServer)(struct J9JITConfig *jitConfig);
+	int32_t (*waitJITServerTermination)(struct J9JITConfig *jitConfig);
+#endif /* JITSERVER_SUPPORT */
 } J9JITConfig;
 
 #define J9JIT_GROW_CACHES  0x100000
@@ -4801,6 +4805,10 @@ typedef struct J9InternalVMFunctions {
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	BOOLEAN ( *areValueTypesEnabled)(struct J9JavaVM *vm);
 	J9Class* ( *peekClassHashTable)(struct J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* className, UDATA classNameLength);
+#if defined(JITSERVER_SUPPORT)
+	BOOLEAN ( *isJITServerEnabled )(struct J9JavaVM *vm);
+#endif /* JITSERVER_SUPPORT */
+	IDATA ( *createJoinableThreadWithCategory)(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend, omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category) ;
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/jitserver_api.h
+++ b/runtime/oti/jitserver_api.h
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef jitserver_api_h
+#define jitserver_api_h
+
+#include "jni.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct JITServer; /* Forward declaration */
+
+typedef struct JITServer {
+	int32_t (* startJITServer)(struct JITServer *);
+	int32_t (* waitForJITServerTermination)(struct JITServer *);
+	JavaVM *jvm;
+} JITServer;
+
+/**
+ * Creates an instance of JITServer.
+ *
+ * @param jitServer pointer to the location where the JITServer interface
+ *			pointer will be placed
+ * @param serverArgs arguments passed to JITServer
+ *
+ * @returns zero on success, else negative error code
+ */
+int32_t JNICALL
+JITServer_CreateServer(JITServer **jitServer, void *serverArgs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* jitserver_api_h */

--- a/runtime/oti/jitserver_error.h
+++ b/runtime/oti/jitserver_error.h
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef jitserver_error_h
+#define jitserver_error_h
+
+#define JITSERVER_OK 0
+
+#define JITSERVER_OOM -1
+#define JITSERVER_CREATE_FAILED -2
+#define JITSERVER_STARTUP_FAILED -3
+#define JITSERVER_THREAD_ATTACH_FAILED -4
+#define JITSERVER_WAIT_TERM_FAILED -5
+#endif /* jitserver_error_h */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,6 +45,7 @@ extern "C" {
 #define J9_CREATEJAVAVM_ARGENCODING_LATIN 2
 #define J9_CREATEJAVAVM_ARGENCODING_UTF8 4
 #define J9_CREATEJAVAVM_ARGENCODING_PLATFORM 8
+#define J9_CREATEJAVAVM_START_JITSERVER 16
 
 typedef struct J9CreateJavaVMParams {
 	UDATA j2seVersion;
@@ -1623,6 +1624,19 @@ registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler);
  */
 IDATA
 registerOSHandler(J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
+
+#if defined(JITSERVER_SUPPORT)
+/**
+ * @brief checks if the runtime flag for enabling JITServer is set or not
+ *
+ * @param[in] vm pointer to a J9JavaVM
+ *
+ * @return TRUE if the flag for JITServer is set, FALSE otherwise
+ */
+BOOLEAN
+isJITServerEnabled(J9JavaVM *vm);
+
+#endif /* JITSERVER_SUPPORT */
 
 /* ---------------- romutil.c ---------------- */
 
@@ -4140,6 +4154,28 @@ getMonitorForWait (J9VMThread* vmThread, j9object_t object);
  */
 IDATA
 createThreadWithCategory(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend,
+	omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category);
+
+/**
+ * Helper function to create a joinable thread with a specific thread category.
+ *
+ * @param[out] handle a pointer to a omrthread_t which will point to the thread (if successfully created)
+ * @param[in] stacksize the size of the new thread's stack (bytes)<br>
+ *			0 indicates use default size
+ * @param[in] priority priorities range from J9THREAD_PRIORITY_MIN to J9THREAD_PRIORITY_MAX (inclusive)
+ * @param[in] suspend set to non-zero to create the thread in a suspended state.
+ * @param[in] entrypoint pointer to the function which the thread will run
+ * @param[in] entryarg a value to pass to the entrypoint function
+ * @param[in] category category of the thread to be created
+ *
+ * @return success or error code
+ * @retval J9THREAD_SUCCESS success
+ * @retval J9THREAD_ERR_xxx failure
+ *
+ * @see omrthread_create
+ */
+IDATA
+createJoinableThreadWithCategory(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend,
 	omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category);
 
 /**

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -370,4 +370,8 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif
 	areValueTypesEnabled,
 	peekClassHashTable,
+#if defined(JITSERVER_SUPPORT)
+	isJITServerEnabled,
+#endif /* JITSERVER_SUPPORT */
+	createJoinableThreadWithCategory,
 };

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -597,6 +597,14 @@ areValueTypesEnabled(J9JavaVM *vm)
 	return J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VALHALLA);
 }
 
+#if defined(JITSERVER_SUPPORT)
+BOOLEAN
+isJITServerEnabled(J9JavaVM *vm)
+{
+	return J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_START_JITSERVER);
+}
+#endif /* JITSERVER_SUPPORT */
+
 void
 freeJavaVM(J9JavaVM * vm)
 {
@@ -993,6 +1001,11 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	if (J9_ARE_ALL_BITS_SET(createParams->flags, J9_CREATEJAVAVM_ARGENCODING_PLATFORM)) {
 		vm->runtimeFlags |= J9_RUNTIME_ARGENCODING_UNICODE;
 	}
+#if defined(JITSERVER_SUPPORT)
+	if (J9_ARE_ALL_BITS_SET(createParams->flags, J9_CREATEJAVAVM_START_JITSERVER)) {
+		vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_START_JITSERVER;
+	}
+#endif /* JITSERVER_SUPPORT */
 
 	initArgs.j2seVersion = createParams->j2seVersion;
 	initArgs.j2seRootDirectory = createParams->j2seRootDirectory;


### PR DESCRIPTION
Added a new JITServer interface that provides APIs for starting
the JITServer. It is used by jitserver launcher to start the JITServer.
This allows elimination of '-XX:StartAsJITServer' option.
All the new code related to JITServer launcher is guarded with
JITSERVER_SUPPORT macro.
A new flag 'build_jitserver' in j9.flags has been added which
translates to J9VM_BUILD_JITSERVER macro.
In j9cfg.h.ftl if J9VM_BUILD_JITSERVER is defined then we define
the macro JITSERVER_SUPPORT.
Currently 'build_jitserver' flag is set to false on all buildspecs.
Only when '--enable-jitserver' is passed to the configure.sh when
building OpenJ9, 'build_jitserver' gets set to true in the buildspec
being used.

Cherry pick of #7940 for the 0.18.0 release.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>