### PR TITLE
Improve performance on a full shared cache.

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -939,7 +939,7 @@ typedef struct J9SharedClassTransaction {
 	U_32 allocatedLocalVariableTableSize;
 	void* allocatedLineNumberTable;
 	void* allocatedLocalVariableTable;
-	void* ClasspathWrapper;
+	void* ClasspathWrapper; /* points to ClasspathItem if it is full/soft full. Otherwise, points to a ClasspathWrapper in the cache */
 	void* cacheAreaForAllocate;
 	void* newItemInCache;
 	j9object_t updatedItemSize;
@@ -949,6 +949,7 @@ typedef struct J9SharedClassTransaction {
 	UDATA oldVMState;
 	UDATA isModifiedClassfile;
 	UDATA takeReadWriteLock;
+	U_64 cacheFullFlags;
 } J9SharedClassTransaction;
 
 typedef struct J9SharedStringTransaction {

--- a/runtime/shared_common/SCImplementedAPI.hpp
+++ b/runtime/shared_common/SCImplementedAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ IDATA j9shr_classStoreTransaction_createSharedClass(void * tobj, const J9RomClas
 IDATA j9shr_classStoreTransaction_updateSharedClassSize(void * tobj, U_32 sizeUsed);
 BOOLEAN j9shr_classStoreTransaction_isOK(void * tobj);
 BOOLEAN j9shr_classStoreTransaction_hasSharedStringTableLock(void * tobj);
+void j9shr_classStoreTransaction_updateUnstoredBytes(U_32 romClassSizeFullSize, void * tobj);
 
 J9ROMClass * j9shr_jclUpdateROMClassMetaData(J9VMThread* currentThread, J9ClassLoader* classloader, J9ClassPathEntry* classPathEntries, UDATA cpEntryCount, UDATA entryIndex, const J9UTF8* partition, const J9ROMClass * existingClass);
 

--- a/runtime/shared_common/include/SCAbstractAPI.h
+++ b/runtime/shared_common/include/SCAbstractAPI.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,6 +56,7 @@ typedef struct SCAbstractAPI
 	IDATA (*classStoreTransaction_updateSharedClassSize)(void * tobj, U_32 sizeUsed);
 	BOOLEAN (*classStoreTransaction_isOK)(void * tobj);
 	BOOLEAN (*classStoreTransaction_hasSharedStringTableLock)(void * tobj);
+	void (*classStoreTransaction_updateUnstoredBytes) (U_32 romClassSizeFullSize, void * tobj);
 
 	/*Function for JCL to update cache metadata for an existing shared class*/
 	J9ROMClass * (*jclUpdateROMClassMetaData)(J9VMThread* currentThread, J9ClassLoader* classloader, J9ClassPathEntry* classPathEntries, UDATA cpEntryCount, UDATA entryIndex, const J9UTF8* partition, const J9ROMClass * existingClass);

--- a/runtime/shared_common/include/SCStoreTransaction.hpp
+++ b/runtime/shared_common/include/SCStoreTransaction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,6 +80,26 @@ public:
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Returns true if cache full is detected by the transaction object.
+	 *
+	 * Called after constructor/method is called to query if the cache if full.
+	 *
+	 */
+	bool isCacheFull()
+	{
+		return (0 != tobj.cacheFullFlags);
+	}
+
+	void updateUnstoredBytes(U_32 romClassSizeFullSize)
+	{
+		if (sharedapi != NULL) {
+			if (J9_ARE_ALL_BITS_SET(tobj.cacheFullFlags, J9SHR_RUNTIMEFLAG_AVAILABLE_SPACE_FULL)) {
+				sharedapi->classStoreTransaction_updateUnstoredBytes(romClassSizeFullSize, (void *) &tobj);
+			}
+		}
 	}
 
 	/**

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2019 IBM Corp. and others
+// Copyright (c) 2006, 2020 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2984,3 +2984,6 @@ TraceEvent=Trc_SHR_CM_storeCacheUniqueID_generateCacheUniqueID_after Overhead=1 
 
 TraceEvent=Trc_SHR_CC_startup_getCacheUniqueID_before Overhead=1 Level=7 Template="CC::startup(): getCacheUniqueID() - (createTime: %llx, metadataBytes: %zx, classesBytes: %zx, lineNumTabBytes: %zx, varTabBytes: %zx) "
 TraceEvent=Trc_SHR_CC_startup_getCacheUniqueID_after Overhead=1 Level=7 Template="CC::startup(): getCacheUniqueID() - the cache unique ID is %s"
+
+TraceEvent=Trc_SHR_API_j9shr_classStoreTransaction_start_cacheFull_Event Overhead=1 Level=3 Template="API j9shr_classStoreTransaction_start : J9SHR_RUNTIMEFLAG_BLOCK_SPACE_FULL is set. The shared cache is full"
+TraceEvent=Trc_SHR_API_j9shr_classStoreTransaction_start_cacheSoftFull_Event Overhead=1 Level=3 Template="API j9shr_classStoreTransaction_start : J9SHR_RUNTIMEFLAG_AVAILABLE_SPACE_FULL is set. The shared cache is soft full"

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -3022,6 +3022,7 @@ initializeSharedAPI(J9JavaVM *vm)
 	scapi->classStoreTransaction_updateSharedClassSize = j9shr_classStoreTransaction_updateSharedClassSize;
 	scapi->classStoreTransaction_isOK = j9shr_classStoreTransaction_isOK;
 	scapi->classStoreTransaction_hasSharedStringTableLock = j9shr_classStoreTransaction_hasSharedStringTableLock;
+	scapi->classStoreTransaction_updateUnstoredBytes = j9shr_classStoreTransaction_updateUnstoredBytes;
 	/*Set JCL functions*/
 	scapi->jclUpdateROMClassMetaData = j9shr_jclUpdateROMClassMetaData;
 	/*Set up functions for finishing share classes initialization*/


### PR DESCRIPTION
We see a significant slow down of startup speed when there are
many JVMs queuing for the write mutex of a full cache. It is not
necessary to acquire the write mutex in this case.

Return from j9shr_classStoreTransaction_start() after acquiring the
segment mutex but before acquiring the cache write mutex if the cache is
full.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>