### PR TITLE
Deprecate XPLINKCallDescriptorSnippet

### DIFF
--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/UnaryEvaluator.cpp \
     omr/compiler/z/codegen/snippet/PPA1Snippet.cpp \
     omr/compiler/z/codegen/snippet/PPA2Snippet.cpp \
-    omr/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.cpp \
     omr/compiler/z/env/OMRCPU.cpp
 
 JIT_PRODUCT_SOURCE_FILES+=\


### PR DESCRIPTION
As part of eclipse/omr#4890 we have deprecated this snippet, but we
couldn't remove it in that PR because we have a dependency here in
OpenJ9. After removing this dependency we can fully remove the snippet.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>