### PR TITLE
Disable double mapping when page size exceeds default page size

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.hpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,7 +128,13 @@ public:
 	/**
 	 * For non-contiguous arraylets (discontiguous arraylets, hybrid not allowed
 	 * when double map is enabled), double maps the arraylet leaves to a contiguous
-	 * region outside the heap, making a discontiguous arraylet look contiguous
+	 * region outside the heap, making a discontiguous arraylet look contiguous.
+	 * Currently double map is enabled by manually passing command line option
+	 * XXgc:enableDoubleMapping; however, if the system supports huge pages and
+	 * double map gets manually enabled, then double map will be disabled. That's
+	 * because double map does support huge pages yet. If one still wants to
+	 * enable double map in such systems, one must manually force the application
+	 * to use the small system page size
 	 *
 	 * @param env thread GC Environment
 	 * @param objectPtr indexable object spine

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,8 +141,10 @@ public:
 
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/**
-	 * Sets enable double mapping
-	 * 
+	 * Sets enable double mapping status. Note that the double map
+	 * status value may differ from the requested one in certain
+	 * circuntances.
+	 *
 	 * @param enableDoubleMapping
 	 */
 	MMINLINE void
@@ -152,9 +154,9 @@ public:
 	}
 
 	/**
-	 * Returns enable double mapping
+	 * Returns enable double mapping status
 	 * 
-	 * @return true if double mapping is enabled, false otherwise
+	 * @return true if double mapping status is set to true, false otherwise.
 	 */
 	MMINLINE bool
 	isDoubleMappingEnabled()

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,12 +165,12 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		if (try_scan(&scan_start, "enableDoubleMapping")) {
-			extensions->indexableObjectModel.setEnableDoubleMapping(true);
+		if (try_scan(&scan_start, "enableArrayletDoubleMapping")) {
+			extensions->isArrayletDoubleMapRequested = true;
 			continue;
                 }
-		if (try_scan(&scan_start, "disableDoubleMapping")) {
-			extensions->indexableObjectModel.setEnableDoubleMapping(false);
+		if (try_scan(&scan_start, "disableArrayletDoubleMapping")) {
+			extensions->isArrayletDoubleMapRequested = false;
 			continue;
 		}
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,6 +96,20 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 	if (NULL == heap) {
 		return NULL;
 	}
+
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	/* Disable double map if requested page sizes used is equal to huge pages.
+	 * Currently double map is not supported when huge pages are used.
+	 * Note that we keep two double map fields: one for requested and another for
+	 * status. If large pages is enabled, it  will only change the STATUS of double
+	 * mapping, keeping the REQUESTED double mapping field intact.
+	 */
+	if (extensions->isArrayletDoubleMapRequested) {
+		if (!extensions->memoryManager->isLargePage(env, heap->getPageSize())) {
+			extensions->indexableObjectModel.setEnableDoubleMapping(true);
+		}
+	}
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 	/* when we try to attach this heap to a region manager, we will need the card table since it needs to be NUMA-affinitized using the same logic as the heap so initialize it here */
 	extensions->cardTable = MM_IncrementalCardTable::newInstance(MM_EnvironmentVLHGC::getEnvironment(env), heap);


### PR DESCRIPTION
Reverts eclipse/openj9#8329 to reinstate #8254

Needed now that eclipse/omr#4705 is promoted, see #8339.