### PR TITLE
Common getOffsetToFirstParm and mapIncomingParms in the linkage class across codegens

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -209,7 +209,7 @@ J9::ARM64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
    // Volatile GPR (0-15, 18) + FPR (0-31) + VFT Reg
    _properties._numberOfDependencyGPRegisters = 17 + 32 + 1;
-   _properties._offsetToFirstParm             = 0;
+   self()->setOffsetToFirstParm(0);
    _properties._offsetToFirstLocal            = -8;
    }
 
@@ -331,7 +331,7 @@ void J9::ARM64::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    TR::ParameterSymbol *parmCursor = parameterIterator.getFirst();
 
-   int32_t offsetToFirstParm = linkageProperties.getOffsetToFirstParm();
+   int32_t offsetToFirstParm = self()->getOffsetToFirstParm();
    uint32_t sizeOfParameterArea = method->getNumParameterSlots() * TR::Compiler->om.sizeofReferenceAddress();
 
    while (parmCursor != NULL)
@@ -532,7 +532,7 @@ void J9::ARM64::PrivateLinkage::createPrologue(TR::Instruction *cursor)
    // The offset to the first parm is the offset between the entry JavaSP and the first
    // mapped parameter.  It is a positive (or zero) offset.
    //
-   int32_t outgoingArgsSize = cg()->getLargestOutgoingArgSize() + properties.getOffsetToFirstParm();
+   int32_t outgoingArgsSize = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm();
 
    int32_t frameSizeIncludingReturnAddress = preservedRegisterSaveSize + localsSize + outgoingArgsSize;
 
@@ -734,7 +734,7 @@ void J9::ARM64::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    TR::RealRegister *javaSP = machine->getRealRegister(properties.getStackPointerRegister()); // x20
 
    // restore preserved GPRs
-   int32_t preservedRegisterOffsetFromJavaSP = cg()->getLargestOutgoingArgSize() + properties.getOffsetToFirstParm(); // outgoingArgsSize
+   int32_t preservedRegisterOffsetFromJavaSP = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm(); // outgoingArgsSize
    TR::RealRegister::RegNum firstPreservedGPR = TR::RealRegister::x21;
    TR::RealRegister::RegNum lastPreservedGPR = TR::RealRegister::x28;
    for (TR::RealRegister::RegNum r = firstPreservedGPR; r <= lastPreservedGPR; r = (TR::RealRegister::RegNum)((uint32_t)r+1))

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -331,7 +331,7 @@ void J9::ARM64::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    TR::ParameterSymbol *parmCursor = parameterIterator.getFirst();
 
-   int32_t offsetToFirstParm = self()->getOffsetToFirstParm();
+   int32_t offsetToFirstParm = getOffsetToFirstParm();
    uint32_t sizeOfParameterArea = method->getNumParameterSlots() * TR::Compiler->om.sizeofReferenceAddress();
 
    while (parmCursor != NULL)
@@ -532,7 +532,7 @@ void J9::ARM64::PrivateLinkage::createPrologue(TR::Instruction *cursor)
    // The offset to the first parm is the offset between the entry JavaSP and the first
    // mapped parameter.  It is a positive (or zero) offset.
    //
-   int32_t outgoingArgsSize = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm();
+   int32_t outgoingArgsSize = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm();
 
    int32_t frameSizeIncludingReturnAddress = preservedRegisterSaveSize + localsSize + outgoingArgsSize;
 
@@ -734,7 +734,7 @@ void J9::ARM64::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    TR::RealRegister *javaSP = machine->getRealRegister(properties.getStackPointerRegister()); // x20
 
    // restore preserved GPRs
-   int32_t preservedRegisterOffsetFromJavaSP = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm(); // outgoingArgsSize
+   int32_t preservedRegisterOffsetFromJavaSP = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm(); // outgoingArgsSize
    TR::RealRegister::RegNum firstPreservedGPR = TR::RealRegister::x21;
    TR::RealRegister::RegNum lastPreservedGPR = TR::RealRegister::x28;
    for (TR::RealRegister::RegNum r = firstPreservedGPR; r <= lastPreservedGPR; r = (TR::RealRegister::RegNum)((uint32_t)r+1))

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -209,7 +209,7 @@ J9::ARM64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
    // Volatile GPR (0-15, 18) + FPR (0-31) + VFT Reg
    _properties._numberOfDependencyGPRegisters = 17 + 32 + 1;
-   self()->setOffsetToFirstParm(0);
+   setOffsetToFirstParm(0);
    _properties._offsetToFirstLocal            = -8;
    }
 

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -58,13 +58,14 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
    {
    uint32_t intArgNum=0, floatArgNum=0, offset;
    TR::Machine *machine = cg->machine();
-   const TR::ARM64LinkageProperties &linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention())->getProperties();
+   TR::Linkage* linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
+   const TR::ARM64LinkageProperties &linkageProperties = linkage->getProperties();
    int32_t argStart = callNode->getFirstArgumentIndex();
 
-   if (linkage.getRightToLeft())
-      offset = linkage.getOffsetToFirstParm();
+   if (linkageProperties.getRightToLeft())
+      offset = linkage->getOffsetToFirstParm();
    else
-      offset = argSize+linkage.getOffsetToFirstParm();
+      offset = argSize+linkage->getOffsetToFirstParm();
 
    for (int32_t i=argStart; i<callNode->getNumChildren();i++)
       {
@@ -74,58 +75,58 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
          case TR::Int8:
          case TR::Int16:
          case TR::Int32:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= TR::Compiler->om.sizeofReferenceAddress();
-            if (intArgNum < linkage.getNumIntArgRegs())
+            if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::strimmw, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::strimmw, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += TR::Compiler->om.sizeofReferenceAddress();
             break;
          case TR::Address:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= TR::Compiler->om.sizeofReferenceAddress();
-            if (intArgNum < linkage.getNumIntArgRegs())
+            if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::strimmx, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::strimmx, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += TR::Compiler->om.sizeofReferenceAddress();
             break;
          case TR::Int64:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 2*TR::Compiler->om.sizeofReferenceAddress();
-            if (intArgNum < linkage.getNumIntArgRegs())
+            if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::strimmx, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::strimmx, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 2*TR::Compiler->om.sizeofReferenceAddress();
             break;
          case TR::Float:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= TR::Compiler->om.sizeofReferenceAddress();
-            if (floatArgNum < linkage.getNumFloatArgRegs())
+            if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::vstrimms, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::vstrimms, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += TR::Compiler->om.sizeofReferenceAddress();
             break;
          case TR::Double:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 2*TR::Compiler->om.sizeofReferenceAddress();
-            if (floatArgNum < linkage.getNumFloatArgRegs())
+            if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::vstrimmd, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::vstrimmd, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 2*TR::Compiler->om.sizeofReferenceAddress();
             break;
          }

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -166,7 +166,7 @@ TR::MemoryReference *J9::ARM::JNILinkage::getOutgoingArgumentMemRef(int32_t     
 printf("JNI: offset %d\n", offset); fflush(stdout);
 #endif
    const TR::ARMLinkageProperties &jniLinkageProperties = getProperties();
-   int32_t                spOffset = offset + self()->getOffsetToFirstParm();
+   int32_t                spOffset = offset + getOffsetToFirstParm();
    TR::RealRegister    *sp       = cg()->machine()->getRealRegister(jniLinkageProperties.getStackPointerRegister());
    TR::MemoryReference *result   = new (trHeapMemory()) TR::MemoryReference(sp, spOffset, cg());
    memArg.argRegister = argReg;

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -166,7 +166,7 @@ TR::MemoryReference *J9::ARM::JNILinkage::getOutgoingArgumentMemRef(int32_t     
 printf("JNI: offset %d\n", offset); fflush(stdout);
 #endif
    const TR::ARMLinkageProperties &jniLinkageProperties = getProperties();
-   int32_t                spOffset = offset + jniLinkageProperties.getOffsetToFirstParm();
+   int32_t                spOffset = offset + self()->getOffsetToFirstParm();
    TR::RealRegister    *sp       = cg()->machine()->getRealRegister(jniLinkageProperties.getStackPointerRegister());
    TR::MemoryReference *result   = new (trHeapMemory()) TR::MemoryReference(sp, spOffset, cg());
    memArg.argRegister = argReg;

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -163,7 +163,7 @@ TR::ARMLinkageProperties J9::ARM::PrivateLinkage::properties =
 J9::ARM::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
    : J9::PrivateLinkage(cg)
    {
-   self()->setOffsetToFirstParm(0);
+   setOffsetToFirstParm(0);
    }
 
 TR::ARMLinkageProperties& J9::ARM::PrivateLinkage::getProperties()

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -289,7 +289,7 @@ void J9::ARM::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
 
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    TR::ParameterSymbol              *parmCursor = parameterIterator.getFirst();
-   int32_t                          offsetToFirstParm = self()->getOffsetToFirstParm();
+   int32_t                          offsetToFirstParm = getOffsetToFirstParm();
    if (linkage.getRightToLeft())
       {
       while (parmCursor != NULL)
@@ -449,7 +449,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
 
    int32_t registerSaveSize = intRegistersSaved * 4 + fpRegistersSaved * 8;
 
-   int32_t outgoingArgSize  = self()->getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
+   int32_t outgoingArgSize  = getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
    int32_t totalFrameSize   = localSize + registerSaveSize + outgoingArgSize;
 
    // Align frame to 8-byte boundaries.
@@ -745,7 +745,7 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
 
    int32_t registerSaveSize  = intRegistersSaved * 4 + fpRegistersSaved * 8;
 
-   int32_t outgoingArgSize   = self()->getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
+   int32_t outgoingArgSize   = getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
    int32_t totalFrameSize    = localSize + registerSaveSize + outgoingArgSize;
 
    if (debug("alignStackFrame"))

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,7 +147,6 @@ TR::ARMLinkageProperties J9::ARM::PrivateLinkage::properties =
        TR::RealRegister::gr11, // vtable index register
        TR::RealRegister::gr0,  // j9method argument register
        15,                       // numberOfDependencyRegisters
-       0,                        // offsetToFirstStackParm
        -4,                       // offsetToFirstLocal
        4,                        // numIntegerArgumentRegisters
        0,                        // firstIntegerArgumentRegister
@@ -160,6 +159,12 @@ TR::ARMLinkageProperties J9::ARM::PrivateLinkage::properties =
        0,                        // firstIntegerReturnRegister
        0                         // firstFloatReturnRegister
    };
+
+J9::ARM::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
+   : J9::PrivateLinkage(cg)
+   {
+   self()->setOffsetToFirstParm(0);
+   }
 
 TR::ARMLinkageProperties& J9::ARM::PrivateLinkage::getProperties()
    {
@@ -284,7 +289,7 @@ void J9::ARM::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
 
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    TR::ParameterSymbol              *parmCursor = parameterIterator.getFirst();
-   int32_t                          offsetToFirstParm = linkage.getOffsetToFirstParm();
+   int32_t                          offsetToFirstParm = self()->getOffsetToFirstParm();
    if (linkage.getRightToLeft())
       {
       while (parmCursor != NULL)
@@ -444,7 +449,7 @@ void J9::ARM::PrivateLinkage::createPrologue(TR::Instruction *cursor)
 
    int32_t registerSaveSize = intRegistersSaved * 4 + fpRegistersSaved * 8;
 
-   int32_t outgoingArgSize  = properties.getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
+   int32_t outgoingArgSize  = self()->getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
    int32_t totalFrameSize   = localSize + registerSaveSize + outgoingArgSize;
 
    // Align frame to 8-byte boundaries.
@@ -740,7 +745,7 @@ void J9::ARM::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
 
    int32_t registerSaveSize  = intRegistersSaved * 4 + fpRegistersSaved * 8;
 
-   int32_t outgoingArgSize   = properties.getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
+   int32_t outgoingArgSize   = self()->getOffsetToFirstParm() + codeGen->getLargestOutgoingArgSize();
    int32_t totalFrameSize    = localSize + registerSaveSize + outgoingArgSize;
 
    if (debug("alignStackFrame"))

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ class PrivateLinkage : public J9::PrivateLinkage
 
    public:
 
-   PrivateLinkage(TR::CodeGenerator *cg) : J9::PrivateLinkage(cg) {}
+   PrivateLinkage(TR::CodeGenerator *cg);
 
    virtual uint32_t getRightToLeft();
    virtual void mapStack(TR::ResolvedMethodSymbol *method);

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,13 +39,14 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
    {
    uint32_t        intArgNum=0, floatArgNum=0, offset;
    TR::Machine *machine = cg->machine();
-   const TR::ARMLinkageProperties &linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention())->getProperties();
+   TR::Linkage* linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
+   const TR::ARMLinkageProperties &linkageProperties = linkage->getProperties();
    int32_t argStart = callNode->getFirstArgumentIndex();
 
-   if (linkage.getRightToLeft())
-      offset = linkage.getOffsetToFirstParm();
+   if (linkageProperties.getRightToLeft())
+      offset = linkage->getOffsetToFirstParm();
    else
-      offset = argSize+linkage.getOffsetToFirstParm();
+      offset = argSize+linkage->getOffsetToFirstParm();
 
    for (int i=argStart; i<callNode->getNumChildren();i++)
       {
@@ -59,58 +60,58 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
          case TR::Float:
 #endif
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 4;
-            if (intArgNum < linkage.getNumIntArgRegs())
+            if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 4;
             break;
          case TR::Int64:
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
          case TR::Double:
 #endif
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 8;
-            if (intArgNum < linkage.getNumIntArgRegs())
+            if (intArgNum < linkageProperties.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
-               if (intArgNum < linkage.getNumIntArgRegs()-1)
+               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               if (intArgNum < linkageProperties.getNumIntArgRegs()-1)
            	  {
-           	  buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
+           	  buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
            	  }
                }
             intArgNum += 2;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 8;
             break;
 #if !defined(__VFP_FP__) || defined(__SOFTFP__)
          case TR::Float:
             /* TODO
-               if (!linkage.getRightToLeft())
+               if (!linkageProperties.getRightToLeft())
                offset -= 4;
-               if (floatArgNum < linkage.getNumFloatArgRegs())
+               if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_stfs, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_stfs, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
-               if (linkage.getRightToLeft())
+               if (linkageProperties.getRightToLeft())
                offset += 4;
             */
             break;
          case TR::Double:
             /* TODO
-               if (!linkage.getRightToLeft())
+               if (!linkageProperties.getRightToLeft())
                offset -= 8;
-               if (floatArgNum < linkage.getNumFloatArgRegs())
+               if (floatArgNum < linkageProperties.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_stfd, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_stfd, buffer, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
-               if (linkage.getRightToLeft())
+               if (linkageProperties.getRightToLeft())
                offset += 8;
             */
             break;

--- a/runtime/compiler/codegen/CMakeLists.txt
+++ b/runtime/compiler/codegen/CMakeLists.txt
@@ -35,4 +35,6 @@ j9jit_files(
 	codegen/J9TreeEvaluator.cpp
 	codegen/J9WatchedInstanceFieldSnippet.cpp
 	codegen/J9WatchedStaticFieldSnippet.cpp
+	codegen/MonitorState.cpp
+	codegen/PrivateLinkage.cpp
 )

--- a/runtime/compiler/codegen/PrivateLinkage.cpp
+++ b/runtime/compiler/codegen/PrivateLinkage.cpp
@@ -46,8 +46,9 @@ J9::PrivateLinkage::entryPointFromInterpretedMethod()
 void
 J9::PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    {
-   int32_t offsetToFirstArg = method->getNumParameterSlots() * TR::Compiler->om.sizeofReferenceAddress() + self()->getOffsetToFirstParm();
+   int32_t offsetToFirstArg = method->getNumParameterSlots() * TR::Compiler->om.sizeofReferenceAddress() + getOffsetToFirstParm();
 
+   const bool is64Bit = cg()->comp()->target().is64Bit();
    ListIterator<TR::ParameterSymbol> paramIterator(&method->getParameterList());
    for (TR::ParameterSymbol* paramCursor = paramIterator.getFirst(); paramCursor != NULL; paramCursor = paramIterator.getNext())
       {
@@ -55,7 +56,7 @@ J9::PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
       // variables take up two stack slots. A stack slot in OpenJ9 is a `uintptr_t`, so on 64-bit int variables
       // are still placed in 64-bit stack slots, hence the need to check for 64-bit in the query below. For more
       // details please see eclipse/openj9#8360.
-      int32_t slotMultiplier = cg()->comp()->target().is64Bit() && paramCursor->getDataType() != TR::Address ? 2 : 1;
+      int32_t slotMultiplier = is64Bit && paramCursor->getDataType() != TR::Address ? 2 : 1;
 
       paramCursor->setParameterOffset(offsetToFirstArg -
          paramCursor->getParameterOffset() -

--- a/runtime/compiler/codegen/PrivateLinkage.cpp
+++ b/runtime/compiler/codegen/PrivateLinkage.cpp
@@ -20,10 +20,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "codegen/PrivateLinkage.hpp"
+
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/Linkage_inlines.hpp"
-#include "codegen/PrivateLinkage.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
+#include "il/ParameterSymbol.hpp"
 
 intptr_t
 J9::PrivateLinkage::entryPointFromCompiledMethod()
@@ -37,4 +41,24 @@ intptr_t
 J9::PrivateLinkage::entryPointFromInterpretedMethod()
    {
    return reinterpret_cast<intptr_t>(cg()->getCodeStart());
+   }
+
+void
+J9::PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
+   {
+   int32_t offsetToFirstArg = method->getNumParameterSlots() * TR::Compiler->om.sizeofReferenceAddress() + self()->getOffsetToFirstParm();
+
+   ListIterator<TR::ParameterSymbol> paramIterator(&method->getParameterList());
+   for (TR::ParameterSymbol* paramCursor = paramIterator.getFirst(); paramCursor != NULL; paramCursor = paramIterator.getNext())
+      {
+      // This is a slightly convoluted way of enforcing the JVM specification which states that long and double 
+      // variables take up two stack slots. A stack slot in OpenJ9 is a `uintptr_t`, so on 64-bit int variables
+      // are still placed in 64-bit stack slots, hence the need to check for 64-bit in the query below. For more
+      // details please see eclipse/openj9#8360.
+      int32_t slotMultiplier = cg()->comp()->target().is64Bit() && paramCursor->getDataType() != TR::Address ? 2 : 1;
+
+      paramCursor->setParameterOffset(offsetToFirstArg -
+         paramCursor->getParameterOffset() -
+         paramCursor->getSize() * slotMultiplier);
+      }
    }

--- a/runtime/compiler/codegen/PrivateLinkage.hpp
+++ b/runtime/compiler/codegen/PrivateLinkage.hpp
@@ -130,6 +130,7 @@ public:
     */
    virtual intptr_t entryPointFromInterpretedMethod();
 
+   virtual void mapIncomingParms(TR::ResolvedMethodSymbol *method);
    };
 
 }

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -63,6 +63,8 @@ J9::Power::JNILinkage::JNILinkage(TR::CodeGenerator *cg)
 
    _properties._preservedRegisterMapForGC = privateLinkageProperties.getPreservedRegisterMapForGC();
 
+   // TODO (#9999): JNI linkage should inherit from system linkage to avoid having to do this copying
+   self()->setOffsetToFirstParm(sysLinkage->getOffsetToFirstParm());
    }
 
 int32_t J9::Power::JNILinkage::buildArgs(TR::Node *callNode,

--- a/runtime/compiler/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCJNILinkage.cpp
@@ -63,8 +63,8 @@ J9::Power::JNILinkage::JNILinkage(TR::CodeGenerator *cg)
 
    _properties._preservedRegisterMapForGC = privateLinkageProperties.getPreservedRegisterMapForGC();
 
-   // TODO (#9999): JNI linkage should inherit from system linkage to avoid having to do this copying
-   self()->setOffsetToFirstParm(sysLinkage->getOffsetToFirstParm());
+   // TODO: JNI linkage should inherit from system linkage to avoid having to do this copying
+   setOffsetToFirstParm(sysLinkage->getOffsetToFirstParm());
    }
 
 int32_t J9::Power::JNILinkage::buildArgs(TR::Node *callNode,

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -569,7 +569,7 @@ void J9::Power::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + self()->getOffsetToFirstParm() - firstLocalOffset);
+   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + getOffsetToFirstParm() - firstLocalOffset);
    }
 
 void J9::Power::PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
@@ -1313,11 +1313,11 @@ void J9::Power::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
 
    if (0 && cg()->comp()->target().is64Bit())
       {
-      saveSize = (cg()->getLargestOutgoingArgSize() * 2) + self()->getOffsetToFirstParm();
+      saveSize = (cg()->getLargestOutgoingArgSize() * 2) + getOffsetToFirstParm();
       }
    else
       {
-      saveSize = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm();
+      saveSize = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm();
       }
 
    while (savedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
@@ -1381,7 +1381,7 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node             
    TR::PPCMemoryArgument           *pushToMemory = NULL;
    TR::Register                    *tempRegister;
    int32_t                          argIndex = 0, memArgs = 0, from, to, step;
-   int32_t                          argSize = -self()->getOffsetToFirstParm(), totalSize = 0;
+   int32_t                          argSize = -getOffsetToFirstParm(), totalSize = 0;
    uint32_t                         numIntegerArgs = 0;
    uint32_t                         numFloatArgs = 0;
    uint32_t                         firstExplicitArg = 0;
@@ -2852,7 +2852,7 @@ TR::MemoryReference *J9::Power::PrivateLinkage::getOutgoingArgumentMemRef(int32_
    TR::Machine *machine = cg()->machine();
 
    TR::MemoryReference *result=new (trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
-                                        argSize+self()->getOffsetToFirstParm(), length, cg());
+                                        argSize+getOffsetToFirstParm(), length, cg());
    memArg.argRegister = argReg;
    memArg.argMemory = result;
    memArg.opCode = opCode;

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -566,36 +566,7 @@ void J9::Power::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
       }
    method->setLocalMappingCursor(stackIndex);
 
-   ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
-   TR::ParameterSymbol              *parmCursor = parameterIterator.getFirst();
-   int32_t                          offsetToFirstParm = linkage.getOffsetToFirstParm();
-   if (linkage.getRightToLeft())
-      {
-      while (parmCursor != NULL)
-         {
-         parmCursor->setParameterOffset(parmCursor->getParameterOffset() + offsetToFirstParm);
-         parmCursor = parameterIterator.getNext();
-         }
-      }
-   else
-      {
-      uint32_t sizeOfParameterArea = method->getNumParameterSlots() * TR::Compiler->om.sizeofReferenceAddress();
-      while (parmCursor != NULL)
-         {
-         if (comp()->target().is64Bit() &&
-             parmCursor->getDataType() != TR::Address)
-            parmCursor->setParameterOffset(sizeOfParameterArea -
-                                        parmCursor->getParameterOffset() -
-                                        parmCursor->getSize()*2 +
-                                        offsetToFirstParm);
-         else
-            parmCursor->setParameterOffset(sizeOfParameterArea -
-                                        parmCursor->getParameterOffset() -
-                                        parmCursor->getSize() +
-                                        offsetToFirstParm);
-         parmCursor = parameterIterator.getNext();
-         }
-      }
+   mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
    atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm - firstLocalOffset);

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -329,7 +329,7 @@ J9::Power::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
       _properties._TOCBaseRegister               = TR::RealRegister::gr16;
       // Volatile GPR (0,2-12) + FPR (0-31) + CCR (0-7) + VR (0-31)
       _properties._numberOfDependencyGPRegisters = 12 + 32 + 8 + 32;
-      self()->setOffsetToFirstParm(0);
+      setOffsetToFirstParm(0);
       _properties._offsetToFirstLocal            = -8;
       }
    else
@@ -345,7 +345,7 @@ J9::Power::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
       else
          // Volatile GPR (0,2-12) + FPR (0-31) + CCR (0-7) + VR (0-31)
          _properties._numberOfDependencyGPRegisters = 12 + 32 + 8 + 32;
-      self()->setOffsetToFirstParm(0);
+      setOffsetToFirstParm(0);
       _properties._offsetToFirstLocal            = -4;
       }
    _properties._computedCallTargetRegister  = TR::RealRegister::gr0; // gr11 = interface, gr12 = virtual, so we need something else for computed

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -329,7 +329,7 @@ J9::Power::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
       _properties._TOCBaseRegister               = TR::RealRegister::gr16;
       // Volatile GPR (0,2-12) + FPR (0-31) + CCR (0-7) + VR (0-31)
       _properties._numberOfDependencyGPRegisters = 12 + 32 + 8 + 32;
-      _properties._offsetToFirstParm             = 0;
+      self()->setOffsetToFirstParm(0);
       _properties._offsetToFirstLocal            = -8;
       }
    else
@@ -345,7 +345,7 @@ J9::Power::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
       else
          // Volatile GPR (0,2-12) + FPR (0-31) + CCR (0-7) + VR (0-31)
          _properties._numberOfDependencyGPRegisters = 12 + 32 + 8 + 32;
-      _properties._offsetToFirstParm             = 0;
+      self()->setOffsetToFirstParm(0);
       _properties._offsetToFirstLocal            = -4;
       }
    _properties._computedCallTargetRegister  = TR::RealRegister::gr0; // gr11 = interface, gr12 = virtual, so we need something else for computed
@@ -569,7 +569,7 @@ void J9::Power::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm - firstLocalOffset);
+   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + self()->getOffsetToFirstParm() - firstLocalOffset);
    }
 
 void J9::Power::PrivateLinkage::mapSingleAutomatic(TR::AutomaticSymbol *p, uint32_t &stackIndex)
@@ -830,6 +830,7 @@ static int32_t calculateFrameSize(TR::RealRegister::RegNum &intSavedFirst,
    {
    TR::Compilation * comp = cg->comp();
    TR::Machine *machine = cg->machine();
+   TR::Linkage* linkage = cg->getLinkage(TR_Private);
    const TR::PPCLinkageProperties& properties = cg->getProperties();
    int32_t                    firstLocalOffset = properties.getOffsetToFirstLocal();
    int32_t                    registerSaveDescription = 0;
@@ -846,11 +847,11 @@ static int32_t calculateFrameSize(TR::RealRegister::RegNum &intSavedFirst,
 
    if (0 && cg->comp()->target().is64Bit())
       {
-      argSize = (cg->getLargestOutgoingArgSize() * 2) + properties.getOffsetToFirstParm();
+      argSize = (cg->getLargestOutgoingArgSize() * 2) + linkage->getOffsetToFirstParm();
       }
    else
       {
-      argSize = cg->getLargestOutgoingArgSize() + properties.getOffsetToFirstParm();
+      argSize = cg->getLargestOutgoingArgSize() + linkage->getOffsetToFirstParm();
       }
 
    while (intSavedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(intSavedFirst)->getHasBeenAssignedInMethod())
@@ -1312,11 +1313,11 @@ void J9::Power::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
 
    if (0 && cg()->comp()->target().is64Bit())
       {
-      saveSize = (cg()->getLargestOutgoingArgSize() * 2) + properties.getOffsetToFirstParm();
+      saveSize = (cg()->getLargestOutgoingArgSize() * 2) + self()->getOffsetToFirstParm();
       }
    else
       {
-      saveSize = cg()->getLargestOutgoingArgSize() + properties.getOffsetToFirstParm();
+      saveSize = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm();
       }
 
    while (savedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
@@ -1380,7 +1381,7 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node             
    TR::PPCMemoryArgument           *pushToMemory = NULL;
    TR::Register                    *tempRegister;
    int32_t                          argIndex = 0, memArgs = 0, from, to, step;
-   int32_t                          argSize = -properties.getOffsetToFirstParm(), totalSize = 0;
+   int32_t                          argSize = -self()->getOffsetToFirstParm(), totalSize = 0;
    uint32_t                         numIntegerArgs = 0;
    uint32_t                         numFloatArgs = 0;
    uint32_t                         firstExplicitArg = 0;
@@ -2851,7 +2852,7 @@ TR::MemoryReference *J9::Power::PrivateLinkage::getOutgoingArgumentMemRef(int32_
    TR::Machine *machine = cg()->machine();
 
    TR::MemoryReference *result=new (trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
-                                        argSize+properties.getOffsetToFirstParm(), length, cg());
+                                        argSize+self()->getOffsetToFirstParm(), length, cg());
    memArg.argRegister = argReg;
    memArg.argMemory = result;
    memArg.opCode = opCode;

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -166,7 +166,7 @@ J9::X86::AMD64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
    // Offsets relative to where the frame pointer *would* point if we had one;
    // namely, the local with the highest address (ie. the "first" local)
-   _properties._offsetToFirstParm = RETURN_ADDRESS_SIZE;
+   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = 0;
 
    // TODO: Need a better way to build the flags so they match the info above

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -166,7 +166,7 @@ J9::X86::AMD64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
    // Offsets relative to where the frame pointer *would* point if we had one;
    // namely, the local with the highest address (ie. the "first" local)
-   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
+   setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = 0;
 
    // TODO: Need a better way to build the flags so they match the info above

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -692,40 +692,6 @@ TR_J2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::Nod
    return thunk;
    }
 
-
-////////////////////////////////////////////////
-//
-// Prologue and Epilogue
-//
-
-void J9::X86::AMD64::PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
-   {
-   TR_ASSERT(!getProperties().passArgsRightToLeft(), "Right-to-left not yet implemented on AMD64");
-
-   ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
-   TR::ParameterSymbol              *parmCursor   = parameterIterator.getFirst();
-
-   // Adjust the offsets to the right relative positions
-   //
-   int32_t offset = 0;
-   for (parmCursor = parameterIterator.getFirst(); parmCursor; parmCursor = parameterIterator.getNext())
-      {
-      offset -= parmCursor->getRoundedSize() * ((DOUBLE_SIZED_ARGS && parmCursor->getDataType() != TR::Address) ? 2 : 1);
-      parmCursor->setParameterOffset(offset);
-      }
-
-   // Now that we know the total size of the parameters, we know where they all go.
-   // Bump the offsets to the right absolute positions.
-   // TODO:AMD64: Isn't there a way to run through the parms backward, and avoid this second pass?
-   //
-   const int32_t bump = getProperties().getOffsetToFirstParm() - offset;
-   for (parmCursor = parameterIterator.getFirst(); parmCursor; parmCursor = parameterIterator.getNext())
-      {
-      parmCursor->setParameterOffset(bump + parmCursor->getParameterOffset());
-      }
-
-   }
-
 TR::Instruction *J9::X86::AMD64::PrivateLinkage::savePreservedRegisters(TR::Instruction *cursor)
    {
    TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
@@ -73,8 +73,6 @@ class PrivateLinkage : public J9::X86::PrivateLinkage
          TR::Node *callNode,
          TR::RegisterDependencyConditions *dependencies);
 
-   virtual void mapIncomingParms(TR::ResolvedMethodSymbol *method);
-
    int32_t buildPrivateLinkageArgs(
          TR::Node *callNode,
          TR::RegisterDependencyConditions *dependencies,

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -106,7 +106,7 @@ J9::X86::I386::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
    _properties._numberOfVolatileGPRegisters  = 3;
    _properties._numberOfVolatileXMMRegisters = 8; // xmm0-xmm7
-   _properties._offsetToFirstParm = 4;
+   self()->setOffsetToFirstParm(4);
    _properties._offsetToFirstLocal = 0;
 
 

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -106,7 +106,7 @@ J9::X86::I386::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 
    _properties._numberOfVolatileGPRegisters  = 3;
    _properties._numberOfVolatileXMMRegisters = 8; // xmm0-xmm7
-   self()->setOffsetToFirstParm(4);
+   setOffsetToFirstParm(4);
    _properties._offsetToFirstLocal = 0;
 
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -3452,53 +3452,6 @@ J9::Z::PrivateLinkage::buildIndirectDispatch(TR::Node * callNode)
    return returnRegister;
    }
 
-////////////////////////////////////////////////////////////////////////////////
-// J9::Z::PrivateLinkage::mapIncomingParms - maps parameters onto the stack for the given method.
-//   This function iterates over the parameters, mapping them onto the stack, either right
-//   to left, or left to right, depending on S390Linkage properties.
-//   This code was removed from J9::Z::PrivateLinkage::mapStack as it is common code that
-//   is now called by J9::Z::PrivateLinkage::mapCompactedStack as well.
-////////////////////////////////////////////////////////////////////////////////
-void
-J9::Z::PrivateLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
-   {
-   ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
-   TR::ParameterSymbol * parmCursor = parameterIterator.getFirst();
-   int32_t offsetToFirstParm = getOffsetToFirstParm();
-   if (getRightToLeft())
-      {
-      while (parmCursor != NULL)
-         {
-         parmCursor->setParameterOffset(parmCursor->getParameterOffset() + offsetToFirstParm);
-         parmCursor = parameterIterator.getNext();
-         }
-      }
-   else
-      {
-      uint32_t sizeOfParameterArea = method->getNumParameterSlots() << (cg()->comp()->target().is64Bit() ? 3 : 2);
-      while (parmCursor != NULL)
-         {
-         if (cg()->comp()->target().is64Bit() && parmCursor->getDataType() != TR::Address)
-            // in 64Bit mode: long and double args takes 2x8 byte slots
-            // all other types takes 1x8 byte
-            {
-            parmCursor->setParameterOffset(sizeOfParameterArea -
-                           parmCursor->getParameterOffset() -
-                           parmCursor->getSize() * 2 +
-                           offsetToFirstParm);
-            }
-         else
-            {
-            parmCursor->setParameterOffset(sizeOfParameterArea -
-                           parmCursor->getParameterOffset() -
-                           parmCursor->getSize() +
-                           offsetToFirstParm);
-            }
-         parmCursor = parameterIterator.getNext();
-         }
-      }
-   }
-
 void
 J9::Z::PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::RegisterDependencyConditions * deps, bool isFastJNI,
       bool isPassReceiver, int64_t & killMask, TR::Node * GlobalRegDeps, bool hasGlRegDeps, TR::SystemLinkage * systemLinkage)

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -613,7 +613,7 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + getOffsetToFirstParm() - firstLocalOffset);
+   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + self()->getOffsetToFirstParm() - firstLocalOffset);
 
    } // scope of the stack memory region
 
@@ -807,7 +807,7 @@ J9::Z::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol * method)
    mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + getOffsetToFirstParm() - firstLocalOffset);
+   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + self()->getOffsetToFirstParm() - firstLocalOffset);
 
 #ifdef DEBUG
       automaticIterator.reset();
@@ -1155,11 +1155,11 @@ J9::Z::PrivateLinkage::createPrologue(TR::Instruction * cursor)
 
    if (0 && cg()->comp()->target().is64Bit())
       {
-      argSize = cg()->getLargestOutgoingArgSize() * 2 + getOffsetToFirstParm();
+      argSize = cg()->getLargestOutgoingArgSize() * 2 + self()->getOffsetToFirstParm();
       }
    else
       {
-      argSize = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm();
+      argSize = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm();
       }
    size = regSaveSize + localSize + argSize;
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -613,7 +613,7 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + self()->getOffsetToFirstParm() - firstLocalOffset);
+   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + getOffsetToFirstParm() - firstLocalOffset);
 
    } // scope of the stack memory region
 
@@ -807,7 +807,7 @@ J9::Z::PrivateLinkage::mapStack(TR::ResolvedMethodSymbol * method)
    mapIncomingParms(method);
 
    atlas->setLocalBaseOffset(lowGCOffset - firstLocalOffset);
-   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + self()->getOffsetToFirstParm() - firstLocalOffset);
+   atlas->setParmBaseOffset(atlas->getParmBaseOffset() + getOffsetToFirstParm() - firstLocalOffset);
 
 #ifdef DEBUG
       automaticIterator.reset();
@@ -1155,11 +1155,11 @@ J9::Z::PrivateLinkage::createPrologue(TR::Instruction * cursor)
 
    if (0 && cg()->comp()->target().is64Bit())
       {
-      argSize = cg()->getLargestOutgoingArgSize() * 2 + self()->getOffsetToFirstParm();
+      argSize = cg()->getLargestOutgoingArgSize() * 2 + getOffsetToFirstParm();
       }
    else
       {
-      argSize = cg()->getLargestOutgoingArgSize() + self()->getOffsetToFirstParm();
+      argSize = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm();
       }
    size = regSaveSize + localSize + argSize;
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
@@ -114,8 +114,6 @@ protected:
    TR::Instruction * buildDirectCall(TR::Node * callNode, TR::SymbolReference * callSymRef,
    TR::RegisterDependencyConditions * dependencies, int32_t argSize);
 
-   virtual void mapIncomingParms(TR::ResolvedMethodSymbol *method);
-
    void callPreJNICallOffloadCheck(TR::Node * callNode);
    void callPostJNICallOffloadCheck(TR::Node * callNode);
    void collapseJNIReferenceFrame(TR::Node * callNode, TR::RealRegister * javaStackPointerRealRegister,


### PR DESCRIPTION
The `getOffsetToFirstParm` API currently belongs to linkage properties
class in each codegen, with the Z codegen being the exception having it
inside of the Z specific `OMRLinkage`. This API is however used
throughout all codegens and can belong to the common code `OMRLinkage`
class. We migrate the API there for use in downstream projects.

The `mapIncomingParms` API has a semantically equivalent implementation 
on all codegens. Given private linkage is platform agnostic it makes sense
of this API to live in the common private linkage class. We also take this
opportunity to document why we double the stack slot size in certain
scenarios.

Closes: #8360
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>