### PR TITLE
Disable DDR tests and some others for AArch64

### DIFF
--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -82,7 +82,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestCallsites$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -118,7 +118,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestJITExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -DEXTRADUMPOPT=$(Q)-Xjit:count=0$(Q) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -154,7 +154,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestSharedClassesExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -49,43 +49,43 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
-	
-	<!-- 
+
+	<!--
 		The nestmate test specifically exercise the JIT$(SQ)s handling of unresolved virtual and interface private methods.
 		The JIT pibBuilder routines will have to handle virtual and interface private methods that are both JIT compiled and interpreted.
 		These private methods will have to be resolved at runtime and gets handled as a direct dispatch, instead of an indirect virtual/interface
 		dispatch. Hence, the need for -Xjit:rtResolve.
-         
+
 		 Variation 1:
 			This variation tests the handling of nestmate private instance methods with the callee being interpreted.
 			The -Xjit option limits the compilation to just one method (the caller), which invokes only once an inner class$(SQ)s private method (the callee).
 			The callee is interpreted because it$(SQ)s only invoked once.
-			
+
 		 Variation 2:
 			This variation tests the handling of nestmate private instance methods that is JIT compiled.
 			The -Xjit option limits the compilation to two methods: a caller (count=0) and a callee (count=100).
 		    The callee is an nestmate private instance method. It$(SQ)s first invoked by the caller 1000 times in a loopy method. The low count=100
 			on the callee ensures that the callee can get JIT compiled early enough so that the last invocation of it jumps to a JIT$(SQ)ed body.
-			
+
 		 Variation 3:
 			Similar to variation 1 except that the callee is an interface private method.
-			
+
 		 Variation 4:
 			Similar to variation 2 except that the callee is an interface private method.
 		 -->
 	<test>
 		<testCaseName>Nestmate_virtual_private</testCaseName>
-		
+
 		<variations>
-		
+
 			<variation>$(SQ)-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedInterpreted*},{org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedInterpreted*}(count=0)$(SQ)</variation>
 			<variation>$(SQ)-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedJitted*,org/openj9/test/nestmates/NestmatesTest$InnerClass.innerPrivateMethod*},{org/openj9/test/nestmates/NestmatesTest.testVirtualUnresolvedInterpreted*}(count=0),{org/openj9/test/nestmates/NestmatesTest$InnerClass.innerPrivateMethod*}(count=100)$(SQ)</variation>
-			
+
 			<variation>$(SQ)-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmates/NestmatesTest.testInterfaceUnresolvedInterpreted*},{org/openj9/test/nestmates/NestmatesTest.testInterfaceUnresolvedInterpreted*}(count=0)$(SQ)</variation>
 			<variation>$(SQ)-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmates/NestmatesTest.testInterfaceUnresolvedJitted*,org/openj9/test/nestmates/NestmatesTest$InnerInterface.innerInterfacePrivateMethod*},{org/openj9/test/nestmates/NestmatesTest.testInterfaceUnresolvedJitted*}(count=0),{org/openj9/test/nestmates/NestmatesTest$InnerInterface.innerInterfacePrivateMethod*}(count=100)$(SQ)</variation>
-	
+
 		</variations>
-			
+
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames NestmatesTest \
@@ -106,7 +106,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-   </test>
+	</test>
 
 
 	<!--
@@ -179,7 +179,8 @@
 			-excludegroups $(DEFAULT_EXCLUDE); \
 			$(TEST_STATUS)
 		</command>
-
+		<!-- aarch64 JIT lacks the support for -Xgcpolicy:balanced -->
+		<platformRequirements>^arch.aarch64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2019 IBM Corp. and others
+Copyright (c) 2017, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<!-- j9ddr.jar is not supported on z/OS; OpenJ9 issue 1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -331,7 +331,8 @@
 	-explainExcludes \
 	-xids all,$(PLATFORM),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JDK_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>^arch.arm</platformRequirements>
+		<!-- Option -XX:+JitInlineWatches is currently unsupported on arm and aarch64 -->
+		<platformRequirements>^arch.arm,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos</platformRequirements>
+		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit disables some tests for AArch64, including DDR, field
watch, and balanced GC.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>