### PR TITLE
Runtime compressed refs work

### DIFF
--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -309,7 +309,7 @@ Java_java_lang_Thread_holdsLock(JNIEnv *env, jclass threadClass, jobject obj)
 		j9object_t lockObject = J9_JNI_UNWRAP_REFERENCE(obj);
 		j9objectmonitor_t *lockAddress = VM_ObjectMonitor::inlineGetLockAddress(currentThread, lockObject);
 		if ((NULL == lockAddress) || ((j9objectmonitor_t)(UDATA)currentThread != J9_LOAD_LOCKWORD(currentThread, lockAddress))) {
-			if (currentThread != getObjectMonitorOwner(vm, currentThread, lockObject, NULL)) {
+			if (currentThread != getObjectMonitorOwner(vm, lockObject, NULL)) {
 				result = JNI_FALSE;
 			}
 		}

--- a/runtime/jvmti/jvmtiObject.c
+++ b/runtime/jvmti/jvmtiObject.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -142,12 +142,7 @@ jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
 
-		/*
-		 * getObjectMonitorOwner requires a J9VMThread solely for multi-tenant support,
-		 *  however, the multi-tenant JVM does not support can_get_monitor_info (see ENSURE_CAPABILITY check above)
-		 *  and therefore will not use jvmtiGetObjectMonitorUsage: so just pass in NULL as the vm thread
-		 */
-		owner = getObjectMonitorOwner(vm, NULL, *((j9object_t*) object), &count);
+		owner = getObjectMonitorOwner(vm, *((j9object_t*) object), &count);
 		memset(info_ptr, 0, sizeof(jvmtiMonitorUsage));
 
 		if (owner && owner->threadObject) {

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -996,7 +996,7 @@ ownedMonitorIterator(J9VMThread* targetThread, J9StackWalkState* walkState, j9ob
 		return;
 	}
 
-	if (obj && getObjectMonitorOwner(vm, targetThread, obj, NULL) == walkState->walkThread
+	if (obj && getObjectMonitorOwner(vm, obj, NULL) == walkState->walkThread
 			&& !isObjectStackAllocated(walkState->walkThread, obj)) {
 		if (NULL != locks) {
 			UDATA i;

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -634,8 +634,11 @@ typedef struct J9IndexableObject* mm_j9array_t;
 				: J9OBJECT_UDATA_STORE_VM(javaVM, object, TMP_OFFSETOF_J9OBJECT_CLAZZ, (UDATA)(((UDATA)(value) & ~((UDATA)(J9_REQUIRED_CLASS_ALIGNMENT - 1))) | J9OBJECT_FLAGS_FROM_CLAZZ_VM((javaVM), (object)))))
 
 #define J9OBJECT_MONITOR_OFFSET(vmThread,object) (J9OBJECT_CLAZZ(vmThread, object)->lockOffset)
+#define J9OBJECT_MONITOR_OFFSET_VM(vm,object) (J9OBJECT_CLAZZ_VM(vm, object)->lockOffset)
 #define LN_HAS_LOCKWORD(vmThread,obj) (((IDATA)J9OBJECT_MONITOR_OFFSET(vmThread, obj)) >= 0)
+#define LN_HAS_LOCKWORD_VM(vm,obj) (((IDATA)J9OBJECT_MONITOR_OFFSET_VM(vm, obj)) >= 0)
 #define J9OBJECT_MONITOR_EA(vmThread, object) ((j9objectmonitor_t*)(((U_8 *)(object)) + J9OBJECT_MONITOR_OFFSET(vmThread, object)))
+#define J9OBJECT_MONITOR_EA_VM(vm, object) ((j9objectmonitor_t*)(((U_8 *)(object)) + J9OBJECT_MONITOR_OFFSET_VM(vm, object)))
 
 /* Note the volatile in these macros may be unncessary, but they replace hard-coded volatile operations in the
  * source, so maintaining the volatility is safest.
@@ -672,6 +675,11 @@ typedef struct J9IndexableObject* mm_j9array_t;
 	(J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) \
 		? (j9objectmonitor_t)J9OBJECT_U32_LOAD(vmThread, object, J9OBJECT_MONITOR_OFFSET(vmThread,object)) \
 		: (j9objectmonitor_t)J9OBJECT_UDATA_LOAD(vmThread, object, J9OBJECT_MONITOR_OFFSET(vmThread,object)))
+
+#define J9OBJECT_MONITOR_VM(vm, object) \
+	(J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) \
+		? (j9objectmonitor_t)J9OBJECT_U32_LOAD_VM(vm, object, J9OBJECT_MONITOR_OFFSET_VM(vm,object)) \
+		: (j9objectmonitor_t)J9OBJECT_UDATA_LOAD_VM(vm, object, J9OBJECT_MONITOR_OFFSET_VM(vm,object)))
 
 #define J9OBJECT_SET_MONITOR(vmThread, object, value) \
 	do { \

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1243,13 +1243,12 @@ jint request_MonitorJlmDumpSize(J9JavaVM *jvm, UDATA *dump_size, jint dump_forma
 /**
 * @brief
 * @param vm 	the Java VM
-* @param vmThread	the vmThread where the monitor was found
 * @param object
 * @param pcount
 * @return J9VMThread*
 */
 J9VMThread* 
-getObjectMonitorOwner(J9JavaVM* vm, J9VMThread *vmThread, j9object_t object, UDATA* pcount);
+getObjectMonitorOwner(J9JavaVM* vm, j9object_t object, UDATA* pcount);
 
 
 /**
@@ -1769,13 +1768,12 @@ getVMThreadRawStatesAll(J9VMThread *targetThread, j9object_t *pLockObject, omrth
 /**
 * @brief
 * @param vm
-* @param targetVMThread	the vmThread where the monitor was found
 * @param object
 * @param lockWord
 * @return J9ThreadAbstractMonitor *
 */
 J9ThreadAbstractMonitor *
-getInflatedObjectMonitor(J9JavaVM *vm, J9VMThread *targetVMThread, j9object_t object, j9objectmonitor_t lockWord);
+getInflatedObjectMonitor(J9JavaVM *vm, j9object_t object, j9objectmonitor_t lockWord);
 
 /* ---------------- thrname.c ---------------- */
 /**

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3958,12 +3958,7 @@ JavaCoreDumpWriter::writeMonitorObject(J9ThreadMonitor* monitor, j9object_t obj,
 	J9Thread*   lockOwner = lock->owner;
 
 	if (obj) {
-		J9VMThread tenantMarker;
-
-		memset(&tenantMarker, 0, sizeof(J9VMThread));
-
-
-		owner = getObjectMonitorOwner(_VirtualMachine, &tenantMarker, obj, &count);
+		owner = getObjectMonitorOwner(_VirtualMachine, obj, &count);
 	} else if (lockOwner) {
 		owner = getVMThreadFromOMRThread(_VirtualMachine, lockOwner);
 		count = lock->count;

--- a/runtime/util/moninfo.c
+++ b/runtime/util/moninfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ isObjectStackAllocated(J9VMThread *targetThread, j9object_t aObj) {
  * If pcount != NULL, return the entry count in pcount.
 */
 J9VMThread * 
-getObjectMonitorOwner(J9JavaVM *vm, J9VMThread *vmThread, j9object_t object, UDATA *pcount)
+getObjectMonitorOwner(J9JavaVM *vm, j9object_t object, UDATA *pcount)
 {
 
 	UDATA count = 0;
@@ -64,19 +64,19 @@ getObjectMonitorOwner(J9JavaVM *vm, J9VMThread *vmThread, j9object_t object, UDA
 
 	Trc_VMUtil_getObjectMonitorOwner_Entry(vm, object, pcount);
 
-	if (!LN_HAS_LOCKWORD(vmThread,object)) {
-		J9ObjectMonitor *objectMonitor = monitorTablePeek(vm, vmThread, object);
+	if (!LN_HAS_LOCKWORD_VM(vm, object)) {
+		J9ObjectMonitor *objectMonitor = monitorTablePeek(vm, object);
 		if (objectMonitor != NULL){
-			lock = J9_LOAD_LOCKWORD(vmThread, &objectMonitor->alternateLockword);
+			lock = J9_LOAD_LOCKWORD_VM(vm, &objectMonitor->alternateLockword);
 		} else {
 			lock = 0;
 		}
 	} else {
-		lock = J9OBJECT_MONITOR(vmThread, object);
+		lock = J9OBJECT_MONITOR_VM(vm, object);
 	}
 
 	if (J9_LOCK_IS_INFLATED(lock)) {
-		J9ThreadAbstractMonitor *monitor = getInflatedObjectMonitor(vm, vmThread, object, lock);
+		J9ThreadAbstractMonitor *monitor = getInflatedObjectMonitor(vm, object, lock);
 
 		/*
 		 * If the monitor is out-of-line and NULL, then it was never entered,

--- a/runtime/util/util_internal.h
+++ b/runtime/util/util_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -192,13 +192,11 @@ char *node_key(node *aNode);
  * 
  * @brief
  * @param vm				the J9JavaVM
- * @param targetVMThread	Used solely by the multi-tenant JVM: identifies the TenantContext of the object, 
- * 								which is needed to determine which monitor table to search
  * @param object			the object who's monitor we are looking for
  * @return J9ThreadAbstractMonitor *
  */
 J9ThreadAbstractMonitor *
-monitorTablePeekMonitor(J9JavaVM *vm, J9VMThread *targetVMThread, j9object_t object);
+monitorTablePeekMonitor(J9JavaVM *vm, j9object_t object);
 
 /**
  * Search the monitor tables in vm->monitorTableList for the inflated monitor corresponding to an object.
@@ -209,8 +207,6 @@ monitorTablePeekMonitor(J9JavaVM *vm, J9VMThread *targetVMThread, j9object_t obj
  *
  * @param[in] vm the JavaVM. For out-of-process: may be a local or target pointer.
  * vm->monitorTable must be a target value.
- * @param targetVMThread	Used solely by the multi-tenant JVM: identifies the TenantContext of the object, which is needed 
- * 								to determine which monitor table to search	
  * @param[in] object the object. For out-of-process: a target pointer.
  * @returns a J9ObjectMonitor from the monitor hashtable
  * @retval NULL There is no corresponding monitor in vm->monitorTable.
@@ -218,7 +214,7 @@ monitorTablePeekMonitor(J9JavaVM *vm, J9VMThread *targetVMThread, j9object_t obj
  * @see monitorTablePeekMonitor
  */
 J9ObjectMonitor *
-monitorTablePeek(J9JavaVM *vm, J9VMThread *targetVMThread, j9object_t object);
+monitorTablePeek(J9JavaVM *vm, j9object_t object);
 
 #ifdef __cplusplus
 }

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -827,7 +827,7 @@ waitForContendedLoadClass(J9VMThread* vmThread, J9ContendedLoadTableEntry *table
 	Assert_VM_mustHaveVMAccess(vmThread);
 	/* get here if and only if someone else is loading the class */
 	/* give up the classloader monitor to allow other threads to run */
-	monitorOwner = getObjectMonitorOwner(vmThread->javaVM, vmThread, tableEntry->classLoader->classLoaderObject, &recursionCount);
+	monitorOwner = getObjectMonitorOwner(vmThread->javaVM, tableEntry->classLoader->classLoaderObject, &recursionCount);
 	if (monitorOwner == vmThread) {
 		Trc_VM_waitForContendedLoadClass_release_object_monitor(vmThread, vmThread, tableEntry->classLoader, classNameLength, className);
 		for (i = 0; i < recursionCount; ++i) {


### PR DESCRIPTION
- Fix missed fj9object_t pointer math in realtime

- Remove unused (and often incorrect) J9VMThread parameter in monitor
query operations

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>