### PR TITLE
Support for CP String patching

### DIFF
--- a/runtime/bcutil/ConstantPoolMap.cpp
+++ b/runtime/bcutil/ConstantPoolMap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -300,6 +300,20 @@ ConstantPoolMap::computeConstantPoolMapAndSizes()
 					Trc_BCU_Assert_ShouldNeverHappen();
 					break;
 			}
+		}
+	}
+
+	J9ClassPatchMap *map = _context->patchMap();
+
+	/**
+	 * If a valid patchMap structure is passed, this class requires ConstantPool patching.
+	 * Record the index mapping from Classfile to J9Class constantpool to allow patching
+	 * the RAM CP after it is created by VM.
+	 */
+	if (map != NULL) {
+		Trc_BCU_Assert_Equals(map->size, cfrCPCount);
+		for (U_16 cfrCPIndex = 0; cfrCPIndex < cfrCPCount; cfrCPIndex++) {
+			map->indexMap[cfrCPIndex] = _constantPoolEntries[cfrCPIndex].romCPIndex;
 		}
 	}
 }

--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -150,13 +150,15 @@ public:
 		_doDebugCompare(false),
 		_existingRomMethod(NULL),
 		_reusingIntermediateClassData(false),
-		_creatingIntermediateROMClass(creatingIntermediateROMClass)
+		_creatingIntermediateROMClass(creatingIntermediateROMClass),
+		_patchMap(NULL)
 	{
 		if ((NULL != _javaVM) && (NULL != _javaVM->dynamicLoadBuffers)) {
 			/* localBuffer should not be NULL */
 			Trc_BCU_Assert_True(NULL != localBuffer);
 			_cpIndex = localBuffer->entryIndex;
 			_loadLocation = localBuffer->loadLocationType;
+			_patchMap = localBuffer->patchMap;
 			_sharedStringInternTable = _javaVM->sharedInvariantInternTable;
 			_interningEnabled = J9_ARE_ALL_BITS_SET(_bcuFlags, BCU_ENABLE_INVARIANT_INTERNING) && J9_ARE_NO_BITS_SET(_findClassFlags, J9_FINDCLASS_FLAG_ANON);
 			if (0 != (bcuFlags & BCU_VERBOSE)) {
@@ -189,6 +191,7 @@ public:
 	J9PortLibrary *portLibrary() const { return _portLibrary; }
 	UDATA cpIndex() const { return _cpIndex; }
 	UDATA loadLocation() const {return _loadLocation; }
+	J9ClassPatchMap *patchMap() const { return _patchMap; }
 	J9SharedInvariantInternTable *sharedStringInternTable() const { return _sharedStringInternTable; }
 
 	U_8 *intermediateClassData() const { return _intermediateClassData; }
@@ -741,6 +744,7 @@ private:
 	J9ROMMethod * _existingRomMethod;
 	bool _reusingIntermediateClassData;
 	bool _creatingIntermediateROMClass;
+	J9ClassPatchMap *_patchMap;
 
 	J9ROMMethod * romMethodFromOffset(IDATA offset);
 };

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,7 +70,7 @@ Java_java_lang_ClassLoader_defineClassImpl(JNIEnv *env, jobject receiver, jstrin
 		options |= J9_FINDCLASS_FLAG_UNSAFE;
 	}
 
-	jclass result = defineClassCommon(env, receiver, className, classRep, offset, length, protectionDomain, options, NULL);
+	jclass result = defineClassCommon(env, receiver, className, classRep, offset, length, protectionDomain, options, NULL, NULL);
 
 	if (J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID) && (NULL == result) && (NULL == currentThread->currentException)) {
 		/*

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 
 jclass 
 defineClassCommon(JNIEnv *env, jobject classLoaderObject,
-	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA options, J9Class *hostClass)
+	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA options, J9Class *hostClass, J9ClassPatchMap *patchMap)
 {
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
 
@@ -68,6 +68,10 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 			throwNewNullPointerException(env, NULL);
 		}
 		goto done;
+	}
+
+	if ((patchMap != NULL) && (patchMap->size != 0)) {
+		localBuffer.patchMap = patchMap;
 	}
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);

--- a/runtime/jcl/common/proxy.c
+++ b/runtime/jcl/common/proxy.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,7 +88,7 @@ static jclass proxyDefineClass(
 		defineClassOptions |= J9_FINDCLASS_FLAG_UNSAFE;
 	}
 #endif /* JAVA_SPEC_VERSION == 8 */
-	return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, defineClassOptions, NULL);
+	return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, defineClassOptions, NULL, NULL);
 }
 
 jclass JNICALL Java_java_lang_reflect_Proxy_defineClassImpl(JNIEnv * env, jclass recvClass, jobject classLoader, jstring className, jbyteArray classBytes)
@@ -119,7 +119,7 @@ Java_java_lang_reflect_Proxy_defineClass0__Ljava_lang_ClassLoader_2Ljava_lang_St
 			defineClassOptions |= J9_FINDCLASS_FLAG_UNSAFE;
 		}
 #endif /* JAVA_SPEC_VERSION == 8 */
-		return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, defineClassOptions, NULL);
+		return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, defineClassOptions, NULL, NULL);
 	}
 }
 

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -133,16 +133,25 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 	if (constPatches != NULL) {
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 		J9Class *clazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9_JNI_UNWRAP_REFERENCE(anonClass));
-
-		j9object_t item = NULL;
 		U_32 *cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(clazz->romClass);
 		J9ConstantPool *ramCP = J9_CP_FROM_CLASS(clazz);
+		J9ROMConstantPoolItem *romCP = ramCP->romConstantPool;
 
+		/* Get J9 constantpool mapped item for patch item, only support patching STRING entries has been added */
 		for (U_16 i = 0; i < cpPatchMap.size; i++) {
-			item = J9JAVAARRAYOFOBJECT_LOAD(currentThread, patchArray, i);
+			j9object_t item = J9JAVAARRAYOFOBJECT_LOAD(currentThread, patchArray, i);
 			if ((item != NULL) && (J9_CP_TYPE(cpShapeDescription, cpPatchMap.indexMap[i]) == J9CPTYPE_STRING)) {
-				J9RAMStringRef *ramStringRef = ((J9RAMStringRef *)ramCP) + cpPatchMap.indexMap[i];
-				J9STATIC_OBJECT_STORE(currentThread, clazz, &ramStringRef->stringObject, item);
+				J9UTF8 *romString = J9ROMSTRINGREF_UTF8DATA((J9ROMStringRef *)&romCP[cpPatchMap.indexMap[i]]);
+
+				/* For each patch object, search the RAM constantpool for identical string entries */
+				for (U_16 j = 1; j < clazz->romClass->ramConstantPoolCount; j++) {
+					if ((J9_CP_TYPE(cpShapeDescription, j) == J9CPTYPE_STRING)
+						&& J9UTF8_EQUALS(romString, J9ROMSTRINGREF_UTF8DATA((J9ROMStringRef *)&romCP[j]))
+					) {
+						J9RAMStringRef *ramStringRef = ((J9RAMStringRef *)ramCP) + j;
+						J9STATIC_OBJECT_STORE(currentThread, clazz, &ramStringRef->stringObject, item);
+					}
+				}
 			}
 		}
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1824,6 +1824,7 @@ typedef struct J9TranslationLocalBuffer {
 	IDATA entryIndex;
 	I_32 loadLocationType;
 	struct J9ClassPathEntry* cpEntryUsed;
+	struct J9ClassPatchMap* patchMap;
 } J9TranslationLocalBuffer;
 
 typedef struct J9TranslationBufferSet {
@@ -1956,6 +1957,11 @@ typedef struct J9ClassPathEntry {
 	U_8 paddingToPowerOf2[12];
 #endif
 } J9ClassPathEntry;
+
+typedef struct J9ClassPatchMap {
+	U_16 size;
+	U_16* indexMap;
+} J9ClassPatchMap;
 
 #define CPE_STATUS_ASSUME_JXE  					0x1
 #define CPE_STATUS_JXE_MISSING_ROM_CLASSES  	0x2

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -708,7 +708,7 @@ UDATA initializeRequiredClasses(J9VMThread *vmThread, char* libName);
 /* J9SourceJclDefineClass*/
 extern J9_CFUNC jclass 
 defineClassCommon (JNIEnv *env, jobject classLoaderObject,
-	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA options, J9Class *hostClass);
+	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA options, J9Class *hostClass, J9ClassPatchMap *patchMap);
 
 /* BBjclNativesCommonAccessController*/
 jboolean JNICALL Java_java_security_AccessController_initializeInternal (JNIEnv *env, jclass thisClz);


### PR DESCRIPTION
- New J9ClassPatchMap structure to store patching info
- Update defineClassCommon code to accept J9ClassPatchMap
- Patch RAM constantpool before returing class object

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>