### PR TITLE
Decouple TR_PrexArgInfo from TR_InlinerTracer

### DIFF
--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -562,7 +562,7 @@ InterpreterEmulator::debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod)
    if(tracer()->heuristicLevel())
       {
       if (resolvedMethod)
-         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex ,tracer()->traceSignature(resolvedMethod));
+         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, resolvedMethod->signature(comp()->trMemory()));
       else
          {
          switch (current())
@@ -575,7 +575,7 @@ InterpreterEmulator::debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod)
                break;
             }
          TR::Method *meth = comp()->fej9()->createMethod(this->trMemory(), _calltarget->_calleeMethod->containingClass(), cpIndex);
-         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, tracer()->traceSignature(meth));
+         heuristicTrace(tracer(), "Depth %d: Call at bc index %d is Cold.  Not searching for targets. Signature %s", _recursionDepth, _bcIndex, meth->signature(comp()->trMemory()));
          }
       }
    }
@@ -848,7 +848,7 @@ InterpreterEmulator::findTargetAndUpdateInfoForCallsite(TR_CallSite *callsite)
             {
             alwaysTrace(tracer(), "propagateReceiverInfoIfAvailable :");
             if (callsite->_ecsPrexArgInfo)
-               tracer()->dumpPrexArgInfo(callsite->_ecsPrexArgInfo);
+               callsite->_ecsPrexArgInfo->dumpTrace();
             }
          }
       }
@@ -865,7 +865,7 @@ InterpreterEmulator::findTargetAndUpdateInfoForCallsite(TR_CallSite *callsite)
             {
             alwaysTrace(tracer(), "propagateArgs :");
             if (callsite->numTargets() && callsite->getTarget(0)->_ecsPrexArgInfo)
-               tracer()->dumpPrexArgInfo(callsite->getTarget(0)->_ecsPrexArgInfo);
+               callsite->getTarget(0)->_ecsPrexArgInfo->dumpTrace();
             }
          }
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.hpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.hpp
@@ -48,14 +48,15 @@
 #ifndef INTERPRETER_EMULATOR_INCL
 #define INTERPRETER_EMULATOR_INCL
 
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
 #include "il/Block.hpp"
 #include "ilgen/ByteCodeIteratorWithState.hpp"
 #include "ilgen/J9ByteCodeIterator.hpp"
-#include "compile/Compilation.hpp"
 #include "optimizer/Inliner.hpp"
-#include "optimizer/J9Inliner.hpp"
 #include "optimizer/J9EstimateCodeSize.hpp"
-#include "env/TRMemory.hpp"
+#include "optimizer/J9Inliner.hpp"
+#include "optimizer/PreExistence.hpp" // TR_PREXARGINFO_TRACER_CLASS
 
 class IconstOperand;
 class KnownObjOperand;
@@ -157,7 +158,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
             TR::ResolvedMethodSymbol * methodSymbol,
             TR_J9VMBase * fe,
             TR::Compilation * comp,
-            TR_InlinerTracer *tracer,
+            TR_PREXARGINFO_TRACER_CLASS *tracer,
             TR_EstimateCodeSize *ecs)
          : Base(methodSymbol, comp),
            _calltarget(calltarget),
@@ -169,7 +170,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
          _flags = NULL;
          _stacks = NULL;
          }
-      TR_InlinerTracer *tracer() { return _tracer; }
+      TR_PREXARGINFO_TRACER_CLASS *tracer() { return _tracer; }
       /* \brief Initialize data needed for looking for callsites
        *
        * \param blocks
@@ -284,7 +285,7 @@ class InterpreterEmulator : public TR_ByteCodeIteratorWithState<TR_J9ByteCode, J
       bool isCurrentCallUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod, bool isUnresolvedInCP);
       void debugUnresolvedOrCold(TR_ResolvedMethod *resolvedMethod);
 
-      TR_InlinerTracer *_tracer;
+      TR_PREXARGINFO_TRACER_CLASS *_tracer;
       TR_EstimateCodeSize *_ecs;
       Operand * _unknownOperand; // used whenever the iterator can't reason about an operand
       TR_CallTarget *_calltarget; // the target method to inline

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1049,7 +1049,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if (tracer()->heuristicLevel() && calltarget->_ecsPrexArgInfo)
       {
       heuristicTrace(tracer(), "ECS CSI -- ArgInfo :");
-      tracer()->dumpPrexArgInfo(calltarget->_ecsPrexArgInfo);
+      calltarget->_ecsPrexArgInfo->dumpTrace();
       }
 
    TR_InlinerDelimiter delimiter(tracer(), "realEstimateCodeSize");

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 #define INLINERTEMPFORJ9_INCL
 
 #include "j9cfg.h"
+#include "ras/LogTracer.hpp"
 #include "runtime/J9ValueProfiler.hpp"
 
 class OMR_InlinerPolicy;
@@ -153,7 +154,7 @@ class TR_J9InlinerUtil: public OMR_InlinerUtil
                    bool &appendTestToBlock1, TR::ResolvedMethodSymbol * callerSymbol, TR::TreeTop *cursorTree,
                    TR::TreeTop *&virtualGuard, TR::Block *block4);
       virtual void refineInliningThresholds(TR::Compilation *comp, int32_t &callerWeightLimit, int32_t &maxRecursiveCallByteCodeSizeEstimate, int32_t &methodByteCodeSizeThreshold, int32_t &methodInWarmBlockByteCodeSizeThreshold, int32_t &methodInColdBlockByteCodeSizeThreshold, int32_t &nodeCountThreshold, int32_t size);
-      static void checkForConstClass(TR_CallTarget *target, TR_InlinerTracer *tracer);
+      static void checkForConstClass(TR_CallTarget *target, TR_LogTracer *tracer);
       virtual bool needTargetedInlining(TR::ResolvedMethodSymbol *callee);
       virtual void requestAdditionalOptimizations(TR_CallTarget *calltarget);
    protected:


### PR DESCRIPTION
I originally submitted these changes in #8419. However, I have made modifications so that this PR does not need to be merged at the same time as a PR in OMR.

This PR in OMR must be merged first: https://github.com/eclipse/omr/pull/4903

- Replace calls to `TR_InlinerTracer::dumpPrexArgInfo` with calls to `TR_PrexArgInfo::dumpTrace`.
  - This will allow the method `dumpPrexArgInfo` to be removed from OMR.

- Prepare TR_PrexArgInfo methods to be changed to have parameters of type `TR_LogTracer` instead of `TR_InlinerTracer`.
  - This is done by using the macro `TR_PREXARGINFO_TRACER_CLASS` which will later be updated in OMR.
  - Since `TR_LogTracer` is a less specialized class than `TR_InlinerTracer`, this should make the `TR_PrexArgInfo` class more reusable.

- Similar modifications to `TR_InterpreterEmulator` and `TR_J9InlinerUtil`.

See: #7936

Signed-off-by: Ryan Shukla <ryans@ibm.com>