### PR TITLE
New field _patchMap in ROMClassCreationContext is uninitialized

### DIFF
--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -71,7 +71,8 @@ public:
 		_doDebugCompare(false),
 		_existingRomMethod(NULL),
 		_reusingIntermediateClassData(false),
-		_creatingIntermediateROMClass(false)
+		_creatingIntermediateROMClass(false),
+		_patchMap(NULL)
 	{
 	}
 
@@ -107,7 +108,8 @@ public:
 		_doDebugCompare(false),
 		_existingRomMethod(NULL),
 		_reusingIntermediateClassData(false),
-		_creatingIntermediateROMClass(false)
+		_creatingIntermediateROMClass(false),
+		_patchMap(NULL)
 	{
 	}
 


### PR DESCRIPTION
New field `_patchMap` needs to be initialized in all
`ROMClassCreationContext` constructors since accessing the uninitialized
field will cause unexpected behavior.

Related: https://github.com/eclipse/openj9/pull/8460

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>