### PR TITLE
Include Xlp Tests on Sanity Functional

### DIFF
--- a/test/functional/VM_Test/j9vm.xml
+++ b/test/functional/VM_Test/j9vm.xml
@@ -4,7 +4,7 @@
 
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,12 +75,12 @@
 		<reason>Only applies to Linux SRT</reason>
 	</include>
 
-	<exclude id="j9vm.test.xlp" platform="all">
-		<reason>This test is run separately and not as part of j9vm test suite</reason>
+	<exclude id="j9vm.test.xlpcodecache" platform="aix_ppc.* | osx_x86.*">
+		<reason>OpenJ9 Issue I8437. This test is unstable on AIXPPC. Xlp is not supported on OSX. </reason>
 	</exclude>
 
-	<exclude id="j9vm.test.xlpcodecache" platform="all">
-		<reason>This test is run separately and not as part of j9vm test suite</reason>
+	<exclude id="j9vm.test.xlp" platform="osx_x86.*">
+		<reason>Xlp is not supported on OSX. </reason>
 	</exclude>
 
 	<exclude id="j9vm.test.classloader.LazyClassLoaderInitTest" platform="all">

--- a/test/functional/VM_Test/src/j9vm/runner/Runner.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Runner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,40 +67,48 @@ public class Runner {
 
 	private void setPlatform() {
 		
-		String spec = System.getProperty("platform");
-		if (spec != null) {
+		String OSSpec = System.getProperty("os.name").toLowerCase();
+		if (OSSpec != null) {
 			/* Get OS from the spec string */
-			if (spec.indexOf("aix") != -1) {
+			if (OSSpec.contains("aix")) {
 				osName = OSName.AIX;
-			} else if (spec.indexOf("linux") != -1){
+			} else if (OSSpec.contains("linux")) {
 				osName = OSName.LINUX;
-			} else if (spec.indexOf("win") != -1) {
+			} else if (OSSpec.contains("windows")) {
 				osName = OSName.WINDOWS;
-			} else if (spec.indexOf("zos") != -1) {
+			} else if (OSSpec.contains("z/os")) {
 				osName = OSName.ZOS;
 			} else {
+				System.out.println("Runner couldn't determine underlying OS. Got OS Name:" + OSSpec);
 				osName = OSName.UNKNOWN;
 			}
-			
+		}
+		String archSpec = System.getProperty("os.arch").toLowerCase();
+		if (archSpec != null) {
 			/* Get arch from spec string */
-			if (spec.indexOf("ppc") != -1) {
+			if (archSpec.contains("ppc")) {
 				osArch = OSArch.PPC;
-			} else if (spec.indexOf("390") != -1) {
+			} else if (archSpec.contains("s390")) {
 				osArch = OSArch.S390X;
-			} else if (spec.indexOf("x86") != -1) {
+			} else if (archSpec.contains("amd64") || archSpec.contains("x86")) {
 				osArch = OSArch.X86;
 			} else {
+				System.out.println("Runner couldn't determine underlying architecture. Got OS Arch:" + archSpec);
 				osArch = OSArch.UNKNOWN;
 			}
-			
-			/* Get address mode */
-			if (spec.indexOf("31") != -1) {
+		}
+
+		String addressingMode = System.getProperty("sun.arch.data.model");
+		if (addressingMode != null) {
+			/* Get address mode. S390 31-Bit addressing mode should return 32. */
+			if ((osArch == OSArch.S390X) && (addressingMode.contains("32"))) {
 				addrMode = AddrMode.BIT31;
-			} else if (spec.indexOf("32") != -1) {
+			} else if (addressingMode.contains("32")) {
 				addrMode = AddrMode.BIT32;
-			} else if (spec.indexOf("64") != -1) {
+			} else if (addressingMode.contains("64")) {
 				addrMode = AddrMode.BIT64;
 			} else {
+				System.out.println("Runner couldn't determine underlying addressing mode. Got addressingMode:" + addressingMode);
 				addrMode = AddrMode.UNKNOWN;
 			}
 		}

--- a/test/functional/VM_Test/src/j9vm/test/xlpcodecache/XlpCodeCacheOptionsTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/xlpcodecache/XlpCodeCacheOptionsTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,9 @@ public class XlpCodeCacheOptionsTestRunner extends Runner {
 	 */
 	protected void populateXlpOptionsList() {
 		xlpOptionsList = new ArrayList<XlpOption>();
-		if (osArch == OSArch.PPC) {
+		switch(osName) {
+
+		case AIX:
 			/* No -Xlp option */
 			xlpOptionsList.add(new XlpOption(null, false));
 			
@@ -108,7 +110,10 @@ public class XlpCodeCacheOptionsTestRunner extends Runner {
 			/* Test multiple -Xlp:codecache: options. In such cases rightmost option wins */
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=64K -Xlp:codecache:pagesize=16M", 16 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, false));
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=16M -Xlp:codecache:pagesize=64K", 64 * ONE_KB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, false));
-		} else if ((osName == OSName.LINUX) || (osName == OSName.WINDOWS)) {
+			break;
+
+		case LINUX:
+		case WINDOWS:
 			/* No -Xlp option */
 			xlpOptionsList.add(new XlpOption(null, false));
 
@@ -125,7 +130,9 @@ public class XlpCodeCacheOptionsTestRunner extends Runner {
 			/* Test multiple -Xlp:codecache: options. In such cases rightmost option wins */
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=2M -Xlp:codecache:pagesize=4M", 4 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, false));
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=4M -Xlp:codecache:pagesize=2M", 2 * ONE_MB, XlpUtil.XLP_PAGE_TYPE_NOT_USED, false));
-		} else if (osName == OSName.ZOS){
+			break;
+
+		case ZOS:
 			/* No -Xlp option */
 			xlpOptionsList.add(new XlpOption(null, false));
 			
@@ -142,8 +149,11 @@ public class XlpCodeCacheOptionsTestRunner extends Runner {
 			/* Test multiple -Xlp:codecache: options. In such cases rightmost option wins */
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=1M,pageable -Xlp:codecache:pagesize=2G,nonpageable", 2 * ONE_GB, XlpUtil.XLP_PAGE_TYPE_NONPAGEABLE, false));
 			xlpOptionsList.add(new XlpOption("-Xlp:codecache:pagesize=2G,nonpageable -Xlp:codecache:pagesize=1M,pageable", ONE_MB, XlpUtil.XLP_PAGE_TYPE_PAGEABLE, false));
-		} else {
+			break;
+
+		default:
 			System.out.println("WARNING: Failed to determine underlying OS. This test needs to know underlying OS.");
+			break;
 		}
 	}
 	


### PR DESCRIPTION
Enabling both the xlpcodecache and xlp(objectheap) tests.

Fixes: #8554 

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>