### PR TITLE
Remove default test targets from variable file

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -473,18 +473,12 @@ def get_test_target_names() {
 
     if (TESTS_TARGETS && TESTS_TARGETS.trim() != 'none') {
         for (target in TESTS_TARGETS.trim().replaceAll("\\s","").toLowerCase().tokenize(',')) {
-            if (VARIABLES.tests_targets && VARIABLES.tests_targets."${target}") {
-                // we might be dealing with a map or a list depending if the variables file has been updated
-                // to use inheritance or not
-                def test_target_names =  VARIABLES.tests_targets."${target}"
-                switch(test_target_names){
-                case Map:
-                    targetNames.addAll(test_target_names.keySet())
+            switch (target) {
+                case ["sanity", "extended"]:
+                    targetNames.add("${target}.functional")
+                    break
                 default:
-                    targetNames.addAll(test_target_names)
-                }
-            } else {
-                targetNames.add(target)
+                    targetNames.add(target)
             }
         }
     }

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -641,12 +641,7 @@ def get_date() {
 * and sets TEST_FLAG for all targets if defined in variable file
 */
 def set_test_targets() {
-    TESTS_TARGETS = params.TESTS_TARGETS
-    if (!TESTS_TARGETS) {
-        // set default TESTS_TARGETS for pipeline job (fetch from variables file)
-        TESTS_TARGETS = get_default_test_targets()
-    }
-
+    TESTS_TARGETS = (params.TESTS_TARGETS) ? params.TESTS_TARGETS : "none"
     EXCLUDED_TESTS = []
     def buildspec = buildspec_manager.getSpec(SPEC)
     def excludedTests = buildspec.getVectorField("excluded_tests", SDK_VERSION)
@@ -664,13 +659,6 @@ def set_test_targets() {
     echo "TEST_FLAG: ${TEST_FLAG}"
 }
 
-def get_default_test_targets() {
-    if (VARIABLES.tests_targets && VARIABLES.tests_targets.default) {
-        return VARIABLES.tests_targets.default.join(',')
-    }
-
-    return ''
-}
 
 def set_slack_channel() {
     SLACK_CHANNEL = params.SLACK_CHANNEL

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -136,7 +136,7 @@ SHORT_NAMES = ['all' : ['ppc64le_linux','ppc64le_linux_xl','s390x_linux','s390x_
 echo "Initialize all PARAMETERS..."
 SETUP_LABEL = (params.SETUP_LABEL) ? params.SETUP_LABEL : "worker"
 echo "Setup SETUP_LABEL:'${SETUP_LABEL}'"
-TESTS_TARGETS = (params.TESTS_TARGETS) ? params.TESTS_TARGETS : ""
+TESTS_TARGETS = (params.TESTS_TARGETS) ? params.TESTS_TARGETS : "none"
 echo "TESTS_TARGETS:'${TESTS_TARGETS}'"
 PERSONAL_BUILD = (params.PERSONAL_BUILD) ? params.PERSONAL_BUILD : ""
 echo "PERSONAL_BUILD:'${PERSONAL_BUILD}'"
@@ -477,11 +477,6 @@ def get_summary_table(identifier) {
     def pipelineBuilds = buildFile.get_downstream_builds(currentBuild, currentBuild.projectName, pipelineNames)
     if (pipelineBuilds.isEmpty()) {
         return ''
-    }
-
-    if (!TESTS_TARGETS) {
-        // default to value set in variables file
-        TESTS_TARGETS = variableFile.get_default_test_targets()
     }
 
     def buildReleases = get_sorted_releases()

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -83,16 +83,6 @@ build_discarder:
 restart_timeout:
   time: '5'
   units: 'HOURS'
-tests_targets:
-  sanity:
-    - sanity.functional
-  extended:
-    - extended.functional
-  default: &defaultTests
-    - extended.functional
-    - extended.system
-    - sanity.functional
-    - sanity.system
 #========================================#
 # Large heap build
 #========================================#
@@ -109,7 +99,10 @@ cmake:
     next: '--disable-ddr'
   extra_make_options: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
   excluded_tests:
-      - *defaultTests
+      - sanity.functional
+      - extended.functional
+      - sanity.system
+      - extended.system
       - special.system
 #========================================#
 # JITServer


### PR DESCRIPTION
- Simplifies processing tests_targets.
- These defaults are unused. All builds are
  setup to specify what testing they run.
- Keep sanity and extended mapping for PR
  build simplicity.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>