### PR TITLE
Fix Dockerfile so compiler can create executables on jdk8 s390x u16

### DIFF
--- a/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ RUN apt-get update \
     libelf-dev \
     libfontconfig1-dev \
     libfreetype6-dev \
+    libmpc3 \
     libx11-dev \
     libxext-dev \
     libxrender-dev \


### PR DESCRIPTION
fixes https://github.com/eclipse/openj9/issues/8556
Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>