### PR TITLE
Don't compress debug information for jdk8

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -317,7 +317,7 @@ aarch64_linux_xl:
 # Windows x86 64bits Compressed Pointers
 #========================================#
 x86-64_windows:
-  extends: ['cuda', 'debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
+  extends: ['cuda', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
     11: '/cygdrive/c/openjdk/jdk11'
@@ -350,7 +350,7 @@ x86-64_windows_xl:
 # Windows x86 32bits
 #========================================#
 x86-32_windows:
-  extends: ['debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
+  extends: ['openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
   release:

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -83,6 +83,12 @@ restart_timeout:
   time: '5'
   units: 'HOURS'
 #========================================#
+# Debug information
+#========================================#
+debuginfo:
+  extra_configure_options:
+    8: '--disable-zip-debug-info'
+#========================================#
 # Large heap build
 #========================================#
 largeheap:
@@ -144,7 +150,7 @@ cuda_version:
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#
 ppc64le_linux:
-  extends: ['freemarker', 'openjdk_reference_repo', 'openssl', 'cuda_version']
+  extends: ['cuda_version', 'debuginfo', 'freemarker', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     8: '/usr/lib/jvm/adoptojdk-java-80'
     11: '/usr/lib/jvm/adoptojdk-java-11'
@@ -187,7 +193,7 @@ ppc64le_linux_jit:
 # IBM 7 for the bootJDK or compiling corba will fail to find Object.
 #========================================#
 s390x_linux:
-  extends: ['freemarker', 'openjdk_reference_repo', 'openssl']
+  extends: ['debuginfo', 'freemarker', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     8: '/usr/lib/jvm/adoptojdk-java-s390x-80'
     11: '/usr/lib/jvm/adoptojdk-java-11'
@@ -220,7 +226,7 @@ s390x_linux_jit:
 # AIX PPC 64bits Compressed Pointers
 #========================================#
 ppc64_aix:
-  extends: ['freemarker', 'openjdk_reference_repo', 'openssl']
+  extends: ['debuginfo', 'freemarker', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     8: '/usr/java7'
     11: '/usr/java11_64'
@@ -251,7 +257,7 @@ ppc64_aix:
 # Linux x86 64bits Compressed Pointers
 #========================================#
 x86-64_linux:
-  extends: ['freemarker', 'openjdk_reference_repo', 'openssl', 'cuda_version']
+  extends: ['cuda_version', 'debuginfo', 'freemarker', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     8: '/usr/lib/jvm/jdk-7'
     11: '/usr/lib/jvm/jdk-11'
@@ -294,7 +300,7 @@ x86-64_linux_xl:
 # Linux Aarch 64bits Compressed Pointers
 #========================================#
 aarch64_linux:
-  extends: ['freemarker', 'openjdk_reference_repo', 'openssl']
+  extends: ['debuginfo', 'freemarker', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
     11: '/usr/lib/jvm/adoptojdk-java-11'
   release:
@@ -311,7 +317,7 @@ aarch64_linux_xl:
 # Windows x86 64bits Compressed Pointers
 #========================================#
 x86-64_windows:
-  extends: ['openjdk_reference_repo', 'openssl_bundle', 'cuda']
+  extends: ['cuda', 'debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
     11: '/cygdrive/c/openjdk/jdk11'
@@ -344,7 +350,7 @@ x86-64_windows_xl:
 # Windows x86 32bits
 #========================================#
 x86-32_windows:
-  extends: ['openjdk_reference_repo', 'openssl_bundle']
+  extends: ['debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
   release:
@@ -365,7 +371,7 @@ x86-32_windows:
 # OSX x86 64bits Compressed Pointers
 #========================================#
 x86-64_mac:
-  extends: ['openssl', 'openssl_bundle']
+  extends: ['debuginfo', 'openssl', 'openssl_bundle']
   boot_jdk:
     8: '/Users/jenkins/bootjdks/adoptojdk-java-8'
     11: '/Users/jenkins/bootjdks/adoptojdk-java-11'


### PR DESCRIPTION
Compression is not the default for other jdk versions.