### PR TITLE
Fix init sequence for flattened fields

### DIFF
--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -374,7 +374,7 @@ doVerify:
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				/* verify flattened fields */
-				if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+				if (NULL != clazz->flattenedClassCache) {
 					UDATA numberOfFlattenedFields = clazz->flattenedClassCache->numberOfEntries;
 
 					for (UDATA i = 0; i < numberOfFlattenedFields; i++) {
@@ -494,7 +494,7 @@ doVerify:
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				/* prepare flattened fields */
-				if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+				if (NULL != clazz->flattenedClassCache) {
 					UDATA numberOfFlattenedFields = clazz->flattenedClassCache->numberOfEntries;
 
 					for (UDATA i = 0; i < numberOfFlattenedFields; i++) {
@@ -611,7 +611,7 @@ doVerify:
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				/* init flattened fields */
-				if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+				if (NULL != clazz->flattenedClassCache) {
 					UDATA numberOfFlattenedFields = clazz->flattenedClassCache->numberOfEntries;
 
 					for (UDATA i = 0; i < numberOfFlattenedFields; i++) {


### PR DESCRIPTION
Fix init sequence for flattened fields

In cases where a flattened field is contained in an identitytype, there
is a bug where the flattenedfield is not being initialized before the
container type is initialized. This is because there is an unneccesary
valuetype guard before that code. Since identitytypes can have flattened
fields, identity type must also ensure that all flattened fields are
initialized before itself.

The flattenedclass cache will be non-NULL if the type is a valuetype or
the type has at least one flattened field. This means that one simply
needs to check if the flattenedClass cache is non-NULL before
initializing flattened fields.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>