### PR TITLE
Refactor JIT implementation of acmp{eq,ne} to handle value types

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -159,6 +159,14 @@ static TR::Node *lowerCASValues(
 void
 J9::CodeGenerator::lowerNonhelperCallIfNeeded(TR::Node *node, TR::TreeTop *tt)
    {
+   if (TR::Compiler->om.areValueTypesEnabled() &&
+       comp()->getSymRefTab()->isNonHelper(
+       node->getSymbolReference(),
+       TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
+      {
+      // for now, just turn the non-helper call into a jit-helper call
+      node->setSymbolReference(comp()->getSymRefTab()->findOrCreateAcmpHelperSymbolRef());
+      }
    }
 
 

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -156,6 +156,12 @@ static TR::Node *lowerCASValues(
    }
 
 
+void
+J9::CodeGenerator::lowerNonhelperCallIfNeeded(TR::Node *node, TR::TreeTop *tt)
+   {
+   }
+
+
 // J9
 //
 // convert dual operators from DAG representation to cyclic representation by cloning
@@ -808,6 +814,11 @@ J9::CodeGenerator::lowerTreeIfNeeded(
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->comp()->fe());
    OMR::CodeGeneratorConnector::lowerTreeIfNeeded(node, childNumberOfNode, parent, tt);
+
+   if (node->getOpCode().isCall())
+      {
+      self()->lowerNonhelperCallIfNeeded(node, tt);
+      }
 
    // J9
    //

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -68,8 +68,6 @@
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
 
-
-
 J9::CodeGenerator::CodeGenerator() :
       OMR::CodeGeneratorConnector(),
    _gpuSymbolMap(TR::comp()->allocator()),
@@ -156,16 +154,167 @@ static TR::Node *lowerCASValues(
    }
 
 
+/**
+ * @brief Add checks to skip (fast-path) acmpHelper call
+ *
+ * @details
+ *
+ * This transformation adds checks for the cases where the acmp can be performed
+ * without calling the VM helper. The trasformed Trees represen the following operation:
+ *
+ * 1. If the address of lhs and rhs are the same, produce an eq (true) result
+ *    and skip the call (note the two objects must be the same regardless of
+ *    whether they are value types are reference types)
+ * 2. Otherwise, do VM helper call
+ *
+ * The transformation looks as follows:
+ *
+ *  +----------------------+
+ *  |ttprev                |
+ *  |treetop               |
+ *  |  icall acmpHelper    |
+ *  |    aload lhs         |
+ *  |    aload rhs         |
+ *  |ificmpeq --> ...      |
+ *  |  ==> icall           |
+ *  |  iconst 0            |
+ *  |BBEnd                 |
+ *  +----------------------+
+ *
+ *  ...becomes...
+ *
+ *  +----------------------+
+ *  |ttprev                |
+ *  |iRegStore x           |
+ *  |  iconst 1            |
+ *  |ifacmpeq  -->---------*---------+
+ *  |  aload lhs           |         |
+ *  |  aload rhs           |         |
+ *  |BBEnd                 |         |
+ *  +----------------------+         |
+ *  |BBStart (extension)   |         |
+ *  |iRegStore x           |         |
+ *  |  icall acmpHelper    |         |
+ *  |    aload lhs         |         |
+ *  |    aload rhs         |         |
+ *  |BBEnd                 |         |
+ *  +----------------------+         |
+ *        |                          |
+ *        +--------------------------+
+ *        |
+ *        v
+ *  +-----------------+
+ *  |BBStart
+ *  |ificmpeq --> ... |
+ *  |  iRegLoad x     |
+ *  |  iconst 0       |
+ *  |BBEnd            |
+ *  +-----------------+
+ *
+ */
+void
+J9::CodeGenerator::fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, const bool trace)
+   {
+   TR::Compilation* comp = self()->comp();
+   TR::CFG* cfg = comp->getFlowGraph();
+   cfg->invalidateStructure();
+
+   // anchor call node after split point to ensure the returned value goes into
+   // either a temp or a global register
+   auto* anchoredCallTT = TR::TreeTop::create(comp, tt, TR::Node::create(TR::treetop, 1, node));
+   if (trace)
+      traceMsg(comp, "Anchoring call node under treetop n%dn (0x%p)\n", anchoredCallTT->getNode()->getGlobalIndex(), anchoredCallTT->getNode());
+
+   // anchor the call arguments just before the call
+   // this ensures the values are live before the call so that we can
+   // propagate their values in global registers if needed
+   auto* anchoredCallArg1TT = TR::TreeTop::create(comp, tt->getPrevTreeTop(), TR::Node::create(TR::treetop, 1, node->getFirstChild()));
+   auto* anchoredCallArg2TT = TR::TreeTop::create(comp, tt->getPrevTreeTop(), TR::Node::create(TR::treetop, 1, node->getSecondChild()));
+   if (trace)
+      {
+      traceMsg(comp, "Anchoring call arguments n%dn and n%dn under treetops n%dn and n%dn\n",
+         node->getFirstChild()->getGlobalIndex(), node->getSecondChild()->getGlobalIndex(), anchoredCallArg1TT->getNode()->getGlobalIndex(), anchoredCallArg2TT->getNode()->getGlobalIndex());
+      }
+
+   // put non-helper call in its own block by block splitting at the
+   // next treetop and then at the current one
+   TR::Block* prevBlock = tt->getEnclosingBlock();
+   TR::Block* targetBlock = prevBlock->splitPostGRA(tt->getNextTreeTop(), cfg, true, NULL);
+   TR::Block* callBlock = prevBlock->split(tt, cfg);
+   callBlock->setIsExtensionOfPreviousBlock(true);
+   if (trace)
+      traceMsg(comp, "Isolated call node n%dn in block_%d\n", node->getGlobalIndex(), callBlock->getNumber());
+
+   // insert store of constant 1
+   // the value must go wherever the value returned by the helper call goes
+   // so that the code in the target block picks up the constant if we fast-path
+   // (i.e. jump around) the call
+   TR::Node* anchoredNode = anchoredCallTT->getNode()->getFirstChild(); // call node is under a treetop node
+   if (trace)
+      traceMsg(comp, "Anchored call has been transformed into %s node n%dn\n", anchoredNode->getOpCode().getName(), anchoredNode->getGlobalIndex());
+   auto* const1Node = TR::Node::iconst(1);
+   TR::Node* storeNode = NULL;
+   if (anchoredNode->getOpCodeValue() == TR::iRegLoad)
+      {
+      if (trace)
+         traceMsg(comp, "Storing constant 1 in register %s\n", comp->getDebug()->getGlobalRegisterName(anchoredNode->getGlobalRegisterNumber()));
+      storeNode = TR::Node::create(TR::iRegStore, 1, const1Node);
+      storeNode->setGlobalRegisterNumber(anchoredNode->getGlobalRegisterNumber());
+      }
+   else if (anchoredNode->getOpCodeValue() == TR::iload)
+      {
+      if (trace)
+         traceMsg(comp, "Storing constant 1 to symref %d (%s)\n", anchoredNode->getSymbolReference()->getReferenceNumber(), anchoredNode->getSymbolReference()->getName(comp->getDebug()));
+      storeNode = TR::Node::create(TR::istore, 1, const1Node);
+      storeNode->setSymbolReference(anchoredNode->getSymbolReference());
+      }
+   else
+      TR_ASSERT_FATAL(false, "Anchord call has been turned into unexpected opcode %s\n", anchoredNode->getOpCode().getName());
+   prevBlock->append(TR::TreeTop::create(comp, storeNode));
+
+   // instert acmpeq for fastpath, taking care to set the proper register dependencies
+   auto* ifacmpeqNode = TR::Node::createif(TR::ifacmpeq, anchoredCallArg1TT->getNode()->getFirstChild(), anchoredCallArg2TT->getNode()->getFirstChild(), targetBlock->getEntry());
+   if (anchoredNode->getOpCodeValue() == TR::iRegLoad)
+      {
+      auto* depNode = TR::Node::create(TR::PassThrough, 1, storeNode->getChild(0));
+      depNode->setGlobalRegisterNumber(storeNode->getGlobalRegisterNumber());
+
+      TR::Node* glRegDeps = TR::Node::create(TR::GlRegDeps);
+      glRegDeps->addChildren(&depNode, 1);
+      ifacmpeqNode->addChildren(&glRegDeps, 1);
+
+      if (callBlock->getExit()->getNode()->getNumChildren() > 0)
+         {
+         TR::Node* expectedDeps = callBlock->getExit()->getNode()->getFirstChild();
+         for (int i = 0; i < expectedDeps->getNumChildren(); ++i)
+            {
+            TR::Node* temp = expectedDeps->getChild(i);
+            if (temp->getGlobalRegisterNumber() == depNode->getGlobalRegisterNumber())
+               continue;
+            glRegDeps->addChildren(&temp, 1);
+            }
+         }
+      }
+   prevBlock->append(TR::TreeTop::create(comp, ifacmpeqNode));
+   }
+
 void
 J9::CodeGenerator::lowerNonhelperCallIfNeeded(TR::Node *node, TR::TreeTop *tt)
    {
+   TR::Compilation* comp = self()->comp();
+
    if (TR::Compiler->om.areValueTypesEnabled() &&
-       comp()->getSymRefTab()->isNonHelper(
+       comp->getSymRefTab()->isNonHelper(
        node->getSymbolReference(),
        TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
       {
-      // for now, just turn the non-helper call into a jit-helper call
-      node->setSymbolReference(comp()->getSymRefTab()->findOrCreateAcmpHelperSymbolRef());
+      // turn the non-helper call into a VM helper call
+      node->setSymbolReference(comp->getSymRefTab()->findOrCreateAcmpHelperSymbolRef());
+      static const bool disableAcmpFastPath =  NULL != feGetEnv("TR_DisableAcmpFastpath");
+      if (!disableAcmpFastPath)
+         {
+         self()->fastpathAcmpHelper(node, tt, comp->getOption(TR_TraceCG));
+         }
       }
    }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -79,6 +79,8 @@ public:
 
    void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
+   void lowerNonhelperCallIfNeeded(TR::Node *node, TR::TreeTop *tt);
+
    void lowerDualOperator(TR::Node *parent, int32_t childNumber, TR::TreeTop *treeTop);
 
    bool collectSymRefs(TR::Node *node, TR_BitVector *symRefs, vcount_t secondVisitCount);

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -80,6 +80,7 @@ public:
    void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
    void lowerNonhelperCallIfNeeded(TR::Node *node, TR::TreeTop *tt);
+   void fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, bool trace);
 
    void lowerDualOperator(TR::Node *parent, int32_t childNumber, TR::TreeTop *treeTop);
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2344,6 +2344,18 @@ J9::SymbolReferenceTable::findOrCreateArrayComponentTypeSymbolRef()
    return element(componentClassSymbol);
    }
 
+TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateObjectEqualityComparisonSymbolRef()
+   {
+   TR::SymbolReference *symRef = element(objectEqualityComparisonSymbol);
+   if (symRef != NULL)
+      return symRef;
+
+   symRef = self()->findOrCreateCodeGenInlinedHelper(objectEqualityComparisonSymbol);
+   symRef->setCanGCandReturn();
+   symRef->setCanGCandExcept();
+   return symRef;
+   }
 
 TR::ParameterSymbol *
 J9::SymbolReferenceTable::createParameterSymbol(

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -244,6 +244,13 @@ J9::SymbolReferenceTable::findOrCreateWriteBarrierBatchStoreSymbolRef(TR::Resolv
 
 
 TR::SymbolReference *
+J9::SymbolReferenceTable::findOrCreateAcmpHelperSymbolRef(TR::ResolvedMethodSymbol * owningMEthodSymbol)
+   {
+   return findOrCreateRuntimeHelper(TR_acmpHelper, true, false, true);
+   }
+
+
+TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateFloatSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
    {
    void * dataAddress = owningMethodSymbol->getResolvedMethod()->floatConstant(cpIndex);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -268,6 +268,15 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    TR::SymbolReference * findOrCreateCheckCastForArrayStoreSymbolRef(TR::ResolvedMethodSymbol *owningMethodSymbol);
 
+   /** \brief
+    *     Finds the <objectEqualityComparison> "nonhelper" symbol reference,
+    *     creating it if necessary.
+    *
+    *  \return
+    *     The <objectEqualityComparison> symbol reference.
+    */
+   TR::SymbolReference *findOrCreateObjectEqualityComparisonSymbolRef();
+
    /**
     * \brief
     *    Creates a new symbol for a parameter within the supplied owning method of the

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -110,6 +110,8 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateWriteBarrierClassStoreRealTimeGCSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateWriteBarrierBatchStoreSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = 0);
 
+   TR::SymbolReference * findOrCreateAcmpHelperSymbolRef(TR::ResolvedMethodSymbol * owningMEthodSymbol = NULL);
+
    TR::SymbolReference * findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore);
    TR::SymbolReference * findOrFabricateShadowSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::Symbol::RecognizedField recognizedField, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, char* name = NULL);
 

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -94,6 +94,7 @@ private:
    int32_t      genGoto(int32_t);
    int32_t      genIfOneOperand(TR::ILOpCodes);
    int32_t      genIfTwoOperand(TR::ILOpCodes);
+   int32_t      genIfAcmpEqNe(TR::ILOpCodes);
    int32_t      genIfImpl(TR::ILOpCodes);
 
    /** \brief

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -473,8 +473,8 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
          case J9BCificmpge:  _bcIndex = genIfTwoOperand(TR::ificmpge); break;
          case J9BCificmpgt:  _bcIndex = genIfTwoOperand(TR::ificmpgt); break;
          case J9BCificmple:  _bcIndex = genIfTwoOperand(TR::ificmple); break;
-         case J9BCifacmpeq:  _bcIndex = genIfTwoOperand(TR::ifacmpeq); break;
-         case J9BCifacmpne:  _bcIndex = genIfTwoOperand(TR::ifacmpne); break;
+         case J9BCifacmpeq:  _bcIndex = genIfAcmpEqNe(TR::ifacmpeq); break;
+         case J9BCifacmpne:  _bcIndex = genIfAcmpEqNe(TR::ifacmpne); break;
 
          case J9BClcmp:  _bcIndex = cmp(TR::lcmp,  _lcmpOps,  lastIndex); break;
          case J9BCfcmpl: _bcIndex = cmp(TR::fcmpl, _fcmplOps, lastIndex); break;
@@ -2589,6 +2589,49 @@ TR_J9ByteCodeIlGenerator::genIfTwoOperand(TR::ILOpCodes nodeop)
       genAsyncCheck();
 
    return genIfImpl(nodeop);
+   }
+
+/** \brief
+ *     Generates IL for a conditional branch bytecode that compares two
+ *     address-typed operands as for bytecode instructions if_acmp{eq,ne}.
+ *     Also generates an asynccheck if the bytecode branches backwards.
+ *
+ *     If value types are not enabled, then a regulare acmp operation is
+ *     generated instead.
+ *
+ *  \param nodeop
+ *     The IL opcode that would be used for non-value references. This opcode
+ *     must be either ifacmpeq or ifacmpne.
+ *
+ *  \return
+ *     The index of the next bytecode to generate.
+ */
+int32_t
+TR_J9ByteCodeIlGenerator::genIfAcmpEqNe(TR::ILOpCodes ifacmpOp)
+   {
+   if (!TR::Compiler->om.areValueTypesEnabled())
+      return genIfTwoOperand(ifacmpOp);
+
+   int32_t branchBC = _bcIndex + next2BytesSigned();
+
+   if (branchBC <= _bcIndex)
+      genAsyncCheck();
+
+   TR::Node *rhs = pop();
+   TR::Node *lhs = pop();
+
+   TR::SymbolReference *comparisonNonHelper =
+      comp()->getSymRefTab()->findOrCreateObjectEqualityComparisonSymbolRef();
+
+   TR::Node *substitutabilityTest =
+      TR::Node::createWithSymRef(TR::icall, 2, 2, lhs, rhs, comparisonNonHelper);
+
+   substitutabilityTest->getByteCodeInfo().setDoNotProfile(true);
+   genTreeTop(substitutabilityTest);
+
+   push(substitutabilityTest);
+   push(TR::Node::iconst(0));
+   return genIfImpl(ifacmpOp == TR::ifacmpeq ? TR::ificmpne : TR::ificmpeq);
    }
 
 //----------------------------------------------


### PR DESCRIPTION
In IlGen, the `ifacmpeq` and `ifacmpne` bytecodes now get turned into a non-helper call that represents the comparison operation.  In Lower Trees, the non-helper call is then transformed into a helper call with fast-paths for cases that are easily handled. Currently, the only fast-path is for when the objects being compared have the same address, in which case the operands are equal regardless of whether they are value types or reference types.

Eventually, more fast-paths will be added and optimizations will recognize the non-helper call and convert it to a regular acmp if the JIT can prove doing so is correct.