### PR TITLE
Performance gain by avoiding unnecessary writes on LoZ

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -2,7 +2,7 @@
 package java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2010 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,9 @@ public SoftReference(T r) {
  */	
 public T get () {
 	/*[PR 124242] SoftReference.get() should reset age*/
-	age = 0;
+	if (age != 0) {
+		age = 0;
+	}
 	return super.get();
 }
 }


### PR DESCRIPTION
While running a client benchmark we noticed that a significant portion of
CPU ticks were spent loading `SoftReference.age` from L3 cache. Upon further
investigation @joransiu discovered that having multiple threads
(8 in our case) write to the same cache line was invalidating cache for other
threads. This resulted in significant portion of CPU ticks spent fetching
from L3.

Wrapping the assignment in a `if` condition block, as suggested by
@fjeremic, increased performance by avoiding unnecessary writes.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>