### PR TITLE
Remove references to deprecated Add/Sub IL Opcode

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -2635,7 +2635,6 @@ J9::CodeGenerator::printNVVMIR(
       }
    else if (node->getOpCodeValue() == TR::bneg || node->getOpCodeValue() == TR::sneg ||
             node->getOpCodeValue() == TR::ineg || node->getOpCodeValue() == TR::lneg || 
-            node->getOpCodeValue() == TR::luneg ||
             node->getOpCodeValue() == TR::fneg || node->getOpCodeValue() == TR::dneg)
       {
       getNodeName(node->getChild(0), name0, self()->comp());

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2634,8 +2634,8 @@ J9::CodeGenerator::printNVVMIR(
                    isLongMul ? "i64" : "i32");
       }
    else if (node->getOpCodeValue() == TR::bneg || node->getOpCodeValue() == TR::sneg ||
-            node->getOpCodeValue() == TR::ineg || node->getOpCodeValue() == TR::lneg ||
-            node->getOpCodeValue() == TR::iuneg || node->getOpCodeValue() == TR::luneg ||
+            node->getOpCodeValue() == TR::ineg || node->getOpCodeValue() == TR::lneg || 
+            node->getOpCodeValue() == TR::luneg ||
             node->getOpCodeValue() == TR::fneg || node->getOpCodeValue() == TR::dneg)
       {
       getNodeName(node->getChild(0), name0, self()->comp());

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -163,7 +163,7 @@ static TR::Node *lowerCASValues(
 //    luaddh
 //      xh
 //      yh
-//      luadd
+//      ladd
 //        xl
 //        yl
 //        ==> luaddh             <=== replace dummy node with this third child to complete cycle


### PR DESCRIPTION
This PR remove any references to unsigned deprecated IL Opcodes of `Add`/`Sub` from OpenJ9.

Issue: eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>