### PR TITLE
Win32 Compile Fix (TGC Parallel)

### DIFF
--- a/runtime/gc_trace/TgcParallel.cpp
+++ b/runtime/gc_trace/TgcParallel.cpp
@@ -305,7 +305,7 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 	uint64_t prevReadObjectBarrierUpdate = 0;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	while (historyRecord < endRecord) {
-		totalRecordUpdates += historyRecord->updates;
+		totalRecordUpdates += (uintptr_t) historyRecord->updates;
 		uint64_t elapsedMicros = extensions->copyScanRatio.getSpannedMicros(env, historyRecord);
 		double majorUpdates = (double)historyRecord->majorUpdates;
 		double lists = (double)historyRecord->lists / majorUpdates;


### PR DESCRIPTION
Fix for compile error on Windows IA32:
```
TgcParallel.cpp(308) : error C2220: warning treated as error - no
'object' file generated
TgcParallel.cpp(308) : warning C4244: '+=' : conversion from 'uint64_t'
to 'uintptr_t', possible loss of data
gmake[3]: *** [TgcParallel.obj] Error 2
```

- Cast `historyRecord->updates` to `(uintptr_t)`

Signed-off-by: Salman Rana <salman.rana@ibm.com>