### PR TITLE
Change realTimeGC option as per compilation

### DIFF
--- a/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMEvaluator.cpp
@@ -932,7 +932,7 @@ static void genHeapAlloc(TR::CodeGenerator  *cg,
                          TR::LabelSymbol     *callLabel,
                          int32_t            allocSize)
    {
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (cg->comp()->getOptions()->realTimeGC())
       {
       TR_ASSERT(0, "genHeapAlloc() not supported for RT");
       return;

--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -346,7 +346,7 @@ void J9::ARM::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register 
       }
    else if (cardMarkIsNeeded)
       {
-      if (!TR::Options::getCmdLineOptions()->realTimeGC())
+      if (!comp->getOptions()->realTimeGC())
          {
          TR::Register *temp1Reg = cg->allocateRegister();
          TR::Register *temp2Reg = cg->allocateRegister();

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -6800,13 +6800,14 @@ static void jitReleaseCodeStackWalk(OMR_VMThread *omrVMThread, condYieldFromGCFu
    bool yieldHappened = false;
    bool doStackWalkForThread = true;
 
+   bool isRealTimeGC = TR::Options::getCmdLineOptions()->realTimeGC();
    do
       {
       J9VMThread *thread = vmThread;
       yieldHappened = false;
       do
          {
-         if (TR::Options::getCmdLineOptions()->realTimeGC() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
+         if (isRealTimeGC && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
             doStackWalkForThread = (thread->dropFlags & 0x1) ? false : true;
 
          if (doStackWalkForThread)
@@ -6818,7 +6819,7 @@ static void jitReleaseCodeStackWalk(OMR_VMThread *omrVMThread, condYieldFromGCFu
             walkState.walkThread = thread;
             vmThread->javaVM->walkStackFrames(vmThread, &walkState);
 
-            if (TR::Options::getCmdLineOptions()->realTimeGC() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
+            if (isRealTimeGC && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
                {
                thread->dropFlags |= 0x1;
                yieldHappened = condYield(omrVMThread, J9_GC_METRONOME_UTILIZATION_COMPONENT_JIT);
@@ -6884,7 +6885,7 @@ static void jitReleaseCodeStackWalk(OMR_VMThread *omrVMThread, condYieldFromGCFu
          OMR::FaintCacheBlock *next = cursor->_next;
          jitReleaseCodeCollectMetaData(jitConfig, vmThread, metaData, cursor);
          cursor = next;
-         if (TR::Options::getCmdLineOptions()->realTimeGC() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
+         if (isRealTimeGC && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
             condYieldCounter += condYield(omrVMThread, J9_GC_METRONOME_UTILIZATION_COMPONENT_JIT);
 
          continue;
@@ -6904,7 +6905,7 @@ static void jitReleaseCodeStackWalk(OMR_VMThread *omrVMThread, condYieldFromGCFu
       cursor->_isStillLive = false;
       }
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
+   if (isRealTimeGC && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIncrementalCCR))
       { //clear flags
       J9VMThread *thr = vmThread;
       do

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1120,6 +1120,18 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getROMMethodFromRAMMethod(std::get<0>(recv)));
          }
          break;
+      case MessageType::VM_getCellSizeForSizeClass:
+         {
+         auto recv = client->getRecvData<uintptr_t>();
+         client->write(response, fe->getCellSizeForSizeClass(std::get<0>(recv)));
+         }
+         break;
+      case MessageType::VM_getObjectSizeClass:
+         {
+         auto recv = client->getRecvData<uintptr_t>();
+         client->write(response, fe->getObjectSizeClass(std::get<0>(recv)));
+         }
+         break;
       case MessageType::mirrorResolvedJ9Method:
          {
          // allocate a new TR_ResolvedJ9Method on the heap, to be used as a mirror for performing actions which are only

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -170,7 +170,9 @@ acquireVMaccessIfNeededInner(J9VMThread *vmThread, TR_YesNoMaybe isCompThread)
                     heldMonitor, TR_J9VMBase::get(jitConfig, NULL)->getJ9MonitorName((J9ThreadMonitor*)heldMonitor->getVMMonitor()));
 #endif // #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 
-         if (TR::Options::getCmdLineOptions()->realTimeGC())
+         TR::Compilation *comp = compInfoPT->getCompilation();
+         if ((comp && comp->getOptions()->realTimeGC()) ||
+              TR::Options::getCmdLineOptions()->realTimeGC())
             compInfoPT->waitForGCCycleMonitor(false); // used only for real-time
 
          acquireVMAccessNoSuspend(vmThread);   // blocking. Will wait for the entire GC
@@ -189,7 +191,6 @@ acquireVMaccessIfNeededInner(J9VMThread *vmThread, TR_YesNoMaybe isCompThread)
             //TR::MonitorTable::get()->readReleaseClassUnloadMonitor(0); // Main code should do it.
             // releaseVMAccess(vmThread);
 
-            TR::Compilation *comp = compInfoPT->getCompilation();
             if (comp)
                {
                comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted by GC unloading classes");

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -628,7 +628,7 @@ public:
    uintptr_t                 getMaxObjectSizeForSizeClass();
    uintptr_t                 thisThreadAllocationCacheCurrentOffset(uintptr_t);
    uintptr_t                 thisThreadAllocationCacheTopOffset(uintptr_t);
-   uintptr_t                 getCellSizeForSizeClass(uintptr_t);
+   virtual uintptr_t         getCellSizeForSizeClass(uintptr_t);
    virtual uintptr_t         getObjectSizeClass(uintptr_t);
 
    uintptr_t                 thisThreadMonitorCacheOffset();

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1805,6 +1805,28 @@ TR_J9ServerVM::getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::Symbo
    return helper;
    }
 
+UDATA
+TR_J9ServerVM::getCellSizeForSizeClass(uintptr_t sizeClass)
+   {
+#if defined(J9VM_GC_REALTIME)
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_getCellSizeForSizeClass, sizeClass);
+   return std::get<0>(stream->read<UDATA>());
+#endif
+   return 0;
+   }
+
+UDATA
+TR_J9ServerVM::getObjectSizeClass(uintptr_t objectSize)
+   {
+#if defined(J9VM_GC_REALTIME)
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_getObjectSizeClass, objectSize);
+   return std::get<0>(stream->read<UDATA>());
+#endif
+   return 0;
+   }
+
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -188,6 +188,9 @@ public:
    virtual bool getReportByteCodeInfoAtCatchBlock() override;
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType) override;
 
+   virtual uintptr_t getCellSizeForSizeClass(uintptr_t) override;
+   virtual uintptr_t getObjectSizeClass(uintptr_t) override;
+
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -89,7 +89,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 0;
+   static const uint16_t MINOR_NUMBER = 1;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -201,6 +201,8 @@ enum MessageType : uint16_t
    VM_getJ2IThunk = 307,
    VM_needsInvokeExactJ2IThunk = 308,
    VM_instanceOfOrCheckCastNoCacheUpdate = 309,
+   VM_getCellSizeForSizeClass = 310,
+   VM_getObjectSizeClass = 311,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400,

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -1255,12 +1255,12 @@ void TR::createCCPreLoadedCode(uint8_t *CCPreLoadedCodeBase, uint8_t *CCPreLoade
    {
    /* If you modify this make sure you update CCPreLoadedCodeSize above as well */
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
-      return;
-
    // We temporarily clobber the first and append instructions so we can use high level codegen to generate pre-loaded code
    // So save the original values here and restore them when done
    TR::Compilation *comp = cg->comp();
+   if (comp->getOptions()->realTimeGC())
+      return;
+
    TR::Instruction *curFirst = cg->getFirstInstruction();
    TR::Instruction *curAppend = cg->getAppendInstruction();
    uint8_t *curBinaryBufferStart = cg->getBinaryBufferStart();
@@ -1315,7 +1315,7 @@ uint8_t *TR::PPCAllocPrefetchSnippet::emitSnippetBody()
    getSnippetLabel()->setCodeLocation(buffer);
    TR::InstOpCode opcode;
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (comp->getOptions()->realTimeGC())
       return NULL;
 
    TR_ASSERT((uintptr_t)((cg()->getCodeCache())->getCCPreLoadedCodeAddress(TR_AllocPrefetch, cg())) != 0xDEADBEEF,
@@ -1347,7 +1347,7 @@ TR::PPCAllocPrefetchSnippet::print(TR::FILE *pOutFile, TR_Debug * debug)
 uint32_t TR::PPCAllocPrefetchSnippet::getLength(int32_t estimatedCodeStart)
    {
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (cg()->comp()->getOptions()->realTimeGC())
       return 0;
 
    return PPC_INSTRUCTION_LENGTH;
@@ -1368,7 +1368,7 @@ uint8_t *TR::PPCNonZeroAllocPrefetchSnippet::emitSnippetBody()
    getSnippetLabel()->setCodeLocation(buffer);
    TR::InstOpCode opcode;
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (comp->getOptions()->realTimeGC())
       return NULL;
 
    TR_ASSERT((uintptr_t)((cg()->getCodeCache())->getCCPreLoadedCodeAddress(TR_NonZeroAllocPrefetch, cg())) != 0xDEADBEEF,
@@ -1400,7 +1400,7 @@ TR::PPCNonZeroAllocPrefetchSnippet::print(TR::FILE *pOutFile, TR_Debug * debug)
 uint32_t TR::PPCNonZeroAllocPrefetchSnippet::getLength(int32_t estimatedCodeStart)
    {
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (cg()->comp()->getOptions()->realTimeGC())
       return 0;
 
    return PPC_INSTRUCTION_LENGTH;

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -34,7 +34,7 @@
 uint8_t *TR::X86AllocPrefetchSnippet::emitSnippetBody()
    {
    TR::Compilation *comp = cg()->comp();
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (comp->getOptions()->realTimeGC())
       return 0;
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -5737,7 +5737,7 @@ static void genHeapAlloc(
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
 
-   if (TR::Options::getCmdLineOptions()->realTimeGC())
+   if (comp->getOptions()->realTimeGC())
       {
 #if defined(J9VM_GC_REALTIME)
       // this will be bogus for variable length allocations because it only includes the header size (+ arraylet ptr for arrays)
@@ -6929,7 +6929,7 @@ static void genInitArrayHeader(
    TR::Compilation *comp = cg->comp();
 
    bool canUseFastInlineAllocation =
-      (!TR::Options::getCmdLineOptions()->realTimeGC() &&
+      (!comp->getOptions()->realTimeGC() &&
        !comp->generateArraylets()) ? true : false;
 
    // Initialize the array size
@@ -7674,7 +7674,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    // --------------------------------------------------------------------------------
 
    bool canUseFastInlineAllocation =
-      (!TR::Options::getCmdLineOptions()->realTimeGC() &&
+      (!comp->getOptions()->realTimeGC() &&
        !comp->generateArraylets()) ? true : false;
 
    bool useRepInstruction;
@@ -10032,9 +10032,9 @@ static void generateWriteBarrierCall(
    TR::LabelSymbol*       doneLabel,
    TR::CodeGenerator*     cg)
    {
-   TR_ASSERT(gcMode != gc_modron_wrtbar_satb && !TR::Options::getCmdLineOptions()->realTimeGC(), "This helper is not for RealTimeGC.");
-
    TR::Compilation *comp = cg->comp();
+   TR_ASSERT(gcMode != gc_modron_wrtbar_satb && !comp->getOptions()->realTimeGC(), "This helper is not for RealTimeGC.");
+
    uint8_t helperArgCount = 0;  // Number of arguments passed on the runtime helper.
    TR::SymbolReference *wrtBarSymRef = NULL;
 
@@ -10119,7 +10119,7 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-   TR_ASSERT(TR::Options::getCmdLineOptions()->realTimeGC(),"Call the non real-time barrier");
+   TR_ASSERT(comp->getOptions()->realTimeGC(),"Call the non real-time barrier");
    auto gcMode = TR::Compiler->om.writeBarrierType();
 
    if (node->getOpCode().isWrtBar() && node->skipWrtBar())
@@ -10346,7 +10346,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-   TR_ASSERT(!(TR::Options::getCmdLineOptions()->realTimeGC()),"Call the real-time barrier");
+   TR_ASSERT(!(comp->getOptions()->realTimeGC()),"Call the real-time barrier");
    auto gcMode = TR::Compiler->om.writeBarrierType();
 
    if (node->getOpCode().isWrtBar() && node->skipWrtBar())
@@ -11017,7 +11017,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(
    TR::Register *sourceRegister = cg->evaluate(sourceObject);
 
    auto gcMode = TR::Compiler->om.writeBarrierType();
-   bool isRealTimeGC = (TR::Options::getCmdLineOptions()->realTimeGC())? true:false;
+   bool isRealTimeGC = (comp->getOptions()->realTimeGC())? true:false;
 
    bool usingCompressedPointers = false;
    bool usingLowMemHeap = false;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1795,7 +1795,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
 
       TR::LabelSymbol *noChkLabel = generateLabelSymbol(cg);
 
-      if (!TR::Options::getCmdLineOptions()->realTimeGC())
+      if (!comp->getOptions()->realTimeGC())
          {
          bool isDefinitelyNonHeapObj = false, isDefinitelyHeapObj = false;
          if (wrtbarNode != NULL && doCompileTimeCheckForHeapObj)
@@ -1912,7 +1912,8 @@ VMCardCheckEvaluator(
       TR::LabelSymbol *doneLabel = NULL,
       bool doCompileTimeCheckForHeapObj = true)
    {
-   if (!TR::Options::getCmdLineOptions()->realTimeGC())
+   TR::Compilation * comp = cg->comp();
+   if (!comp->getOptions()->realTimeGC())
       {
       TR::Node * wrtbarNode = NULL;
       if (node->getOpCodeValue() == TR::awrtbari || node->getOpCodeValue() == TR::awrtbar)
@@ -1928,9 +1929,6 @@ VMCardCheckEvaluator(
          isDefinitelyNonHeapObj = wrtbarNode->isNonHeapObjectWrtBar();
          isDefinitelyHeapObj = wrtbarNode->isHeapObjectWrtBar();
          }
-
-      // Make sure we really should be here
-      TR::Compilation * comp = cg->comp();
 
       // 83613: We used to do inline CM for Old&CM Objects.
       // However, since all Old objects will go through the wrtbar helper,
@@ -7836,7 +7834,7 @@ genHeapAlloc(TR::Node * node, TR::Instruction *& iCursor, bool isVariableLen, TR
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
-   if (!TR::Options::getCmdLineOptions()->realTimeGC())
+   if (!comp->getOptions()->realTimeGC())
       {
       TR::Register *metaReg = cg->getMethodMetaDataRealRegister();
 
@@ -8090,7 +8088,7 @@ genInitObjectHeader(TR::Node * node, TR::Instruction *& iCursor, TR_OpaqueClassB
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    TR_J9VM *fej9vm = (TR_J9VM *)(comp->fe());
-   if (!TR::Options::getCmdLineOptions()->realTimeGC())
+   if (!comp->getOptions()->realTimeGC())
       {
       J9ROMClass *romClass = 0;
       int32_t staticFlag = 0;
@@ -9624,7 +9622,7 @@ void J9::Z::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register *s
 
    else if (doCrdMrk)
       {
-      if (!TR::Options::getCmdLineOptions()->realTimeGC())
+      if (!comp->getOptions()->realTimeGC())
          {
          TR::Register * temp1Reg = cg->allocateRegister();
          conditions->addPostCondition(temp1Reg, TR::RealRegister::AssignAny);


### PR DESCRIPTION
This change is to support the JITServer receiving the `realTimeGC` config setting from the client for per compilation.

Also implemented the server version of `getCellSizeForSizeClass()` and `getObjectSizeClass()` which were missing and are triggered when `realTimeGC` is true.

Related to eclipse/omr#4945

Fixes: #8707

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>