### PR TITLE
Remove redundant -fstack-protector option from makefiles

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,5 +138,4 @@ CONFIGURE_ARGS += 'OMR_TARGET_DATASIZE=$(TEMP_TARGET_DATASIZE)'
 CONFIGURE_ARGS += 'OMR_TOOLCHAIN=gcc'
 
 CONFIGURE_ARGS+= 'GLOBAL_CFLAGS=-fstack-protector'
-CONFIGURE_ARGS+= 'GLOBAL_CPPFLAGS=-fstack-protector'
 CONFIGURE_ARGS+= 'GLOBAL_CXXFLAGS=-fstack-protector'

--- a/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,5 +89,4 @@ CONFIGURE_ARGS += 'OMR_BUILD_TOOLCHAIN=gcc'
 endif
 
 CONFIGURE_ARGS+= 'GLOBAL_CFLAGS=-fstack-protector'
-CONFIGURE_ARGS+= 'GLOBAL_CPPFLAGS=-fstack-protector'
 CONFIGURE_ARGS+= 'GLOBAL_CXXFLAGS=-fstack-protector'

--- a/runtime/gc_glue_java/configure_includes/configure_linux_arm.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_arm.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,5 +81,4 @@ CONFIGURE_ARGS += 'OMR_BUILD_TOOLCHAIN=gcc'
 endif
 
 CONFIGURE_ARGS+= 'GLOBAL_CFLAGS=-fstack-protector'
-CONFIGURE_ARGS+= 'GLOBAL_CPPFLAGS=-fstack-protector'
 CONFIGURE_ARGS+= 'GLOBAL_CXXFLAGS=-fstack-protector'

--- a/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -191,7 +191,6 @@ ifneq (,$(findstring _gcc,$(SPEC)))
 	CONFIGURE_ARGS += 'OMR_TOOLCHAIN=gcc'
 	CONFIGURE_ARGS += 'CXXLINKSHARED=$(CXX)'
 	CONFIGURE_ARGS+= 'GLOBAL_CFLAGS=-fstack-protector'
-	CONFIGURE_ARGS+= 'GLOBAL_CPPFLAGS=-fstack-protector'
 	CONFIGURE_ARGS+= 'GLOBAL_CXXFLAGS=-fstack-protector'
 else
 	ifeq (default,$(origin AS))

--- a/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -171,5 +171,4 @@ CONFIGURE_ARGS += 'OMR_TARGET_DATASIZE=$(TEMP_TARGET_DATASIZE)'
 CONFIGURE_ARGS += 'OMR_TOOLCHAIN=gcc'
 
 CONFIGURE_ARGS+= 'GLOBAL_CFLAGS=-fstack-protector'
-CONFIGURE_ARGS+= 'GLOBAL_CPPFLAGS=-fstack-protector'
 CONFIGURE_ARGS+= 'GLOBAL_CXXFLAGS=-fstack-protector'

--- a/runtime/gc_glue_java/configure_includes/configure_osx.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_osx.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,5 +62,4 @@ CONFIGURE_ARGS += 'OMR_TARGET_DATASIZE=$(TEMP_TARGET_DATASIZE)'
 CONFIGURE_ARGS += 'OMR_TOOLCHAIN=gcc'
 
 CONFIGURE_ARGS+= 'GLOBAL_CFLAGS=-fstack-protector'
-CONFIGURE_ARGS+= 'GLOBAL_CPPFLAGS=-fstack-protector'
 CONFIGURE_ARGS+= 'GLOBAL_CXXFLAGS=-fstack-protector'

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2019 IBM Corp. and others
+Copyright (c) 1998, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -301,15 +301,15 @@ endif
 <#if uma.spec.processor.amd64>
   CFLAGS += -DJ9HAMMER -m64 -fstack-protector
   CXXFLAGS += -DJ9HAMMER -m64 -fstack-protector
-  CPPFLAGS += -DJ9HAMMER -m64 -fstack-protector
+  CPPFLAGS += -DJ9HAMMER -m64
 <#elseif uma.spec.processor.arm>
   CFLAGS += -DJ9ARM -DARMGNU -DARM -DFIXUP_UNALIGNED -I$(XCOMP_TOOLCHAIN_BASEDIR)/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/include -fstack-protector
   CXXFLAGS += -DJ9ARM -DARMGNU -DARM -DFIXUP_UNALIGNED -I$(XCOMP_TOOLCHAIN_BASEDIR)/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/include -fno-threadsafe-statics -fstack-protector
-  CPPFLAGS += -DJ9ARM -DARMGNU -DARM -DFIXUP_UNALIGNED-I$(XCOMP_TOOLCHAIN_BASEDIR)/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/include -fstack-protector
+  CPPFLAGS += -DJ9ARM -DARMGNU -DARM -DFIXUP_UNALIGNED-I$(XCOMP_TOOLCHAIN_BASEDIR)/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/include
 <#elseif uma.spec.processor.aarch64>
   CFLAGS += -DJ9AARCH64 -fstack-protector
   CXXFLAGS += -DJ9AARCH64 -fstack-protector
-  CPPFLAGS += -DJ9AARCH64 -fstack-protector
+  CPPFLAGS += -DJ9AARCH64
 <#elseif uma.spec.processor.ppc>
   CFLAGS += -DLINUXPPC
   CXXFLAGS += -DLINUXPPC
@@ -318,11 +318,11 @@ endif
     ifdef j9vm_env_data64
       CFLAGS += -m64 -DLINUXPPC64 -DPPC64 -fstack-protector
       CXXFLAGS += -m64 -DLINUXPPC64 -DPPC64 -fstack-protector
-      CPPFLAGS += -m64 -DLINUXPPC64 -DPPC64 -fstack-protector
+      CPPFLAGS += -m64 -DLINUXPPC64 -DPPC64
     else
       CFLAGS += -m32 -fstack-protector
       CXXFLAGS += -m32 -fstack-protector
-      CPPFLAGS += -m32 -fstack-protector
+      CPPFLAGS += -m32
     endif
   <#else>
     CFLAGS += -qalias=noansi -qxflag=LTOL:LTOL0 -qxflag=selinux
@@ -373,7 +373,7 @@ endif
 <#elseif uma.spec.processor.x86>
   CFLAGS += -DJ9X86 -m32 -msse2 -fstack-protector
   CXXFLAGS += -DJ9X86 -m32 -msse2 -I/usr/include/nptl -fno-threadsafe-statics -fstack-protector
-  CPPFLAGS += -DJ9X86 -m32 -msse2 -I/usr/include/nptl -fstack-protector
+  CPPFLAGS += -DJ9X86 -m32 -msse2 -I/usr/include/nptl
 </#if>
 
 <#if uma.spec.processor.ppc && !uma.spec.flags.env_gcc.enabled>

--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2019 IBM Corp. and others
+Copyright (c) 1998, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,7 +103,7 @@ endif
 
 CFLAGS += -DOSX -D_REENTRANT -D_FILE_OFFSET_BITS=64 -fstack-protector
 CXXFLAGS += -DOSX -D_REENTRANT -D_FILE_OFFSET_BITS=64 -fstack-protector
-CPPFLAGS += -DOSX -D_REENTRANT -fstack-protector
+CPPFLAGS += -DOSX -D_REENTRANT
 
 <#-- Add Position Independent compile flag -->
 CFLAGS += -fPIC


### PR DESCRIPTION
This commit removes redundnat -fstack-protector option passed to
C preprocessor from makefiles.

Closes: #8491

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>