### PR TITLE
CS hooks and Async Handler

### DIFF
--- a/runtime/gc_glue_java/ScavengerRootClearer.hpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -222,7 +222,7 @@ public:
 		 * However Concurrent Scavenger runs might be interlaced with STW Scavenger time to time
 		 * (for example for reducing amount of floating garbage)
 		 */
-		if (!_scavenger->isConcurrentInProgress())
+		if (!_scavenger->isConcurrentCycleInProgress())
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		{
 			MM_RootScanner::scanJNIWeakGlobalReferences(env);

--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -188,7 +188,7 @@ public:
 		 * However Concurrent Scavenger runs might be interlaced with STW Scavenger time to time
 		 * (for example for reducing amount of floating garbage)
 		 */
-		if (_scavenger->isConcurrentInProgress())
+		if (_scavenger->isConcurrentCycleInProgress())
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		{
 			MM_RootScanner::scanJNIWeakGlobalReferences(env);

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -774,7 +774,7 @@ MM_StandardAccessBarrier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object
 
 	if ((NULL != _extensions->scavenger) && _extensions->scavenger->isObjectInEvacuateMemory(object)) {
 		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
-		Assert_MM_true(_extensions->scavenger->isConcurrentInProgress());
+		Assert_MM_true(_extensions->scavenger->isConcurrentCycleInProgress());
 		Assert_MM_true(_extensions->scavenger->isMutatorThreadInSyncWithCycle(env));
 
 		MM_ForwardedHeader forwardHeader(object, compressed);
@@ -803,7 +803,7 @@ MM_StandardAccessBarrier::preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcA
 	bool const compressed = compressObjectReferences();
 
 	if ((NULL != _extensions->scavenger) && _extensions->scavenger->isObjectInEvacuateMemory(object)) {
-		Assert_MM_true(_extensions->scavenger->isConcurrentInProgress());
+		Assert_MM_true(_extensions->scavenger->isConcurrentCycleInProgress());
 
 		MM_ForwardedHeader forwardHeader(object, compressed);
 		omrobjectptr_t forwardPtr = forwardHeader.getForwardedObject();
@@ -829,7 +829,7 @@ MM_StandardAccessBarrier::preObjectRead(J9VMThread *vmThread, J9Class *srcClass,
 
 	if ((NULL != _extensions->scavenger) && _extensions->scavenger->isObjectInEvacuateMemory(object)) {
 		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
-		Assert_MM_true(_extensions->scavenger->isConcurrentInProgress());
+		Assert_MM_true(_extensions->scavenger->isConcurrentCycleInProgress());
 		Assert_MM_true(_extensions->scavenger->isMutatorThreadInSyncWithCycle(env));
 
 		MM_ForwardedHeader forwardHeader(object, compressed);
@@ -875,7 +875,7 @@ MM_StandardAccessBarrier::preObjectRead(J9VMThread *vmThread, J9Object *srcObjec
 		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
 		Assert_GC_true_with_message(env, !_extensions->scavenger->isObjectInEvacuateMemory((omrobjectptr_t)srcAddress) || _extensions->isScavengerBackOutFlagRaised(), "readObject %llx in Evacuate\n", srcAddress);
 		if (_extensions->scavenger->isObjectInEvacuateMemory(object)) {
-			Assert_GC_true_with_message2(env, _extensions->scavenger->isConcurrentInProgress(),
+			Assert_GC_true_with_message2(env, _extensions->scavenger->isConcurrentCycleInProgress(),
 					"CS not in progress, found a object in Survivor: slot %llx object %llx\n", srcAddress, object);
 			Assert_MM_true(_extensions->scavenger->isMutatorThreadInSyncWithCycle(env));
 			/* since object is still in evacuate, srcObject has not been scanned yet => we cannot assert

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -813,6 +813,16 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->softwareRangeCheckReadBarrier = true;
 			continue;
 		}
+
+		if (try_scan(&scan_start, "enableConcurrentScavengeExhaustiveTermination")) {
+			extensions->concurrentScavengeExhaustiveTermination = true;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "disableConcurrentScavengeExhaustiveTermination")) {
+			extensions->concurrentScavengeExhaustiveTermination = false;
+			continue;
+		}
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 #endif /* defined(J9VM_GC_MODRON_SCAVENGER) */


### PR DESCRIPTION
Populate VM Hooks and Async Handlers with appropriate OMR methods that
do the useful work (flush copy caches).

Introduced a cmdline option that may enable the components of Exhaustive
CS termination (which is still disabled by default).

Some background https://github.com/eclipse/omr/issues/4787

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>