### PR TITLE
JEP-370 Implementation (Part 3)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2466,9 +2466,13 @@ public class MethodHandles {
 	 * @throws NullPointerException If {@code viewArrayClass} or {@code byteOrder} is null
 	 */
 	public static VarHandle byteArrayViewVarHandle(Class<?> viewArrayClass, ByteOrder byteOrder) throws IllegalArgumentException {
-		checkArrayClass(viewArrayClass);
 		Objects.requireNonNull(byteOrder);
+		/*[IF Java14]*/
+		return VarHandles.byteArrayViewHandle(viewArrayClass, (byteOrder == ByteOrder.BIG_ENDIAN));
+		/*[ELSE] Java14
+		checkArrayClass(viewArrayClass);
 		return new ByteArrayViewVarHandle(viewArrayClass.getComponentType(), byteOrder);
+		/*[ENDIF] Java14 */
 	}
 	
 	/**
@@ -2481,9 +2485,13 @@ public class MethodHandles {
 	 * @throws NullPointerException If {@code viewArrayClass} or {@code byteOrder} is null
 	 */
 	public static VarHandle byteBufferViewVarHandle(Class<?> viewArrayClass, ByteOrder byteOrder) throws IllegalArgumentException {
-		checkArrayClass(viewArrayClass);
 		Objects.requireNonNull(byteOrder);
+		/*[IF Java14]*/
+		return VarHandles.makeByteBufferViewHandle(viewArrayClass, (byteOrder == ByteOrder.BIG_ENDIAN));
+		/*[ELSE] Java14
+		checkArrayClass(viewArrayClass);
 		return new ByteBufferViewVarHandle(viewArrayClass.getComponentType(), byteOrder);
+		/*[ENDIF] Java14 */
 	}
 	
 	private static void checkArrayClass(Class<?> arrayClass) throws IllegalArgumentException {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -632,12 +632,17 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return The {@link MethodType} corresponding to the provided {@link AccessMode}.
 	 */
 	public final MethodType accessModeType(AccessMode accessMode) {
-		MethodType internalType = handleTable[accessMode.ordinal()].type;
-		int numOfArguments = internalType.arguments.length;
-		
-		// Drop the internal VarHandle argument
-		MethodType modifiedType = internalType.dropParameterTypes(numOfArguments - 1, numOfArguments);
-		
+		MethodType modifiedType = null;
+		MethodHandle internalHandle = handleTable[accessMode.ordinal()];
+		if (internalHandle == null) {
+			modifiedType = accessModeTypeUncached(accessMode);
+		} else {
+			MethodType internalType = internalHandle.type;
+			int numOfArguments = internalType.arguments.length;
+
+			/* Drop the internal VarHandle argument. */
+			modifiedType = internalType.dropParameterTypes(numOfArguments - 1, numOfArguments);
+		}
 		return modifiedType;
 	}
 	

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -334,6 +334,7 @@ public abstract class VarHandle extends VarHandleInternal
 
 /*[IF Java14]*/
 	static final BiFunction<String, List<Integer>, ArrayIndexOutOfBoundsException> AIOOBE_SUPPLIER = null;
+	private boolean varFormUsed = false;
 /*[ENDIF] Java14 */
 	
 	private final MethodHandle[] handleTable;
@@ -419,6 +420,7 @@ public abstract class VarHandle extends VarHandleInternal
 			this.handleTable = populateMHsJEP370(operationsClass, operationMTs, operationMTs);
 		}
 		this.modifiers = 0;
+		this.varFormUsed = true;
 	}
 
 	/**
@@ -654,6 +656,12 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return A boolean value indicating whether the {@link AccessMode} is supported.
 	 */
 	boolean isAccessModeSupportedHelper(AccessMode accessMode) {
+/*[IF Java14]*/
+		if (varFormUsed) {
+			return (handleTable[accessMode.ordinal()] != null);
+		}
+/*[ENDIF] Java14 */
+		
 		switch (accessMode) {
 		case GET:
 		case GET_VOLATILE:

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -689,6 +689,21 @@ void
 setCurrentExceptionNLS(J9VMThread * vmThread, UDATA exceptionNumber, U_32 moduleName, U_32 messageNumber);
 
 /**
+ * Prepare for throwing an exception. Find the exception class using its name.
+ * Create an object using the exception class. Set an OutOfMemoryError if the
+ * object cannot be created. Otherwise, set an exception pending using the
+ * created object.
+ *
+ * Note this does not generate the "systhrow" dump event.
+ *
+ * @param vmThread[in] the current J9VMThread
+ * @param exceptionClassName[in] the name of the exception class
+ * @return void
+ */
+void
+prepareExceptionUsingClassName(J9VMThread *vmThread, const char *exceptionClassName);
+
+/**
  * @brief Creates exception with nls message; substitutes string values into error message.
  * @param vmThread current VM thread
  * @param nlsModule nls module name

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8269,6 +8269,15 @@ done:
 			/* Get MethodHandle for this operation from the VarHandles handleTable */
 			j9object_t handleTable = J9VMJAVALANGINVOKEVARHANDLE_HANDLETABLE(_currentThread, varHandle);
 			j9object_t methodHandle = J9JAVAARRAYOFOBJECT_LOAD(_currentThread, handleTable, operation);
+
+			if (NULL == methodHandle) {
+				updateVMStruct(REGISTER_ARGS);
+				prepareExceptionUsingClassName(_currentThread, "java/lang/UnsupportedOperationException");
+				VMStructHasBeenUpdated(REGISTER_ARGS);
+				rc = GOTO_THROW_CURRENT_EXCEPTION;
+				goto done;
+			}
+
 			j9object_t handleType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodHandle);
 
 			/* Get call site MethodType */

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -82,6 +82,33 @@ setCurrentExceptionNLS(J9VMThread * vmThread, UDATA exceptionNumber, U_32 module
 	setCurrentExceptionUTF(vmThread, exceptionNumber, msg);
 }
 
+void
+prepareExceptionUsingClassName(J9VMThread *vmThread, const char *exceptionClassName)
+{
+	J9Class *exceptionClass = NULL;
+	j9object_t exception = NULL;
+
+	prepareForExceptionThrow(vmThread);
+
+	exceptionClass = internalFindClassUTF8(
+			vmThread,
+			(U_8 *)exceptionClassName,
+			strlen(exceptionClassName),
+			vmThread->javaVM->systemClassLoader,
+			J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+
+	exception = vmThread->javaVM->memoryManagerFunctions->J9AllocateObject(
+			vmThread,
+			exceptionClass,
+			J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+
+	if (J9_UNEXPECTED(NULL == exception)) {
+		setHeapOutOfMemoryError(vmThread);
+	} else {
+		vmThread->currentException = exception;
+		vmThread->privateFlags |= J9_PRIVATE_FLAGS_REPORT_EXCEPTION_THROW;
+	}
+}
 
 /**
  * Creates exception with nls message; substitutes string values into error message.


### PR DESCRIPTION
Closes: #8292.

**1. Use OpenJDK `ViewHandle`s in Java14+ to support JEP-370**

OpenJDK implementation of `ByteArrayViewHandle` and `ByteBufferViewHandle`
is used to support JEP-370 in Java14+.

OpenJ9 `ViewHandle`s don't handle memory scopes properly. Example:
```
try (MemorySegment segment = MemorySegment.allocateNative(bytes)) {
   ByteBuffer byteBuffer = segment.asByteBuffer();
   MethodHandle handle = Derived from ByteBuffer & ByteBufferViewHandle;
   handle.invoke();
}
```
Invoking `handle.invoke()` outside the memory scope should result in
`IllegalStateException`, which is thrown from `jdk.internal.foreign.MemoryScope`.

With OpenJ9 `ViewHandle`s, the `IllegalStateException` is not thrown. The
correct behavior is achieved by using OpenJDK `ViewHandle`s.

The deficiency in OpenJ9 `ViewHandle`s could not be identified.

**2. Handle `NULL` `VarHandle.handleTable` entries in `VarHandle.accessModeType`**

**3. Handle `NULL` `VarHandle.handleTable` entries in `(Bytecode|MH)Interpreter`**

**4. Handle `NULL` `VarHandle.handleTable` entries in `VarHandle.toMethodHandle`**

**5. Support `isAccessModeSupportedHelper` method with `VarForm` constructor**

OpenJ9 `ViewVarHandle`s have their own implementation for the
`isAccessModeSupported` method. OpenJDK `ViewVarHandle`s are used in OpenJ9
Java 14+ which rely upon `VarHandle.isAccessModeSupported` instead of
having their own `isAccessModeSupported` implementation. 

`VarHandle.isAccessModeSupported` is updated to support OpenJDK
`VarHandle`s, which rely upon OpenJ9's `VarHandle(VarForm varForm)`
constructor.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>