### PR TITLE
Make -Djava.lang.stringBuffer.growAggressively default

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1716,8 +1716,9 @@ static void initFromSystemProperties(Properties props) {
 	String prop = props.getProperty("java.lang.string.create.unique"); //$NON-NLS-1$
 	TOSTRING_COPY_BUFFER_ENABLED = "true".equals(prop) || "StringBuffer".equals(prop); //$NON-NLS-1$ //$NON-NLS-2$
 
-	String growAggressivelyProperty = props.getProperty("java.lang.stringBuffer.growAggressively"); //$NON-NLS-1$
-	growAggressively = "".equals(growAggressivelyProperty) || "true".equalsIgnoreCase(growAggressivelyProperty); //$NON-NLS-1$ //$NON-NLS-2$
+	// growAggressively by default
+	String growAggressivelyProperty = props.getProperty("java.lang.stringBuffer.growAggressively", ""); //$NON-NLS-1$ //$NON-NLS-2$
+	growAggressively = "".equals(growAggressivelyProperty) || Boolean.parseBoolean(growAggressivelyProperty); //$NON-NLS-1$
 }
 
 /**

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1715,8 +1715,9 @@ static void initFromSystemProperties(Properties props) {
 	String prop = props.getProperty("java.lang.string.create.unique"); //$NON-NLS-1$
 	TOSTRING_COPY_BUFFER_ENABLED = "true".equals(prop) || "StringBuilder".equals(prop); //$NON-NLS-1$ //$NON-NLS-2$
 
-	String growAggressivelyProperty = props.getProperty("java.lang.stringBuffer.growAggressively"); //$NON-NLS-1$
-	growAggressively = "".equals(growAggressivelyProperty) || "true".equalsIgnoreCase(growAggressivelyProperty); //$NON-NLS-1$ //$NON-NLS-2$
+	// growAggressively by default
+	String growAggressivelyProperty = props.getProperty("java.lang.stringBuffer.growAggressively", ""); //$NON-NLS-1$ //$NON-NLS-2$
+	growAggressively = "".equals(growAggressivelyProperty) || Boolean.parseBoolean(growAggressivelyProperty); //$NON-NLS-1$
 }
 
 /**


### PR DESCRIPTION
growAggressively becomes the default behavior. Use
-Djava.lang.stringBuffer.growAggressively=false
to disable it.

java.lang.stringBufferAndBuilder.growAggressively was introduced by #8405
and renamed to java.lang.stringBuffer.growAggressively in #8484
Issue #7671

Doc issue https://github.com/eclipse/openj9-docs/issues/497