### PR TITLE
Use API IOUtils.readFully() applicable to both versions

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
@@ -106,7 +106,7 @@ final class SecurityFrameInjector {
 								return Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class").readAllBytes(); //$NON-NLS-1$
 								/*[ELSE]*/
 								InputStream is = Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class"); //$NON-NLS-1$
-								return IOUtils.readAllBytes(is);
+								return IOUtils.readFully(is, Integer.MAX_VALUE, false);
 								/*[ENDIF]*/
 							} catch(java.io.IOException e) {
 								/*[MSG "K056A", "Unable to read java.lang.invoke.SecurityFrame.class bytes"]*/


### PR DESCRIPTION
**Use API IOUtils.readFully() applicable to both versions**

`IOUtils.readFully(is, Integer.MAX_VALUE, false)` is equivalent to `IOUtils.readFully(is, -1, true)` in previous version (`OpenJ9` branch or current `IBM JDK8`), and also is equivalent to `IOUtils.readAllBytes(is)` in latest version in `openj9-staging` branch.

To accommodate current `IBM JDK8 JCL` level, this serves an intermediate solution to allow `OpenJ9 JCL` work with `sun.misc.IOUtils` in latest `openj9-openjdk-jdk8 openj9-staging` branch and also current `IBM JDK8 JCL` level which is same as `openj9` branch.

`IOUtils.readFully(is, Integer.MAX_VALUE, false)` can be changed back to `IOUtils.readAllBytes(is)` when `IBM JDK8` gets latest version of `sun.misc.IOUtils`.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>