### PR TITLE
Cleanup Known object table support in JITServer

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -212,7 +212,7 @@ J9::Compilation::Compilation(int32_t id,
       J9::MethodHandleThunkDetails & thunkDetails = static_cast<J9::MethodHandleThunkDetails &>(details);
       if (thunkDetails.isCustom())
          {
-         TR::KnownObjectTable::Index index = knot->getIndexAt(thunkDetails.getHandleRef());
+         TR::KnownObjectTable::Index index = knot->getOrCreateIndexAt(thunkDetails.getHandleRef());
          ListIterator<TR::ParameterSymbol> parms(&_methodSymbol->getParameterList());
          TR::ParameterSymbol* parm0 = parms.getFirst();
          parm0->setKnownObjectIndex(index);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -421,7 +421,7 @@ J9::SymbolReferenceTable::findOrCreateCallSiteTableEntrySymbol(TR::ResolvedMetho
       {
       TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
       if (knot)
-         knownObjectIndex = knot->getIndexAt((uintptr_t*)entryLocation);
+         knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)entryLocation);
       }
 
    symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1,
@@ -1234,7 +1234,7 @@ J9::SymbolReferenceTable::findOrCreateStringSymbol(TR::ResolvedMethodSymbol * ow
          TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
          if (knot)
             {
-            knownObjectIndex = knot->getIndexAt((uintptr_t*)stringConst);
+            knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)stringConst);
             }
          }
       symRef = findOrCreateCPSymbol(owningMethodSymbol, cpIndex, TR::Address, true, stringConst, knownObjectIndex);
@@ -1657,7 +1657,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
 
                if (createKnownObject)
                   {
-                  knownObjectIndex = knot->getIndexAt((uintptr_t*)dataAddress);
+                  knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)dataAddress);
                   }
                }
             }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2402,7 +2402,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                haveFilterList[i] = (fe->getReferenceElement(filters, i) != 0) ? 1 : 0;
                if (knotEnabled)
                   {
-                  filterIndexList[i] = knot->getIndex(fe->getReferenceElement(filters, i));
+                  filterIndexList[i] = knot->getOrCreateIndex(fe->getReferenceElement(filters, i));
                   filterObjectReferenceLocationList[i] = knot->getPointerLocation(filterIndexList[i]);
                   }
                }
@@ -2614,7 +2614,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                           std::string((char*) bodyInfo->getMethodInfo(), sizeof(TR_PersistentMethodInfo)));
          }
          break;
-      case MessageType::KnownObjectTable_getIndex:
+      case MessageType::KnownObjectTable_getOrCreateIndex:
          {
          uintptr_t objectPointer = std::get<0>(client->getRecvData<uintptr_t>());
          TR::KnownObjectTable::Index index = TR::KnownObjectTable::UNKNOWN;
@@ -2622,17 +2622,17 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 
             {
             TR::VMAccessCriticalSection knownObjectTableGetIndex(fe);
-            index = knot->getIndex(objectPointer);
+            index = knot->getOrCreateIndex(objectPointer);
             objectPointerReference = knot->getPointerLocation(index);
             }
 
          client->write(response, index, objectPointerReference);
          }
          break;
-      case MessageType::KnownObjectTable_getIndexAt:
+      case MessageType::KnownObjectTable_getOrCreateIndexAt:
          {
          uintptr_t *objectPointerReference = std::get<0>(client->getRecvData<uintptr_t*>());
-         client->write(response, knot->getIndexAt(objectPointerReference));
+         client->write(response, knot->getOrCreateIndexAt(objectPointerReference));
          }
          break;
       case MessageType::KnownObjectTable_getPointer:
@@ -2697,7 +2697,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 
                   if (createKnownObject)
                      {
-                     knotIndex = knot->getIndexAt((uintptr_t*)dataAddress);
+                     knotIndex = knot->getOrCreateIndexAt((uintptr_t*)dataAddress);
                      objectPointerReference = knot->getPointerLocation(knotIndex);
                      }
                   }
@@ -2726,7 +2726,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                uintptr_t currentEpoch = fej9->getVolatileReferenceField(mcsObject, "epoch", "Ljava/lang/invoke/MethodHandle;");
                if (currentEpoch)
                   {
-                  knotIndex = knot->getIndex(currentEpoch);
+                  knotIndex = knot->getOrCreateIndex(currentEpoch);
                   objectPointerReference = knot->getPointerLocation(knotIndex);
                   }
                }
@@ -2756,7 +2756,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             if (fieldDeclaringClass && fe->isInstanceOf(baseObjectClass, fieldDeclaringClass, true) == TR_yes)
                {
                fieldAddress = fe->getReferenceFieldAtAddress(baseObjectAddress + fieldOffset);
-               resultIndex = knot->getIndex(fieldAddress);
+               resultIndex = knot->getOrCreateIndex(fieldAddress);
                objectPointerReference = knot->getPointerLocation(resultIndex);
                }
             }
@@ -2781,7 +2781,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             TR_ASSERT_FATAL(fe->isInstanceOf(receiverClass, mutableCallsiteClass, true) == TR_yes, "receiver of mutableCallsite_getTarget must be instance of MutableCallSite (*%p)", knot->getPointerLocation(receiverIndex));
             uintptr_t fieldAddress = fe->getReferenceFieldAt(receiverAddress, targetFieldOffset);
 
-            resultIndex = knot->getIndex(fieldAddress);
+            resultIndex = knot->getOrCreateIndex(fieldAddress);
             objectPointerReference = knot->getPointerLocation(resultIndex);
             }
 
@@ -2807,7 +2807,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 
             if (knotEnabled && knot)
                {
-               resultIndex = knot->getIndex(methodHandle);
+               resultIndex = knot->getOrCreateIndex(methodHandle);
                objectPointerReference = knot->getPointerLocation(resultIndex);
                }
             }
@@ -2827,7 +2827,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             uintptr_t jlClass = (uintptr_t)J9VM_J9CLASS_TO_HEAPCLASS((J9Class*)staticAddress);
             TR_ASSERT(jlClass, "java/lang/Class reference from heap class must be non null");
 
-            resultIndex = knot->getIndexAt(&jlClass);
+            resultIndex = knot->getOrCreateIndexAt(&jlClass);
             objectPointerReference = knot->getPointerLocation(resultIndex);
             }
 
@@ -2853,12 +2853,23 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 
             if (knotEnabled && knot)
                {
-               resultIndex = knot->getIndexAt(&targetObjectReference);
+               resultIndex = knot->getOrCreateIndexAt(&targetObjectReference);
                objectPointerReference = knot->getPointerLocation(resultIndex);
                }
             }
 
          client->write(response, resultIndex, objectPointerReference, targetObjectReference);
+         }
+         break;
+      case MessageType::KnownObjectTable_getKnownObjectTableDumpInfo:
+         {
+         client->getRecvData<JITServer::Void>();
+
+         std::vector<TR_KnownObjectTableDumpInfo> knownObjectTableDumpInfoList;
+
+         knot->getKnownObjectTableDumpInfo(knownObjectTableDumpInfoList);
+
+         client->write(response, knownObjectTableDumpInfoList);
          }
          break;
       default:

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -581,7 +581,7 @@ TR_CHTable::commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> 
             currentIndex = TR::KnownObjectTable::UNKNOWN;
             uintptr_t currentEpoch = fej9->getVolatileReferenceField(*mcsReferenceLocation, "epoch", "Ljava/lang/invoke/MethodHandle;");
             if (currentEpoch)
-               currentIndex = knot->getIndex(currentEpoch);
+               currentIndex = knot->getOrCreateIndex(currentEpoch);
             if (info->mutableCallSiteEpoch() == currentIndex)
                cookie = fej9->mutableCallSiteCookie(*mcsReferenceLocation, potentialCookie);
             else

--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -74,7 +74,7 @@ J9::KnownObjectTable::getIndex(uintptr_t objectPointer)
       {
       TR_ASSERT_FATAL(false, "It is not safe to call getIndex() at the server. The object pointer could have become stale at the client.");
       auto stream = TR::CompilationInfo::getStream();
-      stream->write(JITServer::MessageType::KnownObjectTable_getIndex, objectPointer);
+      stream->write(JITServer::MessageType::KnownObjectTable_getOrCreateIndex, objectPointer);
       auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
 
       TR::KnownObjectTable::Index index = std::get<0>(recv);
@@ -134,7 +134,7 @@ J9::KnownObjectTable::getIndexAt(uintptr_t *objectReferenceLocation)
    if (self()->comp()->isOutOfProcessCompilation())
       {
       auto stream = TR::CompilationInfo::getStream();
-      stream->write(JITServer::MessageType::KnownObjectTable_getIndexAt, objectReferenceLocation);
+      stream->write(JITServer::MessageType::KnownObjectTable_getOrCreateIndexAt, objectReferenceLocation);
       result = std::get<0>(stream->read<TR::KnownObjectTable::Index>());
 
       updateKnownObjectTableAtServer(result, objectReferenceLocation);
@@ -153,6 +153,103 @@ TR::KnownObjectTable::Index
 J9::KnownObjectTable::getIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements)
    {
    Index result = self()->getIndexAt(objectReferenceLocation);
+   if (isArrayWithConstantElements)
+      self()->addArrayWithConstantElements(result);
+   return result;
+   }
+
+
+TR::KnownObjectTable::Index
+J9::KnownObjectTable::getOrCreateIndex(uintptr_t objectPointer)
+   {
+   if (objectPointer == 0)
+      return 0; // Special Index value for NULL
+
+   uint32_t nextIndex = self()->getEndIndex();
+#if defined(J9VM_OPT_JITSERVER)
+   if (self()->comp()->isOutOfProcessCompilation())
+      {
+      TR_ASSERT_FATAL(false, "It is not safe to call getOrCreateIndex() at the server. The object pointer could have become stale at the client.");
+      auto stream = TR::CompilationInfo::getStream();
+      stream->write(JITServer::MessageType::KnownObjectTable_getOrCreateIndex, objectPointer);
+      auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
+
+      TR::KnownObjectTable::Index index = std::get<0>(recv);
+      uintptr_t *objectReferenceLocation = std::get<1>(recv);
+      TR_ASSERT_FATAL(index <= nextIndex, "The KOT index %d at the client is greater than the KOT index %d at the server", index, nextIndex);
+
+      if (index < nextIndex)
+         {
+         return index;
+         }
+      else
+         {
+         updateKnownObjectTableAtServer(index, objectReferenceLocation);
+         }
+      }
+   else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
+      TR_ASSERT(fej9->haveAccess(), "Must haveAccess in J9::KnownObjectTable::getOrCreateIndex");
+
+      // Search for existing matching entry
+      //
+      for (uint32_t i = 1; i < nextIndex; i++)
+         if (*_references.element(i) == objectPointer)
+            return i;
+
+      // No luck -- allocate a new one
+      //
+      J9VMThread *thread = getJ9VMThreadFromTR_VM(self()->fe());
+      TR_ASSERT(thread, "assertion failure");
+      _references.setSize(nextIndex+1);
+      _references[nextIndex] = (uintptr_t*)thread->javaVM->internalVMFunctions->j9jni_createLocalRef((JNIEnv*)thread, (j9object_t)objectPointer);
+      }
+
+   return nextIndex;
+   }
+
+
+TR::KnownObjectTable::Index
+J9::KnownObjectTable::getOrCreateIndex(uintptr_t objectPointer, bool isArrayWithConstantElements)
+   {
+   TR::KnownObjectTable::Index index = self()->getOrCreateIndex(objectPointer);
+   if (isArrayWithConstantElements)
+      {
+      self()->addArrayWithConstantElements(index);
+      }
+   return index;
+   }
+
+
+TR::KnownObjectTable::Index
+J9::KnownObjectTable::getOrCreateIndexAt(uintptr_t *objectReferenceLocation)
+   {
+   TR::KnownObjectTable::Index result = UNKNOWN;
+#if defined(J9VM_OPT_JITSERVER)
+   if (self()->comp()->isOutOfProcessCompilation())
+      {
+      auto stream = TR::CompilationInfo::getStream();
+      stream->write(JITServer::MessageType::KnownObjectTable_getOrCreateIndexAt, objectReferenceLocation);
+      result = std::get<0>(stream->read<TR::KnownObjectTable::Index>());
+
+      updateKnownObjectTableAtServer(result, objectReferenceLocation);
+      }
+   else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      TR::VMAccessCriticalSection getOrCreateIndexAtCriticalSection(self()->comp());
+      uintptr_t objectPointer = *objectReferenceLocation; // Note: object references held as uintptr_t must never be compressed refs
+      result = self()->getOrCreateIndex(objectPointer);
+      }
+   return result;
+   }
+
+TR::KnownObjectTable::Index
+J9::KnownObjectTable::getOrCreateIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements)
+   {
+   Index result = self()->getOrCreateIndexAt(objectReferenceLocation);
    if (isArrayWithConstantElements)
       self()->addArrayWithConstantElements(result);
    return result;
@@ -267,11 +364,8 @@ static int32_t simpleNameOffset(const char *className, int32_t len)
 void
 J9::KnownObjectTable::dumpObjectTo(TR::FILE *file, Index i, const char *fieldName, const char *sep, TR::Compilation *comp, TR_BitVector &visited, TR_VMFieldsInfo **fieldsInfoByIndex, int32_t depth)
    {
-#if defined(J9VM_OPT_JITSERVER)
-   // JITServer KOT TODO
-   if (self()->comp()->isOutOfProcessCompilation())
-      return;
-#endif /* defined(J9VM_OPT_JITSERVER) */
+   TR_ASSERT_FATAL(!comp->isOutOfProcessCompilation(), "dumpObjectTo() should not be executed at the server.");
+
    TR_J9VMBase *j9fe = (TR_J9VMBase*)self()->fe();
    int32_t indent = 2*depth;
    if (comp->getKnownObjectTable()->isNull(i))
@@ -341,36 +435,79 @@ J9::KnownObjectTable::dumpObjectTo(TR::FILE *file, Index i, const char *fieldNam
       }
    }
 
+
+#if defined(J9VM_OPT_JITSERVER)
+void
+J9::KnownObjectTable::getKnownObjectTableDumpInfo(std::vector<TR_KnownObjectTableDumpInfo> &knotDumpInfoList)
+   {
+   TR_ASSERT_FATAL(!self()->comp()->isOutOfProcessCompilation(), "getKnownObjectTableDumpInfo() can not be executed at the server.");
+
+   TR_J9VMBase *j9fe = (TR_J9VMBase*)self()->fe();
+   J9MemoryManagerFunctions * mmf = jitConfig->javaVM->memoryManagerFunctions;
+   TR::KnownObjectTable::Index endIndex = self()->getEndIndex();
+   TR::VMAccessCriticalSection j9KnownObjectTableDumpToCriticalSection(j9fe,
+                                                                        TR::VMAccessCriticalSection::tryToAcquireVMAccess,
+                                                                        self()->comp());
+   if (j9KnownObjectTableDumpToCriticalSection.hasVMAccess())
+      {
+      uintptr_t *ref = NULL;
+      int32_t   len = 0;
+      char      *className = NULL;
+      int32_t   hashCode = 0;
+
+      for (uint32_t i = 0; i < endIndex; i++)
+         {
+         if (self()->isNull(i))
+            {
+            knotDumpInfoList.push_back(make_tuple(TR_KnownObjectTableDumpInfoStruct(NULL, 0, 0), std::string("")));
+            }
+         else
+            {
+            ref = self()->getPointerLocation(i);
+            hashCode = mmf->j9gc_objaccess_getObjectHashCode(jitConfig->javaVM, (J9Object*)(*ref));
+            className = j9fe->getClassNameChars(j9fe->getObjectClass(*ref), len);
+
+            knotDumpInfoList.push_back(make_tuple(TR_KnownObjectTableDumpInfoStruct(ref, *ref, hashCode), std::string(className, len)));
+            }
+         }
+      }
+   }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+
 void
 J9::KnownObjectTable::dumpTo(TR::FILE *file, TR::Compilation *comp)
    {
+   TR::KnownObjectTable::Index endIndex = self()->getEndIndex();
 #if defined(J9VM_OPT_JITSERVER)
-   // JITServer KOT TODO
-   if (self()->comp()->isOutOfProcessCompilation())
-      return;
-#endif /* defined(J9VM_OPT_JITSERVER) */
-   TR_J9VMBase *j9fe = (TR_J9VMBase*)self()->fe();
-   J9MemoryManagerFunctions * mmf = jitConfig->javaVM->memoryManagerFunctions;
-   TR::VMAccessCriticalSection j9KnownObjectTableDumpToCriticalSection(j9fe,
-                                                                        TR::VMAccessCriticalSection::tryToAcquireVMAccess,
-                                                                        comp);
-
-   if (j9KnownObjectTableDumpToCriticalSection.hasVMAccess())
+   if (comp->isOutOfProcessCompilation())
       {
-      trfprintf(file, "<knownObjectTable size=\"%d\"> // ", self()->getEndIndex());
+      auto stream = TR::CompilationInfo::getStream();
+      stream->write(JITServer::MessageType::KnownObjectTable_getKnownObjectTableDumpInfo, JITServer::Void());
+
+      auto recv = stream->read<std::vector<TR_KnownObjectTableDumpInfo>>();
+      auto &knotDumpInfoList = std::get<0>(recv);
+
+      uint32_t numOfEntries = knotDumpInfoList.size();
+      TR_ASSERT_FATAL((numOfEntries == endIndex), "The client table size %u is different from the server table size %u", numOfEntries, endIndex);
+
+      trfprintf(file, "<knownObjectTable size=\"%u\"> // ", numOfEntries);
       int32_t pointerLen = trfprintf(file, "%p", this);
       trfprintf(file, "\n  %-6s   %-*s   %-*s %-8s   Class\n", "id", pointerLen, "JNI Ref", pointerLen, "Address", "Hash");
-      for (Index i = 0; i < self()->getEndIndex(); i++)
+
+      for (uint32_t i = 0; i < numOfEntries; i++)
          {
          trfprintf(file, "  obj%-3d", i);
-         if (self()->isNull(i))
+         if (!std::get<0>(knotDumpInfoList[i]).ref)
             trfprintf(file, "   %*s   NULL\n", pointerLen, "");
          else
             {
-            uintptr_t *ref = self()->getPointerLocation(i);
-            int32_t len; char *className = TR::Compiler->cls.classNameChars(comp, j9fe->getObjectClass(*ref), len);
-            int32_t hashCode = mmf->j9gc_objaccess_getObjectHashCode(jitConfig->javaVM, (J9Object*)(*ref));
-            trfprintf(file, "   %p   %p %8x   %.*s\n", ref, *ref, hashCode, len, className);
+            trfprintf(file, "   %p   %p %8x   %.*s\n",
+                  std::get<0>(knotDumpInfoList[i]).ref,
+                  std::get<0>(knotDumpInfoList[i]).objectPointer,
+                  std::get<0>(knotDumpInfoList[i]).hashCode,
+                  std::get<1>(knotDumpInfoList[i]).size(),
+                  std::get<1>(knotDumpInfoList[i]).c_str());
             }
          }
       trfprintf(file, "</knownObjectTable>\n");
@@ -378,59 +515,96 @@ J9::KnownObjectTable::dumpTo(TR::FILE *file, TR::Compilation *comp)
       if (comp->getOption(TR_TraceKnownObjectGraph))
          {
          trfprintf(file, "<knownObjectGraph>\n");
-
-         Index i;
-
-         {
-         TR::StackMemoryRegion stackMemoryRegion(*comp->trMemory());
-
-         // Collect field info and determine which objects are reachable from other objects
-         //
-         TR_BitVector reachable(self()->getEndIndex(), comp->trMemory(), stackAlloc, notGrowable);
-         TR_VMFieldsInfo **fieldsInfoByIndex = (TR_VMFieldsInfo**)alloca(self()->getEndIndex() * sizeof(TR_VMFieldsInfo*));
-         for (i = 1; i < self()->getEndIndex(); i++)
-            {
-            uintptr_t    object = self()->getPointer(i);
-            J9Class      *clazz  = (J9Class*)j9fe->getObjectClass(object);
-            if (clazz->romClass->modifiers & J9AccClassArray)
-               {
-               fieldsInfoByIndex[i] = NULL;
-               continue; // TODO: Print out what reference arrays contain?
-               }
-            fieldsInfoByIndex[i] = new (comp->trStackMemory()) TR_VMFieldsInfo(comp, clazz, 1, stackAlloc);
-            ListIterator<TR_VMField> fieldIter(fieldsInfoByIndex[i]->getFields());
-            for (TR_VMField *field = fieldIter.getFirst(); field; field = fieldIter.getNext())
-               {
-               // For the purpose of "reachability", we only look at final
-               // fields.  The intent is to reduce nondeterminism in the object
-               // graph log.
-               //
-               if (field->isReference() && (field->modifiers & J9AccFinal))
-                  {
-                  uintptr_t target = j9fe->getReferenceField(object, field->name, field->signature);
-                  Index targetIndex = self()->getExistingIndexAt(&target);
-                  if (targetIndex != UNKNOWN)
-                     reachable.set(targetIndex);
-                  }
-               }
-            }
-
-         // At the top level, walk objects not reachable from other objects
-         //
-         TR_BitVector visited(self()->getEndIndex(), comp->trMemory(), stackAlloc, notGrowable);
-         for (i = 1; i < self()->getEndIndex(); i++)
-            {
-            if (!reachable.isSet(i) && !visited.isSet(i))
-               self()->dumpObjectTo(file, i, "", "", comp, visited, fieldsInfoByIndex, 0);
-            }
-
-         } // scope of the stack memory region
-
+         // JITServer KOT TODO
          trfprintf(file, "</knownObjectGraph>\n");
          }
       }
    else
+#endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      trfprintf(file, "<knownObjectTable size=\"%d\"/> // unable to acquire VM access to print table contents\n", self()->getEndIndex());
+      TR_J9VMBase *j9fe = (TR_J9VMBase*)self()->fe();
+      J9MemoryManagerFunctions * mmf = jitConfig->javaVM->memoryManagerFunctions;
+      TR::VMAccessCriticalSection j9KnownObjectTableDumpToCriticalSection(j9fe,
+                                                                           TR::VMAccessCriticalSection::tryToAcquireVMAccess,
+                                                                           comp);
+
+      if (j9KnownObjectTableDumpToCriticalSection.hasVMAccess())
+         {
+         trfprintf(file, "<knownObjectTable size=\"%d\"> // ", endIndex);
+         int32_t pointerLen = trfprintf(file, "%p", this);
+         trfprintf(file, "\n  %-6s   %-*s   %-*s %-8s   Class\n", "id", pointerLen, "JNI Ref", pointerLen, "Address", "Hash");
+         for (Index i = 0; i < endIndex; i++)
+            {
+            trfprintf(file, "  obj%-3d", i);
+            if (self()->isNull(i))
+               trfprintf(file, "   %*s   NULL\n", pointerLen, "");
+            else
+               {
+               uintptr_t *ref = self()->getPointerLocation(i);
+               int32_t len; char *className = TR::Compiler->cls.classNameChars(comp, j9fe->getObjectClass(*ref), len);
+               int32_t hashCode = mmf->j9gc_objaccess_getObjectHashCode(jitConfig->javaVM, (J9Object*)(*ref));
+               trfprintf(file, "   %p   %p %8x   %.*s\n", ref, *ref, hashCode, len, className);
+               }
+            }
+         trfprintf(file, "</knownObjectTable>\n");
+
+         if (comp->getOption(TR_TraceKnownObjectGraph))
+            {
+            trfprintf(file, "<knownObjectGraph>\n");
+
+            Index i;
+
+            {
+            TR::StackMemoryRegion stackMemoryRegion(*comp->trMemory());
+
+            // Collect field info and determine which objects are reachable from other objects
+            //
+            TR_BitVector reachable(endIndex, comp->trMemory(), stackAlloc, notGrowable);
+            TR_VMFieldsInfo **fieldsInfoByIndex = (TR_VMFieldsInfo**)alloca(endIndex * sizeof(TR_VMFieldsInfo*));
+            for (i = 1; i < endIndex; i++)
+               {
+               uintptr_t    object = self()->getPointer(i);
+               J9Class      *clazz  = (J9Class*)j9fe->getObjectClass(object);
+               if (clazz->romClass->modifiers & J9AccClassArray)
+                  {
+                  fieldsInfoByIndex[i] = NULL;
+                  continue; // TODO: Print out what reference arrays contain?
+                  }
+               fieldsInfoByIndex[i] = new (comp->trStackMemory()) TR_VMFieldsInfo(comp, clazz, 1, stackAlloc);
+               ListIterator<TR_VMField> fieldIter(fieldsInfoByIndex[i]->getFields());
+               for (TR_VMField *field = fieldIter.getFirst(); field; field = fieldIter.getNext())
+                  {
+                  // For the purpose of "reachability", we only look at final
+                  // fields.  The intent is to reduce nondeterminism in the object
+                  // graph log.
+                  //
+                  if (field->isReference() && (field->modifiers & J9AccFinal))
+                     {
+                     uintptr_t target = j9fe->getReferenceField(object, field->name, field->signature);
+                     Index targetIndex = self()->getExistingIndexAt(&target);
+                     if (targetIndex != UNKNOWN)
+                        reachable.set(targetIndex);
+                     }
+                  }
+               }
+
+            // At the top level, walk objects not reachable from other objects
+            //
+            TR_BitVector visited(endIndex, comp->trMemory(), stackAlloc, notGrowable);
+            for (i = 1; i < endIndex; i++)
+               {
+               if (!reachable.isSet(i) && !visited.isSet(i))
+                  self()->dumpObjectTo(file, i, "", "", comp, visited, fieldsInfoByIndex, 0);
+               }
+
+            } // scope of the stack memory region
+
+            trfprintf(file, "</knownObjectGraph>\n");
+            }
+         }
+      else
+         {
+         trfprintf(file, "<knownObjectTable size=\"%d\"/> // unable to acquire VM access to print table contents\n", endIndex);
+         }
       }
    }

--- a/runtime/compiler/env/J9KnownObjectTable.hpp
+++ b/runtime/compiler/env/J9KnownObjectTable.hpp
@@ -36,6 +36,11 @@ namespace J9 { typedef J9::KnownObjectTable KnownObjectTableConnector; }
 #include "infra/Annotations.hpp"
 #include "infra/Array.hpp"
 #include "infra/BitVector.hpp"
+#if defined(J9VM_OPT_JITSERVER)
+#include <tuple>
+#include <vector>
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
 namespace J9 { class Compilation; }
 namespace TR { class Compilation; }
 class TR_J9VMBase;
@@ -43,6 +48,25 @@ namespace J9 { class ObjectModel; }
 class TR_DebugExt;
 class TR_VMFieldsInfo;
 class TR_BitVector;
+
+#if defined(J9VM_OPT_JITSERVER)
+struct
+TR_KnownObjectTableDumpInfoStruct
+   {
+   uintptr_t  *ref;
+   uintptr_t   objectPointer;
+   int32_t     hashCode;
+
+   TR_KnownObjectTableDumpInfoStruct(uintptr_t *objRef, uintptr_t objPtr, int32_t code) :
+      ref(objRef),
+      objectPointer(objPtr),
+      hashCode(code) {}
+   };
+
+// <TR_KnownObjectTableDumpInfoStruct, std::string classNameStr>
+using TR_KnownObjectTableDumpInfo = std::tuple<TR_KnownObjectTableDumpInfoStruct, std::string>;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
 
 namespace J9
 {
@@ -64,6 +88,8 @@ public:
    Index getEndIndex();
    Index getIndex(uintptr_t objectPointer);
    Index getIndex(uintptr_t objectPointer, bool isArrayWithConstantElements);
+   Index getOrCreateIndex(uintptr_t objectPointer);
+   Index getOrCreateIndex(uintptr_t objectPointer, bool isArrayWithConstantElements);
    uintptr_t *getPointerLocation(Index index);
    bool isNull(Index index);
 
@@ -71,12 +97,15 @@ public:
 
    Index getIndexAt(uintptr_t *objectReferenceLocation);
    Index getIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements);
+   Index getOrCreateIndexAt(uintptr_t *objectReferenceLocation);
+   Index getOrCreateIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements);
    Index getExistingIndexAt(uintptr_t *objectReferenceLocation);
 
    uintptr_t getPointer(Index index);
 
 #if defined(J9VM_OPT_JITSERVER)
    void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation);
+   void getKnownObjectTableDumpInfo(std::vector<TR_KnownObjectTableDumpInfo> &knotDumpInfoList);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 private:

--- a/runtime/compiler/env/JITServerCHTable.cpp
+++ b/runtime/compiler/env/JITServerCHTable.cpp
@@ -390,7 +390,7 @@ JITClientCommitVirtualGuard(const VirtualGuardInfoForCHTable *info, std::vector<
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
             // JITServer KOT:
             // This method is called by JITClientCHTableCommit() at the client.
-            // Although accessing VM is not an issue, getIndex() could update the KOT
+            // Although accessing VM is not an issue, getOrCreateIndex() could update the KOT
             // at the client directly and the KOT at the server could be out of sync.
             // However, JITClientCHTableCommit() is called at the end of compilation,
             // and therefore it cannot cause any issues.
@@ -399,7 +399,7 @@ JITClientCommitVirtualGuard(const VirtualGuardInfoForCHTable *info, std::vector<
             currentIndex = TR::KnownObjectTable::UNKNOWN;
             uintptr_t currentEpoch = fej9->getVolatileReferenceField(*mcsReferenceLocation, "epoch", "Ljava/lang/invoke/MethodHandle;");
             if (currentEpoch)
-               currentIndex = knot->getIndex(currentEpoch);
+               currentIndex = knot->getOrCreateIndex(currentEpoch);
             if (info->_mutableCallSiteEpoch == currentIndex)
                cookie = fej9->mutableCallSiteCookie(*mcsReferenceLocation, potentialCookie);
             else

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4004,7 +4004,7 @@ TR_J9VMBase::getCompiledMethodReceiverKnownObjectIndex(TR::Compilation *comp)
          J9::MethodHandleThunkDetails & thunkDetails = static_cast<J9::MethodHandleThunkDetails &>(details);
          if (thunkDetails.isCustom())
             {
-            return knot->getIndexAt(thunkDetails.getHandleRef());
+            return knot->getOrCreateIndexAt(thunkDetails.getHandleRef());
             }
          }
       }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9075,7 +9075,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                // to determine if a filter is null later on
                haveFilter[i] = fej9->getReferenceElement(filters, i) != 0;
                if (knotEnabled)
-                  filterIndexList[i] = knot->getIndex(fej9->getReferenceElement(filters, i));
+                  filterIndexList[i] = knot->getOrCreateIndex(fej9->getReferenceElement(filters, i));
                }
                
 

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -289,7 +289,7 @@ MethodHandleThunkDetails::printDetails(TR_FrontEnd *fe, TR::FILE *file)
    // annoying: knot can only be accessed from the compilation object which isn't always handy: wait for thread locals
    TR::KnownObjectTable *knot = fe->getKnownObjectTable();
    if (knot)
-      trfprintf(file, "obj%d,%s", knot->getIndexAt(getHandleRef()), fe->sampleSignature((TR_OpaqueMethodBlock *)getMethod()));
+      trfprintf(file, "obj%d,%s", knot->getOrCreateIndexAt(getHandleRef()), fe->sampleSignature((TR_OpaqueMethodBlock *)getMethod()));
    else
 #endif
       trfprintf(file, "%p,%s", getHandleRef(), fe->sampleSignature((TR_OpaqueMethodBlock *)getMethod()));

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -89,7 +89,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 1;
+   static const uint16_t MINOR_NUMBER = 2;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -280,8 +280,8 @@ enum MessageType : uint16_t
    ClassInfo_getRemoteROMString = 1100,
 
    // for KnownObjectTable
-   KnownObjectTable_getIndex = 1200,
-   KnownObjectTable_getIndexAt = 1201,
+   KnownObjectTable_getOrCreateIndex = 1200,
+   KnownObjectTable_getOrCreateIndexAt = 1201,
    KnownObjectTable_getPointer = 1202,
    KnownObjectTable_getExistingIndexAt = 1203,
    // for KnownObjectTable outside J9::KnownObjectTable class
@@ -292,6 +292,7 @@ enum MessageType : uint16_t
    KnownObjectTable_createSymRefWithKnownObject = 1208,
    KnownObjectTable_getReferenceField = 1209,
    KnownObjectTable_invokeDirectHandleDirectCall = 1210,
+   KnownObjectTable_getKnownObjectTableDumpInfo = 1211,
    MessageType_MAXTYPE
    };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5012,7 +5012,7 @@ TR_J9InlinerUtil::computePrexInfo(TR_CallTarget *target)
             //
             if (priorKnowledge < KNOWN_OBJECT)
                {
-               TR::KnownObjectTable::Index methodHandleIndex = comp()->getKnownObjectTable()->getIndexAt(target->_calleeSymbol->getResolvedMethod()->getMethodHandleLocation());
+               TR::KnownObjectTable::Index methodHandleIndex = comp()->getKnownObjectTable()->getOrCreateIndexAt(target->_calleeSymbol->getResolvedMethod()->getMethodHandleLocation());
                TR_PrexArgument *prexArg = new (inliner()->trStackMemory()) TR_PrexArgument(methodHandleIndex, comp());
                if (target->_guard->_kind == TR_MutableCallSiteTargetGuard)
                   prexArg->setTypeInfoForInlinedBody();
@@ -5156,7 +5156,7 @@ void TR_J9InlinerUtil::checkForConstClass(TR_CallTarget *target, TR_LogTracer *t
                if (knot)
                   {
                   TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
-                  knownObjectIndex = knot->getIndexAt((uintptr_t*)(objectReferenceLocation + fej9->getOffsetOfJavaLangClassFromClassField()));
+                  knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)(objectReferenceLocation + fej9->getOffsetOfJavaLangClassFromClassField()));
                   knownObjectClass = true;
                   }
                }
@@ -6065,7 +6065,7 @@ TR_J9InlinerUtil::createPrexArgInfoForCallTarget(TR_VirtualGuardSelection *guard
           implementer->getMethodHandleLocation() &&
           comp()->getOrCreateKnownObjectTable())
          {
-         myPrexArgInfo->set(0, new (comp()->trHeapMemory()) TR_PrexArgument(comp()->getKnownObjectTable()->getIndexAt(implementer->getMethodHandleLocation()), comp()));
+         myPrexArgInfo->set(0, new (comp()->trHeapMemory()) TR_PrexArgument(comp()->getKnownObjectTable()->getOrCreateIndexAt(implementer->getMethodHandleLocation()), comp()));
          }
       }
    return myPrexArgInfo;

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -136,7 +136,7 @@ InterpreterEmulator::maintainStackForGetField()
                if (fieldDeclaringClass && comp()->fej9()->isInstanceOf(baseObjectClass, fieldDeclaringClass, true) == TR_yes)
                   {
                   uintptr_t fieldAddress = comp()->fej9()->getReferenceFieldAtAddress(baseObjectAddress + fieldOffset);
-                  newOperand = new (trStackMemory()) KnownObjOperand(knot->getIndex(fieldAddress));
+                  newOperand = new (trStackMemory()) KnownObjOperand(knot->getOrCreateIndex(fieldAddress));
                   int32_t len = 0;
                   debugTrace(tracer(), "dereference obj%d (%p)from field %s(offset = %d) of base obj%d(%p)\n",
                         newOperand->getKnownObjectIndex(), (void *)fieldAddress, _calltarget->_calleeMethod->fieldName(cpIndex, len, this->trMemory()),
@@ -393,7 +393,7 @@ InterpreterEmulator::getReturnValueForInvokevirtual(TR_ResolvedMethod *callee)
             TR_OpaqueClassBlock *receiverClass = comp()->fej9()->getObjectClass(receiverAddress);
             TR_ASSERT_FATAL(comp()->fej9()->isInstanceOf(receiverClass, mutableCallsiteClass, true) == TR_yes, "receiver of mutableCallsite_getTarget must be instance of MutableCallSite (*%p)", knot->getPointerLocation(receiverIndex));
             uintptr_t fieldAddress = comp()->fej9()->getReferenceFieldAt(receiverAddress, targetFieldOffset);
-            resultIndex = knot->getIndex(fieldAddress);
+            resultIndex = knot->getOrCreateIndex(fieldAddress);
             result = new (trStackMemory()) MutableCallsiteTargetOperand(resultIndex, receiverIndex);
             }
          }
@@ -481,7 +481,7 @@ InterpreterEmulator::refineResolvedCalleeForInvokestatic(TR_ResolvedMethod *&cal
                uintptr_t methodHandle = *_calltarget->_calleeMethod->getMethodHandleLocation();
                vmSlot = fej9->getInt64Field(methodHandle, "vmSlot");
                jlClass = fej9->getReferenceField(methodHandle, "defc", "Ljava/lang/Class;");
-               debugTrace(tracer(), "refine resolved method for leaf methodHandle [obj%d]\n", knot ? knot->getIndex(methodHandle) : -1);
+               debugTrace(tracer(), "refine resolved method for leaf methodHandle [obj%d]\n", knot ? knot->getOrCreateIndex(methodHandle) : -1);
                }
 
             if (isInterface)
@@ -611,7 +611,7 @@ InterpreterEmulator::visitInvokedynamic()
       isIndirectCall = true;
       uintptr_t *entryLocation = (uintptr_t*)owningMethod->callSiteTableEntryAddress(cpIndex);
       // Add callsite handle to known object table
-      knot->getIndexAt((uintptr_t*)entryLocation);
+      knot->getOrCreateIndexAt((uintptr_t*)entryLocation);
       TR_ResolvedMethod * resolvedMethod = comp()->fej9()->createMethodHandleArchetypeSpecimen(this->trMemory(), entryLocation, owningMethod);
       bool allconsts= false;
 

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -723,7 +723,7 @@ bool TR_J9MutableCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inlin
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fej9());
             uintptr_t currentEpoch = fej9->getVolatileReferenceField(mcsObject, "epoch", "Ljava/lang/invoke/MethodHandle;");
             if (currentEpoch)
-               vgs->_mutableCallSiteEpoch = knot->getIndex(currentEpoch);
+               vgs->_mutableCallSiteEpoch = knot->getOrCreateIndex(currentEpoch);
             }
          else
             {

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -557,7 +557,7 @@ J9::TransformUtil::transformIndirectLoad(TR::Compilation *comp, TR::Node *node)
                      TR::VMAccessCriticalSection createSymRefWithKnownObject(comp->fej9());
                      uintptr_t jlClass = (uintptr_t)J9VM_J9CLASS_TO_HEAPCLASS((J9Class*)baseObject->getSymbol()->castToStaticSymbol()->getStaticAddress());
                      TR_ASSERT(jlClass, "java/lang/Class reference from heap class must be non null");
-                     TR::KnownObjectTable::Index knotIndex = knot->getIndexAt(&jlClass);
+                     TR::KnownObjectTable::Index knotIndex = knot->getOrCreateIndexAt(&jlClass);
                      if (knotIndex != TR::KnownObjectTable::UNKNOWN)
                         {
                         improvedSymRef = comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(node->getSymbolReference(), knotIndex);
@@ -909,7 +909,7 @@ J9::TransformUtil::transformIndirectLoad(TR::Compilation *comp, TR::Node *node)
 
                   if (knot)
                      {
-                     TR::KnownObjectTable::Index knotIndex = knot->getIndexAt(&targetObjectReference);
+                     TR::KnownObjectTable::Index knotIndex = knot->getOrCreateIndexAt(&targetObjectReference);
                      if (knotIndex != TR::KnownObjectTable::UNKNOWN)
                         improvedSymRef = comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(node->getSymbolReference(), knotIndex);
                      }

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -555,7 +555,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
                if (knot)
                   {
-                  TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptr_t*)(arrayComponentClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
+                  TR::KnownObjectTable::Index knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)(arrayComponentClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
                   addBlockOrGlobalConstraint(node,
                         TR::VPClass::create(this,
                            TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),
@@ -632,7 +632,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
                if (knot)
                   {
-                  TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptr_t*)(superClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
+                  TR::KnownObjectTable::Index knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)(superClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
                   addBlockOrGlobalConstraint(node,
                         TR::VPClass::create(this,
                            TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),


### PR DESCRIPTION

* Replace `getIndex()` and `getIndexAt()` with `getOrCreateIndex()` and `getOrCreateIndexAt()`. 
* Add JITServer known object table information dump in `KnownObjectTable::dumpTo()` for the compilation logs.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>