### PR TITLE
(v0.20.0): ExitOnOutOfMemory for systhrow only

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -329,8 +329,8 @@ enum INIT_STAGE {
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
 #define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
 #define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
-#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError"
-#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE "-Xdump:exit:none:events=throw+systhrow,filter=java/lang/OutOfMemoryError"
+#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=systhrow,filter=java/lang/OutOfMemoryError"
+#define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE "-Xdump:exit:none:events=systhrow,filter=java/lang/OutOfMemoryError"
 
 #define VMOPT_XSOFTREFTHRESHOLD "-XSoftRefThreshold"
 #define VMOPT_XAGGRESSIVE "-Xaggressive"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4220,11 +4220,11 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XXONOUTOFMEMORYERROR_EQUALS, VMOPT_XDUMP_TOOL_OUTOFMEMORYERROR_EXEC_EQUALS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
-	/* Map -XX:+ExitOnOutOfMemoryError to -Xdump:exit:events=throw+systhrow,filter=java/lang/OutOfMemoryError */ 
+	/* Map -XX:+ExitOnOutOfMemoryError to -Xdump:exit:events=systhrow,filter=java/lang/OutOfMemoryError */ 
 	if (registerCmdLineMapping(vm, MAPOPT_XXENABLEEXITONOUTOFMEMORYERROR, VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
-	/* Map -XX:-ExitOnOutOfMemoryError to -Xdump:exit:none:events=throw+systhrow,filter=java/lang/OutOfMemoryError */ 
+	/* Map -XX:-ExitOnOutOfMemoryError to -Xdump:exit:none:events=systhrow,filter=java/lang/OutOfMemoryError */ 
 	if (registerCmdLineMapping(vm, MAPOPT_XXDISABLEEXITONOUTOFMEMORYERROR, VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR_DISABLE, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}


### PR DESCRIPTION
This exit option should work for system thrown OutOfMemoryError to match ri.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>