### PR TITLE
Improve JITServer functional tests and re-enable them

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -523,7 +523,6 @@
 		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
 	fi; \
 	$(TEST_STATUS)</command>
-		<disabled>https://github.com/eclipse/openj9/issues/8806</disabled>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>

--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -511,7 +511,7 @@
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 		-DSERVER_EXE=$(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) \
 		-DCLIENT_EXE=$(JAVA_COMMAND) \
-		-DCLIENT_PROGRAM=$(SQ)$(JVM_OPTIONS) -cp $(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar -DjarTesterArgs=$(TEST_RESROOT)$(D)jitt.jar org.testng.TestNG -d $(REPORTDIR)$(D)client $(TEST_RESROOT)$(D)testng.xml -testnames JarTesterTest -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE)$(SQ) \
+		-DCLIENT_PROGRAM=$(SQ)$(JVM_OPTIONS) -cp $(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar -DjarTesterArgs=$(Q)-loopforever $(TEST_RESROOT)$(D)jitt.jar$(Q) org.testng.TestNG -d $(REPORTDIR)$(D)client $(TEST_RESROOT)$(D)testng.xml -testnames JarTesterTest -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE)$(SQ) \
 		org.testng.TestNG \
 		-d $(REPORTDIR) \
 		$(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \

--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -92,11 +92,13 @@ public class JITServerTest {
 	private static void dumpProcessLog(final ProcessBuilder b) {
 		File log = b.redirectOutput().file();
 		try {
+			final String topAndBottom = "////////////////////////////////////////////////////////////////////////";
+			final String leftMargin = "//// ";
 			Scanner s = new Scanner(log);
-			System.err.println("Dumping the contents of log file: " + log.getAbsolutePath() + "\n");
+			System.err.println("Dumping the contents of log file: " + log.getAbsolutePath() + "\n" + topAndBottom);
 			while (s.hasNextLine())
-				System.err.println(s.nextLine());
-			System.err.println("");
+				System.err.println(leftMargin + s.nextLine());
+			System.err.println(topAndBottom);
 		}
 		catch (FileNotFoundException e) {
 			System.err.println("Attempted to dump the log file '" + log.getAbsolutePath() + "' but it was not found.\n" + e.getMessage());
@@ -117,9 +119,10 @@ public class JITServerTest {
 
 		// The process may exit normally before we can destroy it so we have to accept two possible return values.
 		if ((exitValue != SUCCESS_RETURN_VALUE) && (exitValue != SIGTERM_RETURN_VALUE)) {
-			System.err.println("Expected a return value of " + SUCCESS_RETURN_VALUE + " or " + SIGTERM_RETURN_VALUE + ", got " + exitValue + " instead.");
+			final String errorText = "Expected an exit value of " + SUCCESS_RETURN_VALUE + " or " + SIGTERM_RETURN_VALUE + ", got " + exitValue + " instead.";
+			System.err.println(errorText);
 			dumpProcessLog(builder);
-			AssertJUnit.fail();
+			AssertJUnit.fail(errorText);
 		}
 	}
 
@@ -129,9 +132,10 @@ public class JITServerTest {
 		final Process p = builder.start();
 		// We expect these processes to be fairly long running; if they exit almost immediately abort the test.
 		if (p.waitFor(PROCESS_START_WAIT_TIME_MS, TimeUnit.MILLISECONDS)) {
-			System.err.println("Failed to start " + name);
+			final String errorText = "Failed to properly start " + name + ", it terminated prematurely with exit value: " + p.exitValue();
+			System.err.println(errorText);
 			dumpProcessLog(builder);
-			AssertJUnit.fail();
+			AssertJUnit.fail(errorText);
 		}
 		return p;
 	}


### PR DESCRIPTION
The patches in this PR 1) make the tests less reliant on timing by making sure the client JVM is constantly generating compilation activity, 2) improve the diagnostic output, and 3) re-enables the tests.