### PR TITLE
(0.20.0) Remove all properties from pipeline config

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
@@ -39,8 +39,6 @@ UPDATE_BUILD_NODES = params.UPDATE_BUILD_NODES
 
 EXTENSIONS_REPOS = [[name: "openj9", url: "https://github.com/eclipse/openj9.git"]]
 
-properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10'))])
-
 def jobs = [:]
 
 timeout(time: 6, unit: 'HOURS') {


### PR DESCRIPTION
Remove build discarder property from Update-Ref-Repo job.
Follow up to f7795600acf895f1fc26a9d0d31406291f9e48ca
Can not have some properties configured in pipeline and
some manually on the UI. The pipeline version will overwrite
the UI and, in this case, remove any configured cron schedule.
Removing all properties will allow properties to be set on the
UI on a per Jenkins basis.

[skip ci]
Related #8827

Cherry pick of #8829 for the 0.20.0 release. We don't want builds of 0.20.0 to overwrite the cron schedule of the jenkins job.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>