### PR TITLE
JVM_LoadLibrary releases VM Access before invoking registerBootstrapLibrary()

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3591,9 +3591,14 @@ JVM_LoadLibrary(const char* libName)
 	J9VMThread* currentThread = vmFuncs->currentVMThread(javaVM);
 
 	Trc_SC_LoadLibrary_Entry(libName);
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	/* registerBootstrapLibrary can't have VM access */
+	vmFuncs->internalReleaseVMAccess(currentThread);
 	if (vmFuncs->registerBootstrapLibrary(currentThread, libName, &nativeLibrary, FALSE) == J9NATIVELIB_LOAD_OK) {
 		result = (void*)nativeLibrary->handle;
 	}
+	/* No need to acquire VM access since next is to exit VM */
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	Trc_SC_LoadLibrary_Exit(result);
 	return result;


### PR DESCRIPTION
**JVM_LoadLibrary releases VM Access before invoking registerBootstrapLibrary()**

Invoking `internalReleaseVMAccess()` before `registerBootstrapLibrary()`.

Verified in a personal build with `openj9-staging` branch.

closes: #8909 

Reviewer: @gacholio @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>