### PR TITLE
Fix definingClass for StaticFieldVarHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -35,8 +35,12 @@ import com.ibm.oti.vm.VM;
 
 abstract class FieldVarHandle extends VarHandle {
 	final long vmslot;
-	final Class<?> definingClass;
 	final String fieldName;
+
+	/* definingClass cannot be a final field since it is modified twice, once in
+	 * Java code and once in native code.
+	 */
+	Class<?> definingClass;
 
 	/**
 	 * Constructs a VarHandle referencing a field.
@@ -55,7 +59,10 @@ abstract class FieldVarHandle extends VarHandle {
 		this.definingClass = lookupClass;
 		this.fieldName = fieldName;
 		int header = (isStatic ? 0 : VM.OBJECT_HEADER_SIZE);
+
+		/* The native lookupField method also modifies the definingClass field. */
 		this.vmslot = lookupField(definingClass, fieldName, MethodType.getBytecodeStringName(fieldType), fieldType, isStatic, accessClass) + header;
+
 		checkSetterFieldFinality(handleTable);
 	}
 	

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,6 +85,7 @@ Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jc
 	J9VMThread *vmThread = (J9VMThread *) env;
 	J9JavaVM *vm = vmThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	j9object_t varHandle = NULL;
 	PORT_ACCESS_FROM_ENV(env);
 
 	vmFuncs->internalEnterVMFromJNI(vmThread);
@@ -111,7 +112,18 @@ Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jc
 		goto _cleanup;
 	}
 
-	J9VMJAVALANGINVOKEVARHANDLE_SET_MODIFIERS(vmThread, J9_JNI_UNWRAP_REFERENCE(handle), ((J9ROMFieldShape*) romField)->modifiers);
+	varHandle = J9_JNI_UNWRAP_REFERENCE(handle);
+	J9VMJAVALANGINVOKEVARHANDLE_SET_MODIFIERS(vmThread, varHandle, ((J9ROMFieldShape *)romField)->modifiers);
+
+	/* StaticFieldVarHandle and InstanceFieldVarHandle extend FieldVarHandle. For StaticFieldVarHandle, isStatic
+	 * is true, and the definingClass field is set to the owner of the static field. For InstanceFieldVarHandle,
+	 * isStatic is false, and the definingClass field is set to the lookupClass, which is also the instance class,
+	 * in FieldVarHandle's constructor.
+	 */
+	if (isStatic) {
+		Assert_JCL_notNull(definingClass);
+		J9VMJAVALANGINVOKEFIELDVARHANDLE_SET_DEFININGCLASS(vmThread, varHandle, J9VM_J9CLASS_TO_HEAPCLASS(definingClass));
+	}
 
 _cleanup:
 	vmFuncs->internalExitVMToJNI(vmThread);

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -130,6 +130,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<classref name="java/lang/Module" flags="opt_module" versions="9-"/>
 	<classref name="java/lang/invoke/VarHandle" versions="9-"/>
 	<classref name="java/lang/invoke/VarHandleInvokeHandle" versions="9-"/>
+	<classref name="java/lang/invoke/FieldVarHandle" versions="9-"/>
 
 	<fieldref class="java/lang/ClassLoader" name="parent" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/ClassLoader" name="vmRef" signature="J" cast="struct J9ClassLoader *"/>
@@ -327,6 +328,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/invoke/MethodHandleCache" name="directHandlesHead" signature="Lcom/ibm/oti/util/WeakReferenceNode;" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/VarHandleInvokeHandle" name="operation" signature="I" versions="9-"/>
 	<fieldref class="java/lang/invoke/VarHandleInvokeHandle" name="accessModeType" signature="Ljava/lang/invoke/MethodType;" versions="9-"/>
+	<fieldref class="java/lang/invoke/FieldVarHandle" name="definingClass" signature="Ljava/lang/Class;" versions="9-"/>
 
 	<fieldref class="java/lang/Module" name="loader" signature="Ljava/lang/ClassLoader;" flags="opt_module" versions="9-"/>
 	<fieldref class="java/lang/Module" name="name" signature="Ljava/lang/String;" flags="opt_module" versions="9-"/>

--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticFieldVarHandleTests.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticFieldVarHandleTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,6 +46,8 @@ public class StaticFieldVarHandleTests {
 	private final static VarHandle VH_FINAL_INT;
 	private final static VarHandle VH_FINAL_NOINIT_INT;
 	
+	private final static VarHandle VH_STRING_FROM_CHILD;
+	
 	static {
 		StaticHelper.reset();
 		
@@ -62,6 +64,11 @@ public class StaticFieldVarHandleTests {
 			VH_CLASS = MethodHandles.lookup().findStaticVarHandle(StaticHelper.class, "l2", Class.class);
 			VH_FINAL_INT = MethodHandles.lookup().findStaticVarHandle(StaticHelper.class, "finalI", int.class);
 			VH_FINAL_NOINIT_INT = MethodHandles.lookup().findStaticVarHandle(StaticHelper.StaticNoInitializationHelper.class, "finalI", int.class);
+			
+			/* l1 is a field in StaticHelper (parent class), and StaticHelperChild extends StaticHelper. */
+			VH_STRING_FROM_CHILD = MethodHandles.lookup()
+					.in(StaticHelperChild.class)
+					.findStaticVarHandle(StaticHelperChild.class, "l1", String.class);
 		} catch (Throwable t) {
 			throw new Error(t);
 		}
@@ -2483,5 +2490,422 @@ public class StaticFieldVarHandleTests {
 	
 	private long commonVarHandleCallSite(VarHandle vh, long value) {
 		return (long)vh.get();
+	}
+	
+	/**
+	 * Perform the get operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_get() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.get();
+		Assert.assertEquals("1", lFromVH);
+	}
+	
+	/**
+	 * Perform the set operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_set() {
+		VH_STRING_FROM_CHILD.set("2");
+		Assert.assertEquals("2", StaticHelper.l1);
+	}
+	
+	/**
+	 * Perform the getOpaque operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getOpaque() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.getOpaque();
+		Assert.assertEquals("1", lFromVH);
+	}
+	
+	/**
+	 * Perform the setOpaque operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_setOpaque() {
+		VH_STRING_FROM_CHILD.setOpaque("3");
+		Assert.assertEquals("3", StaticHelper.l1);
+	}
+	
+	/**
+	 * Perform the getVolatile operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getVolatile() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.getVolatile();
+		Assert.assertEquals("1", lFromVH);
+	}
+	
+	/**
+	 * Perform the setVolatile operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_setVolatile() {
+		VH_STRING_FROM_CHILD.setVolatile("4");
+		Assert.assertEquals("4", StaticHelper.l1);
+	}
+	
+	/**
+	 * Perform the getAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAcquire() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.getAcquire();
+		Assert.assertEquals("1", lFromVH);
+		
+	}
+	
+	/**
+	 * Perform the setRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_setRelease() {
+		VH_STRING_FROM_CHILD.setRelease("5");
+		Assert.assertEquals("5", StaticHelper.l1);
+	}		
+		
+	/**
+	 * Perform the compareAndSet operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_compareAndSet() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		boolean casResult = (boolean)VH_STRING_FROM_CHILD.compareAndSet("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertFalse(casResult);
+	
+		/* Success */
+		casResult = (boolean)VH_STRING_FROM_CHILD.compareAndSet("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertTrue(casResult);
+	}
+	
+	/**
+	 * Perform the compareAndExchange operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_compareAndExchange() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		String caeResult = (String)VH_STRING_FROM_CHILD.compareAndExchange("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertEquals("1", caeResult);
+
+		/* Success */
+		caeResult = (String)VH_STRING_FROM_CHILD.compareAndExchange("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertEquals("1", caeResult);
+	}
+	
+	/**
+	 * Perform the compareAndExchangeAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_compareAndExchangeAcquire() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		String caeResult = (String)VH_STRING_FROM_CHILD.compareAndExchangeAcquire("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertEquals("1", caeResult);
+
+		/* Success */
+		caeResult = (String)VH_STRING_FROM_CHILD.compareAndExchangeAcquire("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertEquals("1", caeResult);
+	}
+	
+	/**
+	 * Perform the compareAndExchangeRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_compareAndExchangeRelease() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		String caeResult = (String)VH_STRING_FROM_CHILD.compareAndExchangeRelease("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertEquals("1", caeResult);
+
+		/* Success */
+		caeResult = (String)VH_STRING_FROM_CHILD.compareAndExchangeRelease("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertEquals("1", caeResult);
+	}
+	
+	/**
+	 * Perform the weakCompareAndSet operation available on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_weakCompareAndSet() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		boolean casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSet("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertFalse(casResult);
+
+		/* Success */
+		casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSet("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertTrue(casResult);
+	}
+	
+	/**
+	 * Perform the weakCompareAndSetAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_weakCompareAndSetAcquire() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		boolean casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSetAcquire("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertFalse(casResult);
+
+		/* Success */
+		casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSetAcquire("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertTrue(casResult);
+	}
+	
+	/**
+	 * Perform the weakCompareAndSetRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_weakCompareAndSetRelease() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		boolean casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSetRelease("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertFalse(casResult);
+
+		/* Success */
+		casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSetRelease("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertTrue(casResult);
+	}
+	
+	/**
+	 * Perform the weakCompareAndSetPlain operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_weakCompareAndSetPlain() {
+		StaticHelper.reset();
+		
+		/* Fail */
+		boolean casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSetPlain("2", "3");
+		Assert.assertEquals("1", StaticHelper.l1);
+		Assert.assertFalse(casResult);
+
+		/* Success */
+		casResult = (boolean)VH_STRING_FROM_CHILD.weakCompareAndSetPlain("1", "2");
+		Assert.assertEquals("2", StaticHelper.l1);
+		Assert.assertTrue(casResult);
+	}
+	
+	/**
+	 * Perform the getAndSet operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndSet() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.getAndSet("2");
+		Assert.assertEquals("1", lFromVH);
+		Assert.assertEquals("2", StaticHelper.l1);
+	}
+	
+	/**
+	 * Perform the getAndSetAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndSetAcquire() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.getAndSetAcquire("2");
+		Assert.assertEquals("1", lFromVH);
+		Assert.assertEquals("2", StaticHelper.l1);
+	}
+	
+	/**
+	 * Perform the getAndSetRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndSetRelease() {
+		StaticHelper.reset();
+		String lFromVH = (String)VH_STRING_FROM_CHILD.getAndSetRelease("2");
+		Assert.assertEquals("1", lFromVH);
+		Assert.assertEquals("2", StaticHelper.l1);
+	}
+	
+	/**
+	 * Perform the getAndAdd operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndAdd() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndAdd("2");
+			Assert.fail("Successfully added reference types (String)");
+		} catch (UnsupportedOperationException e) {	}
+	}
+	
+	/**
+	 * Perform the getAndAddAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndAddAcquire() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndAddAcquire("2");
+			Assert.fail("Successfully added reference types (String)");
+		} catch (UnsupportedOperationException e) {	}
+	}
+	
+	/**
+	 * Perform the getAndAddRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndAddRelease() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndAddRelease("2");
+			Assert.fail("Successfully added reference types (String)");
+		} catch (UnsupportedOperationException e) {	}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseAnd operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseAnd() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseAnd("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseAndAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseAndAcquire() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseAndAcquire("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseAndRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseAndRelease() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseAndRelease("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseOr operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseOr() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseOr("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseOrAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseOrAcquire() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseOrAcquire("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseOrRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseOrRelease() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseOrRelease("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseXor operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseXor() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseXor("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseXorAcquire operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseXorAcquire() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseXorAcquire("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform the getAndBitwiseXorRelease operation on a StaticFieldVarHandle referencing a {@link String} field of a
+	 * parent class via the child class.
+	 */
+	@Test
+	public void testReferenceInParentFromChild_getAndBitwiseXorRelease() {
+		try {
+			String lFromVH = (String)VH_STRING_FROM_CHILD.getAndBitwiseXorRelease("3");
+			Assert.fail("Expected UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {}
 	}
 }

--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticFieldVarHandleTests.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticFieldVarHandleTests.java
@@ -75,7 +75,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link byte} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link byte} field.
 	 */
 	@Test
 	public void testByte() {
@@ -293,7 +293,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link char} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link char} field.
 	 */
 	@Test
 	public void testChar() {
@@ -511,7 +511,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link double} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link double} field.
 	 */
 	@Test
 	public void testDouble() {
@@ -729,7 +729,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link float} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link float} field.
 	 */
 	@Test
 	public void testFloat() {
@@ -947,7 +947,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link int} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link int} field.
 	 */
 	@Test
 	public void testInt() {
@@ -1165,7 +1165,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link int} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link int} field.
 	 */
 	@Test
 	public void testLong() {
@@ -1383,7 +1383,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link String} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link String} field.
 	 */
 	@Test
 	public void testReference() {
@@ -1604,7 +1604,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link Class} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link Class} field.
 	 */
 	@Test
 	public void testReferenceOtherType() {
@@ -1837,7 +1837,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link short} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link short} field.
 	 */
 	@Test
 	public void testShort() {
@@ -2055,7 +2055,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a {@link boolean} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a {@link boolean} field.
 	 */
 	@Test
 	public void testBoolean() {
@@ -2273,7 +2273,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a <b>final</b> {@link int} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a <b>final</b> {@link int} field.
 	 */
 	@Test
 	public void testFinalField() {
@@ -2459,7 +2459,7 @@ public class StaticFieldVarHandleTests {
 	}
 	
 	/**
-	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a <b>final</b> {@link int} field.
+	 * Perform all the operations available on a StaticFieldVarHandle referencing a <b>final</b> {@link int} field.
 	 * Note: The static field StaticHelper.StaticNoInitializationHelper.finalI hasn't been initialized implicitly
 	 * by StaticHelper.reset() before VarHandle.get() is invoked.
 	 */

--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticHelperChild.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticHelperChild.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.varhandle;
+
+public class StaticHelperChild extends StaticHelper {
+	/* StaticHelperChild is used to test if StaticFieldVarHandle functions
+	 * properly while accessing the static fields of StaticHelper (parent
+	 * class) via StaticHelperChild (child class).
+	 */
+}


### PR DESCRIPTION
For a `StaticFieldVarHandle`, `definingClass` should point to the owner of
the static field.
 
Example:
```
    public class P { public static String publicObject = "s"; }
    public class C extends P { }
    VarHandle vh =
    	MethodHandles.lookup()
    		.in(C.class)
    		.findStaticVarHandle(C.class, "publicObject", String.class);
```

In the above example, `vh` is an instance of `StaticFieldVarHandle`, which
extends `FieldVarHandle`. `vh.definingClass` should contain `class P` since it
defines the `publicObject`.

Currently, `vh.definingClass` is set to `class C`, which is not the owner of
the static field. This fix correctly sets the defining class for a
`StaticFieldVarHandle`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>