### PR TITLE
Transform indexOf call node when receiver is known string

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -171,6 +171,7 @@
    java_lang_String_lengthInternal,
    java_lang_String_indexOf_String,
    java_lang_String_indexOf_String_int,
+   java_lang_String_indexOf_char,
    java_lang_String_indexOf_native,
    java_lang_String_indexOf_fast,
    java_lang_String_isCompressed,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4131,6 +4131,8 @@ static bool foldFinalFieldsIn(const char *className, int32_t classNameLength, TR
       return true;
    else if (classNameLength >= 38 && !strncmp(className, "java/util/concurrent/ThreadLocalRandom", 38))
       return true;
+   else if (classNameLength == 16 && !strncmp(className, "java/lang/String", 16))
+      return true;
    else
       return false;
    }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3115,6 +3115,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_String_equals,              "equals",              "(Ljava/lang/Object;)Z")},
       {x(TR::java_lang_String_indexOf_String,      "indexOf",             "(Ljava/lang/String;)I")},
       {x(TR::java_lang_String_indexOf_String_int,  "indexOf",             "(Ljava/lang/String;I)I")},
+      {x(TR::java_lang_String_indexOf_char,        "indexOf",             "(I)I")},
       {x(TR::java_lang_String_indexOf_native,      "indexOf",             "(II)I")},
       {x(TR::java_lang_String_indexOf_fast,        "indexOf",             "(Ljava/lang/String;Ljava/lang/String;IIC)I")},
       {x(TR::java_lang_String_isCompressed,        "isCompressed",        "()Z")},


### PR DESCRIPTION
Based on my benchmarking, this optimization caused a 10-20% increase in performance on power, a 40-50% increase on Z, and a 30-40% increase on x when measured against the following bumblebench benchmark:

```java
import net.adoptopenjdk.bumblebench.core.MicroBench;
public final class URIParseIntenseBench extends MicroBench {
        public volatile String  uri = "http://192.168.90.176:8080/ping/simple";
        //public volatile String  uri = "http://jones@example.com:98?name=Fred#1";
        public static java.net.URI uriResult = null;
        protected long doBatch(long numIterations) throws InterruptedException {
                long i = 0;
                try {
                        for (i = 0; i < numIterations; ++i) {
                                uriResult = new java.net.URI(uri);
                        }
                } catch (Exception e) {
                        throw new AssertionError("Unexpected exception " + e.toString());
                }
                return i;
        }
}
```

This PR in omr will further simplify the trees generated by this transformation:
https://github.com/eclipse/omr/pull/4904

The above omr PR should be merged first so that the transformations done in this code can have the most benefit.

- Add new method `J9::ValuePropagation::transformIndexOfKnownString` which
  checks if the receiver has a KnownObject or ConstString constraint.
  If so, the call node is replaced by an equivalent constant, icmpeq, or iselect
  node or tree of nodes.

- Add indexOf(I)I as a recognized method so that the above transformations can
  be applied to it.

These changes were originally authored by Andrew Craik who is listed as a
co-author below.

Co-authored-by: Andrew Craik <ajcraik@ca.ibm.com>

Signed-off-by: Ryan Shukla <ryans@ibm.com>