### PR TITLE
Force Jit in Java -version after compile

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -273,7 +273,7 @@ def build() {
     }
     stage('Java Version') {
         dir(OPENJDK_CLONE_DIR) {
-            sh "build/$RELEASE/images/$JDK_FOLDER/bin/java -version"
+            sh "build/$RELEASE/images/$JDK_FOLDER/bin/java -Xjit -version"
         }
     }
 }


### PR DESCRIPTION
- When a compile is done we run java -version
  for our own sanity. If the jit fails to load,
  by default it will revert back to running
  without it and exit 0. Adding this option will
  force the Jit on and if it fails to load the
  exit will be non-zero. This will help identify
  potential issues before we get to test.

Related #8257
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>