### PR TITLE
Moving supportVMInternalNatives from OMR to Openj9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -521,6 +521,11 @@ J9::CodeGenerator::lowerCompressedRefs(
       }
    }
 
+bool 
+J9::CodeGenerator::supportVMInternalNatives() 
+   { 
+   return !self()->comp()->compileRelocatableCode(); 
+   }
 
 // J9
 //

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -534,6 +534,12 @@ public:
    TR::Node *generatePoisonNode(
       TR::Block *currentBlock,
       TR::SymbolReference *liveAutoSymRef);
+   
+
+   /**
+    * \brief Determines whether VM Internal Natives is supported or not
+    */
+   bool supportVMInternalNatives();
 
 private:
 


### PR DESCRIPTION
Moving supportVMInternalNatives from OMR to Openj9

Moved CodeGenerator::supportVMInternalNatives() from OMRCodeGenerator to J9CodeGenerator with no other changes

    Resolves: Github issue eclipse/omr #1865

Signed-off-by: Siri Sahithi Ponangi <sahithi.ponangi@unb.ca>