### PR TITLE
Move double map command line option from -XXgc to -Xgc

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.hpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.hpp
@@ -129,12 +129,12 @@ public:
 	 * For non-contiguous arraylets (discontiguous arraylets, hybrid not allowed
 	 * when double map is enabled), double maps the arraylet leaves to a contiguous
 	 * region outside the heap, making a discontiguous arraylet look contiguous.
-	 * Currently double map is enabled by manually passing command line option
-	 * XXgc:enableDoubleMapping; however, if the system supports huge pages and
-	 * double map gets manually enabled, then double map will be disabled. That's
-	 * because double map does support huge pages yet. If one still wants to
-	 * enable double map in such systems, one must manually force the application
-	 * to use the small system page size
+	 * Double map is enabled by default, if one wants to disable it, manually pass
+	 * command line option -Xgc:disableArrayletDoubleMapping; however, if the
+	 * system supports huge pages then double map will be disabled. That's because
+	 * double map does support huge pages yet. If one still wants to enable double
+	 * map in such systems, one must manually force the application to use the
+	 * small system page size
 	 *
 	 * @param env thread GC Environment
 	 * @param objectPtr indexable object spine

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -164,16 +164,6 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->nonDeterministicSweep = true;
 			continue;
 		}
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		if (try_scan(&scan_start, "enableDoubleMapping")) {
-			extensions->isArrayletDoubleMapRequested = true;
-			continue;
-                }
-		if (try_scan(&scan_start, "disableDoubleMapping")) {
-			extensions->isArrayletDoubleMapRequested = false;
-			continue;
-		}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 		if(try_scan(&scan_start, "disableNonDeterministicSweep")) {
 			extensions->nonDeterministicSweep = false;
 			continue;

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1443,6 +1443,17 @@ gcParseXgcArguments(J9JavaVM *vm, char *optArg)
 			}
 			continue;
 		}
+
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		if (try_scan(&scan_start, "enableArrayletDoubleMapping")) {
+			extensions->isArrayletDoubleMapRequested = true;
+			continue;
+		}
+		if (try_scan(&scan_start, "disableArrayletDoubleMapping")) {
+			extensions->isArrayletDoubleMapRequested = false;
+			continue;
+		}
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 #if defined (J9VM_GC_VLHGC)
 		if (try_scan(&scan_start, "fvtest_tarokForceNUMANode=")) {


### PR DESCRIPTION
Update comments to match double map default value (true)

Related to issue: https://github.com/eclipse/openj9/issues/8349

Signed-off-by: Igor Braga <higorb1@gmail.com>