### PR TITLE
WIP: Clean up linkage info

### DIFF
--- a/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/arm/codegen/J9CodeGenerator.cpp
@@ -283,19 +283,10 @@ void J9::ARM::CodeGenerator::doBinaryEncoding()
       cursorInstruction = cursorInstruction->getNext();
       if (isPrivateLinkage && cursorInstruction == j2jEntryInstruction)
          {
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(comp->getReturnInfo());
          TR_ASSERT(_returnTypeInfoInstruction && _returnTypeInfoInstruction->getOpCodeValue() == ARMOp_dd, "assertion failure");
-         ((TR::ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(magicWord);
-         *(uint32_t *)(_returnTypeInfoInstruction->getBinaryEncoding()) = magicWord;
 
-         if (recomp != NULL && recomp->couldBeCompiledAgain())
-            {
-            J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(self()->getCodeStart());
-            if (recomp->useSampling())
-               lkInfo->setSamplingMethodBody();
-            else
-               lkInfo->setCountingMethodBody();
-            }
+         uint32_t linkageInfoWord = self()->initializeLinkageInfo(_returnTypeInfoInstruction->getBinaryEncoding());
+         ((TR::ARMImmInstruction *)_returnTypeInfoInstruction)->setSourceImmediate(linkageInfoWord);
          }
       }
    // Create exception table entries for outlined instructions.

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -32,6 +32,7 @@
 #include "codegen/Relocation.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/MonitorState.hpp"
+#include "codegen/PrivateLinkage.hpp"
 #include "compile/AOTClassInfo.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/OSRData.hpp"
@@ -4991,4 +4992,24 @@ J9::CodeGenerator::getMonClass(TR::Node* monNode)
       if (_monitorMapping[i] == monNode)
          return (TR_OpaqueClassBlock *) _monitorMapping[i+1];
    return 0;
+   }
+
+uint32_t
+J9::CodeGenerator::initializeLinkageInfo(void *linkageInfoPtr)
+   {
+   J9::PrivateLinkage::LinkageInfo *linkageInfo = (J9::PrivateLinkage::LinkageInfo *)linkageInfoPtr;
+
+   TR::Recompilation * recomp = self()->comp()->getRecompilationInfo();
+   if (recomp && recomp->couldBeCompiledAgain())
+      {
+      if (recomp->useSampling())
+         linkageInfo->setSamplingMethodBody();
+      else
+         linkageInfo->setCountingMethodBody();
+      }
+
+   linkageInfo->setReservedWord((self()->getBinaryBufferCursor() - self()->getCodeStart()));
+   linkageInfo->setReturnInfo(self()->comp()->getReturnInfo());
+
+   return linkageInfo->getWord();
    }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5013,3 +5013,9 @@ J9::CodeGenerator::initializeLinkageInfo(void *linkageInfoPtr)
 
    return linkageInfo->getWord();
    }
+
+uint32_t
+J9::CodeGenerator::getJitEntryOffset()
+   {
+   return J9::PrivateLinkage::LinkageInfo::get(self()->getCodeStart())->getReservedWord();
+   }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -541,6 +541,15 @@ public:
     */
    bool supportVMInternalNatives();
 
+   /**
+    * \brief Intializes the Linkage Info word found before the interpreter entry point.
+    *
+    * \param[in] linkageInfo : pointer to the linkage info word
+    *
+    * \return Linkage Info word
+    */
+   uint32_t initializeLinkageInfo(void *linkageInfoPtr);
+
 private:
 
    enum // Flags

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -550,6 +550,11 @@ public:
     */
    uint32_t initializeLinkageInfo(void *linkageInfoPtr);
 
+   /**
+    * \brief Returns the JIT Entry Offset from the Interpreter Entry Point
+    */
+   uint32_t getJitEntryOffset();
+
 private:
 
    enum // Flags

--- a/runtime/compiler/codegen/PrivateLinkage.hpp
+++ b/runtime/compiler/codegen/PrivateLinkage.hpp
@@ -24,6 +24,7 @@
 #define J9_PRIVATELINKAGE_INCL
 
 #include "codegen/Linkage.hpp"
+#include "compile/CompilationTypes.hpp"
 #include "infra/Assert.hpp"
 
 namespace TR { class CodeGenerator; }
@@ -84,6 +85,11 @@ public:
 
       inline uint16_t getReservedWord() { return (_word & ReservedMask) >> 16; }
       inline void setReservedWord(uint16_t w) { _word |= ((w << 16) & ReservedMask); }
+
+      inline TR_ReturnInfo getReturnInfo() { return (TR_ReturnInfo)(_word & ReturnInfoMask); }
+      inline void setReturnInfo(TR_ReturnInfo w) { _word |= (w & ReturnInfoMask); }
+
+      inline uint32_t getWord() { return _word; }
 
       int32_t getJitEntryOffset()
          {


### PR DESCRIPTION
In this PR, the code that sets up the data in the Linkage Info word found right before the interpreter entry point is unified and cleaned up. Additionally, because the ARM implementation is in OpenJ9, it is updated to use the new common code.

The switch for other platforms will happen in OMR (https://github.com/eclipse/omr/pull/4908)