### PR TITLE
Retrieve constant dynamic info from the JITClient

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1080,7 +1080,7 @@ TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateConstantDynamicSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, char* symbolTypeSig, int32_t symbolTypeSigLength, bool isCondyPrimitive)
    {
    TR_ResolvedMethod * owningMethod = owningMethodSymbol->getResolvedMethod();
-   void * dynamicConst = owningMethod->dynamicConstant(cpIndex);
+   void * dynamicConst = owningMethod->dynamicConstant(cpIndex, NULL);
    TR::SymbolReference * symRef;
    if (owningMethod->isUnresolvedConstantDynamic(cpIndex))
       {

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6045,10 +6045,15 @@ TR_ResolvedJ9Method::isUnresolvedConstantDynamic(I_32 cpIndex)
    }
 
 void *
-TR_ResolvedJ9Method::dynamicConstant(I_32 cpIndex)
+TR_ResolvedJ9Method::dynamicConstant(I_32 cpIndex, uintptrj_t *obj)
    {
    TR_ASSERT_FATAL(cpIndex != -1, "ConstantDynamic cpIndex shouldn't be -1");
-   return &((J9RAMConstantDynamicRef *) literals())[cpIndex].value;
+   uintptrj_t *objLocation = (uintptrj_t *)&(((J9RAMConstantDynamicRef *) literals())[cpIndex].value);
+   if (obj)
+      {
+      *obj = *objLocation;
+      }
+   return objLocation;
    }
 
 bool

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -397,10 +397,15 @@ public:
     *  \param cpIndex
     *     The constant pool index of the constant dynamic.
     *
+    *  \param obj
+    *     Return the resolved constant dynamic value.
+    *
     *  \return
     *     Opaque pointer to the slot containing the resolved constant dynamic value.
+    *     The returned pointer should always be dereferenced by using the passed-in
+    *     parameter "obj".
     */
-   virtual void *                  dynamicConstant(int32_t cpIndex);
+   virtual void *                  dynamicConstant(int32_t cpIndex, uintptrj_t *obj);
    virtual void *                  methodTypeConstant(int32_t cpIndex);
    virtual bool                    isUnresolvedMethodType(int32_t cpIndex);
    virtual void *                  methodHandleConstant(int32_t cpIndex);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -156,7 +156,12 @@ public:
    virtual TR_OpaqueClassBlock * getClassFromConstantPool( TR::Compilation *, uint32_t cpIndex, bool returnClassToAOT = false) override;
    virtual TR_OpaqueClassBlock * getDeclaringClassFromFieldOrStatic( TR::Compilation *comp, int32_t cpIndex) override;
    virtual TR_OpaqueClassBlock * classOfStatic(int32_t cpIndex, bool returnClassForAOT = false) override;
+
+   virtual void * getConstantDynamicTypeFromCP(int32_t cpIndex) override;
    virtual bool isConstantDynamic(I_32 cpIndex) override;
+   virtual bool isUnresolvedConstantDynamic(int32_t cpIndex) override;
+   virtual void * dynamicConstant(int32_t cpIndex, uintptrj_t *obj) override;
+
    virtual bool isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false) override;
    virtual TR_ResolvedMethod * getResolvedVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP) override;
    virtual TR_ResolvedMethod *   getResolvedPossiblyPrivateVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP) override;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -5466,8 +5466,8 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
             if (!isCondyPrimitive && !isCondyUnresolved)
                {
                TR::VMAccessCriticalSection condyCriticalSection(comp()->fej9());
-               uintptrj_t* objLocation = (uintptrj_t*)_methodSymbol->getResolvedMethod()->dynamicConstant(cpIndex);
-               uintptrj_t obj = *objLocation;
+               uintptrj_t obj = 0;
+               uintptrj_t* objLocation = (uintptrj_t*)_methodSymbol->getResolvedMethod()->dynamicConstant(cpIndex, &obj);
                if (obj == 0)
                   {
                   loadConstant(TR::aconst, (void *)0);
@@ -5568,8 +5568,8 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
                                                             comp());
                   if (primitiveCondyCriticalSection.hasVMAccess())
                      {
-                     uintptrj_t* objLocation = (uintptrj_t*)_methodSymbol->getResolvedMethod()->dynamicConstant(cpIndex);
-                     uintptrj_t obj = *objLocation;
+                     uintptrj_t obj = 0;
+                     uintptrj_t* objLocation = (uintptrj_t*)_methodSymbol->getResolvedMethod()->dynamicConstant(cpIndex, &obj);
                      TR_ASSERT(obj, "Resolved primitive Constant Dynamic-type CP entry %d must have autobox object", cpIndex);
                      switch (returnTypeUtf8Data[0])
                         {

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -158,7 +158,7 @@ protected:
    ZeroCopyOutputStream *_outputStream;
 
    static const uint8_t MAJOR_NUMBER = 0;
-   static const uint16_t MINOR_NUMBER = 2;
+   static const uint16_t MINOR_NUMBER = 3;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
    };

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -113,6 +113,10 @@ enum MessageType
    ResolvedMethod_varHandleMethodTypeTableEntryAddress = 152;
    ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry = 153;
 
+   ResolvedMethod_getConstantDynamicTypeFromCP = 154;
+   ResolvedMethod_isUnresolvedConstantDynamic = 155;
+   ResolvedMethod_dynamicConstant = 156;
+
    ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 160;
    ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 161;
    ResolvedRelocatableMethod_fieldAttributes = 162;


### PR DESCRIPTION
Dynamic constant is not stored at the `JITServer`. It needs to be retrieved from the client side. This PR has dependency on the new `dynamicConstant` API defined in eclipse/omr#4726. 

Also increased the JITServer `MINOR_NUMBER` to `3` since the new message types have to be handled at the client as well.

This commit fixes the server crash when running `Java 11` sanity test `CondyPrimitive_1`.

Related to #7567.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>