### PR TITLE
Fix incorrect profiling of arraycopy length

### DIFF
--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -980,7 +980,7 @@ TR_ValueProfileInfoManager::getValueInfo(TR_ByteCodeInfo &bcInfo, TR::Compilatio
          info = _jitValueProfileInfo->getValueInfo(bcInfo, comp, kind, ArrayProfiler, true);
       }
 
-   if (external && (!info || info->getTotalFrequency() == 0))
+   if (external && (!info || info->getTotalFrequency() == 0) && kind == AddressInfo)
       {
       TR_ExternalValueProfileInfo *iVPInfo = comp->fej9()->getValueProfileInfoFromIProfiler(bcInfo, comp);
       if (iVPInfo)


### PR DESCRIPTION
Under some circumstances, it is possible for a call to Object.clone on
an object which has a known array type to be turned into an allocation
of a new array followed by an arraycopy. When this occurs, the resulting
arraycopy node will have the same bytecode information as the call node
it was created from.

While this is generally fine, it can create issues later when we attempt
to read profiling information for the arraycopy node, which we expect to
contain the profiled length of the arraycopy. However, the IProfiler
information that is read is actually related to the original call node,
containing profiled J9Class pointers. This can result in the arraycopy
node being specialized with a nonsensical (and possibly invalid) length.

This has been corrected by ensuring that addresses are being requested
before reading IProfiler value profiling information in response to a
request for profiling information. Instead, no profiling information
will be read, thus preventing the node from being specialized.

Signed-off-by: Ben Thomas <ben@benthomas.ca>