### PR TITLE
Fix valueType array flags

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2894,12 +2894,19 @@ fail:
 				} else {
 					arity = 1;
 					leafComponentType = elementClass;
+					/* For arrays of valueType elements (where componentType is a valuetype), the arrays themselves are not
+					 * valuetypes but they should inherit the layout characteristics (ie. flattenable, etc.)
+					 * of the valuetype elements. A 2D (or more) array of valuetype elements (where leafComponentType is a Valuetype but
+					 * componentType is not) is not direct array array of valuetype elements, therefore it should not inherit any layout
+					 * properties from the leafComponentType. A 2D array is an array of references so it can never be flattened, however, its
+					 * elements may be flattened arrays.
+					 */
+					ramArrayClass->classFlags |= (elementClass->classFlags & (J9ClassIsFlattened | J9ClassLargestAlignmentConstraintReference | J9ClassLargestAlignmentConstraintDouble));
 				}
 				ramArrayClass->leafComponentType = leafComponentType;
 				ramArrayClass->arity = arity;
 				ramArrayClass->componentType = elementClass;
 				ramArrayClass->module = leafComponentType->module;
-				ramArrayClass->classFlags |= ((J9ClassIsValueType | J9ClassIsFlattened) & elementClass->classFlags);
 
 				if (J9_IS_J9CLASS_FLATTENED(elementClass)) {
 					if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintDouble)) {


### PR DESCRIPTION
For arrays of valueType elements (where componentType is a valuetype),
the arrays themselves are not valuetypes but they should inherit the
layout characteristics (ie. flattenable, etc.) of the valuetype
elements. A 2D (or more) array of valuetype elements (where
leafComponentType is a Valuetype but componentType is not) is not direct
array array of valuetype elements, therefore it should not inherit any
layout properties from the leafComponentType. A 2D array is an array of
references so it can never be flattened, however, its elements may be
flattened arrays.

Given `inline class Point { ... }` //value type

`[LPoint;` is an array of valuetype elements, this means that if `Point` is flattened then `[LPoint;` is a flattened array. It also means that `[LPoint;` can never contain a null element. However, `[LPoint;` itself is not a valuetype it has identity (it can be locked), a field of this type can be NULL, etc. 

A two dimensional array of `Point` (`[[LPoint;`) is an array where its element type is `[LPoint;`. Therefore `[[LPoint;` is not an array of valuetype elements, it is just a regular reference array.

This PR ensures that the following is true:
- For a given array, if it contains the `J9ClassIsFlattened` flag in the array classFlags then all the elements are flattened, and the size of each element can be retrieved by using `J9ARRAYCLASS_GET_STRIDE(arrayClass)`. 
- For a given array, if it contains the `J9ClassLargestAlignmentConstraintReference` or `J9ClassLargestAlignmentConstraintReference` flag and the  `J9ClassIsFlattened` is also set then each element requires either reference (compressedRefs size) or double (64bit) alignment. If neither `J9ClassLargestAlignmentConstraintReference` or `J9ClassLargestAlignmentConstraintReference` is present then it requires single (32bit) alginment.

From a GC perspective, valuetype or not valuetype isn't relevant, all that matters is flattened or unflattened. With this change there should be no reason to fetch the element class, all the data should be in the array class.