### PR TITLE
Add support for -XX:+PrintCodeCache

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3191,6 +3191,22 @@ void TR::CompilationInfo::stopCompilationThreads()
       }
 
    static char * printCompMem = feGetEnv("TR_PrintCompMem");
+   static char * printCCUsage = feGetEnv("TR_PrintCodeCacheUsage");
+
+   // Example:
+   // CodeCache: size=262144Kb used=2048Kb max_used=1079Kb free=260096Kb
+   if (TR::Options::getCmdLineOptions()->getOption(TR_PrintCodeCacheUsage) || printCompMem || printCCUsage)
+      {
+      unsigned long currTotalUsedKB = (unsigned long)(TR::CodeCacheManager::instance()->getCurrTotalUsedInBytes()/1024);
+      unsigned long maxUsedKB = (unsigned long)(TR::CodeCacheManager::instance()->getMaxUsedInBytes()/1024);
+
+      fprintf(stderr, "\nCodeCache: size=%luKb used=%luKb max_used=%luKb free=%luKb\n\n",
+              _jitConfig->codeCacheTotalKB,
+              currTotalUsedKB,
+              maxUsedKB,
+              (_jitConfig->codeCacheTotalKB - currTotalUsedKB));
+      }
+
    if (printCompMem)
       {
       int32_t codeCacheAllocated = TR::CodeCacheManager::instance()->getCurrentNumberOfCodeCaches() * _jitConfig->codeCacheKB;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1425,6 +1425,17 @@ J9::Options::fePreProcess(void * base)
          }
       }
 
+   // -XX:+PrintCodeCache will be parsed twice into both AOT and JIT options here.
+   const char *xxPrintCodeCacheOption = "-XX:+PrintCodeCache";
+   const char *xxDisablePrintCodeCacheOption = "-XX:-PrintCodeCache";
+   int32_t xxPrintCodeCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxPrintCodeCacheOption, 0);
+   int32_t xxDisablePrintCodeCacheArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, xxDisablePrintCodeCacheOption, 0);
+
+   if (xxPrintCodeCacheArgIndex > xxDisablePrintCodeCacheArgIndex)
+      {
+      self()->setOption(TR_PrintCodeCacheUsage);
+      }
+
    // Enable on X and Z, also on P.
    // PPC supports -Xlp:codecache option.. since it's set via environment variables.  JVM should always request 4k pages.
    // fePreProcess is called twice - for AOT and JIT options parsing, which is redundant in terms of

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -683,7 +683,7 @@ J9::CodeCache::resetAllocationPointers()
    size_t warmSize = self()->getWarmCodeAlloc() - _warmCodeAllocBase;
    size_t coldSize = _coldCodeAllocBase - self()->getColdCodeAlloc();
    size_t freedSpace = warmSize + coldSize;
-   _manager->increaseFreeSpaceInCodeCacheRepository(freedSpace);
+   _manager->decreaseCurrTotalUsedInBytes(freedSpace);
    self()->setWarmCodeAlloc(_warmCodeAllocBase);
    self()->setColdCodeAlloc(_coldCodeAllocBase);
    }


### PR DESCRIPTION
When `-XX:+PrintCodeCache` is passed to the JVM or
`TR_PrintCodeCacheUsage=1` is set, the following
code cache usage data will be shown when the JVM exits:

`CodeCache: size=262144Kb used=454Kb max_used=457Kb free=261690Kb`.

This implementation requires the code cache usage data
implemented in eclipse/omr#4743.

If `TR_PrintCompMem` is set, the above code cache usage
information will be shown as well.

Fixes #8184

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>