### PR TITLE
Stop setting OMR_GC_COMPRESSED_POINTERS

### DIFF
--- a/runtime/cmake/caches/cmprssptrs.cmake
+++ b/runtime/cmake/caches/cmprssptrs.cmake
@@ -21,7 +21,6 @@
 ################################################################################
 
 set(OMR_GC_POINTER_MODE "compressed" CACHE STRING "")
-set(OMR_GC_COMPRESSED_POINTERS ON CACHE BOOL "")
 set(J9VM_GC_CLASSES_ON_HEAP ON CACHE BOOL "")
 set(J9VM_GC_COMPRESSED_POINTERS ON CACHE BOOL "")
 set(J9VM_INTERP_COMPRESSED_OBJECT_HEADER ON CACHE BOOL "")


### PR DESCRIPTION
This option was deprecated, and is no longer used in the autoconf
builds. ~Remove the flag `J9VM_GC_COMPRESSED_POINTERS` as it appears to
be entirely unused, and only exists in the cmake build system.~
cc @gacholio @dnakamura 