### PR TITLE
Ability to pass extra labels to test jobs if defined in variable file

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -479,11 +479,6 @@ def get_summary_table(identifier) {
         return ''
     }
 
-    if (!TESTS_TARGETS) {
-        // default to value set in variables file
-        TESTS_TARGETS = variableFile.get_default_test_targets()
-    }
-
     def buildReleases = get_sorted_releases()
 
     def headerCols = ['&nbsp;']

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,10 +22,10 @@
 
 ARGS = ['SDK_VERSION', 'PLATFORM']
 
-SETUP_LABEL = params.SETUP_LABEL
-if (!SETUP_LABEL) {
-    SETUP_LABEL = 'worker'
-}
+SETUP_LABEL = (params.SETUP_LABEL) ? params.SETUP_LABEL : 'worker'
+TESTS_TARGETS = (params.TESTS_TARGETS) ? params.TESTS_TARGETS : 'none'
+echo "TESTS_TARGETS:'${TESTS_TARGETS}'"
+
 def BUILD_NAME = 'Build-JDK'
 
 timestamps {

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -83,16 +83,6 @@ build_discarder:
 restart_timeout:
   time: '5'
   units: 'HOURS'
-tests_targets:
-  sanity:
-    - sanity.functional
-  extended:
-    - extended.functional
-  default: &defaultTests
-    - extended.functional
-    - extended.system
-    - sanity.functional
-    - sanity.system
 #========================================#
 # Large heap build
 #========================================#
@@ -109,7 +99,10 @@ cmake:
     next: '--disable-ddr'
   extra_make_options: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
   excluded_tests:
-      - *defaultTests
+      - sanity.functional
+      - extended.functional
+      - sanity.system
+      - extended.system
       - special.system
 #========================================#
 # JITServer


### PR DESCRIPTION
- Adds the ability to pass parameter LABEL_ADDITION to
  the test pipelines when extra_test_labels is defined
  in the variable file.
- Refactor some of the code that initializes the test
  targets.
- Remove default test targets from variable file. Simplifies
  processing of tests_targets. All builds are setup to specify
  the test targets to run so this is unnecessary code.
- Keep sanity and extended definition mapping to functional
  testing respectively.
    
[skip ci]
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>