### PR TITLE
Use OMR_GC_POINTER_MODE

### DIFF
--- a/runtime/cmake/caches/cmprssptrs.cmake
+++ b/runtime/cmake/caches/cmprssptrs.cmake
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_GC_POINTER_MODE "compressed" CACHE STRING "")
 set(OMR_GC_COMPRESSED_POINTERS ON CACHE BOOL "")
 set(J9VM_GC_CLASSES_ON_HEAP ON CACHE BOOL "")
 set(J9VM_GC_COMPRESSED_POINTERS ON CACHE BOOL "")

--- a/runtime/gc_glue_java/configure_includes/configure_aix_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_aix_ppc.mk
@@ -34,7 +34,8 @@ ifeq (aix_ppc-64_cmprssptrs, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (aix_ppc-64_cmprssptrs_purec, $(SPEC))
@@ -43,7 +44,8 @@ ifeq (aix_ppc-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (aix_ppc-64_codecov, $(SPEC))
@@ -52,7 +54,8 @@ ifeq (aix_ppc-64_codecov, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (aix_ppc-64, $(SPEC))
@@ -62,7 +65,8 @@ ifeq (aix_ppc-64, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (aix_ppc-64_purec, $(SPEC))
@@ -71,7 +75,8 @@ ifeq (aix_ppc-64_purec, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (aix_ppc_codecov, $(SPEC))
@@ -79,7 +84,8 @@ ifeq (aix_ppc_codecov, $(SPEC))
 		--enable-OMRTHREAD_LIB_AIX \
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (aix_ppc, $(SPEC))
@@ -87,7 +93,8 @@ ifeq (aix_ppc, $(SPEC))
 		--enable-OMRTHREAD_LIB_AIX \
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (aix_ppc_purec, $(SPEC))
@@ -95,7 +102,8 @@ ifeq (aix_ppc_purec, $(SPEC))
 		--enable-OMRTHREAD_LIB_AIX \
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
@@ -39,7 +39,8 @@ ifeq (linux_390-64_cmprssptrs_codecov, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_390-64_cmprssptrs, $(SPEC))
@@ -51,7 +52,8 @@ ifeq (linux_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_390-64_cmprssptrs_purec, $(SPEC))
@@ -61,7 +63,8 @@ ifeq (linux_390-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_390-64_codecov, $(SPEC))
@@ -71,7 +74,8 @@ ifeq (linux_390-64_codecov, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_390-64, $(SPEC))
@@ -83,7 +87,8 @@ ifeq (linux_390-64, $(SPEC))
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_390-64_purec, $(SPEC))
@@ -93,7 +98,8 @@ ifeq (linux_390-64_purec, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_390, $(SPEC))
@@ -101,7 +107,8 @@ ifeq (linux_390, $(SPEC))
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_390_purec, $(SPEC))
@@ -109,7 +116,8 @@ ifeq (linux_390_purec, $(SPEC))
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_aarch64.mk
@@ -39,10 +39,12 @@ CONFIGURE_ARGS += \
 
 ifneq (,$(findstring _cmprssptrs,$(SPEC)))
 	CONFIGURE_ARGS += \
-		--enable-OMR_GC_COMPRESSED_POINTERS
+		--enable-OMR_GC_COMPRESSED_POINTERS \
+		OMR_GC_POINTER_MODE=compressed
 else
 	CONFIGURE_ARGS += \
-		--enable-OMR_GC_FULL_POINTERS
+		--enable-OMR_GC_FULL_POINTERS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifneq (,$(findstring _cross,$(SPEC)))

--- a/runtime/gc_glue_java/configure_includes/configure_linux_arm.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_arm.mk
@@ -38,7 +38,8 @@ ifneq (,$(findstring linux_arm, $(SPEC)))
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (default,$(origin AS))

--- a/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
@@ -38,7 +38,8 @@ ifeq (linux_ppc-64_cmprssptrs_le, $(SPEC))
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
@@ -53,7 +54,8 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_ppc-64_cmprssptrs_le_purec, $(SPEC))
@@ -65,7 +67,8 @@ ifeq (linux_ppc-64_cmprssptrs_le_purec, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_ppc-64_cmprssptrs, $(SPEC))
@@ -78,7 +81,8 @@ ifeq (linux_ppc-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_ppc-64_cmprssptrs_purec, $(SPEC))
@@ -89,7 +93,8 @@ ifeq (linux_ppc-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_ppc-64_le, $(SPEC))
@@ -103,7 +108,8 @@ ifeq (linux_ppc-64_le, $(SPEC))
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_ppc-64_le_gcc, $(SPEC))
@@ -118,7 +124,8 @@ ifeq (linux_ppc-64_le_gcc, $(SPEC))
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_ppc-64_le_purec, $(SPEC))
@@ -130,7 +137,8 @@ ifeq (linux_ppc-64_le_purec, $(SPEC))
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_ppc-64_purec, $(SPEC))
@@ -141,7 +149,8 @@ ifeq (linux_ppc-64_purec, $(SPEC))
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_ppc-64, $(SPEC))
@@ -154,7 +163,8 @@ ifeq (linux_ppc-64, $(SPEC))
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_ppc, $(SPEC))
@@ -163,7 +173,8 @@ ifeq (linux_ppc, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_ppc_purec, $(SPEC))
@@ -172,7 +183,8 @@ ifeq (linux_ppc_purec, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/runtime/gc_glue_java/configure_includes/configure_linux_riscv.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_riscv.mk
@@ -48,10 +48,12 @@ endif
 
 ifneq (,$(findstring _cmprssptrs, $(SPEC)))
 	CONFIGURE_ARGS += \
-		--enable-OMR_GC_COMPRESSED_POINTERS
+		--enable-OMR_GC_COMPRESSED_POINTERS \
+		OMR_GC_POINTER_MODE=compressed
 else
 	CONFIGURE_ARGS += \
-		--enable-OMR_GC_FULL_POINTERS
+		--enable-OMR_GC_FULL_POINTERS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifneq (,$(findstring _cross, $(SPEC)))

--- a/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
@@ -40,7 +40,8 @@ ifeq (linux_x86-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_x86-64_cmprssptrs_panama, $(SPEC))
@@ -55,7 +56,8 @@ ifeq (linux_x86-64_cmprssptrs_panama, $(SPEC))
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		--enable-OMR_PORT_NUMA_SUPPORT \
-		--enable-OMR_JITBUILDER
+		--enable-OMR_JITBUILDER \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_x86-64_codecov, $(SPEC))
@@ -68,7 +70,8 @@ ifeq (linux_x86-64_codecov, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_x86-64, $(SPEC))
@@ -83,7 +86,8 @@ ifeq (linux_x86-64, $(SPEC))
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_x86_codecov, $(SPEC))
@@ -94,7 +98,8 @@ ifeq (linux_x86_codecov, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_x86, $(SPEC))
@@ -106,7 +111,8 @@ ifeq (linux_x86, $(SPEC))
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_x86-64_cmprssptrs_purec, $(SPEC))
@@ -119,7 +125,8 @@ ifeq (linux_x86-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (linux_x86-64_purec, $(SPEC))
@@ -132,7 +139,8 @@ ifeq (linux_x86-64_purec, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_x86_purec, $(SPEC))
@@ -143,7 +151,8 @@ ifeq (linux_x86_purec, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT
+		--enable-OMR_PORT_NUMA_SUPPORT \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
@@ -32,7 +32,8 @@ CONFIGURE_ARGS += \
 	--enable-OMR_ARCH_S390 \
 	--enable-OMR_GC_FULL_POINTERS \
 	--enable-OMR_ENV_DATA64 \
-	--enable-OMR_GC_CONCURRENT_SCAVENGER
+	--enable-OMR_GC_CONCURRENT_SCAVENGER \
+	OMR_GC_POINTER_MODE=full
 
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/runtime/gc_glue_java/configure_includes/configure_osx.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_osx.mk
@@ -37,10 +37,12 @@ CONFIGURE_ARGS += \
 
 ifeq (osx_x86-64_cmprssptrs, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_GC_COMPRESSED_POINTERS
+		--enable-OMR_GC_COMPRESSED_POINTERS \
+		OMR_GC_POINTER_MODE=compressed
 else
 	CONFIGURE_ARGS += \
-		--enable-OMR_GC_FULL_POINTERS
+		--enable-OMR_GC_FULL_POINTERS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.dylib arlibext=.a objext=.o

--- a/runtime/gc_glue_java/configure_includes/configure_win_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_win_x86.mk
@@ -37,7 +37,8 @@ ifeq (win_x86-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (win_x86-64_cmprssptrs_purec, $(SPEC))
@@ -49,7 +50,8 @@ ifeq (win_x86-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (win_x86-64, $(SPEC))
@@ -62,7 +64,8 @@ ifeq (win_x86-64, $(SPEC))
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (win_x86-64_purec, $(SPEC))
@@ -74,7 +77,8 @@ ifeq (win_x86-64_purec, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (win_x86, $(SPEC))
@@ -85,7 +89,8 @@ ifeq (win_x86, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (win_x86_purec, $(SPEC))
@@ -96,7 +101,8 @@ ifeq (win_x86_purec, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix= exeext=.exe solibext=.dll arlibext=.lib objext=.obj

--- a/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
+++ b/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
@@ -41,7 +41,8 @@ ifeq (zos_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (zos_390-64_cmprssptrs_purec, $(SPEC))
@@ -50,7 +51,8 @@ ifeq (zos_390-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=compressed
 endif
 
 ifeq (zos_390-64, $(SPEC))
@@ -61,7 +63,8 @@ ifeq (zos_390-64, $(SPEC))
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (zos_390-64_purec, $(SPEC))
@@ -70,7 +73,8 @@ ifeq (zos_390-64_purec, $(SPEC))
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_FULL_POINTERS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (zos_390, $(SPEC))
@@ -79,7 +83,8 @@ ifeq (zos_390, $(SPEC))
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_PORT_ZOS_CEEHDLRSUPPORT \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (zos_390_purec, $(SPEC))
@@ -88,7 +93,8 @@ ifeq (zos_390_purec, $(SPEC))
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_GC_FULL_POINTERS \
 		--enable-OMR_PORT_ZOS_CEEHDLRSUPPORT \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
+		OMR_GC_POINTER_MODE=full
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o


### PR DESCRIPTION
Instead of specifying either `OMR_GC_COMPRESSED_POINTERS` or
`OMR_GC_FULL_POINTERS`, we will be using an enumeration to specify mode of
references in OMR. `OMR_GC_POINTER_MODE` can be set to `full`, `compressed`, or `mixed`.

This is the first of several changes to migrate OpenJ9 to the new
option. The next change is [here](https://github.com/eclipse/omr/pull/4923).
cc @gacholio This should be merged before the OMR side goes in.