### PR TITLE
Fix options for valhalla tests

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2017, 2019 IBM Corp. and others
+  Copyright (c) 2017, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,13 +25,12 @@
 	<test>
 		<testCaseName>ValueTypeTests</testCaseName>
 		<variations>
-                  <variation>-XX:ValueTypeFlatteningThreshold=1</variation>
-		  <variation>NoOptions</variation>
-          	</variations>
+			<variation>-XX:ValueTypeFlatteningThreshold=1</variation>
+			<variation>-Xgcpolicy:nogc</variation>
+		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xverify:none \
 		-Xint \
-		-Xgcpolicy:nogc \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		-XX:+EnableValhalla \
 		-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1381,7 +1381,7 @@ public class ValueTypeTests {
 	 * 	int y;
 	 * }
 	 */
-	@Test(priority=1)
+	@Test(enabled = false, priority=1)
 	static public void testCreateLargeNumberOfPoint2D() throws Throwable {
 		String fields[] = {"x:I", "y:I"};
 		String className = "Point2D";


### PR DESCRIPTION
Fix options for valhalla tests

Some of the existing tests cannot pass with the noGC options. The noGC
option is required while the GC work on scanning flattened arrays is
still underway. noGC is not required when when flattening is disabled.
The variation options are updated to reflect this.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>