### PR TITLE
GetNanoTimeAdjustment only supported on jdk11+, exclude test from jdk8

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,7 +67,6 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>8</subset>
 			<subset>11+</subset>
 		</subsets>
 		<impls>


### PR DESCRIPTION
Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>