### PR TITLE
AIX: Create .debuginfo file for JIT shared library

### DIFF
--- a/runtime/compiler/build/rules/aix-xlc/common.mk
+++ b/runtime/compiler/build/rules/aix-xlc/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@ JIT_PRODUCT_OBJECTS=$(patsubst %,$(FIXED_OBJBASE)/%.o,$(basename $(JIT_PRODUCT_S
 
 # Figure out the name of the .so file
 JIT_PRODUCT_SONAME=$(FIXED_DLL_DIR)/lib$(PRODUCT_NAME).so
+JIT_PRODUCT_DEBUGINFO=$(JIT_PRODUCT_SONAME:.so=.debuginfo)
 
 # Add build name to JIT
 JIT_PRODUCT_BUILDNAME_SRC=$(FIXED_OBJBASE)/omr/compiler/env/TRBuildName.cpp
@@ -43,11 +44,15 @@ jit: $(JIT_PRODUCT_SONAME)
 
 $(JIT_PRODUCT_SONAME): $(JIT_PRODUCT_OBJECTS) | jit_createdirs
 	$(SOLINK_CMD) $(SOLINK_FLAGS) $(patsubst %,-L%,$(SOLINK_LIBPATH)) -o $@ $(SOLINK_PRE_OBJECTS) $(JIT_PRODUCT_OBJECTS) $(SOLINK_POST_OBJECTS) $(patsubst %,-l%,$(SOLINK_SLINK)) $(SOLINK_EXTRA_ARGS)
+ifeq ($(BUILD_CONFIG),prod)
+	cp -f $@ $(JIT_PRODUCT_DEBUGINFO)
+	strip -X32_64 -t $@
+endif
 
 JIT_DIR_LIST+=$(dir $(JIT_PRODUCT_SONAME))
 
 jit_cleandll::
-	rm -f $(JIT_PRODUCT_SONAME)
+	rm -f $(JIT_PRODUCT_SONAME) $(JIT_PRODUCT_DEBUGINFO)
 
 $(call RULE.cpp,$(JIT_PRODUCT_BUILDNAME_OBJ),$(JIT_PRODUCT_BUILDNAME_SRC))
 


### PR DESCRIPTION
See also https://github.com/eclipse/openj9/pull/8686

On AIX the .debuginfo file is a copy of the original .so file before debug symbol table information is stripped.