### PR TITLE
Handle indirect stores with loadaddr as base in Escape Analysis

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -1953,8 +1953,8 @@ void TR_EscapeAnalysis::checkDefsAndUses()
 
             if ((baseChild && (baseChild->getOpCodeValue() == TR::loadaddr) &&
                 baseChild->getSymbolReference()->getSymbol()->isAuto() &&
-                baseChild->getSymbolReference()->getSymbol()->isLocalObject() &&
-                !baseChild->cannotTrackLocalUses()))
+                baseChild->getSymbolReference()->getSymbol()->isLocalObject())
+               )
                {
                baseChildVN = _valueNumberInfo->getValueNumber(baseChild);
                if (node->getOpCodeValue() == TR::arraycopy)
@@ -1967,10 +1967,19 @@ void TR_EscapeAnalysis::checkDefsAndUses()
                   }
                else
                   {
-                  storeOfObjectIntoField = true;
-                  storeIntoOtherLocalObject = true;
-                  if (trace())
-                     traceMsg(comp(), "Reached 1 with baseChild %p VN %d\n", baseChild, baseChildVN);
+                  if (!baseChild->cannotTrackLocalUses())
+                     {
+                     storeOfObjectIntoField = true;
+                     storeIntoOtherLocalObject = true;
+                     if (trace())
+                        traceMsg(comp(), "Reached 1 with baseChild %p VN %d\n", baseChild, baseChildVN);
+                     }
+                  else
+                     {
+                     _notOptimizableLocalObjectsValueNumbers->set(baseChildVN);
+                     _notOptimizableLocalStringObjectsValueNumbers->set(baseChildVN);
+                     storeOfObjectIntoField = false;
+                     }
                   }
                }
             else if (baseChild && _useDefInfo)


### PR DESCRIPTION
Code in `checkDefsAndUses` analyses indirect stores and array copies and tracks the value numbers of the base for the indirect store along with the value numbers of the base's definitions in `_notOptimizableLocalObjectsValueNumbers`.

This is not handling the situations in which a `loadaddr` appears directly as the base of an indirect store as opposed to being assigned to a temporary or other symbol that is then used as the base for the indirect store, if the node for the base has the `cannotTrackLocalUses` bit set.

Revised the handling of a use of a `loadaddr` directly as the base to match the situation where the value of the `loadaddr` is accessed through another symbol.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>