### PR TITLE
WIP Remove `$` as a restricted character in shared cache names

### DIFF
--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -2715,7 +2715,6 @@ modifyCacheName(J9JavaVM *vm, const char* origName, UDATA verboseFlags, char** m
 			/* List of un-acceptable characters in cache name */
 			if (*cursorOrig == '/' ||
 			*cursorOrig == '\\' ||
-			*cursorOrig == '$' ||
 			*cursorOrig == '&' ||
 			*cursorOrig == '*' ||
 			((U_8)*cursorOrig) == SHRINIT_ASCII_OF_POUND_SYMBOL ||


### PR DESCRIPTION
Not sure why it was restricted, both Linux and Windows allow it in file
names.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>