### PR TITLE
Support running Java14andUp for jdknext

### DIFF
--- a/test/functional/Java14andUp/build.xml
+++ b/test/functional/Java14andUp/build.xml
@@ -51,7 +51,7 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
-			<compilerarg line='--enable-preview --release 14' />
+			<compilerarg line='--enable-preview --release ${JDK_VERSION}' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>


### PR DESCRIPTION
- modified Java14andUp build.xml to support running for jdknext(jdk15)

issue: #8551

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>