### PR TITLE
Async handler for Concurrent Scavenger

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,7 @@ class MM_EnvironmentDelegate
 	/* Data members */
 private:
 	MM_EnvironmentBase *_env;
+	J9VMThread *_vmThread;
 	GC_Environment _gcEnv;
 protected:
 public:
@@ -118,6 +119,11 @@ public:
 	 * Release shared VM access.
 	 */
 	void releaseVMAccess();
+	
+	/**
+	 * Returns true if a mutator threads entered native code without releasing VM access
+	 */
+	bool inNative();	
 
 	/**
 	 * Check whether another thread is requesting exclusive VM access. This method must be
@@ -175,7 +181,10 @@ public:
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 
 	MM_EnvironmentDelegate()
+		
+	
 		: _env(NULL)
+		, _vmThread(NULL)
 	{ }
 };
 

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,6 +113,19 @@
 
 class MM_AllocationContext;
 
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+extern "C" {
+
+void
+concurrentScavengerAsyncCallbackHandlerDelegate(J9VMThread *vmThread, IDATA handlerKey, void *userData)
+{
+	/* This will be populated once concurrentScavengerAsyncCallbackHandler is introduced in OMR */
+}
+
+} /* extern "C" */
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
+
 /**
  * Initialize the collector's internal structures and values.
  * @return true if initialization completed, false otherwise
@@ -120,6 +133,12 @@ class MM_AllocationContext;
 bool
 MM_ScavengerDelegate::initialize(MM_EnvironmentBase *env)
 {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		_flushCachesAsyncCallbackKey = _javaVM->internalVMFunctions->J9RegisterAsyncEvent(_javaVM, concurrentScavengerAsyncCallbackHandlerDelegate, NULL);
+	}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 	return true;
 }
 
@@ -714,6 +733,31 @@ MM_ScavengerDelegate::switchConcurrentForThread(MM_EnvironmentBase *env)
 #endif
     }
 }
+
+void
+MM_ScavengerDelegate::signalThreadsToFlushCaches(MM_EnvironmentBase *envBase)
+{
+	J9InternalVMFunctions const * const vmFuncs = _javaVM->internalVMFunctions;
+	J9VMThread *walkThread = NULL;
+
+	GC_VMThreadListIterator vmThreadListIterator(_javaVM);
+
+	GC_VMInterface::lockVMThreadList(_extensions);
+
+	while((walkThread = vmThreadListIterator.nextVMThread()) != NULL) {
+		vmFuncs->J9SignalAsyncEvent(_javaVM, walkThread, _flushCachesAsyncCallbackKey);
+	}
+
+	GC_VMInterface::unlockVMThreadList(_extensions);
+}
+
+void
+MM_ScavengerDelegate::cancelSignalToFlushCaches(MM_EnvironmentBase *env)
+{
+	_javaVM->internalVMFunctions->J9CancelAsyncEvent(_javaVM, NULL, _flushCachesAsyncCallbackKey);
+}
+
+
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
@@ -742,6 +786,9 @@ MM_ScavengerDelegate::MM_ScavengerDelegate(MM_EnvironmentBase* env)
 #if defined(J9VM_GC_FINALIZATION)
 	, _finalizationRequired(false)
 #endif /* J9VM_GC_FINALIZATION */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	, _flushCachesAsyncCallbackKey(-1)
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 {
 	_typeId = __FUNCTION__;
 }

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,10 @@ private:
 	bool _finalizationRequired; /**< Scavenger variable used to determine if finalization should be triggered */
 #endif /* J9VM_GC_FINALIZATION */
 
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	IDATA _flushCachesAsyncCallbackKey;
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 protected:
 public:
 
@@ -129,6 +133,8 @@ public:
 	void switchConcurrentForThread(MM_EnvironmentBase *env);
 	void fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	bool shouldYield();
+	void signalThreadsToFlushCaches(MM_EnvironmentBase *env);
+	void cancelSignalToFlushCaches(MM_EnvironmentBase *env);
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	/**

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3060,14 +3060,41 @@ hookAcquireVMAccess(J9HookInterface** hook, UDATA eventNum, void* voidEventData,
 {
 	J9VMAcquireVMAccessEvent* eventData = (J9VMAcquireVMAccessEvent*)voidEventData;
 
-	J9VMThread *vmThread = eventData->currentThread;
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
-	MM_GCExtensions* ext = MM_GCExtensions::getExtensions(vmThread);
+	J9VMThread *currentThread = eventData->currentThread;
+	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(currentThread->omrVMThread);
+	MM_GCExtensions* ext = MM_GCExtensions::getExtensions(currentThread);
 
 	Assert_MM_true(ext->concurrentScavenger);
 
 	ext->scavenger->switchConcurrentForThread(env);
 }
+
+static void
+hookReleaseVMAccess(J9HookInterface** hook, UDATA eventNum, void* voidEventData, void* userData)
+{
+	J9VMReleaseVMAccessEvent* eventData = (J9VMReleaseVMAccessEvent*)voidEventData;
+
+	J9VMThread *currentThread = eventData->currentThread;
+	MM_GCExtensions* ext = MM_GCExtensions::getExtensions(currentThread);
+
+	if (ext->isConcurrentScavengerInProgress()) {
+		/* to call a variant of OMR's flushGCcaches, once it's properly adjusted */
+	}
+}
+
+static void
+hookAcquiringExclusiveInNative(J9HookInterface** hook, UDATA eventNum, void* voidEventData, void* userData)
+{
+	J9VMAcquringExclusiveInNativeEvent* eventData = (J9VMAcquringExclusiveInNativeEvent*)voidEventData;
+
+	J9VMThread *currentThread = eventData->currentThread;
+	MM_GCExtensions* ext = MM_GCExtensions::getExtensions(currentThread);
+
+	if (ext->isConcurrentScavengerInProgress()) {
+		/* to call a variant of OMR's flushGCcaches, once it's properly adjusted */
+	}
+}
+
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 /**
@@ -3179,8 +3206,14 @@ gcInitializeVMHooks(MM_GCExtensionsBase *extensions)
 		result = false;
 	}
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	else if (extensions->concurrentScavenger && (*vmHookInterface)->J9HookRegisterWithCallSite(vmHookInterface, J9HOOK_VM_ACQUIREVMACCESS, hookAcquireVMAccess, OMR_GET_CALLSITE(), NULL)) {
-		result = false;
+	else if (extensions->concurrentScavenger) {
+		if ((*vmHookInterface)->J9HookRegisterWithCallSite(vmHookInterface, J9HOOK_VM_ACQUIREVMACCESS, hookAcquireVMAccess, OMR_GET_CALLSITE(), NULL)) {
+			result = false;
+		} else if ((*vmHookInterface)->J9HookRegisterWithCallSite(vmHookInterface, J9HOOK_VM_RELEASEVMACCESS, hookReleaseVMAccess, OMR_GET_CALLSITE(), NULL)) {
+			result = false;
+		} else if ((*vmHookInterface)->J9HookRegisterWithCallSite(vmHookInterface, J9HOOK_VM_ACQUIRING_EXCLUSIVE_IN_NATIVE, hookAcquiringExclusiveInNative, OMR_GET_CALLSITE(), NULL)) {
+			result = false;
+		}
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
@@ -3195,6 +3228,13 @@ gcCleanupVMHooks(MM_GCExtensionsBase *extensions)
 	if (NULL != vmHookInterface) {
 		(*vmHookInterface)->J9HookUnregister(vmHookInterface, J9HOOK_VM_THREAD_CRASH, hookValidatorVMThreadCrash, NULL);
 		(*vmHookInterface)->J9HookUnregister(vmHookInterface, J9HOOK_REGISTRATION_EVENT, hookVMRegistrationEvent, javaVM);
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		if (extensions->concurrentScavenger) {
+			(*vmHookInterface)->J9HookUnregister(vmHookInterface, J9HOOK_VM_ACQUIREVMACCESS, hookAcquireVMAccess, NULL);
+			(*vmHookInterface)->J9HookUnregister(vmHookInterface, J9HOOK_VM_RELEASEVMACCESS, hookReleaseVMAccess, NULL);
+			(*vmHookInterface)->J9HookUnregister(vmHookInterface, J9HOOK_VM_ACQUIRING_EXCLUSIVE_IN_NATIVE, hookAcquiringExclusiveInNative, NULL);
+		}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	}
 }
 


### PR DESCRIPTION
Introduced an Async handler that will be later used by CS to force
mutator thread to promptly flush its copy cache to the scan queue. The
handler is to be activated toward the end of CS cycle when scan queue is
empty (yet to be implemented).

Also, GC registered for two VM hooks, that will help mutator threads
flush their copy caches by themselves

The async handler and hooks are empty at the moment, but will eventually
call a flush-copy-cash method this is yet to be introduced.

The only functional change is: moved VMAccess release hook trigger in
JNICriticalRegion::releaseAccess() to an earlier point to be consistent
with internalReleaseVMAccessNoMutexNoCheck

Minor cleanup: cached J9VMThread in EnvironmentDelegate, since it's
re-fetched about a dozen of times at various spots.

Some background: https://github.com/eclipse/omr/issues/4787

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>