### PR TITLE
Runtime compressed refs work

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -669,7 +669,7 @@ TR_J9ServerVM::getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_TOTAL_INSTANCE_SIZE, (void *)&totalInstanceSize);
 
-   uint32_t objectSize = sizeof(J9Object) + (uint32_t)totalInstanceSize;
+   uint32_t objectSize = getObjectHeaderSizeInBytes() + (uint32_t)totalInstanceSize;
    return ((objectSize >= J9_GC_MINIMUM_OBJECT_SIZE) ? objectSize : J9_GC_MINIMUM_OBJECT_SIZE);
    }
 

--- a/runtime/gc_base/ClassModel.hpp
+++ b/runtime/gc_base/ClassModel.hpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,13 +108,14 @@ public:
 	/**
 	 * Calculate the number of object slots in the class.
 	 * @param[in] clazz Pointer to the class
+	 * @param[in] vm The J9JavaVM
 	 * @return number of object slots.
 	 */
 	MMINLINE static UDATA
-	getNumberOfObjectSlots(J9Class *clazz)
+	getNumberOfObjectSlots(J9Class *clazz, J9JavaVM *vm)
 	{
 		UDATA totalInstanceSize = clazz->totalInstanceSize;
-		IDATA scanLimit = (IDATA) (totalInstanceSize / sizeof(fj9object_t));
+		IDATA scanLimit = (IDATA) (totalInstanceSize / J9JAVAVM_REFERENCE_SIZE(vm));
 		UDATA tempDescription = (UDATA)clazz->instanceDescription;
 
 		UDATA slotCount = 0;

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,7 +90,7 @@ MM_GCExtensions::initialize(MM_EnvironmentBase *env)
 
 #if defined(J9VM_GC_REALTIME)
 	/* only ref slots, size in bytes: 2 * minObjectSize - header size */
-	minArraySizeToSetAsScanned = 2 * (1 << J9VMGC_SIZECLASSES_LOG_SMALLEST) - sizeof(J9IndexableObjectContiguous);
+	minArraySizeToSetAsScanned = 2 * (1 << J9VMGC_SIZECLASSES_LOG_SMALLEST) - J9JAVAVM_CONTIGUOUS_HEADER_SIZE(getJavaVM());
 #endif /* J9VM_GC_REALTIME */
 
 #if defined(J9VM_GC_JNI_ARRAY_CACHE)

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,7 +116,13 @@ MM_ObjectAccessBarrier::tearDown(MM_EnvironmentBase *env)
 mm_j9object_t
 MM_ObjectAccessBarrier::readObjectImpl(J9VMThread *vmThread, mm_j9object_t srcObject, fj9object_t *srcAddress, bool isVolatile)
 {
-	return convertPointerFromToken(*srcAddress);
+	mm_j9object_t result = NULL;
+	if (compressObjectReferences()) {
+		result = convertPointerFromToken(*(uint32_t*)srcAddress);
+	} else {
+		result = (mm_j9object_t)*(uintptr_t*)srcAddress;
+	}
+	return result;
 }
 
 /**
@@ -164,7 +170,11 @@ MM_ObjectAccessBarrier::readObjectFromInternalVMSlotImpl(J9VMThread *vmThread, j
 void 
 MM_ObjectAccessBarrier::storeObjectImpl(J9VMThread *vmThread, mm_j9object_t destObject, fj9object_t *destAddress, mm_j9object_t value, bool isVolatile)
 {
-	*destAddress = convertTokenFromPointer(value);
+	if (compressObjectReferences()) {
+		*(uint32_t*)destAddress = (uint32_t)convertTokenFromPointer(value);
+	} else {
+		*(uintptr_t*)destAddress = (uintptr_t)value;
+	}
 }
 
 /**
@@ -780,7 +790,8 @@ MM_ObjectAccessBarrier::mixedObjectStoreI64(J9VMThread *vmThread, J9Object *dest
 J9Object *
 MM_ObjectAccessBarrier::indexableReadObject(J9VMThread *vmThread, J9IndexableObject *srcObject, I_32 srcIndex, bool isVolatile)
 {
-	fj9object_t *actualAddress = (fj9object_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(fj9object_t));
+	UDATA const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
+	fj9object_t *actualAddress = (fj9object_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, referenceSize);
 	J9Object *result = NULL;
 
 	/* No preObjectRead yet because no barrier require it */
@@ -953,7 +964,8 @@ MM_ObjectAccessBarrier::indexableReadI64(J9VMThread *vmThread, J9IndexableObject
 void
 MM_ObjectAccessBarrier::indexableStoreObject(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 destIndex, J9Object *value, bool isVolatile)
 {
-	fj9object_t *actualAddress = (fj9object_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(fj9object_t));
+	UDATA const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
+	fj9object_t *actualAddress = (fj9object_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, referenceSize);
 	
 	if (preObjectStore(vmThread, (J9Object *)destObject, actualAddress, value)) {
 		protectIfVolatileBefore(vmThread, isVolatile, false, false);
@@ -1383,6 +1395,8 @@ MM_ObjectAccessBarrier::structuralCompareFlattenedObjects(J9VMThread *vmThread, 
 	bool result = true;
 	const UDATA *descriptionPtr = (UDATA *) valueClass->instanceDescription;
 	UDATA descriptionBits = 0;
+	bool const compressed = J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread);
+	UDATA const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
 
 	Assert_MM_true(J9_IS_J9CLASS_VALUETYPE(valueClass));
 
@@ -1411,9 +1425,10 @@ MM_ObjectAccessBarrier::structuralCompareFlattenedObjects(J9VMThread *vmThread, 
 				result = false;
 				break;
 			}
-
 		} else {
-			if (*(fj9object_t *)((UDATA)lhsObject + startOffset + offset) != *(fj9object_t *)((UDATA)rhsObject + startOffset + offset)) {
+			fomrobject_t lhsValue = GC_SlotObject::readSlot((fomrobject_t*)((UDATA)lhsObject + startOffset + offset), compressed);
+			fomrobject_t rhsValue = GC_SlotObject::readSlot((fomrobject_t*)((UDATA)rhsObject + startOffset + offset), compressed);
+			if (lhsValue != rhsValue) {
 				result = false;
 				break;
 			}
@@ -1423,7 +1438,7 @@ MM_ObjectAccessBarrier::structuralCompareFlattenedObjects(J9VMThread *vmThread, 
 			descriptionBits = *descriptionPtr++;
 			descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 		}
-		offset += sizeof(fj9object_t);
+		offset += referenceSize;
 	}
 
 	return result;
@@ -1477,6 +1492,7 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 	UDATA descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 	UDATA offset = 0;
 	UDATA limit = objectClass->totalInstanceSize;
+	UDATA const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
 
 	if (isValueType) {
 		U_32 firstFieldOffset = (U_32) objectClass->backfillOffset;
@@ -1494,14 +1510,20 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 			J9Object *objectPtr = mixedObjectReadObject(vmThread, srcObject, srcOffset + offset, false);
 			mixedObjectStoreObject(vmThread, destObject, destOffset + offset, objectPtr, false);
 		} else {
-			*(fj9object_t *)((UDATA)destObject + destOffset + offset) = *(fj9object_t *)((UDATA)srcObject + srcOffset + offset);
+			UDATA srcAddress = (UDATA)srcObject + srcOffset + offset;
+			UDATA destAddress = (UDATA)destObject + srcOffset + offset;
+			if (sizeof(uint32_t) == referenceSize) {
+				*(uint32_t *)destAddress = *(uint32_t *)srcAddress;
+			} else {
+				*(uintptr_t *)destAddress = *(uintptr_t *)srcAddress;
+			}
 		}
 		descriptionBits >>= 1;
 		if(descriptionIndex-- == 0) {
 			descriptionBits = *descriptionPtr++;
 			descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 		}
-		offset += sizeof(fj9object_t);
+		offset += referenceSize;
 	}
 
 	if (!isValueType) {
@@ -2034,13 +2056,23 @@ MM_ObjectAccessBarrier::fillArrayOfObjects(J9VMThread *vmThread, j9array_t destO
 	/* (assert here to verify that we aren't defaulting to this implementation through some unknown path - delete once combination is stable) */
 	Assert_MM_unreachable();
 #endif /* defined(J9VM_GC_COMBINATION_SPEC) */
-	fj9object_t *destPtr = (fj9object_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(fj9object_t));
-	fj9object_t actualValue = convertTokenFromPointer(value);
-	fj9object_t *endPtr = destPtr + count;
-
-	while (destPtr < endPtr) {
-		*destPtr++ = actualValue;	
-	} 	
+	if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread)) {
+		uint32_t *destPtr = (uint32_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(uint32_t));
+		uint32_t actualValue = (uint32_t)convertTokenFromPointer(value);
+		uint32_t *endPtr = destPtr + count;
+	
+		while (destPtr < endPtr) {
+			*destPtr++ = actualValue;	
+		}
+	} else {
+		uintptr_t *destPtr = (uintptr_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(uintptr_t));
+		uintptr_t actualValue = (uintptr_t)convertTokenFromPointer(value);
+		uintptr_t *endPtr = destPtr + count;
+	
+		while (destPtr < endPtr) {
+			*destPtr++ = actualValue;	
+		}
+	}
 }
 
 /**
@@ -2078,12 +2110,22 @@ MM_ObjectAccessBarrier::doCopyContiguousBackward(J9VMThread *vmThread, J9Indexab
 	srcIndex += lengthInSlots;
 	destIndex += lengthInSlots;
 
-	fj9object_t *srcSlot = (fj9object_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(fj9object_t));
-	fj9object_t *destSlot = (fj9object_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(fj9object_t));
-	fj9object_t *srcEndSlot = srcSlot - lengthInSlots;
-	
-	while (srcSlot > srcEndSlot) {
-		*--destSlot = *--srcSlot;
+	if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread)) {
+		uint32_t *srcSlot = (uint32_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(uint32_t));
+		uint32_t *destSlot = (uint32_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(uint32_t));
+		uint32_t *srcEndSlot = srcSlot - lengthInSlots;
+		
+		while (srcSlot > srcEndSlot) {
+			*--destSlot = *--srcSlot;
+		}
+	} else {
+		uintptr_t *srcSlot = (uintptr_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(uintptr_t));
+		uintptr_t *destSlot = (uintptr_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(uintptr_t));
+		uintptr_t *srcEndSlot = srcSlot - lengthInSlots;
+		
+		while (srcSlot > srcEndSlot) {
+			*--destSlot = *--srcSlot;
+		}	
 	}
 	
 	return ARRAY_COPY_SUCCESSFUL;
@@ -2095,12 +2137,22 @@ MM_ObjectAccessBarrier::doCopyContiguousBackward(J9VMThread *vmThread, J9Indexab
 I_32
 MM_ObjectAccessBarrier::doCopyContiguousForward(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots)
 {
-	fj9object_t *srcSlot = (fj9object_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(fj9object_t));
-	fj9object_t *destSlot = (fj9object_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(fj9object_t));
-	fj9object_t *srcEndSlot = srcSlot + lengthInSlots;
-	
-	while (srcSlot < srcEndSlot) {
-		*destSlot++ = *srcSlot++;
+	if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread)) {
+		uint32_t *srcSlot = (uint32_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(uint32_t));
+		uint32_t *destSlot = (uint32_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(uint32_t));
+		uint32_t *srcEndSlot = srcSlot + lengthInSlots;
+		
+		while (srcSlot < srcEndSlot) {
+			*destSlot++ = *srcSlot++;
+		}
+	} else {
+		uintptr_t *srcSlot = (uintptr_t *)indexableEffectiveAddress(vmThread, srcObject, srcIndex, sizeof(uintptr_t));
+		uintptr_t *destSlot = (uintptr_t *)indexableEffectiveAddress(vmThread, destObject, destIndex, sizeof(uintptr_t));
+		uintptr_t *srcEndSlot = srcSlot + lengthInSlots;
+		
+		while (srcSlot < srcEndSlot) {
+			*destSlot++ = *srcSlot++;
+		}
 	}
 	
 	return ARRAY_COPY_SUCCESSFUL;	
@@ -2116,7 +2168,8 @@ void
 MM_ObjectAccessBarrier::setFinalizeLink(j9object_t object, j9object_t value)
 {
 	fj9object_t* finalizeLink = getFinalizeLinkAddress(object);
-	*finalizeLink = convertTokenFromPointer(value);
+	GC_SlotObject slot(_extensions->getOmrVM(), finalizeLink);
+	slot.writeReferenceToSlot(value);
 }
 
 void 
@@ -2127,7 +2180,8 @@ MM_ObjectAccessBarrier::setReferenceLink(j9object_t object, j9object_t value)
 	/* offset will be UDATA_MAX until java/lang/ref/Reference is loaded */
 	Assert_MM_true(UDATA_MAX != linkOffset);
 	fj9object_t *referenceLink = (fj9object_t*)((UDATA)object + linkOffset);
-	*referenceLink = convertTokenFromPointer(value);
+	GC_SlotObject slot(_extensions->getOmrVM(), referenceLink);
+	slot.writeReferenceToSlot(value);
 }
 
 void
@@ -2142,7 +2196,8 @@ MM_ObjectAccessBarrier::setOwnableSynchronizerLink(j9object_t object, j9object_t
 		value = object;
 	}
 	fj9object_t *ownableSynchronizerLink = (fj9object_t*)((UDATA)object + linkOffset);
-	*ownableSynchronizerLink = convertTokenFromPointer(value);
+	GC_SlotObject slot(_extensions->getOmrVM(), ownableSynchronizerLink);
+	slot.writeReferenceToSlot(value);
 }
 
 void

--- a/runtime/gc_base/ObjectCheck.cpp
+++ b/runtime/gc_base/ObjectCheck.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -151,7 +151,7 @@ j9gc_ext_check_is_valid_heap_object(J9JavaVM *javaVM, J9Object *ptr, UDATA flags
 	if (extensions->objectModel.isObjectArray(ptr)
 		|| extensions->objectModel.isPrimitiveArray(ptr)) {
 		/* ensure that the array size fits into the segment */
-		if (((UDATA)highAddress - (UDATA)ptr) < sizeof(J9IndexableObjectContiguous)) {
+		if (((UDATA)highAddress - (UDATA)ptr) < J9JAVAVM_CONTIGUOUS_HEADER_SIZE(javaVM)) {
 			return J9OBJECTCHECK_INVALID;
 		}
 	}

--- a/runtime/gc_base/ReferenceChainWalker.hpp
+++ b/runtime/gc_base/ReferenceChainWalker.hpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -188,17 +187,19 @@ private:
 	MMINLINE void setOverflow(J9Object *object)
 	{
 		if (isHeapObject(object)) {
+			UDATA referenceSize = _env->compressObjectReferences() ? sizeof(uint32_t) : sizeof(uintptr_t);
 			/* set both mark bits - set 11 */
 			_markMap->setBit(object);
-			_markMap->setBit((J9Object *)((UDATA)object + sizeof(fj9object_t)));
+			_markMap->setBit((J9Object *)((UDATA)object + referenceSize));
 		}
 	}
 
 	MMINLINE bool isOverflow(J9Object * object)
 	{
 		if (isHeapObject(object)) {
+			UDATA referenceSize = _env->compressObjectReferences() ? sizeof(uint32_t) : sizeof(uintptr_t);
 			/* check both bits in mark map - return true if 11 */
-			return (_markMap->isBitSet(object) && _markMap->isBitSet((J9Object *)((UDATA)object + sizeof(fj9object_t))));
+			return (_markMap->isBitSet(object) && _markMap->isBitSet((J9Object *)((UDATA)object + referenceSize)));
 		} else {
 			return false;
 		}
@@ -207,9 +208,10 @@ private:
 	MMINLINE void clearOverflow(J9Object * object)
 	{
 		if (isHeapObject(object)) {
+			UDATA referenceSize = _env->compressObjectReferences() ? sizeof(uint32_t) : sizeof(uintptr_t);
 			/* clear both mark bits - set 00 */
 			_markMap->clearBit(object);
-			_markMap->clearBit((J9Object *)((UDATA)object + sizeof(fj9object_t)));
+			_markMap->clearBit((J9Object *)((UDATA)object + referenceSize));
 		}
 	}
 

--- a/runtime/gc_base/modron.h
+++ b/runtime/gc_base/modron.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,12 +103,16 @@
  * NOTE: since these macros use getOmrVM() they only work in-process (not out-of-process).
  * They may not be used in gccheck.
  */
-#define J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, object) (*(fj9object_t*)((U_8*)(object) + J9VMJAVALANGREFREFERENCE_REFERENT_OFFSET((J9VMThread*)(env)->getLanguageVMThread())))
-#define J9GC_J9VMJAVALANGREFERENCE_QUEUE(env, object) (*(fj9object_t*)((U_8*)(object) + J9VMJAVALANGREFREFERENCE_QUEUE_OFFSET((J9VMThread*)(env)->getLanguageVMThread())))
+#define J9GC_READ_OBJECT_SLOT(env, object, offset) \
+	((env)->compressObjectReferences() \
+		? (fj9object_t)(*(uint32_t*)((U_8*)(object) + (offset))) \
+		: (fj9object_t)(*(uintptr_t*)((U_8*)(object) + (offset))) \
+	)
+#define J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, object) ((fj9object_t*)((U_8*)(object) + J9VMJAVALANGREFREFERENCE_REFERENT_OFFSET((J9VMThread*)(env)->getLanguageVMThread())))
+#define J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, object) J9GC_READ_OBJECT_SLOT(env, object, J9VMJAVALANGREFREFERENCE_REFERENT_OFFSET((J9VMThread*)(env)->getLanguageVMThread()))
+#define J9GC_J9VMJAVALANGREFERENCE_QUEUE(env, object) J9GC_READ_OBJECT_SLOT(env, object, J9VMJAVALANGREFREFERENCE_QUEUE_OFFSET((J9VMThread*)(env)->getLanguageVMThread()))
 #define J9GC_J9VMJAVALANGREFERENCE_STATE(env, object) (*(I_32*)((U_8*)(object) + J9VMJAVALANGREFREFERENCE_STATE_OFFSET((J9VMThread*)(env)->getLanguageVMThread())))
 #define J9GC_J9VMJAVALANGSOFTREFERENCE_AGE(env, object) (*(I_32*)((U_8*)(object) + J9VMJAVALANGREFSOFTREFERENCE_AGE_OFFSET((J9VMThread*)(env)->getLanguageVMThread())))
-
-#define J9GC_J9OBJECT_FIELD_EA(object, byteOffset) ((fj9object_t*)((U_8 *)(object) + (byteOffset) + sizeof(J9Object)))
 
 #define J9GC_J9CLASSLOADER_CLASSLOADEROBJECT(classLoader) ((j9object_t)(classLoader)->classLoaderObject)
 #define J9GC_J9CLASSLOADER_CLASSLOADEROBJECT_EA(classLoader) (&(classLoader)->classLoaderObject)

--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -471,7 +471,7 @@ GC_CheckEngine::checkJ9Object(J9JavaVM *javaVM, J9Object* objectPtr, J9MM_Iterat
 		}
 
 		/* TODO: find out what the indexable header size should really be */
-		if (extensions->objectModel.isIndexable(objectPtr) && (delta < sizeof(J9IndexableObjectContiguous))) {
+		if (extensions->objectModel.isIndexable(objectPtr) && (delta < J9JAVAVM_CONTIGUOUS_HEADER_SIZE(javaVM))) {
 			return J9MODRON_GCCHK_RC_INVALID_RANGE;
 		}
 

--- a/runtime/gc_check/CheckReporterTTY.cpp
+++ b/runtime/gc_check/CheckReporterTTY.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -150,8 +149,8 @@ GC_CheckReporterTTY::report(GC_CheckError *error)
 		UDATA slotValue;
 		
 		if (error->_objectType == check_type_object) {
-			fj9object_t fieldValue = *((fj9object_t*)slot);
-			slotValue = (UDATA)fieldValue;
+			GC_SlotObject slotObj(_javaVM->omrVM, (fomrobject_t*)slot);
+			slotValue = (UDATA)slotObj.readReferenceFromSlot();
 		} else {
 			if (error->_objectType == check_type_thread) {
 				/* slots from thread stacks are always local */

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,6 +112,8 @@ public:
 	getObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, void *scannerSpace, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo)
 	{
 		J9Class *clazz = J9GC_J9OBJECT_CLAZZ(objectPtr, env);
+		UDATA const referenceSize = env->compressObjectReferences() ? sizeof(uint32_t) : sizeof(uintptr_t);
+
 		/* object class must have proper eye catcher */
 		Assert_MM_true((UDATA)0x99669966 == clazz->eyecatcher);
 
@@ -125,7 +126,7 @@ public:
 		case GC_ObjectModel::SCAN_CLASS_OBJECT:
 		case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 			objectScanner = GC_MixedObjectScanner::newInstance(env, objectPtr, scannerSpace, 0);
-			*sizeToDo = sizeof(fomrobject_t) + ((GC_MixedObjectScanner *)objectScanner)->getBytesRemaining();
+			*sizeToDo = referenceSize + ((GC_MixedObjectScanner *)objectScanner)->getBytesRemaining();
 			break;
 		case GC_ObjectModel::SCAN_POINTER_ARRAY_OBJECT:
 		{
@@ -144,7 +145,7 @@ public:
 		{
 			fomrobject_t *referentSlotPtr = setupReferenceObjectScanner(env, objectPtr, reason);
 			objectScanner = GC_ReferenceObjectScanner::newInstance(env, objectPtr, referentSlotPtr, scannerSpace, 0);
-			*sizeToDo = sizeof(fomrobject_t) + ((GC_ReferenceObjectScanner *)objectScanner)->getBytesRemaining();
+			*sizeToDo = referenceSize + ((GC_ReferenceObjectScanner *)objectScanner)->getBytesRemaining();
 			break;
 		}
 		case GC_ObjectModel::SCAN_PRIMITIVE_ARRAY_OBJECT:

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1332,7 +1332,7 @@ MM_MetronomeDelegate::processReferenceList(MM_EnvironmentRealtime *env, MM_HeapR
 
 		J9Object* nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
 
-		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, referenceObj));
+		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, referenceObj));
 		J9Object *referent = referentSlotObject.readReferenceFromSlot();
 		if (NULL != referent) {
 			UDATA referenceObjectType = J9CLASS_FLAGS(J9GC_J9OBJECT_CLAZZ(referenceObj, env)) & J9AccClassReferenceMask;

--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -583,19 +583,23 @@ public:
 		 * pointer if another thread copied the object underneath us). In non-compressed, this field should still be readable
 		 * out of the heap.
 		 */
-		 uint32_t size = 0;
+		uint32_t size = 0;
 #if defined (OMR_GC_COMPRESSED_POINTERS)
 		if (compressObjectReferences()) {
 			size = forwardedHeader->getPreservedOverlap();
 		} else
 #endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 		{
-			size = ((J9IndexableObjectContiguous *)forwardedHeader->getObject())->size;
+			size = ((J9IndexableObjectContiguousFull *)forwardedHeader->getObject())->size;
 		}
 
 		if (0 == size) {
 			/* Discontiguous */
-			size = ((J9IndexableObjectDiscontiguous *)forwardedHeader->getObject())->size;
+			if (compressObjectReferences()) {
+				size = ((J9IndexableObjectDiscontiguousCompressed *)forwardedHeader->getObject())->size;
+			} else {
+				size = ((J9IndexableObjectDiscontiguousFull *)forwardedHeader->getObject())->size;
+			}
 		}
 
 		return size;
@@ -619,7 +623,7 @@ public:
 		} else
 #endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 		{
-			size = ((J9IndexableObjectContiguous *)forwardedHeader->getObject())->size;
+			size = ((J9IndexableObjectContiguousFull *)forwardedHeader->getObject())->size;
 		}
 		
 		if (0 != size) {

--- a/runtime/gc_glue_java/PointerArrayObjectScanner.hpp
+++ b/runtime/gc_glue_java/PointerArrayObjectScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,12 @@ protected:
 	 * @param[in] flags Scanning context flags
 	 */
 	MMINLINE GC_PointerArrayObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t arrayPtr, fomrobject_t *basePtr, fomrobject_t *limitPtr, fomrobject_t *scanPtr, fomrobject_t *endPtr, uintptr_t flags)
-		: GC_IndexableObjectScanner(env, arrayPtr, basePtr, limitPtr, scanPtr, endPtr, ((endPtr - scanPtr) < _bitsPerScanMap) ? (((uintptr_t)1 << (endPtr - scanPtr)) - 1) : UDATA_MAX, sizeof(fomrobject_t), flags)
+		: GC_IndexableObjectScanner(env, arrayPtr, basePtr, limitPtr, scanPtr, endPtr
+			, (GC_SlotObject::subtractSlotAddresses(endPtr, scanPtr, env->compressObjectReferences()) < _bitsPerScanMap)
+				? ((uintptr_t)1 << GC_SlotObject::subtractSlotAddresses(endPtr, scanPtr, env->compressObjectReferences())) - 1
+				: UDATA_MAX
+			, env->compressObjectReferences() ? sizeof(uint32_t) : sizeof(uintptr_t)
+			, flags)
 		, _mapPtr(_scanPtr)
 	{
 		_typeId = __FUNCTION__;
@@ -88,16 +93,17 @@ public:
 	{
 		GC_PointerArrayObjectScanner *objectScanner = (GC_PointerArrayObjectScanner *)allocSpace;
 		if (NULL != objectScanner) {
+			bool const compressed = env->compressObjectReferences();
 			GC_ArrayObjectModel *arrayObjectModel = &(env->getExtensions()->indexableObjectModel);
 			omrarrayptr_t arrayPtr = (omrarrayptr_t)objectPtr;
 			uintptr_t sizeInElements = arrayObjectModel->getSizeInElements(arrayPtr);
-			fomrobject_t *basePtr = (fj9object_t *)arrayObjectModel->getDataPointerForContiguous(arrayPtr);
-			fomrobject_t *scanPtr = basePtr + startIndex;
-			fomrobject_t *limitPtr = basePtr + sizeInElements;
+			fomrobject_t *basePtr = (fomrobject_t *)arrayObjectModel->getDataPointerForContiguous(arrayPtr);
+			fomrobject_t *scanPtr = GC_SlotObject::addToSlotAddress(basePtr, startIndex, compressed);
+			fomrobject_t *limitPtr = GC_SlotObject::addToSlotAddress(basePtr, sizeInElements, compressed);
 			fomrobject_t *endPtr = limitPtr;
 
 			if (!GC_ObjectScanner::isIndexableObjectNoSplit(flags)) {
-				fomrobject_t *splitPtr = scanPtr + splitAmount;
+				fomrobject_t *splitPtr = GC_SlotObject::addToSlotAddress(scanPtr, splitAmount, compressed);
 				if ((splitPtr > scanPtr) && (splitPtr < endPtr)) {
 					endPtr = splitPtr;
 				}
@@ -112,7 +118,7 @@ public:
 		return objectScanner;
 	}
 
-	MMINLINE uintptr_t getBytesRemaining() { return sizeof(fomrobject_t) * (_endPtr - _scanPtr); }
+	MMINLINE uintptr_t getBytesRemaining() { return (uintptr_t)_endPtr - (uintptr_t)_scanPtr; }
 
 	/**
 	 * @param env The scanning thread environment
@@ -127,7 +133,7 @@ public:
 
 		Assert_MM_true(_limitPtr >= _endPtr);
 		/* Downsize splitAmount if larger than the tail of this scanner */
-		uintptr_t remainder = (uintptr_t)(_limitPtr - _endPtr);
+		uintptr_t remainder = GC_SlotObject::subtractSlotAddresses(_limitPtr, _endPtr, compressObjectReferences());
 		if (splitAmount > remainder) {
 			splitAmount = remainder;
 		}
@@ -136,7 +142,7 @@ public:
 		/* If splitAmount is 0 the new scanner will return NULL on the first call to getNextSlot(). */
 		splitScanner = (GC_PointerArrayObjectScanner *)allocSpace;
 		/* Create new scanner for next chunk of array starting at the end of current chunk size splitAmount elements */
-		new(splitScanner) GC_PointerArrayObjectScanner(env, getArrayObject(), _basePtr, _limitPtr, _endPtr, _endPtr + splitAmount, _flags);
+		new(splitScanner) GC_PointerArrayObjectScanner(env, getArrayObject(), _basePtr, _limitPtr, _endPtr, GC_SlotObject::addToSlotAddress(_endPtr, splitAmount, compressObjectReferences()), _flags);
 		splitScanner->initialize(env);
 
 		return splitScanner;
@@ -155,10 +161,11 @@ public:
 	virtual fomrobject_t *
 	getNextSlotMap(uintptr_t *slotMap, bool *hasNextSlotMap)
 	{
+		bool const compressed = compressObjectReferences();
 		fomrobject_t *result = NULL;
-		_mapPtr += _bitsPerScanMap;
+		_mapPtr = GC_SlotObject::addToSlotAddress(_mapPtr, _bitsPerScanMap, compressed);
 		if (_endPtr > _mapPtr) {
-			intptr_t remainder = _endPtr - _mapPtr;
+			intptr_t remainder = GC_SlotObject::subtractSlotAddresses(_endPtr, _mapPtr, compressed);
 			if (remainder >= _bitsPerScanMap) {
 				*slotMap = UDATA_MAX;
 			} else {

--- a/runtime/gc_glue_java/ReferenceObjectScanner.hpp
+++ b/runtime/gc_glue_java/ReferenceObjectScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ private:
 	{
 		if (_referentSlotAddress > mapPtr) {
 			/* Skip over referent slot */
-			intptr_t referentSlotDistance = _referentSlotAddress - mapPtr;
+			intptr_t referentSlotDistance = GC_SlotObject::subtractSlotAddresses(_referentSlotAddress, mapPtr, compressObjectReferences());
 			if (referentSlotDistance < _bitsPerScanMap) {
 				scanMap &= ~((uintptr_t)1 << referentSlotDistance);
 			}

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -61,12 +61,12 @@ class MM_ParallelSweepScheme;
  */
 class MM_ScavengerDelegate : public MM_BaseNonVirtual {
 private:
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
-	bool _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	OMR_VM *_omrVM;
 	J9JavaVM *_javaVM;
 	MM_GCExtensions *_extensions;
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	bool _compressObjectReferences;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	volatile bool _shouldScavengeFinalizableObjects; /**< Set to true at the beginning of a collection if there are any pending finalizable objects */
 	volatile bool _shouldScavengeUnfinalizedObjects; /**< Set to true at the beginning of a collection if there are any unfinalized objects */
 	volatile bool _shouldScavengeSoftReferenceObjects; /**< Set to true if there are any SoftReference objects discovered */

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,7 @@ MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_He
 		Assert_GC_true_with_message(env, _scavenger->isObjectInNewSpace(referenceObj), "Scavenged reference object not in new space: %p\n", referenceObj);
 
 		omrobjectptr_t nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
-		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, referenceObj));
+		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, referenceObj));
 		omrobjectptr_t referent = referentSlotObject.readReferenceFromSlot();
 		if (NULL != referent) {
 			/* update the referent if it's been forwarded */

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,14 +141,14 @@ MM_ReadBarrierVerifier::healSlot(MM_GCExtensionsBase *extensions, fomrobject_t *
 {
 	uintptr_t shadowHeapBase = (uintptr_t)extensions->shadowHeapBase;
 	uintptr_t shadowHeapTop = (uintptr_t)extensions->shadowHeapTop;
-	omrobjectptr_t object = convertPointerFromToken(*srcAddress);
+	GC_SlotObject slotObject(extensions->getOmrVM(), srcAddress);
+	omrobjectptr_t object = slotObject.readReferenceFromSlot();
 
 	if ((shadowHeapTop > (uintptr_t)object) && (shadowHeapBase <= (uintptr_t)object)) {
 
 		uintptr_t heapBase = (uintptr_t)extensions->heap->getHeapBase();
 		uintptr_t healedAddress = heapBase + ((uintptr_t)object - shadowHeapBase);
 
-		GC_SlotObject slotObject(extensions->getOmrVM(), srcAddress);
 		/* We don't care if the write fails, some other thread probably wrote a healed value to the slot */
 		slotObject.atomicWriteReferenceToSlot(object, (omrobjectptr_t)healedAddress);
 

--- a/runtime/gc_realtime/EnvironmentRealtime.hpp
+++ b/runtime/gc_realtime/EnvironmentRealtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,9 +49,7 @@ private:
 	
 	I_32 _yieldDisableDepth;
 
-	uintptr_t _scannedBytes;         /**< Number of bytes, objects, pointer fields scanned in current major GC */
-	uintptr_t _scannedObjects;
-	uintptr_t _scannedPointerFields;
+	uintptr_t _scannedObjects;			/**< Number of objects scanned in current major GC */
 	
 	MM_HeapRegionDescriptorRealtime **_overflowCache; /**< Local cache of overflowed regions.  Can only be manipulated by IncrementalOverflow */
 	uintptr_t _overflowCacheCount; /**< Count of used elements in the _overflowCache array. Can on be manipulated by IncrementalOverflow */
@@ -105,17 +103,11 @@ public:
 	
 	void setRootScanner(MM_RealtimeRootScanner *rootScanner) { _rootScanner = rootScanner; }
 	
-	uintptr_t getScannedBytes() const { return _scannedBytes; }
-	void addScannedBytes(uintptr_t scannedBytes) { _scannedBytes += scannedBytes; }
 	uintptr_t getScannedObjects() const { return _scannedObjects; }
 	void incScannedObjects() { _scannedObjects++; }
-	uintptr_t getScannedPointerFields() const { return _scannedPointerFields; }
-	void addScannedPointerFields(uintptr_t scannedPointerFields) { _scannedPointerFields += scannedPointerFields; }
 	void resetScannedCounters() 
 	{
-		_scannedBytes = 0;
 		_scannedObjects = 0;
-		_scannedPointerFields = 0;
 	}
 	MM_Timer *getTimer() {return _timer;}
 	

--- a/runtime/gc_realtime/RealtimeAccessBarrier.cpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -188,6 +188,7 @@ MM_RealtimeAccessBarrier::validateWriteBarrier(J9VMThread *vmThread, J9Object *d
 {
 	J9JavaVM *javaVM = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	bool const compressed = J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread);
 
 	switch(_extensions->objectModel.getScanType(dstObject)) {
 	case GC_ObjectModel::SCAN_MIXED_OBJECT_LINKED:
@@ -198,12 +199,12 @@ MM_RealtimeAccessBarrier::validateWriteBarrier(J9VMThread *vmThread, J9Object *d
 	case GC_ObjectModel::SCAN_CLASSLOADER_OBJECT:
 	case GC_ObjectModel::SCAN_REFERENCE_MIXED_OBJECT:
 	{
-		if (((fj9object_t *) dstAddress) - ((fj9object_t *) dstObject)) {
+		intptr_t slotIndex = GC_SlotObject::subtractSlotAddresses(dstAddress, (fj9object_t*)dstObject, compressed);
+		if (slotIndex < 0) {
 			j9tty_printf(PORTLIB, "validateWriteBarrier: slotIndex is negative dstAddress %d and dstObject %d\n", dstAddress, dstObject);
 		}
-		UDATA slotIndex = ((fj9object_t *) dstAddress) - ((fj9object_t *) dstObject);
 		UDATA dataSizeInSlots = MM_Bits::convertBytesToSlots(_extensions->objectModel.getSizeInBytesWithHeader(dstObject));
-		if (slotIndex >= dataSizeInSlots) {
+		if ((UDATA)slotIndex >= dataSizeInSlots) {
 			j9tty_printf(PORTLIB, "validateWriteBarrier: slotIndex (%d) >= object size in slots (%d)", slotIndex, dataSizeInSlots);
 			printClass(javaVM, J9GC_J9OBJECT_CLAZZ_VM(dstObject, javaVM));
 			j9tty_printf(PORTLIB, "\n");
@@ -282,7 +283,7 @@ MM_RealtimeAccessBarrier::validateWriteBarrier(J9VMThread *vmThread, J9Object *d
 
 	case GC_ObjectModel::SCAN_PRIMITIVE_ARRAY_OBJECT:
 		j9tty_printf(PORTLIB, "validateWriteBarrier: writeBarrier called on array of primitive\n");
-		j9tty_printf(PORTLIB, "value being overwritten is %d\n", *dstAddress);
+		j9tty_printf(PORTLIB, "value being overwritten is %d\n", GC_SlotObject::readSlot(dstAddress, compressed));
 		printClass(javaVM, J9GC_J9OBJECT_CLAZZ_VM(dstObject, javaVM));
 		j9tty_printf(PORTLIB, "\n");
 		break;
@@ -740,7 +741,7 @@ MM_RealtimeAccessBarrier::preObjectStoreInternal(J9VMThread *vmThread, J9Object 
 		
 			J9Object *oldObject = NULL;
 			protectIfVolatileBefore(vmThread, isVolatile, true, false);
-			oldObject = mmPointerFromToken(vmThread, *destAddress);
+			oldObject = mmPointerFromToken(vmThread, GC_SlotObject::readSlot(destAddress, compressObjectReferences()));
 			protectIfVolatileAfter(vmThread, isVolatile, true, false);
 			rememberObject(env, oldObject);
 		}

--- a/runtime/gc_structs/MixedObjectDeclarationOrderIterator.cpp
+++ b/runtime/gc_structs/MixedObjectDeclarationOrderIterator.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,8 +41,8 @@ GC_MixedObjectDeclarationOrderIterator::nextSlot()
 	if (NULL == _fieldShape) {
 		return NULL;
 	}
-	
-	_slotObject.writeAddressToSlot(J9GC_J9OBJECT_FIELD_EA(_objectPtr, _walkState.fieldOffsetWalkState.result.offset));
+
+	_slotObject.writeAddressToSlot((fomrobject_t*)((uintptr_t)_objectPtr + _walkState.fieldOffsetWalkState.result.offset + J9JAVAVM_OBJECT_HEADER_SIZE(_javaVM)));
 	_index = _walkState.referenceIndexOffset + _walkState.classIndexAdjust + _walkState.fieldOffsetWalkState.result.index - 1;
 	_fieldShape = _javaVM->internalVMFunctions->fullTraversalFieldOffsetsNextDo(&_walkState);
 	return &_slotObject;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2335,7 +2335,7 @@ MM_CopyForwardScheme::scanReferenceObjectSlots(MM_EnvironmentVLHGC *env, MM_Allo
 		}
 	}
 	
-	GC_SlotObject referentPtr(_javaVM->omrVM, &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, objectPtr));
+	GC_SlotObject referentPtr(_javaVM->omrVM, J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, objectPtr));
 
 	/* Iterating and copyforwarding regular reference slots, except the special (soft) referent slot. Not making use of leaf bit optimization,
 	 * sacrificing minor performance to avoid code complication. Could optimize later, if/when using ObjectScanner */
@@ -3040,7 +3040,7 @@ MM_CopyForwardScheme::incrementalScanReferenceObjectSlots(MM_EnvironmentVLHGC *e
 	bool hasPartiallyScannedObject, MM_CopyScanCacheVLHGC** nextScanCache)
 {
 	GC_MixedObjectIterator mixedObjectIterator(_javaVM->omrVM);
-	fj9object_t *referentPtr = &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, objectPtr);
+	fj9object_t *referentPtr = J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, objectPtr);
 	bool referentMustBeMarked = false;
 
 	if (!hasPartiallyScannedObject) {
@@ -4944,7 +4944,7 @@ MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegi
 
 		J9Object* nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
 
-		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, referenceObj));
+		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, referenceObj));
 		J9Object *referent = referentSlotObject.readReferenceFromSlot();
 		if (NULL != referent) {
 			UDATA referenceObjectType = J9CLASS_FLAGS(J9GC_J9OBJECT_CLAZZ(referenceObj, env)) & J9AccClassReferenceMask;

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -594,7 +594,7 @@ MM_GlobalMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Obj
 		Assert_MM_unreachable();
 	}
 	
-	GC_SlotObject referentPtr(_javaVM->omrVM, &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, objectPtr));
+	GC_SlotObject referentPtr(_javaVM->omrVM, J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, objectPtr));
 
 	if (SCAN_REASON_OVERFLOWED_REGION == reason) {
 		/* handled when we empty packet to overflow */
@@ -1622,7 +1622,7 @@ MM_GlobalMarkingScheme::processReferenceList(MM_EnvironmentVLHGC *env, J9Object*
 	
 		J9Object* nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
 
-		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, referenceObj));
+		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, referenceObj));
 		J9Object *referent = referentSlotObject.readReferenceFromSlot();
 		if (NULL != referent) {
 			UDATA referenceObjectType = J9CLASS_FLAGS(J9GC_J9OBJECT_CLAZZ(referenceObj, env)) & J9AccClassReferenceMask;

--- a/runtime/gc_vlhgc/PartialMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -583,7 +583,7 @@ MM_PartialMarkingScheme::scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Ob
 		Assert_MM_unreachable();
 	}
 	
-	GC_SlotObject referentPtr(_javaVM->omrVM, &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, objectPtr));
+	GC_SlotObject referentPtr(_javaVM->omrVM, J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, objectPtr));
 
 	if (SCAN_REASON_OVERFLOWED_REGION == reason) {
 		/* handled when we empty packet to overflow */
@@ -1737,7 +1737,7 @@ MM_PartialMarkingScheme::processReferenceList(MM_EnvironmentVLHGC *env, J9Object
 		
 		J9Object* nextReferenceObj = _extensions->accessBarrier->getReferenceLink(referenceObj);
 
-		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), &J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, referenceObj));
+		GC_SlotObject referentSlotObject(_extensions->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(env, referenceObj));
 		J9Object *referent = referentSlotObject.readReferenceFromSlot();
 		if (NULL != referent) {
 			UDATA referenceObjectType = J9CLASS_FLAGS(J9GC_J9OBJECT_CLAZZ(referenceObj, env)) & J9AccClassReferenceMask;

--- a/runtime/gc_vlhgc/RegionBasedOverflowVLHGC.cpp
+++ b/runtime/gc_vlhgc/RegionBasedOverflowVLHGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -210,7 +210,7 @@ MM_RegionBasedOverflowVLHGC::overflowItemInternal(MM_EnvironmentBase *env, void 
 				}
 
 				if (referentMustBeCleared) {
-					GC_SlotObject referentPtr(envVLHGC->getOmrVM(), &J9GC_J9VMJAVALANGREFERENCE_REFERENT(envVLHGC, objectPtr));
+					GC_SlotObject referentPtr(envVLHGC->getOmrVM(), J9GC_J9VMJAVALANGREFERENCE_REFERENT_ADDRESS(envVLHGC, objectPtr));
 					referentPtr.writeReferenceToSlot(NULL);
 					J9GC_J9VMJAVALANGREFERENCE_STATE(envVLHGC, objectPtr) = GC_ObjectModel::REF_STATE_CLEARED;
 				}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5063,16 +5063,13 @@ typedef struct J9VMThread {
 #if defined(OMR_GC_FULL_POINTERS)
 /* Mixed mode - necessarily 64-bit */
 #define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) (0 != (vmThread)->compressObjectReferences)
-#define J9VMTHREAD_REFERENCE_SHIFT(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? 2 : 3)
 #else /* OMR_GC_FULL_POINTERS */
 /* Compressed only - necessarily 64-bit */
 #define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) TRUE
-#define J9VMTHREAD_REFERENCE_SHIFT(vmThread) 2
 #endif /* OMR_GC_FULL_POINTERS */
 #else /* OMR_GC_COMPRESSED_POINTERS */
 /* Full only - could be 32 or 64-bit */
 #define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) FALSE
-#define J9VMTHREAD_REFERENCE_SHIFT(vmThread) OMR_LOG_POINTER_SIZE
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 #define J9VMTHREAD_REFERENCE_SIZE(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? sizeof(U_32) : sizeof(UDATA))
 #define J9VMTHREAD_OBJECT_HEADER_SIZE(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))
@@ -5524,16 +5521,13 @@ typedef struct J9JavaVM {
 #if defined(OMR_GC_FULL_POINTERS)
 /* Mixed mode - necessarily 64-bit */
 #define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) J9_ARE_ANY_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES)
-#define J9JAVAVM_REFERENCE_SHIFT(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? 2 : 3)
 #else /* OMR_GC_FULL_POINTERS */
 /* Compressed only - necessarily 64-bit */
 #define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) TRUE
-#define J9JAVAVM_REFERENCE_SHIFT(vm) 2
 #endif /* OMR_GC_FULL_POINTERS */
 #else /* OMR_GC_COMPRESSED_POINTERS */
 /* Full only - could be 32 or 64-bit */
 #define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) FALSE
-#define J9JAVAVM_REFERENCE_SHIFT(vm) OMR_LOG_POINTER_SIZE
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 #define J9JAVAVM_REFERENCE_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(U_32) : sizeof(UDATA))
 #define J9JAVAVM_OBJECT_HEADER_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3292,10 +3292,9 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 	{
 		IDATA compressed = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XCOMPRESSEDREFS, NULL);
 		IDATA nocompressed = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XNOCOMPRESSEDREFS, NULL);
-		if (compressed > nocompressed) {
+		/* Compressed refs by default */
+		if (compressed >= nocompressed) {
 			vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES;
-		} else if (compressed < nocompressed) {
-			vm->extendedRuntimeFlags2 &= ~(UDATA)J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES;
 		}
 	}
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
@@ -5807,8 +5806,6 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	}
 #endif
 
-	initializeROMClasses(vm);
-
 #ifdef J9VM_RAS_EYECATCHERS
 	J9RASInitialize(vm);
 #endif
@@ -5994,6 +5991,9 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	if (JNI_OK != processVMArgsFromFirstToLast(vm)) {
 		goto error;
 	}
+
+	/* Must be done after the compressed/full determination has been made */
+	initializeROMClasses(vm);
 
 #if !defined(WIN32)
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags,J9_EXTENDED_RUNTIME_HANDLE_SIGXFSZ)) {


### PR DESCRIPTION
Remove assumptions about the compile-time size of various types (f9object_t/fomrobject_t/object headers).

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>