### PR TITLE
Remove references to deprecated unsigned store IL Opcodes

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -421,8 +421,8 @@ createIdiomArrayStoreBodyInLoop(TR_PCISCGraph *tgt, int32_t ctrl, int dagId, TR_
    else
       {
       i2c = new (PERSISTENT_NEW) TR_PCISCNode(tgt->trMemory(),
-                                              (opcode == TR::cstorei) ? (TR_CISCOps)TR::i2s : TR_conversion,
-                                              (opcode == TR::cstorei) ? TR::Int16 : TR::NoType,
+                                              (opcode == TR::sstorei) ? (TR_CISCOps)TR::i2s : TR_conversion,
+                                              (opcode == TR::sstorei) ? TR::Int16 : TR::NoType,
                                               tgt->incNumNodes(),  dagId,   1,   1, pred); tgt->addNode(i2c);
       i2c->setIsOptionalNode();
       pred = i2c;

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1763,8 +1763,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                {
                opcode = TR::sstorei;
                int32_t constValue = (int32_t)arrayset.getConstant();
-               if (istoreNode->getOpCodeValue() == TR::bstorei ||
-                   istoreNode->getOpCodeValue() == TR::bustorei)
+               if (istoreNode->getOpCodeValue() == TR::bstorei)
                   {
                   uint8_t byteConstValue = (uint8_t) constValue;
                   constValue = (int32_t) byteConstValue;
@@ -1778,8 +1777,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                {
                opcode = TR::istorei;
                int32_t constValue = (int32_t)arrayset.getConstant();
-               if (istoreNode->getOpCodeValue() == TR::bstorei ||
-                   istoreNode->getOpCodeValue() == TR::bustorei)
+               if (istoreNode->getOpCodeValue() == TR::bstorei)
                   {
                   uint8_t byteConstValue = (uint8_t) constValue;
                   constValue = (int32_t) byteConstValue;
@@ -1802,8 +1800,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                int64_t longConstValue = (int64_t) constValue;
                constValueNode = TR::Node::create(istoreNode, TR::lconst, 0, 0);
 
-               if (istoreNode->getOpCodeValue() == TR::bstorei ||
-                   istoreNode->getOpCodeValue() == TR::bustorei)
+               if (istoreNode->getOpCodeValue() == TR::bstorei)
                   {
                   uint8_t byteConstValue = (uint8_t) longConstValue;
                   longConstValue = (int64_t) byteConstValue;

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1783,7 +1783,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                   constValue = (int32_t) byteConstValue;
                   constValue = ((constValue << 24) | (constValue << 16) | (constValue << 8) | constValue);
                   }
-               else if ((istoreNode->getOpCodeValue() == TR::cstorei) || (istoreNode->getOpCodeValue() == TR::sstorei))
+               else if (istoreNode->getOpCodeValue() == TR::sstorei)
                   {
                   uint16_t shortConstValue = (uint16_t) constValue;
                   constValue = (int32_t) shortConstValue;
@@ -1807,7 +1807,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
                   longConstValue = ((longConstValue << 56) | (longConstValue << 48) | (longConstValue << 40) | (longConstValue << 32) |
                                     (longConstValue << 24) | (longConstValue << 16) | (longConstValue << 8) | longConstValue);
                   }
-               else if ((istoreNode->getOpCodeValue() == TR::cstorei) || (istoreNode->getOpCodeValue() == TR::sstorei))
+               else if (istoreNode->getOpCodeValue() == TR::sstorei)
                   {
                   uint16_t shortConstValue = (uint16_t) longConstValue;
                   longConstValue = (int64_t) shortConstValue;


### PR DESCRIPTION
This PR remove any references to unsigned deprecated IL Opcodes of `Store` from OpenJ9.

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com