### PR TITLE
Use sun.misc.IOUtils new API readAllBytes()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corp. and others
+ * Copyright (c) 2012, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,7 +106,7 @@ final class SecurityFrameInjector {
 								return Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class").readAllBytes(); //$NON-NLS-1$
 								/*[ELSE]*/
 								InputStream is = Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class"); //$NON-NLS-1$
-								return IOUtils.readFully(is, -1, true);
+								return IOUtils.readAllBytes(is);
 								/*[ENDIF]*/
 							} catch(java.io.IOException e) {
 								/*[MSG "K056A", "Unable to read java.lang.invoke.SecurityFrame.class bytes"]*/


### PR DESCRIPTION
**Use sun.misc.IOUtils new API readAllBytes()**

Replace `IOUtils.readFully(is, -1, true)` with `IOUtils.readAllBytes(is)` to avoid `IOException: length cannot be negative: -1`.

`[ci skip]` because the new API `readAllBytes(is)` is not available at extension repo `openj9` branch.

Notes:
1. Though `readNBytes(is, Integer.MAX_VALUE)` has same result, `readAllBytes(is)` seems better choice;
2. API doc within `sun.misc.IOUtils` specifies `@since 1.9` or `@since 11` though this is a dedicated `Java 8` extension rep https://github.com/ibmruntimes/openj9-openjdk-jdk8/blob/e6095d9adfe3c072d483a7df3fcdf1eeec76044b/jdk/src/share/classes/sun/misc/IOUtils.java#L284-L302
@andrew-m-leonard any insights?

Reviewer: @DanHeidinga 

Fixes #8308 
Fixes #8309 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>