### PR TITLE
(0.19.0) Fix method handle inlining and small improvements

### DIFF
--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,13 @@ class TR_EstimateCodeSize
    virtual bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true) = 0;
 
 
-   bool returnCleanup(int32_t);      // common tasks requiring completion before returning from estimation
+   /*
+    *  \brief common tasks requiring completion before returning from estimation
+    *
+    *  \param errorNumber
+    *       an unique number used to identify where estimate code size bailed out
+    */
+   bool returnCleanup(int32_t errorNumber );
 
    /* Fields */
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -200,8 +200,10 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
        *
        * \param withState
        *       whether the bytecode iteration should be with or without state
+       *
+       * \return whether callsites are created successfully. Return false if failed for reasons like unexpected bytecodes etc.
        */
-      void findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessfull, bool withState);
+      bool findAndCreateCallsitesFromBytecodes(bool wasPeekingSuccessfull, bool withState);
       void setBlocks(TR::Block **blocks) { _blocks = blocks; }
       TR_StackMemory trStackMemory()            { return _trMemory; }
       bool _nonColdCallExists;
@@ -224,8 +226,10 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       void initializeIteratorWithState();
       /*
        * push and pop operands on stack according to given bytecode
+       *
+       * \return false if some error occurred such as unexpected bytecodes.
        */
-      void maintainStack(TR_J9ByteCode bc);
+      bool maintainStack(TR_J9ByteCode bc);
       void maintainStackForIf(TR_J9ByteCode bc);
       void maintainStackForGetField();
       void maintainStackForAload(int slotIndex);

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1144,9 +1144,9 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
    const static bool debugMHInlineWithOutPeeking = feGetEnv("TR_DebugMHInlineWithOutPeeking") ? true: false;
    bool mhInlineWithPeeking =  comp()->getOption(TR_DisableMHInlineWithoutPeeking);
-   bool isCalleeMethodHandleThunk = calltarget->_calleeMethod->convertToMethod()->isArchetypeSpecimen();
+   bool isCalleeMethodHandleThunkInFirstPass = calltarget->_calleeMethod->convertToMethod()->isArchetypeSpecimen() && _inliner->firstPass();
    if (nph.doPeeking() && recurseDown ||
-       isCalleeMethodHandleThunk && mhInlineWithPeeking)
+       isCalleeMethodHandleThunkInFirstPass && mhInlineWithPeeking)
       {
 
       heuristicTrace(tracer(), "*** Depth %d: ECS CSI -- needsPeeking is true for calltarget %p",
@@ -1160,7 +1160,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          wasPeekingSuccessfull = true;
          }
       }
-   else if (isCalleeMethodHandleThunk && !mhInlineWithPeeking && debugMHInlineWithOutPeeking)
+   else if (isCalleeMethodHandleThunkInFirstPass && !mhInlineWithPeeking && debugMHInlineWithOutPeeking)
       {
       traceMsg(comp(), "printing out trees and bytecodes through peeking because DebugMHInlineWithOutPeeking is on\n");
       methodSymbol->getResolvedMethod()->genMethodILForPeekingEvenUnderMethodRedefinition(methodSymbol, comp(), false, NULL);
@@ -1178,7 +1178,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    //
    TR_ValueProfileInfoManager * profileManager = TR_ValueProfileInfoManager::get(comp());
    bool callGraphEnabled = !comp()->getOption(TR_DisableCallGraphInlining);//profileManager->isCallGraphProfilingEnabled(comp());
-   if (!_inliner->firstPass() || isCalleeMethodHandleThunk)
+   if (!_inliner->firstPass() || isCalleeMethodHandleThunkInFirstPass)
       callGraphEnabled = false; // TODO: Work out why this doesn't function properly on subsequent passes
    if (callGraphEnabled && recurseDown)
       {
@@ -1276,8 +1276,12 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if (!callsitesAreCreatedFromTrees)
       {
       bci.prepareToFindAndCreateCallsites(blocks, flags, callSites, &cfg, &newBCInfo, _recursionDepth, &callStack);
-      bool iteratorWithState = isCalleeMethodHandleThunk && !mhInlineWithPeeking;
-      bci.findAndCreateCallsitesFromBytecodes(wasPeekingSuccessfull, iteratorWithState);
+      bool iteratorWithState = isCalleeMethodHandleThunkInFirstPass && !mhInlineWithPeeking;
+      if (!bci.findAndCreateCallsitesFromBytecodes(wasPeekingSuccessfull, iteratorWithState))
+         {
+         heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. bci.findAndCreateCallsitesFromBytecode failed", _recursionDepth, calltarget, callerName);
+         return returnCleanup(7);
+         }
       _hasNonColdCalls = bci._nonColdCallExists;
       }
 


### PR DESCRIPTION
This change fixes a bug in interpreter emulator. When loading an
auto check the index to make sure it's an argument before goes ahead
extracting arg type info from it.

This change also makes to small improvements
1.stops recursive inlining if a method handle thunk contains
unexpected bytecodes.
2. dont use interpreter emulator for targeted inlining since the
interpreter emulator is intended for general inlining.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>