### PR TITLE
Ability to set test param KEEP_REPORTDIR per target

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -679,9 +679,16 @@ def set_test_misc() {
 
     TEST_FLAG = buildspec.getScalarField("test_flags", SDK_VERSION) ?: ''
 
+    // Set test param KEEP_REPORTDIR to false unless set true in variable file.
+    TEST_KEEP_REPORTDIR = [:]
+    TARGET_NAMES.each { target ->
+        TEST_KEEP_REPORTDIR[target] = buildspec_manager.getSpec('misc').getScalarField("test_keep_reportdir", target) ?: 'false'
+    }
+
     echo "EXCLUDED_TESTS:'${EXCLUDED_TESTS}'"
     echo "TEST_FLAG:'${TEST_FLAG}'"
     echo "EXTRA_TEST_LABELS:'${EXTRA_TEST_LABELS}'"
+    echo "TEST_KEEP_REPORTDIR:'${TEST_KEEP_REPORTDIR}'"
 }
 
 

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -64,6 +64,10 @@ misc:
   jdk_image_dir:
     all: 'jdk'
     8: 'j2sdk-image'
+  test_keep_reportdir:
+    sanity.openjdk: 'true'
+    extended.openjdk: 'true'
+    special.openjdk: 'true'
 credentials:
   github: 'b6987280-6402-458f-bdd6-7affc2e360d4'
 test_dependencies_job_name: 'test.getDependency'


### PR DESCRIPTION
- Use variable file to set KEEP_REPORTDIR per test target.
- Set false by default.
- Set true for all openjdk targets

Related #7780 #8434
Depends #8421
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>