### PR TITLE
(0.19.0) Revert "Revert to gcc 7.3 on xlinux" which switches to gcc 7.5

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -265,7 +265,7 @@ x86-64_linux:
     8: '--enable-jitserver'
     11: '--enable-jitserver'
   build_env:
-    cmd: 'source /opt/rh/devtoolset-7/enable'
+    cmd: 'source /home/jenkins/set_gcc7.5.0_env'
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
   excluded_tests:
     11:


### PR DESCRIPTION
Cherry pick of https://github.com/eclipse/openj9/pull/8559 for the 0.19 release. Required for successful xlinux builds now that protobuf has been updated on the build machines https://github.com/eclipse/openj9/issues/8534.