### PR TITLE
Temporarily exclude Jep359 tests from mac/ppc

### DIFF
--- a/test/functional/Java14andUp/playlist.xml
+++ b/test/functional/Java14andUp/playlist.xml
@@ -36,6 +36,8 @@
                   -excludegroups $(DEFAULT_EXCLUDE); \
                   $(TEST_STATUS)
           </command>
+          <!-- temporary exclusion for https://github.com/eclipse/openj9/issues/8582 -->
+          <platformRequirements>^arch.ppc,^os.osx</platformRequirements>
           <levels>
                   <level>sanity</level>
           </levels>


### PR DESCRIPTION
temporary exclude for now: https://github.com/eclipse/openj9/issues/8582

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>