### PR TITLE
Pruning the cards from InterRegionRememberedsets after GMP

### DIFF
--- a/runtime/gc_vlhgc/CycleStateVLHGC.hpp
+++ b/runtime/gc_vlhgc/CycleStateVLHGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@
 #include "VLHGCCycleStats.hpp"
 
 class MM_CycleState;
+class MM_SchedulingDelegate;
 
 /**
  * Per cycle state information
@@ -37,11 +38,13 @@ class MM_CycleStateVLHGC : public MM_CycleState {
 public:
 	MM_VLHGCIncrementStats _vlhgcIncrementStats; /**< Stats for the various phases / operations within an increment */
 	MM_VLHGCCycleStats _vlhgcCycleStats; /**< Stats for the various phases / operations within a cycle */
+	MM_SchedulingDelegate *_schedulingDelegate;
 
 	MM_CycleStateVLHGC()
 		: MM_CycleState()
 		, _vlhgcIncrementStats()
 		, _vlhgcCycleStats()
+		, _schedulingDelegate(NULL)
 	{
 	}
 };

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -848,6 +848,7 @@ MM_IncrementalGenerationalGC::taxationEntryPoint(MM_EnvironmentBase *envModron, 
 		Assert_MM_true(NULL == env->_cycleState);
 		MM_CycleStateVLHGC cycleState;
 		env->_cycleState = &cycleState;
+		cycleState._schedulingDelegate = &_schedulingDelegate;
 		env->_cycleState->_gcCode = MM_GCCode(J9MMCONSTANT_IMPLICIT_GC_DEFAULT);
 		env->_cycleState->_collectionType = MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION;
 		env->_cycleState->_type = OMR_GC_CYCLE_TYPE_VLHGC_PARTIAL_GARBAGE_COLLECT;
@@ -1350,6 +1351,7 @@ MM_IncrementalGenerationalGC::partialGarbageCollectUsingCopyForward(MM_Environme
 
 	/* flush the RSList and RSM from our currently selected regions into the card table since we will rebuild them as we process the table */
 	flushRememberedSetIntoCardTable(env);
+
 	_interRegionRememberedSet->flushBuffersForDecommitedRegions(env);
 
 	Assert_MM_true(env->_cycleState->_markMap == _markMapManager->getPartialGCMap());

--- a/runtime/gc_vlhgc/InterRegionRememberedSet.cpp
+++ b/runtime/gc_vlhgc/InterRegionRememberedSet.cpp
@@ -34,7 +34,6 @@
 #include "CardTable.hpp"
 #include "ClassLoaderRememberedSet.hpp"
 #include "CollectionStatisticsVLHGC.hpp"
-#include "CompressedCardTable.hpp"
 #include "CycleState.hpp"
 #include "Dispatcher.hpp"
 #include "EnvironmentVLHGC.hpp"
@@ -914,7 +913,12 @@ void
 MM_InterRegionRememberedSet::clearFromRegionReferencesForMarkDirect(MM_EnvironmentVLHGC* env)
 {
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
-	MM_CardTable *cardTable = MM_GCExtensions::getExtensions(env)->cardTable;
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	MM_CardTable *cardTable = extensions->cardTable;
+	MM_MarkMap *markMap = NULL;
+	if (static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_schedulingDelegate->isFirstPGCAfterGMP()) {
+		markMap = env->_cycleState->_markMap;
+	}
 	U_64 startTime = j9time_hires_clock();
 
 	GC_HeapRegionIteratorVLHGC regionIterator(_heapRegionManager);
@@ -933,11 +937,12 @@ MM_InterRegionRememberedSet::clearFromRegionReferencesForMarkDirect(MM_Environme
 				while(0 != (card = rsclCardIterator.nextReferencingCard(env))) {
 					MM_HeapRegionDescriptorVLHGC *fromRegion = tableDescriptorForRememberedSetCard(card);
 					Card * cardAddress = rememberedSetCardToCardAddr(env, card);
-					/* Regions that are completely swept after a GMP, might still have outgoing references (thus we consider empty regions too) */
-					if (fromRegion->_markData._shouldMark  || !fromRegion->containsObjects() || isDirtyCardForPartialCollect(env, cardTable, cardAddress)) {
+					/* Regions that are completely swept or parts of regions that are partially swept after a GMP might still have outgoing references. If they do, cards should be removed. */
+					if (fromRegion->_markData._shouldMark  || !cardMayContainObjects(card, fromRegion, markMap) || isDirtyCardForPartialCollect(env, cardTable, cardAddress)) {
 						toRemoveCount += 1;
 						rsclCardIterator.removeCurrentCard(env);
 					}
+
 					totalCountBefore +=1;
 				}
 
@@ -969,8 +974,13 @@ void
 MM_InterRegionRememberedSet::clearFromRegionReferencesForMarkOptimized(MM_EnvironmentVLHGC* env)
 {
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
-	MM_CardTable *cardTable = MM_GCExtensions::getExtensions(env)->cardTable;
-	MM_CompressedCardTable *compressedCardTable = MM_GCExtensions::getExtensions(env)->compressedCardTable;
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	MM_CardTable *cardTable = extensions->cardTable;
+	MM_CompressedCardTable *compressedCardTable = extensions->compressedCardTable;
+	MM_MarkMap *markMap = NULL;
+	if (static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_schedulingDelegate->isFirstPGCAfterGMP()) {
+		markMap = env->_cycleState->_markMap;
+	}
 	U_64 startTime = j9time_hires_clock();
 
 	rebuildCompressedCardTableForMark(env);
@@ -996,16 +1006,16 @@ MM_InterRegionRememberedSet::clearFromRegionReferencesForMarkOptimized(MM_Enviro
 					bool remove = true;
 					if (tableIsReady) {
 						/* Rebuild of Compressed Card Table has been completed - use it */
-						remove = compressedCardTable->isCompressedCardDirtyForPartialCollect(env, convertHeapAddressFromRememberedSetCard(card));
+						remove = isCompressedCardDirtyForPartialCollect(env, card, compressedCardTable, markMap);
 					} else {
 						if (compressedCardTable->isReady()) {
 							tableIsReady = true;
 							/* Rebuild of Compressed Card Table has been completed - use it for first time */
-							remove = compressedCardTable->isCompressedCardDirtyForPartialCollect(env, convertHeapAddressFromRememberedSetCard(card));
+							remove = isCompressedCardDirtyForPartialCollect(env, card, compressedCardTable, markMap);
 						} else {
 							/* rebuild is not complete - look at the region PGC selection and card itself directly */
 							MM_HeapRegionDescriptorVLHGC *fromRegion = tableDescriptorForRememberedSetCard(card);
-							if (fromRegion->containsObjects() && !fromRegion->_markData._shouldMark) {
+							if (cardMayContainObjects(card, fromRegion, markMap) && !fromRegion->_markData._shouldMark) {
 								Card * cardAddress = rememberedSetCardToCardAddr(env, card);
 								remove = isDirtyCardForPartialCollect(env, cardTable, cardAddress);
 							}


### PR DESCRIPTION
	After Global Marking Phase, the cards reference from "free memory"
	should be pruned from InterRegionRememberedsets, in order to
	reuse the free memory in future, currently we have card refresh
	and card pruning in beginning PGC, so piggyback existing logic
	add extra condition for pruning cards related with "free memory"
	in first PGC after GMP.

	- During Rememberedsets flush in the beginning PGC(for
	collection set), extra condition check for dirty card (do not
	dirty card if corresponding MarkMap is 0)
	- During global Rememberedsets prune, extra condition check
	for pruning the card (do remove the card if corresponding
	MarkMap is 0).

depends on: https://github.com/eclipse/omr/pull/4928

Signed-off-by: Lin Hu <linhu@ca.ibm.com>