### PR TITLE
(v0.19.0) Fix stackmap always marking ConstantDynamic as objects

### DIFF
--- a/runtime/stackmap/stackmap.c
+++ b/runtime/stackmap/stackmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -349,8 +349,15 @@ mapStack(UDATA *scratch, UDATA totalStack, U_8 * map, J9ROMClass * romClass, J9R
 					index = PARAM_16(bcIndex, 1);
 				}
 
-				if (pool[index].slot2) {
-					PUSH(OBJ);
+				if (0 != pool[index].slot2) {
+					/* Check for primitive values resolved from ConstantDynamic */
+					if ((J9DescriptionCpTypeConstantDynamic == (pool[index].slot2 & J9DescriptionCpTypeMask))
+					&& (0 != (pool[index].slot2 >> J9DescriptionReturnTypeShift))
+					) {
+						PUSH(INT);
+					} else {
+						PUSH(OBJ);
+					}
 				} else {
 					PUSH(INT);
 				}


### PR DESCRIPTION
- Check Condy return type before marking stack slot

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>