### PR TITLE
AArch64: Add support for jitInduceOSRAtCurrentPC

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1055,6 +1055,11 @@ void J9::ARM64::PrivateLinkage::buildDirectCall(TR::Node *callNode,
          0, dependencies,
          new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), label),
          snippet);
+
+      // Nop is necessary due to confusion when resolving shared slots at a transition
+      if (callSymRef->isOSRInductionHelper())
+         cg()->generateNop(callNode);
+
       }
 
    gcPoint->ARM64NeedsGCMap(cg(), callSymbol->getLinkageConvention() == TR_Helper ? 0xffffffff : pp.getPreservedRegisterMapForGC());


### PR DESCRIPTION
This commit adds support for `jitInduceOSRAtCurrentPC` helper in aarch64.

Depends on https://github.com/eclipse/omr/pull/4722 and https://github.com/eclipse/openj9/pull/8306

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>