### PR TITLE
AArch64: Exclude gptest hardwareFloat tests

### DIFF
--- a/test/functional/cmdLineTests/gptest/cmdlineopttest_exclude.xml
+++ b/test/functional/cmdLineTests/gptest/cmdlineopttest_exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2018 IBM Corp. and others
+  Copyright (c) 2004, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,6 +114,9 @@
 
 <exclude id="hardwareFloat  " platform="(.*ppc.*)" shouldFix="true"><reason>mechanism to trigger hardware float does not work on PPC</reason></exclude>
 <exclude id="hardwareFloat thread" platform="(.*ppc.*)" shouldFix="true"><reason>mechanism to trigger hardware float dose not work on PPC</reason></exclude>
+
+<exclude id="hardwareFloat  " platform=".*aarch64.*" shouldFix="false"><reason>mechanism to trigger hardware float does not work on AArch64</reason></exclude>
+<exclude id="hardwareFloat thread" platform=".*aarch64.*" shouldFix="false"><reason>mechanism to trigger hardware float dose not work on AArch64</reason></exclude>
 
 <include id="hardware float -Xsignal:userConditionHandler=percolate  " platform="zos_390-31.*" shouldFix="false"><reason>Only applies to 31-bit zOS</reason></include>
 <include id="hardware float -Xsignal:userConditionHandler=percolate thread" platform="zos_390-31.*" shouldFix="false"><reason>Only applies to 31-bit zOS</reason></include>


### PR DESCRIPTION
This commit excludes gptest hardwareFloat tests when the target is
an AArch64 platform.
AArch64 integer division instructions do not raise signals when the
divisor is zero.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>