### PR TITLE
Support uploading to multiple Artifactory servers

### DIFF
--- a/buildenv/jenkins/ARTIFACTORY.md
+++ b/buildenv/jenkins/ARTIFACTORY.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,13 @@ Edit the file in /home/jenkins/artifactory/etc/binarystore.xml and create the fo
 </config>
 ```
 
+Edit the Artifactory defaults values `/home/jenkins/artifactory/bin/artifactory.default`
+```
+export ARTIFACTORY_HOME=/home/jenkins/artifactory/artifactory-oss-6.5.2
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-ppc64el
+```
+Also for the UNB setup, Artifactory was complaining that `-Xss` should be set to greater than default 256k. I set it to 512k.
+
 # Reverse Proxy
 Next is to install a reverse proxy. In this case, NGINX was installed
 A Reverse Proxy was used so that https can be configured.
@@ -54,9 +61,11 @@ A Reverse Proxy was used so that https can be configured.
 To install NGINX use this command
 ` sudo apt install nginx`
 
-Then the reverse configuration needs to be set
+Then the reverse configuration needs to be set.
 The template for the reverse proxy was taken from https://www.jfrog.com/confluence/display/RTF/Configuring+NGINX and there were some changes to it.
 This is the copy that is currently being used
+
+`/etc/nginx/sites-enabled/artifactory.conf`
 ```
 ## server configuration
 server {
@@ -111,6 +120,48 @@ All of the lines with the `# managed by Certbot` were added when adding in the s
 
 Those lines do not need to be added as they were automatically added by certbot
 
+`/etc/nginx/sites-available/artifactory.conf`
+```
+## server configuration
+server {
+    listen 443 ssl;
+    listen 80 ;
+
+    server_name _;
+    if ($http_x_forwarded_proto = '') {
+        set $http_x_forwarded_proto  $scheme;
+    }
+
+    ## add ssl entries when https has been set in config
+    ssl_certificate      /etc/nginx/ssl/artifactory.crt;
+    ssl_certificate_key  /etc/nginx/ssl/artifactory.key;
+    ssl_session_cache shared:SSL:1m;
+    ssl_prefer_server_ciphers   on;
+
+    ## Application specific logs
+    ## access_log /var/log/nginx/artifactory.log timing;
+    ## error_log /var/log/nginx/artifactory-error.log;
+    rewrite ^/$ /artifactory/webapp/ redirect;
+    rewrite ^/artifactory/?(/webapp)?$ /artifactory/webapp/ redirect;
+    chunked_transfer_encoding on;
+    client_max_body_size 0;
+    location / {
+    proxy_read_timeout  900;
+    proxy_pass_header   Server;
+    proxy_cookie_path   ~*^/.* /;
+    if ( $request_uri ~ ^/artifactory/(.*)$ ) {
+        proxy_pass          http://localhost:8081/artifactory/$1;
+    }
+    proxy_pass         http://localhost:8081/artifactory/;
+    proxy_set_header   Host $host;
+    proxy_set_header    X-Forwarded-Port  $server_port;
+    proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header    Host              $http_host;
+    proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+    }
+}
+```
+
 I am getting my certificate from Let's Encrypt and their install tool certbot. Firstly, I installed certbot:
 ```
 sudo apt-get update
@@ -122,9 +173,26 @@ sudo apt-get install certbot python-certbot-nginx
 ```
 Then I used the certbot automated script to add the certificates and to automatically renew the certificates:
 ```
-sudo certbot -nginx
+sudo certbot --nginx
 ```
 Follow the onscreen instructions and everything should work out.
+
+UNB uses a self-signed certificate. Because it is behind a VPN, Let's Encrypt can't auth the cert.
+
+Create the keys
+https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-apache-in-ubuntu-18-04
+```
+openssl req -x509 -nodes -days 99999 -newkey rsa:2048 -keyout /etc/ssl/private/apache-selfsigned.key -out /etc/ssl/certs/apache-selfsigned.crt
+```
+Update the 2 files above with the key and crt generated from the above command.
+
+Useful nginx commands
+```
+service nginx start
+```
+```
+service nginx reload
+```
 
 # Open the Ports
 Log into OpenStack (https://openpower-controller.osuosl.org/auth/login/?next=/project/) and go to network security groups
@@ -162,6 +230,8 @@ Give the permission a name like `Jenkins-perm` and include the `ci-eclipse-openj
 
 Under the Admin tab on the left side, select Services -> Backups and make sure that they are disabled. To see if they are disabled, click on the backup and see if the enabled button is checked. If it is, uncheck it and save. The backups take up too much memory for what ends up being needed.
 
+Under the Admin tab on the left side, select Configuration -> General Configuration. Disable trash can. Save.
+
 Now logoff of the admin account and log into the Jenkins account. Edit the profile of Jenkins by clicking on Welcome, Jenkins -> Edit Profile. Insert the password to unlock the account and generate the API key. Copy that key to the secrets repo and update Jenkins so that it can upload artifacts.
 
 I also added in a separate shell command to restart Artifactory.
@@ -177,6 +247,35 @@ The command used is `crontab -e`
 This line was added
 ```
 @reboot bash /home/jenkins/artifactory/artifactory-oss-6.5.2/bin/artifactory_restart.sh
+```
+
+# Configure UNB nodes for curl redirection
+
+Create a curl wrapper to redirect OSU requests to UNB. Also strip off user info as the creds will be wrong for the UNB server. Take note of what is default curl before you override.
+```
+/usr/local/bin/curl
+```
+```
+echo $@ | sed 's#--user .*:.* ##' | xargs /usr/bin/curl --resolve 140-211-168-230-openstack.osuosl.org:443:192.168.10.216
+```
+
+# Configure UNB nodes to accept self-signed certificate (upload only)
+
+UNB nodes uploading to UNB Artifactory need to trust the self signed cert. Curl doesn't need it for download since we use the -k option to ignore the cert.
+https://confluence.atlassian.com/kb/how-to-import-a-public-ssl-certificate-into-a-jvm-867025849.html
+
+```
+openssl s_client -connect 192.168.10.216:443 -servername ub18p8art.casa.cs.unb.ca:443 < /dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > public.crt
+```
+Substitute whatever JAVA_HOME the node agent is running.
+```
+/usr/lib/jvm/java-8-openjdk-amd64/bin/keytool -import -alias ub18p8art.casa.cs.unb.ca -keystore /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -file public.crt
+```
+```
+Enter keystore password:changeit
+```
+```
+Trust this certificate? [no]:  y
 ```
 
 # Useful Links

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -48,11 +48,24 @@ adoptopenjdk:
 #========================================#
 # Artifactory settings
 #========================================#
-artifactory_server: 'ci-eclipse-openj9'
-artifactory_repo: 'ci-eclipse-openj9'
-artifactory_num_artifacts: 30
-artifactory_days_to_keep_artifacts: 50
-artifactory_manual_cleanup: true
+artifactory:
+  defaultGeo: 'osu'
+  server:
+    osu: 'ci-eclipse-openj9'
+    unb: 'ci-eclipse-openj9-unb'
+  repo: 'ci-eclipse-openj9'
+  numArtifacts:
+    osu: 30
+    unb: 5
+  daysToKeepArtifacts:
+    osu: 50
+    unb: 2
+  manualCleanup:
+    osu: true
+    unb: true
+  vpn:
+    osu: false
+    unb: true
 #========================================#
 # Miscellaneous settings
 #========================================#

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -52,7 +52,7 @@ artifactory:
   defaultGeo: 'osu'
   server:
     osu: 'ci-eclipse-openj9'
-    unb: 'ci-eclipse-openj9-unb'
+    #unb: 'ci-eclipse-openj9-unb' TEMP DISABLE. See #8817
   repo: 'ci-eclipse-openj9'
   numArtifacts:
     osu: 30


### PR DESCRIPTION
Add support for multiple Artifactory servers

Artifactory bandwidth has become an issue in the CI builds.
This has caused issues with upload and download times, as well
as failing downloads due to infrastructure inadequacy.
Particularly for UNB machines, where a large portion of the
farm is located, combined with the pipe into UNB being small.

Being able to setup multiple Artifactory servers spread across
geographies and colocated with pools of machines will allow us 
to push and more importantly pull from a nearby server.

The design leaves one site as the main (default) server (OSU). We
will always upload to the default server. We will only upload
to a secondary server(s) if there are machines with a matching
platform, colocated with another (non-default) server. The design
is laid out so it will scale with more servers without any code
change other than adding to the defaults.yml config.

Since we cannot determine where a test will land (geographically),
we need to upload to any/all servers that are colocated with machines
of matching platform. We also will always pass the default SDK URL.
We will add a curl wrapper on the nodes which have colocated servers.
This wrapper will redirect requests from one server to another. In 
this case redirect OSU requests to UNB. We will also strip off 
the user/password since a) The servers allow anonymous access and
b) The user's api key will be different for every server.

Changes introduced:
- Redesign the Artifactory config in defaults.yml to support multiple
  servers. Identify servers based on geo(graphy) and identify one
  geo as default.
- Redesign the Artifactory variables as a single hashmap. This keeps
  all the config together. Continue to write out the default server 
  values to env, in order for the parent job to continue as-is.
- Move Artifactory setup onto the compile node. This is needed
  in order to determine where we are compiling and where we need
  to upload.
- Add support for uploading to a server behind a vpn. If we aren't 
  compiling behind the vpn, stash the SDK for later when we can
  grab a node in the same geo as the server we need to push to.
  Note: We cannot publish buildInfo to vpn'd servers. Artifacts
  come from nodes but buildInfo comes from Master, so Master needs
  to see the server.
- Add some more details to the Artifacotry README. Also add more 
  info specific to the UNB setup.

Also:
- Unrelated change to stop adding JAVADOC_LIB_URL to the CUSTOMIZED_SDK_URL.
  CUSTOMIZED_SDK_URL is for test and test doesn't need JAVADOC.

[skip ci]
Issue #8425

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

### 4 use cases
1. Compile & Test with default server (OSU) (eg. zlinux)
1. Compile & Test at UNB (eg. xlinux)
1. Compile at OSU and Test at UNB (eg. plinux)
1. Compile at UNB and Test at OSU (eg. plinux)