### PR TITLE
WIP: Decouple TR_PrexArgInfo from TR_InlinerTracer

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -3228,14 +3228,14 @@ bool TR_MultipleCallTargetInliner::inlineCallTargets(TR::ResolvedMethodSymbol *c
                   if (tracer()->heuristicLevel())
                      {
                      alwaysTrace(tracer(), "compArgInfo :");
-                     tracer()->dumpPrexArgInfo(compArgInfo);
+                     compArgInfo->dumpTrace();
                      }
                   compArgInfo->clearArgInfoForNonInvariantArguments(thisCallSiteCallerSymbol, tracer());
                   TR_PrexArgInfo::propagateArgsFromCaller(thisCallSiteCallerSymbol, callsite, compArgInfo, tracer());
                   if (tracer()->heuristicLevel())
                      {
                      alwaysTrace(tracer(), "callsite->getTarget(0)->_ecsPrexArgInfo :");
-                     tracer()->dumpPrexArgInfo(callsite->getTarget(0)->_ecsPrexArgInfo);
+                     callsite->getTarget(0)->_ecsPrexArgInfo->dumpTrace();
                      }
                   }
 
@@ -5405,7 +5405,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
       }
 
    heuristicTrace(tracer, "ARGS PROPAGATION: argsFromSymbol (from calleeSymbol)");
-   tracer->dumpPrexArgInfo(argsFromSymbol);
+   argsFromSymbol->dumpTrace();
 
    //validation
    TR_FrontEnd* fe = TR::comp()->fe();
@@ -5438,7 +5438,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
    TR_PrexArgInfo::enhance(argsFromTarget, argsFromSymbol, TR::comp()); //otherwise just pick more specific
 
    heuristicTrace(tracer, "ARGS PROPAGATION: final argInfo after merging argsFromTarget %p", argsFromTarget);
-   tracer->dumpPrexArgInfo(argsFromTarget);
+   argsFromTarget->dumpTrace();
 
    return true;
    }
@@ -5471,7 +5471,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
       if (cleanedAnything)
          {
          debugTrace(tracer, "ARGS PROPAGATION: argInfo %p after clear arg info for non-invariant arguments", this);
-         tracer->dumpPrexArgInfo(this);
+         dumpTrace();
          }
       }
 
@@ -5506,7 +5506,7 @@ void TR_PrexArgInfo::propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSym
 
    heuristicTrace(tracer, "ARGS PROPAGATION: argsFromTarget before args propagation");
    for (int i = 0; i < callsite->numTargets(); i++)
-      tracer->dumpPrexArgInfo(callsite->getTarget(i)->_ecsPrexArgInfo);
+      callsite->getTarget(i)->_ecsPrexArgInfo->dumpTrace();
 
    for (int i = callNode->getFirstArgumentIndex(); i < callNode->getNumChildren(); i++)
       {
@@ -5548,7 +5548,7 @@ void TR_PrexArgInfo::propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSym
       {
       heuristicTrace(tracer, "ARGS PROPAGATION: ArgInfo after propagating the args from the caller");
       for (int i = 0; i < callsite->numTargets(); i++)
-         tracer->dumpPrexArgInfo(callsite->getTarget(i)->_ecsPrexArgInfo);
+         callsite->getTarget(i)->_ecsPrexArgInfo->dumpTrace();
       }
    }
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5405,7 +5405,8 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
       }
 
    heuristicTrace(tracer, "ARGS PROPAGATION: argsFromSymbol (from calleeSymbol)");
-   argsFromSymbol->dumpTrace();
+   if (tracer->heuristicLevel())
+      argsFromSymbol->dumpTrace();
 
    //validation
    TR_FrontEnd* fe = TR::comp()->fe();
@@ -5438,7 +5439,8 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
    TR_PrexArgInfo::enhance(argsFromTarget, argsFromSymbol, TR::comp()); //otherwise just pick more specific
 
    heuristicTrace(tracer, "ARGS PROPAGATION: final argInfo after merging argsFromTarget %p", argsFromTarget);
-   argsFromTarget->dumpTrace();
+   if (tracer->heuristicLevel())
+      argsFromTarget->dumpTrace();
 
    return true;
    }
@@ -5471,7 +5473,8 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
       if (cleanedAnything)
          {
          debugTrace(tracer, "ARGS PROPAGATION: argInfo %p after clear arg info for non-invariant arguments", this);
-         dumpTrace();
+         if (tracer->heuristicLevel())
+            dumpTrace();
          }
       }
 
@@ -5506,7 +5509,8 @@ void TR_PrexArgInfo::propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSym
 
    heuristicTrace(tracer, "ARGS PROPAGATION: argsFromTarget before args propagation");
    for (int i = 0; i < callsite->numTargets(); i++)
-      callsite->getTarget(i)->_ecsPrexArgInfo->dumpTrace();
+      if (tracer->heuristicLevel())
+         callsite->getTarget(i)->_ecsPrexArgInfo->dumpTrace();
 
    for (int i = callNode->getFirstArgumentIndex(); i < callNode->getNumChildren(); i++)
       {

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5103,7 +5103,7 @@ void TR_J9InlinerUtil::checkForConstClass(TR_CallTarget *target, TR_InlinerTrace
    TR_PrexArgInfo *ecsArgInfo = target->_ecsPrexArgInfo;
    if (!ecsArgInfo) return;
 
-   TR::Compilation * comp = tracer->comp();
+   TR::Compilation * comp = TR::comp();
    bool tracePrex = comp->trace(OMR::inlining) || comp->trace(OMR::invariantArgumentPreexistence);
 
    if (tracePrex)
@@ -5398,7 +5398,7 @@ void TR_PrexArgInfo::propagateReceiverInfoIfAvailable (TR::ResolvedMethodSymbol*
 
 bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_InlinerTracer *tracer)
    {
-   if (!argsFromSymbol || !argsFromTarget || tracer->comp()->getOption(TR_DisableInlinerArgsPropagation))
+   if (!argsFromSymbol || !argsFromTarget || TR::comp()->getOption(TR_DisableInlinerArgsPropagation))
       {
       heuristicTrace(tracer, "ARGS PROPAGATION: argsFromSymbol %p or argsFromTarget %p are missing\n", argsFromSymbol, argsFromTarget);
       return true;
@@ -5408,7 +5408,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
    tracer->dumpPrexArgInfo(argsFromSymbol);
 
    //validation
-   TR_FrontEnd* fe = tracer->comp()->fe();
+   TR_FrontEnd* fe = TR::comp()->fe();
    int32_t numArgsToEnhance = std::min(argsFromTarget->getNumArgs(), argsFromSymbol->getNumArgs());
    for (int32_t i = 0; i < numArgsToEnhance; i++)
       {
@@ -5435,7 +5435,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
       }
 
 
-   TR_PrexArgInfo::enhance(argsFromTarget, argsFromSymbol, tracer->comp()); //otherwise just pick more specific
+   TR_PrexArgInfo::enhance(argsFromTarget, argsFromSymbol, TR::comp()); //otherwise just pick more specific
 
    heuristicTrace(tracer, "ARGS PROPAGATION: final argInfo after merging argsFromTarget %p", argsFromTarget);
    tracer->dumpPrexArgInfo(argsFromTarget);
@@ -5446,7 +5446,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
 
    void TR_PrexArgInfo::clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer)
       {
-      if (tracer->comp()->getOption(TR_DisableInlinerArgsPropagation))
+      if (TR::comp()->getOption(TR_DisableInlinerArgsPropagation))
          return;
 
       bool cleanedAnything = false;
@@ -5478,7 +5478,7 @@ bool TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* ar
 void TR_PrexArgInfo::propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
                            TR_PrexArgInfo * argInfo, TR_InlinerTracer *tracer)
    {
-   if (tracer->comp()->getOption(TR_DisableInlinerArgsPropagation))
+   if (TR::comp()->getOption(TR_DisableInlinerArgsPropagation))
       return;
 
    TR_ASSERT(argInfo, "otherwise we shouldn't even peek");

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -815,7 +815,7 @@ InterpreterEmulator::findTargetAndUpdateInfoForCallsite(TR_CallSite *callsite)
             {
             alwaysTrace(tracer(), "propagateReceiverInfoIfAvailable :");
             if (callsite->_ecsPrexArgInfo)
-               tracer()->dumpPrexArgInfo(callsite->_ecsPrexArgInfo);
+               callsite->_ecsPrexArgInfo->dumpTrace();
             }
          }
       }
@@ -832,7 +832,7 @@ InterpreterEmulator::findTargetAndUpdateInfoForCallsite(TR_CallSite *callsite)
             {
             alwaysTrace(tracer(), "propagateArgs :");
             if (callsite->numTargets() && callsite->getTarget(0)->_ecsPrexArgInfo)
-               tracer()->dumpPrexArgInfo(callsite->getTarget(0)->_ecsPrexArgInfo);
+               callsite->getTarget(0)->_ecsPrexArgInfo->dumpTrace();
             }
          }
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -529,7 +529,7 @@ InterpreterEmulator::debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod)
    if(tracer()->heuristicLevel())
       {
       if (resolvedMethod)
-         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex ,tracer()->traceSignature(resolvedMethod));
+         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, resolvedMethod->signature(TR::comp()->trMemory()));
       else
          {
          switch (current())
@@ -542,7 +542,7 @@ InterpreterEmulator::debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod)
                break;
             }
          TR::Method *meth = comp()->fej9()->createMethod(this->trMemory(), _calltarget->_calleeMethod->containingClass(), cpIndex);
-         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, tracer()->traceSignature(meth));
+         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, meth->signature(TR::comp()->trMemory()));
          }
       }
    }

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -157,7 +157,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
             TR::ResolvedMethodSymbol * methodSymbol,
             TR_J9VMBase * fe,
             TR::Compilation * comp,
-            TR_InlinerTracer *tracer,
+            TR_LogTracer *tracer,
             TR_EstimateCodeSize *ecs)
          : Base(methodSymbol, comp),
            _calltarget(calltarget),
@@ -169,7 +169,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
          _flags = NULL;
          _stacks = NULL;
          }
-      TR_InlinerTracer *tracer() { return _tracer; }
+      TR_LogTracer *tracer() { return _tracer; }
       /* \brief Initialize data needed for looking for callsites
        *
        * \param blocks
@@ -280,7 +280,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       bool isCurrentCallUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod, bool isUnresolvedInCP);
       void debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod);
 
-      TR_InlinerTracer *_tracer;
+      TR_LogTracer *_tracer;
       TR_EstimateCodeSize *_ecs;
       Operand * _unknownOperand; // used whenever the iterator can't reason about an operand
       TR_CallTarget *_calltarget; // the target method to inline

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1049,7 +1049,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if (tracer()->heuristicLevel() && calltarget->_ecsPrexArgInfo)
       {
       heuristicTrace(tracer(), "ECS CSI -- ArgInfo :");
-      tracer()->dumpPrexArgInfo(calltarget->_ecsPrexArgInfo);
+      calltarget->_ecsPrexArgInfo->dumpTrace();
       }
 
    TR_InlinerDelimiter delimiter(tracer(), "realEstimateCodeSize");

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -611,8 +611,6 @@ bool TR_J9InterfaceCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inl
       _ecsPrexArgInfo->set(0, NULL);
       }
 
-   //inliner->tracer()->dumpPrexArgInfo(_ecsPrexArgInfo);
-
    if (!_receiverClass)
       {
       int32_t len = _interfaceMethod->classNameLength();

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -153,7 +153,7 @@ class TR_J9InlinerUtil: public OMR_InlinerUtil
                    bool &appendTestToBlock1, TR::ResolvedMethodSymbol * callerSymbol, TR::TreeTop *cursorTree,
                    TR::TreeTop *&virtualGuard, TR::Block *block4);
       virtual void refineInliningThresholds(TR::Compilation *comp, int32_t &callerWeightLimit, int32_t &maxRecursiveCallByteCodeSizeEstimate, int32_t &methodByteCodeSizeThreshold, int32_t &methodInWarmBlockByteCodeSizeThreshold, int32_t &methodInColdBlockByteCodeSizeThreshold, int32_t &nodeCountThreshold, int32_t size);
-      static void checkForConstClass(TR_CallTarget *target, TR_InlinerTracer *tracer);
+      static void checkForConstClass(TR_CallTarget *target, TR_LogTracer *tracer);
       virtual bool needTargetedInlining(TR::ResolvedMethodSymbol *callee);
       virtual void requestAdditionalOptimizations(TR_CallTarget *calltarget);
    protected:


### PR DESCRIPTION
Move code from TR_InlinerTracer into TR_PrexArgInfo class so that TR_PrexArgInfo is no longer tightly couple to the TR_InlinerTracer class.

This should make the TR_PrexArgInfo class more reusable.

Note: this should be merged at the same time as https://github.com/eclipse/omr/pull/4779

- Replace calls to `TR_InlinerTracer::dumpPrexArgInfo` with calls to `TR_PrexArgInfo::dumpTrace`
- Access comp through static method `TR::comp` instead of using `tracer->comp()`
- Modify `TR_InterpreterEmulator` class to use the `TR_LogTracer` class instead of `TR_InlinerTracer` since `TR_LogTracer` is a less specialized class

Fixes: #7936

Signed-off-by: Ryan Shukla <ryans@ibm.com>