### PR TITLE
JDK15 : Add loadLibraryWithPath package access APIs & Invoke registerBootstrapLibrary() in JVM_LoadLibrary

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1957,6 +1957,15 @@ static void loadLibrary(Class<?> caller, String name, boolean fullPath) {
 		loadLibraryWithClassLoader(name, caller.getClassLoaderImpl());
 }
 
+/*[IF Java15]*/
+static void loadLibrary(Class<?> caller, File file) {
+	loadLibraryWithPath(file.getAbsolutePath(), caller.getClassLoaderImpl(), null);
+}
+static void loadLibrary(Class<?> caller, String libName) {
+	loadLibraryWithClassLoader(libName, caller.getClassLoaderImpl());
+}
+/*[ENDIF] Java15 */
+
 /**
  * Sets the assertion status of a class.
  *

--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2018 IBM Corp. and others
+// Copyright (c) 2006, 2020 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,9 +183,9 @@ TraceExit=Trc_SC_LatestUserDefinedLoader_Exit Overhead=1 Level=3 Template="JVM_L
 TraceEntry=Trc_SC_Listen_Entry NoEnv Overhead=1 Level=1 Template="JVM_Listen(descriptor=%d, count=%d)"
 TraceExit=Trc_SC_Listen_Exit NoEnv Overhead=1 Level=1 Template="JVM_Listen -- return %d"
 
-TraceEntry=Trc_SC_LoadLibrary_Entry NoEnv Overhead=1 Level=1 Template="JVM_LoadLibrary(name=%s)"
+TraceEntry=Trc_SC_LoadLibrary_Entry NoEnv Overhead=1 Level=2 Template="JVM_LoadLibrary(name=%s)"
 TraceExit-Exception=Trc_SC_LoadLibrary_Error Obsolete NoEnv Overhead=1 Level=1 Template="JVM_LoadLibrary -- error. Return %d"
-TraceExit=Trc_SC_LoadLibrary_Exit NoEnv Overhead=1 Level=1 Template="JVM_LoadLibrary -- return %d"
+TraceExit=Trc_SC_LoadLibrary_Exit NoEnv Overhead=1 Level=2 Template="JVM_LoadLibrary -- return %d"
 
 TraceEntry=Trc_SC_Lseek_Entry NoEnv Overhead=1 Level=3 Template="JVM_Lseek(descriptor=%d, bytesToSeek=%lld, origin=%d)"
 TraceExit-Exception=Trc_SC_Lseek_bad_descriptor NoEnv Overhead=1 Level=1 Template="invalid descriptor"

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3577,69 +3577,26 @@ JVM_LoadSystemLibrary(const char *libName)
  *	DLL: jvm
  */
 
-/* NOTE THIS IS NOT REQUIRED FOR 1.4 */
+/* NOTE this is required by JDK15+ jdk.internal.loader.NativeLibraries.load().
+ *  it is only invoked by jdk.internal.loader.BootLoader.loadLibrary(),
+ */
 
 void* JNICALL
-JVM_LoadLibrary(const char *libName)
+JVM_LoadLibrary(const char* libName)
 {
-	JNIEnv *env;
-	JavaVM *vm = (JavaVM *) BFUjavaVM;
-	char errMsg[512];
-
-#ifdef WIN32
-	HINSTANCE dllHandle;
-	UINT prevMode;
+	void* result = NULL;
+	J9NativeLibrary* nativeLibrary = NULL;
+	J9JavaVM* javaVM = (J9JavaVM*)BFUjavaVM;
+	J9InternalVMFunctions* vmFuncs = javaVM->internalVMFunctions;
+	J9VMThread* currentThread = vmFuncs->currentVMThread(javaVM);
 
 	Trc_SC_LoadLibrary_Entry(libName);
-
-	prevMode = SetErrorMode( SEM_NOOPENFILEERRORBOX|SEM_FAILCRITICALERRORS );
-
-	/* LoadLibrary will try appending .DLL if necessary */
-	dllHandle = LoadLibrary ((LPCSTR)libName);
-	if (NULL == dllHandle) {
-		goto _end;
+	if (vmFuncs->registerBootstrapLibrary(currentThread, libName, &nativeLibrary, FALSE) == J9NATIVELIB_LOAD_OK) {
+		result = (void*)nativeLibrary->handle;
 	}
 
-	SetErrorMode(prevMode);
-	Trc_SC_LoadLibrary_Exit(dllHandle);
-	return dllHandle;
-
-_end:
-	SetErrorMode(prevMode);
-
-#endif
-
-#if defined(J9UNIX) || defined(J9ZOS390)
-	void *dllHandle;
-#if defined(AIXPPC)
-	/* CMVC 137341:
-	 * dlopen() searches for libraries using the LIBPATH envvar as it was when the process
-	 * was launched.  This causes multiple issues such as:
-	 *  - finding 32 bit binaries for libomrsig.so instead of the 64 bit binary needed and vice versa
-	 *  - finding compressed reference binaries instead of non-compressed ref binaries
-	 *
-	 * calling loadAndInit(libname, 0 -> no flags, NULL -> use the currently defined LIBPATH) allows
-	 * us to load the library with the current libpath instead of the one at process creation
-	 * time. We can then call dlopen() as per normal and the just loaded library will be found.
-	 * */
-	loadAndInit((char *)libName, L_RTLD_LOCAL, NULL);
-#endif
-	dllHandle = dlopen( (char *)libName, RTLD_LAZY );
-	if(NULL != dllHandle) {
-		Trc_SC_LoadLibrary_Exit(dllHandle);
-		return dllHandle;
-	}
-#endif /* defined(J9UNIX) || defined(J9ZOS390) */
-
-	/* We are here means we failed to load library. Throw java.lang.UnsatisfiedLinkError */
- 	(*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_2);
- 	if (NULL != env) {
- 		j9portLibrary.omrPortLibrary.str_printf(&j9portLibrary.omrPortLibrary, errMsg, sizeof(errMsg), "Failed to load library \"%s\"", libName);
- 		throwNewUnsatisfiedLinkError(env, errMsg);
- 	}
-
-	Trc_SC_LoadLibrary_Exit(NULL);
-	return NULL;
+	Trc_SC_LoadLibrary_Exit(result);
+	return result;
 }
 
 


### PR DESCRIPTION
**JDK15 : Add loadLibraryWithPath package access APIs & Invoke registerBootstrapLibrary() in JVM_LoadLibrary**

`static void loadLibrary(Class<?> caller, File file)` is added which calls `loadLibraryWithPath(String libName, ClassLoade loader, String libraryPath)`;
`static void loadLibrary(Class<?> caller, String libName)` is added which calls `loadLibraryWithClassLoader(String libName, ClassLoader loader)`;
Invoke `registerBootstrapLibrary()` in `JVM_LoadLibrary`.

Verified in a local build.

Additional note:
1. `JVM_LoadLibrary()` is not used before `JDK15`;
2. It is only invoked by `jdk.internal.loader.BootLoader.loadLibrary()`;
3. `OpenJ9` has its own implementation of `java.lang.ClassLoader` which invokes `loadLibraryWithPath()` and its friends, not `JVM_LoadLibrary()`. 

Fixes #8853

Reviewer: @pshipton 
FYI: @DanHeidinga @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>