### PR TITLE
ExitOnOutOfMemory for systhrow only

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -329,8 +329,8 @@ enum INIT_STAGE {
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
 #define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
 #define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
-#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError"
-#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE "-Xdump:exit:none:events=throw+systhrow,filter=java/lang/OutOfMemoryError"
+#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=systhrow,filter=java/lang/OutOfMemoryError"
+#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE "-Xdump:exit:none:events=systhrow,filter=java/lang/OutOfMemoryError"
 
 #define VMOPT_XSOFTREFTHRESHOLD "-XSoftRefThreshold"
 #define VMOPT_XAGGRESSIVE "-Xaggressive"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4220,11 +4220,11 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XXONOUTOFMEMORYERROR_EQUALS, VMOPT_XDUMP_TOOL_OUTOFMEMORYERROR_EXEC_EQUALS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
-	/* Map -XX:+ExitOnOutOfMemoryError to -Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError */ 
+	/* Map -XX:+ExitOnOutOfMemoryError to -Xdump:exit:events=systhrow,filter=java/lang/OutOfMemoryError */ 
 	if (registerCmdLineMapping(vm, MAPOPT_XXENABLEEXITONOUTOFMEMORYERROR, VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
-	/* Map -XX:-ExitOnOutOfMemoryError to -Xdump:exit:none:events=throw+systhrow,filter=java/lang/OutOfMemoryError */ 
+	/* Map -XX:-ExitOnOutOfMemoryError to -Xdump:exit:none:events=systhrow,filter=java/lang/OutOfMemoryError */ 
 	if (registerCmdLineMapping(vm, MAPOPT_XXDISABLEEXITONOUTOFMEMORYERROR, VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}


### PR DESCRIPTION
This exit option should work for system thrown OutOfMemoryError to match the ri.

Port to v0.20.0: https://github.com/eclipse/openj9/pull/8887

`-X:+ExitOnOutOfMemory` is an alias to `-Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError`. During some AOT testing as discussed in the [OpenJ9 slack channel](https://openj9.slack.com/archives/C8312LCV9/p1584452514071200?thread_ts=1584371464.060300&cid=C8312LCV9) it was discovered that `ExitOnOutOfMemory` was disabling AOT by including the `throw` event:

> @theresa.mammarella when I run with
-Xshareclasses:verbose -XX:+ExitOnOutOfMemoryError -version
I get the line
JVMJITM007W AOT code in shared class cache cannot run with current JVMPI or JVMTI settings. Ignoring AOT code in shared class cache.
which is caused by [1], which is the same code path as when you do -Xdump:...:events=throw,filter=...
Was -XX:+ExitOnOutOfMemoryError implemented similar to how the events=throw was implemented?
[1] https://github.com/eclipse/openj9/blob/b542db86f655d22d1697c64d071bd483c3da3695/runtime/compiler/control/J9Options.cpp#L2339-L2354 

Testing against the ri confirmed that `ExitOnOutOfMemory` should apply to system OOMs only. This pr removes the `throw` event from the `ExitOnOutOfMemoryError` alias.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>