### PR TITLE
Formal thread argument for detachVMThread method

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.cpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.cpp
@@ -129,7 +129,7 @@ MM_EnvironmentDelegate::detachVMThread(OMR_VM *omrVM, OMR_VMThread *omrThread, u
 
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
 	if ((MM_EnvironmentBase::ATTACH_THREAD != reason) &&  (NULL != javaVM->javaOffloadSwitchOnWithReasonFunc)) {
-		(*javaVM->javaOffloadSwitchOffWithReasonFunc)(_vmThread, reason);
+		(*javaVM->javaOffloadSwitchOffWithReasonFunc)((J9VMThread *)omrThread->_language_vmthread, reason);
 	}
 #endif
 
@@ -177,7 +177,7 @@ MM_EnvironmentDelegate::releaseVMAccess()
 bool
 MM_EnvironmentDelegate::inNative()
 {
-	return (bool)_vmThread->inNative;
+	return (FALSE != _vmThread->inNative);
 }
 
 bool


### PR DESCRIPTION
detachVMThread is a static method and can't use class member _vmThread.
It should be using thread passed through formal arguments

Fixes compile problems introduced in #8448 

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>