### PR TITLE
Ensure the systemProperties is initialized

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -451,8 +451,6 @@ private static void ensureProperties(boolean isInitialization) {
 	StringBuilder.initFromSystemProperties(systemProperties);
 /*[ENDIF] Sidecar19-SE */
 /*[ENDIF] Java12 */
-	/* Preload system property jdk.serialFilter to prevent later modification */
-	jdk.internal.util.StaticProperty.jdkSerialFilter();
 
 /*[IF Java12]*/
 	String javaRuntimeVersion = initializedProperties.get("java.runtime.version"); //$NON-NLS-1$
@@ -495,6 +493,9 @@ private static void ensureProperties(boolean isInitialization) {
 /*[ELSE]
 	systemProperties = initializedProperties;
 /*[ENDIF] Java12 */
+	
+	/* Preload system property jdk.serialFilter to prevent later modification */
+	jdk.internal.util.StaticProperty.jdkSerialFilter();
 }
 
 /* Converts a Map<String, String> to a properties object.


### PR DESCRIPTION
**Ensure the systemProperties is initialized**

Moved `jdk.internal.util.StaticProperty.jdkSerialFilter()` to the end of `ensureProperties()` to ensure the `systemProperties` is initialized for `Java 14+`.

Verified that this works with `JDK14`.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>