### PR TITLE
Skip zero init of Matcher internal arrays

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -262,6 +262,9 @@
    java_util_concurrent_atomic_Fences_orderReads,
    java_util_concurrent_atomic_Fences_orderWrites,
    java_util_concurrent_atomic_Fences_reachabilityFence,
+
+   java_util_regex_Matcher_init,
+   java_util_regex_Matcher_usePattern,
 
    java_util_HashMap_all,
    java_util_ArrayList_all,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4166,6 +4166,13 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod},
       };
 
+   static X JavaUtilRegexMatcherMethods [] =
+      {
+      {x(TR::java_util_regex_Matcher_init, "<init>", "(Ljava/util/regex/Pattern;Ljava/lang/CharSequence;)V")},
+      {x(TR::java_util_regex_Matcher_usePattern, "usePattern", "(Ljava/util/regex/Pattern;)Ljava/util/regex/Matcher;")},
+      {TR::unknownMethod}
+      };
+
    struct Y { const char * _class; X * _methods; };
 
    /* classXX where XX is the number of characters in the class name */
@@ -4269,6 +4276,7 @@ void TR_ResolvedJ9Method::construct()
       { "java/lang/reflect/Array", ArrayMethods},
       { "java/nio/HeapByteBuffer", HeapByteBufferMethods},
       { "sun/nio/ch/NativeThread", NativeThreadMethods},
+      { "java/util/regex/Matcher", JavaUtilRegexMatcherMethods },
       { 0 }
       };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -494,6 +494,8 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    //TR::java_util_Arrays_copyOf,
    TR::java_io_Writer_write_lStringII,
    TR::java_io_Writer_write_I,
+   TR::java_util_regex_Matcher_init,
+   TR::java_util_regex_Matcher_usePattern,
    TR::unknownMethod
    };
 


### PR DESCRIPTION
The implementation of java/util/regex/Matcher uses two int arrays internally
to track matched regions. These arrays are created and then all elements are
set to -1. This changes skips the zero init of the int arrays at allocation-
time as the arrays will be immediately overwritten with -1s.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>