### PR TITLE
Fix compilation failure in vthelper

### DIFF
--- a/runtime/vm/valueTypeHelpers.cpp
+++ b/runtime/vm/valueTypeHelpers.cpp
@@ -23,6 +23,7 @@
 #include "j9.h"
 #include "ut_j9vm.h"
 #include "ObjectAccessBarrierAPI.hpp"
+#include "valueTypeHelpers.hpp"
 
 extern "C" {
 void


### PR DESCRIPTION
Fix compilation failure in vthelper

Compiles are broken when J9VM_OPT_VALHALLA_VALUE_TYPES is turned on

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>