### PR TITLE
Implement setParameterLinkageRegisterIndex pure virtual function

### DIFF
--- a/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,16 @@ public:
 
    virtual void createPrologue(TR::Instruction * cursor) { TR_ASSERT(false, "Not Implemented"); }
    virtual void createEpilogue(TR::Instruction * cursor) { TR_ASSERT(false, "Not Implemented"); }
+
+   virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * method)
+      {
+      TR_ASSERT_FATAL(false, "CHelperLinkage should only be used for call-outs");
+      }
+
+   virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol>&parmList)
+      {
+      TR_ASSERT_FATAL(false, "CHelperLinkage should only be used for call-outs");
+      }
 
    virtual void mapStack(TR::ResolvedMethodSymbol *symbol) { TR_ASSERT(false, "Not Implemented"); }
    virtual void mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex) { TR_ASSERT(false, "Not Implemented"); }


### PR DESCRIPTION
This pure virtual function as introduced in OMR to ensure all
subclasses of the linkage class implement it properly. Since
CHelperLinkage is only used for call-outs to CHelper APIs we cannot
implement this function properly, nor do we need to since no one should
ever be calling it. We add a fatal assert to ensure this is the case.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>