### PR TITLE
Add empty default case to switch() to fix compile error for xlc 16

### DIFF
--- a/runtime/compiler/p/runtime/Emulation.c
+++ b/runtime/compiler/p/runtime/Emulation.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -783,6 +783,10 @@ int32_t p9emu_process(p9emu_ctx_t *ctx, ucontext_t *uctx)
          break;
       case P9EMU_MADDLD:
          maddld(insn, gpregs);
+         break;
+      default:
+         /* Do nothing */
+         /* this is to avoid compiler warnings for unhandled enumeration values */
          break;
       }
 


### PR DESCRIPTION
Unhandled enumeration values in switch statement generates an warning
that is treated as error for xlc 16 compiler. Added empty default case
to avoid compilation error.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>