### PR TITLE
WIP: Recognize FMA method on aarch64

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -134,3 +134,20 @@ J9::ARM64::CodeGenerator::generateBinaryEncodingPrePrologue(TR_ARM64BinaryEncodi
       generateImmInstruction(self(), TR::InstOpCode::dd, startNode, high, cursor);
       }
    }
+
+bool
+J9::ARM64::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
+   {
+
+   printf("surpress Inlining \n");
+   switch (method)
+      {
+         case TR::java_lang_Math_fma_D:
+         case TR::java_lang_StrictMath_fma_D:
+         case TR::java_lang_Math_fma_F:
+         case TR::java_lang_StrictMath_fma_F:
+         return true;
+      default:
+         return false;
+      }
+   }

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -78,6 +78,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    uint32_t encodeHelperBranchAndLink(TR::SymbolReference *symRef, uint8_t *cursor, TR::Node *node, bool omitLink = false);
    
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
+
+   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
    
    /**
     * @brief Generates pre-prologue

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1029,6 +1029,7 @@ VMinlineFMA(TR::Node *node, TR::CodeGenerator *cg)
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
    cg->decReferenceCount(thirdChild);
+   TR_ASSERT_FATAL(false, "FMA inlined...\n");
    return src1Register;
    }
 
@@ -1038,8 +1039,16 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
    TR::CodeGenerator *cg = self();
    TR::MethodSymbol * methodSymbol = node->getSymbol()->getMethodSymbol();
 
+   
+
    if (methodSymbol)
       {
+      if(methodSymbol->getRecognizedMethod()!= 0)
+      {
+         printf("XDDDDD: methodSymbol = %d\n", methodSymbol->getRecognizedMethod());
+         printf("XDDDDD: TR::java_lang_Math_fma_D = %d\n", TR::java_lang_Math_fma_D);
+      }
+
       switch (methodSymbol->getRecognizedMethod())
          {
          case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
@@ -1061,6 +1070,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          case TR::java_lang_StrictMath_fma_D:
          case TR::java_lang_Math_fma_F:
          case TR::java_lang_StrictMath_fma_F:
+            printf("RECONGIZED FMA METHOD, GOING TO EVALUATE FMA CALL...\n");
             resultReg = VMinlineFMA(node, cg);
             return true;
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4776,6 +4776,10 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
       bool disableRecMethods = !comp  ? true
          : (fej9()->getSupportsRecognizedMethods() && !comp->getOption(TR_DisableRecognizedMethods)) ? false : true;
 
+      printf("XDDDDDDDDDD disableRecmethods = %d\n", disableRecMethods);
+      printf("XDDDDDDDDDD comp->getOption(TR_DisableRecognizedMethods) = %d\n", comp->getOption(TR_DisableRecognizedMethods));
+
+
       if (disableRecMethods && fej9()->isAOT_DEPRECATED_DO_NOT_USE()) // AOT_JIT_GAP
          {
          switch (rm) {


### PR DESCRIPTION
- Enable inlineDirectCall() in aarch64 for recognizing methods.
- Added FMA methods in inlineDirectCall()

Note that this PR requires support from OMR: https://github.com/eclipse/omr/pull/4893

Issue: #7474
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com