### PR TITLE
Grow StringBuffer and StringBuilder aggressively from 1G to 2G

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -3,7 +3,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,8 @@ public final class StringBuffer extends AbstractStringBuilder implements Seriali
 	
 	
 	private static boolean TOSTRING_COPY_BUFFER_ENABLED = false;
+	private static boolean growAggressively = false;
+
 	
 	// Used to access compression related helper methods
 	private static final com.ibm.jit.JITHelpers helpers = com.ibm.jit.JITHelpers.getHelpers();
@@ -760,6 +762,10 @@ private void ensureCapacityImpl(int min) {
 	int currentCapacity = capacityInternal();
 	
 	int newCapacity = (currentCapacity << 1) + 2;
+
+	if (growAggressively && (newCapacity < currentCapacity)) {
+		newCapacity = Integer.MAX_VALUE;
+	}
 
 	int newLength = min > newCapacity ? min : newCapacity;
 	
@@ -1709,6 +1715,9 @@ public synchronized String substring(int start, int end) {
 static void initFromSystemProperties(Properties props) {
 	String prop = props.getProperty("java.lang.string.create.unique"); //$NON-NLS-1$
 	TOSTRING_COPY_BUFFER_ENABLED = "true".equals(prop) || "StringBuffer".equals(prop); //$NON-NLS-1$ //$NON-NLS-2$
+
+	String growAggressivelyProperty = props.getProperty("java.lang.stringBufferAndBuilder.growAggressively"); //$NON-NLS-1$
+	growAggressively = "".equals(growAggressivelyProperty) || "true".equalsIgnoreCase(growAggressivelyProperty); //$NON-NLS-1$ //$NON-NLS-2$
 }
 
 /**

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -3,7 +3,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,6 +64,7 @@ public final class StringBuilder extends AbstractStringBuilder implements Serial
 	
 	
 	private static boolean TOSTRING_COPY_BUFFER_ENABLED = false;
+	private static boolean growAggressively = false;
 	
 	// Used to access compression related helper methods
 	private static final com.ibm.jit.JITHelpers helpers = com.ibm.jit.JITHelpers.getHelpers();
@@ -759,6 +760,10 @@ private void ensureCapacityImpl(int min) {
 	int currentCapacity = capacityInternal();
 	
 	int newCapacity = (currentCapacity << 1) + 2;
+
+	if (growAggressively && (newCapacity < currentCapacity)) {
+		newCapacity = Integer.MAX_VALUE;
+	}
 
 	int newLength = min > newCapacity ? min : newCapacity;
 	
@@ -1709,6 +1714,9 @@ public String substring(int start, int end) {
 static void initFromSystemProperties(Properties props) {
 	String prop = props.getProperty("java.lang.string.create.unique"); //$NON-NLS-1$
 	TOSTRING_COPY_BUFFER_ENABLED = "true".equals(prop) || "StringBuilder".equals(prop); //$NON-NLS-1$ //$NON-NLS-2$
+
+	String growAggressivelyProperty = props.getProperty("java.lang.stringBufferAndBuilder.growAggressively"); //$NON-NLS-1$
+	growAggressively = "".equals(growAggressivelyProperty) || "true".equalsIgnoreCase(growAggressivelyProperty); //$NON-NLS-1$ //$NON-NLS-2$
 }
 
 /**

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2009, 2019 IBM Corp. and others
+  Copyright (c) 2009, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -544,6 +544,12 @@
  <test id="Test option -Xjit:count=0,disableZ15">
   <command>$EXE$ -Xjit:count=0,disableZ15 -version</command>
   <output regex="no" type="success">version</output>
+ </test>
+ 
+ <test id="Test StringBuffer/StringBuilder growth">
+  <command>$EXE$ -Xdump:none -Xmx7g -Djava.lang.stringBufferAndBuilder.growAggressively -cp $Q$$JARPATH$$Q$ TestStringBufferAndBuilderGrowth</command>
+  <output regex="no" type="success">StringBuffer capacity=2147483647 StringBuilder capacity=2147483647</output>
+  <output regex="no" type="success">Option too large</output>
  </test>
 
 </suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 	<test>
 		<testCaseName>cmdLineTest_J9test_SE80</testCaseName>
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DJARPATH=$(Q)$(TEST_RESROOT)$(D)cmdLineTest_J9tests.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) \
 	-Xint -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)j9tests_Java8.xml$(Q) \

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/TestStringBufferAndBuilderGrowth.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/TestStringBufferAndBuilderGrowth.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file TestStringBufferAndBuilderGrowth.java
+ * @brief Grows a StringBuffer and StringBuilder to Integer.MAX_VALUE
+ */
+public class TestStringBufferAndBuilderGrowth {
+
+public static void main(String[] args) {
+	char[] cbuf = new char[Integer.MAX_VALUE / 32];
+
+	// Create a StringBuffer big enough that the default algorithm to
+	// grow it will overflow Integer.MAX_VALUE. Some smaller sizes could
+	// be used without affecting the test, such as the default size, but
+	// starting it big avoids unnecessary copying so the test runs faster.
+	StringBuffer sbuf = new StringBuffer((Integer.MAX_VALUE / 2) + 1);
+	// 17 iterations adds approximately 1G + 64M (minus a few bytes)
+	// to the Buffer, causing it to grow.
+	for (int i = 0; i < 17; i++) {
+		try {
+ 	 		sbuf.append(cbuf);
+		} catch (OutOfMemoryError e) {
+			System.out.println("OOM StringBuffer occurred iteration " + i);
+			return;
+		}
+	}
+	int sbufCapacity = sbuf.capacity();
+	// sbuf is no longer used after this point and will be GCed. Nulling it
+	// isn't technically required for OpenJ9, but make it explicit for clarity.
+	sbuf = null;
+
+	// Duplicate the above test for StringBuilder.
+	StringBuilder sbld = new StringBuilder((Integer.MAX_VALUE / 2) + 1);
+	for (int i = 0; i < 17; i++) {
+		try {
+ 	 		sbld.append(cbuf);
+		} catch (OutOfMemoryError e) {
+			System.out.println("OOM StringBuilder occurred iteration " + i);
+			return;
+		}
+	}
+	int sbldCapacity = sbld.capacity();
+
+	System.out.println("StringBuffer capacity=" + sbufCapacity + " StringBuilder capacity=" + sbldCapacity);
+}
+}


### PR DESCRIPTION
Affects jdk8 only. jdk11 and later already grow aggressively.
When `-Djava.lang.stringBufferAndBuilder.growAggressively` or
`-Djava.lang.stringBufferAndBuilder.growAggressively=true` is set on
the command line, and doubling the capacity overflows Integer.MAX_VALUE, 
grow StringBuffer and StringBuilder to Integer.MAX_VALUE instead of
only increasing the capacity by the size of the String being appended.
Compatible with Hotspot behavior.

Add testing for the same.

Fixes #7671

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>