### PR TITLE
Use 25% RAM as default maximum heap size for Java 8

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -234,12 +234,14 @@ MM_GCExtensions::updateIdentityHashDataForSaltIndex(UDATA index)
 	getJavaVM()->identityHashData->hashSaltTable[index] = (U_32)convertValueToHash(getJavaVM(), getJavaVM()->identityHashData->hashSaltTable[index]);
 }
 
+/*
+ * computeDefaultMaxHeapForJava is for Java only, it will be called during gcParseCommandLineAndInitializeWithValues(),
+ *  computeDefaultMaxHeap() will still be called during MM_GCExtensionsBase::initialize(), computeDefaultMaxHeapForJava() can overwrite value of memoryMax.
+ */
 void
-MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
+MM_GCExtensions::computeDefaultMaxHeapForJava(bool enableOriginalJDK8HeapSizeCompatibilityOption)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-
-	MM_GCExtensionsBase::computeDefaultMaxHeap(env);
+	OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
 
 	if (OMR_CGROUP_SUBSYSTEM_MEMORY == omrsysinfo_cgroup_are_subsystems_enabled(OMR_CGROUP_SUBSYSTEM_MEMORY)) {
 		if (omrsysinfo_cgroup_is_memlimit_set()) {
@@ -256,7 +258,7 @@ MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
 	}
 
 #if defined(OMR_ENV_DATA64)
-	if (J2SE_VERSION((J9JavaVM *)getOmrVM()->_language_vm) >= J2SE_V11) {
+	if (!enableOriginalJDK8HeapSizeCompatibilityOption) {
 		/* extend java default max memory to 25% of usable RAM */
 		memoryMax = OMR_MAX(memoryMax, usablePhysicalMemory / 4);
 	}
@@ -266,6 +268,7 @@ MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
 #endif /* OMR_ENV_DATA64 */
 
 	memoryMax = MM_Math::roundToFloor(heapAlignment, memoryMax);
+	maxSizeDefaultMemorySpace = memoryMax;
 }
 
 MM_OwnableSynchronizerObjectList *

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -192,11 +192,12 @@ private:
 protected:
 	virtual bool initialize(MM_EnvironmentBase* env);
 	virtual void tearDown(MM_EnvironmentBase* env);
-	virtual void computeDefaultMaxHeap(MM_EnvironmentBase* env);
 
 public:
 	static MM_GCExtensions* newInstance(MM_EnvironmentBase* env);
 	virtual void kill(MM_EnvironmentBase* env);
+
+	void computeDefaultMaxHeapForJava(bool enableOriginalJDK8HeapSizeCompatibilityOption);
 
 	MMINLINE J9HookInterface** getHookInterface() { return J9_HOOK_INTERFACE(hookInterface); };
 

--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1472,6 +1472,20 @@ gcParseCommandLineAndInitializeWithValues(J9JavaVM *vm, IDATA *memoryParameters)
 	/* Parse the command line 
 	 * Order is important for parameters that match as substrings (-Xmrx/-Xmr)
 	 */
+	{
+		bool enableOriginalJDK8HeapSizeCompatibilityOption = false;
+		/* only parse VMOPT_XXENABLEORIGINALJDK8HEAPSIZECOMPATIBILITY option for Java 8 and below */
+		if (J2SE_18 >= J2SE_VERSION(vm)) {
+
+			IDATA enabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXENABLEORIGINALJDK8HEAPSIZECOMPATIBILITY, NULL);
+			IDATA disabled = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXDISABLEORIGINALJDK8HEAPSIZECOMPATIBILITY, NULL);
+			if (enabled > disabled) {
+				enableOriginalJDK8HeapSizeCompatibilityOption = true;
+			}
+		}
+		/* set default max heap for Java */
+		extensions->computeDefaultMaxHeapForJava(enableOriginalJDK8HeapSizeCompatibilityOption);
+	}
 	result = option_set_to_opt(vm, OPT_XMCA, &index, EXACT_MEMORY_MATCH, &vm->ramClassAllocationIncrement);
 	if (OPTION_OK != result) {
 		goto _error;

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -375,6 +375,8 @@ enum INIT_STAGE {
 #define VMOPT_XXDISABLEALWAYSSPLITBYTECODES "-XX:-AlwaysSplitBytecodes"
 #define VMOPT_XXENABLEPOSITIVEHASHCODE "-XX:+PositiveIdentityHash"
 #define VMOPT_XXDISABLEPOSITIVEHASHCODE "-XX:-PositiveIdentityHash"
+#define VMOPT_XXENABLEORIGINALJDK8HEAPSIZECOMPATIBILITY "-XX:+OriginalJDK8HeapSizeCompatibilityMode"
+#define VMOPT_XXDISABLEORIGINALJDK8HEAPSIZECOMPATIBILITY "-XX:-OriginalJDK8HeapSizeCompatibilityMode"
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 #define VMOPT_XXENABLEVALHALLA "-XX:+EnableValhalla"


### PR DESCRIPTION
	- new -XX:[+-]OriginalJDK8HeapSizeCompatibilityMode option
	- recognize this option in Java 8 only, ignore in Java 11 and higher
	- use 512m as default for heap size if
	 -XX:+OriginalJDK8HeapSizeCompatibilityMode option is
	 provided explicitly.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>