### PR TITLE
Add the installation of GCC back to JITServer docker file

### DIFF
--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,8 +36,16 @@ ARG omr_repo=https://github.com/eclipse/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    g++-7 \
+    gcc-7 \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# JITServer needs to be built with a newer GCC
+RUN ln -sf /usr/bin/g++ /usr/bin/c++ \
+ && ln -sf /usr/bin/g++-7 /usr/bin/g++ \
+ && ln -sf /usr/bin/gcc /usr/bin/cc \
+ && ln -sf /usr/bin/gcc-7 /usr/bin/gcc
 
 # Install protobuf
 WORKDIR /

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildenv/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildenv/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,16 @@ ENV JITSERVER_SUPPORT=1
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    g++-7 \
+    gcc-7 \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# JITServer needs to be built with a newer GCC
+RUN ln -sf /usr/bin/g++ /usr/bin/c++ \
+ && ln -sf /usr/bin/g++-7 /usr/bin/g++ \
+ && ln -sf /usr/bin/gcc /usr/bin/cc \
+ && ln -sf /usr/bin/gcc-7 /usr/bin/gcc
 
 # Install protobuf
 WORKDIR /

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildserver/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/jitserver/buildserver/Dockerfile
@@ -37,8 +37,16 @@ ARG omr_repo=https://github.com/eclipse/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    g++-7 \
+    gcc-7 \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# JITServer needs to be built with a newer GCC
+RUN ln -sf /usr/bin/g++ /usr/bin/c++ \
+ && ln -sf /usr/bin/g++-7 /usr/bin/g++ \
+ && ln -sf /usr/bin/gcc /usr/bin/cc \
+ && ln -sf /usr/bin/gcc-7 /usr/bin/gcc
 
 # Install protobuf
 WORKDIR /

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/build/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,8 +37,16 @@ ARG omr_repo=https://github.com/eclipse/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    g++-7 \
+    gcc-7 \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# JITServer needs to be built with a newer GCC
+RUN ln -sf /usr/bin/g++ /usr/bin/c++ \
+ && ln -sf /usr/bin/g++-7 /usr/bin/g++ \
+ && ln -sf /usr/bin/gcc /usr/bin/cc \
+ && ln -sf /usr/bin/gcc-7 /usr/bin/gcc
 
 # Install protobuf
 WORKDIR /

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildenv/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildenv/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,8 +34,16 @@ FROM openj9:latest
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    g++-7 \
+    gcc-7 \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# JITServer needs to be built with a newer GCC
+RUN ln -sf /usr/bin/g++ /usr/bin/c++ \
+ && ln -sf /usr/bin/g++-7 /usr/bin/g++ \
+ && ln -sf /usr/bin/gcc /usr/bin/cc \
+ && ln -sf /usr/bin/gcc-7 /usr/bin/gcc
 
 # Install protobuf
 WORKDIR /

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile
@@ -36,8 +36,16 @@ ARG omr_repo=https://github.com/eclipse/openj9-omr.git
 
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    g++-7 \
+    gcc-7 \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# JITServer needs to be built with a newer GCC
+RUN ln -sf /usr/bin/g++ /usr/bin/c++ \
+ && ln -sf /usr/bin/g++-7 /usr/bin/g++ \
+ && ln -sf /usr/bin/gcc /usr/bin/cc \
+ && ln -sf /usr/bin/gcc-7 /usr/bin/gcc
 
 # Install protobuf
 WORKDIR /

--- a/doc/compiler/jitserver/Docker.md
+++ b/doc/compiler/jitserver/Docker.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,7 @@ JITServer Dockerfiles are located under: `openj9/buildenv/docker/jdk<version>/<p
    - Runs make commands to build JITServer
 - `buildenv/Dockerfile`
     - Similar to `jitserver/build/Dockerfile`. The difference is that it does not build JITServer. It only pulls the source code and sets up the environment for JITServer build
-- `run/Dockerfile`
+- `buildserver/Dockerfile`
    - Starts up a JITServer server
 - `test/Dockerfile`
    - Sets up the OpenJ9 test environment for JITServer
@@ -82,12 +82,12 @@ JITServer Dockerfiles are located under: `openj9/buildenv/docker/jdk<version>/<p
   -t=openj9-jitserver-build .
   ```
 
-### [run/Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/run/Dockerfile)
+### [buildserver/Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk8/x86_64/ubuntu18/jitserver/buildserver/Dockerfile)
 - **Prerequisite**: [`openj9-jitserver-build`](#openj9-jitserver-build) image
-- Build `openj9-jitserver-run-server` using `run/Dockerfile`
+- Build `openj9-jitserver-run-server` using `buildserver/Dockerfile`
    ```
    docker build -f \
-   buildenv/docker/jdk<version>/<platform>/ubuntu<version>/jitserver/run/Dockerfile \
+   buildenv/docker/jdk<version>/<platform>/ubuntu<version>/jitserver/buildserver/Dockerfile \
    -t=openj9-jitserver-run-server .
    ```
 - <a name="openj9-jitserver-run-server"></a>Use the image to start up a JITServer server:


### PR DESCRIPTION
`JITServer` requires to be built with `OpenSSL`.
The header files from `OpenSSL` require `opensslconf.h`,
which is located under `/usr/include/x86_64-linux-gnu/openssl/`.
`/usr/include/x86_64-linux-gnu` needs to be in the `GCC` search path.
Add the installation of `g++-7` and `gcc-7` back to `JITServer` docker
build environment which is removed in 71c75a53.

Also updated `JITServer` doc `Docker.md` to reflect previous directory
name change from `jitserver/run` to `jitserver/buildserver`.

This commit fixes the following error while building `JITServer` docker image:
`fatal error: openssl/opensslconf.h: No such file or directory`

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>