### PR TITLE
Handle unexpected bytecodes in method handle thunk

### DIFF
--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,13 @@ class TR_EstimateCodeSize
    virtual bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true) = 0;
 
 
-   bool returnCleanup(int32_t);      // common tasks requiring completion before returning from estimation
+   /*
+    *  \brief common tasks requiring completion before returning from estimation
+    *
+    *  \param errorNumber
+    *       an unique number used to identify where estimate code size bailed out
+    */
+   bool returnCleanup(int32_t errorNumber );
 
    /* Fields */
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -200,8 +200,10 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
        *
        * \param withState
        *       whether the bytecode iteration should be with or without state
+       *
+       * \return whether callsites are created successfully. Return false if failed for reasons like unexpected bytecodes etc.
        */
-      void findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessfull, bool withState);
+      bool findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessfull, bool withState);
       void setBlocks(TR::Block **blocks) { _blocks = blocks; }
       TR_StackMemory trStackMemory()            { return _trMemory; }
       bool _nonColdCallExists;
@@ -224,8 +226,10 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       void initializeIteratorWithState();
       /*
        * push and pop operands on stack according to given bytecode
+       *
+       * \return false if some error occurred such as unexpected bytecodes.
        */
-      void maintainStack(TR_J9ByteCode bc);
+      bool maintainStack(TR_J9ByteCode bc);
       void maintainStackForIf(TR_J9ByteCode bc);
       void maintainStackForGetField();
       void maintainStackForAload(int slotIndex);


### PR DESCRIPTION
This change fixes a bug in interpreter emulator. When loading an
auto check the index to make sure it's an argument before goes ahead
extracting arg type info from it.

This change also makes two small improvements
1.stops recursive inlining if a method handle thunk contains
unexpected bytecodes.
2. dont use interpreter emulator with state for targeted inlining since the
 interpreter emulator with state is intended for method handle inlining in general inlining.
fixes: #8553 
fixes: #8694 
Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>