### PR TITLE
Disable field flattening by default

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2202,8 +2202,8 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			}
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-			/* TODO pick a reasonable default */
-			vm->valueFlatteningThreshold = UDATA_MAX;
+			/* By default flattening is disabled */
+			vm->valueFlatteningThreshold = 0;
 			if ((argIndex = FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, VMOPT_VALUEFLATTENINGTHRESHOLD_EQUALS, NULL)) >= 0) {
 				UDATA threshold = 0;
 				char *optname = VMOPT_VALUEFLATTENINGTHRESHOLD_EQUALS;

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -25,8 +25,8 @@
 	<test>
 		<testCaseName>ValueTypeTests</testCaseName>
 		<variations>
-			<variation>-XX:ValueTypeFlatteningThreshold=1</variation>
-			<variation>-Xgcpolicy:nogc</variation>
+			<variation>NoOptions</variation>
+			<variation>-Xgcpolicy:nogc -XX:ValueTypeFlatteningThreshold=99999</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		-Xverify:none \


### PR DESCRIPTION
Disable field flattening by default

Field flatteneding can be re-anabled using
`-XX:ValueTypeFlatteningThreshold=[maxFieldSizeForFlattening]` option.
The reason for this change is that the JIT currently doesn't support
flattening.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>