### PR TITLE
Runtime compressed refs work

### DIFF
--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -581,12 +581,16 @@ define({CURRENT_DONE},CONCAT(done,SYM_COUNT))dnl
 ZZ The ugly formatting in this macro is due to restrictions
 ZZ in the assembler regarding line length and spacing before
 ZZ comments.
+ZZ
+ZZ The +7 below is because TM operates on a byte. The compressed
+ZZ flag is in the LSB of the word, which is byte 7 on 64-bit
+ZZ big endian.
 
 define({IfCompressedElse},{dnl
 ifdef({ASM_OMR_GC_COMPRESSED_POINTERS},{dnl
 ifdef({ASM_OMR_GC_FULL_POINTERS},{dnl
 GENSYM
-TM      J9TR_VMThreadCompressObjectReferences(r13),1
+TM      J9TR_VMThreadCompressObjectReferences+7(r13),1
 JZ      CURRENT_FULL
 $1
 j       CURRENT_DONE

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -196,7 +196,10 @@ dnl Load the updated object pointer into CARG2
     LG CARG1,J9TR_VMThread_gsParameters_operandAddr(J9VMTHREAD)
 ifdef({ASM_OMR_GC_COMPRESSED_POINTERS},{
 ifdef({ASM_OMR_GC_FULL_POINTERS},{
-    TM J9TR_VMThreadCompressObjectReferences(J9VMTHREAD),1
+dnl The +7 below is because TM operates on a byte. The compressed
+dnl flag is in the LSB of the word, which is byte 7 on 64-bit
+dnl big endian.
+    TM J9TR_VMThreadCompressObjectReferences+7(J9VMTHREAD),1
     JZ LABEL_NAME(L_GS_SKIP_SHIFT)
 }) dnl ASM_OMR_GC_FULL_POINTERS
 dnl Some objects may be stored in a decompressed format on the heap.


### PR DESCRIPTION
- Use runtime compressed check in Z TreeEvaluator
- Fix compressed check in Z PicBuilder and friends

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>