### PR TITLE
(0.20.0) Restore --disable-zip-debug-info for jdk8 Windows builds

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -317,7 +317,7 @@ aarch64_linux_xl:
 # Windows x86 64bits Compressed Pointers
 #========================================#
 x86-64_windows:
-  extends: ['cuda', 'openjdk_reference_repo', 'openssl_bundle']
+  extends: ['cuda', 'debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
     11: '/cygdrive/c/openjdk/jdk11'
@@ -350,7 +350,7 @@ x86-64_windows_xl:
 # Windows x86 32bits
 #========================================#
 x86-32_windows:
-  extends: ['openjdk_reference_repo', 'openssl_bundle']
+  extends: ['debuginfo', 'openjdk_reference_repo', 'openssl_bundle']
   boot_jdk:
     8: '/cygdrive/c/openjdk/jdk7'
   release:


### PR DESCRIPTION
This is a replay of #8859 for the 0.20.0 release branch; it depends on ibmruntimes/openj9-openjdk-jdk8#385.