### PR TITLE
Remove the prefix 'debug-image' from paths in debug info archives

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -281,7 +281,7 @@ def build() {
 def archive_sdk() {
     stage('Archive') {
         def buildDir = "build/${RELEASE}/images/"
-        def debugImageDir = "debug-image"
+        def debugImageDir = "${buildDir}debug-image/"
         def testDir = "test"
 
         dir(OPENJDK_CLONE_DIR) {
@@ -290,18 +290,18 @@ def archive_sdk() {
             if (fileExists("${buildDir}${testDir}")) {
                 if (SPEC.contains('zos')) {
                     // Note: to preserve the files ACLs set _OS390_USTAR=Y env variable (see variable files)
-                    sh "pax  -wvz -s#${buildDir}${testDir}#test-images#g -f ${TEST_FILENAME} ${buildDir}${testDir}"
+                    sh "pax -wvz -s#${buildDir}${testDir}#test-images# -f ${TEST_FILENAME} ${buildDir}${testDir}"
                 } else {
                     sh "tar -C ${buildDir} -zcvf ${TEST_FILENAME} ${testDir} --transform 's,${testDir},test-images,'"
                 }
             }
             // test if the debug-image directory is present
-            if (fileExists("${buildDir}${debugImageDir}")) {
+            if (fileExists("${debugImageDir}")) {
                 if (SPEC.contains('zos')) {
                     // Note: to preserve the files ACLs set _OS390_USTAR=Y env variable (see variable files)
-                    sh "pax  -wvz -s#${buildDir}${debugImageDir}#test-images#g -f ${DEBUG_IMAGE_FILENAME} ${buildDir}${debugImageDir}"
+                    sh "pax -wvz -s#${debugImageDir}## -f ${DEBUG_IMAGE_FILENAME} ${debugImageDir}"
                 } else {
-                    sh "tar -C ${buildDir} -zcvf ${DEBUG_IMAGE_FILENAME} ${debugImageDir}"
+                    sh "tar -C ${debugImageDir} -zcvf ${DEBUG_IMAGE_FILENAME} ."
                 }
             }
             if (params.ARCHIVE_JAVADOC) {
@@ -339,7 +339,7 @@ def archive_sdk() {
                                        "props": "build.buildIdentifier=${BUILD_IDENTIFIER}"]
                     specs.add(javadocSpec)
                 }
-                def uploadFiles =   [files : specs]
+                def uploadFiles = [files : specs]
                 def uploadSpec = JsonOutput.toJson(uploadFiles)
                 upload_artifactory(uploadSpec)
                 env.CUSTOMIZED_SDK_URL = "${ARTIFACTORY_URL}/${ARTIFACTORY_UPLOAD_DIR}${SDK_FILENAME}"


### PR DESCRIPTION
Prior to this change, one would need to use the `--strip-components=1` option:
```
  tar xzf --strip-components=1 debug-image.tar.gz
```
Now, the archive will have the proper structure for use directly:
```
  tar xzf debug-image.tar.gz
```

Fixes: #8757.