### PR TITLE
(0.20.0) Use openssl 1.1.1e for all platforms but Windows

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -118,7 +118,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1d'
+  extra_getsource_options: '--openssl-version=1.1.1e'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Windows openssl is pre-built and will be updated separately

Cherry pick of #8901 for the 0.20.0 branch.