### PR TITLE
Recognize fma method on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3817,6 +3817,8 @@ extern TR::Register *inlineIntrinsicIndexOf(TR::Node* node, TR::CodeGenerator* c
 extern TR::Register *inlineDoubleMax(TR::Node *node, TR::CodeGenerator *cg);
 extern TR::Register *inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg);
 
+extern TR::Register *inlineMathFma(TR::Node *node, TR::CodeGenerator *cg);
+
 #define IS_OBJ      true
 #define IS_NOT_OBJ  false
 
@@ -4107,6 +4109,28 @@ J9::Z::CodeGenerator::inlineDirectCall(
                break;
             }
          }
+      if (cg->getSupportsVectorRegisters())
+         {
+         switch (methodSymbol->getRecognizedMethod())
+            {
+            case TR::java_lang_Math_fma_D:
+            case TR::java_lang_StrictMath_fma_D:
+               resultReg = inlineMathFma(node, cg);
+               return true;
+
+            case TR::java_lang_Math_fma_F:
+            case TR::java_lang_StrictMath_fma_F:
+               if (comp->target().cpu.getSupportsVectorFacilityEnhancement1())
+                  {
+                  resultReg = inlineMathFma(node, cg);
+                  return true;
+                  }
+               break;
+            default:
+               break;
+            }
+         }
+
 
      switch (methodSymbol->getRecognizedMethod())
         {

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3727,6 +3727,20 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
          }
       }
 
+   if (self()->getSupportsVectorRegisters()){
+      if (method == TR::java_lang_Math_fma_D ||
+          method == TR::java_lang_StrictMath_fma_D)
+         {
+         return true;
+         }
+      if (self()->comp()->target().cpu.getSupportsVectorFacilityEnhancement1() &&
+            (method == TR::java_lang_Math_fma_F ||
+             method == TR::java_lang_StrictMath_fma_F))
+         { 
+         return true;
+         }
+   }
+
    if (method == TR::java_lang_Integer_highestOneBit ||
        method == TR::java_lang_Integer_numberOfLeadingZeros ||
        method == TR::java_lang_Integer_numberOfTrailingZeros ||

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1101,6 +1101,29 @@ inlineDoubleMin(TR::Node *node, TR::CodeGenerator *cg)
    return doubleMaxMinHelper(node, cg, false);
    }
 
+extern TR::Register * 
+inlineMathFma(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR_ASSERT_FATAL(node->getNumChildren() == 3, 
+   "In function inlineMathFma, the node at address %p should have exactly 3 children, but got %u instead", node, node->getNumChildren());
+
+   TR::Register      * targetRegister      = cg->allocateRegister(TR_FPR);  
+
+   TR::Register      * v1      = cg->evaluate(node->getFirstChild());
+   TR::Register      * v2      = cg->evaluate(node->getSecondChild());
+   TR::Register      * v3      = cg->evaluate(node->getThirdChild());
+
+   uint8_t mask6 = getVectorElementSizeMask(TR::DataType::getSize(node->getDataType()));
+   generateVRReInstruction(cg, TR::InstOpCode::VFMA, node, targetRegister, v1, v2, v3, mask6, 0);
+
+   node->setRegister(targetRegister);
+
+   cg->decReferenceCount(node->getFirstChild());
+   cg->decReferenceCount(node->getSecondChild());
+   cg->decReferenceCount(node->getThirdChild());
+
+   return targetRegister;
+   }
 
 /*
  * J9 S390 specific tree evaluator table overrides

--- a/test/functional/Java9andUp/src/org/openj9/test/java/lang/Test_Math_Fma.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/java/lang/Test_Math_Fma.java
@@ -24,10 +24,25 @@ package org.openj9.test.java.lang;
 import org.testng.annotations.Test;
 import org.testng.AssertJUnit;
 
-@Test(groups={ "level.sanity" }, invocationCount=2)
 public class Test_Math_Fma 
     {
-    @Test
+    public static void commoning_double(double a)
+        {
+        double b = 2.0, c = 3.0; 
+        double r = Math.fma(a, b, c) + Math.fma(b, c, a);
+        double expected = 18.0;
+        AssertJUnit.assertEquals(r, expected);
+        }
+
+    public static void commoning_float(float a)
+        {
+        float b = 2.0f, c = 3.0f; 
+        float r = Math.fma(a, b, c) + Math.fma(b, c, a);
+        float expected = 18.0f;
+        AssertJUnit.assertEquals(r, expected);
+        }
+
+    @Test(groups={ "level.sanity" }, invocationCount=2)
 	public void test_Math_fma_double() 
         {
         double random_double = 0.9085095723204865;
@@ -205,6 +220,11 @@ public class Test_Math_Fma
         AssertJUnit.assertEquals(r, expected);
 
         /**
+         * Testing with children being commoned in JIT compiler
+         */
+        commoning_double(3.0);
+
+        /**
          * Testing against numbers that invoke rounding: 
          */
         a = 0.3333333333333333;
@@ -315,7 +335,7 @@ public class Test_Math_Fma
         AssertJUnit.assertEquals(r, expected);
         }
 
-    @Test
+    @Test(groups={ "level.sanity" }, invocationCount=2)
     public void test_Math_fma_float() 
         {
         float random_float = 0.5877134f;
@@ -491,6 +511,11 @@ public class Test_Math_Fma
         r = Math.fma(a, b, c);
         expected = 1.1880896f;
         AssertJUnit.assertEquals(r, expected);
+
+        /**
+         * Testing with children being commoned in JIT compiler
+         */
+        commoning_float(3.0f);
         
         /**
          * Testing against numbers that invoke rounding: 
@@ -518,6 +543,7 @@ public class Test_Math_Fma
         //result with higher presicion = 0.02040816326530609183673469387756
         expected = 0.020408165f;
         AssertJUnit.assertEquals(r, expected);
+
 
         /**
          * Testing against boundaries: 

--- a/test/functional/Java9andUp/src/org/openj9/test/java/lang/Test_StrictMath_Fma.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/java/lang/Test_StrictMath_Fma.java
@@ -24,10 +24,25 @@ package org.openj9.test.java.lang;
 import org.testng.annotations.Test;
 import org.testng.AssertJUnit;
 
-@Test(groups={ "level.sanity" }, invocationCount=2)
 public class Test_StrictMath_Fma 
     {
-    @Test
+    public static void commoning_double(double a)
+        {
+        double b = 2.0, c = 3.0; 
+        double r = StrictMath.fma(a, b, c) + StrictMath.fma(b, c, a);
+        double expected = 18.0;
+        AssertJUnit.assertEquals(r, expected);
+        }
+
+    public static void commoning_float(float a)
+        {
+        float b = 2.0f, c = 3.0f; 
+        float r = StrictMath.fma(a, b, c) + StrictMath.fma(b, c, a);
+        float expected = 18.0f;
+        AssertJUnit.assertEquals(r, expected);
+        }
+
+    @Test(groups={ "level.sanity" }, invocationCount=2)
 	public void test_StrictMath_fma_double() 
         {
         double random_double = 0.9085095723204865;
@@ -205,6 +220,11 @@ public class Test_StrictMath_Fma
         AssertJUnit.assertEquals(r, expected);
 
         /**
+         * Testing with children being commoned in JIT compiler
+         */
+        commoning_double(3.0);
+
+        /**
          * Testing against numbers that invoke rounding: 
          */
         a = 0.3333333333333333;
@@ -315,7 +335,7 @@ public class Test_StrictMath_Fma
         AssertJUnit.assertEquals(r, expected);
         }
 
-    @Test
+    @Test(groups={ "level.sanity" }, invocationCount=2)
     public void test_StrictMath_fma_float() 
         {
         float random_float = 0.5877134f;
@@ -491,6 +511,11 @@ public class Test_StrictMath_Fma
         r = StrictMath.fma(a, b, c);
         expected = 1.1880896f;
         AssertJUnit.assertEquals(r, expected);
+
+        /**
+         * Testing with children being commoned in JIT compiler
+         */
+        commoning_float(3.0f);
         
         /**
          * Testing against numbers that invoke rounding: 


### PR DESCRIPTION
Using vector form `fma` Instruction Opcode: `VFMA` to generate a customized sequence of any calls to the `Math.fma()` method. 
_Note that if the method is of the type `float`, it will recognize the method only if `VectorFacilityEnhancement1` is installed._

Issue:#7474
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>