### PR TITLE
Statically link libstdc++ library with JIT on AArch64

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -486,6 +486,13 @@ ifeq ($(HOST_ARCH),z)
         SOLINK_FLAGS+=-m31
     endif
 
+    SUPPORT_STATIC_LIBCXX = $(shell $(SOLINK_CMD) -static-libstdc++ 2>&1 | grep "unrecognized option" > /dev/null; echo $$?)
+    ifneq ($(SUPPORT_STATIC_LIBCXX),0)
+        SOLINK_FLAGS+=-static-libgcc -static-libstdc++
+    endif
+endif
+
+ifeq ($(HOST_ARCH),aarch64)
     SUPPORT_STATIC_LIBCXX = $(shell $(SOLINK_CMD) -static-libstdc++ 2>&1 | grep "unrecognized option" > /dev/null; echo $$?)
     ifneq ($(SUPPORT_STATIC_LIBCXX),0)
         SOLINK_FLAGS+=-static-libgcc -static-libstdc++


### PR DESCRIPTION
Add the necessary support to the autotools build files.  CMake builds
already have this support.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>