### PR TITLE
CMake: Add dependency on generating tracegen files

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -287,6 +287,7 @@ add_dependencies(j9vm_interface
 	j9vm_hookgen
 	j9vm_m4gen
 	j9vm_nlsgen
+	run_tracegen
 )
 
 # j9vm_gc_includes is used to track the include directories that are consumed by the various gc components


### PR DESCRIPTION
Add run_tracegen as a dependency of j9vm_interface. This should force
tracegen to run before any compilation.

Fixes #8166

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>