### PR TITLE
Add option to disable aliasing of primitive box class final fields

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1959,15 +1959,18 @@ J9::SymbolReferenceTable::checkImmutable(TR::SymbolReference *symRef)
       "java/lang/String"
       };
 
-   TR_ASSERT(sizeof(names)/sizeof(char *) == _numImmutableClasses,"Size of names array is not correct\n");
-   int32_t i;
-   for (i = 0; i < _numImmutableClasses; i++)
+   if (!comp()->getOption(TR_DisableImmutableFieldAliasing))
       {
-      if (strcmp(names[i].name, name) == 0)
+      TR_ASSERT(sizeof(names)/sizeof(char *) == _numImmutableClasses,"Size of names array is not correct\n");
+      int32_t i;
+      for (i = 0; i < _numImmutableClasses; i++)
          {
-         _hasImmutable = true;
-         _immutableSymRefNumbers[i]->set(symRef->getReferenceNumber());
-         break;
+         if (strcmp(names[i].name, name) == 0)
+            {
+            _hasImmutable = true;
+            _immutableSymRefNumbers[i]->set(symRef->getReferenceNumber());
+            break;
+            }
          }
       }
 


### PR DESCRIPTION
Add an option to prevent the JIT from assuming that the final fields
in the primitive box types (i.e Integer) are immutable. This prevents
LocalCSE from propagating final field initialization values into future
uses. This can be a problem for Java code that uses Unsafe or JNI code
to modify final fields of these primitive box classes.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>