### PR TITLE
WIP: Replace protobuf in JITServer

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -392,6 +392,9 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/VMJ9Server.cpp \
     compiler/net/ClientStream.cpp \
     compiler/net/CommunicationStream.cpp \
+    compiler/net/CommunicationStreamRaw.cpp \
+    compiler/net/MessageBuffer.cpp \
+    compiler/net/Message.cpp \
     compiler/net/ProtobufTypeConvert.cpp \
     compiler/net/ServerStream.cpp \
     compiler/runtime/CompileService.cpp \

--- a/runtime/compiler/net/CMakeLists.txt
+++ b/runtime/compiler/net/CMakeLists.txt
@@ -23,6 +23,9 @@
 j9jit_files(
 	net/ClientStream.cpp
 	net/CommunicationStream.cpp
+        net/CommunicationStreamRaw.cpp
+        net/MessageBuffer.cpp
+        net/Message.cpp
 	net/ProtobufTypeConvert.cpp
 	net/ServerStream.cpp
 )

--- a/runtime/compiler/net/ClientStream.cpp
+++ b/runtime/compiler/net/ClientStream.cpp
@@ -258,7 +258,7 @@ BIO *openSSLConnection(SSL_CTX *ctx, int connfd)
    }
 
 ClientStream::ClientStream(TR::PersistentInfo *info)
-   : CommunicationStream(), _versionCheckStatus(NOT_DONE)
+   : CommunicationStreamRaw(), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITServerAddress(), info->getJITServerPort(), info->getSocketTimeout());
    BIO *ssl = openSSLConnection(_sslCtx, connfd);
@@ -267,12 +267,11 @@ ClientStream::ClientStream(TR::PersistentInfo *info)
    }
 #else // JITSERVER_ENABLE_SSL
 ClientStream::ClientStream(TR::PersistentInfo *info)
-   : CommunicationStream(), _versionCheckStatus(NOT_DONE)
+   : CommunicationStreamRaw(), _versionCheckStatus(NOT_DONE)
    {
    int connfd = openConnection(info->getJITServerAddress(), info->getJITServerPort(), info->getSocketTimeout());
    initStream(connfd);
    _numConnectionsOpened++;
    }
 #endif
-
 };

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -60,6 +60,8 @@ public:
       return ((((uint64_t)CONFIGURATION_FLAGS) << 32) | (MAJOR_NUMBER << 24) | (MINOR_NUMBER << 8));
       }
 
+   int getConnFD() { return _connfd; }
+
 protected:
    CommunicationStream()
       : _inputStream(NULL),

--- a/runtime/compiler/net/CommunicationStreamRaw.cpp
+++ b/runtime/compiler/net/CommunicationStreamRaw.cpp
@@ -1,0 +1,52 @@
+#include "control/CompilationRuntime.hpp"
+#include "net/CommunicationStreamRaw.hpp"
+
+namespace JITServer
+{
+uint32_t CommunicationStreamRaw::CONFIGURATION_FLAGS = 0;
+
+void
+CommunicationStreamRaw::initVersion()
+   {
+   if (TR::Compiler->target.is64Bit() && TR::Options::useCompressedPointers())
+      {
+      CONFIGURATION_FLAGS |= JITServerCompressedRef;
+      }
+   CONFIGURATION_FLAGS |= JAVA_SPEC_VERSION & JITServerJavaVersionMask;
+   }
+
+void
+CommunicationStreamRaw::readMessage(Message &msg)
+   {
+   msg.clearForRead();
+   // read message meta data,
+   // which contains the message type
+   // and the number of data points
+   uint32_t serializedSize;
+   readBlocking(serializedSize);
+   // if (serializedSize > 10000)
+      // fprintf(stderr, "read message size=%d\n", serializedSize);
+   uint32_t messageSize = serializedSize - sizeof(uint32_t);
+   msg.getBuffer()->expandIfNeeded(serializedSize);
+   msg.getBuffer()->writeValue(serializedSize);
+   readBlocking(msg.getBuffer()->getBufferStart() + sizeof(uint32_t), messageSize);
+   // msg.checkIntegrity();
+
+   msg.reconstruct();
+   
+   // fprintf(stderr, "readMessage numDataPoints=%d serializedSize=%ld\n", msg.getMetaData()->numDataPoints, serializedSize);
+   }
+
+void
+CommunicationStreamRaw::writeMessage(Message &msg)
+   {
+   char *serialMsg = msg.serialize();
+   // fprintf(stderr, "writeMessage numDataPoints=%d serializedSize=%ld\n", msg.getMetaData()->numDataPoints, msg.serializedSize());
+   //
+   // if (msg.serializedSize() > 10000)
+      // fprintf(stderr, "write message size=%d\n", msg.serializedSize());
+   // msg.checkIntegrity();
+   writeBlocking(serialMsg, msg.serializedSize());
+   msg.clearForWrite();
+   }
+}

--- a/runtime/compiler/net/CommunicationStreamRaw.hpp
+++ b/runtime/compiler/net/CommunicationStreamRaw.hpp
@@ -1,0 +1,135 @@
+#ifndef COMMUNICATION_STREAM_RAW_H
+#define COMMUNICATION_STREAM_RAW_H
+
+#include "net/Message.hpp"
+#include "env/TRMemory.hpp"
+#include "env/CompilerEnv.hpp" // for TR::Compiler->target.is64Bit()
+#include "control/Options.hpp" // TR::Options::useCompressedPointers()
+#include "net/MessageBuffer.hpp"
+#include <unistd.h>
+
+namespace JITServer
+{
+class CommunicationStreamRaw
+   {
+protected:
+   CommunicationStreamRaw()
+      {
+      // what is to be done with the memory allocation?
+      // Ideally, want to use per-compilation region memory,
+      // maybe not here, but definitely in RawTypeConvert.
+      // But on the server side, the first message is received
+      // before the compilation object is created, so cannot do that
+      //
+      // Could just use persistent memory, but then would need to 
+      // free it manually. In the communication stream that should be fine,
+      // since we are normally keeping the stream for multiple compilations,
+      // so recycling the same persistent memory space should be fine, even if
+      // we end up consuming more memory than ideally possible, we would cut down
+      // on the number of allocations. Although I doubt that would matter a lot,
+      // since the compilations themselves do a ton of allocations.
+      // what's important is cutting down on the number of copies and tons of small allocations
+      //
+      // Another solution could be to create a separate per-compilation region on the server,
+      // look at CompilationThread.cpp:7564 for example on how to do that.
+      //
+      // In any case, I need to resolve all other issues first and test if this actually
+      // consumes less CPU before tackling that problem
+      }
+
+   ~CommunicationStreamRaw()
+      {
+      close(_connfd);
+      }
+
+#if defined(JITSERVER_ENABLE_SSL)
+   void initStream(int connfd, BIO *ssl)
+#else
+   void initStream(int connfd)
+#endif
+      {
+      _connfd = connfd;
+#if defined(JITSERVER_ENABLE_SSL)
+      _ssl = ssl;
+#endif
+      }
+
+
+   void readMessage(Message &msg);
+   void writeMessage(Message &msg);
+
+   int getConnFD() { return _connfd; }
+
+   static void initVersion();
+
+   static uint64_t getJITServerVersion()
+      {
+      return ((((uint64_t)CONFIGURATION_FLAGS) << 32) | (MAJOR_NUMBER << 24) | (MINOR_NUMBER << 8));
+      }
+   
+   int _connfd;
+   ServerMessage _sMsg;
+   ClientMessage _cMsg;
+
+   static const uint8_t MAJOR_NUMBER = 0;
+   static const uint16_t MINOR_NUMBER = 1;
+   static const uint8_t PATCH_NUMBER = 0;
+   static uint32_t CONFIGURATION_FLAGS;
+
+private:
+   // readBlocking and writeBlocking are functions that directly read/write
+   // passed object from/to the socket. For the object to be correctly written,
+   // it needs to be contiguous.
+   template <typename T>
+   void readBlocking(T &val)
+      {
+      readBlocking(&val, sizeof(T));
+      }
+
+   template <typename T>
+   void readBlocking(T *ptr, size_t size)
+      {
+      int32_t bytesRead = read(_connfd, ptr, size);
+      if (bytesRead == -1)
+         {
+         throw JITServer::StreamFailure("JITServer I/O error: read error");
+         }
+      else if (bytesRead < size)
+         {
+         char *remainingPtr = reinterpret_cast<char *>(ptr) + bytesRead;
+         int32_t remainingRead = read(_connfd, remainingPtr, size - bytesRead);
+         if (remainingRead != size - bytesRead)
+            {
+            throw JITServer::StreamFailure("JITServer I/O error: read error");
+            }
+         }
+      }
+
+   template <typename T>
+   void writeBlocking(const T &val)
+      {
+      writeBlocking(&val, sizeof(T));
+      }
+
+   template <typename T>
+   void writeBlocking(T *ptr, size_t size)
+      {
+      int32_t bytesWritten = write(_connfd, ptr, size);
+      if (bytesWritten == -1)
+         {
+         throw JITServer::StreamFailure("JITServer I/O error: write error");
+         }
+      else if (bytesWritten < size)
+         {
+         char *remainingPtr = reinterpret_cast<char *>(ptr) + bytesWritten;
+         int32_t remainingWritten = write(_connfd, remainingPtr, size - bytesWritten);
+         if (remainingWritten != size - bytesWritten)
+            {
+            throw JITServer::StreamFailure("JITServer I/O error: write error");
+            }
+         }
+      }
+   };
+};
+
+#endif

--- a/runtime/compiler/net/Message.cpp
+++ b/runtime/compiler/net/Message.cpp
@@ -1,0 +1,145 @@
+#include "net/Message.hpp"
+#include "infra/Assert.hpp"
+
+namespace JITServer
+{
+void
+Message::DataDescriptor::print()
+   {
+   fprintf(stderr, "DataDescriptor[%p]: type=%d size=%lu\n", this, type, size);
+   if (!isContiguous())
+      {
+      DataDescriptor *curDesc = static_cast<DataDescriptor *>(getDataStart());
+      while ((char *) curDesc->getDataStart() + curDesc->size - (char *) getDataStart() <= size)
+         {
+         curDesc->print();
+         curDesc = reinterpret_cast<DataDescriptor *>(reinterpret_cast<char *>(curDesc->getDataStart()) + curDesc->size);
+         }
+      }
+   fprintf(stderr, "DataDescriptor[%p] end\n", this);
+   }
+
+uint32_t
+Message::DataDescriptor::checkIntegrity(uint32_t serializedSize)
+   {
+   TR_ASSERT(size < serializedSize, "Descriptor corrupted");
+   if (!isContiguous())
+      {
+      uint32_t totalSize = 0;
+      DataDescriptor *curDesc = static_cast<DataDescriptor *>(getDataStart());
+      uint32_t numNestedPoints = 0;
+      while ((char *) curDesc->getDataStart() + curDesc->size - (char *) getDataStart() <= size)
+         {
+         totalSize += curDesc->checkIntegrity(serializedSize);
+         curDesc = reinterpret_cast<DataDescriptor *>(reinterpret_cast<char *>(curDesc->getDataStart()) + curDesc->size);
+         numNestedPoints++;
+         }
+      TR_ASSERT(totalSize + numNestedPoints * sizeof(DataDescriptor) ==  size, "Nested descriptors corrupted");
+      return size;
+      }
+   else
+      {
+      return size;
+      }
+   }
+
+void
+Message::checkIntegrity()
+   {
+   uint32_t serializedSize = *_buffer.getValueAtOffset<uint32_t>(0);
+   
+   uint32_t numDescriptors = 0;
+   DataDescriptor *curDesc = _buffer.getValueAtOffset<DataDescriptor>(20);
+   while ((char *) curDesc < _buffer.getBufferStart() + serializedSize)
+      {
+      if (serializedSize > 20000)
+         curDesc->print();
+      // check integrity of nested descriptors
+      curDesc->checkIntegrity(serializedSize);
+      curDesc = _buffer.getValueAtOffset<DataDescriptor>(_buffer.offset((char *) curDesc->getDataStart()) + curDesc->size);
+      numDescriptors++;
+      }
+   }
+
+Message::Message()
+   {
+   // metadata is always in the beginning of the message
+   _serializedSizeOffset = _buffer.reserveValue<uint32_t>();
+   _metaDataOffset = _buffer.reserveValue<Message::MetaData>();
+   }
+
+Message::MetaData *
+Message::getMetaData() const
+   {
+   return _buffer.getValueAtOffset<MetaData>(_metaDataOffset);
+   }
+
+void
+Message::addData(const DataDescriptor &desc, const void *dataStart)
+   {
+   uint32_t descOffset = _buffer.writeValue(desc);
+   _buffer.writeData(dataStart, desc.size);
+   _descriptorOffsets.push_back(descOffset);
+   }
+
+uint32_t
+Message::reserveDescriptor()
+   {
+   uint32_t descOffset = _buffer.reserveValue<DataDescriptor>();
+   _descriptorOffsets.push_back(descOffset);
+   return descOffset;
+   }
+
+Message::DataDescriptor *
+Message::getDescriptor(size_t idx) const
+   {
+   uint32_t offset = _descriptorOffsets[idx];
+   return _buffer.getValueAtOffset<DataDescriptor>(offset);
+   }
+
+Message::DataDescriptor *
+Message::getLastDescriptor() const
+   {
+   return _buffer.getValueAtOffset<DataDescriptor>(_descriptorOffsets.back());
+   }
+
+void
+Message::reconstruct()
+   {
+   // Assume that buffer is populated with data that defines a valid message
+   // Reconstruct the message by setting correct meta data and pointers to descriptors
+   _metaDataOffset = _buffer.readValue<MetaData>();
+   for (uint16_t i = 0; i < getMetaData()->numDataPoints; ++i)
+      {
+      uint32_t descOffset = _buffer.readValue<DataDescriptor>();
+      _descriptorOffsets.push_back(descOffset);
+      // skip the actual data
+      _buffer.readData(getLastDescriptor()->size);
+      }
+   }
+
+char *
+Message::serialize()
+   {
+   *_buffer.getValueAtOffset<uint32_t>(_serializedSizeOffset) = _buffer.size();
+   return _buffer.getBufferStart();
+   }
+
+void
+Message::clearForRead()
+   {
+   _descriptorOffsets.clear();
+   _buffer.clear();
+   _metaDataOffset = 0;
+   // _serializedSizeOffset = _buffer.reserveValue<uint32_t>();
+   }
+
+void
+Message::clearForWrite()
+   {
+   _descriptorOffsets.clear();
+   _buffer.clear();
+   _serializedSizeOffset = _buffer.reserveValue<uint32_t>();
+   _metaDataOffset = _buffer.reserveValue<MetaData>();
+   }
+};

--- a/runtime/compiler/net/Message.hpp
+++ b/runtime/compiler/net/Message.hpp
@@ -1,0 +1,103 @@
+
+#ifndef MESSAGE_H
+#define MESSAGE_H
+
+#include <stdlib.h>
+#include "net/MessageBuffer.hpp"
+#include "net/gen/compile.pb.h"
+
+namespace JITServer
+{
+
+class Message
+   {
+public:
+   enum DataType
+      {
+      INT32,
+      INT64,
+      UINT32,
+      UINT64,
+      BOOL,
+      STRING,
+      OBJECT, // only trivially-copyable,
+      ENUM,
+      VECTOR,
+      TUPLE
+      };
+
+   // Struct containing message metadata,
+   // i.e. number of data points, type and message type.
+   struct MetaData
+      {
+      MetaData() :
+         numDataPoints(0)
+         {}
+
+      uint16_t numDataPoints; // number of data points in a message
+      MessageType type;
+      uint64_t version;
+      };
+
+   // Struct describing a single data point in a message.
+   struct DataDescriptor
+      {
+      DataType type;
+      uint32_t size; // size of the data segment, which can include nested data
+
+      DataDescriptor(DataType type, uint32_t size) :
+         type(type),
+         size(size)
+         {}
+
+      uint32_t checkIntegrity(uint32_t serializedSize);
+
+      bool isContiguous() const { return type != VECTOR && type != TUPLE; }
+
+      void *getDataStart() { return static_cast<void *>(&size + 1); }
+
+      void print();
+      };
+
+   Message();
+
+   void checkIntegrity();
+   MetaData *getMetaData() const;
+
+   void addData(const DataDescriptor &desc, const void *dataStart);
+   uint32_t reserveDescriptor();
+   DataDescriptor *getDescriptor(size_t idx) const;
+   DataDescriptor *getLastDescriptor() const;
+   void reconstruct();
+
+   void setType(MessageType type) { getMetaData()->type = type; }
+   MessageType type() const { return getMetaData()->type; }
+
+   MessageBuffer *getBuffer() { return &_buffer; }
+
+   char *serialize();
+   uint32_t serializedSize() { return _buffer.size(); }
+
+   void clearForRead();
+   void clearForWrite();
+protected:
+   uint32_t _metaDataOffset;
+   std::vector<uint32_t> _descriptorOffsets;
+   uint32_t _serializedSizeOffset;
+   MessageBuffer _buffer;
+   };
+
+
+class ServerMessage : public Message
+   {
+   };
+
+class ClientMessage : public Message
+   {
+public:
+   uint64_t version() { return getMetaData()->version; }
+   void setVersion(uint64_t version) { getMetaData()->version = version; }
+   void clearVersion() { getMetaData()->version = 0; }
+   };
+};
+#endif

--- a/runtime/compiler/net/MessageBuffer.cpp
+++ b/runtime/compiler/net/MessageBuffer.cpp
@@ -1,0 +1,63 @@
+#include "net/MessageBuffer.hpp"
+#include <cstring>
+
+namespace JITServer
+{
+MessageBuffer::MessageBuffer() :
+   _capacity(10000)
+   {
+   _storage = static_cast<char *>(malloc(_capacity));
+   _curPtr = _storage;
+   }
+
+uint32_t
+MessageBuffer::size()
+   {
+   return _curPtr - _storage;
+   }
+
+void
+MessageBuffer::expandIfNeeded(uint32_t requiredSize)
+   {
+   if (requiredSize > _capacity)
+      {
+      // deallocate current storage and reallocate it to fit the message,
+      // copying the values
+      char *oldPtr = _curPtr;
+      _capacity = requiredSize * 2;
+      char *newStorage = static_cast<char *>(malloc(_capacity));
+      uint32_t curSize = size();
+      memcpy(newStorage, _storage, curSize);
+      free(_storage);
+      _storage = newStorage;
+      _curPtr = _storage + curSize;
+      // all pointers in message will be invalidated by this, need to fix
+      // probably the easiest solution is to have _descriptors vector
+      // contain offsets from the start of the storage to the beginning
+      // of descriptor i, instead of the direct address
+      printf("\nExpanded message buffer to %u old curPtr=%p new curPtr=%p\n", _capacity, oldPtr, _curPtr);
+
+      }
+   }
+
+uint32_t
+MessageBuffer::writeData(const void *dataStart, uint32_t dataSize)
+   {
+   // write size number of bytes starting from dataStart
+   // into the buffer. Expand it if needed
+   uint32_t requiredSize = size() + dataSize;
+   expandIfNeeded(requiredSize);
+   char *data = _curPtr;
+   memcpy(_curPtr, dataStart, dataSize);
+   _curPtr += dataSize;
+   return offset(data);
+   }
+
+uint32_t
+MessageBuffer::readData(uint32_t dataSize)
+   {
+   char *data = _curPtr;
+   _curPtr += dataSize;
+   return offset(data);
+   }
+};

--- a/runtime/compiler/net/MessageBuffer.hpp
+++ b/runtime/compiler/net/MessageBuffer.hpp
@@ -1,0 +1,65 @@
+#ifndef MESSAGE_BUFFER_H
+#define MESSAGE_BUFFER_H
+
+#include <stdlib.h>
+#include "env/jittypes.h"
+#include <cstring>
+
+namespace JITServer
+{
+class MessageBuffer
+   {
+public:
+   MessageBuffer();
+
+   ~MessageBuffer()
+      {
+      free(_storage);
+      }
+
+
+   uint32_t size();
+   char *getBufferStart() { return _storage; }
+
+   uint32_t offset(char *addr) const { return addr - _storage; }
+
+   template <typename T>
+   T *getValueAtOffset(uint32_t offset) const
+      {
+      return reinterpret_cast<T *>(_storage + offset);
+      }
+
+   template <typename T>
+   uint32_t writeValue(const T &val)
+      {
+      return writeData(&val, sizeof(T));
+      }
+
+   uint32_t writeData(const void *dataStart, uint32_t dataSize);
+
+   template <typename T>
+   uint32_t reserveValue()
+      {
+      expandIfNeeded(size() + sizeof(T));
+      char *valStart = _curPtr;
+      _curPtr += sizeof(T);
+      return offset(valStart);
+      }
+
+   template <typename T>
+   uint32_t readValue()
+      {
+      return readData(sizeof(T));
+      }
+   uint32_t readData(uint32_t dataSize);
+
+   void clear() { _curPtr = _storage; }
+   void expandIfNeeded(uint32_t requiredSize);
+
+private:
+   uint32_t _capacity;
+   char *_storage;
+   char *_curPtr;
+   };
+};
+#endif

--- a/runtime/compiler/net/RawTypeConvert.hpp
+++ b/runtime/compiler/net/RawTypeConvert.hpp
@@ -1,0 +1,285 @@
+
+#ifndef RAW_TYPE_CONVERT_H
+#define RAW_TYPE_CONVERT_H
+
+#include <cstdint>
+#include <utility>
+#include <type_traits>
+#include "StreamExceptions.hpp"
+#include "omrcomp.h"
+#include "net/Message.hpp"
+
+class J9Class;
+class TR_ResolvedJ9Method;
+
+namespace JITServer
+   {
+   // Things required for converting data passed to type converter into
+   // a format that we can simply write into the socket and vice versa.
+   // 1. Receive tuple of data points in stream::write
+   // 2. For every data point, convert it to a format acceptable by socket write
+   //   - For primitive and trivially copyable data types no conversion needed
+   //   - For strings, send the buffer containing chars
+   //   - For vectors, send the buffer containing elements
+   //   - For tuples, convert tuple to a vector and then send the vector
+   //   This should cover all currently supported cases of data structures.
+   // 3. Write message type to the socket
+   // 4. Write the number of data points sent to the socket
+   // 5. Before writing every data point, write metadata that should describe
+   // the type of the data and its size.
+   // 6. Write every serialized data point to the socket.
+   //
+   // On the receiving side:
+   // 1. Read message type.
+   // 2. Read number of data points
+   // 3. For every data point, first read the metadata
+   // 4. Read data point and convert it to its original data type.
+   //   - for primitives and trivially copyable types we just cast to the type
+   //   - for vectors, will need to allocate vector filled with received values
+   //   - for tuples will need to create a tuple filled with received values
+   // 5. Create a tuple of all deserialized data points and return it.
+
+   template <typename T, typename = void> struct RawTypeConvert { };
+   template <> struct RawTypeConvert<uint32_t>
+      {
+      static inline uint32_t onRecv( Message::DataDescriptor *desc) { return *static_cast<uint32_t *>(desc->getDataStart()); }
+      static inline uint32_t onSend(Message &msg, const uint32_t &val)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::UINT32, sizeof(uint32_t)), &val);
+         return sizeof(uint32_t);
+         }
+      };
+   template <> struct RawTypeConvert<uint64_t>
+      {
+      static inline uint64_t onRecv( Message::DataDescriptor *desc) { return *static_cast<uint64_t *>(desc->getDataStart()); }
+      static inline uint32_t onSend(Message &msg, const uint64_t &val)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::UINT64, sizeof(uint64_t)), &val);
+         return sizeof(uint64_t);
+         }
+      };
+   template <> struct RawTypeConvert<int32_t>
+      {
+      static inline int32_t onRecv( Message::DataDescriptor *desc) { return *static_cast<int32_t *>(desc->getDataStart()); }
+      static inline uint32_t onSend(Message &msg, const int32_t &val)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::INT32, sizeof(int32_t)), &val);
+         return sizeof(int32_t);
+         }
+      };
+   template <> struct RawTypeConvert<int64_t>
+      {
+      static inline int64_t onRecv( Message::DataDescriptor *desc) { return *static_cast<int64_t *>(desc->getDataStart()); }
+      static inline uint32_t onSend(Message &msg, const int64_t &val)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::INT64, sizeof(int64_t)), &val);
+         return sizeof(int64_t);
+         }
+      };
+   template <> struct RawTypeConvert<bool>
+      {
+      static inline bool onRecv( Message::DataDescriptor *desc) { return *static_cast<bool *>(desc->getDataStart()); }
+      static inline uint32_t onSend(Message &msg, const bool &val)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::BOOL, sizeof(bool)), &val);
+         return sizeof(bool);
+         }
+      };
+   template <> struct RawTypeConvert<const std::string>
+      {
+      static inline std::string onRecv( Message::DataDescriptor *desc)
+         {
+         return std::string(static_cast<char *>(desc->getDataStart()), desc->size);
+         }
+      static inline uint32_t onSend(Message &msg, const std::string &value)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::STRING, value.length()), &value[0]);
+         return value.length();
+         }
+      };
+
+   template <> struct RawTypeConvert<std::string> : RawTypeConvert<const std::string> {};
+
+   // For trivially copyable classes
+   template <typename T> struct RawTypeConvert<T, typename std::enable_if<std::is_trivially_copyable<T>::value>::type>
+      {
+      static inline T onRecv( Message::DataDescriptor *desc) { return *static_cast<T *>(desc->getDataStart()); }
+      static inline uint32_t onSend(Message &msg, const T &value)
+         {
+         msg.addData(Message::DataDescriptor(Message::DataType::OBJECT, sizeof(T)), &value);
+         return sizeof(T);
+         }
+      };
+
+   // For vectors
+   template <typename T> struct RawTypeConvert<T, typename std::enable_if<std::is_same<T, std::vector<typename T::value_type>>::value>::type>
+      {
+      static inline T onRecv( Message::DataDescriptor *desc)
+         {
+         Message::DataDescriptor *sizeDesc = static_cast<Message::DataDescriptor *>(desc->getDataStart());
+         uint32_t size = RawTypeConvert<uint32_t>::onRecv(sizeDesc);
+
+         std::vector<typename T::value_type> values;
+         values.reserve(size);
+
+         auto curDesc = reinterpret_cast<Message::DataDescriptor *>(static_cast<char *>(sizeDesc->getDataStart()) + sizeDesc->size);
+         char *ptr = reinterpret_cast<char *>(curDesc);
+         for (int32_t i = 0; i < size; ++i)
+            {
+            values.push_back(RawTypeConvert<typename T::value_type>::onRecv(curDesc));
+            ptr = static_cast<char *>(curDesc->getDataStart()) + curDesc->size;
+            curDesc = reinterpret_cast<Message::DataDescriptor *>(ptr);
+            }
+         return values;
+         }
+      static inline uint32_t onSend(Message &msg, const T &value)
+         {
+         uint32_t descOffset = msg.reserveDescriptor();
+         // Serialize each element in a vector as its own datapoint
+         // Write the size of the vector as a data point
+         uint32_t totalSize = (value.size() + 1) * sizeof(Message::DataDescriptor);
+         totalSize += RawTypeConvert<uint32_t>::onSend(msg, value.size());
+         for (int32_t i = 0; i < value.size(); ++i)
+            {
+            // Will write n additional data points to the buffer
+            // Undesired sideeffect is that numDataPoints is now higher than needed.
+            // Maybe we can ignore that for now, because we can still iterate over
+            // outer data points by looking at the size 
+            //
+            // TODO: this does not work if elements are tuples, e.g. CHTable data
+            totalSize += RawTypeConvert<typename T::value_type>::onSend(msg, value[i]);
+            }
+         Message::DataDescriptor *desc = msg.getBuffer()->getValueAtOffset<Message::DataDescriptor>(descOffset);
+         desc->type = Message::DataType::VECTOR;
+         desc->size = totalSize;
+         return totalSize;
+         }
+      };
+   // For tuples
+   //
+   // used to unpack a tuple into variadic args
+   template <size_t... I> struct index_tuple_raw { template <size_t N> using type = index_tuple_raw<I..., N>; };
+   template <size_t N> struct index_tuple_gen_raw { using type = typename index_tuple_gen_raw<N - 1>::type::template type<N - 1>; };
+   template <> struct index_tuple_gen_raw<0> { using type = index_tuple_raw<>; };
+
+   template <size_t n, typename Arg1, typename... Args>
+   struct TupleTypeConvert
+      {
+      static inline std::tuple<Arg1, Args...> onRecvImpl(Message::DataDescriptor *desc)
+         {
+         return std::tuple_cat(TupleTypeConvert<n, Arg1>::onRecvImpl(desc),
+                               TupleTypeConvert<n + 1, Args...>::onRecvImpl(
+                                 reinterpret_cast<Message::DataDescriptor *>(
+                                    static_cast<char *>(desc->getDataStart()) + desc->size
+                                 )));
+         }
+      static inline uint32_t onSendImpl(Message &msg, const Arg1 &arg1, const Args&... args)
+         {
+         uint32_t totalSize = TupleTypeConvert<n, Arg1>::onSendImpl(msg, arg1);
+         totalSize += TupleTypeConvert<n + 1, Args...>::onSendImpl(msg, args...);
+         return totalSize;
+         }
+      };
+
+   template <size_t n, typename Arg1>
+   struct TupleTypeConvert<n, Arg1>
+      {
+      static inline std::tuple<Arg1> onRecvImpl(Message::DataDescriptor *desc)
+         {
+         return std::make_tuple(RawTypeConvert<Arg1>::onRecv(desc));
+         }
+      static inline uint32_t onSendImpl(Message &msg, const Arg1 &arg1)
+         {
+         return RawTypeConvert<Arg1>::onSend(msg, arg1) + sizeof(Message::DataDescriptor);
+         }
+      };
+
+   template <typename... T> struct RawTypeConvert<const std::tuple<T...>>
+      {
+      static inline std::tuple<T...> onRecv(Message::DataDescriptor *desc)
+         {
+         return TupleTypeConvert<0, T...>::onRecvImpl(static_cast<Message::DataDescriptor *>(desc->getDataStart()));
+         }
+
+      template <typename Tuple, size_t... Idx>
+      static inline uint32_t onSendImpl(Message &msg, const Tuple &val, index_tuple_raw<Idx...>)
+         {
+         // size_t tupleSize = std::tuple_size<typename std::decay<decltype(val)>::type>::value;
+         // uint32_t totalSize = tupleSize * sizeof(Message::DataDescriptor);
+         uint32_t descOffset = msg.reserveDescriptor();
+         uint32_t totalSize = TupleTypeConvert<0, T...>::onSendImpl(msg, std::get<Idx>(val)...);
+         // only get pointer to descriptor after all elements were serialized,
+         // because buffer might have been reallocated
+         Message::DataDescriptor *desc = msg.getBuffer()->getValueAtOffset<Message::DataDescriptor>(descOffset);
+         desc->type = Message::DataType::TUPLE;
+         desc->size = totalSize;
+         return totalSize;
+         }
+      
+      static inline uint32_t onSend(Message &msg, const std::tuple<T...> &val)
+         {
+         // Serialize each element in a tuple as its own datapoint
+         // call onSend for every value of the tuple and put the result in a newly allocated buffer;
+         using Idx = typename index_tuple_gen_raw<sizeof...(T)>::type;
+         return onSendImpl(msg, val, Idx());
+         }
+      };
+
+   template <typename... T> struct RawTypeConvert<std::tuple<T...>> : RawTypeConvert<const std::tuple<T...>> { };
+
+   // setArgs fills out a message with values from a variadic argument list.
+   // calls RawTypeConvert::onSend for each argument.
+   template <typename Arg1, typename... Args>
+   struct SetArgsRaw
+      {
+      static void setArgs(Message &message, Arg1 &arg1, Args&... args)
+         {
+         SetArgsRaw<Arg1>::setArgs(message, arg1);
+         SetArgsRaw<Args...>::setArgs(message, args...);
+         }
+      };
+   template <typename Arg1>
+   struct SetArgsRaw<Arg1>
+      {
+      static void setArgs(Message &message, Arg1 &arg1)
+         {
+         RawTypeConvert<Arg1>::onSend(message, arg1);
+         }
+      };
+   template <typename... Args>
+   void setArgsRaw(Message &message, Args&... args)
+      {
+      message.getMetaData()->numDataPoints = sizeof...(args);
+      SetArgsRaw<Args...>::setArgs(message, args...);
+      }
+
+   // getArgs returns a tuple of values which are extracted from a protobuf AnyData message.
+   // It calls ProtobufTypeConvert::onRecv for each value extracted.
+   template <typename Arg1, typename... Args>
+   struct GetArgsRaw
+      {
+      static std::tuple<Arg1, Args...> getArgs(const Message &message, size_t n)
+         {
+         return std::tuple_cat(GetArgsRaw<Arg1>::getArgs(message, n), GetArgsRaw<Args...>::getArgs(message, n + 1));
+         }
+      };
+   template <typename Arg>
+   struct GetArgsRaw<Arg>
+      {
+      static std::tuple<Arg> getArgs(const Message &message, size_t n)
+         {
+         Message::DataDescriptor *desc = message.getDescriptor(n);
+         // if (data.type_case() != AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase())
+            // throw StreamTypeMismatch("Received type " + std::to_string(data.type_case()) + " but expect type " + std::to_string(AnyPrimitive<typename ProtobufTypeConvert<Arg>::ProtoType>::typeCase()));
+         return std::make_tuple(RawTypeConvert<Arg>::onRecv(desc));
+         }
+      };
+   template <typename... Args>
+   std::tuple<Args...> getArgsRaw(const Message &message)
+      {
+      // if (sizeof...(Args) != message.getMetaData()->numDataPoints)
+         // throw StreamArityMismatch("Received " + std::to_string(message.getMetaData()->numDataPoints) + " args to unpack but expect " + std::to_string(sizeof...(Args)) + "-tuple");
+      return GetArgsRaw<Args...>::getArgs(message, 0);
+      }
+   };
+#endif

--- a/runtime/compiler/net/ServerStream.cpp
+++ b/runtime/compiler/net/ServerStream.cpp
@@ -47,14 +47,14 @@ int ServerStream::_numConnectionsClosed = 0;
 
 #if defined(JITSERVER_ENABLE_SSL)
 ServerStream::ServerStream(int connfd, BIO *ssl)
-   : CommunicationStream()
+   : CommunicationStreamRaw()
    {
    initStream(connfd, ssl);
    _numConnectionsOpened++;
    }
 #else // JITSERVER_ENABLE_SSL
 ServerStream::ServerStream(int connfd)
-   : CommunicationStream()
+   : CommunicationStreamRaw()
    {
    initStream(connfd);
    _numConnectionsOpened++;
@@ -285,6 +285,7 @@ ServerStream::serveRemoteCompilationRequests(BaseCompileDispatcher *compiler, TR
       ServerStream *stream = new (PERSISTENT_NEW) ServerStream(connfd, bio);
 #else
       ServerStream *stream = new (PERSISTENT_NEW) ServerStream(connfd);
+      // ServerStreamRaw *streamRaw = new (PERSISTENT_NEW) ServerStreamRaw(connfd);
 #endif
       compiler->compile(stream);
       }

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -25,9 +25,13 @@
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "net/ProtobufTypeConvert.hpp"
+#include "net/RawTypeConvert.hpp"
 #include "net/CommunicationStream.hpp"
+#include "net/CommunicationStreamRaw.hpp"
 #include "env/VerboseLog.hpp"
 #include "control/Options.hpp"
+
+#include <unistd.h>
 
 #if defined(JITSERVER_ENABLE_SSL)
 #include <openssl/ssl.h>
@@ -63,7 +67,7 @@ class BaseCompileDispatcher;
    7) When compilation is completed successfully, the server responds with finishCompilation(T... args).
       When compilation is aborted, the sever responds with writeError(uint32_t statusCode).
  */
-class ServerStream : public CommunicationStream
+class ServerStream : public CommunicationStreamRaw
    {
 public:
    /**
@@ -78,6 +82,9 @@ public:
 #else
    explicit ServerStream(int connfd);
 #endif
+   // ServerStream(int connfd) :
+      // CommunicationStreamRaw(connfd)
+      // {}
    virtual ~ServerStream()
       {
       _numConnectionsClosed++;
@@ -89,12 +96,12 @@ public:
       @param [in] type Message type to be sent
       @param [in] args Variable number of additional paramaters to be sent
    */
-   template <typename ...T>
-   void write(MessageType type, T... args)
+   template <typename ...Args>
+   void write(MessageType type, Args... args)
       {
-      setArgs<T...>(_sMsg.mutable_data(), args...);
-      _sMsg.set_type(type);
-      writeBlocking(_sMsg);
+      _sMsg.setType(type);
+      setArgsRaw<Args...>(_sMsg, args...);
+      writeMessage(_sMsg);
       }
 
    /**
@@ -112,7 +119,7 @@ public:
    template <typename ...T>
    std::tuple<T...> read()
       {
-      readBlocking(_cMsg);
+      readMessage(_cMsg);
       switch (_cMsg.type())
          {
          case MessageType::compilationInterrupted:
@@ -130,7 +137,7 @@ public:
                throw StreamMessageTypeMismatch(_sMsg.type(), _cMsg.type());
             }
          }
-      return getArgs<T...>(_cMsg.mutable_data());
+      return getArgsRaw<T...>(_cMsg);
       }
 
    /**
@@ -150,7 +157,9 @@ public:
    template <typename... T>
    std::tuple<T...> readCompileRequest()
       {
-      readBlocking(_cMsg);
+      // fprintf(stderr, "readCompileRequest ClientMessage=%p\n", &_cMsg);
+      readMessage(_cMsg);
+      // fprintf(stderr, "numArgs=%d\n", _cMsg.getMetaData().numDataPoints);
       if (_cMsg.version() != 0 && _cMsg.version() != getJITServerVersion())
          {
          throw StreamVersionIncompatible(getJITServerVersion(), _cMsg.version());
@@ -169,7 +178,7 @@ public:
             }
          case MessageType::compilationRequest:
             {
-            return getArgs<T...>(_cMsg.mutable_data());
+            return getArgsRaw<T...>(_cMsg);
             }
          default:
             {
@@ -184,7 +193,7 @@ public:
    template <typename... T>
    std::tuple<T...> getRecvData()
       {
-      return getArgs<T...>(_cMsg.mutable_data());
+      return getArgsRaw<T...>(_cMsg);
       }
 
    /**


### PR DESCRIPTION
[skip ci]
DO NOT REVIEW
This is a preliminary draft of the new networking code
meant to replace protobuf for JITServer.
It works in benchmarks that we run but seems to degrade
throughput by a few percent. More work is needed, but this
version should be functional.
Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>