### PR TITLE
Use IOUtils.readFully() to accommodate other lagging JCL levels

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SecurityFrameInjector.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar17]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 2012, 2020 IBM Corp. and others
  *
@@ -106,7 +106,7 @@ final class SecurityFrameInjector {
 								return Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class").readAllBytes(); //$NON-NLS-1$
 								/*[ELSE]*/
 								InputStream is = Lookup.class.getResourceAsStream("/java/lang/invoke/SecurityFrame.class"); //$NON-NLS-1$
-								return IOUtils.readAllBytes(is);
+								return IOUtils.readFully(is, Integer.MAX_VALUE, false);
 								/*[ENDIF]*/
 							} catch(java.io.IOException e) {
 								/*[MSG "K056A", "Unable to read java.lang.invoke.SecurityFrame.class bytes"]*/


### PR DESCRIPTION
**Use IOUtils.readFully() to accommodate other lagging JCL levels**

`IOUtils.readAllBytes(is)` is equivalent to `IOUtils.readFully(is,Integer.MAX_VALUE, false)` which is available in current and earlier `IOUtils` versions.

Verified that `pConfig` still compiles.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>