### PR TITLE
Disable Power arraycopy inlining for very long lengths

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -73,6 +73,7 @@
 #include "runtime/CodeCache.hpp"
 #include "env/VMJ9.h"
 
+#define MAX_PPC_ARRAYCOPY_INLINE 256
 #define AIX_NULL_ZERO_AREA_SIZE 256
 #define NUM_PICS 3
 
@@ -13615,7 +13616,7 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
       // inlineArrayCopy_ICF is not currently capable of handling very long lengths correctly. Under some circumstances,
       // it will generate an li instruction with an out-of-bounds immediate, which triggers an assert in the binary
       // encoder.
-      if (len >= 0 && len < 0x100000000LL)
+      if (len >= 0 && len < MAX_PPC_ARRAYCOPY_INLINE)
          {
          /*
           * This path generates code to perform a runtime check on whether concurrent GC is done moving objects or not.

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -13611,7 +13611,11 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
    if (node->isForwardArrayCopy() && lengthNode->getOpCode().isLoadConst())
       {
       len = (lengthNode->getType().isInt32() ? lengthNode->getInt() : lengthNode->getLongInt());
-      if (len >= 0)
+
+      // inlineArrayCopy_ICF is not currently capable of handling very long lengths correctly. Under some circumstances,
+      // it will generate an li instruction with an out-of-bounds immediate, which triggers an assert in the binary
+      // encoder.
+      if (len >= 0 && len < 0x100000000LL)
          {
          /*
           * This path generates code to perform a runtime check on whether concurrent GC is done moving objects or not.


### PR DESCRIPTION
As it turns out, the code for performing an arraycopy inline on Power is
currently broken for certain very long byte lengths. While this usually
doesn't matter, since the maximum length is bounded by the fact that
Java uses ints to represent array indices, it's possible for the
optimizer to create arraycopy nodes with very long lengths on
unreachable paths.

As part of the ongoing refactor of the Power binary encoder, a number of
new asserts are being added that catch any out of range immediates.
These asserts trigger on code generated for such arraycopy nodes even
though they're unreachable, since the code generated is nonsense.

This has been corrected by completely disabling arraycopy inlining on
Power for arraycopy nodes with lengths that do not fit in a 32-bit
integer.

Signed-off-by: Ben Thomas <ben@benthomas.ca>