### PR TITLE
Reduce number of ResolvedMethod_definingClassFromCPFieldRef messages

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -312,6 +312,7 @@ ClientSessionData::ClassInfo::ClassInfo() :
    _staticAttributesCacheAOT(decltype(_fieldAttributesCacheAOT)::allocator_type(TR::Compiler->persistentAllocator())),
    _jitFieldsCache(decltype(_jitFieldsCache)::allocator_type(TR::Compiler->persistentAllocator())),
    _fieldOrStaticDeclaringClassCache(decltype(_fieldOrStaticDeclaringClassCache)::allocator_type(TR::Compiler->persistentAllocator())),
+   _fieldOrStaticDefiningClassCache(decltype(_fieldOrStaticDefiningClassCache)::allocator_type(TR::Compiler->persistentAllocator())),	
    _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(TR::Compiler->persistentAllocator()))
    {
    }

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -262,6 +262,9 @@ class ClientSessionData
       TR_FieldAttributesCache _staticAttributesCacheAOT;
       TR_JitFieldsCache _jitFieldsCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDeclaringClassCache;
+      // The following cache is very similar to _fieldOrStaticDeclaringClassCache but it uses
+      // a different API to populate it. In the future we may want to unify these two caches
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDefiningClassCache;
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
 
       char* getROMString(int32_t& len, void *basePtr, std::initializer_list<size_t> offsets);


### PR DESCRIPTION
Use a hashtable to cache <cpIndex, definingClass> mappings in order
to reduce the number of ResolvedMethod_definingClassFromCPFieldRef
messages. When desired information is not found in the hashtable,
send a message to the client to fetch the definingClass and cache
it.

Closes: #8639

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>