### PR TITLE
Change stackWalkerMaySkipFrames to avoid AOT failures

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -577,6 +577,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             vmThread->javaVM->srConstructorAccessor ? (TR_OpaqueClassBlock *) J9VM_J9CLASS_FROM_JCLASS(vmThread, vmThread->javaVM->srConstructorAccessor) : NULL);
          }
          break;
+      case MessageType::VM_stackWalkerMaySkipFramesSVM:
+         {
+         auto recv = client->getRecvData<TR_OpaqueMethodBlock*, TR_OpaqueClassBlock*>();
+         TR_OpaqueMethodBlock *method = std::get<0>(recv);
+         TR_OpaqueClassBlock *clazz = std::get<1>(recv);
+         client->write(response, fe->stackWalkerMaySkipFrames(method, clazz));
+         }
+         break;
       case MessageType::VM_hasFinalFieldsInClass:
          {
          TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2100,12 +2100,22 @@ TR_J9SharedCacheServerVM::isPrimitiveClass(TR_OpaqueClassBlock * classPointer)
 bool
 TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
    {
-   bool skipFrames = TR_J9ServerVM::stackWalkerMaySkipFrames(method, methodClass);
+   bool skipFrames = false;
    TR::Compilation *comp = _compInfoPT->getCompilation();
+   // For AOT with SVM do not optimize the messages by calling TR_J9ServerVM::stackWalkerMaySkipFrames
+   // because this will call isInstanceOf() and then isSuperClass() which will fail the 
+   // the SVM validation check and result in an AOT compilation failure
    if (comp && comp->getOption(TR_UseSymbolValidationManager))
       {
+      JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+      stream->write(JITServer::MessageType::VM_stackWalkerMaySkipFramesSVM, method, methodClass);
+      skipFrames = std::get<0>(stream->read<bool>());
       bool recordCreated = comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames);
       SVM_ASSERT(recordCreated, "Failed to validate addStackWalkerMaySkipFramesRecord");
+      }
+   else
+      {
+      skipFrames = TR_J9ServerVM::stackWalkerMaySkipFrames(method, methodClass);
       }
    return skipFrames;
    }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -89,7 +89,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 1;
+   static const uint16_t MINOR_NUMBER = 2;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -203,6 +203,7 @@ enum MessageType : uint16_t
    VM_instanceOfOrCheckCastNoCacheUpdate = 309,
    VM_getCellSizeForSizeClass = 310,
    VM_getObjectSizeClass = 311,
+   VM_stackWalkerMaySkipFramesSVM = 312,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400,


### PR DESCRIPTION
Current implementation of `TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames`
tries to avoid messages to the client by using a couple of calls to
`TR_J9ServerVM::isInstanceOf()`. However, under the covers, the call to
`TR_J9ServerVM::isInstanceOf()` will result into calls to
`TR_J9SharedCacheServerVM::getSuperClass()` which will check to see if
a SVM validation record for the given class is already present, which is
not. As a consequence, the SVM validation check will fail the AOT
compilation.
The solution implemented in this commit is more or less a workaround:
when SVM is used during an AOT compilation, do not try to optimize
`TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames`, but rather send a
message to the client to find the answer.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>