### PR TITLE
CMake: Split debug info on all targets

### DIFF
--- a/runtime/cmake/omr_config.cmake
+++ b/runtime/cmake/omr_config.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018, 2019 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,3 +28,4 @@ set(OMR_DDR OFF CACHE BOOL "")
 set(OMR_EXAMPLE OFF CACHE INTERNAL "")
 set(OMR_FVTEST OFF CACHE INTERNAL "")
 set(OMR_GC ON CACHE INTERNAL "")
+set(OMR_SEPARATE_DEBUG_INFO ON CACHE INTERNAL "")


### PR DESCRIPTION
Ensure that debug info is split, even if they are not processed by DDR

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>