### PR TITLE
Recognizing Vector Facility Enhancement 1 feature on Z

### DIFF
--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -272,6 +272,11 @@ CPU::initializeS390ProcessorFeatures()
       if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL))
          {
          TR::Compiler->target.cpu.setSupportsVectorPackedDecimalFacility(true);
+         }
+
+      if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1))
+         {
+         TR::Compiler->target.cpu.setSupportsVectorFacilityEnhancement1(true);
          }
 
       if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE))


### PR DESCRIPTION
Determine whether the s390 cpu supports vector facility enhancement 1 on
z14. 
Note that this PR requires support from https://github.com/eclipse/omr/pull/4781

Issue: #7474 
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>