### PR TITLE
Fix init sequence for flattenable fields

### DIFF
--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2019 IBM Corp. and others
+// Copyright (c) 2006, 2020 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -781,3 +781,7 @@ TraceException=Trc_VM_CreateRAMClassFromROMClass_nestedValueClassNotVisible Over
 TraceEvent=Trc_VM_CreateRAMClassFromROMClass_valueTypeIsFlattened Overhead=1 Level=7 Template="ValueType is eligible for flattening name=%.*s j9class=%p"
 
 TraceException=Trc_VM_classInitStateMachine_classRelationshipValidationFailed Group=classinit Overhead=1 Level=1 Template="Class relationship validation failed between child: %.*s and parent: %.*s"
+
+TraceEvent=Trc_VM_classInitStateMachine_verifyFlattenableField Group=classinit Overhead=1 Level=3 Template="verify flattenable field clazz=%p"
+TraceEvent=Trc_VM_classInitStateMachine_prepareFlattenableField Group=classinit Overhead=1 Level=3 Template="prepare flattenable field clazz=%p"
+TraceEvent=Trc_VM_classInitStateMachine_initFlattenableField Group=classinit Overhead=1 Level=3 Template="initialize flattenable field clazz=%p"


### PR DESCRIPTION
Fix init sequence for flattenable fields

Flattenable(non-nullable) valuetype fields need to be initialized before
the contianer is initialized because the flatteneable fields will be
pre-instanciated when the container is instanciated. This is similar to
the dependency between super and subclasses.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>