### PR TITLE
AArch64: Make arguments to Atomic CAS uncompressed

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -688,7 +688,7 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       // Hiding compressedref logic from CodeGen doesn't seem a good practise, the evaluator always need the uncompressedref node for write barrier,
       // therefore, this part is deprecated. It'll be removed once P and Z update their corresponding evaluators.
       static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
-      if (self()->comp()->useCompressedPointers() && (UseOldCompareAndSwapObject || !self()->comp()->target().cpu.isX86()))
+      if (self()->comp()->useCompressedPointers() && (UseOldCompareAndSwapObject || !(self()->comp()->target().cpu.isX86() || self()->comp()->target().cpu.isARM64())))
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
          // In Java9 Unsafe could be the jdk.internal JNI method or the sun.misc ordinary method wrapper,


### PR DESCRIPTION
Change `J9::CodeGenerator::lowerTreesPreChildrenVisit` not to lower
4th and 5th arguments to `Unsafe.compareAndSwapObject` for aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>