### PR TITLE
Preload property jdk.serialFilter to prevent later modification

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -451,6 +451,8 @@ private static void ensureProperties(boolean isInitialization) {
 	StringBuilder.initFromSystemProperties(systemProperties);
 /*[ENDIF] Sidecar19-SE */
 /*[ENDIF] Java12 */
+	/* Preload system property jdk.serialFilter to prevent later modification */
+	jdk.internal.util.StaticProperty.jdkSerialFilter();
 
 /*[IF Java12]*/
 	String javaRuntimeVersion = initializedProperties.get("java.runtime.version"); //$NON-NLS-1$


### PR DESCRIPTION
**Preload property jdk.serialFilter to prevent later modification**

The system property `jdk.serialFilter` is required to be initialized and cached at early startup stage and no later modification is allowed.

closes: #8352 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>