### PR TITLE
0.19: record attribute is not part of code attribute

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2200,7 +2200,7 @@ checkAttributes(J9CfrClassFile* classfile, J9CfrAttribute** attributes, U_32 att
 					errorCode = J9NLS_CFR_ERR_RECORD_COMPONENT_DESCRIPTOR_NOT_UTF8__ID;
 					goto _errorFound;
 				}
-				if (checkAttributes(classfile, recordComponent->attributes, recordComponent->attributesCount, segment, -1, code->codeLength, flags)) {
+				if (checkAttributes(classfile, recordComponent->attributes, recordComponent->attributesCount, segment, -1, OUTSIDE_CODE, flags)) {
 					return -1;
 				}
 			}


### PR DESCRIPTION
Port https://github.com/eclipse/openj9/pull/8644 to 0.19 release

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>