### PR TITLE
(v0.18.0-release) Use sun.misc.IOUtils new API readAllBytes()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corp. and others
+ * Copyright (c) 2012, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,7 +106,7 @@ final class SecurityFrameInjector {
 								return Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class").readAllBytes(); //$NON-NLS-1$
 								/*[ELSE]*/
 								InputStream is = Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class"); //$NON-NLS-1$
-								return IOUtils.readFully(is, -1, true);
+								return IOUtils.readAllBytes(is);
 								/*[ENDIF]*/
 							} catch(java.io.IOException e) {
 								/*[MSG "K056A", "Unable to read java.lang.invoke.SecurityFrame.class bytes"]*/


### PR DESCRIPTION
**Use sun.misc.IOUtils new API readAllBytes()**

Replace `IOUtils.readFully(is, -1, true)` with `IOUtils.readAllBytes(is)` to avoid `IOException: length cannot be negative: -1`.

`[ci skip]` because the new API `readAllBytes(is)` is not available at extension repo `openj9` branch.

Note: though `readNBytes(is, Integer.MAX_VALUE)` has same result, `readAllBytes(is)` seems better choice.

Reviewer: @DanHeidinga 

Cherry pick from https://github.com/eclipse/openj9/pull/8312 for the 0.18.0 release.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>