### PR TITLE
Implement lock reservation frontend queries for JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -429,10 +429,10 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getOSRFrameSizeInBytes(method));
          }
          break;
-      case MessageType::VM_getByteOffsetToLockword:
+      case MessageType::VM_getInitialLockword:
          {
-         TR_OpaqueClassBlock * clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
-         client->write(response, fe->getByteOffsetToLockword(clazz));
+         TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
+         client->write(response, fe->getInitialLockword(clazz));
          }
          break;
       case MessageType::VM_isString1:
@@ -500,6 +500,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._floatInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false)->getMethodAddress();
          vmInfo._doubleInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false)->getMethodAddress();
          vmInfo._interpreterVTableOffset = TR::Compiler->vm.getInterpreterVTableOffset();
+         vmInfo._enableGlobalLockReservation = vmThread->javaVM->enableGlobalLockReservation;
 
          // For multi-layered SCC support
          std::vector<uintptr_t> listOfCacheStartAddress;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1983,8 +1983,6 @@ TR_J9VMBase::getWriteBarrierGCFlagMaskAsByte()
 int32_t
 TR_J9VMBase::getByteOffsetToLockword(TR_OpaqueClassBlock * clazzPointer)
    {
-   J9JavaVM * jvm = _jitConfig->javaVM;
-
    if (clazzPointer == NULL)
       return 0;
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -678,7 +678,7 @@ public:
    virtual int32_t            getByteOffsetToLockword(TR_OpaqueClassBlock *clazzPointer);
    virtual int32_t            getInitialLockword(TR_OpaqueClassBlock* clazzPointer);
 
-   bool                       isEnableGlobalLockReservationSet();
+   virtual bool               isEnableGlobalLockReservationSet();
 
    virtual bool               javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, int32_t &result);
    virtual int32_t            getJavaLangClassHashCode(TR::Compilation * comp, TR_OpaqueClassBlock * clazzPointer, bool &hashCodeComputed);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -90,6 +90,8 @@ public:
    virtual bool isClassInitialized(TR_OpaqueClassBlock * clazz) override;
    virtual UDATA getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method) override;
    virtual int32_t getByteOffsetToLockword(TR_OpaqueClassBlock * clazz) override;
+   virtual int32_t getInitialLockword(TR_OpaqueClassBlock* clazzPointer) override;
+   virtual bool isEnableGlobalLockReservationSet() override;
    virtual bool isString(TR_OpaqueClassBlock * clazz) override;
    virtual void * getMethods(TR_OpaqueClassBlock * clazz) override;
    virtual void getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, List<TR_ResolvedMethod> * resolvedMethodsInClass) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -158,7 +158,7 @@ protected:
    ZeroCopyOutputStream *_outputStream;
 
    static const uint8_t MAJOR_NUMBER = 0;
-   static const uint16_t MINOR_NUMBER = 5;
+   static const uint16_t MINOR_NUMBER = 6;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
    };

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -156,7 +156,7 @@ enum MessageType
    VM_getStaticHookAddress = 228;
    VM_isClassInitialized = 229;
    VM_getOSRFrameSizeInBytes = 230;
-   VM_getByteOffsetToLockword = 231;
+   VM_getInitialLockword = 231;
    VM_isString1 = 232;
    VM_getMethods = 233;
    /* VM_canMethodEnterEventBeHooked = 234; */

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -322,6 +322,7 @@ class ClientSessionData
       void *_floatInvokeExactThunkHelper;
       void *_doubleInvokeExactThunkHelper;
       size_t _interpreterVTableOffset;
+      uint32_t _enableGlobalLockReservation;
       }; // struct VMInfo
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)


### PR DESCRIPTION
A couple of frontend methods related to lock reservation were added
recently to the code base:
```
int32_t TR_J9VMBase::getInitialLockword(TR_OpaqueClassBlock* ramClass)
bool TR_J9VMBase::isEnableGlobalLockReservationSet()
```
At JITServer we need to override those methods to be able to extract
desired information from the client. Caching has been employed for
`isEnableGlobalLockReservationSet()` to reduce the number of messages
exchanged between server and client. For `getInitialLockword()` we
cannot use any caching because the answer depends on some 'per class'
counters which are updated continuously.

Moreover, the implementation of `TR_J9ServerVM::getByteOffsetToLockword()`
has been updated to be in sync with its TR_J9VMBase counterpart.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>