### PR TITLE
Fix for zlinux JCL_Test_JITHelpers hangs on z15

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -261,8 +261,7 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
    const uint32_t elementSizeMask = isUTF16 ? 1 : 0;
    const int8_t vectorSize = cg->machine()->getVRFSize();
    const uintptrj_t headerSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
-   // TODO (#8274): Re-enable VSTRS support in inlineVectorizedStringIndexOf
-   const bool supportsVSTRS = cg->comp()->target().cpu.getSupportsVectorFacilityEnhancement2() && feGetEnv("TR_EnableVectorStringSearch") != NULL;
+   const bool supportsVSTRS = cg->comp()->target().cpu.getSupportsVectorFacilityEnhancement2();
    TR::Compilation* comp = cg->comp();
 
    if (comp->getOption(TR_TraceCG))
@@ -450,8 +449,8 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
 
       // s2 header not found in s1
       // Load the next 16 bytes of s1 and continue
+      generateRIEInstruction(cg, TR::InstOpCode::getCmpRegAndBranchRelOpCode(), node, s1VecStartIndexReg, maxIndexReg, labelStringNotFound, TR::InstOpCode::COND_BNL);
       generateRRInstruction(cg, TR::InstOpCode::getAddRegOpCode(), node, s1VecStartIndexReg, loadLenReg);
-      generateRIEInstruction(cg, TR::InstOpCode::getCmpRegAndBranchRelOpCode(), node, s1VecStartIndexReg, maxIndexReg, labelStringNotFound, TR::InstOpCode::COND_BHR);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelFindS2Head);
 
       // s2 header full match
@@ -613,7 +612,6 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
       // Byte-index to char-index conversion
       generateRSInstruction(cg, TR::InstOpCode::SRA, node, resultReg, 1);
       }
-
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelResultDone);
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelStringNotFound);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -451,6 +451,7 @@ inlineVectorizedStringIndexOf(TR::Node* node, TR::CodeGenerator* cg, bool isUTF1
       // Load the next 16 bytes of s1 and continue
       generateRIEInstruction(cg, TR::InstOpCode::getCmpRegAndBranchRelOpCode(), node, s1VecStartIndexReg, maxIndexReg, labelStringNotFound, TR::InstOpCode::COND_BNL);
       generateRRInstruction(cg, TR::InstOpCode::getAddRegOpCode(), node, s1VecStartIndexReg, loadLenReg);
+      generateRIEInstruction(cg, TR::InstOpCode::getCmpRegAndBranchRelOpCode(), node, s1VecStartIndexReg, s1LenReg, labelStringNotFound, TR::InstOpCode::COND_BNL);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelFindS2Head);
 
       // s2 header full match

--- a/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
@@ -746,6 +746,7 @@ public class Test_JITHelpers {
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnop"), 16, valueField.get("ab"), 2, 0), 0);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnop"), 16, valueField.get("abc"), 3, 0), 0);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnop"), 16, valueField.get("abcdefghijklmnop"), 16, 0), 0);
+				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnopx"), 16, valueField.get("x"), 1, 0), -1);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnop"), 16, valueField.get("x"), 1, 0), -1);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnop"), 16, valueField.get("x"), 1, 1), -1);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghijklmnop"), 16, valueField.get("x"), 1, 7), -1);

--- a/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/com/ibm/jit/Test_JITHelpers.java
@@ -1,7 +1,7 @@
 package org.openj9.test.com.ibm.jit;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -912,6 +912,7 @@ public class Test_JITHelpers {
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("ab12345678901234567cdefghijklmnopq"), 34, valueField.get("de"), 2, 5), 20);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("ab12345678901234567cdefghijklmnopq"), 34, valueField.get("def"), 3, 5), 20);
 				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("ab12345678901234567cdefghijklmnopq"), 34, valueField.get("defghijklmn"), 11, 5), 20);
+				Assert.assertEquals(helpers.intrinsicIndexOfStringLatin1(valueField.get("abcdefghiklmnopqrstwyzabcdefghikabcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 71, valueField.get("abcdefghiklmnopqlmmnopqrstwyzabcdepoisd"), 39, 0), 32);
 			}
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
Compare and branch condition has been chagned to greater than or equal
from greater than. Previously this resulted in the evaluator skipping
the last index, hence the test failures. Moving the compare and branch
instruction a line above s1VecStartIndex add instruction fixes those
test failures.

Added test to force branch to `labelS2PartialMatch` from within
`labelMatchS2Loop`

This fix is based on @fjeremic's suggestion in eclipse#8159

fixes #8274

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>