### PR TITLE
Remove ineffective OMR includes

### DIFF
--- a/runtime/jit_vm/CMakeLists.txt
+++ b/runtime/jit_vm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,6 @@ target_include_directories(j9jit_vm
 		${PROJECT_SOURCE_DIR}/oti
 		${PROJECT_SOURCE_DIR}/include
 		${PROJECT_SOURCE_DIR}/gc_include
-		${PROJECT_SOURCE_DIR}/omr/include_core
 		${PROJECT_SOURCE_DIR}/codert_vm
 )
 

--- a/runtime/rastrace/CMakeLists.txt
+++ b/runtime/rastrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,6 @@ add_library(j9trc SHARED
 
 target_include_directories(j9trc
 	PRIVATE
-		../omr/include_core
 		../nls
 		${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/runtime/simplepool/CMakeLists.txt
+++ b/runtime/simplepool/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,6 @@ add_library(j9simplepool STATIC
 )
 target_include_directories(j9simplepool
 	PRIVATE
-		../omr/include_core
 		${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(j9simplepool

--- a/runtime/stackmap/CMakeLists.txt
+++ b/runtime/stackmap/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,6 @@ add_library(j9stackmap STATIC
 
 target_include_directories(j9stackmap
 	PRIVATE
-		../omr/include_core
 		${CMAKE_CURRENT_BINARY_DIR}
 )
 


### PR DESCRIPTION
**Remove ineffective OMR includes**

`${PROJECT_SOURCE_DIR}/omr/include_core` points to `openj9-openjdk-jdk11/openj9/runtime/omr/include_core` which doesn't exist.

The path `openj9-openjdk-jdk11/omr/include_core` effected is specified via `${J9VM_OMR_DIR}/include_core` within `openj9/runtime/CMakeLists.txt`.

This was discovered while investigating CMake failure in https://github.com/eclipse/openj9/pull/8495#issuecomment-586276348.

Reviewers: @dnakamura @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>