### PR TITLE
Add java/lang/StringUTF16.newBytesFor to alwaysWorthInlining list

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -205,6 +205,7 @@
 
    java_lang_StringUTF16_getChar,
    java_lang_StringUTF16_indexOf,
+   java_lang_StringUTF16_newBytesFor,
    java_lang_StringUTF16_toBytes,
 
    java_lang_StringBuffer_append,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3526,6 +3526,7 @@ void TR_ResolvedJ9Method::construct()
       {
       { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",        "([BI)C")},
       { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",        "([BI[BII)I")},
+      { x(TR::java_lang_StringUTF16_newBytesFor,                              "newBytesFor",    "(I)[B")},
       { x(TR::java_lang_StringUTF16_toBytes,                                  "toBytes",        "([CII)[B")},
       { TR::unknownMethod }
       };

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -375,6 +375,7 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_StringBuffer_lengthInternalUnsynchronized:
       case TR::java_lang_StringBuilder_capacityInternal:
       case TR::java_lang_StringBuilder_lengthInternal:
+      case TR::java_lang_StringUTF16_newBytesFor:
       case TR::java_util_HashMap_get:
       case TR::java_util_HashMap_getNode:
       case TR::java_lang_String_getChars_charArray:


### PR DESCRIPTION
As part of #8830 we started using this API in several String
constructors which are quite performance sensitive. Rather than relying
on frequency information always being correct we simply force the
inlining of this small method which will exposed the allocation of the
array which we will store into the String object.

Closes: #8831

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>