### PR TITLE
Improve overflow checking in String classes

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -568,7 +568,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				compressedArrayCopy(data, start, value, 0, length);
 			} else {
-				value = new byte[length * 2];
+				value = StringUTF16.newBytesFor(length);
 				coder = UTF16;
 
 				high <<= 8;
@@ -676,6 +676,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int slen = s.lengthInternal();
 
 		int concatlen = slen + 1;
+		if (concatlen < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
 		// Check if the String is compressed
 		if (enableCompression && (null == compressionFlag || s.coder == LATIN1) && c <= 255) {
@@ -686,7 +690,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			helpers.putByteInArrayByIndex(value, slen, (byte) c);
 		} else {
-			value = new byte[concatlen * 2];
+			value = StringUTF16.newBytesFor(concatlen);
 			coder = UTF16;
 
 			decompressedArrayCopy(s.value, 0, value, 0, slen);
@@ -726,7 +730,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			compress(data, 0, value, 0, data.length);
 		} else {
-			value = new byte[data.length * 2];
+			value = StringUTF16.newBytesFor(data.length);
 			coder = UTF16;
 
 			decompressedArrayCopy(data, 0, value, 0, data.length);
@@ -761,7 +765,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				compress(data, start, value, 0, length);
 			} else {
-				value = new byte[length * 2];
+				value = StringUTF16.newBytesFor(length);
 				coder = UTF16;
 
 				decompressedArrayCopy(data, start, value, 0, length);
@@ -824,7 +828,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				if (start == 0 && data.length == length * 2) {
 					value = data;
 				} else {
-					value = new byte[length * 2];
+					value = StringUTF16.newBytesFor(length);
 
 					decompressedArrayCopy(data, start, value, 0, length);
 				}
@@ -887,7 +891,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				if (sharingIsAllowed && start == 0 && data.length == length * 2) {
 					value = data;
 				} else {
-					value = new byte[length * 2];
+					value = StringUTF16.newBytesFor(length);
 
 					decompressedArrayCopy(data, start, value, 0, length);
 				}
@@ -939,6 +943,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int s2len = s2.lengthInternal();
 
 		int concatlen = s1len + s2len;
+		if (concatlen < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
 		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			value = new byte[concatlen];
@@ -947,7 +955,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			compressedArrayCopy(s1.value, 0, value, 0, s1len);
 			compressedArrayCopy(s2.value, 0, value, s1len, s2len);
 		} else {
-			value = new byte[concatlen * 2];
+			value = StringUTF16.newBytesFor(concatlen);
 			coder = UTF16;
 
 			// Check if the String is compressed
@@ -990,7 +998,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int s2len = s2.lengthInternal();
 		int s3len = s3.lengthInternal();
 
-		int concatlen = s1len + s2len + s3len;
+		long totalLen = (long) s1len + (long) s2len + (long) s3len;
+		if (totalLen > Integer.MAX_VALUE) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
+		int concatlen = (int) totalLen;
 
 		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder | s3.coder) == LATIN1)) {
 			value = new byte[concatlen];
@@ -1000,7 +1013,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			compressedArrayCopy(s2.value, 0, value, s1len, s2len);
 			compressedArrayCopy(s3.value, 0, value, s1len + s2len, s3len);
 		} else {
-			value = new byte[concatlen * 2];
+			value = StringUTF16.newBytesFor(concatlen);
 			coder = UTF16;
 
 			// Check if the String is compressed
@@ -1056,6 +1069,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		// Char length of the final String
 		int len = s1len + v1len;
+		if (len < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
 		if (enableCompression && (null == compressionFlag || s1.coder == LATIN1)) {
 			value = new byte[len];
@@ -1081,7 +1098,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			// Copy in s1 contents
 			compressedArrayCopy(s1.value, 0, value, 0, s1len);
 		} else {
-			value = new byte[len * 2];
+			value = StringUTF16.newBytesFor(len);
 			coder = UTF16;
 
 			// Copy in v1
@@ -1159,7 +1176,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		// Char length of the final String
-		int len = s1len + v1len + v2len + s2len + s3len;
+		long totalLen = (long) s1len + (long) v1len + (long) v2len + (long) s2len + (long) s3len;
+		if (totalLen > Integer.MAX_VALUE) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
+		int len = (int) totalLen;
 
 		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder | s3.coder) == LATIN1)) {
 			value = new byte[len];
@@ -1213,7 +1235,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				helpers.putByteInArrayByIndex(value, index1--, (byte) '-');
 			}
 		} else {
-			value = new byte[len * 2];
+			value = StringUTF16.newBytesFor(len);
 			coder = UTF16;
 
 			int start = len;
@@ -1504,8 +1526,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		int concatlen = s1len + s2len;
+		if (concatlen < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
-		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
+		if (enableCompression && ((null == compressionFlag) || ((s1.coder | s2.coder) == LATIN1))) {
 			byte[] buffer = new byte[concatlen];
 
 			compressedArrayCopy(s1.value, 0, buffer, 0, s1len);
@@ -1513,7 +1539,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			return new String(buffer, LATIN1);
 		} else {
-			byte[] buffer = new byte[concatlen * 2];
+			byte[] buffer = StringUTF16.newBytesFor(concatlen);
 
 			// Check if the String is compressed
 			if (enableCompression && s1.coder == LATIN1) {
@@ -2432,7 +2458,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				return new String(buffer, LATIN1);
 			} else {
-				byte[] buffer = new byte[len * 2];
+				byte[] buffer = StringUTF16.newBytesFor(len);
 
 				decompress(value, 0, buffer, 0, len);
 
@@ -2443,7 +2469,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				return new String(buffer, UTF16);
 			}
 		} else {
-			byte[] buffer = new byte[len * 2];
+			byte[] buffer = StringUTF16.newBytesFor(len);
 
 			decompressedArrayCopy(value, 0, buffer, 0, len);
 
@@ -2692,7 +2718,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		return toLowerCase(Locale.getDefault());
 	}
 
-	private int toLowerCase(int codePoint) {
+	private static int toLowerCase(int codePoint) {
 		if (codePoint < 128) {
 			if ('A' <= codePoint && codePoint <= 'Z') {
 				return codePoint + ('a' - 'A');
@@ -2704,7 +2730,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 	}
 
-	private int toUpperCase(int codePoint) {
+	private static int toUpperCase(int codePoint) {
 		if (codePoint < 128) {
 			if ('a' <= codePoint && codePoint <= 'z') {
 				return codePoint - ('a' - 'A');
@@ -2726,16 +2752,18 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String toLowerCase(Locale locale) {
 		// check locale for null
 		String language = locale.getLanguage();
+		int sLength = lengthInternal();
 
-		if (isEmpty()) {
+		if (sLength == 0) {
 			return this;
 		}
 
-		int sLength = lengthInternal();
+		boolean useIntrinsic = helpers.supportsIntrinsicCaseConversion()
+				&& (language == "en") //$NON-NLS-1$
+				&& (sLength <= (Integer.MAX_VALUE / 2));
 
-		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
-
-			if (helpers.supportsIntrinsicCaseConversion() && language == "en") { //$NON-NLS-1$
+		if (enableCompression && ((null == compressionFlag) || (coder == LATIN1))) {
+			if (useIntrinsic) {
 				byte[] output = new byte[sLength << coder];
 
 				if (helpers.toLowerIntrinsicLatin1(value, output, sLength)) {
@@ -2744,7 +2772,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			}
 			return StringLatin1.toLowerCase(this, value, locale);
 		} else {
-			if (helpers.supportsIntrinsicCaseConversion() && language == "en") { //$NON-NLS-1$
+			if (useIntrinsic) {
 				byte[] output = new byte[sLength << coder];
 
 				if (helpers.toLowerIntrinsicUTF16(value, output, sLength * 2)) {
@@ -2783,16 +2811,18 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public String toUpperCase(Locale locale) {
 		String language = locale.getLanguage();
+		int sLength = lengthInternal();
 
-		if (isEmpty()) {
+		if (sLength == 0) {
 			return this;
 		}
 
-		int sLength = lengthInternal();
+		boolean useIntrinsic = helpers.supportsIntrinsicCaseConversion()
+				&& (language == "en") //$NON-NLS-1$
+				&& (sLength <= (Integer.MAX_VALUE / 2));
 
 		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
-
-			if (helpers.supportsIntrinsicCaseConversion() && language == "en") { //$NON-NLS-1$
+			if (useIntrinsic) {
 				byte[] output = new byte[sLength << coder];
 
 				if (helpers.toUpperIntrinsicLatin1(value, output, sLength)) {
@@ -2801,7 +2831,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			}
 			return StringLatin1.toUpperCase(this, value, locale);
 		} else {
-			if (helpers.supportsIntrinsicCaseConversion() && language == "en") { //$NON-NLS-1$
+			if (useIntrinsic) {
 				byte[] output = new byte[sLength << coder];
 
 				if (helpers.toUpperIntrinsicUTF16(value, output, sLength * 2)) {
@@ -3090,7 +3120,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 					}
 					return new String(newChars, 0, newCharIndex, true);
 				} else if (!enableCompression || !isCompressed()) {
-					byte[] newChars = new byte[length << 1];
+					byte[] newChars = StringUTF16.newBytesFor(length);
 					char toReplace = regex.charAtInternal(0);
 					char replacement = (char)-1; // assign dummy value that will never be used
 					if (substituteLength == 1) {
@@ -3210,8 +3240,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			}
 			java.util.ArrayList<String> parts = new java.util.ArrayList<String>((max > 0 && max < 100) ? max : 10);
 
-			byte[]
-			chars = this.value;
+			byte[] chars = this.value;
 
 			final boolean compressed = enableCompression && (null == compressionFlag || coder == LATIN1);
 
@@ -3233,8 +3262,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			} else {
 				int rLength = regex.lengthInternal();
 
-				byte[]
-				splitChars = regex.value;
+				byte[] splitChars = regex.value;
 
 				char firstChar = charAtInternal(0, regex.value);
 				while (current < end) {
@@ -3614,7 +3642,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int sequence1len = sequence1.length();
 
 		if (sequence1len == 0) {
-			StringBuilder builder = new StringBuilder((len + 1) * sequence2.length());
+			int sequence2len = sequence2.length();
+
+			if ((sequence2len != 0) && (len >= ((Integer.MAX_VALUE - len) / sequence2len))) {
+				/*[MSG "K0D01", "Array capacity exceeded"]*/
+				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+			}
+
+			StringBuilder builder = new StringBuilder(len + ((len + 1) * sequence2len));
 
 			builder.append(sequence2);
 
@@ -3626,26 +3661,29 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			StringBuilder builder = new StringBuilder();
 
-			int start = 0, copyStart = 0, firstIndex;
+			int start = 0;
+			int copyStart = 0;
 
 			char charAt0 = sequence1.charAt(0);
 
 			while (start < len) {
-				if ((firstIndex = indexOf(charAt0, start)) == -1) {
+				int firstIndex = indexOf(charAt0, start);
+
+				if (firstIndex == -1) {
 					break;
 				}
 
 				boolean found = true;
 
-				if (sequence1.length() > 1) {
-					if (firstIndex + sequence1len > len) {
+				if (sequence1len > 1) {
+					if (sequence1len > len - firstIndex) {
+						/* the tail of this string is too short to find sequence1 */
 						break;
 					}
 
 					for (int i = 1; i < sequence1len; i++) {
 						if (charAt(firstIndex + i) != sequence1.charAt(i)) {
 							found = false;
-
 							break;
 						}
 					}
@@ -3936,6 +3974,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		int length = lengthInternal();
+		if (length > Integer.MAX_VALUE / count) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 		int repeatlen = length * count;
 
 		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
@@ -3947,7 +3989,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			return new String(buffer, LATIN1);
 		} else {
-			byte[] buffer = new byte[repeatlen * 2];
+			byte[] buffer = StringUTF16.newBytesFor(repeatlen);
 
 			for (int i = 0; i < count; i++) {
 				decompressedArrayCopy(value, 0, buffer, i * length, length);
@@ -4291,7 +4333,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			if (enableCompression) {
 				if (canEncodeAsLatin1(buffer, 0, buffer.length)) {
-					value = new char[(buffer.length + 1) / 2];
+					value = new char[(buffer.length + 1) >>> 1];
 					count = buffer.length;
 
 					compress(buffer, 0, value, 0, buffer.length);
@@ -4336,7 +4378,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
 			if (enableCompression) {
 				if (high == 0) {
-					value = new char[(length + 1) / 2];
+					value = new char[(length + 1) >>> 1];
 					count = length;
 
 					compressedArrayCopy(data, start, value, 0, length);
@@ -4411,7 +4453,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			if (enableCompression) {
 				if (canEncodeAsLatin1(buffer, 0, buffer.length)) {
-					value = new char[(buffer.length + 1) / 2];
+					value = new char[(buffer.length + 1) >>> 1];
 					count = buffer.length;
 
 					compress(buffer, 0, value, 0, buffer.length);
@@ -4469,11 +4511,15 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int slen = s.lengthInternal();
 
 		int concatlen = slen + 1;
+		if (concatlen < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
 		if (enableCompression) {
 			// Check if the String is compressed
 			if ((null == compressionFlag || s.count >= 0) && c <= 255) {
-				value = new char[(concatlen + 1) / 2];
+				value = new char[(concatlen + 1) >>> 1];
 				count = concatlen;
 
 				compressedArrayCopy(s.value, 0, value, 0, slen);
@@ -4522,7 +4568,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	String(char[] data, boolean ignore) {
 		if (enableCompression) {
 			if (canEncodeAsLatin1(data, 0, data.length)) {
-				value = new char[(data.length + 1) / 2];
+				value = new char[(data.length + 1) >>> 1];
 				count = data.length;
 
 				compress(data, 0, value, 0, data.length);
@@ -4562,7 +4608,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (start >= 0 && 0 <= length && length <= data.length - start) {
 			if (enableCompression) {
 				if (canEncodeAsLatin1(data, start, length)) {
-					value = new char[(length + 1) / 2];
+					value = new char[(length + 1) >>> 1];
 					count = length;
 
 					compress(data, start, value, 0, length);
@@ -4620,7 +4666,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 						value = data;
 						count = length;
 					} else {
-						value = new char[(length + 1) / 2];
+						value = new char[(length + 1) >>> 1];
 						count = length;
 
 						compressedArrayCopy(data, start, value, 0, length);
@@ -4643,7 +4689,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (length == 0) {
 				value = emptyValue;
 				count = 0;
-			} else if (length == 1 && data[start] < 256) {
+			} else if (length == 1 && data[start] <= 255) {
 				char theChar = data[start];
 
 				value = decompressedAsciiTable[theChar];
@@ -4698,7 +4744,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 						value = data;
 						count = length;
 					} else {
-						value = new char[(length + 1) / 2];
+						value = new char[(length + 1) >>> 1];
 						count = length;
 
 						compressedArrayCopy(data, start, value, 0, length);
@@ -4797,10 +4843,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int s2len = s2.lengthInternal();
 
 		int concatlen = s1len + s2len;
+		if (concatlen < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
 		if (enableCompression) {
 			if (null == compressionFlag || (s1.count | s2.count) >= 0) {
-				value = new char[(concatlen + 1) / 2];
+				value = new char[(concatlen + 1) >>> 1];
 				count = concatlen;
 
 				compressedArrayCopy(s1.value, 0, value, 0, s1len);
@@ -4853,12 +4903,17 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int s1len = s1.lengthInternal();
 		int s2len = s2.lengthInternal();
 		int s3len = s3.lengthInternal();
+		long totalLen = (long) s1len + (long) s2len + (long) s3len;
+		if (totalLen > Integer.MAX_VALUE) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
-		int concatlen = s1len + s2len + s3len;
+		int concatlen = (int) totalLen;
 
 		if (enableCompression) {
 			if (null == compressionFlag || (s1.count | s2.count | s3.count) >= 0) {
-				value = new char[(concatlen + 1) / 2];
+				value = new char[(concatlen + 1) >>> 1];
 				count = concatlen;
 
 				compressedArrayCopy(s1.value, 0, value, 0, s1len);
@@ -4927,11 +4982,15 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		// Char length of the final String
 		int len = s1len + v1len;
+		if (len < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
 		if (enableCompression) {
 			// Check if the String is compressed
 			if (null == compressionFlag || s1.count >= 0) {
-				value = new char[(len + 1) / 2];
+				value = new char[(len + 1) >>> 1];
 				count = len;
 
 				// Copy in v1
@@ -5054,11 +5113,17 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		// Char length of the final String
-		int len = s1len + v1len + v2len + s2len + s3len;
+		long totalLen = (long) s1len + (long) v1len + (long) v2len + (long) s2len + (long) s3len;
+		if (totalLen > Integer.MAX_VALUE) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
+
+		int len = (int) totalLen;
 
 		if (enableCompression) {
 			if (null == compressionFlag || (s1.count | s2.count | s3.count) >= 0) {
-				value = new char[(len + 1) / 2];
+				value = new char[(len + 1) >>> 1];
 				count = len;
 
 				int start = len;
@@ -5337,8 +5402,8 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 						helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s1Value, o1++)) -
 						helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s2Value, o2++))) != 0) {
 					return result;
-					}
 				}
+			}
 		} else {
 			while (o1 < end) {
 				if ((result = s1.charAtInternal(o1++, s1Value) - s2.charAtInternal(o2++, s2Value)) != 0) {
@@ -5350,7 +5415,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		return s1len - s2len;
 	}
 
-	private char compareValue(char c) {
+	private static char compareValue(char c) {
 		if (c < 128) {
 			if ('A' <= c && c <= 'Z') {
 				return (char) (c + ('a' - 'A'));
@@ -5360,7 +5425,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		return Character.toLowerCase(Character.toUpperCase(c));
 	}
 
-	private char compareValue(byte b) {
+	private static char compareValue(byte b) {
 		if ('A' <= b && b <= 'Z') {
 			return (char) (helpers.byteToCharUnsigned(b) + ('a' - 'A'));
 		}
@@ -5392,7 +5457,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
 
-		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
+		if (enableCompression && ((null == compressionFlag) || ((s1.count | s2.count) >= 0))) {
 			while (o1 < end) {
 				byte byteAtO1;
 				byte byteAtO2;
@@ -5445,9 +5510,13 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		int concatlen = s1len + s2len;
+		if (concatlen < 0) {
+			/*[MSG "K0D01", "Array capacity exceeded"]*/
+			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+		}
 
-		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
-			char[] buffer = new char[(concatlen + 1) / 2];
+		if (enableCompression && ((null == compressionFlag) || ((s1.count | s2.count) >= 0))) {
+			char[] buffer = new char[(concatlen + 1) >>> 1];
 
 			compressedArrayCopy(s1.value, 0, buffer, 0, s1len);
 			compressedArrayCopy(s2.value, 0, buffer, s1len, s2len);
@@ -5674,15 +5743,15 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			// In order to tell 2 chars are different:
 			// Under string compression, the compressible char set obeys 1-1 mapping for upper/lower case,
 			// converting to lower cases then compare should be sufficient.
-			byte byteAtO1Last = helpers.getByteFromArrayByIndex(s1Value, s1len-1);
-			byte byteAtO2Last = helpers.getByteFromArrayByIndex(s2Value, s1len-1);
+			byte byteAtO1Last = helpers.getByteFromArrayByIndex(s1Value, s1len - 1);
+			byte byteAtO2Last = helpers.getByteFromArrayByIndex(s2Value, s1len - 1);
 
 			if (byteAtO1Last != byteAtO2Last
 					&& toUpperCase(helpers.byteToCharUnsigned(byteAtO1Last)) != toUpperCase(helpers.byteToCharUnsigned(byteAtO2Last))) {
 				return false;
 			}
 
-			while (o1 < end-1) {
+			while (o1 < end - 1) {
 				byte byteAtO1 = helpers.getByteFromArrayByIndex(s1Value, o1++);
 				byte byteAtO2 = helpers.getByteFromArrayByIndex(s2Value, o2++);
 
@@ -5696,22 +5765,22 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			// In order to tell 2 chars are different:
 			// If at least one char is ASCII, converting to upper cases then compare should be sufficient.
 			// If both chars are not in ASCII char set, need to convert to lower case and compare as well.
-			char charAtO1Last = s1.charAtInternal(s1len-1, s1Value);
-			char charAtO2Last = s2.charAtInternal(s1len-1, s2Value);
+			char charAtO1Last = s1.charAtInternal(s1len - 1, s1Value);
+			char charAtO2Last = s2.charAtInternal(s1len - 1, s2Value);
 
 			if (charAtO1Last != charAtO2Last
 					&& toUpperCase(charAtO1Last) != toUpperCase(charAtO2Last)
-					&& ((charAtO1Last < 256 && charAtO2Last < 256) || Character.toLowerCase(charAtO1Last) != Character.toLowerCase(charAtO2Last))) {
+					&& ((charAtO1Last <= 255 && charAtO2Last <= 255) || Character.toLowerCase(charAtO1Last) != Character.toLowerCase(charAtO2Last))) {
 				return false;
 			}
 
-			while (o1 < end-1) {
+			while (o1 < end - 1) {
 				char charAtO1 = s1.charAtInternal(o1++, s1Value);
 				char charAtO2 = s2.charAtInternal(o2++, s2Value);
 
 				if (charAtO1 != charAtO2
 						&& toUpperCase(charAtO1) != toUpperCase(charAtO2)
-						&& ((charAtO1 < 256 && charAtO2 < 256) || Character.toLowerCase(charAtO1) != Character.toLowerCase(charAtO2))) {
+						&& ((charAtO1 <= 255 && charAtO2 <= 255) || Character.toLowerCase(charAtO1) != Character.toLowerCase(charAtO2))) {
 					return false;
 				}
 			}
@@ -6470,7 +6539,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		// Check if the String is compressed
 		if (enableCompression && (null == compressionFlag || count >= 0)) {
 			if (newChar <= 255) {
-				char[] buffer = new char[(len + 1) / 2];
+				char[] buffer = new char[(len + 1) >>> 1];
 
 				compressedArrayCopy(value, 0, buffer, 0, len);
 
@@ -6629,7 +6698,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		return toLowerCase(Locale.getDefault());
 	}
 
-	private int toLowerCase(int codePoint) {
+	private static int toLowerCase(int codePoint) {
 		if (codePoint < 128) {
 			if ('A' <= codePoint && codePoint <= 'Z') {
 				return codePoint + ('a' - 'A');
@@ -6641,7 +6710,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 	}
 
-	private int toUpperCase(int codePoint) {
+	private static int toUpperCase(int codePoint) {
 		if (codePoint < 128) {
 			if ('a' <= codePoint && codePoint <= 'z') {
 				return codePoint - ('a' - 'A');
@@ -6728,20 +6797,19 @@ written authorization of the copyright holder.
 	public String toLowerCase(Locale locale) {
 		// check locale for null
 		String language = locale.getLanguage();
+		int sLength = lengthInternal();
 
-		if (isEmpty()) {
+		if (sLength == 0) {
 			return this;
 		}
 
-		if (helpers.supportsIntrinsicCaseConversion() && language == "en") { //$NON-NLS-1$
-			int sLength = lengthInternal();
-
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
-				char[] output = new char[(sLength + 1) / 2];
+		if (helpers.supportsIntrinsicCaseConversion() && (language == "en")) { //$NON-NLS-1$
+			if (enableCompression && ((null == compressionFlag) || (count >= 0))) {
+				char[] output = new char[(sLength + 1) >>> 1];
 				if (helpers.toLowerIntrinsicLatin1(value, output, sLength)) {
 					return new String(output, 0, sLength, true);
 				}
-			} else {
+			} else if (sLength <= (Integer.MAX_VALUE / 2)) {
 				char[] output = new char[sLength];
 				if (helpers.toLowerIntrinsicUTF16(value, output, sLength * 2)) {
 					return new String(output, 0, sLength, false);
@@ -6868,7 +6936,7 @@ written authorization of the copyright holder.
 		int high = data.length - 1;
 
 		while (low <= high) {
-			mid = (low + high) >> 1;
+			mid = (low + high) >>> 1;
 
 			value = data[mid];
 
@@ -6957,11 +7025,11 @@ written authorization of the copyright holder.
 		return false;
 	}
 
-	private boolean isWordPart(int codePoint) {
+	private static boolean isWordPart(int codePoint) {
 		return codePoint == 0x345 || isWordStart(codePoint);
 	}
 
-	private boolean isWordStart(int codePoint) {
+	private static boolean isWordStart(int codePoint) {
 		int type = Character.getType(codePoint);
 
 		return (type >= Character.UPPERCASE_LETTER && type <= Character.TITLECASE_LETTER) || (codePoint >= 0x2B0 && codePoint <= 0x2B8)
@@ -7004,7 +7072,7 @@ written authorization of the copyright holder.
 	 *
 	 * @return the index into the upperValues table, or -1
 	 */
-	private int upperIndex(int ch) {
+	private static int upperIndex(int ch) {
 		int index = -1;
 
 		if (ch <= 0x587) {
@@ -7061,22 +7129,21 @@ written authorization of the copyright holder.
 	 */
 	public String toUpperCase(Locale locale) {
 		String language = locale.getLanguage();
+		int sLength = lengthInternal();
 
-		if (isEmpty()) {
+		if (sLength == 0) {
 			return this;
 		}
 
-		if (helpers.supportsIntrinsicCaseConversion() && language == "en") { //$NON-NLS-1$
-			int sLength = lengthInternal();
-
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
-				char[] output = new char[(sLength + 1) / 2];
-				if (helpers.toUpperIntrinsicLatin1(value, output, sLength)){
+		if (helpers.supportsIntrinsicCaseConversion() && (language == "en")) { //$NON-NLS-1$
+			if (enableCompression && ((null == compressionFlag) || (count >= 0))) {
+				char[] output = new char[(sLength + 1) >>> 1];
+				if (helpers.toUpperIntrinsicLatin1(value, output, sLength)) {
 					return new String(output, 0, sLength, true);
 				}
-			} else {
+			} else if (sLength <= (Integer.MAX_VALUE / 2)) {
 				char[] output = new char[sLength];
-				if (helpers.toUpperIntrinsicUTF16(value, output, sLength * 2)){
+				if (helpers.toUpperIntrinsicUTF16(value, output, sLength * 2)) {
 					return new String(output, 0, sLength, false);
 				}
 			}
@@ -7406,7 +7473,7 @@ written authorization of the copyright holder.
 			int length = lengthInternal();
 			if (substituteLength < 2) {
 				if (enableCompression && isCompressed() && (substituteLength == 0 || substitute.isCompressed())) {
-					char[] newChars = new char[(length + 1) >> 1];
+					char[] newChars = new char[(length + 1) >>> 1];
 					byte toReplace = helpers.getByteFromArrayByIndex(regex.value, 0);
 					byte replacement = (byte)-1;  // assign dummy value that will never be used
 					if (substituteLength == 1) {
@@ -7679,7 +7746,7 @@ written authorization of the copyright holder.
 			}
 
 			if (canEncodeAsLatin1) {
-				value = new char[(size + 1) / 2];
+				value = new char[(size + 1) >>> 1];
 				count = size;
 
 				for (int i = start, j = 0; i < start + length; ++i) {
@@ -8018,7 +8085,14 @@ written authorization of the copyright holder.
 		int sequence1len = sequence1.length();
 
 		if (sequence1len == 0) {
-			StringBuilder builder = new StringBuilder((len + 1) * sequence2.length());
+			int sequence2len = sequence2.length();
+
+			if ((sequence2len != 0) && (len >= ((Integer.MAX_VALUE - len) / sequence2len))) {
+				/*[MSG "K0D01", "Array capacity exceeded"]*/
+				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
+			}
+
+			StringBuilder builder = new StringBuilder(len + ((len + 1) * sequence2len));
 
 			builder.append(sequence2);
 
@@ -8030,26 +8104,29 @@ written authorization of the copyright holder.
 		} else {
 			StringBuilder builder = new StringBuilder();
 
-			int start = 0, copyStart = 0, firstIndex;
+			int start = 0;
+			int copyStart = 0;
 
 			char charAt0 = sequence1.charAt(0);
 
 			while (start < len) {
-				if ((firstIndex = indexOf(charAt0, start)) == -1) {
+				int firstIndex = indexOf(charAt0, start);
+
+				if (firstIndex == -1) {
 					break;
 				}
 
 				boolean found = true;
 
-				if (sequence1.length() > 1) {
-					if (firstIndex + sequence1len > len) {
+				if (sequence1len > 1) {
+					if (sequence1len > len - firstIndex) {
+						/* the tail of this string is too short to find sequence1 */
 						break;
 					}
 
 					for (int i = 1; i < sequence1len; i++) {
 						if (charAt(firstIndex + i) != sequence1.charAt(i)) {
 							found = false;
-
 							break;
 						}
 					}
@@ -8175,7 +8252,7 @@ written authorization of the copyright holder.
 
 			if (enableCompression) {
 				if (canEncodeAsLatin1(chars, 0, chars.length)) {
-					value = new char[(chars.length + 1) / 2];
+					value = new char[(chars.length + 1) >>> 1];
 					count = chars.length;
 
 					compress(chars, 0, value, 0, chars.length);

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1,7 +1,4 @@
 /*[INCLUDE-IF Sidecar16 & !Sidecar19-SE]*/
-
-package java.lang;
-
 /*******************************************************************************
  * Copyright (c) 2005, 2020 IBM Corp. and others
  *
@@ -23,14 +20,15 @@ package java.lang;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package java.lang;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Properties;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.InvalidObjectException;
 
 /**
  * StringBuilder is not thread safe. For a synchronized implementation, use
@@ -56,13 +54,11 @@ import java.io.InvalidObjectException;
  * 
  * @since 1.5
  */
- 
 public final class StringBuilder extends AbstractStringBuilder implements Serializable, CharSequence, Appendable {
 	private static final long serialVersionUID = 4383685877147921099L;
 	
 	private static final int INITIAL_SIZE = 16;
-	
-	
+
 	private static boolean TOSTRING_COPY_BUFFER_ENABLED = false;
 	private static boolean growAggressively = false;
 	
@@ -83,23 +79,23 @@ public final class StringBuilder extends AbstractStringBuilder implements Serial
 	private int decompress(int min) {
 		int currentLength = lengthInternal();
 		int currentCapacity = capacityInternal();
-		
-		char[] newValue = null;
-		
+		char[] newValue;
+
 		if (min > currentCapacity) {
+			/* twice may be negative, in which case we'll use min */
 			int twice = (currentCapacity << 1) + 2;
-			
+
 			newValue = new char[min > twice ? min : twice];
 		} else {
 			newValue = new char[currentCapacity];
 		}
 
 		String.decompress(value, 0, newValue, 0, currentLength);
-		
+
 		count = count | uncompressedBit;
 		value = newValue;
 		capacity = newValue.length;
-		
+
 		String.initCompressionFlag();
 		return capacity;
 	}
@@ -129,11 +125,7 @@ public StringBuilder(int capacity) {
 	int arraySize = capacity;
 	
 	if (String.enableCompression) {
-		if (capacity == Integer.MAX_VALUE) {
-			arraySize = (capacity / 2) + 1;
-		} else {
-			arraySize = (capacity + 1) / 2;
-		}
+		arraySize = (capacity + 1) >>> 1;
 	}
 	value = new char[arraySize];
 	
@@ -157,11 +149,7 @@ public StringBuilder (String string) {
 	
 	if (String.enableCompression) {
 		if (string.isCompressed ()) {
-			if (newLength == Integer.MAX_VALUE) {
-				value = new char[(newLength / 2) + 1];
-			} else {
-				value = new char[(newLength + 1) / 2];
-			}
+			value = new char[(newLength + 1) >>> 1];
 
 			capacity = newLength;
 			
@@ -203,7 +191,7 @@ public StringBuilder append (char[] chars) {
 	int currentCapacity = capacityInternal();
 	
 	int newLength = currentLength + chars.length;
-	if (newLength < currentLength) {
+	if (newLength < 0) {
 		/*[MSG "K0D01", "Array capacity exceeded"]*/
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
@@ -264,7 +252,7 @@ public StringBuilder append (char chars[], int start, int length) {
 		int currentCapacity = capacityInternal();
 		
 		int newLength = currentLength + length;
-		if (newLength < currentLength) {
+		if (newLength < 0) {
 			/*[MSG "K0D01", "Array capacity exceeded"]*/
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
@@ -314,7 +302,7 @@ StringBuilder append (char[] chars, int start, int length, boolean compressed) {
 	int currentCapacity = capacityInternal();
 	
 	int newLength = currentLength + length;
-	if (newLength < currentLength) {
+	if (newLength < 0) {
 		/*[MSG "K0D01", "Array capacity exceeded"]*/
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
@@ -371,12 +359,13 @@ StringBuilder append (char[] chars, int start, int length, boolean compressed) {
  * @param		ch	a character
  * @return		this StringBuilder
  */
+@Override
 public StringBuilder append(char ch) {
 	int currentLength = lengthInternal();
 	int currentCapacity = capacityInternal();
 	
 	int newLength = currentLength + 1;
-	if (newLength < currentLength) {
+	if (newLength < 0) {
 		/*[MSG "K0D01", "Array capacity exceeded"]*/
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
@@ -464,7 +453,7 @@ public StringBuilder append(int value) {
 			}
 
 			int newLength = currentLength + valueLength;
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
@@ -513,7 +502,7 @@ public StringBuilder append(long value) {
 			}
 
 			int newLength = currentLength + valueLength;
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
@@ -566,7 +555,7 @@ public StringBuilder append (String string) {
 	int stringLength = string.lengthInternal();
 	
 	int newLength = currentLength + stringLength;
-	if (newLength < currentLength) {
+	if (newLength < 0) {
 		/*[MSG "K0D01", "Array capacity exceeded"]*/
 		throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 	}
@@ -655,6 +644,7 @@ int capacityInternal() {
  * @exception	IndexOutOfBoundsException when {@code index < 0} or
  *				{@code index >= length()}
  */
+@Override
 public char charAt(int index) {
 	int currentLength = lengthInternal();
 	
@@ -804,17 +794,11 @@ private void ensureCapacityImpl(int min) {
 	
 	// Check if the StringBuilder is compressed
 	if (String.enableCompression && count >= 0) {
-		char[] newData;
-		if (newLength == Integer.MAX_VALUE) { 
-			newData = new char[(newLength / 2) + 1];
-		} else {
-			newData = new char[(newLength + 1) / 2];
-		}
+		char[] newData = new char[(newLength + 1) >>> 1];
 		
 		String.compressedArrayCopy(value, 0, newData, 0, currentLength);
 		
 		value = newData;
-		
 	} else {
 		char[] newData = new char[newLength];
 		
@@ -1201,6 +1185,7 @@ public StringBuilder insert(int index, boolean value) {
  *
  * @return		the number of characters in this StringBuilder
  */
+@Override
 public int length() {
 	return lengthInternal();
 }
@@ -1244,18 +1229,13 @@ private void move(int size, int index) {
 			newLength = currentCapacity;
 		} else {
 			newLength = Integer.max(currentLength + size, (currentCapacity << 1) + 2);
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
 		}
 
-		char[] newData;
-		if (newLength == Integer.MAX_VALUE) {
-			newData = new char[(newLength / 2) + 1];
-		} else {
-			newData = new char[(newLength + 1) / 2];
-		}
+		char[] newData = new char[(newLength + 1) >>> 1];
 		
 		String.compressedArrayCopy(value, 0, newData, 0, index);
 		String.compressedArrayCopy(value, index, newData, index + size, currentLength - index);
@@ -1277,7 +1257,7 @@ private void move(int size, int index) {
 			newLength = currentCapacity;
 		} else {
 			newLength = Integer.max(currentLength + size, (currentCapacity << 1) + 2);
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
@@ -1778,6 +1758,7 @@ static void initFromSystemProperties(Properties props) {
  *
  * @return		a String containing the characters in this StringBuilder
  */
+@Override
 public String toString () {
 	int currentLength = lengthInternal();
 	int currentCapacity = capacityInternal();
@@ -1846,11 +1827,7 @@ private void readObject(ObjectInputStream stream) throws IOException, ClassNotFo
 	
 	if (String.enableCompression) {
 		if (String.canEncodeAsLatin1(streamValue, 0, streamValue.length)) {
-			if (streamValue.length == Integer.MAX_VALUE) {
-				value = new char[(streamValue.length / 2) + 1];
-			} else {
-				value = new char[(streamValue.length + 1) / 2];
-			}
+			value = new char[(streamValue.length + 1) >>> 1];
 			
 			String.compress(streamValue, 0, value, 0, streamValue.length);
 			
@@ -1909,6 +1886,7 @@ public StringBuilder append(StringBuffer buffer) {
  * @exception	IndexOutOfBoundsException when {@code start < 0, start > end} or
  *				{@code end > length()}
  */
+@Override
 public CharSequence subSequence(int start, int end) {
 	return substring(start, end);
 }
@@ -1982,7 +1960,8 @@ public int indexOf(String subString, int start) {
 				int o1 = i;
 				int o2 = 0;
 				
-				while (++o2 < subStringLength && helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, ++o1)) == subString.charAtInternal(o2));
+				while (++o2 < subStringLength && helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, ++o1)) == subString.charAtInternal(o2))
+					;
 				
 				if (o2 == subStringLength) {
 					return i;
@@ -2011,7 +1990,8 @@ public int indexOf(String subString, int start) {
 				int o1 = i;
 				int o2 = 0;
 				
-				while (++o2 < subStringLength && value[++o1] == subString.charAtInternal(o2));
+				while (++o2 < subStringLength && value[++o1] == subString.charAtInternal(o2))
+					;
 				
 				if (o2 == subStringLength) {
 					return i;
@@ -2092,7 +2072,8 @@ public int lastIndexOf(String subString, int start) {
 					int o1 = i;
 					int o2 = 0;
 					
-					while (++o2 < subStringLength && helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, ++o1)) == subString.charAtInternal(o2));
+					while (++o2 < subStringLength && helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, ++o1)) == subString.charAtInternal(o2))
+						;
 					
 					if (o2 == subStringLength) {
 						return i;
@@ -2120,7 +2101,8 @@ public int lastIndexOf(String subString, int start) {
 					int o1 = i;
 					int o2 = 0;
 					
-					while (++o2 < subStringLength && value[++o1] == subString.charAtInternal(o2));
+					while (++o2 < subStringLength && value[++o1] == subString.charAtInternal(o2))
+						;
 					
 					if (o2 == subStringLength) {
 						return i;
@@ -2176,11 +2158,7 @@ public StringBuilder(CharSequence sequence) {
 	}
 	
 	if (String.enableCompression) {
-		if (newLength == Integer.MAX_VALUE) { 
-			value = new char[(newLength / 2) + 1];
-		} else {
-			value = new char[(newLength + 1) / 2];
-		}
+		value = new char[(newLength + 1) >>> 1];
 	} else {
 		value = new char[newLength];
 	}
@@ -2236,6 +2214,7 @@ public StringBuilder(CharSequence sequence) {
  * @param		sequence	the CharSequence
  * @return		this StringBuilder
  */
+@Override
 public StringBuilder append(CharSequence sequence) {
 	if (sequence == null) {
 		return append(String.valueOf(sequence));
@@ -2259,7 +2238,7 @@ public StringBuilder append(CharSequence sequence) {
 		int sequenceLength = sequence.length();
 		
 		int newLength = currentLength + sequenceLength;
-		if (newLength < currentLength) {
+		if (newLength < 0) {
 			/*[MSG "K0D01", "Array capacity exceeded"]*/
 			throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 		}
@@ -2331,6 +2310,7 @@ public StringBuilder append(CharSequence sequence) {
  * @exception	IndexOutOfBoundsException when {@code start < 0, start > end} or
  *				{@code end > length()}
  */
+@Override
 public StringBuilder append(CharSequence sequence, int start, int end) {
 	if (sequence == null) {
 		return append(String.valueOf(sequence), start, end);
@@ -2341,7 +2321,7 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
 			int currentLength = lengthInternal();
 			int currentCapacity = capacityInternal();
 			int newLength = currentLength + end - start;
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
@@ -2408,7 +2388,7 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
 			int currentCapacity = capacityInternal();
 			
 			int newLength = currentLength + end - start;
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}
@@ -2894,7 +2874,7 @@ public StringBuilder appendCodePoint(int codePoint) {
 			int currentCapacity = capacityInternal();
 
 			int newLength = currentLength + 2;
-			if (newLength < currentLength) {
+			if (newLength < 0) {
 				/*[MSG "K0D01", "Array capacity exceeded"]*/
 				throw new OutOfMemoryError(com.ibm.oti.util.Msg.getString("K0D01")); //$NON-NLS-1$
 			}


### PR DESCRIPTION
* fix char array length computation to handle Integer.MAX_VALUE
* check length in private String constructors
* check length in String.concat()
* check length in String.repeat()
* check length in String.replace(CharSequence, CharSequence)
* use StringUTF16.newBytesFor() to allocate byte arrays for jdk11+ uncompressed strings
* compare chars with 255 consistently (not 256 some places)
* make private methods static where possible
* avoid using intrinsics if byte count would exceed Integer.MAX_VALUE