### PR TITLE
Don't run StringBuffer/Builder growth test in constrained environments

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
@@ -550,6 +550,7 @@
   <command>$EXE$ -Xdump:none -Xmx7g -Djava.lang.stringBufferAndBuilder.growAggressively -cp $Q$$JARPATH$$Q$ TestStringBufferAndBuilderGrowth</command>
   <output regex="no" type="success">StringBuffer capacity=2147483647 StringBuilder capacity=2147483647</output>
   <output regex="no" type="success">Option too large</output>
+  <output regex="no" type="success">Not enough resource to run test</output>
  </test>
 
 </suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/TestStringBufferAndBuilderGrowth.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/TestStringBufferAndBuilderGrowth.java
@@ -20,6 +20,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+import com.sun.management.OperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+
 /**
  * @file TestStringBufferAndBuilderGrowth.java
  * @brief Grows a StringBuffer and StringBuilder to Integer.MAX_VALUE
@@ -27,6 +30,16 @@
 public class TestStringBufferAndBuilderGrowth {
 
 public static void main(String[] args) {
+	OperatingSystemMXBean opBean = (OperatingSystemMXBean)ManagementFactory.getOperatingSystemMXBean();
+	long physicalMemory = opBean.getTotalPhysicalMemorySize();
+	System.out.println("Machine has physical memory " + physicalMemory + " bytes or " + (physicalMemory >> 20) + " MB or " + (physicalMemory >> 30) + " GB");
+	// An AIX machine with 7616 MB doesn't work
+	long limit = 8000L << 20; 
+	if (physicalMemory < limit) {
+		System.out.println("Not enough resource to run test.");
+		return;
+	}
+
 	char[] cbuf = new char[Integer.MAX_VALUE / 32];
 
 	// Create a StringBuffer big enough that the default algorithm to


### PR DESCRIPTION
Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>