### PR TITLE
Fix dependencies on generated protobuf code

### DIFF
--- a/runtime/compiler/build/files/net.mk
+++ b/runtime/compiler/build/files/net.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,6 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
 PROTO_GEN_FILES=\
-    compiler/net/gen/compile.pb.cpp
+    compiler/net/gen/compile.pb.cc
 
 JIT_PRODUCT_SOURCE_FILES+=$(PROTO_GEN_FILES)

--- a/runtime/compiler/build/rules/common.mk
+++ b/runtime/compiler/build/rules/common.mk
@@ -24,9 +24,7 @@ clean: jit_cleanobjs jit_cleandeps jit_cleandll
 cleanobjs: jit_cleanobjs
 cleandeps: jit_cleandeps
 cleandll: jit_cleandll
-ifneq ($(J9VM_OPT_JITSERVER),)
-proto: protoc
-endif
+
 #
 # Define our targets. "jit_cleanobjs" "jit_cleandeps" and "jit_cleandll" are double-colon so they can be appended to
 # throughout the makefile.
@@ -37,8 +35,5 @@ jit_createdirs::
 jit_cleanobjs::
 jit_cleandeps::
 jit_cleandll::
-ifneq ($(J9VM_OPT_JITSERVER),)
-protoc:
-endif
 
 include $(JIT_MAKE_DIR)/rules/$(TOOLCHAIN)/common.mk

--- a/runtime/compiler/build/rules/gnu/filetypes.mk
+++ b/runtime/compiler/build/rules/gnu/filetypes.mk
@@ -30,22 +30,25 @@ ifneq ($(J9VM_OPT_JITSERVER),)
    PROTO_DIR=$(FIXED_SRCBASE)/compiler/net/protos
 
    #
-   # Compile .proto file into .cpp and .h files
+   # Compile .proto file into .cc and .h files
    #
    define DEF_RULE.proto
 
-   $(1).pb.cpp $(1).pb.h: $(2) | jit_createdirs
+   $(1).pb.cc $(1).pb.h: $(2) | jit_createdirs
 	   $$(PROTO_CMD) --cpp_out=$$(PROTO_GEN_DIR) -I $$(PROTO_DIR) $$<
-	   cp $(1).pb.cc $(1).pb.cpp
 
    JIT_DIR_LIST+=$(dir $(1))
 
    jit_cleanobjs::
-	   rm -f $(1).pb.cpp $(1).pb.cc $(1).pb.h
+	   rm -f $(1).pb.cc $(1).pb.h
 
    endef # DEF_RULE.proto
 
    RULE.proto=$(eval $(DEF_RULE.proto))
+
+   # Reuse the .cpp rule for .pb.cc files.
+   DEF_RULE.cc=$(DEF_RULE.cpp)
+   RULE.cc=$(eval $(DEF_RULE.cc))
 endif
 
 #

--- a/runtime/compiler/compiler.mk
+++ b/runtime/compiler/compiler.mk
@@ -18,12 +18,15 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
+#
+# "all" should be the first target to appear so it's the default
+#
+all: ; @echo SUCCESS - All files are up-to-date
+clean: ; @echo SUCCESS - All files are cleaned
+cleanobjs: ; @echo SUCCESS - All objects are cleaned
+cleandeps: ; @echo SUCCESS - All dependencies are cleaned
+cleandll: ; @echo SUCCESS - All shared libraries are cleaned
 .PHONY: all clean cleanobjs cleandeps cleandll
-all:
-clean:
-cleanobjs:
-cleandeps:
-cleandll:
 
 # This is the logic right now for locating Clang and LLVM-config
 # There's probably a nicer way to do all of this... it's pretty bad
@@ -90,35 +93,12 @@ ifneq ($(findstring DPROD_WITH_ASSUMES, $(USERCFLAGS)),)
     ASSUMES=1
 endif
 
-#
-# "all" should be the first target to appear so it's the default
-#
-.PHONY: all clean cleanobjs cleandeps cleandll
-all: ; @echo SUCCESS - All files are up-to-date
-ifneq ($(J9VM_OPT_JITSERVER),)
-.PHONY : proto
-all : proto
-endif
-clean: ; @echo SUCCESS - All files are cleaned
-cleanobjs: ; @echo SUCCESS - All objects are cleaned
-cleandeps: ; @echo SUCCESS - All dependencies are cleaned
-cleandll: ; @echo SUCCESS - All shared libraries are cleaned
-ifneq ($(J9VM_OPT_JITSERVER),)
-proto: ; @echo SUCCESS - All proto files are recompiled
-endif
-
 # Handy macro to check to make sure variables are set
 REQUIRE_VARS=$(foreach VAR,$(1),$(if $($(VAR)),,$(error $(VAR) must be set)))
 
 # Verify SDK pointer for non-cleaning targets
-ifneq ($(J9VM_OPT_JITSERVER),)
-    ifeq (,$(filter proto clean cleandeps cleandll,$(MAKECMDGOALS)))
-        $(call REQUIRE_VARS,J9SRC)
-    endif
-else
-    ifeq (,$(filter clean cleandeps cleandll,$(MAKECMDGOALS)))
-        $(call REQUIRE_VARS,J9SRC)
-    endif
+ifeq (,$(filter clean cleandeps cleandll,$(MAKECMDGOALS)))
+    $(call REQUIRE_VARS,J9SRC)
 endif
 
 #


### PR DESCRIPTION
Fixes: #8681

* All object files depend upon compile.pb.h until a depend.mk file is produced by the first compile. This forces generation of that header file to occur soon enough. Afterward, the depend.mk file lists a dependency on compile.pb.h only where appropriate.

* Don't copy generated .pb.cc to .pb.cpp (which may fail).

* Reuse .cpp rule for .cc files.