### PR TITLE
AArch64: Define OBJCOPY for native build

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
@@ -64,6 +64,8 @@ ifneq (,$(findstring _cross,$(SPEC)))
 		AR = $(OPENJ9_CC_PREFIX)-ar
 	endif
 	OBJCOPY = $(OPENJ9_CC_PREFIX)-objcopy
+else
+	OBJCOPY ?= objcopy
 endif
 
 CONFIGURE_ARGS += 'AS=$(AS)'


### PR DESCRIPTION
This commit adds a definition of OBJCOPY for native build on AArch64
Linux.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>