### PR TITLE
Remove cron schedule from Update Ref Repo

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
@@ -39,9 +39,7 @@ UPDATE_BUILD_NODES = params.UPDATE_BUILD_NODES
 
 EXTENSIONS_REPOS = [[name: "openj9", url: "https://github.com/eclipse/openj9.git"]]
 
-properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
-            pipelineTriggers([cron('''# Daily at 11:00pm
-                                        0 23 * * *''')])])
+properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10'))])
 
 def jobs = [:]
 


### PR DESCRIPTION
- Since we run this script on multiple Jenkins,
  we should not force a set schedule. This will
  allow it to be configured per instance.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>