### PR TITLE
Use openssl 1.1.1e for all platforms but Windows

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -118,7 +118,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1d'
+  extra_getsource_options: '--openssl-version=1.1.1e'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Windows openssl is pre-built and will be updated separately

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>