### PR TITLE
Improve performance of iterateStackTrace

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corp. and others
+ * Copyright (c) 2002, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1421,7 +1421,7 @@ typedef struct GetStackTraceElementUserData {
 
 /* Return TRUE to keep iterating, FALSE to halt the walk. */
 static UDATA
-getStackTraceElementIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader)
+getStackTraceElementIterator(J9VMThread * vmThread, void * voidUserData, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass)
 {
 	GetStackTraceElementUserData * userData = voidUserData;
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4254,7 +4254,7 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	void  ( *cleanUpClassLoader)(struct J9VMThread *vmThread, struct J9ClassLoader* classLoader) ;
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
-	UDATA  ( *iterateStackTrace)(struct J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (struct J9VMThread * vmThread, void * userData, struct J9ROMClass * romClass, struct J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, struct J9ClassLoader* classLoader), void * userData, UDATA pruneConstructors) ;
+	UDATA  ( *iterateStackTrace)(struct J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (struct J9VMThread * vmThread, void * userData, struct J9ROMClass * romClass, struct J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, struct J9ClassLoader* classLoader, struct J9Class* ramClass), void * userData, UDATA pruneConstructors) ;
 	void  ( *internalReleaseVMAccessNoMutex)(struct J9VMThread * vmThread) ;
 	struct J9HookInterface**  ( *getVMHookInterface)(struct J9JavaVM* vm) ;
 	IDATA  ( *internalAttachCurrentThread)(struct J9JavaVM * vm, struct J9VMThread ** p_env, struct J9JavaVMAttachArgs * thr_args, UDATA threadType, void * osThread) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -551,13 +551,14 @@ internalExceptionDescribe(J9VMThread *vmThread);
 * @param userData
 * @param method
 * @param fileName
-* @param lineNumber)
+* @param lineNumber
+* @param ramClass)
 * @param userData
 * @param pruneConstructors
 * @return UDATA
 */
 UDATA
-iterateStackTrace(J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (J9VMThread * vmThread, void * userData, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader), void * userData, UDATA pruneConstructors);
+iterateStackTrace(J9VMThread * vmThread, j9object_t* exception,  UDATA  (*callback) (J9VMThread * vmThread, void * userData, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass), void * userData, UDATA pruneConstructors);
 
 
 /* ---------------- exceptionsupport.c ---------------- */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -79,7 +79,7 @@
 
 /* Callback Function prototypes */
 UDATA writeFrameCallBack          (J9VMThread* vmThread, J9StackWalkState* state);
-UDATA writeExceptionFrameCallBack (J9VMThread* vmThread, void* userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber, J9ClassLoader* classLoader);
+UDATA writeExceptionFrameCallBack (J9VMThread* vmThread, void* userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass);
 void  writeLoaderCallBack         (void* classLoader, void* userData);
 void  writeLibrariesCallBack      (void* classLoader, void* userData);
 void  writeClassesCallBack        (void* classLoader, void* userData);
@@ -219,7 +219,7 @@ private :
 
 	/* Allow the callback functions access */
 	friend UDATA writeFrameCallBack          (J9VMThread* vmThread, J9StackWalkState* state);
-	friend UDATA writeExceptionFrameCallBack (J9VMThread* vmThread, void* userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber, J9ClassLoader* classLoader);
+	friend UDATA writeExceptionFrameCallBack (J9VMThread* vmThread, void* userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass);
 	friend void  writeLoaderCallBack         (void* classLoader, void* userData);
 	friend void  writeLibrariesCallBack      (void* classLoader, void* userData);
 	friend void  writeClassesCallBack        (void* classLoader, void* userData);
@@ -5356,7 +5356,7 @@ writeFrameCallBack(J9VMThread* vmThread, J9StackWalkState* state)
 }
 
 UDATA
-writeExceptionFrameCallBack(J9VMThread* vmThread, void* userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber, J9ClassLoader* classLoader)
+writeExceptionFrameCallBack(J9VMThread* vmThread, void* userData, J9ROMClass* romClass, J9ROMMethod* romMethod, J9UTF8* sourceFile, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass)
 {
 	JavaCoreDumpWriter *jcdw = (JavaCoreDumpWriter *)((J9StackWalkState*)userData)->userData1;
 	return jcdw->writeExceptionFrame(userData, romClass, romMethod, sourceFile, lineNumber);

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,7 +126,7 @@ struct ExceptionStackFrame
 };
 
 static UDATA
-countExceptionStackFrame(J9VMThread *vmThread, void *userData, J9ROMClass *romClass, J9ROMMethod *romMethod, J9UTF8 *fileName, UDATA lineNumber, J9ClassLoader* classLoader)
+countExceptionStackFrame(J9VMThread *vmThread, void *userData, J9ROMClass *romClass, J9ROMMethod *romMethod, J9UTF8 *fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass)
 {
 	struct ExceptionStackFrame *frame = (struct ExceptionStackFrame *) userData;
 

--- a/runtime/shared_common/include/SCQueryFunctions.h
+++ b/runtime/shared_common/include/SCQueryFunctions.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@ extern "C"
 #if defined (J9VM_SHRTEST) && defined (J9SHR_CACHELET_SUPPORT)
 /*This function is not used from shrtest -Xrealtime */
 #else
-static BOOLEAN
+static VMINLINE BOOLEAN
 j9shr_Query_IsCacheFull(J9JavaVM *vm)
 {
 	BOOLEAN retval = TRUE;
@@ -70,7 +70,7 @@ j9shr_Query_IsCacheFull(J9JavaVM *vm)
 #if defined (J9VM_SHRTEST) && defined (J9SHR_CACHELET_SUPPORT)
 /*This function is not used from shrtest -Xrealtime */
 #else
-static BOOLEAN
+static VMINLINE BOOLEAN
 j9shr_Query_IsAddressInCache(J9JavaVM *vm, void *address, UDATA length)
 {
 	BOOLEAN retval = FALSE;
@@ -93,7 +93,7 @@ j9shr_Query_IsAddressInCache(J9JavaVM *vm, void *address, UDATA length)
  * @return TRUE if the the address range is in the readWrite cache. False otherwise.
  **/
 
-static BOOLEAN
+static VMINLINE BOOLEAN
 j9shr_Query_IsAddressInReadWriteCache(J9JavaVM *vm, void *address, UDATA length)
 {
 	BOOLEAN retval = FALSE;
@@ -108,7 +108,7 @@ j9shr_Query_IsAddressInReadWriteCache(J9JavaVM *vm, void *address, UDATA length)
 #endif
 
 #if !defined (J9VM_SHRTEST)
-static void
+static VMINLINE void
 j9shr_Query_PopulatePreinitConfigDefaults(J9JavaVM *vm, J9SharedClassPreinitConfig *updatedWithDefaults)
 {
 	if ((NULL != vm) && (NULL != vm->sharedClassConfig)) {

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -33,6 +33,7 @@
 #include "objhelp.h"
 #include "vm_internal.h"
 #include "jvminit.h"
+#include "SCQueryFunctions.h"
 
 typedef UDATA (*callback_func_t) (J9VMThread * vmThread, void * userData, J9ROMClass * romClass, J9ROMMethod * romMethod, J9UTF8 * fileName, UDATA lineNumber, J9ClassLoader* classLoader, J9Class* ramClass);
 
@@ -343,11 +344,46 @@ inlinedEntry:
 					pruneConstructors = FALSE;
 #endif
 					romClass = findROMClassFromPC(vmThread, methodPC, &classLoader);
-					if(romClass) {
-						romMethod = findROMMethodInROMClass(vmThread, romClass, methodPC);
-						if (romMethod != NULL) {
-							methodPC -= (UDATA) J9_BYTECODE_START_FROM_ROM_METHOD(romMethod);
+					if (NULL != romClass) {
+						J9UTF8 const *utfClassName = J9ROMCLASS_CLASSNAME(romClass);
+
+						ramClass = peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+						if (ramClass == NULL) {
+							if (j9shr_Query_IsAddressInCache(vm, romClass, romClass->romSize)) {
+								/* Probe the application loader to determine if it has the J9Class for the current class.
+								 * This secondary probe is required as all ROMClasses from the SCC appear to be owned
+								 * by the bootstrap classloader.
+								 */
+								ramClass = peekClassHashTable(vmThread, vm->applicationClassLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+							}
 						}
+
+						while (NULL != ramClass) {
+							U_32 i = 0;
+							J9Method *methods = ramClass->ramMethods;
+							for (i = 0; i < romClass->romMethodCount; ++i) {
+								J9ROMMethod *possibleMethod = J9_ROM_METHOD_FROM_RAM_METHOD(&methods[i]);
+
+								/* Note that we cannot use `J9_BYTECODE_START_FROM_ROM_METHOD` here because native method PCs
+								 * point to the start of the J9ROMMethod data structure
+								 */
+								if ((methodPC >= (UDATA)possibleMethod) && (methodPC < (UDATA)J9_BYTECODE_END_FROM_ROM_METHOD(possibleMethod))) {
+									romMethod = possibleMethod;
+									methodPC -= (UDATA)J9_BYTECODE_START_FROM_ROM_METHOD(romMethod);
+									goto foundROMMethod;
+								}
+							}
+
+							ramClass = ramClass->replacedClass;
+						}
+
+						if (NULL == romMethod) {
+							romMethod = findROMMethodInROMClass(vmThread, romClass, methodPC);
+							if (NULL != romMethod) {
+								methodPC -= (UDATA)J9_BYTECODE_START_FROM_ROM_METHOD(romMethod);
+							}
+						}
+foundROMMethod: ;
 					}
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 				}
@@ -535,7 +571,3 @@ isSubclassOfThreadDeath(J9VMThread *vmThread, j9object_t exception)
 
 	return FALSE;
 }
-
-
-
-


### PR DESCRIPTION
The changes contained in this PR are a consequence of the discussions and investigations from #8053. In particular the changes within this PR have been measured [1] to improve a real workload while keeping the implementation simple. There are two changes within the PR, spearated out into two separate commits:

Cache J9Class in iterateStackTrace callback

Avoid having to lookup the `J9Class*` within `getStackTraceIterator`
by optionally passing the `J9Class*` as an argument. If the caller
has the `J9Class*` available we will avoid an extra call to
`peekClassHashTable` which will improve the performance of the
callback.

Iterate over J9Method* rather than J9ROMMethod* for performance

ROMMethods are variable sized making walking them more expensive. For
JITTed methods, we have the RAMClass in hand already which would
allow walking the J9Methods which are fixed sized. This improves the
speed of that operation.

Issue: #7776

[1] https://github.com/eclipse/openj9/pull/8053#issuecomment-582081345