### PR TITLE
Remove obsolete specs from config files

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_aix_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_aix_ppc.mk
@@ -37,24 +37,6 @@ ifeq (aix_ppc-64_cmprssptrs, $(SPEC))
 		OMR_GC_POINTER_MODE=compressed
 endif
 
-ifeq (aix_ppc-64_cmprssptrs_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_AIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
-ifeq (aix_ppc-64_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_AIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (aix_ppc-64, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_AIX \
@@ -65,32 +47,7 @@ ifeq (aix_ppc-64, $(SPEC))
 		OMR_GC_POINTER_MODE=full
 endif
 
-ifeq (aix_ppc-64_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_AIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (aix_ppc_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_AIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (aix_ppc, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_AIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (aix_ppc_purec, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_AIX \
 		--enable-OMR_ARCH_POWER \

--- a/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
@@ -32,16 +32,6 @@ CONFIGURE_ARGS += \
 	--enable-OMR_THR_YIELD_ALG \
 	--enable-OMR_THR_SPIN_WAKE_CONTROL
 
-ifeq (linux_390-64_cmprssptrs_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
 ifeq (linux_390-64_cmprssptrs, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
@@ -52,26 +42,6 @@ ifeq (linux_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		OMR_GC_POINTER_MODE=compressed
-endif
-
-ifeq (linux_390-64_cmprssptrs_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
-ifeq (linux_390-64_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
 endif
 
 ifeq (linux_390-64, $(SPEC))
@@ -86,25 +56,7 @@ ifeq (linux_390-64, $(SPEC))
 		OMR_GC_POINTER_MODE=full
 endif
 
-ifeq (linux_390-64_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (linux_390, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (linux_390_purec, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \

--- a/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
@@ -56,18 +56,6 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
 		OMR_GC_POINTER_MODE=compressed
 endif
 
-ifeq (linux_ppc-64_cmprssptrs_le_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
 ifeq (linux_ppc-64_cmprssptrs, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
@@ -76,17 +64,6 @@ ifeq (linux_ppc-64_cmprssptrs, $(SPEC))
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
-ifeq (linux_ppc-64_cmprssptrs_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		--enable-OMR_PORT_NUMA_SUPPORT \
 		OMR_GC_POINTER_MODE=compressed
@@ -121,29 +98,6 @@ ifeq (linux_ppc-64_le_gcc, $(SPEC))
 		OMR_GC_POINTER_MODE=full
 endif
 
-ifeq (linux_ppc-64_le_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (linux_ppc-64_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (linux_ppc-64, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
@@ -158,15 +112,6 @@ ifeq (linux_ppc-64, $(SPEC))
 endif
 
 ifeq (linux_ppc, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_POWER \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (linux_ppc_purec, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_POWER \

--- a/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
@@ -58,19 +58,6 @@ ifeq (linux_x86-64_cmprssptrs_panama, $(SPEC))
 		OMR_GC_POINTER_MODE=compressed
 endif
 
-ifeq (linux_x86-64_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (linux_x86-64, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
@@ -86,60 +73,12 @@ ifeq (linux_x86-64, $(SPEC))
 		OMR_GC_POINTER_MODE=full
 endif
 
-ifeq (linux_x86_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (linux_x86, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_X86 \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (linux_x86-64_cmprssptrs_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
-ifeq (linux_x86-64_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		--enable-OMR_PORT_NUMA_SUPPORT \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (linux_x86_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		--enable-OMR_PORT_NUMA_SUPPORT \

--- a/runtime/gc_glue_java/configure_includes/configure_win_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_win_x86.mk
@@ -40,18 +40,6 @@ ifeq (win_x86-64_cmprssptrs, $(SPEC))
 		OMR_GC_POINTER_MODE=compressed
 endif
 
-ifeq (win_x86-64_cmprssptrs_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_WIN32 \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
 ifeq (win_x86-64, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_WIN32 \
@@ -65,30 +53,7 @@ ifeq (win_x86-64, $(SPEC))
 		OMR_GC_POINTER_MODE=full
 endif
 
-ifeq (win_x86-64_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_WIN32 \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (win_x86, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_WIN32 \
-		--enable-OMR_ARCH_X86 \
-		--enable-OMR_ENV_LITTLE_ENDIAN \
-		--enable-OMR_GC_TLH_PREFETCH_FTA \
-		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (win_x86_purec, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_WIN32 \
 		--enable-OMR_ARCH_X86 \

--- a/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
+++ b/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
@@ -44,15 +44,6 @@ ifeq (zos_390-64_cmprssptrs, $(SPEC))
 		OMR_GC_POINTER_MODE=compressed
 endif
 
-ifeq (zos_390-64_cmprssptrs_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_ZOS \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=compressed
-endif
-
 ifeq (zos_390-64, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_ZOS \
@@ -64,25 +55,7 @@ ifeq (zos_390-64, $(SPEC))
 		OMR_GC_POINTER_MODE=full
 endif
 
-ifeq (zos_390-64_purec, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_ZOS \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
 ifeq (zos_390, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_ZOS \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_PORT_ZOS_CEEHDLRSUPPORT \
-		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
-		OMR_GC_POINTER_MODE=full
-endif
-
-ifeq (zos_390_purec, $(SPEC))
 	CONFIGURE_ARGS += \
 		--enable-OMRTHREAD_LIB_ZOS \
 		--enable-OMR_ARCH_S390 \


### PR DESCRIPTION
Remove the purec and codecov configurations.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>