### PR TITLE
(0.20.0) Query CodeGenerator recompilation capability to decide recompilation

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -526,6 +526,12 @@ J9::Compilation::isShortRunningMethod(int32_t callerIndex)
 bool
 J9::Compilation::isRecompilationEnabled()
    {
+
+   if (!self()->cg()->getSupportsRecompilation())
+      {
+      return false;
+      }
+
    if (self()->isDLT())
       {
       return false;


### PR DESCRIPTION
Modify `Compilation::isRecompilationEnabled()` to deny recompilation if
the target CodeGenerator does not support it.

Original PR merged into master: #8812

Signed-off-by: Daryl Maier <maier@ca.ibm.com>