### PR TITLE
Create frontend query for OMR function numConcreteClasses

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8351,6 +8351,28 @@ TR_J9VM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    return J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
    }
 
+bool 
+TR_J9VM::noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses)
+   {
+   TR::Compilation *comp = _compInfoPT->getCompilation();
+   int count = 0;
+   ListIterator<TR_PersistentClassInfo> i(subClasses);
+   for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
+      {
+      TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
+      if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+         {
+         count++;
+         }
+      if (count > 1)
+         {
+         return false;
+         }
+      }
+
+   return true;
+   }
+
 //////////////////////////////////////////////////////////
 // TR_J9SharedCacheVM
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -61,6 +61,7 @@ class TR_ExternalProfiler;
 class TR_JitPrivateConfig;
 class TR_DataCacheManager;
 class TR_EstimateCodeSize;
+class TR_PersistentClassInfo;
 #if defined(J9VM_OPT_JITSERVER)
 class TR_Listener;
 class JITServerStatisticsThread;
@@ -1127,6 +1128,8 @@ public:
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod);
 
    TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
+
+   virtual bool noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses);
 
 private:
    void transformJavaLangClassIsArrayOrIsPrimitive( TR::Compilation *, TR::Node * callNode,  TR::TreeTop * treeTop, int32_t andMask);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -187,6 +187,7 @@ public:
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
    virtual bool getReportByteCodeInfoAtCatchBlock() override;
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType) override;
+   virtual bool noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses) override;
 
    virtual uintptr_t getCellSizeForSizeClass(uintptr_t) override;
    virtual uintptr_t getObjectSizeClass(uintptr_t) override;


### PR DESCRIPTION
This PR moves a OMR function `numConcreteClasses` into OpenJ9 frontend. 

This function takes a list of subclasses and count the number of concrete classes. It is called only once in the code base and compare number of concrete class with two. Thus it is safe to modify this function and return a boolean value once number of concrete class reaches two. This is also included in the change. 

This change reduces JITServer messages between client and server. Since this function can be now executed on the server instead of sending messages to client.

This change contains two PRs, one in OpenJ9 and one in OMR. The OMR PR depends on this PR, thus this should be merged fist. 

Reference: https://github.com/eclipse/openj9/issues/8699
OMR PR: https://github.com/eclipse/omr/pull/4959

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>