### PR TITLE
Implement compressed refs override and split BytecodeInterpreter

### DIFF
--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -24,8 +24,17 @@
 
 #define OBJECTACCESSBARRIERAPI_HPP_
 
-#include "j9.h"
 #include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define MM_ObjectAccessBarrierAPI MM_ObjectAccessBarrierAPICompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define MM_ObjectAccessBarrierAPI MM_ObjectAccessBarrierAPIFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+
+#include "j9.h"
 #include "j9modron.h"
 #include "omrmodroncore.h"
 #include "omr.h"

--- a/runtime/gc_include/ObjectAllocationAPI.hpp
+++ b/runtime/gc_include/ObjectAllocationAPI.hpp
@@ -23,6 +23,16 @@
 #if !defined(OBJECTALLOCATIONAPI_HPP_)
 #define OBJECTALLOCATIONAPI_HPP_
 
+#include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define MM_ObjectAllocationAPI MM_ObjectAllocationAPICompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define MM_ObjectAllocationAPI MM_ObjectAllocationAPIFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+
 #include "j9.h"
 #include "j9consts.h"
 #include "j9generated.h"

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -1,4 +1,4 @@
-# Copyright (c) 1998, 2019 IBM Corp. and others
+# Copyright (c) 1998, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -520,11 +520,17 @@ CLANG_CXXFLAGS+=-std=c++0x -D_CRT_SUPPRESS_RESTRICT -DVS12AndHigher
 	CLANG_CXXFLAGS+=-D_M_X64
 </#if>
 endif
-# special handling BytecodeInterpreter.cpp and DebugBytecodeInterpreter.cpp
-BytecodeInterpreter$(UMA_DOT_O):BytecodeInterpreter.cpp
+# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+BytecodeInterpreterFull$(UMA_DOT_O):BytecodeInterpreterFull.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
 
-DebugBytecodeInterpreter$(UMA_DOT_O):DebugBytecodeInterpreter.cpp
+BytecodeInterpreterCompressed$(UMA_DOT_O):BytecodeInterpreterCompressed.cpp
+	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
+
+DebugBytecodeInterpreterFull$(UMA_DOT_O):DebugBytecodeInterpreterFull.cpp
+	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
+
+DebugBytecodeInterpreterCompressed$(UMA_DOT_O):DebugBytecodeInterpreterCompressed.cpp
 	$(CLANG_CXX) $(CLANG_CXXFLAGS) -c $< -o $@
 
 MHInterpreter$(UMA_DOT_O):MHInterpreter.cpp
@@ -548,7 +554,7 @@ SharedService$(UMA_DOT_O):SharedService.c
 
 <#if uma.spec.processor.ppc>
 ifndef USE_PPC_GCC
-# special handling BytecodeInterpreter.cpp and DebugBytecodeInterpreter.cpp
+# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
 FLAGS_TO_REMOVE += -O3
 NEW_OPTIMIZATION_FLAG=-O2 -qdebug=lincomm:ptranl:tfbagg
 <#if uma.spec.type.linux>
@@ -557,10 +563,16 @@ NEW_OPTIMIZATION_FLAG+=-qmaxmem=-1 -qpic
 </#if>
 SPECIALCXXFLAGS=$(filter-out $(FLAGS_TO_REMOVE),$(CXXFLAGS))
 
-BytecodeInterpreter$(UMA_DOT_O):BytecodeInterpreter.cpp
+BytecodeInterpreterFull$(UMA_DOT_O):BytecodeInterpreterFull.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
 
-DebugBytecodeInterpreter$(UMA_DOT_O):DebugBytecodeInterpreter.cpp
+BytecodeInterpreterCompressed$(UMA_DOT_O):BytecodeInterpreterCompressed.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
+
+DebugBytecodeInterpreterFull$(UMA_DOT_O):DebugBytecodeInterpreterFull.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
+
+DebugBytecodeInterpreterCompressed$(UMA_DOT_O):DebugBytecodeInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(NEW_OPTIMIZATION_FLAG) -c $<
 
 MHInterpreter$(UMA_DOT_O):MHInterpreter.cpp

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -517,11 +517,18 @@ endif
 <#if uma.spec.processor.ppc && !uma.spec.type.aix>
 ifdef USE_PPC_GCC
 
-# special handling BytecodeInterpreter.cpp and DebugBytecodeInterpreter.cpp
-BytecodeInterpreter$(UMA_DOT_O) : BytecodeInterpreter.cpp
+# special handling BytecodeInterpreterFull.cpp, BytecodeInterpreterCompressed.cpp, DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp
+
+BytecodeInterpreterFull$(UMA_DOT_O) : BytecodeInterpreterFull.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
 
-DebugBytecodeInterpreter$(UMA_DOT_O) : DebugBytecodeInterpreter.cpp
+BytecodeInterpreterCompressed$(UMA_DOT_O) : BytecodeInterpreterCompressed.cpp
+	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
+
+DebugBytecodeInterpreterFull$(UMA_DOT_O) : DebugBytecodeInterpreterFull.cpp
+	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
+
+DebugBytecodeInterpreterCompressed$(UMA_DOT_O) : DebugBytecodeInterpreterCompressed.cpp
 	$(PPC_GCC_CXX) $(PPC_GCC_CXXFLAGS) -c $<
 
 MHInterpreter$(UMA_DOT_O) : MHInterpreter.cpp

--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -128,10 +128,17 @@ endif
 MRABIG = -Wc,"TBYDBG(-qdebug=MRABIG)"
 SPECIALCXXFLAGS = $(filter-out -Wc$(COMMA)debug -O3,$(CXXFLAGS))
 NEW_OPTIMIZATION_FLAG = -O2 -Wc,"TBYDBG(-qdebug=lincomm:ptranl:tfbagg)" -Wc,"FEDBG(-qxflag=InlineDespiteVolatileInArgs)"
-BytecodeInterpreter.o : BytecodeInterpreter.cpp
+
+BytecodeInterpreterFull.o : BytecodeInterpreterFull.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist
 
-DebugBytecodeInterpreter.o : DebugBytecodeInterpreter.cpp
+BytecodeInterpreterCompressed.o : BytecodeInterpreterCompressed.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist
+
+DebugBytecodeInterpreterFull.o : DebugBytecodeInterpreterFull.cpp
+	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist
+
+DebugBytecodeInterpreterCompressed.o : DebugBytecodeInterpreterCompressed.cpp
 	$(CXX) $(SPECIALCXXFLAGS) $(MRABIG) $(NEW_OPTIMIZATION_FLAG) -c $< > $*.asmlist
 
 MHInterpreter$(UMA_DOT_O) : MHInterpreter.cpp

--- a/runtime/oti/ArrayCopyHelpers.hpp
+++ b/runtime/oti/ArrayCopyHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,16 @@
 #if defined(TYPESTUBS_H)
 #define ARRAYCOPYHELPERS_STUB
 #endif /* defined(TYPESTUBS_H) */
+
+#include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define VM_ArrayCopyHelpers VM_ArrayCopyHelpersCompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define VM_ArrayCopyHelpers VM_ArrayCopyHelpersFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
 
 #include "j9.h"
 #include "j9protos.h"

--- a/runtime/oti/ObjectHash.hpp
+++ b/runtime/oti/ObjectHash.hpp
@@ -23,6 +23,16 @@
 #if !defined(OBJECTHASH_HPP_)
 #define OBJECTHASH_HPP_
 
+#include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define VM_ObjectHash VM_ObjectHashCompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define VM_ObjectHash VM_ObjectHashFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+
 #include "j9.h"
 #include "j9accessbarrier.h"
 #include "j9consts.h"

--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -23,6 +23,16 @@
 #if !defined(OBJECTMONITOR_HPP_)
 #define OBJECTMONITOR_HPP_
 
+#include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define VM_ObjectMonitor VM_ObjectMonitorCompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define VM_ObjectMonitor VM_ObjectMonitorFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+
 #include "j9.h"
 #include "j9accessbarrier.h"
 #include "j9consts.h"

--- a/runtime/oti/UnsafeAPI.hpp
+++ b/runtime/oti/UnsafeAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,16 @@
 
 #if !defined(UNSAFEAPI_HPP_)
 #define UNSAFEAPI_HPP_
+
+#include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define VM_UnsafeAPI VM_UnsafeAPICompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define VM_UnsafeAPI VM_UnsafeAPIFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
 
 #include "j9.h"
 #include "ArrayCopyHelpers.hpp"

--- a/runtime/oti/VMAccess.hpp
+++ b/runtime/oti/VMAccess.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,8 @@
 #define J9_EXCLUSIVE_SLOW_TOLERANCE_STANDARD 50
 #define J9_EXCLUSIVE_SLOW_REASON_JNICRITICAL 1
 #define J9_EXCLUSIVE_SLOW_REASON_EXCLUSIVE   2
+
+#include "objectreferencesmacros_undefine.inc"
 
 class VM_VMAccess
 {
@@ -437,5 +439,7 @@ public:
 	}
 
 };
+
+#include "objectreferencesmacros_define.inc"
 
 #endif /* VMACCESS_HPP_ */

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -23,6 +23,16 @@
 #if !defined(VMHELPERS_HPP_)
 #define VMHELPERS_HPP_
 
+#include "j9cfg.h"
+
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#if J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define VM_VMHelpers VM_VMHelpersCompressed
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define VM_VMHelpers VM_VMHelpersFull
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+
 #include "j9.h"
 #include "j9protos.h"
 #include "j9consts.h"

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4711,18 +4711,6 @@ typedef struct J9VMThread {
 #define J9VMTHREAD_SET_BLOCKINGENTEROBJECT(vmThread, object, value) J9VMTHREAD_JAVAVM(vmThread)->memoryManagerFunctions->j9gc_objaccess_storeObjectToInternalVMSlot((vmThread), (j9object_t*)&((object)->blockingEnterObject), (value))
 #define TMP_J9VMTHREAD_BLOCKINGENTEROBJECT(object) ((object)->blockingEnterObject)
 
-#if defined(OMR_GC_COMPRESSED_POINTERS)
-#if defined(OMR_GC_FULL_POINTERS)
-/* Mixed mode - necessarily 64-bit */
-#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) (0 != (vmThread)->compressObjectReferences)
-#else /* OMR_GC_FULL_POINTERS */
-/* Compressed only - necessarily 64-bit */
-#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) TRUE
-#endif /* OMR_GC_FULL_POINTERS */
-#else /* OMR_GC_COMPRESSED_POINTERS */
-/* Full only - could be 32 or 64-bit */
-#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) FALSE
-#endif /* OMR_GC_COMPRESSED_POINTERS */
 #define J9VMTHREAD_REFERENCE_SIZE(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? sizeof(U_32) : sizeof(UDATA))
 #define J9VMTHREAD_OBJECT_HEADER_SIZE(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))
 #define J9VMTHREAD_CONTIGUOUS_HEADER_SIZE(vmThread) (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) ? sizeof(J9IndexableObjectContiguousCompressed) : sizeof(J9IndexableObjectContiguousFull))
@@ -5186,18 +5174,6 @@ typedef struct J9JavaVM {
  */
 #define J9_OBJECT_MONITOR_BLOCKING 3
 
-#if defined(OMR_GC_COMPRESSED_POINTERS)
-#if defined(OMR_GC_FULL_POINTERS)
-/* Mixed mode - necessarily 64-bit */
-#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) J9_ARE_ANY_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES)
-#else /* OMR_GC_FULL_POINTERS */
-/* Compressed only - necessarily 64-bit */
-#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) TRUE
-#endif /* OMR_GC_FULL_POINTERS */
-#else /* OMR_GC_COMPRESSED_POINTERS */
-/* Full only - could be 32 or 64-bit */
-#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) FALSE
-#endif /* OMR_GC_COMPRESSED_POINTERS */
 #define J9JAVAVM_REFERENCE_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(U_32) : sizeof(UDATA))
 #define J9JAVAVM_OBJECT_HEADER_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))
 #define J9JAVAVM_CONTIGUOUS_HEADER_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(J9IndexableObjectContiguousCompressed) : sizeof(J9IndexableObjectContiguousFull))
@@ -5449,5 +5425,7 @@ typedef struct J9CInterpreterStackFrame {
 #error Unknown architecture
 #endif /* J9VM_ARCH_X86 */
 } J9CInterpreterStackFrame;
+
+#include "objectreferencesmacros_define.inc"
 
 #endif /* J9NONBUILDER_H */

--- a/runtime/oti/objectreferencesmacros_define.inc
+++ b/runtime/oti/objectreferencesmacros_define.inc
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+/* Mixed mode - necessarily 64-bit */
+#if defined(J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES
+#else /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) (0 != (vmThread)->compressObjectReferences)
+#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) J9_ARE_ANY_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_COMPRESS_OBJECT_REFERENCES)
+#endif /* J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES */
+#else /* OMR_GC_FULL_POINTERS */
+/* Compressed only - necessarily 64-bit */
+#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) TRUE
+#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) TRUE
+#endif /* OMR_GC_FULL_POINTERS */
+#else /* OMR_GC_COMPRESSED_POINTERS */
+/* Full only - could be 32 or 64-bit */
+#define J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread) FALSE
+#define J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) FALSE
+#endif /* OMR_GC_COMPRESSED_POINTERS */

--- a/runtime/oti/objectreferencesmacros_undefine.inc
+++ b/runtime/oti/objectreferencesmacros_undefine.inc
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9nonbuilder.h"
+
+#undef J9VMTHREAD_COMPRESS_OBJECT_REFERENCES
+#undef J9JAVAVM_COMPRESS_OBJECT_REFERENCES

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4090,26 +4090,6 @@ typedef enum {
 void*
 J9_GetInterface(J9_INTERFACE_SELECTOR interfaceSelector, J9PortLibrary* portLib, void *userData);
 
-/* -------------------- BytecodeInterpreter.cpp ------------ */
-
-/**
-* @brief Execute the bytecode loop
-* @param currentThread
-* @return UDATA the action to take upon return to the builder interpreter
-*/
-UDATA  
-bytecodeLoop(J9VMThread *currentThread);
-
-/* -------------------- DebugBytecodeInterpreter.cpp ------------ */
-
-/**
-* @brief Execute the bytecode loop
-* @param currentThread
-* @return UDATA the action to take upon return to the builder interpreter
-*/
-UDATA  
-debugBytecodeLoop(J9VMThread *currentThread);
-
 /* -------------------- ClassInitialization.cpp ------------ */
 
 /**

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -67,10 +67,7 @@
 #if defined(DEBUG_VERSION)
 #define DO_HOOKS
 #define DO_SINGLE_STEP
-#define INTERPRETER_CLASS VM_DebugBytecodeInterpreter
-#else
-#define INTERPRETER_CLASS VM_BytecodeInterpreter
-#endif
+#endif /* DEBUG_VERSION */
 
 typedef enum {
 	VM_NO,

--- a/runtime/vm/BytecodeInterpreter.inc
+++ b/runtime/vm/BytecodeInterpreter.inc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,12 +27,6 @@
 /* MSVC compiler hangs on this file at max opt (/Ox) */
 #pragma optimize( "g", off )
 #endif /* _MSC_VER */
-
-#if defined(DEBUG_VERSION)
-#define LOOP_NAME debugBytecodeLoop
-#else
-#define LOOP_NAME bytecodeLoop
-#endif
 
 /* USE_COMPUTED_GOTO on Windows has a performance improvement of 15%.
  * USE_COMPUTED_GOTO on Linux amd64 has a performance improvement of 3%.
@@ -102,6 +96,11 @@ getMethodName(J9PortLibrary *PORTLIB, J9Method *method, U_8 *pc, char *buffer)
 #include "BytecodeInterpreter.hpp"
 
 /* Entry point must be C, not C++ */
+/**
+* @brief Execute the bytecode loop specified by LOOP_NAME
+* @param currentThread the current thread
+* @return UDATA the action to take upon return to the builder interpreter
+*/
 extern "C" UDATA
 LOOP_NAME(J9VMThread *currentThread)
 {

--- a/runtime/vm/BytecodeInterpreterCompressed.cpp
+++ b/runtime/vm/BytecodeInterpreterCompressed.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#define J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
+#define LOOP_NAME bytecodeLoopCompressed
+#define INTERPRETER_CLASS VM_BytecodeInterpreterCompressed
+#include "BytecodeInterpreter.inc"
+#else
+#define LOOP_NAME 0
+#endif /* OMR_GC_COMPRESSED_POINTERS */

--- a/runtime/vm/BytecodeInterpreterFull.cpp
+++ b/runtime/vm/BytecodeInterpreterFull.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#define DEBUG_VERSION
+#include "j9cfg.h"
 
-#include "BytecodeInterpreter.cpp"
+#if defined(OMR_GC_FULL_POINTERS)
+#define J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES 0
+#define LOOP_NAME bytecodeLoopFull
+#define INTERPRETER_CLASS VM_BytecodeInterpreterFull
+#include "BytecodeInterpreter.inc"
+#else
+#define LOOP_NAME 0
+#endif /* OMR_GC_FULL_POINTERS */

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -26,7 +26,8 @@ add_library(j9vm SHARED
 	AsyncMessageHandler.cpp
 	bchelper.c
 	bindnatv.cpp
-	BytecodeInterpreter.cpp
+	BytecodeInterpreterFull.cpp
+	BytecodeInterpreterCompressed.cpp
 	callin.cpp
 	classallocation.c
 	ClassInitialization.cpp
@@ -34,7 +35,8 @@ add_library(j9vm SHARED
 	classseg.c
 	classsupport.c
 	createramclass.cpp
-	DebugBytecodeInterpreter.cpp
+	DebugBytecodeInterpreterFull.cpp
+	DebugBytecodeInterpreterCompressed.cpp
 	description.c
 	dllsup.c
 	drophelp.c

--- a/runtime/vm/DebugBytecodeInterpreterCompressed.cpp
+++ b/runtime/vm/DebugBytecodeInterpreterCompressed.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#define DEBUG_VERSION
+#define J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES 1
+#define LOOP_NAME debugBytecodeLoopCompressed
+#define INTERPRETER_CLASS VM_DebugBytecodeInterpreterCompressed
+#include "BytecodeInterpreter.inc"
+#else
+#define LOOP_NAME 0
+#endif /* OMR_GC_COMPRESSED_POINTERS */

--- a/runtime/vm/DebugBytecodeInterpreterFull.cpp
+++ b/runtime/vm/DebugBytecodeInterpreterFull.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9cfg.h"
+
+#if defined(OMR_GC_FULL_POINTERS)
+#define DEBUG_VERSION
+#define J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES 0
+#define LOOP_NAME debugBytecodeLoopFull
+#define INTERPRETER_CLASS VM_DebugBytecodeInterpreterFull
+#include "BytecodeInterpreter.inc"
+#else
+#define LOOP_NAME 0
+#endif /* OMR_GC_FULL_POINTERS */

--- a/runtime/vm/OutOfLineINL.hpp
+++ b/runtime/vm/OutOfLineINL.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,8 @@
 #include "j9.h"
 #include "rommeth.h"
 #include "BytecodeAction.hpp"
+
+#include "objectreferencesmacros_undefine.inc"
 
 extern "C" {
 
@@ -129,5 +131,7 @@ public:
  		restoreSpecialStackFrameLeavingArgs(currentThread, ((UDATA*)(nativeMethodFrame + 1)) - 1);
  	}
 };
+
+#include "objectreferencesmacros_define.inc"
 
 #endif /* VM_OUTOFLINEINL_HPP_ */

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -29,6 +29,8 @@
 #include "ObjectAccessBarrierAPI.hpp"
 #include "VMHelpers.hpp"
 
+#include "objectreferencesmacros_undefine.inc"
+
 class VM_ValueTypeHelpers {
 	/*
 	 * Data members
@@ -95,5 +97,7 @@ public:
 	}
 
 };
+
+#include "objectreferencesmacros_define.inc"
 
 #endif /* VALUETYPEHELPERS_HPP_ */


### PR DESCRIPTION
Related: https://github.com/eclipse/openj9/issues/8878

## Implement compressed refs override and split BytecodeInterpreter 
- Add new override macro `J9_OVERRIDE_COMPRESS_OBJECT_REFERENCES`.
- Split BytecodeInterpreter.cpp into BytecodeInterpreterFull.cpp and BytecodeInterpreterCompressed.cpp.
- Rename BytecodeInterpreter.cpp to BytecodeInterpreter.inc; only compile BytecodeInterpreterFull.cpp and BytecodeInterpreterCompressed.cpp
- Move bytecode `LOOP_NAME` definitions from BytecodeInterpreter.inc and `INTERPRETER_CLASS` definitions into individual wrapper files (Debug, Full and Compressed).
- In BytecodeInterpreterFull.cpp and BytecodeInterpreterCompressed.cpp, define the override macro as:
    `TRUE` if `OMR_GC_COMPRESSED_POINTERS` is defined
    `FALSE` if `OMR_GC_FULL_POINTERS` is defined
- If the override macro is defined, set `J9VMTHREAD_COMPRESS_OBJECT_REFERENCES`
and `J9JAVAVM_COMPRESS_OBJECT_REFERENCES` to be the same value as the override macro.

## Split BytecodeInterpreter included class names into Full/Compressed
Of the classes that BytecodeInterpreter.hpp includes, `#include "objectreferencesmacros_undefine.inc"` and `#include "objectreferencesmacros_define.inc"` were added to determine whether or not to split the class names into Full/Compressed versions. If compile/runtime errors occurred with the undefine+define, then the appropriate class name would be split.

**Split into Full/Compressed (failed undefine+define objectreferencesmacros)**
- ArrayCopyHelpers.hpp
- ObjectAccessBarrierAPI.hpp
- ObjectAllocationAPI.hpp
- ObjectHash.hpp
- ObjectMonitor.hpp
- UnsafeAPI.hpp
- VMHelpers.hpp

**Not Split (did not fail undefine+define objectreferencesmacros; the undefine+define remain in case future changes require these to be split)**
- OutOfLineINL.hpp
- VMAccess.hpp
- ValueTypeHelpers.hpp

**Untouched**
- AtomicSupport.hpp (in OMR)
- BytecodeAction.hpp (no inline functions)
- JITInterface.hpp (JIT-related)
- MHInterpreter.hpp (further investigation needed)

## Move bytecodeLoop prototypes from vm_api.h to jvminit.c
bytecodeLoop prototypes were relocated to jvminit.c since they do not need to be exposed to anything else.

## Split DebugBytecodeInterpreter into Full/Compressed
- Split DebugBytecodeInterpreter.cpp into DebugBytecodeInterpreterFull.cpp and DebugBytecodeInterpreterCompressed.cpp.
- Remove DebugBytecodeInterpreter.cpp

## Add dummy define in split files to avoid OSX compile issue
OSX complains about empty object files. As a temporary solution, `#define LOOP_NAME 0` in split interpreter files so that the resulting object files are not empty if their respective code is not enabled.

To actually address this problem, these files should not be compiled if their code is disabled. Work will need to be done in makefiles, i.e. runtime/makelib/targets.mk.ftl, to skip compiling the appropriate files.

Flags in omrcfg.h, i.e. `OMR_GC_COMPRESSED_POINTERS` and `OMR_GC_FULL_POINTERS` would be helpful in identifying which files should be compiled. Need to look into if these can be accessed in OpenJ9 makefiles or if there is an OpenJ9 equivalent to the flags.