### PR TITLE
Include Xlp Tests on Sanity Functional

### DIFF
--- a/test/functional/VM_Test/j9vm.xml
+++ b/test/functional/VM_Test/j9vm.xml
@@ -4,7 +4,7 @@
 
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,12 +75,8 @@
 		<reason>Only applies to Linux SRT</reason>
 	</include>
 
-	<exclude id="j9vm.test.xlp" platform="all">
-		<reason>This test is run separately and not as part of j9vm test suite</reason>
-	</exclude>
-
-	<exclude id="j9vm.test.xlpcodecache" platform="all">
-		<reason>This test is run separately and not as part of j9vm test suite</reason>
+	<exclude id="j9vm.test.xlpcodecache" platform="aix_ppc.*">
+		<reason>OpenJ9 Issue I8437. This test is unstable on AIXPPC. </reason>
 	</exclude>
 
 	<exclude id="j9vm.test.classloader.LazyClassLoaderInitTest" platform="all">

--- a/test/functional/VM_Test/src/j9vm/runner/Runner.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Runner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,40 +67,45 @@ public class Runner {
 
 	private void setPlatform() {
 		
-		String spec = System.getProperty("platform");
-		if (spec != null) {
+		String OSSpec = System.getProperty("os.name").toLowerCase();
+		if (OSSpec != null) {
 			/* Get OS from the spec string */
-			if (spec.indexOf("aix") != -1) {
+			if (OSSpec.contains("aix")) {
 				osName = OSName.AIX;
-			} else if (spec.indexOf("linux") != -1){
+			} else if (OSSpec.contains("linux")) {
 				osName = OSName.LINUX;
-			} else if (spec.indexOf("win") != -1) {
+			} else if (OSSpec.contains("windows")) {
 				osName = OSName.WINDOWS;
-			} else if (spec.indexOf("zos") != -1) {
+			} else if (OSSpec.contains("z/os")) {
 				osName = OSName.ZOS;
 			} else {
+				System.out.println("Runner couldn't determine underlying OS. Got OS Name:" + OSSpec);
 				osName = OSName.UNKNOWN;
 			}
-			
+		}
+		String archSpec = System.getProperty("os.arch").toLowerCase();
+		if (archSpec != null) {
 			/* Get arch from spec string */
-			if (spec.indexOf("ppc") != -1) {
+			if (archSpec.contains("ppc")) {
 				osArch = OSArch.PPC;
-			} else if (spec.indexOf("390") != -1) {
+			} else if (archSpec.contains("s390")) {
 				osArch = OSArch.S390X;
-			} else if (spec.indexOf("x86") != -1) {
+			} else if (archSpec.contains("amd64") || archSpec.contains("x86")) {
 				osArch = OSArch.X86;
 			} else {
+				System.out.println("Runner couldn't determine underlying architecture. Got OS Arch:" + archSpec);
 				osArch = OSArch.UNKNOWN;
 			}
 			
 			/* Get address mode */
-			if (spec.indexOf("31") != -1) {
+			if (archSpec.contains("31")) {
 				addrMode = AddrMode.BIT31;
-			} else if (spec.indexOf("32") != -1) {
+			} else if (archSpec.contains("32")) {
 				addrMode = AddrMode.BIT32;
-			} else if (spec.indexOf("64") != -1) {
+			} else if (archSpec.contains("64") || archSpec.contains("s390")) {
 				addrMode = AddrMode.BIT64;
 			} else {
+				System.out.println("Runner couldn't determine underlying addressing mode. Got OS Arch:" + archSpec);
 				addrMode = AddrMode.UNKNOWN;
 			}
 		}


### PR DESCRIPTION
Enabling both the xlpcodecache and xlp(objectheap) tests.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>