### PR TITLE
Remove final from fields being set in native methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -198,9 +198,9 @@ public abstract class MethodHandle
 	private native void requestCustomThunkFromJit(ThunkTuple tt);
 
 	@VMCONSTANTPOOL_FIELD
-	final MethodType type;		/* Type of the MethodHandle */
+	final MethodType type; /* Type of the MethodHandle */
 	@VMCONSTANTPOOL_FIELD
-	final byte kind;				/* The kind (STATIC/SPECIAL/etc) of this MethodHandle */
+	byte kind; /* The kind (STATIC/SPECIAL/etc) of this MethodHandle */
 	
 	@VMCONSTANTPOOL_FIELD
 	int invocationCount; /* used to determine how many times the MH has been invoked*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -340,7 +340,7 @@ public abstract class VarHandle extends VarHandleInternal
 	private final MethodHandle[] handleTable;
 	final Class<?> fieldType;
 	final Class<?>[] coordinateTypes;
-	final int modifiers;
+	int modifiers;
 /*[IF Java12]*/
 	private int hashCode = 0;
 /*[ENDIF] Java12 */


### PR DESCRIPTION
A `final` field should not be modified after initialization. The two `final`
fields mentioned below are modified after initialization in native code
so they no longer satisfy the conditions of the `final` keyword. Hence,
the `final` keyword is removed for the two fields.

`MethodHandle.kind` is set in the following native method:
1. [Java_java_lang_invoke_PrimitiveHandle_lookupMethod](https://github.com/eclipse/openj9/blob/be03cea0cb7cdd829a61b283d6558b02c542b308/runtime/jcl/common/java_dyn_methodhandle.c#L286)

`VarHandle.modifiers` is set in the following native methods:
1. [Java_java_lang_invoke_FieldVarHandle_lookupField](https://github.com/eclipse/openj9/blob/be03cea0cb7cdd829a61b283d6558b02c542b308/runtime/jcl/common/java_lang_invoke_VarHandle.c#L114)
2. [Java_java_lang_invoke_FieldVarHandle_unreflectField](https://github.com/eclipse/openj9/blob/be03cea0cb7cdd829a61b283d6558b02c542b308/runtime/jcl/common/java_lang_invoke_VarHandle.c#L148)

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>