### PR TITLE
AArch64: Fix for monitorEnter/monitorExit snippets

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -391,7 +391,7 @@ J9::ARM64::TreeEvaluator::monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg
 
    if (comp->getOption(TR_OptimizeForSpace) ||
        comp->getOption(TR_FullSpeedDebug) ||
-       comp->getOption(TR_DisableInlineMonEnt) ||
+       comp->getOption(TR_DisableInlineMonExit) ||
        lwOffset <= 0)
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();

--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -863,7 +863,7 @@ TR::Register *OMR::ARM::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Co
 
    if (comp->getOption(TR_OptimizeForSpace) ||
        (comp->getOption(TR_FullSpeedDebug) /*&& !comp->getOption(TR_EnableLiveMonitorMetadata)*/) ||
-       comp->getOption(TR_DisableInlineMonEnt) ||
+       comp->getOption(TR_DisableInlineMonExit) ||
        lwOffset <= 0)
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();


### PR DESCRIPTION
This code fixes the code generation of monitorEnter/monitorExit
snippets for AArch64.

- Encoding of the immediate value for the andimmx instruction was wrong
- The mask used in monitorExit was wrong

Also fixing some typos.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>