### PR TITLE
Disable fieldwatch remote compilations on Power

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6896,6 +6896,10 @@ TR::CompilationInfoPerThreadBase::shouldPerformLocalComp(const TR_MethodToBeComp
       (!JITServerHelpers::isServerAvailable() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))))
       doLocalComp = true;
 
+   // Do a local compile because the Power codegen is missing some FieldWatch relocation support.
+   if (TR::Compiler->target.cpu.isPower() && _jitConfig->inlineFieldWatches)
+      doLocalComp = true;
+
    return doLocalComp;
    }
 #endif /* defined(JITSERVER_SUPPORT) */


### PR DESCRIPTION
Relocatable compiles for FieldWatch are not supported
in the Power codegen. Hence this commit disables JIT
compiles that are done remotely when fieldwatch is enabled.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>