### PR TITLE
Eliminate JITServer message VM_getNewArrayTypeFromClass

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -596,12 +596,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->classInitIsFinished(clazz));
          }
          break;
-      case MessageType::VM_getNewArrayTypeFromClass:
-         {
-         TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
-         client->write(response, fe->getNewArrayTypeFromClass(clazz));
-         }
-         break;
       case MessageType::VM_getClassFromNewArrayType:
          {
          int32_t index = std::get<0>(client->getRecvData<int32_t>());

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -761,8 +761,13 @@ int32_t
 TR_J9ServerVM::getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getNewArrayTypeFromClass, clazz);
-   return std::get<0>(stream->read<int32_t>());
+   ClientSessionData::VMInfo * vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   for (int32_t i = 0; i < 8; ++i)
+      {
+      if ((void*)vmInfo->_arrayTypeClasses[i] == (void*)clazz)
+         return i + 4;
+      }
+   return -1;
    }
 
 TR_OpaqueClassBlock *

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -222,7 +222,7 @@ enum MessageType
    VM_createMethodHandleArchetypeSpecimen = 295;
    /* VM_getSystemClassLoader = 296; */
    VM_instanceOfOrCheckCast = 297;
-   VM_getNewArrayTypeFromClass = 298;
+   /* VM_getNewArrayTypeFromClass = 298; */
    VM_getResolvedMethodsAndMirror = 300;
    VM_getVMInfo = 301;
    VM_isAnonymousClass = 302;


### PR DESCRIPTION
We want to eliminate `VM_getNewArrayTypeFromClass` message between jitserver and client JVM. This information is cached on the server. When server needs this information, it reads from cache instead of querying the client. 

Reference: https://github.com/eclipse/openj9/issues/8506

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>