### PR TITLE
Add double map functionality to JNI string critical

### DIFF
--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,11 @@ private:
 	void copyBackArrayCritical(J9VMThread *vmThread, GC_ArrayObjectModel *indexableObjectModel,
 				J9InternalVMFunctions *functions, void *elems,
 				J9IndexableObject **arrayObject, jint mode);
+	void copyStringCritical(J9VMThread *vmThread, GC_ArrayObjectModel *indexableObjectModel,
+				J9InternalVMFunctions *functions, jchar **data, J9JavaVM *javaVM,
+				J9IndexableObject *valueObject, J9Object *stringObject,
+				jboolean *isCopy, bool isCompressed);
+	void freeStringCritical(J9VMThread *vmThread, J9InternalVMFunctions *functions, const jchar* elems);
 
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);


### PR DESCRIPTION
Leverage double map feature to boost JNI string
critical. Strings are stored internally as char or byte
arrays; therefore if double mapping is enabled and these
arrays are large enough, they will be double mapped.

Related to: https://github.com/eclipse/openj9/pull/5318

Signed-off-by: Igor Braga <higorb1@gmail.com>