### PR TITLE
AArch64: Enable encodeHelperBranchAndLink to encode `b` instruction

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -91,7 +91,7 @@ J9::ARM64::CodeGenerator::allocateRecompilationInfo()
    }
 
 uint32_t
-J9::ARM64::CodeGenerator::encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node)
+J9::ARM64::CodeGenerator::encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node, bool omitLink)
    {
    TR::CodeGenerator *cg = self();
    uintptrj_t target = (uintptrj_t)symRef->getMethodAddress();
@@ -111,7 +111,7 @@ J9::ARM64::CodeGenerator::encodeHelperBranchAndLink(TR::SymbolReference *symRef,
                              __FILE__, __LINE__, node);
 
    uintptr_t distance = target - (uintptr_t)cursor;
-   return TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::bl) | ((distance >> 2) & 0x3ffffff); /* imm26 */
+   return TR::InstOpCode::getOpCodeBinaryEncoding(omitLink ? (TR::InstOpCode::b) : (TR::InstOpCode::bl)) | ((distance >> 2) & 0x3ffffff); /* imm26 */
    }
 
 void

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,13 +68,14 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    TR::Linkage *createLinkage(TR_LinkageConventions lc);
 
    /**
-    * @brief Encode a BL instruction to the specified symbol
+    * @brief Encode a BL (or B) instruction to the specified symbol
     * @param[in] symRef : target symbol
     * @param[in] cursor : instruction cursor
     * @param[in] node : node
-    * @return Endoded BL instruction
+    * @param[in] omitLink : use `b` instruction if true
+    * @return Endoded BL (or B) instruction
     */
-   uint32_t encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node);
+   uint32_t encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node, bool omitLink = false);
    
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
    


### PR DESCRIPTION
This commit modifies `encodeHelperBranchAndLink` function and
enables it to encode `b` instruction.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>