### PR TITLE
Create frontend query for javaVM->byteArrayClass

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -487,6 +487,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             {
             vmInfo._arrayTypeClasses[i] = fe->getClassFromNewArrayTypeNonNull(i + 4);
             }
+         vmInfo._byteArrayClass = fe->getByteArrayClass();
          vmInfo._readBarrierType = TR::Compiler->om.readBarrierType();
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6760,6 +6760,12 @@ TR_J9VM::getSystemClassFromClassName(const char * name, int32_t length, bool isV
    return result;
    }
 
+TR_OpaqueClassBlock *
+TR_J9VMBase::getByteArrayClass()
+   {
+   return convertClassPtrToClassOffset(_jitConfig->javaVM->byteArrayClass);
+   }
+
 void *
 TR_J9VMBase::getSystemClassLoader()
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -577,6 +577,7 @@ public:
    virtual TR_OpaqueClassBlock *getClassFromJavaLangClass(uintptrj_t objectPointer);
    virtual TR_arrayTypeCode    getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz);
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool callSiteVettedForAOT=false) { return 0; }
+   virtual TR_OpaqueClassBlock * getByteArrayClass();
 
    virtual uintptrj_t         getOffsetOfLastITableFromClassField();
    virtual uintptrj_t         getOffsetOfInterfaceClassFromITableField();

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -204,6 +204,14 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
    return clazz;
    }
 
+TR_OpaqueClassBlock *
+TR_J9ServerVM::getByteArrayClass()
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   return vmInfo->_byteArrayClass;
+   }
+
 bool
 TR_J9ServerVM::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,6 +66,7 @@ public:
                                                                  char *signature, int32_t signatureLength, TR_ResolvedMethod * owningMethod) override;
    virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed = true, bool optimizeForAOT = false) override;
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT = false) override;
+   virtual TR_OpaqueClassBlock * getByteArrayClass() override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool canMethodEnterEventBeHooked() override;
    virtual bool canMethodExitEventBeHooked() override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -158,7 +158,7 @@ protected:
    ZeroCopyOutputStream *_outputStream;
 
    static const uint8_t MAJOR_NUMBER = 0;
-   static const uint16_t MINOR_NUMBER = 3;
+   static const uint16_t MINOR_NUMBER = 4;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
    };

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -79,7 +79,7 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
    anchorAllChildren(node, treetop);
    prepareToReplaceNode(node);
 
-   int32_t byteArrayType = fej9->getNewArrayTypeFromClass(reinterpret_cast<TR_OpaqueClassBlock*>(fej9->getJ9JITConfig()->javaVM->byteArrayClass));
+   int32_t byteArrayType = fej9->getNewArrayTypeFromClass(fej9->getByteArrayClass());
 
    TR::Node::recreateWithoutProperties(node, TR::newarray, 2,
       TR::Node::create(TR::ishl, 2,

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -306,6 +306,7 @@ class ClientSessionData
       bool _elgibleForPersistIprofileInfo;
       bool _reportByteCodeInfoAtCatchBlock;
       TR_OpaqueClassBlock *_arrayTypeClasses[8];
+      TR_OpaqueClassBlock *_byteArrayClass;
       MM_GCReadBarrierType _readBarrierType;
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;


### PR DESCRIPTION
The optimizer uses javaVM->byteArrayClass directly which creates problems
for JITServer. We need to use a frontend call, which in the JITServer
implementation will retrieve the correct value from the client.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>