### PR TITLE
Remove hardcoded valuetype flag

### DIFF
--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -60,8 +60,6 @@ extern "C" {
 </#if>
 </#list>
 
-#undef J9VM_OPT_VALHALLA_VALUE_TYPES
-
 #if JAVA_SPEC_VERSION >= 11
 #define J9VM_OPT_VALHALLA_NESTMATES
 #endif


### PR DESCRIPTION
Remove hardcoded valuetype flag

Related to https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/183

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>