### PR TITLE
Check if pointer is in SCC

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
     * pointer passed in as a parameter.
     *
     * If the ptr isn't in the the SCC, then the current method will abort the
-    * compilation. If the ptr is in the SCC, then the updated cacheOffset will
+    * compilation. If the ptr is in the SCC, then the cacheOffset will be updated.
     *
     * @param sharedCache pointer to the TR_SharedCache object
     * @param ptr pointer whose offset in the SCC is required

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -29,6 +29,7 @@
 #include "compile/ResolvedMethod.hpp"
 #include "env/jittypes.h"
 #include "env/VMAccessCriticalSection.hpp"
+#include "exceptions/PersistenceFailure.hpp"
 #include "runtime/CodeRuntime.hpp"
 #include "control/CompilationRuntime.hpp"
 #include "env/VMJ9.h"
@@ -906,7 +907,45 @@ TR_J9SharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR
    {
    void *loaderForClazz = _fe->getClassLoader(clazz);
    void *classChainIdentifyingLoaderForClazz = persistentClassLoaderTable()->lookupClassChainAssociatedWithClassLoader(loaderForClazz);
-   uintptrj_t classChainOffsetInSharedCache = offsetInSharedCacheFromPointer(classChainIdentifyingLoaderForClazz);
+
+   uintptrj_t classChainOffsetInSharedCache;
+   TR::Compilation *comp = TR::comp();
+   if (comp)
+      {
+      /*
+       * TR_J9SharedCache::offsetInSharedCacheFromPointer asserts if the pointer
+       * passed in does not exist in the SCC. Under HCR, when an agent redefines
+       * a class, it causes the J9Class pointer to stay the same, but the
+       * J9ROMClass pointer changes. This means that if the compiler has a
+       * reference to a J9Class who J9ROMClass was in the SCC at one point in the
+       * compilation, it may no longer be so at another point in the compilation.
+       *
+       * This means that the compilation is no longer valid and should be aborted.
+       * Even if there isn't an abort during the compilation, at the end of the
+       * compilation, the compiler will fail the compile if such a redefinition
+       * occurred.
+       *
+       * Calling TR_J9SharedCache::offsetInSharedCacheFromPointer after such a
+       * redefinition could result in an assert. Therefore, this method exists as
+       * a wrapper around TR_J9SharedCache::isPointerInSharedCache which doesn't
+       * assert and conveniently, updates the location referred to by the cacheOffset
+       * pointer passed in as a parameter.
+       *
+       * If the ptr isn't in the the SCC, then the current method will abort the
+       * compilation. If the ptr is in the SCC, then the cacheOffset will be updated.
+       */
+      if (!isPointerInSharedCache(classChainIdentifyingLoaderForClazz, &classChainOffsetInSharedCache))
+         comp->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find pointer in SCC");
+      }
+   else
+      {
+      /*
+       * If we're not in a compilation, then perhaps it's better to call this API
+       * which will assert if anything's amiss
+       */
+      classChainOffsetInSharedCache = offsetInSharedCacheFromPointer(classChainIdentifyingLoaderForClazz);
+      }
+
    return classChainOffsetInSharedCache;
    }
 


### PR DESCRIPTION
Yet another PR to catch a case where HCR caused a class that used to be in the SCC to not be in the SCC. I missed this path when I opened https://github.com/eclipse/openj9/pull/7379.