### PR TITLE
Runtime compressed refs work

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -187,16 +187,8 @@ MM_RootScanner::scanMonitorReferencesComplete(MM_EnvironmentBase *env)
 void
 MM_RootScanner::doMonitorLookupCacheSlot(j9objectmonitor_t* slotPtr)
 {
-	// TODO: Local version of compressObjectReferences() ?
-	// TODO: Add new lockword macros (pass boolean)
-	if (_env->compressObjectReferences()) {
-		if (0 != *(U_32*)slotPtr) {
-			*(U_32*)slotPtr = 0;
-		}
-	} else {
-		if (0 != *(UDATA*)slotPtr) {
-			*(UDATA*)slotPtr = 0;
-		}
+	if(0 != *slotPtr) {
+		*slotPtr = 0;
 	}
 }
 

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,7 +88,8 @@ void
 cacheObjectMonitorForLookup(J9JavaVM* vm, J9VMThread* vmStruct, J9ObjectMonitor* objectMonitor)
 {
 	j9object_t object = J9MONITORTABLE_OBJECT_LOAD(vmStruct, &((J9ThreadAbstractMonitor*)(objectMonitor->monitor))->userData);
-	J9_STORE_LOCKWORD(vmStruct, vmStruct->objectMonitorLookupCache + J9_OBJECT_MONITOR_LOOKUP_SLOT(object,vm), objectMonitor);
+
+	vmStruct->objectMonitorLookupCache[J9_OBJECT_MONITOR_LOOKUP_SLOT(object,vm)] = (j9objectmonitor_t) ((UDATA) objectMonitor);
 }
 
 


### PR DESCRIPTION
Undo an incorrect change in the monitor table (restore the original
code).

The existing code works in the normal builds because j9objectmonitor_t
and the lockword size are identical.

Mixed mode on X appears to work because the table is zeroed to start
with, and since X is little endian, if the stored value is smaller than
4Gb then there's no problem. If any J9ObjectMonitor instances were
allocated above the 4Gb bar, I expect things would fail.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>