### PR TITLE
Add valueType checks to monitor enter

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1240,6 +1240,7 @@ slow_jitMonitorEnterImpl(J9VMThread *currentThread, bool forMethod)
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		if (J9_OBJECT_MONITOR_OOM == monstatus) {
 			addr = setNativeOutOfMemoryErrorFromJIT(currentThread, J9NLS_VM_FAILED_TO_ALLOCATE_MONITOR);
+			goto done;
 		}
 	} else {
 		currentThread->javaVM->internalVMFunctions->objectMonitorEnterBlocking(currentThread);

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -457,7 +457,7 @@ Java_sun_misc_Unsafe_tryMonitorEnter(JNIEnv *env, jobject receiver, jobject obj)
 	} else {
 		j9object_t object = J9_JNI_UNWRAP_REFERENCE(obj);
 		if (!VM_ObjectMonitor::inlineFastObjectMonitorEnter(currentThread, object)) {
-			if (vmFuncs->objectMonitorEnterNonBlocking(currentThread, object) <= 1) {
+			if (vmFuncs->objectMonitorEnterNonBlocking(currentThread, object) <= J9_OBJECT_MONITOR_BLOCKING) {
 				entered = JNI_FALSE;
 			}
 		}

--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -267,7 +267,11 @@ done:
 	inlineFastObjectMonitorEnter(J9VMThread *currentThread, j9object_t object)
 	{
 		bool locked = false;
-		if (LN_HAS_LOCKWORD(currentThread, object)) {
+		if (LN_HAS_LOCKWORD(currentThread, object)
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		&& !J9_IS_J9CLASS_VALUETYPE(J9OBJECT_CLAZZ(currentThread, object))
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+		) {
 			locked = inlineFastInitAndEnterMonitor(currentThread, J9OBJECT_MONITOR_EA(currentThread, object));
 		}
 		return locked;
@@ -311,7 +315,7 @@ done:
 		IDATA rc = (IDATA)object;
 		if (!inlineFastObjectMonitorEnter(currentThread, object)) {
 			rc = J9_VM_FUNCTION(currentThread, objectMonitorEnterNonBlocking)(currentThread, object);
-			if (1 == rc) {
+			if (J9_OBJECT_MONITOR_BLOCKING == rc) {
 				rc = J9_VM_FUNCTION(currentThread, objectMonitorEnterBlocking)(currentThread);
 			}
 		}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5176,6 +5176,16 @@ typedef struct J9JavaVM {
 #define J9VM_DEBUG_ATTRIBUTE_UNUSED_0x800000  0x800000
 #define J9VM_DEFLATION_POLICY_NEVER  0
 
+/* objectMonitorEnterNonBlocking return codes */
+#define J9_OBJECT_MONITOR_OOM 0
+#define J9_OBJECT_MONITOR_VALUE_TYPE_IMSE 1
+/*
+ * Currently, not needed but reserving it for future use
+ *
+ * #define J9_OBJECT_MONITOR_PRIMITIVE_WRAPPER_IMSE 2
+ */
+#define J9_OBJECT_MONITOR_BLOCKING 3
+
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
 /* Mixed mode - necessarily 64-bit */

--- a/runtime/vm/BytecodeAction.hpp
+++ b/runtime/vm/BytecodeAction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,9 @@ typedef enum {
 	THROW_AIOB,
 	THROW_ARRAY_STORE,
 	THROW_DIVIDE_BY_ZERO,
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE,
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	THROW_ILLEGAL_MONITOR_STATE,
 	THROW_INCOMPATIBLE_CLASS_CHANGE,
 	THROW_WRONG_METHOD_TYPE,

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1595,12 +1595,8 @@ obj:;
 					}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 					if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
-						J9UTF8 *badClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(_currentThread, syncObject)->romClass);
-						updateVMStruct(REGISTER_ARGS);
-						prepareForExceptionThrow(_currentThread);
-						setCurrentExceptionNLSWithArgs(_currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(badClassName), J9UTF8_DATA(badClassName));
-						VMStructHasBeenUpdated(REGISTER_ARGS);
-						rc = GOTO_THROW_CURRENT_EXCEPTION;
+						_currentThread->tempSlot = (UDATA) syncObject;
+						rc = THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE;
 					} else
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 					{
@@ -1667,12 +1663,8 @@ done:
 			*bp |= J9SF_A0_INVISIBLE_TAG;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 			if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
-				J9UTF8 *badClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(_currentThread, syncObject)->romClass);
-				updateVMStruct(REGISTER_ARGS);
-				prepareForExceptionThrow(_currentThread);
-				setCurrentExceptionNLSWithArgs(_currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(badClassName), J9UTF8_DATA(badClassName));
-				VMStructHasBeenUpdated(REGISTER_ARGS);
-				rc = GOTO_THROW_CURRENT_EXCEPTION;
+				_currentThread->tempSlot = (UDATA) syncObject;
+				rc = THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE;
 			} else
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			{
@@ -1797,12 +1789,8 @@ throwStackOverflow:
 					*(_arg0EA + relativeBP) |= J9SF_A0_INVISIBLE_TAG;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 					if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
-						J9UTF8 *badClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(_currentThread, syncObject)->romClass);
-						updateVMStruct(REGISTER_ARGS);
-						prepareForExceptionThrow(_currentThread);
-						setCurrentExceptionNLSWithArgs(_currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(badClassName), J9UTF8_DATA(badClassName));
-						VMStructHasBeenUpdated(REGISTER_ARGS);
-						rc = GOTO_THROW_CURRENT_EXCEPTION;
+						_currentThread->tempSlot = (UDATA) syncObject;
+						rc = THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE;
 					} else
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 					{
@@ -2155,12 +2143,8 @@ done:
 			if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
-					J9UTF8 *badClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(_currentThread, receiver)->romClass);
-					updateVMStruct(REGISTER_ARGS);
-					prepareForExceptionThrow(_currentThread);
-					setCurrentExceptionNLSWithArgs(_currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(badClassName), J9UTF8_DATA(badClassName));
-					VMStructHasBeenUpdated(REGISTER_ARGS);
-					rc = GOTO_THROW_CURRENT_EXCEPTION;
+					_currentThread->tempSlot = (UDATA) receiver;
+					rc = THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE;
 				} else
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 				{
@@ -7774,12 +7758,8 @@ done:
 			if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
-					J9UTF8 *badClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(_currentThread, obj)->romClass);
-					updateVMStruct(REGISTER_ARGS);
-					prepareForExceptionThrow(_currentThread);
-					setCurrentExceptionNLSWithArgs(_currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(badClassName), J9UTF8_DATA(badClassName));
-					VMStructHasBeenUpdated(REGISTER_ARGS);
-					rc = GOTO_THROW_CURRENT_EXCEPTION;
+					_currentThread->tempSlot = (UDATA) obj;
+					rc = THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE;
 				} else
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 				{
@@ -9062,6 +9042,14 @@ public:
 #define DEBUG_ACTIONS
 #endif
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#define PERFORM_ACTION_VALUE_TYPE_IMSE \
+	case THROW_VALUE_TYPE_ILLEGAL_MONITOR_STATE: \
+	goto valueTypeIllegalMonitorState;
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#define PERFORM_ACTION_VALUE_TYPE_IMSE
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 #define PERFORM_ACTION(functionCall) \
 	do { \
 		DEBUG_UPDATE_VMSTRUCT(); \
@@ -9119,6 +9107,7 @@ public:
 		case RUN_METHOD_COMPILED: \
 			goto i2j; \
 		DEBUG_ACTIONS \
+		PERFORM_ACTION_VALUE_TYPE_IMSE \
 		default: \
 			Assert_VM_unreachable(); \
 		} \
@@ -9712,6 +9701,17 @@ illegalMonitorState:
 	setCurrentExceptionUTF(_currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, NULL);
 	VMStructHasBeenUpdated(REGISTER_ARGS);
 	goto throwCurrentException;
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+valueTypeIllegalMonitorState:
+	updateVMStruct(REGISTER_ARGS);
+	prepareForExceptionThrow(_currentThread);
+#define badClassName J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(_currentThread, (j9object_t)_currentThread->tempSlot)->romClass)
+	setCurrentExceptionNLSWithArgs(_currentThread, J9NLS_VM_ERROR_BYTECODE_OBJECTREF_CANNOT_BE_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGILLEGALMONITORSTATEEXCEPTION, J9UTF8_LENGTH(badClassName), J9UTF8_DATA(badClassName));
+	_currentThread->tempSlot = 0;
+	VMStructHasBeenUpdated(REGISTER_ARGS);
+	goto throwCurrentException;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 incompatibleClassChange:
 	updateVMStruct(REGISTER_ARGS);

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -309,11 +309,18 @@ objectMonitorEnterNonBlocking(J9VMThread *currentThread, j9object_t object)
 {
 	IDATA result = (IDATA)(UDATA)object;
 	j9objectmonitor_t volatile *lwEA = VM_ObjectMonitor::inlineGetLockAddress(currentThread, object);
-	
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	J9Class * objClass = J9OBJECT_CLAZZ(currentThread, object);
+	if (J9_IS_J9CLASS_VALUETYPE(objClass)) {
+		result = J9_OBJECT_MONITOR_VALUE_TYPE_IMSE;
+		goto done;
+	}
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */	
 restart:
 	if (NULL == lwEA) {
 		/* out of memory */
-		result = 0;
+		result = J9_OBJECT_MONITOR_OOM;
 		goto done;
 	} else {
 		/* check for a recursive flat lock */
@@ -427,7 +434,7 @@ restart:
 						objectMonitor = objectMonitorInflate(currentThread, object, lock);
 						if (NULL == objectMonitor) {
 							/* out of memory */
-							result = 0;
+							result = J9_OBJECT_MONITOR_OOM;
 							goto done;
 						}
 					} else {
@@ -442,7 +449,7 @@ restart:
 						 */
 						if (NULL == monitorTableAt(currentThread, object)) {
 							/* out of memory */
-							result = 0;
+							result = J9_OBJECT_MONITOR_OOM;
 							goto done;
 						}
 						goto wouldBlock;
@@ -461,7 +468,7 @@ restart:
 wouldBlock:
 	/* unable to get thin lock by spinning - follow blocking path */
 	J9VMTHREAD_SET_BLOCKINGENTEROBJECT(currentThread, currentThread, object);
-	result = 1;
+	result = J9_OBJECT_MONITOR_BLOCKING;
 done:
 	return result;
 }

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -278,7 +278,7 @@ objectMonitorEnter(J9VMThread* vmStruct, j9object_t object)
 {
 	IDATA rc = objectMonitorEnterNonBlocking(vmStruct, object);
 
-	if (rc == 1) {
+	if (J9_OBJECT_MONITOR_BLOCKING == rc) {
 		rc = objectMonitorEnterBlocking(vmStruct);
 	}
 

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,12 +111,31 @@ public class ValueTypeGenerator extends ClassLoader {
 				makeGeneric(cw, className, "makeValueGeneric", "makeValue", makeValueSig, makeValueGenericSig, fields, makeMaxLocal);
 			}
 		}
-
+		addStaticSynchronizedMethods(cw);
+		addSynchronizedMethods(cw);
 		cw.visitEnd();
 		return cw.toByteArray();
 		
 	}
 
+	private static void addStaticSynchronizedMethods(ClassWriter cw) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC + ACC_SYNCHRONIZED, "staticSynchronizedMethodReturnInt", "()I", null, null);
+		mv.visitCode();
+		mv.visitInsn(ICONST_1);
+		mv.visitInsn(IRETURN);
+		mv.visitMaxs(1, 1);
+		mv.visitEnd();
+	}
+	
+	private static void addSynchronizedMethods(ClassWriter cw) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNCHRONIZED, "synchronizedMethodReturnInt", "()I", null, null);
+		mv.visitCode();
+		mv.visitInsn(ICONST_1);
+		mv.visitInsn(IRETURN);
+		mv.visitMaxs(1, 1);
+		mv.visitEnd();
+	}
+	
 	private static void generateFieldMethods(ClassWriter cw, String[] nameAndSigValue, String className, boolean isVerifiable, boolean isRef) {
 		if ((nameAndSigValue.length > 2) && nameAndSigValue[2].equals("static")) {
 			generateSetterStatic(cw, nameAndSigValue, className);

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -664,6 +664,51 @@ public class ValueTypeTests {
 		}
 	}
 
+
+	@Test(priority=2)
+	static public void testSynchMethodsOnValueTypes() throws Throwable {
+		int x = 1;
+		int y = 1;
+		Object valueType = makePoint2D.invoke(x, y);
+		MethodHandle syncMethod = lookup.findVirtual(point2DClass, "synchronizedMethodReturnInt", MethodType.methodType(int.class));
+		MethodHandle staticSyncMethod = lookup.findStatic(point2DClass, "staticSynchronizedMethodReturnInt", MethodType.methodType(int.class));
+		
+		try {
+			syncMethod.invoke(valueType);
+			Assert.fail("should throw exception. Synchronized methods cannot be used with ValueType");
+		} catch (IllegalMonitorStateException e) {}
+		
+		try {
+			staticSyncMethod.invoke();
+		} catch (IllegalMonitorStateException e) {
+			Assert.fail("should not throw exception. Synchronized static methods can be used with ValueType");
+		}
+	}
+	
+	@Test(priority=2)
+	static public void testSynchMethodsOnRefTypes() throws Throwable {
+		String fields[] = {"longField:J"};
+		Class<?> refTypeClass = ValueTypeGenerator.generateRefClass("RefType", fields);
+		MethodHandle makeRef = lookup.findStatic(refTypeClass, "makeRef", MethodType.methodType(refTypeClass, long.class));
+		Object refType = makeRef.invoke(1L);
+		
+		MethodHandle syncMethod = lookup.findVirtual(refTypeClass, "synchronizedMethodReturnInt", MethodType.methodType(int.class));
+		MethodHandle staticSyncMethod = lookup.findStatic(refTypeClass, "staticSynchronizedMethodReturnInt", MethodType.methodType(int.class));
+		
+		try {
+			syncMethod.invoke(refType);
+		} catch (IllegalMonitorStateException e) {
+			Assert.fail("should not throw exception. Synchronized static methods can be used with RefType");
+		}
+		
+		try {
+			staticSyncMethod.invoke();
+		} catch (IllegalMonitorStateException e) {
+			Assert.fail("should not throw exception. Synchronized static methods can be used with RefType");
+		}
+	}
+	
+	
 	/*
 	 * Test monitorEnter with refType
 	 * 


### PR DESCRIPTION
Add valueType checks to monitor enter

The change updates the non-blocking monitor enter code to detect
valuetype receivers and return an appropriate error code. This means
that the `1 == rc` check that is currently being done will not work as
there is now more than one error code in the non-blocking enter case.

Instead the following check must be done:
`(monstatus < J9_OBJECT_MONITOR_BLOCKING)`

More error codes may be added in the future.

It is not necessarry to modify the monitorExit code in the case of
valuetypes because the monitorExit code will throw IMSE if the receiver
is not locked. So it is only necesarry to disallow valueType receiver
from being locked in the first place.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>