### PR TITLE
Move double mapping after null leaf pointer has been initialized

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.cpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.cpp
@@ -258,6 +258,15 @@ MM_IndexableObjectAllocationModel::layoutDiscontiguousArraylet(MM_EnvironmentBas
 	if (NULL != spine) {
 		switch (_layout) {
 		case GC_ArrayletObjectModel::Discontiguous:
+			/* if last arraylet leaf is empty (contains 0 bytes) arrayoid pointer is set to NULL */
+			if (arrayoidIndex == (_numberOfArraylets - 1)) {
+				Assert_MM_true(0 == (_dataSize % arrayletLeafSize));
+				GC_SlotObject slotObject(env->getOmrVM(), &(arrayoidPtr[arrayoidIndex]));
+				slotObject.writeReferenceToSlot(NULL);
+			} else {
+				Assert_MM_true(0 != (_dataSize % arrayletLeafSize));
+				Assert_MM_true(arrayoidIndex == _numberOfArraylets);
+			}
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 			if (extensions->indexableObjectModel.isDoubleMappingEnabled()) {
 				/**
@@ -269,15 +278,6 @@ MM_IndexableObjectAllocationModel::layoutDiscontiguousArraylet(MM_EnvironmentBas
 				}
 			}
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-			/* if last arraylet leaf is empty (contains 0 bytes) arrayoid pointer is set to NULL */
-			if (arrayoidIndex == (_numberOfArraylets - 1)) {
-				Assert_MM_true(0 == (_dataSize % arrayletLeafSize));
-				GC_SlotObject slotObject(env->getOmrVM(), GC_SlotObject::addToSlotAddress(arrayoidPtr, arrayoidIndex, compressed));
-				slotObject.writeReferenceToSlot(NULL);
-			} else {
-				Assert_MM_true(0 != (_dataSize % arrayletLeafSize));
-				Assert_MM_true(arrayoidIndex == _numberOfArraylets);
-			}
 			break;
 
 		case GC_ArrayletObjectModel::Hybrid:


### PR DESCRIPTION
Whenever the size of a discontiguous arraylet is a multiple of
region size in balanced GC, the GC creates an extra arraylet
leaf which contain zero bytes. In this case the arrayoid
corresponding to such leaf is set to NULL. If we double map
before the arrayed is set to NULL it is possible that such
arrayoid might contain garbage, which explains the assertion
failure (double map expects that an  arrayoid pointing to an
empty arraylet leaf to be NULL). Hence we move the double
mapping call to after setting the arrayoid to NULL.

Ran the test "CriticalRegionTest" which is the source of failures
1000 times here and all passed:
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/5871/

Fixes: https://github.com/eclipse/openj9/issues/8383

Signed-off-by: Igor Braga <higorb1@gmail.com>