### PR TITLE
Fix Assert due to live register

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -673,6 +673,7 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
    cg->stopUsingRegister(maxIndexReg);
    cg->stopUsingRegister(s2VecStartIndexReg);
    cg->stopUsingRegister(loadLenReg);
+   cg->stopUsingRegister(fromIndexReg);
 
    cg->stopUsingRegister(s1PartialVReg);
    cg->stopUsingRegister(s2PartialVReg);


### PR DESCRIPTION
In the evaluator to inline stringIndexOf, a register was not marked dead after it was not needed. This was causing an assert in build with ASSERTS enabled. This commit fixes the issue.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>