### PR TITLE
Update Jep359 test exclusion comment

### DIFF
--- a/test/functional/Java14andUp/playlist.xml
+++ b/test/functional/Java14andUp/playlist.xml
@@ -42,7 +42,7 @@
           <groups>
                   <group>functional</group>
           </groups>
-          <!-- Temporarily removed support for JDK 15 due to https://github.com/eclipse/openj9/issues/8590 -->
+          <!-- Run for Java 14 only since this is a preview feature. -->
           <subsets>
                   <subset>14</subset>
           </subsets>


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/8590

[skip ci]

Jep359 records preview tests should be run for Java 14 only

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>