### PR TITLE
Check if SCC is valid at startup

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5931,18 +5931,14 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
          //
          if (vmThread->javaVM->sharedClassConfig->existsCachedCodeForROMMethod(vmThread, J9_ROM_METHOD_FROM_RAM_METHOD(method)))
             {
-            TR_J9SharedCacheVM *fe = (TR_J9SharedCacheVM *) TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM);
-            if (
-               static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader == TR_yes
-               || (
-                  static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader == TR_maybe
-                  && _sharedCacheReloRuntime.validateAOTHeader(fe, vmThread)
-                  )
-               )
+            if (static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader == TR_yes)
                {
                methodIsInSharedCache = TR_yes;
-//             if (getPersistentInfo()->isClassLoadingPhase() || TR::Options::getCmdLineOptions()->getOption(TR_ForceLoadAOT))
-                  useCodeFromSharedCache = true;
+               useCodeFromSharedCache = true;
+               }
+            else
+               {
+               TR_ASSERT_FATAL(static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader != TR_maybe, "Should not be possible for aotValidHeader to be TR_maybe at this point\n");
                }
             }
          }
@@ -11757,10 +11753,7 @@ TR::CompilationInfo::storeAOTInSharedCache(
       }
    else if (static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader == TR_maybe)
       {
-      // If validation has been performed, then a header already existed
-      // or one was already been created in this JVM
-      TR_J9SharedCacheVM *fe = (TR_J9SharedCacheVM *) TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM);
-      safeToStore = entry->_compInfoPT->reloRuntime()->storeAOTHeader(fe, vmThread);
+      TR_ASSERT_FATAL(static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader != TR_maybe, "Should not be possible for aotValidHeader to be TR_maybe at this point\n");
       }
    else
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1868,13 +1868,40 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
 #if defined(J9VM_OPT_SHARED_CLASSES)
    if (isSharedAOT)
       {
-      /* If AOT Shared Classes is turned ON, perform compatibility checks for AOT Shared Classes */
-      if (0) //!validateSharedClassAOTHeader(javaVM, curThread, compInfo))
+      bool validateSCC = true;
+
+#if defined(J9VM_OPT_JITSERVER)
+      if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+         validateSCC = false;
+#endif
+
+      if (validateSCC)
          {
-         TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
-         TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
-         TR::Options::setSharedClassCache(false);
-         TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
+         /* If AOT Shared Classes is turned ON, perform compatibility checks for AOT Shared Classes
+          *
+          * This check has to be done after latePostProcessJIT so that all the necessary JIT options
+          * can be set
+          */
+         TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, curThread);
+         if (!compInfo->reloRuntime()->validateAOTHeader(fe, curThread))
+            {
+            TR_ASSERT_FATAL(static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader != TR_yes,
+                            "aotValidHeader is TR_yes after failing to validate AOT header\n");
+
+            /* If this is the second run, then failing to validate AOT header will cause aotValidHeader
+             * to be TR_no, in which case the SCC is not valid for use. However, if this is the first
+             * run, then aotValidHeader will be TR_maybe; try to store the AOT Header in this case.
+             */
+            if (static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader == TR_no
+                || !compInfo->reloRuntime()->storeAOTHeader(fe, curThread))
+               {
+               static_cast<TR_JitPrivateConfig *>(jitConfig->privateConfig)->aotValidHeader = TR_no;
+               TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
+               TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
+               TR::Options::setSharedClassCache(false);
+               TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
+               }
+            }
          }
 
       if (TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT))


### PR DESCRIPTION
Currently the check to see if the SCC is valid is done at the first
compilation. This is done on the load run to see if it is ok to load a
method that was stored to the SCC. However, other parts of the compiler,
such as the IProfiler, don't use this check.

This PR checks the validity of the SCC at startup and updates the
global flag that all parts of the compiler check.

Fixes #7890
Fixes #8404
Fixes #8517 
