### PR TITLE
Fix double read in KnownObjectTable at JITServer

### DIFF
--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -135,7 +135,6 @@ J9::KnownObjectTable::getIndexAt(uintptrj_t *objectReferenceLocation)
       {
       auto stream = TR::CompilationInfo::getStream();
       stream->write(JITServer::MessageType::KnownObjectTable_getIndexAt, objectReferenceLocation);
-      auto recv = stream->read<TR::KnownObjectTable::Index>();
       result = std::get<0>(stream->read<TR::KnownObjectTable::Index>());
 
       updateKnownObjectTableAtServer(result, objectReferenceLocation);


### PR DESCRIPTION
This commit fixes a bug of Known Object Table support for JITServer
where the server attempts to read twice the same piece of data.

Closes: #8836

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>