### PR TITLE
Handle jitNewValue in code generators

### DIFF
--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifdef TR_TARGET_ARM
 #include <stdint.h>
 #include "j9.h"
 #include "j9cfg.h"
@@ -1716,11 +1715,3 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
    {
    /* @@ not implemented @@ */
    }
-
-#else /* TR_TARGET_ARM   */
-// the following is to force an export to keep ilib happy
-int J9ARMEvaluator=0;
-#endif /* TR_TARGET_ARM   */
-
-
-

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -1213,10 +1213,15 @@ TR::Register *OMR::ARM::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGe
 
    // AOT does not support inline allocates - cannot currently guarantee totalInstanceSize
 
+   // If the helper symbol set on the node is TR_newValue, we are (expecting to be)
+   // dealing with a value type. Since we do not fully support value types yet, always
+   // call the JIT helper to do the allocation.
+
    TR::ILOpCodes opCode        = node->getOpCodeValue();
    int32_t      objectSize    = cg->comp()->canAllocateInlineOnStack(node, (TR_OpaqueClassBlock *&) clazz);
    bool         isVariableLen = (objectSize == 0);
-   if (objectSize < 0 || comp->compileRelocatableCode() || comp->suppressAllocationInlining())
+   if (objectSize < 0 || comp->compileRelocatableCode() || comp->suppressAllocationInlining() ||
+       (TR::Compiler->om.areValueTypesEnabled() && node->getSymbolReference() == comp->getSymRefTab()->findOrCreateNewValueSymbolRef(comp->getMethodSymbol()))
       {
       TR::Node::recreate(node, TR::acall);
       callResult = directCallEvaluator(node, cg);

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,15 @@ public:
    void initialize();
 
    bool mayRequireSpineChecks();
+
+   bool areValueTypesEnabled()
+      {
+      #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
+      return true;
+      #else
+      return false;
+      #endif
+      }
 
    int32_t sizeofReferenceField();
    uintptrj_t elementSizeOfBooleanArray();

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -2164,7 +2164,13 @@ TR::Register *J9::Power::TreeEvaluator::checkcastAndNULLCHKEvaluator(TR::Node *n
 
 TR::Register *J9::Power::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (cg->comp()->suppressAllocationInlining())
+   // If the helper symbol set on the node is TR_newValue, we are (expecting to be)
+   // dealing with a value type. Since we do not fully support value types yet, always
+   // call the JIT helper to do the allocation.
+   //
+   TR::Compilation* comp = cg->comp();
+   if (cg->comp()->suppressAllocationInlining() ||
+       (TR::Compiler->om.areValueTypesEnabled() && node->getSymbolReference() == comp->getSymRefTab()->findOrCreateNewValueSymbolRef(comp->getMethodSymbol())))
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
       TR::Node::recreate(node, TR::acall);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifdef TR_TARGET_POWER
 #include <limits.h>
 #include <math.h>
 #include <stdint.h>
@@ -14130,11 +14129,6 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
    return OMR::TreeEvaluatorConnector::arraycopyEvaluator(node, cg);
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
    }
-
-#else /* TR_TARGET_POWER */
-// the following is to force an export to keep ilib happy
-int J9PPCEvaluator=0;
-#endif /* TR_TARGET_POWER */
 
 TR::Register *
 J9::Power::TreeEvaluator::NULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1223,6 +1223,17 @@ TR::Register *J9::X86::TreeEvaluator::newEvaluator(TR::Node *node, TR::CodeGener
    TR::Compilation *comp = cg->comp();
    TR::Register *targetRegister=NULL;
 
+   // If the helper symbol set on the node is TR_newValue, we are (expecting to be)
+   // dealing with a value type. Since we do not fully support value types yet, always
+   // call the JIT helper to do the allocation.
+   //
+   if (TR::Compiler->om.areValueTypesEnabled() && node->getSymbolReference() == comp->getSymRefTab()->findOrCreateNewValueSymbolRef(comp->getMethodSymbol()))
+      {
+      TR_OpaqueClassBlock *classInfo;
+      bool spillFPRegs = comp->canAllocateInlineOnStack(node, classInfo) <= 0;
+      return TR::TreeEvaluator::performHelperCall(node, NULL, TR::acall, spillFPRegs, cg);
+      }
+
    targetRegister = TR::TreeEvaluator::VMnewEvaluator(node, cg);
    if (!targetRegister)
       {

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -2873,7 +2873,13 @@ J9::Z::TreeEvaluator::generateHelperCallForVMNewEvaluators(TR::Node *node, TR::C
 TR::Register *
 J9::Z::TreeEvaluator::newObjectEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (cg->comp()->suppressAllocationInlining())
+   // If the helper symbol set on the node is TR_jitNewValue, we are (expecting to be)
+   // dealing with a value type. Since we do not fully support value types yet, always
+   // call the JIT helper to do the allocation.
+   //
+   TR::Compilation* comp = cg->comp();
+   if (cg->comp()->suppressAllocationInlining() ||
+       (TR::Compiler->om.areValueTypesEnabled() && node->getSymbolReference() == comp->getSymRefTab()->findOrCreateNewValueSymbolRef(comp->getMethodSymbol())))
       return generateHelperCallForVMNewEvaluators(node, cg);
    else
       return TR::TreeEvaluator::VMnewEvaluator(node, cg);


### PR DESCRIPTION
Because `newvalue` support is not implemented in the code generators, the opcode is lowered to `new`. When lowering happens, the symbol on the `new` is set to be the same as the one for `newvalue`, namely jitNewValue.

As a result, `new` evaluators must check the node's symbol to determine if the allocation is for a value type.

To avoid having to implement full support for inline value type allocations, for now, we unconditionally call the JIT helper. While not ideal for performance, it is a necessary step in incrementally implementing value types.

Note that the AARCH64 code generator already calls whatever helper is set on the `new` node unconditionally, so no special handling for jitNewValue is required.