### PR TITLE
Re-add message names

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -126,7 +126,7 @@ JITServerHelpers::printJITServerMsgStats(J9JITConfig *jitConfig)
    for (int i = 0; i < JITServer::MessageType_ARRAYSIZE; ++i)
       {
       if (JITServerHelpers::serverMsgTypeCount[i] > 0)
-         j9tty_printf(PORTLIB, "#%04d %7u\n", i, JITServerHelpers::serverMsgTypeCount[i]);
+         j9tty_printf(PORTLIB, "#%04d %7u %s\n", i, JITServerHelpers::serverMsgTypeCount[i], JITServer::messageNames[i]);
       }
    }
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -61,6 +61,9 @@ protected:
       _ssl(NULL),
       _connfd(-1)
       {
+      static_assert(
+         sizeof(messageNames) / sizeof(messageNames[0]) == MessageType_ARRAYSIZE,
+         "wrong number of message names");
       }
 
    virtual ~CommunicationStream()
@@ -89,7 +92,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 2;
+   static const uint16_t MINOR_NUMBER = 3;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -28,275 +28,523 @@ namespace JITServer
    {
 enum MessageType : uint16_t
    {
-   compilationCode = 0, // Send the compiled code back to the client
-   compilationFailure = 1,
-   mirrorResolvedJ9Method = 2,
-   get_params_to_construct_TR_j9method = 3,
-   getUnloadedClassRanges = 4,
-   compilationRequest = 5, // type used when client sends remote compilation requests
-   compilationInterrupted = 6, // type used when client informs the server to abort the remote compilation
-   clientSessionTerminate = 7, // type used when client process is about to terminate
-   connectionTerminate = 8, // type used when client informs the server to close the connection
+   compilationCode, // Send the compiled code back to the client
+   compilationFailure,
+   mirrorResolvedJ9Method,
+   get_params_to_construct_TR_j9method,
+   getUnloadedClassRanges,
+   compilationRequest, // type used when client sends remote compilation requests
+   compilationInterrupted, // type used when client informs the server to abort the remote compilation
+   clientSessionTerminate, // type used when client process is about to terminate
+   connectionTerminate, // type used when client informs the server to close the connection
 
    // For TR_ResolvedJ9JITServerMethod methods
-   ResolvedMethod_isJNINative = 100,
-   ResolvedMethod_isInterpreted = 101,
-   ResolvedMethod_setRecognizedMethodInfo = 102,
-   ResolvedMethod_startAddressForInterpreterOfJittedMethod = 103,
-   ResolvedMethod_jniNativeMethodProperties = 104,
-   ResolvedMethod_staticAttributes = 105,
-   ResolvedMethod_getClassFromConstantPool = 106,
-   ResolvedMethod_getDeclaringClassFromFieldOrStatic = 107,
-   ResolvedMethod_classOfStatic = 108,
-   ResolvedMethod_startAddressForJNIMethod = 109,
-   ResolvedMethod_fieldAttributes = 110,
-   ResolvedMethod_getResolvedStaticMethodAndMirror = 111,
-   ResolvedMethod_getResolvedSpecialMethodAndMirror = 112,
-   ResolvedMethod_classCPIndexOfMethod = 113,
-   ResolvedMethod_startAddressForJittedMethod = 114,
-   ResolvedMethod_localName = 115,
-   ResolvedMethod_getResolvedPossiblyPrivateVirtualMethodAndMirror = 116,
-   ResolvedMethod_virtualMethodIsOverridden = 117,
-   ResolvedMethod_getResolvedInterfaceMethod_2 = 118, // arity 2
-   ResolvedMethod_getResolvedInterfaceMethodAndMirror_3 = 119, // arity 3
-   ResolvedMethod_getResolvedInterfaceMethodOffset = 120,
-   ResolvedMethod_getUnresolvedStaticMethodInCP = 121,
-   ResolvedMethod_isSubjectToPhaseChange = 122,
-   ResolvedMethod_getUnresolvedSpecialMethodInCP = 123,
-   ResolvedMethod_getUnresolvedFieldInCP = 124,
-   ResolvedMethod_getRemoteROMString = 125,
-   ResolvedMethod_fieldOrStaticName = 126,
-   ResolvedMethod_getRemoteROMClassAndMethods = 127,
-   ResolvedMethod_getResolvedHandleMethod = 128,
-   ResolvedMethod_isUnresolvedMethodTypeTableEntry = 129,
-   ResolvedMethod_methodTypeTableEntryAddress = 130,
-   ResolvedMethod_isUnresolvedCallSiteTableEntry = 131,
-   ResolvedMethod_callSiteTableEntryAddress = 132,
-   ResolvedMethod_getResolvedDynamicMethod = 133,
-   ResolvedMethod_shouldFailSetRecognizedMethodInfoBecauseOfHCR = 134,
-   ResolvedMethod_isSameMethod = 135,
-   ResolvedMethod_isBigDecimalMethod = 136,
-   ResolvedMethod_isBigDecimalConvertersMethod = 137,
-   ResolvedMethod_isInlineable = 139,
-   ResolvedMethod_setWarmCallGraphTooBig = 141,
-   ResolvedMethod_setVirtualMethodIsOverridden = 142,
-   ResolvedMethod_addressContainingIsOverriddenBit = 143,
-   ResolvedMethod_methodIsNotzAAPEligible = 144,
-   ResolvedMethod_setClassForNewInstance = 145,
-   ResolvedMethod_getJittedBodyInfo = 146,
-   ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror = 147,
-   ResolvedMethod_isUnresolvedString = 148,
-   ResolvedMethod_stringConstant = 149,
-   ResolvedMethod_getResolvedVirtualMethod = 150,
-   ResolvedMethod_getMultipleResolvedMethods = 151,
-   ResolvedMethod_varHandleMethodTypeTableEntryAddress = 152,
-   ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry = 153,
-   ResolvedMethod_getConstantDynamicTypeFromCP = 154,
-   ResolvedMethod_isUnresolvedConstantDynamic = 155,
-   ResolvedMethod_dynamicConstant = 156,
-   ResolvedMethod_definingClassFromCPFieldRef = 157,
+   ResolvedMethod_isJNINative,
+   ResolvedMethod_isInterpreted,
+   ResolvedMethod_setRecognizedMethodInfo,
+   ResolvedMethod_startAddressForInterpreterOfJittedMethod,
+   ResolvedMethod_jniNativeMethodProperties,
+   ResolvedMethod_staticAttributes,
+   ResolvedMethod_getClassFromConstantPool,
+   ResolvedMethod_getDeclaringClassFromFieldOrStatic,
+   ResolvedMethod_classOfStatic,
+   ResolvedMethod_startAddressForJNIMethod,
+   ResolvedMethod_fieldAttributes,
+   ResolvedMethod_getResolvedStaticMethodAndMirror,
+   ResolvedMethod_getResolvedSpecialMethodAndMirror,
+   ResolvedMethod_classCPIndexOfMethod,
+   ResolvedMethod_startAddressForJittedMethod,
+   ResolvedMethod_localName,
+   ResolvedMethod_getResolvedPossiblyPrivateVirtualMethodAndMirror,
+   ResolvedMethod_virtualMethodIsOverridden,
+   ResolvedMethod_getResolvedInterfaceMethod_2, // arity 2
+   ResolvedMethod_getResolvedInterfaceMethodAndMirror_3, // arity 3
+   ResolvedMethod_getResolvedInterfaceMethodOffset,
+   ResolvedMethod_getUnresolvedStaticMethodInCP,
+   ResolvedMethod_isSubjectToPhaseChange,
+   ResolvedMethod_getUnresolvedSpecialMethodInCP,
+   ResolvedMethod_getUnresolvedFieldInCP,
+   ResolvedMethod_getRemoteROMString,
+   ResolvedMethod_fieldOrStaticName,
+   ResolvedMethod_getRemoteROMClassAndMethods,
+   ResolvedMethod_getResolvedHandleMethod,
+   ResolvedMethod_isUnresolvedMethodTypeTableEntry,
+   ResolvedMethod_methodTypeTableEntryAddress,
+   ResolvedMethod_isUnresolvedCallSiteTableEntry,
+   ResolvedMethod_callSiteTableEntryAddress,
+   ResolvedMethod_getResolvedDynamicMethod,
+   ResolvedMethod_shouldFailSetRecognizedMethodInfoBecauseOfHCR,
+   ResolvedMethod_isSameMethod,
+   ResolvedMethod_isBigDecimalMethod,
+   ResolvedMethod_isBigDecimalConvertersMethod,
+   ResolvedMethod_isInlineable,
+   ResolvedMethod_setWarmCallGraphTooBig,
+   ResolvedMethod_setVirtualMethodIsOverridden,
+   ResolvedMethod_addressContainingIsOverriddenBit,
+   ResolvedMethod_methodIsNotzAAPEligible,
+   ResolvedMethod_setClassForNewInstance,
+   ResolvedMethod_getJittedBodyInfo,
+   ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror,
+   ResolvedMethod_isUnresolvedString,
+   ResolvedMethod_stringConstant,
+   ResolvedMethod_getResolvedVirtualMethod,
+   ResolvedMethod_getMultipleResolvedMethods,
+   ResolvedMethod_varHandleMethodTypeTableEntryAddress,
+   ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry,
+   ResolvedMethod_getConstantDynamicTypeFromCP,
+   ResolvedMethod_isUnresolvedConstantDynamic,
+   ResolvedMethod_dynamicConstant,
+   ResolvedMethod_definingClassFromCPFieldRef,
 
-   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 160,
-   ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 161,
-   ResolvedRelocatableMethod_fieldAttributes = 162,
-   ResolvedRelocatableMethod_staticAttributes = 163,
-   ResolvedRelocatableMethod_getFieldType = 164,
+   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method,
+   ResolvedRelocatableMethod_storeValidationRecordIfNecessary,
+   ResolvedRelocatableMethod_fieldAttributes,
+   ResolvedRelocatableMethod_staticAttributes,
+   ResolvedRelocatableMethod_getFieldType,
 
    // For TR_J9ServerVM methods
-   VM_isClassLibraryClass = 200,
-   VM_isClassLibraryMethod = 201,
-   VM_getSuperClass = 202,
-   VM_isInstanceOf = 203,
-   VM_isClassArray = 205,
-   VM_transformJlrMethodInvoke = 206,
-   VM_getStaticReferenceFieldAtAddress = 207,
-   VM_getSystemClassFromClassName = 208,
-   VM_isMethodTracingEnabled = 209,
-   VM_getClassClassPointer = 211,
-   VM_setJ2IThunk = 212,
-   VM_getClassOfMethod = 213,
-   VM_getBaseComponentClass = 214,
-   VM_getLeafComponentClassFromArrayClass = 215,
-   VM_isClassLoadedBySystemClassLoader = 216,
-   VM_getClassFromSignature = 217,
-   VM_jitFieldsAreSame = 218,
-   VM_jitStaticsAreSame = 219,
-   VM_getComponentClassFromArrayClass = 220,
-   VM_classHasBeenReplaced = 221,
-   VM_classHasBeenExtended = 222,
-   VM_compiledAsDLTBefore = 223,
-   VM_isThunkArchetype = 226,
-   VM_printTruncatedSignature = 227,
-   VM_getStaticHookAddress = 228,
-   VM_isClassInitialized = 229,
-   VM_getOSRFrameSizeInBytes = 230,
-   VM_getInitialLockword = 231,
-   VM_isString1 = 232,
-   VM_getMethods = 233,
-   VM_isPrimitiveArray = 236,
-   VM_getAllocationSize = 237,
-   VM_getObjectClass = 238,
-   VM_stackWalkerMaySkipFrames = 239,
-   VM_hasFinalFieldsInClass = 240,
-   VM_getClassNameSignatureFromMethod = 241,
-   VM_getHostClass = 242,
-   VM_getStringUTF8Length = 243,
-   VM_classInitIsFinished = 244,
-   VM_getClassFromNewArrayType = 245,
-   VM_isCloneable = 246,
-   VM_canAllocateInlineClass = 247,
-   VM_getArrayClassFromComponentClass = 248,
-   VM_matchRAMclassFromROMclass = 249,
-   VM_getReferenceFieldAtAddress = 250,
-   VM_getVolatileReferenceFieldAt = 251,
-   VM_getInt32FieldAt = 252,
-   VM_getInt64FieldAt = 253,
-   VM_setInt64FieldAt = 254,
-   VM_compareAndSwapInt64FieldAt = 255,
-   VM_getArrayLengthInElements = 256,
-   VM_getClassFromJavaLangClass = 257,
-   VM_getOffsetOfClassFromJavaLangClassField = 258,
-   VM_getIdentityHashSaltPolicy = 261,
-   VM_getOffsetOfJLThreadJ9Thread = 262,
-   VM_getVFTEntry = 263,
-   VM_scanReferenceSlotsInClassForOffset = 264,
-   VM_findFirstHotFieldTenuredClassOffset = 265,
-   VM_getResolvedVirtualMethod = 266,
-   VM_sameClassLoaders = 267,
-   VM_isUnloadAssumptionRequired = 268,
-   VM_getInstanceFieldOffset = 270,
-   VM_getJavaLangClassHashCode = 271,
-   VM_hasFinalizer = 272,
-   VM_getClassDepthAndFlagsValue = 273,
-   VM_getMethodFromName = 274,
-   VM_getMethodFromClass = 275,
-   VM_isClassVisible = 276,
-   VM_markClassForTenuredAlignment = 277,
-   VM_getReferenceSlotsInClass = 278,
-   VM_getMethodSize = 279,
-   VM_addressOfFirstClassStatic = 280,
-   VM_getStaticFieldAddress = 281,
-   VM_getInterpreterVTableSlot = 282,
-   VM_revertToInterpreted = 283,
-   VM_getLocationOfClassLoaderObjectPointer = 284,
-   VM_isOwnableSyncClass = 285,
-   VM_getClassFromMethodBlock = 286,
-   VM_fetchMethodExtendedFlagsPointer = 287,
-   VM_stringEquals = 288,
-   VM_getStringHashCode = 289,
-   VM_getLineNumberForMethodAndByteCodeIndex = 290,
-   VM_getObjectNewInstanceImplMethod = 291,
-   VM_getBytecodePC = 292,
-   VM_getClassFromStatic = 293,
-   VM_setInvokeExactJ2IThunk = 294,
-   VM_createMethodHandleArchetypeSpecimen = 295,
-   VM_instanceOfOrCheckCast = 297,
-   VM_getResolvedMethodsAndMirror = 300,
-   VM_getVMInfo = 301,
-   VM_isAnonymousClass = 302,
-   VM_dereferenceStaticAddress = 303,
-   VM_getClassFromCP = 304,
-   VM_getROMMethodFromRAMMethod = 305,
-   VM_getReferenceFieldAt = 306,
-   VM_getJ2IThunk = 307,
-   VM_needsInvokeExactJ2IThunk = 308,
-   VM_instanceOfOrCheckCastNoCacheUpdate = 309,
-   VM_getCellSizeForSizeClass = 310,
-   VM_getObjectSizeClass = 311,
-   VM_stackWalkerMaySkipFramesSVM = 312,
+   VM_isClassLibraryClass,
+   VM_isClassLibraryMethod,
+   VM_getSuperClass,
+   VM_isInstanceOf,
+   VM_isClassArray,
+   VM_transformJlrMethodInvoke,
+   VM_getStaticReferenceFieldAtAddress,
+   VM_getSystemClassFromClassName,
+   VM_isMethodTracingEnabled,
+   VM_getClassClassPointer,
+   VM_setJ2IThunk,
+   VM_getClassOfMethod,
+   VM_getBaseComponentClass,
+   VM_getLeafComponentClassFromArrayClass,
+   VM_isClassLoadedBySystemClassLoader,
+   VM_getClassFromSignature,
+   VM_jitFieldsAreSame,
+   VM_jitStaticsAreSame,
+   VM_getComponentClassFromArrayClass,
+   VM_classHasBeenReplaced,
+   VM_classHasBeenExtended,
+   VM_compiledAsDLTBefore,
+   VM_isThunkArchetype,
+   VM_printTruncatedSignature,
+   VM_getStaticHookAddress,
+   VM_isClassInitialized,
+   VM_getOSRFrameSizeInBytes,
+   VM_getInitialLockword,
+   VM_isString1,
+   VM_getMethods,
+   VM_isPrimitiveArray,
+   VM_getAllocationSize,
+   VM_getObjectClass,
+   VM_stackWalkerMaySkipFrames,
+   VM_hasFinalFieldsInClass,
+   VM_getClassNameSignatureFromMethod,
+   VM_getHostClass,
+   VM_getStringUTF8Length,
+   VM_classInitIsFinished,
+   VM_getClassFromNewArrayType,
+   VM_isCloneable,
+   VM_canAllocateInlineClass,
+   VM_getArrayClassFromComponentClass,
+   VM_matchRAMclassFromROMclass,
+   VM_getReferenceFieldAtAddress,
+   VM_getVolatileReferenceFieldAt,
+   VM_getInt32FieldAt,
+   VM_getInt64FieldAt,
+   VM_setInt64FieldAt,
+   VM_compareAndSwapInt64FieldAt,
+   VM_getArrayLengthInElements,
+   VM_getClassFromJavaLangClass,
+   VM_getOffsetOfClassFromJavaLangClassField,
+   VM_getIdentityHashSaltPolicy,
+   VM_getOffsetOfJLThreadJ9Thread,
+   VM_getVFTEntry,
+   VM_scanReferenceSlotsInClassForOffset,
+   VM_findFirstHotFieldTenuredClassOffset,
+   VM_getResolvedVirtualMethod,
+   VM_sameClassLoaders,
+   VM_isUnloadAssumptionRequired,
+   VM_getInstanceFieldOffset,
+   VM_getJavaLangClassHashCode,
+   VM_hasFinalizer,
+   VM_getClassDepthAndFlagsValue,
+   VM_getMethodFromName,
+   VM_getMethodFromClass,
+   VM_isClassVisible,
+   VM_markClassForTenuredAlignment,
+   VM_getReferenceSlotsInClass,
+   VM_getMethodSize,
+   VM_addressOfFirstClassStatic,
+   VM_getStaticFieldAddress,
+   VM_getInterpreterVTableSlot,
+   VM_revertToInterpreted,
+   VM_getLocationOfClassLoaderObjectPointer,
+   VM_isOwnableSyncClass,
+   VM_getClassFromMethodBlock,
+   VM_fetchMethodExtendedFlagsPointer,
+   VM_stringEquals,
+   VM_getStringHashCode,
+   VM_getLineNumberForMethodAndByteCodeIndex,
+   VM_getObjectNewInstanceImplMethod,
+   VM_getBytecodePC,
+   VM_getClassFromStatic,
+   VM_setInvokeExactJ2IThunk,
+   VM_createMethodHandleArchetypeSpecimen,
+   VM_instanceOfOrCheckCast,
+   VM_getResolvedMethodsAndMirror,
+   VM_getVMInfo,
+   VM_isAnonymousClass,
+   VM_dereferenceStaticAddress,
+   VM_getClassFromCP,
+   VM_getROMMethodFromRAMMethod,
+   VM_getReferenceFieldAt,
+   VM_getJ2IThunk,
+   VM_needsInvokeExactJ2IThunk,
+   VM_instanceOfOrCheckCastNoCacheUpdate,
+   VM_getCellSizeForSizeClass,
+   VM_getObjectSizeClass,
+   VM_stackWalkerMaySkipFramesSVM,
 
    // For static TR::CompilationInfo methods
-   CompInfo_isCompiled = 400,
-   CompInfo_getInvocationCount = 401,
-   CompInfo_setInvocationCount = 402,
-   CompInfo_getJ9MethodExtra = 403,
-   CompInfo_isJNINative = 404,
-   CompInfo_isJSR292 = 405,
-   CompInfo_getMethodBytecodeSize = 406,
-   CompInfo_setJ9MethodExtra = 407,
-   CompInfo_setInvocationCountAtomic = 408,
-   CompInfo_isClassSpecial = 409,
-   CompInfo_getJ9MethodStartPC = 410,
+   CompInfo_isCompiled,
+   CompInfo_getInvocationCount,
+   CompInfo_setInvocationCount,
+   CompInfo_getJ9MethodExtra,
+   CompInfo_isJNINative,
+   CompInfo_isJSR292,
+   CompInfo_getMethodBytecodeSize,
+   CompInfo_setJ9MethodExtra,
+   CompInfo_setInvocationCountAtomic,
+   CompInfo_isClassSpecial,
+   CompInfo_getJ9MethodStartPC,
 
    // For J9::ClassEnv Methods
-   ClassEnv_classFlagsValue = 500,
-   ClassEnv_classDepthOf = 501,
-   ClassEnv_classInstanceSize = 502,
-   ClassEnv_superClassesOf = 504,
-   ClassEnv_indexedSuperClassOf = 505,
-   ClassEnv_iTableOf = 506,
-   ClassEnv_iTableNext = 507,
-   ClassEnv_iTableRomClass = 508,
-   ClassEnv_getITable = 509,
-   ClassEnv_classHasIllegalStaticFinalFieldModification = 510,
-   ClassEnv_getROMClassRefName = 511,
+   ClassEnv_classFlagsValue,
+   ClassEnv_classDepthOf,
+   ClassEnv_classInstanceSize,
+   ClassEnv_superClassesOf,
+   ClassEnv_indexedSuperClassOf,
+   ClassEnv_iTableOf,
+   ClassEnv_iTableNext,
+   ClassEnv_iTableRomClass,
+   ClassEnv_getITable,
+   ClassEnv_classHasIllegalStaticFinalFieldModification,
+   ClassEnv_getROMClassRefName,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache = 600,
-   SharedCache_rememberClass = 601,
-   SharedCache_addHint = 602,
-   SharedCache_storeSharedData = 603,
+   SharedCache_getClassChainOffsetInSharedCache,
+   SharedCache_rememberClass,
+   SharedCache_addHint,
+   SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect = 700,
-   runFEMacro_invokeExplicitCastHandleConvertArgs = 701,
-   runFEMacro_targetTypeL = 702,
-   runFEMacro_invokeILGenMacrosInvokeExactAndFixup = 703,
-   runFEMacro_invokeArgumentMoverHandlePermuteArgs = 704,
-   runFEMacro_invokePermuteHandlePermuteArgs = 705,
-   runFEMacro_invokeGuardWithTestHandleNumGuardArgs = 706,
-   runFEMacro_invokeInsertHandle = 707,
-   runFEMacro_invokeDirectHandleDirectCall = 708,
-   runFEMacro_invokeSpreadHandleArrayArg = 709,
-   runFEMacro_invokeSpreadHandle = 710,
-   runFEMacro_invokeFoldHandle = 711,
-   runFEMacro_invokeFoldHandle2 = 712,
-   runFEMacro_invokeFinallyHandle = 713,
-   runFEMacro_invokeFilterArgumentsHandle = 714,
-   runFEMacro_invokeFilterArgumentsHandle2 = 715,
-   runFEMacro_invokeCatchHandle = 716,
-   runFEMacro_invokeILGenMacrosParameterCount = 717,
-   runFEMacro_invokeILGenMacrosArrayLength = 718,
-   runFEMacro_invokeILGenMacrosGetField = 719,
-   runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs = 720,
-   runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition = 721,
-   runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices = 722,
-   runFEMacro_invokeCollectHandleAllocateArray = 723,
+   runFEMacro_invokeCollectHandleNumArgsToCollect,
+   runFEMacro_invokeExplicitCastHandleConvertArgs,
+   runFEMacro_targetTypeL,
+   runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
+   runFEMacro_invokeArgumentMoverHandlePermuteArgs,
+   runFEMacro_invokePermuteHandlePermuteArgs,
+   runFEMacro_invokeGuardWithTestHandleNumGuardArgs,
+   runFEMacro_invokeInsertHandle,
+   runFEMacro_invokeDirectHandleDirectCall,
+   runFEMacro_invokeSpreadHandleArrayArg,
+   runFEMacro_invokeSpreadHandle,
+   runFEMacro_invokeFoldHandle,
+   runFEMacro_invokeFoldHandle2,
+   runFEMacro_invokeFinallyHandle,
+   runFEMacro_invokeFilterArgumentsHandle,
+   runFEMacro_invokeFilterArgumentsHandle2,
+   runFEMacro_invokeCatchHandle,
+   runFEMacro_invokeILGenMacrosParameterCount,
+   runFEMacro_invokeILGenMacrosArrayLength,
+   runFEMacro_invokeILGenMacrosGetField,
+   runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs,
+   runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition,
+   runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices,
+   runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo = 800,
-   CHTable_getClassInfoUpdates = 801,
-   CHTable_commit = 802,
-   CHTable_clearReservable = 803,
+   CHTable_getAllClassInfo,
+   CHTable_getClassInfoUpdates,
+   CHTable_commit,
+   CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample = 900,
-   IProfiler_searchForMethodSample = 901,
-   IProfiler_getMaxCallCount = 902,
-   IProfiler_setCallCount = 903,
+   IProfiler_profilingSample,
+   IProfiler_searchForMethodSample,
+   IProfiler_getMaxCallCount,
+   IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo = 1000,
-   Recompilation_getJittedBodyInfoFromPC = 1001,
+   Recompilation_getExistingMethodInfo,
+   Recompilation_getJittedBodyInfoFromPC,
 
-   ClassInfo_getRemoteROMString = 1100,
+   ClassInfo_getRemoteROMString,
 
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex = 1200,
-   KnownObjectTable_getOrCreateIndexAt = 1201,
-   KnownObjectTable_getPointer = 1202,
-   KnownObjectTable_getExistingIndexAt = 1203,
+   KnownObjectTable_getOrCreateIndex,
+   KnownObjectTable_getOrCreateIndexAt,
+   KnownObjectTable_getPointer,
+   KnownObjectTable_getExistingIndexAt,
    // for KnownObjectTable outside J9::KnownObjectTable class
-   KnownObjectTable_symbolReferenceTableCreateKnownObject = 1204,
-   KnownObjectTable_mutableCallSiteEpoch = 1205,
-   KnownObjectTable_dereferenceKnownObjectField = 1206,
-   KnownObjectTable_dereferenceKnownObjectField2 = 1207,
-   KnownObjectTable_createSymRefWithKnownObject = 1208,
-   KnownObjectTable_getReferenceField = 1209,
-   KnownObjectTable_invokeDirectHandleDirectCall = 1210,
-   KnownObjectTable_getKnownObjectTableDumpInfo = 1211,
+   KnownObjectTable_symbolReferenceTableCreateKnownObject,
+   KnownObjectTable_mutableCallSiteEpoch,
+   KnownObjectTable_dereferenceKnownObjectField,
+   KnownObjectTable_dereferenceKnownObjectField2,
+   KnownObjectTable_createSymRefWithKnownObject,
+   KnownObjectTable_getReferenceField,
+   KnownObjectTable_invokeDirectHandleDirectCall,
+   KnownObjectTable_getKnownObjectTableDumpInfo,
    MessageType_MAXTYPE
    };
 
-   const int MessageType_ARRAYSIZE = MessageType_MAXTYPE;
+const int MessageType_ARRAYSIZE = MessageType_MAXTYPE;
+   
+static const char *messageNames[MessageType_ARRAYSIZE] =
+   {
+   "compilationCode", // 0
+   "compilationFailure", // 1
+   "mirrorResolvedJ9Method", // 2
+   "get_params_to_construct_TR_j9method", // 3
+   "getUnloadedClassRanges", // 4
+   "compilationRequest", // 5
+   "compilationInterrupted", // 6
+   "clientSessionTerminate", // 7
+   "connectionTerminate", // 8
+   "ResolvedMethod_isJNINative", // 9
+   "ResolvedMethod_isInterpreted", // 10
+   "ResolvedMethod_setRecognizedMethodInfo", // 11
+   "ResolvedMethod_startAddressForInterpreterOfJittedMethod", // 12
+   "ResolvedMethod_jniNativeMethodProperties", // 13
+   "ResolvedMethod_staticAttributes", // 14
+   "ResolvedMethod_getClassFromConstantPool", // 15
+   "ResolvedMethod_getDeclaringClassFromFieldOrStatic", // 16
+   "ResolvedMethod_classOfStatic", // 17
+   "ResolvedMethod_startAddressForJNIMethod", // 18
+   "ResolvedMethod_fieldAttributes", // 19
+   "ResolvedMethod_getResolvedStaticMethodAndMirror", // 20
+   "ResolvedMethod_getResolvedSpecialMethodAndMirror", // 21
+   "ResolvedMethod_classCPIndexOfMethod", // 22
+   "ResolvedMethod_startAddressForJittedMethod", // 23
+   "ResolvedMethod_localName", // 24
+   "ResolvedMethod_getResolvedPossiblyPrivateVirtualMethodAndMirror", // 25
+   "ResolvedMethod_virtualMethodIsOverridden", // 26
+   "ResolvedMethod_getResolvedInterfaceMethod_2", // 27
+   "ResolvedMethod_getResolvedInterfaceMethodAndMirror_3", // 28
+   "ResolvedMethod_getResolvedInterfaceMethodOffset", // 29
+   "ResolvedMethod_getUnresolvedStaticMethodInCP", // 30
+   "ResolvedMethod_isSubjectToPhaseChange", // 31
+   "ResolvedMethod_getUnresolvedSpecialMethodInCP", // 32
+   "ResolvedMethod_getUnresolvedFieldInCP", // 33
+   "ResolvedMethod_getRemoteROMString", // 34
+   "ResolvedMethod_fieldOrStaticName", // 35
+   "ResolvedMethod_getRemoteROMClassAndMethods", // 36
+   "ResolvedMethod_getResolvedHandleMethod", // 37
+   "ResolvedMethod_isUnresolvedMethodTypeTableEntry", // 38
+   "ResolvedMethod_methodTypeTableEntryAddress", // 39
+   "ResolvedMethod_isUnresolvedCallSiteTableEntry", // 40
+   "ResolvedMethod_callSiteTableEntryAddress", // 41
+   "ResolvedMethod_getResolvedDynamicMethod", // 42
+   "ResolvedMethod_shouldFailSetRecognizedMethodInfoBecauseOfHCR", // 43
+   "ResolvedMethod_isSameMethod", // 44
+   "ResolvedMethod_isBigDecimalMethod", // 45
+   "ResolvedMethod_isBigDecimalConvertersMethod", // 46
+   "ResolvedMethod_isInlineable", // 47
+   "ResolvedMethod_setWarmCallGraphTooBig", // 48
+   "ResolvedMethod_setVirtualMethodIsOverridden", // 49
+   "ResolvedMethod_addressContainingIsOverriddenBit", // 50
+   "ResolvedMethod_methodIsNotzAAPEligible", // 51
+   "ResolvedMethod_setClassForNewInstance", // 52
+   "ResolvedMethod_getJittedBodyInfo", // 53
+   "ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror", // 54
+   "ResolvedMethod_isUnresolvedString", // 55
+   "ResolvedMethod_stringConstant", // 56
+   "ResolvedMethod_getResolvedVirtualMethod", // 57
+   "ResolvedMethod_getMultipleResolvedMethods", // 58
+   "ResolvedMethod_varHandleMethodTypeTableEntryAddress", // 59
+   "ResolvedMethod_isUnresolvedVarHandleMethodTypeTableEntry", // 60
+   "ResolvedMethod_getConstantDynamicTypeFromCP", // 61
+   "ResolvedMethod_isUnresolvedConstantDynamic", // 62
+   "ResolvedMethod_dynamicConstant", // 63
+   "ResolvedMethod_definingClassFromCPFieldRef", // 64
+   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 65
+   "ResolvedRelocatableMethod_storeValidationRecordIfNecessary", // 66
+   "ResolvedRelocatableMethod_fieldAttributes", // 67
+   "ResolvedRelocatableMethod_staticAttributes", // 68
+   "ResolvedRelocatableMethod_getFieldType", // 69
+   "VM_isClassLibraryClass", // 70
+   "VM_isClassLibraryMethod", // 71
+   "VM_getSuperClass", // 72
+   "VM_isInstanceOf", // 73
+   "VM_isClassArray", // 74
+   "VM_transformJlrMethodInvoke", // 75
+   "VM_getStaticReferenceFieldAtAddress", // 76
+   "VM_getSystemClassFromClassName", // 77
+   "VM_isMethodTracingEnabled", // 78
+   "VM_getClassClassPointer", // 79
+   "VM_setJ2IThunk", // 80
+   "VM_getClassOfMethod", // 81
+   "VM_getBaseComponentClass", // 82
+   "VM_getLeafComponentClassFromArrayClass", // 83
+   "VM_isClassLoadedBySystemClassLoader", // 84
+   "VM_getClassFromSignature", // 85
+   "VM_jitFieldsAreSame", // 86
+   "VM_jitStaticsAreSame", // 87
+   "VM_getComponentClassFromArrayClass", // 88
+   "VM_classHasBeenReplaced", // 89
+   "VM_classHasBeenExtended", // 90
+   "VM_compiledAsDLTBefore", // 91
+   "VM_isThunkArchetype", // 92
+   "VM_printTruncatedSignature", // 93
+   "VM_getStaticHookAddress", // 94
+   "VM_isClassInitialized", // 95
+   "VM_getOSRFrameSizeInBytes", // 96
+   "VM_getInitialLockword", // 97
+   "VM_isString1", // 98
+   "VM_getMethods", // 99
+   "VM_isPrimitiveArray", // 100
+   "VM_getAllocationSize", // 101
+   "VM_getObjectClass", // 102
+   "VM_stackWalkerMaySkipFrames", // 103
+   "VM_hasFinalFieldsInClass", // 104
+   "VM_getClassNameSignatureFromMethod", // 105
+   "VM_getHostClass", // 106
+   "VM_getStringUTF8Length", // 107
+   "VM_classInitIsFinished", // 108
+   "VM_getClassFromNewArrayType", // 109
+   "VM_isCloneable", // 110
+   "VM_canAllocateInlineClass", // 111
+   "VM_getArrayClassFromComponentClass", // 112
+   "VM_matchRAMclassFromROMclass", // 113
+   "VM_getReferenceFieldAtAddress", // 114
+   "VM_getVolatileReferenceFieldAt", // 115
+   "VM_getInt32FieldAt", // 116
+   "VM_getInt64FieldAt", // 117
+   "VM_setInt64FieldAt", // 118
+   "VM_compareAndSwapInt64FieldAt", // 119
+   "VM_getArrayLengthInElements", // 120
+   "VM_getClassFromJavaLangClass", // 121
+   "VM_getOffsetOfClassFromJavaLangClassField", // 122
+   "VM_getIdentityHashSaltPolicy", // 123
+   "VM_getOffsetOfJLThreadJ9Thread", // 124
+   "VM_getVFTEntry", // 125
+   "VM_scanReferenceSlotsInClassForOffset", // 126
+   "VM_findFirstHotFieldTenuredClassOffset", // 127
+   "VM_getResolvedVirtualMethod", // 128
+   "VM_sameClassLoaders", // 129
+   "VM_isUnloadAssumptionRequired", // 130
+   "VM_getInstanceFieldOffset", // 131
+   "VM_getJavaLangClassHashCode", // 132
+   "VM_hasFinalizer", // 133
+   "VM_getClassDepthAndFlagsValue", // 134
+   "VM_getMethodFromName", // 135
+   "VM_getMethodFromClass", // 136
+   "VM_isClassVisible", // 137
+   "VM_markClassForTenuredAlignment", // 138
+   "VM_getReferenceSlotsInClass", // 139
+   "VM_getMethodSize", // 140
+   "VM_addressOfFirstClassStatic", // 141
+   "VM_getStaticFieldAddress", // 142
+   "VM_getInterpreterVTableSlot", // 143
+   "VM_revertToInterpreted", // 144
+   "VM_getLocationOfClassLoaderObjectPointer", // 145
+   "VM_isOwnableSyncClass", // 146
+   "VM_getClassFromMethodBlock", // 147
+   "VM_fetchMethodExtendedFlagsPointer", // 148
+   "VM_stringEquals", // 149
+   "VM_getStringHashCode", // 150
+   "VM_getLineNumberForMethodAndByteCodeIndex", // 151
+   "VM_getObjectNewInstanceImplMethod", // 152
+   "VM_getBytecodePC", // 153
+   "VM_getClassFromStatic", // 154
+   "VM_setInvokeExactJ2IThunk", // 155
+   "VM_createMethodHandleArchetypeSpecimen", // 156
+   "VM_instanceOfOrCheckCast", // 157
+   "VM_getResolvedMethodsAndMirror", // 158
+   "VM_getVMInfo", // 159
+   "VM_isAnonymousClass", // 160
+   "VM_dereferenceStaticAddress", // 161
+   "VM_getClassFromCP", // 162
+   "VM_getROMMethodFromRAMMethod", // 163
+   "VM_getReferenceFieldAt", // 164
+   "VM_getJ2IThunk", // 165
+   "VM_needsInvokeExactJ2IThunk", // 166
+   "VM_instanceOfOrCheckCastNoCacheUpdate", // 167
+   "VM_getCellSizeForSizeClass", // 168
+   "VM_getObjectSizeClass", // 169
+   "VM_stackWalkerMaySkipFramesSVM", // 170
+   "CompInfo_isCompiled", // 171
+   "CompInfo_getInvocationCount", // 172
+   "CompInfo_setInvocationCount", // 173
+   "CompInfo_getJ9MethodExtra", // 174
+   "CompInfo_isJNINative", // 175
+   "CompInfo_isJSR292", // 176
+   "CompInfo_getMethodBytecodeSize", // 177
+   "CompInfo_setJ9MethodExtra", // 178
+   "CompInfo_setInvocationCountAtomic", // 179
+   "CompInfo_isClassSpecial", // 180
+   "CompInfo_getJ9MethodStartPC", // 181
+   "ClassEnv_classFlagsValue", // 182
+   "ClassEnv_classDepthOf", // 183
+   "ClassEnv_classInstanceSize", // 184
+   "ClassEnv_superClassesOf", // 185
+   "ClassEnv_indexedSuperClassOf", // 186
+   "ClassEnv_iTableOf", // 187
+   "ClassEnv_iTableNext", // 188
+   "ClassEnv_iTableRomClass", // 189
+   "ClassEnv_getITable", // 190
+   "ClassEnv_classHasIllegalStaticFinalFieldModification", // 191
+   "ClassEnv_getROMClassRefName", // 192
+   "SharedCache_getClassChainOffsetInSharedCache", // 193
+   "SharedCache_rememberClass", // 194
+   "SharedCache_addHint", // 195
+   "SharedCache_storeSharedData", // 196
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 197
+   "runFEMacro_invokeExplicitCastHandleConvertArgs", // 198
+   "runFEMacro_targetTypeL", // 199
+   "runFEMacro_invokeILGenMacrosInvokeExactAndFixup", // 200
+   "runFEMacro_invokeArgumentMoverHandlePermuteArgs", // 201
+   "runFEMacro_invokePermuteHandlePermuteArgs", // 202
+   "runFEMacro_invokeGuardWithTestHandleNumGuardArgs", // 203
+   "runFEMacro_invokeInsertHandle", // 204
+   "runFEMacro_invokeDirectHandleDirectCall", // 205
+   "runFEMacro_invokeSpreadHandleArrayArg", // 206
+   "runFEMacro_invokeSpreadHandle", // 207
+   "runFEMacro_invokeFoldHandle", // 208
+   "runFEMacro_invokeFoldHandle2", // 209
+   "runFEMacro_invokeFinallyHandle", // 210
+   "runFEMacro_invokeFilterArgumentsHandle", // 211
+   "runFEMacro_invokeFilterArgumentsHandle2", // 212
+   "runFEMacro_invokeCatchHandle", // 213
+   "runFEMacro_invokeILGenMacrosParameterCount", // 214
+   "runFEMacro_invokeILGenMacrosArrayLength", // 215
+   "runFEMacro_invokeILGenMacrosGetField", // 216
+   "runFEMacro_invokeFilterArgumentsWithCombinerHandleNumSuffixArgs", // 217
+   "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition", // 218
+   "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices", // 219
+   "runFEMacro_invokeCollectHandleAllocateArray", // 220
+   "CHTable_getAllClassInfo", // 221
+   "CHTable_getClassInfoUpdates", // 222
+   "CHTable_commit", // 223
+   "CHTable_clearReservable", // 224
+   "IProfiler_profilingSample", // 225
+   "IProfiler_searchForMethodSample", // 226
+   "IProfiler_getMaxCallCount", // 227
+   "IProfiler_setCallCount", // 228
+   "Recompilation_getExistingMethodInfo", // 229
+   "Recompilation_getJittedBodyInfoFromPC", // 230
+   "ClassInfo_getRemoteROMString", // 231
+   "KnownObjectTable_getOrCreateIndex", // 232
+   "KnownObjectTable_getOrCreateIndexAt", // 233
+   "KnownObjectTable_getPointer", // 234
+   "KnownObjectTable_getExistingIndexAt", // 235
+   "KnownObjectTable_symbolReferenceTableCreateKnownObject", // 236
+   "KnownObjectTable_mutableCallSiteEpoch", // 237
+   "KnownObjectTable_dereferenceKnownObjectField", // 238
+   "KnownObjectTable_dereferenceKnownObjectField2", // 239
+   "KnownObjectTable_createSymRefWithKnownObject", // 240
+   "KnownObjectTable_getReferenceField", // 241
+   "KnownObjectTable_invokeDirectHandleDirectCall", // 242
+   "KnownObjectTable_getKnownObjectTableDumpInfo" // 243
+   };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP


### PR DESCRIPTION
Removing protobuf removed auto-generated message names.
This commit re-adds them as an array of strings, with index
of each name corresponding to the same index in message enum.

When adding new message types, both enum and name array need to be
updated now.