### PR TITLE
Change double map command line option to fix functional test

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -165,11 +165,11 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		if (try_scan(&scan_start, "enableArrayletDoubleMapping")) {
+		if (try_scan(&scan_start, "enableDoubleMapping")) {
 			extensions->isArrayletDoubleMapRequested = true;
 			continue;
                 }
-		if (try_scan(&scan_start, "disableArrayletDoubleMapping")) {
+		if (try_scan(&scan_start, "disableDoubleMapping")) {
 			extensions->isArrayletDoubleMapRequested = false;
 			continue;
 		}


### PR DESCRIPTION
Revert double map command line option to fix extended
functional tests. Command line option change from
-XXgc:enableArrayletDoubleMapping
to
-XXgc:enableDoubleMapping

Related to issue #8321 

Signed-off-by: Igor Braga <higorb1@gmail.com>