### PR TITLE
Revert to gcc 7.3 on xlinux

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -265,7 +265,7 @@ x86-64_linux:
     8: '--enable-jitserver'
     11: '--enable-jitserver'
   build_env:
-    cmd: 'source /home/jenkins/set_gcc7.5.0_env'
+    cmd: 'source /opt/rh/devtoolset-7/enable'
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
   excluded_tests:
     11:


### PR DESCRIPTION
Using gcc 7.5 is causing a protobuf undefined symbol

`undefined symbol: _ZNK6google8protobuf7Message11GetTypeNameB5cxx11Ev`