### PR TITLE
(v0.20.0) AArch64: Disable j9sysinfo_test_get_levels_and_types()

### DIFF
--- a/runtime/tests/port/si.c
+++ b/runtime/tests/port/si.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2273,9 +2273,9 @@ j9sysinfo_runTests(struct J9PortLibrary *portLibrary, char *argv0)
 	rc |= j9sysinfo_test_get_groups(portLibrary);
 #endif /* !(defined(WIN32) || defined(WIN64)) */
 	rc |= j9sysinfo_test_get_l1dcache_line_size(portLibrary);
-#if !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM) || defined(OSX))
+#if !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM) || defined(J9AARCH64) || defined(OSX))
 	rc |= j9sysinfo_test_get_levels_and_types(portLibrary);
-#endif /* !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM) || defined(OSX)) */
+#endif /* !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM) || defined(J9AARCH64) || defined(OSX)) */
 #if defined(LINUX) || defined(AIXPPC)
 	/* Not supported on Z & OSX (and Windows, of course).  Enable, when available. */
 	rc |= j9sysinfo_test_get_open_file_count(portLibrary);


### PR DESCRIPTION
This commit disables running j9sysinfo_test_get_levels_and_types()
on AArch64.

Original PR for master: #8711

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>