### PR TITLE
Eliminate all traces of `gen` directory used by protobuf

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -138,7 +138,6 @@ add_subdirectory(ras)
 add_subdirectory(runtime)
 
 if(J9VM_OPT_JITSERVER)
-	j9jit_files(${CMAKE_CURRENT_SOURCE_DIR}/net/gen/compile.pb.cpp)
 	add_subdirectory(net)
 endif()
 

--- a/runtime/compiler/build/toolcfg/common.mk
+++ b/runtime/compiler/build/toolcfg/common.mk
@@ -87,7 +87,6 @@ ifneq ($(J9VM_OPT_JITSERVER),)
 # Networking
 #
 PRODUCT_INCLUDES+=\
-    $(FIXED_SRCBASE)/compiler/net/gen \
     $(FIXED_SRCBASE)/compiler/net
 endif
 #


### PR DESCRIPTION
Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>