### PR TITLE
Fix -Xjit:perfTool option in JITServer mode

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9111,7 +9111,11 @@ TR::CompilationInfoPerThreadBase::compile(
          }
 
       _methodBeingCompiled->_compErrCode = compilationOK;
-      if (!_methodBeingCompiled->isAotLoad() && !_methodBeingCompiled->isRemoteCompReq())
+      if (!_methodBeingCompiled->isAotLoad()
+#if defined(J9VM_OPT_JITSERVER)
+          && !_methodBeingCompiled->isRemoteCompReq()
+#endif /* defined(J9VM_OPT_JITSERVER) */
+         )
          {
          class TraceMethodMetadata
             {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9175,8 +9175,6 @@ TR::CompilationInfoPerThreadBase::compile(
                );
             }
 
-         setMetadata(metaData);
-
          // Put a metaData pointer into the Code Cache Header(s).
          //
          uint8_t *warmMethodHeader = compiler->cg()->getBinaryBufferStart() - sizeof(OMR::CodeCacheMethodHeader);
@@ -9194,6 +9192,8 @@ TR::CompilationInfoPerThreadBase::compile(
          // and in fact it would be wrong to do so because code during chtable.commit is
          // expecting something in the compiler object
          }
+
+      setMetadata(metaData);
 
       if (compiler->getOption(TR_BreakAfterCompile))
          {


### PR DESCRIPTION
`-Xjit:perfTool` is broken in JITServer mode because `CompilationInfoPerThreadBase::setMetadata()` isn't being called for remote compiles (or AOT compiles), but only for local JIT compiles.