### PR TITLE
Refactor areValueTypesEnabled object model query to call VM helper

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -100,6 +100,14 @@ J9::ObjectModel::initialize()
    }
 
 
+bool
+J9::ObjectModel::areValueTypesEnabled()
+   {
+   J9JavaVM * javaVM = TR::Compiler->javaVM;
+   return javaVM->internalVMFunctions->areValueTypesEnabled(javaVM);
+   }
+
+
 int32_t
 J9::ObjectModel::sizeofReferenceField()
    {

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -61,14 +61,7 @@ public:
 
    bool mayRequireSpineChecks();
 
-   bool areValueTypesEnabled()
-      {
-      #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
-      return true;
-      #else
-      return false;
-      #endif
-      }
+   bool areValueTypesEnabled();
 
    int32_t sizeofReferenceField();
    uintptrj_t elementSizeOfBooleanArray();


### PR DESCRIPTION
Previously, the query used a build flag to detect if value types support
was enabled. However, value types support is supposed to be a runtime
setting. So, this commit refactors the implementation of the query to
call the appropriate VM helper instead.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>