### PR TITLE
Remove references to unsigned deprecated load IL Opcode from OpenJ9

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -6863,7 +6863,7 @@ TR_CISCTransformer::analyzeCharBoolTable(TR_CISCNode *boolTable, uint8_t *table6
       case TR::su2i:
          if (defNode->isOptionalNode()) defNode = defNode->getChild(0);
          // fall through
-      case TR::cloadi:
+      case TR::sloadi:
          defBV.setAll(0, 65535);
          break;
       default:


### PR DESCRIPTION
Remove all references to the IL Opcodes in the load category.

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>