### PR TITLE
Rename system property to java.lang.stringBuffer.growAggressively

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1716,7 +1716,7 @@ static void initFromSystemProperties(Properties props) {
 	String prop = props.getProperty("java.lang.string.create.unique"); //$NON-NLS-1$
 	TOSTRING_COPY_BUFFER_ENABLED = "true".equals(prop) || "StringBuffer".equals(prop); //$NON-NLS-1$ //$NON-NLS-2$
 
-	String growAggressivelyProperty = props.getProperty("java.lang.stringBufferAndBuilder.growAggressively"); //$NON-NLS-1$
+	String growAggressivelyProperty = props.getProperty("java.lang.stringBuffer.growAggressively"); //$NON-NLS-1$
 	growAggressively = "".equals(growAggressivelyProperty) || "true".equalsIgnoreCase(growAggressivelyProperty); //$NON-NLS-1$ //$NON-NLS-2$
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1715,7 +1715,7 @@ static void initFromSystemProperties(Properties props) {
 	String prop = props.getProperty("java.lang.string.create.unique"); //$NON-NLS-1$
 	TOSTRING_COPY_BUFFER_ENABLED = "true".equals(prop) || "StringBuilder".equals(prop); //$NON-NLS-1$ //$NON-NLS-2$
 
-	String growAggressivelyProperty = props.getProperty("java.lang.stringBufferAndBuilder.growAggressively"); //$NON-NLS-1$
+	String growAggressivelyProperty = props.getProperty("java.lang.stringBuffer.growAggressively"); //$NON-NLS-1$
 	growAggressively = "".equals(growAggressivelyProperty) || "true".equalsIgnoreCase(growAggressivelyProperty); //$NON-NLS-1$ //$NON-NLS-2$
 }
 

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
@@ -547,7 +547,7 @@
  </test>
  
  <test id="Test StringBuffer/StringBuilder growth">
-  <command>$EXE$ -Xdump:none -Xmx7g -Djava.lang.stringBufferAndBuilder.growAggressively -cp $Q$$JARPATH$$Q$ TestStringBufferAndBuilderGrowth</command>
+  <command>$EXE$ -Xdump:none -Xmx7g -Djava.lang.stringBuffer.growAggressively -cp $Q$$JARPATH$$Q$ TestStringBufferAndBuilderGrowth</command>
   <output regex="no" type="success">StringBuffer capacity=2147483647 StringBuilder capacity=2147483647</output>
   <output regex="no" type="success">Option too large</output>
   <output regex="no" type="success">Not enough resource to run test</output>


### PR DESCRIPTION
In order to have a shorter option, rename the system property
java.lang.stringBufferAndBuilder.growAggressively added via #8405 to
java.lang.stringBuffer.growAggressively

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>