### PR TITLE
Fix ByteOrder handling in ddr blob parsing

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureHeader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureHeader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,7 +133,11 @@ public class StructureHeader {
 		ddrStream.mark();
 		coreVersion = ddrStream.readInt();
 		if (coreVersion > 0xFFFF) {
-			ddrStream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+			if (ddrStream.getByteOrder() == ByteOrder.BIG_ENDIAN) {
+				ddrStream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+			} else {
+				ddrStream.setByteOrder(ByteOrder.BIG_ENDIAN);
+			}
 			ddrStream.reset();
 			coreVersion = ddrStream.readInt();
 		}


### PR DESCRIPTION
Correctly handle case where the ByteOrder of the image stream is improperly
set. Current code assumes that the image stream has a ByteOrder of
BIG_ENDIAN.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>