### PR TITLE
Invoke addHint inside try/catch block in wrappedCompile

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7770,18 +7770,17 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 
    // cleanup the compilationShouldBeInterrupted flag.
    that->setCompilationShouldBeInterrupted(0);
-
-   if (that->_methodBeingCompiled->isDLTCompile())
-      {
-      TR_J9SharedCache *sc = (TR_J9SharedCache *) (vm->sharedCache());
-      if (sc)
-        sc->addHint(that->_methodBeingCompiled->getMethodDetails().getMethod(), TR_HintDLT);
-      }
-
    that->setMetadata(NULL);
 
    try
       {
+      if (that->_methodBeingCompiled->isDLTCompile())
+         {
+         TR_J9SharedCache *sc = (TR_J9SharedCache *) (vm->sharedCache());
+         if (sc)
+            sc->addHint(that->_methodBeingCompiled->getMethodDetails().getMethod(), TR_HintDLT);
+         }
+
       InterruptibleOperation generatingCompilationObject(*that);
       TR::IlGeneratorMethodDetails & details = that->_methodBeingCompiled->getMethodDetails();
       TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *) details.getMethod();


### PR DESCRIPTION
With the introduction of the `TR_J9JITServerSharedCache` class,
a `TR_J9SharedCache`'s `addHint` method can now throw exceptions. Thus we move the
invocation of that method down into the appropriate try/catch block
in `::wrappedCompile` so that any thrown exception gets handled correctly
at runtime.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>