### PR TITLE
Fix "Test StringBuffer/StringBuilder growth" timeouts and failures

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
@@ -551,6 +551,7 @@
   <output regex="no" type="success">StringBuffer capacity=2147483647 StringBuilder capacity=2147483647</output>
   <output regex="no" type="success">Option too large</output>
   <output regex="no" type="success">Not enough resource to run test</output>
+  <output regex="no" type="success">Failed to instantiate heap</output>
  </test>
 
 </suite>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/src/TestStringBufferAndBuilderGrowth.java
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/src/TestStringBufferAndBuilderGrowth.java
@@ -34,8 +34,9 @@ public static void main(String[] args) {
 	long physicalMemory = opBean.getTotalPhysicalMemorySize();
 	System.out.println("Machine has physical memory " + physicalMemory + " bytes or " + (physicalMemory >> 20) + " MB or " + (physicalMemory >> 30) + " GB");
 	// An AIX machine with 7616 MB doesn't work
-	long limit = 8000L << 20; 
+	long limit = 8193L << 20; 
 	if (physicalMemory < limit) {
+		// Machines with less memory may swap and timeout trying to run the test
 		System.out.println("Not enough resource to run test.");
 		return;
 	}


### PR DESCRIPTION
Increase the amount of physical memory required to run the test. Catch
the case where the JVM gives a "Failed to instantiate heap" error.

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>