### PR TITLE
CPU cache line size for Linux aarch64

### DIFF
--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1668,6 +1668,16 @@ j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, const J9CacheInfoQue
 			omrcpu_get_cache_line_size(&result);
 #endif
 		}
+#elif defined(LINUX) && defined(J9AARCH64)
+	if ((query->cmd == J9PORT_CACHEINFO_QUERY_LINESIZE)
+	    && (query->cacheType == J9PORT_CACHEINFO_DCACHE)
+	    && (query->level == 1)) {
+		/* L1 data cache line size */
+		int32_t rc = (int32_t)sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+		if (rc >= 0) {
+			result = rc;
+		}
+	}
 #endif
 	Trc_PRT_sysinfo_get_cache_info_exit(result);
 	return result;

--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -1670,8 +1670,9 @@ j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, const J9CacheInfoQue
 		}
 #elif defined(LINUX) && defined(J9AARCH64)
 	if ((query->cmd == J9PORT_CACHEINFO_QUERY_LINESIZE)
-	    && (query->cacheType == J9PORT_CACHEINFO_DCACHE)
-	    && (query->level == 1)) {
+	&& (query->cacheType == J9PORT_CACHEINFO_DCACHE)
+	&& (query->level == 1)
+	) {
 		/* L1 data cache line size */
 		int32_t rc = (int32_t)sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
 		if (rc >= 0) {


### PR DESCRIPTION
This commit adds code to j9sysinfo_get_cache_info() so that Linux
AArch64 systems can answer the L1 data cache line size.

The information is used by protectedInitializeJavaVM() in
runtime/vm/jvminit.c.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>