### PR TITLE
JEP-370 Implementation (Part 2)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -25,6 +25,7 @@
 package java.lang.invoke;
 
 import java.lang.reflect.Method;
+import sun.invoke.util.Wrapper;
 
 /*
  * Stub class to compile OpenJDK j.l.i.MethodHandleImpl
@@ -116,7 +117,30 @@ class LambdaForm {
 		V_TYPE;
 
 		static BasicType basicType(Class<?> cls) {
-			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+			/* Wrapper.forPrimitiveType throws an IllegalArgumentException for
+			 * non-primitive types (L_TYPE).
+			 */
+			Wrapper wrapper = Wrapper.forPrimitiveType(cls);
+			BasicType basicType = null;
+			if (wrapper != null) {
+				char basicTypeChar = wrapper.basicTypeChar();
+				if ((basicTypeChar == 'C') || (basicTypeChar == 'B') || (basicTypeChar == 'Z')
+					|| (basicTypeChar == 'I') || (basicTypeChar == 'S')
+				) {
+					basicType = I_TYPE;
+				} else if (basicTypeChar == 'J') {
+					basicType = J_TYPE;
+				} else if (basicTypeChar == 'F') {
+					basicType = F_TYPE;
+				} else if (basicTypeChar == 'D') {
+					basicType = D_TYPE;
+				} else if (basicTypeChar == 'V') {
+					basicType = V_TYPE;
+				} else {
+					throw new InternalError("Unknown basic type char: " + basicTypeChar);
+				}
+			}
+			return basicType;
 		}
 	}
 	/*[IF Java10]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -51,8 +51,10 @@ final class MemberName {
 	/*[ENDIF] Java11 */
 
 	/*[IF Java14]*/
+	Method method;
+
 	public MemberName(Method method) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		this.method = method;
 	}
 
 	public boolean isStatic() {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -46,8 +46,10 @@ import java.lang.constant.DynamicConstantDesc;
 import java.util.Objects;
 /*[ENDIF] Java12 */
 
-/*[IF Java14]*/
 import java.util.Map;
+import java.util.HashMap;
+
+/*[IF Java14]*/
 import java.util.function.BiFunction;
 /*[ENDIF] Java14 */
 
@@ -227,9 +229,13 @@ public abstract class VarHandle extends VarHandleInternal
 		boolean isSetter;
 		private String methodName;
 
-/*[IF Java14]*/
-		static final Map<String, AccessMode> methodNameToAccessMode = null;
-/*[ENDIF] Java14 */
+		static final Map<String, AccessMode> methodNameToAccessMode;
+		static {
+			methodNameToAccessMode = new HashMap<>();
+			for (AccessMode accessMode : values()) {
+				methodNameToAccessMode.put(accessMode.methodName, accessMode);
+			}
+		}
 
 		AccessMode(String methodName, AccessType signatureType, boolean isSetter) {
 			this.methodName = methodName;
@@ -251,10 +257,9 @@ public abstract class VarHandle extends VarHandleInternal
 		 * @return The AccessMode associated with the provided method name.
 		 */
 		public static AccessMode valueFromMethodName(String methodName) {
-			for (AccessMode m : values()) {
-				if (m.methodName.equals(methodName)) {
-					return m;
-				}
+			AccessMode accessMode = methodNameToAccessMode.get(methodName);
+			if (accessMode != null) {
+				return accessMode;
 			}
 
 			/*[MSG "K0633", "{0} is not a valid AccessMode."]*/


### PR DESCRIPTION
Related: https://github.com/eclipse/openj9/issues/8292.

This pull request has commits from and is dependent on https://github.com/eclipse/openj9/pull/8330 and https://github.com/eclipse/openj9/pull/8369.

The top seven commits are new, and they are described below. `Files changed` will show all the commits. So, individually refer to the new commits in order to review the changes specific to this pull request.

**1. Implement `LambdaForm.BasicType.basicType(Class<?> cls)`**

`BasicType.basicType` takes a class as input and outputs the corresponding
`BasicType` enum value depending on the class's basic type char. The
class's basic type char is derived using the `sun.invoke.util.Wrapper`
class.

**2. Implement the constructor `MemberName(Method method)`**

The `method` passed in the constructor, `MemberName(Method method)`, is
cached in the `MemberName` instance.

**3. Initialize `AccessMode.methodNameToAccessMode` (`HashMap`)**

`AccessMode.methodNameToAccessMode` is a `HashMap<String, AccessMode>`,
where the key is the `method name` and the value is the `AccessMode` enum
value. This hashmap is used in `AccessMode.valueFromMethodName` to
retrieve the AccessMode enum value for the corresponding method name. It
is also directly accessed from `VarForm.linkFromStatic`. It is needed so
that OpenJ9 can consume OpenJDK's VarForm class.

**4. Implement constructor `VarHandle(VarForm varForm)`**

In this constructor, `fieldType`, `coordinateTypes`, `handleTable` and
`modifiers` are initialized using the `VarForm` class. This should allow us
to consume OpenJDK's VarHandles with OpenJ9's `VarHandle` class as the
base class. Currently, it will only be used for OpenJDK's `MemoryAddress`
VarHandles.

**5. Handle conversion from OpenJDK to OpenJ9 VarHandle operation methods**

OpenJDK VarHandle operation methods have the following parameter
sequence: `{VarHandle, Receiver, Intermediate ..., Value}`.

During invocation, OpenJ9 uses the following parameter sequence for the
VarHandle operations: `{Receiver, Intermediate ..., Value, VarHandle}`.

The location of the `VarHandle` argument is different in the above two
cases. `MethodHandles.permuteArguments` is used to translate from the
OpenJ9 to OpenJDK invocation.

**6. Implement VarHandle.AccessType.accessModeType**

`AccessType.accessModeType` is implemented to retrieve the receiver class
from the derived `VarHandle` class since `VarForm` does not provide the
exact receiver class. In `VarForm`, the receiver class is always
`java.lang.Object`.

**7. Initialize VarHandle.handleTable with exact method types**

When the `AccessMode` methods have the receiver class defined generically
or as `java.lang.Object` in the derived `VarHandle` classes, then the
`handleTable` needs to be initialized with the exact method types, which
will be used during invocation of the `AccessMode` methods. The exact
method types need to specify the actual receiver class. This change
yields correct behavior with respect to `WrongMethodTypeException` and
`ClassCastException`. Without this change, `ClassCastException` is thrown
when `WrongMethodTypeException` is expected.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>