### PR TITLE
Support Known Object Table in JITServer

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -764,14 +764,19 @@ J9::Compilation::freeKnownObjectTable()
    {
    if (_knownObjectTable)
       {
-      TR::VMAccessCriticalSection freeKnownObjectTable(self()->fej9());
+#if defined(J9VM_OPT_JITSERVER)
+      if (!isOutOfProcessCompilation())
+#endif /* defined(J9VM_OPT_JITSERVER) */
+         {
+         TR::VMAccessCriticalSection freeKnownObjectTable(self()->fej9());
 
-      J9VMThread *thread = self()->fej9()->vmThread();
-      TR_ASSERT(thread, "assertion failure");
+         J9VMThread *thread = self()->fej9()->vmThread();
+         TR_ASSERT(thread, "assertion failure");
 
-      TR_ArrayIterator<uintptrj_t> i(&_knownObjectTable->_references);
-      for (uintptrj_t *ref = i.getFirst(); !i.pastEnd(); ref = i.getNext())
-         thread->javaVM->internalVMFunctions->j9jni_deleteLocalRef((JNIEnv*)thread, (jobject)ref);
+         TR_ArrayIterator<uintptrj_t> i(&_knownObjectTable->_references);
+         for (uintptrj_t *ref = i.getFirst(); !i.pastEnd(); ref = i.getNext())
+            thread->javaVM->internalVMFunctions->j9jni_deleteLocalRef((JNIEnv*)thread, (jobject)ref);
+         }
       }
 
    _knownObjectTable = NULL;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2080,7 +2080,6 @@ J9::Options::setupJITServerOptions()
       self()->setIsVariableHeapBaseForBarrierRange0(true);
       self()->setOption(TR_DisableProfiling); // JITServer limitation, JIT profiling data is not available to remote compiles yet
       self()->setOption(TR_DisableEDO); // JITServer limitation, EDO counters are not relocatable yet
-      self()->setOption(TR_DisableKnownObjectTable);
       self()->setOption(TR_DisableMethodIsCold); // Shady heuristic; better to disable to reduce client/server traffic
       self()->setOption(TR_DisableDecimalFormatPeephole);// JITServer decimalFormatPeephole,
 

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -558,6 +558,13 @@ TR_CHTable::commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> 
       static char *dontInvalidateMCSTargetGuards = feGetEnv("TR_dontInvalidateMCSTargetGuards");
       if (!dontInvalidateMCSTargetGuards)
          {
+#if defined(J9VM_OPT_JITSERVER)
+         // JITServer KOT: At the moment this method is called only by TR_CHTable::commit().
+         // TR_CHTable::commit() already checks comp->isOutOfProcessCompilation().
+         // Adding the following check as a precaution in case commitVirtualGuard() is called
+         // outside TR_CHTable::commit() in the future.
+         TR_ASSERT(!comp->isOutOfProcessCompilation(), "TR_CHTable::commitVirtualGuard() should not be called at the server\n");
+#endif /* defined(J9VM_OPT_JITSERVER) */
          uintptrj_t *mcsReferenceLocation = info->mutableCallSiteObject();
          TR::KnownObjectTable *knot = comp->getKnownObjectTable();
          TR_ASSERT(knot, "MutableCallSiteTargetGuard requires the Known Object Table");

--- a/runtime/compiler/env/J9KnownObjectTable.hpp
+++ b/runtime/compiler/env/J9KnownObjectTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,12 +59,25 @@ public:
 
    KnownObjectTable(TR::Compilation *comp);
 
-   virtual Index getEndIndex();
-   virtual Index getIndex(uintptrj_t objectPointer);
-   virtual uintptrj_t *getPointerLocation(Index index);
-   virtual bool isNull(Index index);
+   TR::KnownObjectTable *self();
 
-   virtual void dumpTo(TR::FILE *file, TR::Compilation *comp);
+   Index getEndIndex();
+   Index getIndex(uintptrj_t objectPointer);
+   Index getIndex(uintptrj_t objectPointer, bool isArrayWithConstantElements);
+   uintptrj_t *getPointerLocation(Index index);
+   bool isNull(Index index);
+
+   void dumpTo(TR::FILE *file, TR::Compilation *comp);
+
+   Index getIndexAt(uintptrj_t *objectReferenceLocation);
+   Index getIndexAt(uintptrj_t *objectReferenceLocation, bool isArrayWithConstantElements);
+   Index getExistingIndexAt(uintptrj_t *objectReferenceLocation);
+
+   uintptrj_t getPointer(Index index);
+
+#if defined(J9VM_OPT_JITSERVER)
+   void updateKnownObjectTableAtServer(Index index, uintptrj_t *objectReferenceLocation);
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
 private:
 

--- a/runtime/compiler/env/JITServerCHTable.cpp
+++ b/runtime/compiler/env/JITServerCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -388,6 +388,12 @@ JITClientCommitVirtualGuard(const VirtualGuardInfoForCHTable *info, std::vector<
 
             {
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
+            // JITServer KOT:
+            // This method is called by JITClientCHTableCommit() at the client.
+            // Although accessing VM is not an issue, getIndex() could update the KOT
+            // at the client directly and the KOT at the server could be out of sync.
+            // However, JITClientCHTableCommit() is called at the end of compilation,
+            // and therefore it cannot cause any issues.
             TR::VMAccessCriticalSection invalidateMCSTargetGuards(fej9);
             // TODO: Code duplication with TR_InlinerBase::findInlineTargets
             currentIndex = TR::KnownObjectTable::UNKNOWN;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -158,7 +158,7 @@ protected:
    ZeroCopyOutputStream *_outputStream;
 
    static const uint8_t MAJOR_NUMBER = 0;
-   static const uint16_t MINOR_NUMBER = 6;
+   static const uint16_t MINOR_NUMBER = 7;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
    };

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -291,6 +291,7 @@ enum MessageType
    runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs = 720;
    runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition = 721;
    runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices = 722;
+   runFEMacro_invokeCollectHandleAllocateArray = 723;
 
    // for JITServerPersistentCHTable
    CHTable_getAllClassInfo = 800;
@@ -308,6 +309,20 @@ enum MessageType
    Recompilation_getJittedBodyInfoFromPC = 1001;
 
    ClassInfo_getRemoteROMString = 1100;
+
+   // for KnownObjectTable
+   KnownObjectTable_getIndex = 1200;
+   KnownObjectTable_getIndexAt = 1201;
+   KnownObjectTable_getPointer = 1202;
+   KnownObjectTable_getExistingIndexAt = 1203;
+   // for KnownObjectTable outside J9::KnownObjectTable class
+   KnownObjectTable_symbolReferenceTableCreateKnownObject = 1204;
+   KnownObjectTable_mutableCallSiteEpoch = 1205;
+   KnownObjectTable_dereferenceKnownObjectField = 1206;
+   KnownObjectTable_dereferenceKnownObjectField2 = 1207;
+   KnownObjectTable_createSymRefWithKnownObject = 1208;
+   KnownObjectTable_getReferenceField = 1209;
+   KnownObjectTable_invokeDirectHandleDirectCall = 1210;
    }
 
 message J9ServerMessage


### PR DESCRIPTION
Two main issues to consider when supporting KOT at the server:
1) Prevent the object pointer from being dereferenced directly at the server since it requires the VM access. 
2) The known object table is created at the client and the server. Some operations might cause the KOT to be updated directly at the client without going through the server first. Need to make sure the tables at the client and the server in sync. 

Major changes include: 
Add `KnownObjectTable::updateKnownObjectTableAtServer()` which is used to update KOT at the server.

Replace the direct dereference of `getPointerLocation()` with `getPointer()`. When `getPointer()` is called at the server, it sends a message to the client to dereference it with the proper VM access. 

Send messages to the client to dereference the object pointer or retrieve the index if `getIndex()` is called.

Although there are a few places the known object pointers are dereferenced directly, it wouldn’t cause a problem if the critical section is created with `VMAccessCriticalSection::tryToAcquireVMAccess`, because at the server the VM access will not be granted. 

== TODOs ==
- Rename `getIndex()` with a name that reflects this method could also create a new reference which ends up increasing the size of KOT.
- Implement `KnownObjectTable::dumpTo()` and `KnownObjectTable::dumpObjectTo()` at the server.



Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>