### PR TITLE
Revert "Change stackWalkerMaySkipFrames to avoid AOT failures"

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -577,14 +577,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             vmThread->javaVM->srConstructorAccessor ? (TR_OpaqueClassBlock *) J9VM_J9CLASS_FROM_JCLASS(vmThread, vmThread->javaVM->srConstructorAccessor) : NULL);
          }
          break;
-      case MessageType::VM_stackWalkerMaySkipFramesSVM:
-         {
-         auto recv = client->getRecvData<TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *>();
-         TR_OpaqueMethodBlock *method = std::get<0>(recv);
-         TR_OpaqueClassBlock *clazz = std::get<1>(recv);
-         client->write(response, fe->stackWalkerMaySkipFrames(method, clazz));
-         }
-         break;
       case MessageType::VM_hasFinalFieldsInClass:
          {
          TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2078,22 +2078,12 @@ TR_J9SharedCacheServerVM::isPrimitiveClass(TR_OpaqueClassBlock * classPointer)
 bool
 TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
    {
-   bool skipFrames = false;
+   bool skipFrames = TR_J9ServerVM::stackWalkerMaySkipFrames(method, methodClass);
    TR::Compilation *comp = _compInfoPT->getCompilation();
-   // For AOT with SVM do not optimize the messages by calling TR_J9ServerVM::stackWalkerMaySkipFrames
-   // because this will call isInstanceOf() and then isSuperClass() which will fail the 
-   // the SVM validation check and result in an AOT compilation failure
    if (comp && comp->getOption(TR_UseSymbolValidationManager))
       {
-      JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-      stream->write(JITServer::MessageType::VM_stackWalkerMaySkipFramesSVM, method, methodClass);
-      skipFrames = std::get<0>(stream->read<bool>());
       bool recordCreated = comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames);
       SVM_ASSERT(recordCreated, "Failed to validate addStackWalkerMaySkipFramesRecord");
-      }
-   else
-      {
-      skipFrames = TR_J9ServerVM::stackWalkerMaySkipFrames(method, methodClass);
       }
    return skipFrames;
    }

--- a/runtime/compiler/net/protos/compile.proto
+++ b/runtime/compiler/net/protos/compile.proto
@@ -233,7 +233,6 @@ enum MessageType
    VM_getJ2IThunk = 307;
    VM_needsInvokeExactJ2IThunk = 308;
    VM_instanceOfOrCheckCastNoCacheUpdate = 309;
-   VM_stackWalkerMaySkipFramesSVM = 310;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
Reverts eclipse/openj9#8898

Breaks jdk8, jdk11 xlinux and plinux compilation.
```
22:21:41  /home/jenkins/jenkins-agent/workspace/Build_JDK8_ppc64le_linux_Nightly/build/linux-ppc64le-normal-server-release/vm/compiler/../compiler/control/JITClientCompilationThread.cpp: In function 'bool handleServerMessage(JITServer::ClientStream*, TR_J9VM*, JITServer::MessageType&)':
22:21:41  /home/jenkins/jenkins-agent/workspace/Build_JDK8_ppc64le_linux_Nightly/build/linux-ppc64le-normal-server-release/vm/compiler/../compiler/control/JITClientCompilationThread.cpp:580:25: error: 'VM_stackWalkerMaySkipFramesSVM' is not a member of 'JITServer::MessageType'
22:21:41         case MessageType::VM_stackWalkerMaySkipFramesSVM:
22:21:41                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```