### PR TITLE
Print JITServer client UID in client JVM

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8787,13 +8787,20 @@ TR::CompilationInfoPerThreadBase::compile(
                {
                TR_ASSERT(_compiler.getHotnessName(_compiler.getMethodHotness()), "expected to have a hotness string");
                if (_compiler.getOutFile() != NULL && _compiler.getOption(TR_TraceAll))
-                  traceMsg(&_compiler, "<compile\n"
-                          "\tmethod=\"%s\"\n"
-                          "\thotness=\"%s\"\n"
-                          "\tisProfilingCompile=%d>\n",
-                          _compiler.signature(),
-                          _compiler.getHotnessName(_compiler.getMethodHotness()),
-                          _compiler.isProfilingCompilation());
+                  {
+                  traceMsg(&_compiler, "<compile\n");
+                  traceMsg(&_compiler, "\tmethod=\"%s\"\n", _compiler.signature());
+                  traceMsg(&_compiler, "\thotness=\"%s\"\n", _compiler.getHotnessName(_compiler.getMethodHotness()));
+                  traceMsg(&_compiler, "\tisProfilingCompile=%d", _compiler.isProfilingCompilation());
+#if defined(JITSERVER_SUPPORT)
+                  if (TR::compInfoPT->getClientData()) // not NULL
+                     {
+                     traceMsg(&_compiler, "\n");
+                     traceMsg(&_compiler, "\tclientID=%llu", TR::compInfoPT->getClientData()->getClientUID());
+                     }
+#endif /* defined(JITSERVER_SUPPORT) */
+                  traceMsg(&_compiler, ">\n");
+                  }
                }
             ~CompilationTrace() throw()
                {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -39,7 +39,6 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <time.h>
-#include <inttypes.h>
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9protos.h"
@@ -101,6 +100,7 @@
 #include "runtime/JITClientSession.hpp"
 #include "net/ClientStream.hpp"
 #include "net/ServerStream.hpp"
+#include "omrformatconsts.h"
 #endif /* defined(JITSERVER_SUPPORT) */
 #ifdef COMPRESS_AOT_DATA
 #include "shcdatatypes.h" // For CompiledMethodWrapper
@@ -8797,7 +8797,7 @@ TR::CompilationInfoPerThreadBase::compile(
                   if (_compiler.isOutOfProcessCompilation() && TR::compInfoPT->getClientData()) // using jitserver && client JVM
                      {
                      traceMsg(&_compiler, "\n");
-                     traceMsg(&_compiler, "\tclientID=%" PRIu64, TR::compInfoPT->getClientData()->getClientUID());
+                     traceMsg(&_compiler, "\tclientID=%" OMR_PRIu64, TR::compInfoPT->getClientData()->getClientUID());
                      }
 #endif /* defined(JITSERVER_SUPPORT) */
                   traceMsg(&_compiler, ">\n");

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -39,6 +39,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <time.h>
+#include <inttypes.h>
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9protos.h"
@@ -8793,10 +8794,10 @@ TR::CompilationInfoPerThreadBase::compile(
                   traceMsg(&_compiler, "\thotness=\"%s\"\n", _compiler.getHotnessName(_compiler.getMethodHotness()));
                   traceMsg(&_compiler, "\tisProfilingCompile=%d", _compiler.isProfilingCompilation());
 #if defined(JITSERVER_SUPPORT)
-                  if (TR::compInfoPT->getClientData()) // not NULL
+                  if (_compiler.isOutOfProcessCompilation() && TR::compInfoPT->getClientData()) // using jitserver && client JVM
                      {
                      traceMsg(&_compiler, "\n");
-                     traceMsg(&_compiler, "\tclientID=%llu", TR::compInfoPT->getClientData()->getClientUID());
+                     traceMsg(&_compiler, "\tclientID=%" PRIu64, TR::compInfoPT->getClientData()->getClientUID());
                      }
 #endif /* defined(JITSERVER_SUPPORT) */
                   traceMsg(&_compiler, ">\n");

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2079,11 +2079,13 @@ J9::Options::setupJITServerOptions()
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Server Mode. Port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerPort(), persistentInfo->getSocketTimeout());
       else if (persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT)
+         {
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Client Mode. Server address: %s port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerAddress().c_str(), persistentInfo->getJITServerPort(),
                persistentInfo->getSocketTimeout());
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,"Identifier for current client JVM: %llu\n", 
                compInfo->getPersistentInfo()->getClientUID());
+         }
       }
 
    }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -28,7 +28,6 @@
 #endif /* defined(JITSERVER_SUPPORT) */
 #include <ctype.h>
 #include <stdint.h>
-#include <inttypes.h>
 #include "jitprotos.h"
 #include "j2sever.h"
 #include "j9.h"
@@ -37,6 +36,7 @@
 #include "jvminit.h"
 #if defined(JITSERVER_SUPPORT)
 #include "j9vmnls.h"
+#include "omrformatconsts.h"
 #endif /* defined(JITSERVER_SUPPORT) */
 #include "codegen/CodeGenerator.hpp"
 #include "compile/Compilation.hpp"
@@ -2094,7 +2094,7 @@ J9::Options::setupJITServerOptions()
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Client Mode. Server address: %s port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerAddress().c_str(), persistentInfo->getJITServerPort(),
                persistentInfo->getSocketTimeout());
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Identifier for current client JVM: %" PRIu64 "\n",
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Identifier for current client JVM: %" OMR_PRIu64 "\n",
                compInfo->getPersistentInfo()->getClientUID());
          }
       }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2078,6 +2078,8 @@ J9::Options::setupJITServerOptions()
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Client Mode. Server address: %s port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerAddress().c_str(), persistentInfo->getJITServerPort(),
                persistentInfo->getSocketTimeout());
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,"Identifier for current client JVM: %llu\n", 
+               compInfo->getPersistentInfo()->getClientUID());
       }
 
    }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1989,11 +1989,15 @@ J9::Options::fePreProcess(void * base)
          std::random_device rd;
          std::mt19937_64 rng(rd());
          std::uniform_int_distribution<uint64_t> dist;
-         compInfo->getPersistentInfo()->setClientUID(dist(rng));
+         uint64_t clientUID = dist(rng);
+         compInfo->getPersistentInfo()->setClientUID(clientUID);
+         jitConfig->clientUID = clientUID;
+
          // _safeReservePhysicalMemoryValue is set as 0 for the JITClient because compilations
          // are done remotely. The user can still override it with a command line option
          J9::Options::_safeReservePhysicalMemoryValue = 0;
          }
+      jitConfig->isClient = (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT) ? 1 : 0; 
       }
 #endif /* defined(JITSERVER_SUPPORT) */
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3763,8 +3763,7 @@ typedef struct J9JITConfig {
 #if defined(JITSERVER_SUPPORT)
 	int32_t (*startJITServer)(struct J9JITConfig *jitConfig);
 	int32_t (*waitJITServerTermination)(struct J9JITConfig *jitConfig);
-	int32_t isClient;
-	int64_t clientUID;
+	uint64_t clientUID;
 #endif /* JITSERVER_SUPPORT */
 } J9JITConfig;
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3763,6 +3763,8 @@ typedef struct J9JITConfig {
 #if defined(JITSERVER_SUPPORT)
 	int32_t (*startJITServer)(struct J9JITConfig *jitConfig);
 	int32_t (*waitJITServerTermination)(struct J9JITConfig *jitConfig);
+	int32_t isClient;
+	int64_t clientUID;
 #endif /* JITSERVER_SUPPORT */
 } J9JITConfig;
 

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -23,7 +23,6 @@
 /* Includes */
 #include <string.h>
 #include <stdlib.h>
-#include <inttypes.h>
 #ifdef WIN32
 #include <malloc.h>
 #elif defined(LINUX) || defined(AIXPPC)
@@ -57,6 +56,10 @@
 #include "ute.h"
 
 #include "ut_j9dmp.h"
+
+#if defined(JITSERVER_SUPPORT)
+#include "omrformatconsts.h"
+#endif /* defined(JITSERVER_SUPPORT) */
 
 #if defined(J9VM_ENV_DATA64)
 #define SEGMENT_HEADER             "NULL           segment            start              alloc              end                type       size\n"
@@ -1074,7 +1077,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 #if defined(JITSERVER_SUPPORT)
 	if (0 != jitConfig->clientUID) {
 		_OutputStream.writeCharacters("1CICLIENTID    Client UID ");
-		_OutputStream.writeInteger64(jitConfig->clientUID, "%" PRIu64);
+		_OutputStream.writeInteger64(jitConfig->clientUID, "%" OMR_PRIu64);
 		_OutputStream.writeCharacters("\n");
 	}
 #endif /* JITSERVER_SUPPORT */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1052,13 +1052,30 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	/* Write the running mode data */
 	_OutputStream.writeCharacters("1CIRUNNINGAS   Running as ");
 
+	/* If JITServer enabled, print running mode as JITServer and client UID*/
+#ifdef JITSERVER_SUPPORT
+	if (jitConfig->isClient == 1) {
+		_OutputStream.writeCharacters("a JITServer Client");
+	} else {
+		_OutputStream.writeCharacters("a JITServer Server");
+	}
 	/* NB : I can't find any code for making this decision in the existing implementation */
-#ifdef J9VM_BUILD_J2SE
+#elif J9VM_BUILD_J2SE
 	_OutputStream.writeCharacters("a standalone");
 #else
 	_OutputStream.writeCharacters("an embedded");
 #endif
 	_OutputStream.writeCharacters(" JVM\n");
+
+#ifdef JITSERVER_SUPPORT
+	if (jitConfig->isClient == 1) {
+		char valueString[_MaximumGPValueLength]; 
+		sprintf(valueString, "%llu", (unsigned long long) jitConfig->clientUID);
+		_OutputStream.writeCharacters("1CICLIENTID    Client UID "); 
+		_OutputStream.writeCharacters(valueString);
+		_OutputStream.writeCharacters("\n");
+	}
+#endif
 
 	_OutputStream.writeCharacters("1CIVMIDLESTATE VM Idle State: ");
 	writeVMRuntimeState(_VirtualMachine->internalVMFunctions->getVMRuntimeState(_VirtualMachine));

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2019 IBM Corp. and others
+ * Copyright (c) 2003, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
Add unique UID to client JVM verbose log, javacore, and compilation log. 

Related to: #8346 

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>