### PR TITLE
Strip debug info from executables

### DIFF
--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -34,7 +34,7 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(UMA_OBJECTS) \
 		$(UMA_DLL_LINK_POSTFLAGS)
 ifdef j9vm_uma_gnuDebugSymbols
-	cp $(UMA_DLLTARGET) $(@:$(UMA_DOT_DLL)=.debuginfo)
+	cp $@ $(@:$(UMA_DOT_DLL)=.debuginfo)
 endif
 	strip -X32_64 -t $@
 </#assign>
@@ -46,6 +46,10 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(UMA_LINK_LIBRARIES) \
 		-o $@ -lm -lpthread -liconv -ldl \
 		$(UMA_EXE_LINK_POSTFLAGS)
+ifdef j9vm_uma_gnuDebugSymbols
+	cp $@ $(@:$(UMA_DOT_EXE)=.debuginfo)
+endif
+	strip -X32_64 -t $@
 </#assign>
 
 ifeq ($(j9vm_env_data64),1)

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -61,6 +61,11 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(UMA_END_DASH_L) \
 		$(UMA_LINK_SHARED_LIBRARIES) \
 		-o $@ $(UMA_EXE_POSTFIX_FLAGS)
+ifdef j9vm_uma_gnuDebugSymbols
+	$(OBJCOPY) --only-keep-debug $@ $(@:$(UMA_DOT_EXE)=.debuginfo)
+	$(OBJCOPY) --strip-debug $@
+	$(OBJCOPY) --add-gnu-debuglink=$(@:$(UMA_DOT_EXE)=.debuginfo) $@
+endif
 </#assign>
 
 <#if uma.spec.processor.s390>

--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -31,7 +31,9 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(VMLINK) $(UMA_LINK_PATH) -o $@ \
 		$(UMA_OBJECTS) \
 		$(UMA_DLL_LINK_POSTFLAGS)
+ifdef j9vm_uma_gnuDebugSymbols
 	dsymutil -o $@.dSYM $@
+endif
 </#assign>
 
 <#assign exe_target_rule>
@@ -43,6 +45,9 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(UMA_END_DASH_L) \
 		$(UMA_LINK_SHARED_LIBRARIES) \
 		-o $@ $(UMA_EXE_POSTFIX_FLAGS)
+ifdef j9vm_uma_gnuDebugSymbols
+	dsymutil -o $@.dSYM $@
+endif
 </#assign>
 
 UMA_BEGIN_DASH_L =

--- a/runtime/makelib/targets.mk.ztpf.inc.ftl
+++ b/runtime/makelib/targets.mk.ztpf.inc.ftl
@@ -56,6 +56,11 @@ $(UMA_EXETARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 	$(UMA_END_DASH_L) \
 	$(UMA_LINK_SHARED_LIBRARIES) \
 	-o $@ $(UMA_EXE_POSTFIX_FLAGS)
+ifdef j9vm_uma_gnuDebugSymbols
+	cp $@ $(@:$(UMA_DOT_EXE)=.debuginfo)
+	objcopy --strip-debug $@
+	objcopy --add-gnu-debuglink=$(@:$(UMA_DOT_EXE)=.debuginfo) $@
+endif
 </#assign>
 
 TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit


### PR DESCRIPTION
This change is to ensure the executables, like dlls, are stripped of
debug info.
Also added a check for j9vm_uma_gnuDebugSymbols before removing debug
symbols on osx, to be consistent with other platforms.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>