### PR TITLE
Add walkReferenceChain JITServer Support

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1014,8 +1014,6 @@ public:
    void markCHTableUpdateDone(uint8_t threadId) { _chTableUpdateFlags |= (1 << threadId); }
    void resetCHTableUpdateDone(uint8_t threadId) { _chTableUpdateFlags &= ~(1 << threadId); }
    uint8_t getCHTableUpdateDone() const { return _chTableUpdateFlags; }
-   uint32_t getLocalGCCounter() const { return _localGCCounter; }
-   void incrementLocalGCCounter() { _localGCCounter++; }
 
    const PersistentVector<std::string> &getJITServerSslKeys() const { return _sslKeys; }
    void  addJITServerSslKey(const std::string &key) { _sslKeys.push_back(key); }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1049,8 +1049,6 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
       {
       _classesThatShouldNotBeNewlyExtended = NULL;
       }
-
-   _lastLocalGCCounter = 0;
 #endif /* defined(JITSERVER_SUPPORT) */
    }
 
@@ -12854,12 +12852,6 @@ TR::CompilationInfo::canRelocateMethod(TR::Compilation *comp)
    }
 
 #if defined(JITSERVER_SUPPORT)
-void
-TR::CompilationInfoPerThread::updateLastLocalGCCounter()
-   {
-   _lastLocalGCCounter = getCompilationInfo()->getLocalGCCounter();
-   }
-
 // This method is executed by the JITServer to queue a placeholder for
 // a compilation request received from the client. At the time the new
 // entry is queued we do not know any details about the compilation request.

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -393,8 +393,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    J9ROMClass               *getAndCacheRemoteROMClass(J9Class *, TR_Memory *trMemory=NULL);
    J9ROMClass               *getRemoteROMClassIfCached(J9Class *);
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() const { return _classesThatShouldNotBeNewlyExtended; }
-   uint32_t                  getLastLocalGCCounter() const { return _lastLocalGCCounter; }
-   void                      updateLastLocalGCCounter();
 #endif /* defined(JITSERVER_SUPPORT) */
 
    protected:
@@ -418,7 +416,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    // The following hastable caches <classLoader,classname> --> <J9Class> mappings
    // The cache only lives during a compilation due to class unloading concerns
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;
-   uint32_t               _lastLocalGCCounter;
 #endif /* defined(JITSERVER_SUPPORT) */
 
    }; // CompilationInfoPerThread

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1563,11 +1563,6 @@ static void jitHookLocalGCEnd(J9HookInterface * * hookInterface, UDATA eventNum,
 
    if (jitConfig->runtimeFlags & J9JIT_GC_NOTIFY)
       printf("}");
-
-#if defined(JITSERVER_SUPPORT)
-   TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);
-   compInfo->incrementLocalGCCounter();
-#endif
    }
 
 static void initThreadAfterCreation(J9VMThread *vmThread)

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2376,10 +2376,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, permuteLength, argIndices);
          }
          break;
-      case MessageType::runFEMacro_invokeILGenMacros:
+      case MessageType::runFEMacro_invokeILGenMacrosParameterCount:
          {
          auto recv = client->getRecvData<uintptrj_t*, std::vector<uintptrj_t> >();
-         TR::VMAccessCriticalSection invokeILGenMacros(fe);
+         TR::VMAccessCriticalSection invokeILGenMacrosParameterCount(fe);
          uintptrj_t receiverHandle = *std::get<0>(recv);
          std::vector<uintptrj_t> listOfOffsets = std::get<1>(recv);
          uintptrj_t methodHandle = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
@@ -2391,7 +2391,29 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, parameterCount);
          }
          break;
-
+      case MessageType::runFEMacro_invokeILGenMacrosArrayLength:
+         {
+         auto recv = client->getRecvData<uintptrj_t*, std::vector<uintptrj_t> >();
+         TR::VMAccessCriticalSection invokeILGenMacrosArrayLength(fe);
+         uintptrj_t receiverHandle = *std::get<0>(recv);
+         std::vector<uintptrj_t> listOfOffsets = std::get<1>(recv);
+         uintptrj_t array = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
+         int32_t arrayLength = (int32_t)fej9->getArrayLengthInElements(array);
+         client->write(response, arrayLength);
+         }
+         break;
+      case MessageType::runFEMacro_invokeILGenMacrosGetField:
+         {
+         auto recv = client->getRecvData<uintptrj_t*, uintptrj_t, std::vector<uintptrj_t> >();
+         TR::VMAccessCriticalSection invokeILGenMacrosGetField(fe);
+         uintptrj_t receiverHandle = *std::get<0>(recv);
+         uintptrj_t fieldOffset = std::get<1>(recv);
+         std::vector<uintptrj_t> listOfOffsets = std::get<2>(recv);
+         uintptrj_t baseObject = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
+         int32_t result = fej9->getInt32FieldAt(baseObject, fieldOffset);;
+         client->write(response, result);
+         }
+         break;
       case MessageType::CHTable_getAllClassInfo:
          {
          client->getRecvData<JITServer::Void>();

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2054,7 +2054,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptrj_t*, std::vector<uintptrj_t> >();
          TR::VMAccessCriticalSection invokeILGenMacrosInvokeExactAndFixup(fe);
          uintptrj_t receiverHandle = *std::get<0>(recv);
-         std::vector<uintptrj_t> listOfOffsets = std::get<1>(recv);
+         const std::vector<uintptrj_t>& listOfOffsets = std::get<1>(recv);
          uintptrj_t methodHandle = listOfOffsets.size() == 0 ? receiverHandle : JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
          uintptrj_t methodDescriptorRef = fe->getReferenceField(fe->getReferenceField(
             methodHandle,
@@ -2394,7 +2394,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptrj_t*, std::vector<uintptrj_t> >();
          TR::VMAccessCriticalSection invokeILGenMacrosParameterCount(fe);
          uintptrj_t receiverHandle = *std::get<0>(recv);
-         std::vector<uintptrj_t> listOfOffsets = std::get<1>(recv);
+         const std::vector<uintptrj_t>& listOfOffsets = std::get<1>(recv);
          uintptrj_t methodHandle = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
          uintptrj_t arguments = fe->getReferenceField(fe->getReferenceField(
             methodHandle,
@@ -2409,7 +2409,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptrj_t*, std::vector<uintptrj_t> >();
          TR::VMAccessCriticalSection invokeILGenMacrosArrayLength(fe);
          uintptrj_t receiverHandle = *std::get<0>(recv);
-         std::vector<uintptrj_t> listOfOffsets = std::get<1>(recv);
+         const std::vector<uintptrj_t>& listOfOffsets = std::get<1>(recv);
          uintptrj_t array = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
          int32_t arrayLength = (int32_t)fe->getArrayLengthInElements(array);
          client->write(response, arrayLength);
@@ -2421,7 +2421,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          TR::VMAccessCriticalSection invokeILGenMacrosGetField(fe);
          uintptrj_t receiverHandle = *std::get<0>(recv);
          uintptrj_t fieldOffset = std::get<1>(recv);
-         std::vector<uintptrj_t> listOfOffsets = std::get<2>(recv);
+         const std::vector<uintptrj_t>& listOfOffsets = std::get<2>(recv);
          uintptrj_t baseObject = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
          int32_t result = fe->getInt32FieldAt(baseObject, fieldOffset);
          client->write(response, result);

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2063,14 +2063,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, ptr);
          }
          break;
-      case MessageType::runFEMacro_derefUintptrjPtr:
-         {
-         // should not be used anymore
-         TR::VMAccessCriticalSection deref(fe);
-         compInfoPT->updateLastLocalGCCounter();
-         client->write(response, *std::get<0>(client->getRecvData<uintptrj_t*>()));
-         }
-         break;
       case MessageType::runFEMacro_invokeILGenMacrosInvokeExactAndFixup:
          {
          auto recv = client->getRecvData<uintptrj_t*, std::vector<uintptrj_t> >();
@@ -2398,7 +2390,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptrj_t receiverHandle = *std::get<0>(recv);
          std::vector<uintptrj_t> listOfOffsets = std::get<1>(recv);
          uintptrj_t array = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
-         int32_t arrayLength = (int32_t)fej9->getArrayLengthInElements(array);
+         int32_t arrayLength = (int32_t)fe->getArrayLengthInElements(array);
          client->write(response, arrayLength);
          }
          break;
@@ -2410,7 +2402,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          uintptrj_t fieldOffset = std::get<1>(recv);
          std::vector<uintptrj_t> listOfOffsets = std::get<2>(recv);
          uintptrj_t baseObject = JITServerHelpers::walkReferenceChainWithOffsets(fe, listOfOffsets, receiverHandle);
-         int32_t result = fej9->getInt32FieldAt(baseObject, fieldOffset);;
+         int32_t result = fe->getInt32FieldAt(baseObject, fieldOffset);
          client->write(response, result);
          }
          break;

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -656,13 +656,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          break;
       case MessageType::VM_getInt32FieldAt:
          {
-         if (compInfoPT->getLastLocalGCCounter() != compInfoPT->getCompilationInfo()->getLocalGCCounter())
-            {
-            // GC happened, fail compilation
-            auto comp = compInfoPT->getCompilation();
-            comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted due to GC");
-            }
-
          auto recv = client->getRecvData<uintptrj_t, uintptrj_t>();
          uintptrj_t objectPointer = std::get<0>(recv);
          uintptrj_t fieldOffset = std::get<1>(recv);
@@ -699,13 +692,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          break;
       case MessageType::VM_getArrayLengthInElements:
          {
-         if (compInfoPT->getLastLocalGCCounter() != compInfoPT->getCompilationInfo()->getLocalGCCounter())
-            {
-            // GC happened, fail compilation
-            auto comp = compInfoPT->getCompilation();
-            comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted due to GC");
-            }
-
          uintptrj_t objectPointer = std::get<0>(client->getRecvData<uintptrj_t>());
          client->write(response, fe->getArrayLengthInElements(objectPointer));
          }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -659,6 +659,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptrj_t, uintptrj_t>();
          uintptrj_t objectPointer = std::get<0>(recv);
          uintptrj_t fieldOffset = std::get<1>(recv);
+         TR::VMAccessCriticalSection getInt32FieldAt(fe);
          client->write(response, fe->getInt32FieldAt(objectPointer, fieldOffset));
          }
          break;
@@ -667,6 +668,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<uintptrj_t, uintptrj_t>();
          uintptrj_t objectPointer = std::get<0>(recv);
          uintptrj_t fieldOffset = std::get<1>(recv);
+         TR::VMAccessCriticalSection getInt64FieldAt(fe);
          client->write(response, fe->getInt64FieldAt(objectPointer, fieldOffset));
          }
          break;
@@ -693,6 +695,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
       case MessageType::VM_getArrayLengthInElements:
          {
          uintptrj_t objectPointer = std::get<0>(client->getRecvData<uintptrj_t>());
+         TR::VMAccessCriticalSection getArrayLengthInElements(fe);
          client->write(response, fe->getArrayLengthInElements(objectPointer));
          }
          break;

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include "control/JITServerCompilationThread.hpp"
 #include "control/MethodToBeCompiled.hpp"
 #include "infra/CriticalSection.hpp"
+
 
 uint32_t     JITServerHelpers::serverMsgTypeCount[] = {};
 uint64_t     JITServerHelpers::_waitTimeMs = 1000;
@@ -549,3 +550,16 @@ JITServerHelpers::isAddressInROMClass(const void *address, const J9ROMClass *rom
    {
    return ((address >= romClass) && (address < (((uint8_t*) romClass) + romClass->romSize)));
    }
+
+
+uintptrj_t
+JITServerHelpers::walkReferenceChainWithOffsets(TR_J9VM * fe, std::vector<uintptrj_t>& listOfOffsets, uintptrj_t receiver)
+   {
+   uintptrj_t result = receiver;
+   for (size_t i = 0; i < listOfOffsets.size(); i++)
+      {
+      result = fe->getReferenceFieldAt(result, listOfOffsets[i]);
+      }
+   return result;
+   }
+

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -553,7 +553,7 @@ JITServerHelpers::isAddressInROMClass(const void *address, const J9ROMClass *rom
 
 
 uintptrj_t
-JITServerHelpers::walkReferenceChainWithOffsets(TR_J9VM * fe, std::vector<uintptrj_t>& listOfOffsets, uintptrj_t receiver)
+JITServerHelpers::walkReferenceChainWithOffsets(TR_J9VM * fe, const std::vector<uintptrj_t>& listOfOffsets, uintptrj_t receiver)
    {
    uintptrj_t result = receiver;
    for (size_t i = 0; i < listOfOffsets.size(); i++)

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,6 +96,8 @@ class JITServerHelpers
    static uint32_t serverMsgTypeCount[JITServer::MessageType_ARRAYSIZE];
 
    static bool isAddressInROMClass(const void *address, const J9ROMClass *romClass);
+
+   static uintptrj_t walkReferenceChainWithOffsets(TR_J9VM * fe, std::vector<uintptrj_t>& listOfOffsets, uintptrj_t receiver);
 
    private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -97,7 +97,7 @@ class JITServerHelpers
 
    static bool isAddressInROMClass(const void *address, const J9ROMClass *romClass);
 
-   static uintptrj_t walkReferenceChainWithOffsets(TR_J9VM * fe, std::vector<uintptrj_t>& listOfOffsets, uintptrj_t receiver);
+   static uintptrj_t walkReferenceChainWithOffsets(TR_J9VM * fe, const std::vector<uintptrj_t>& listOfOffsets, uintptrj_t receiver);
 
    private:
    static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -8630,6 +8630,24 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          uintptrj_t methodHandle;
          uintptrj_t argumentIndices;
+
+#if defined(JITSERVER_SUPPORT)
+         if (comp()->isOutOfProcessCompilation())
+            {
+            auto stream = TR::CompilationInfo::getStream();
+            stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices, thunkDetails->getHandleRef());
+
+            auto recv = stream->read<int32_t, std::vector<int32_t>>();
+            int32_t arrayLength = std::get<0>(recv);
+            std::vector<int32_t> argIndices = std::get<1>(recv);
+            // Push the indices in reverse order
+            for (int i = arrayLength - 1; i >= 0; i--) {
+               loadConstant(TR::iconst, argIndices[i]);
+            }
+            loadConstant(TR::iconst, arrayLength); // number of arguments
+            }
+         else
+#endif /* defined(JITSERVER_SUPPORT) */
             {
             TR::VMAccessCriticalSection invokeFilterArgumentsWithCombinerHandle(fej9);
             methodHandle = *thunkDetails->getHandleRef();
@@ -8683,6 +8701,16 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          uintptrj_t methodHandle;
          int32_t filterPosition;
+
+#if defined(JITSERVER_SUPPORT)
+         if (comp()->isOutOfProcessCompilation())
+            {
+            auto stream = TR::CompilationInfo::getStream();
+            stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition, thunkDetails->getHandleRef());
+            filterPosition = std::get<0>(stream->read<int32_t>());
+            }
+         else
+#endif /* defined(JITSERVER_SUPPORT) */
             {
             TR::VMAccessCriticalSection invokeFilterArgumentsWithCombinerHandle(fej9);
             methodHandle = *thunkDetails->getHandleRef();
@@ -8788,6 +8816,17 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          int32_t numArguments;
          int32_t filterPos;
 
+#if defined(JITSERVER_SUPPORT)
+         if (comp()->isOutOfProcessCompilation())
+            {
+            auto stream = TR::CompilationInfo::getStream();
+            stream->write(JITServer::MessageType::runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs, thunkDetails->getHandleRef());
+            auto recv = stream->read<int32_t, int32_t>();
+            numArguments = std::get<0>(recv);
+            filterPos = std::get<1>(recv);
+            }
+         else
+#endif /* defined(JITSERVER_SUPPORT) */
             {
             TR::VMAccessCriticalSection invokeFilterArgumentsWithCombinerHandle(fej9);
             methodHandle = *thunkDetails->getHandleRef();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9055,7 +9055,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             auto stream = TR::CompilationInfo::getStream();
             std::vector<uintptrj_t> listOfOffsets;
             packReferenceChainOffsets(pop(), listOfOffsets);
-            stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacros, thunkDetails->getHandleRef(), listOfOffsets);
+            stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacrosParameterCount, thunkDetails->getHandleRef(), listOfOffsets);
             parameterCount = std::get<0>(stream->read<int32_t>());
             }
          else
@@ -9086,10 +9086,10 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          if (comp()->isOutOfProcessCompilation())
             {
             auto stream = TR::CompilationInfo::getStream();
-            stream->write(JITServer::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
-            uintptrj_t receiverHandle = std::get<0>(stream->read<uintptrj_t>());
-            uintptrj_t array            = walkReferenceChain(pop(), receiverHandle);
-            arrayLength = (int32_t)fej9->getArrayLengthInElements(array);
+            std::vector<uintptrj_t> listOfOffsets;
+            packReferenceChainOffsets(pop(), listOfOffsets);
+            stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacrosArrayLength, thunkDetails->getHandleRef(), listOfOffsets);
+            arrayLength = std::get<0>(stream->read<int32_t>());
             }
          else
 #endif /* defined(JITSERVER_SUPPORT) */
@@ -9123,11 +9123,11 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          if (comp()->isOutOfProcessCompilation())
             {
             auto stream = TR::CompilationInfo::getStream();
-            stream->write(JITServer::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
-            uintptrj_t receiverHandle = std::get<0>(stream->read<uintptrj_t>());
-            uintptrj_t baseObject       = walkReferenceChain(baseObjectNode, receiverHandle);
+            std::vector<uintptrj_t> listOfOffsets;
+            packReferenceChainOffsets(baseObjectNode, listOfOffsets);
             TR_ASSERT(fieldSym->getDataType() == TR::Int32, "ILGenMacros.getField expecting int field; found load of %s", comp()->getDebug()->getName(symRef));
-            result = fej9->getInt32FieldAt(baseObject, fieldOffset); // TODO: Handle types other than int32
+            stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacrosGetField, thunkDetails->getHandleRef(), fieldOffset, listOfOffsets);
+            result = std::get<0>(stream->read<int32_t>());
             }
          else
 #endif /* defined(JITSERVER_SUPPORT) */

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9220,7 +9220,7 @@ TR_J9ByteCodeIlGenerator::walkReferenceChain(TR::Node *node, uintptrj_t receiver
          }
       TR::Symbol *sym = symRef->getSymbol();
       TR_ASSERT(sym->isShadow() && symRef->getCPIndex() > 0, "walkReferenceChain expecting field load; found load of %s", comp()->getDebug()->getName(symRef));
-      uintptrj_t fieldOffset = symRef->getOffset() - TR::Compiler->om.objectHeaderSizeInBytes(); // blah
+      uintptrj_t fieldOffset = symRef->getOffset() - TR::Compiler->om.objectHeaderSizeInBytes();
       result = fej9->getReferenceFieldAt(walkReferenceChain(node->getFirstChild(), receiver), fieldOffset);
       }
    else
@@ -9262,7 +9262,7 @@ TR_J9ByteCodeIlGenerator::packReferenceChainOffsets(TR::Node *node, std::vector<
          }
       TR::Symbol *sym = symRef->getSymbol();
       TR_ASSERT(sym->isShadow() && symRef->getCPIndex() > 0, "walkReferenceChain expecting field load; found load of %s", comp()->getDebug()->getName(symRef));
-      uintptrj_t fieldOffset = symRef->getOffset() - TR::Compiler->om.objectHeaderSizeInBytes(); // blah
+      uintptrj_t fieldOffset = symRef->getOffset() - TR::Compiler->om.objectHeaderSizeInBytes();
       packReferenceChainOffsets(node->getFirstChild(), listOfOffsets);
       listOfOffsets.push_back(fieldOffset);
       }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9053,11 +9053,9 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          if (comp()->isOutOfProcessCompilation())
             {
             auto stream = TR::CompilationInfo::getStream();
-            stream->write(JITServer::MessageType::runFEMacro_derefUintptrjPtr, thunkDetails->getHandleRef());
-            uintptrj_t receiverHandle = std::get<0>(stream->read<uintptrj_t>());
-            uintptrj_t methodHandle     = walkReferenceChain(pop(), receiverHandle);
-
-            stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacros, methodHandle);
+            std::vector<uintptrj_t> listOfOffsets;
+            packReferenceChainOffsets(pop(), listOfOffsets);
+            stream->write(JITServer::MessageType::runFEMacro_invokeILGenMacros, thunkDetails->getHandleRef(), listOfOffsets);
             parameterCount = std::get<0>(stream->read<int32_t>());
             }
          else

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -342,6 +342,10 @@ private:
    bool replaceStatic(TR::Node* node, char* dstClassName, char* staticName, char* type);
 
    uintptrj_t walkReferenceChain(TR::Node *node, uintptrj_t receiver);
+#if defined(JITSERVER_SUPPORT)
+   void packReferenceChainOffsets(TR::Node *node, std::vector<uintptrj_t>& listOfOffsets);
+#endif
+
    bool hasFPU();
 
    // data

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -158,7 +158,7 @@ protected:
    ZeroCopyOutputStream *_outputStream;
 
    static const uint8_t MAJOR_NUMBER = 0;
-   static const uint16_t MINOR_NUMBER = 1;
+   static const uint16_t MINOR_NUMBER = 2;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
    };

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -284,6 +284,9 @@ enum MessageType
    runFEMacro_invokeILGenMacrosParameterCount = 717;
    runFEMacro_invokeILGenMacrosArrayLength = 718;
    runFEMacro_invokeILGenMacrosGetField = 719;
+   runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs = 720;
+   runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition = 721;
+   runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices = 722;
 
    // for JITServerPersistentCHTable
    CHTable_getAllClassInfo = 800;

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -284,7 +284,6 @@ enum MessageType
    runFEMacro_invokeILGenMacrosParameterCount = 717;
    runFEMacro_invokeILGenMacrosArrayLength = 718;
    runFEMacro_invokeILGenMacrosGetField = 719;
-   runFEMacro_derefUintptrjPtr = 720;
 
    // for JITServerPersistentCHTable
    CHTable_getAllClassInfo = 800;

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -281,8 +281,10 @@ enum MessageType
    runFEMacro_invokeFilterArgumentsHandle = 714;
    runFEMacro_invokeFilterArgumentsHandle2 = 715;
    runFEMacro_invokeCatchHandle = 716;
-   runFEMacro_invokeILGenMacros = 717;
-   runFEMacro_derefUintptrjPtr = 718;
+   runFEMacro_invokeILGenMacrosParameterCount = 717;
+   runFEMacro_invokeILGenMacrosArrayLength = 718;
+   runFEMacro_invokeILGenMacrosGetField = 719;
+   runFEMacro_derefUintptrjPtr = 720;
 
    // for JITServerPersistentCHTable
    CHTable_getAllClassInfo = 800;

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
The purpose of this change is to avoid using object addresses on JITServer. Using object addresses on JITServer creates problems when GC moves the object (thus changing the addresses). Instead, JITServer must use some kind of handle (a GlobalReference or some other GC root) to hold the object so that JITServer always has the valid object addresses when it tries to perform operations on it.

`walkReferenceChain()` is special in that it needs half of its information from JITServer(TR::Node) and half of its information from JITClient(object address). During the walk, we need vmaccess so that GC doesn't move the object of interest. We can only have vmaccess on JITClient, which means we need to do the walk on JITClient.

This change makes JITServer generate the offset information JITClient needs for the walk and passes to JITClient in the form of a vector.

Originally we have a LocalGCCounter hack where we can detect if the object has been moved to a different location. And when object has been moved, JITClient will abort the compilation. However, this does not work for all gcpolicies and also is not very efficient because JITClient can abort compilations that might not need to be aborted. This change offers a better solution: since the walk is done on JITClient and JITClient has control over vmaccess, object is guaranteed to not be moved during the operation.

I have also noticed a few misuses of globalreference read and vmaccess and have corrected them. We must have vmaccess before we perform a read.

Issue: #8109

Signed-off-by: Harry Yu <harryyu1994@gmail.com>