### PR TITLE
AArch64: Implement ZEROCHKEvaluator without OOL code section

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -676,42 +676,28 @@ J9::ARM64::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::CodeGenerator
 TR::Register *
 J9::ARM64::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   // TODO: Use OutOfLineCodeSection if it is correctly implemented.
+   // Because OOL is tricky to get it right, we defer implementing it to future work.
+   // We instead use ARM64HelperCallSnippet to call helper and assumes that the helper takes no arguments
+
+   TR_ASSERT_FATAL(node->getNumChildren() == 1, "We assume that ZEROCHKEvaluator has only 1 child");
    TR::LabelSymbol *slowPathLabel = generateLabelSymbol(cg);
-   TR::LabelSymbol *restartLabel = generateLabelSymbol(cg);
-   slowPathLabel->setStartInternalControlFlow();
-   restartLabel->setEndInternalControlFlow();
 
-   // Temporarily hide the first child so it doesn't appear in the outlined call
-   //
-   node->rotateChildren(node->getNumChildren()-1, 0);
-   node->setNumChildren(node->getNumChildren()-1);
 
-   // Outlined instructions for check failure
-   // Note: we don't pass the restartLabel in here because we don't want a
-   // restart branch.
-   //
-   TR_ARM64OutOfLineCodeSection *outlinedHelperCall = new (cg->trHeapMemory()) TR_ARM64OutOfLineCodeSection(node, TR::call, NULL, slowPathLabel, restartLabel, cg);
-   cg->getARM64OutOfLineCodeSectionList().push_front(outlinedHelperCall);
-
-   // Restore the first child
-   //
-   node->setNumChildren(node->getNumChildren()+1);
-   node->rotateChildren(0, node->getNumChildren()-1);
-
-   // Children other than the first are only for the outlined path; we don't need them here
-   //
-   for (int32_t i = 1; i < node->getNumChildren(); i++)
-      cg->recursivelyDecReferenceCount(node->getChild(i));
-
-   // In-line instructions for the check
+   // Instructions for the check
    // ToDo: Optimize isBooleanCompare() case
    //
    TR::Node *valueToCheck = node->getFirstChild();
    TR::Register *value = cg->evaluate(valueToCheck);
-   generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, value, slowPathLabel);
-   cg->decReferenceCount(node->getFirstChild());
 
-   generateLabelInstruction(cg, TR::InstOpCode::label, node, restartLabel);
+   // We do not need restart label because the helper throws exception
+   TR::Snippet *snippet = new (cg->trHeapMemory()) TR::ARM64HelperCallSnippet(cg, node, slowPathLabel, node->getSymbolReference());
+   cg->addSnippet(snippet);
+
+   TR::Instruction *gcPoint = generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, value, slowPathLabel);
+   gcPoint->ARM64NeedsGCMap(cg, 0xFFFFFFFF);
+   snippet->gcMap().setGCRegisterMask(0xffffffff);
+   cg->decReferenceCount(node->getFirstChild());
 
    return NULL;
    }


### PR DESCRIPTION
Implement `ZEROCHKEvaluator` without OOL code section
because OOL code section is currently incomplete for aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>