### PR TITLE
Revert "Enable CFG Simplifier"

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,10 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
+   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
+   if (enableCFGSimplification == NULL)
+      return false;
+
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
           || simplifyResolvedRequireNonNull(needToDuplicateTree)
           || simplifyUnresolvedRequireNonNull(needToDuplicateTree)


### PR DESCRIPTION
I'm not sure what's going wrong, but enabling CFG simplifier appears to expose another problem.  This reverts commit ed96ff0e14d4f810b80e1e37213dc14d2d07f3ed, placing CFG simplification back under control of the environment variable `TR_enableCFGSimplificaiton`.

Fixes:  Issue #8396

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>