### PR TITLE
Define OPENJ9_BUILD for JIT when similarly named env var is set

### DIFF
--- a/runtime/compiler/build/toolcfg/common.mk
+++ b/runtime/compiler/build/toolcfg/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,6 +66,10 @@ ifdef ENABLE_GPU
 
     PRODUCT_INCLUDES+=$(CUDA_HOME)/include $(CUDA_HOME)/nvvm/include $(GDK_HOME)
     PRODUCT_DEFINES+=ENABLE_GPU
+endif
+
+ifneq ($(OPENJ9_BUILD),)
+    CX_DEFINES+=OPENJ9_BUILD
 endif
 
 PRODUCT_RELEASE?=tr.open.java


### PR DESCRIPTION
The JIT code looks at the following macro:
  `J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm)`
which in turn depends on `OPENJ9_BUILD` being defined.
VM makefiles define `OPENJ9_BUILD` based on a similarly named
environment variable:

ifeq ($(OPENJ9_BUILD),true)
CFLAGS+=-DOPENJ9_BUILD
CXXFLAGS+=-DOPENJ9_BUILD
CPPFLAGS+=-DOPENJ9_BUILD
endif

However, this define does not apply to the JIT code.
This commit rectifies the situation by changing the JIT makefiles
to inspect OPENJ9_BUILD environment variable and to set the
OPENJ9_BUILD define accordingly.

Closes: #8660

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>