### PR TITLE
AIX shared object has .so suffix

### DIFF
--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -241,11 +241,7 @@ void mapLibraryToPlatformName(const char *inPath, char *outPath) {
 #else
 	strcpy(outPath, "lib");
 	strcat(outPath,inPath);
-#if defined(AIXPPC)
-	strcat(outPath, ".a");
-#else /* AIXPPC */
 	strcat(outPath, J9PORT_LIBRARY_SUFFIX);
-#endif /* AIXPPC */
 #endif
 }
 


### PR DESCRIPTION
**AIX shared object has .so suffix**

`.so` suffix is the correct platform extension for `AIX` shared object, otherwise the native library can't be located and loaded properly which eventually causes following `UnsatisfiedLinkError`:
```
12:35:36  Exception in thread "main" java/lang/UnsatisfiedLinkError: sun/nio/fs/UnixNativeDispatcher.init()I
12:35:36  	at sun/nio/fs/UnixNativeDispatcher.<clinit> (java.base@9/UnixNativeDispatcher.java:654)
12:35:36  	at sun/nio/fs/UnixFileSystem.<init> (java.base@9/UnixFileSystem.java:65)
12:35:36  	at sun/nio/fs/AixFileSystem.<init> (java.base@9/AixFileSystem.java:42)
12:35:36  	at sun/nio/fs/AixFileSystemProvider.newFileSystem (java.base@9/AixFileSystemProvider.java:42)
12:35:36  	at sun/nio/fs/AixFileSystemProvider.newFileSystem (java.base@9/AixFileSystemProvider.java:35)
12:35:36  	at sun/nio/fs/UnixFileSystemProvider.<init> (java.base@9/UnixFileSystemProvider.java:56)
12:35:36  	at sun/nio/fs/DefaultFileSystemProvider.<clinit> (java.base@9/DefaultFileSystemProvider.java:35)
12:35:36  	at java/nio/file/FileSystems.getDefault (java.base@9/FileSystems.java:185)
12:35:36  	at java/nio/file/Path.of (java.base@9/Path.java:147)
12:35:36  	at jdk/internal/module/SystemModuleFinders.ofSystem (java.base@9/SystemModuleFinders.java:188)
12:35:36  	at jdk/internal/module/ModuleBootstrap.boot (java.base@9/ModuleBootstrap.java:214)
12:35:36  	at java/lang/ClassLoader.initializeClassLoaders (java.base@9/ClassLoader.java:211)
12:35:36  	at java/lang/Thread.initialize (java.base@9/Thread.java:430)
12:35:36  	at java/lang/Thread.<init> (java.base@9/Thread.java:155)
```
This PR fixes `OpenJDK` `AIX` acceptance build such as https://ci.eclipse.org/openj9/job/Build_JDKnext_ppc64_aix_OpenJDK/100/console

In addition, `RI Java 8/11 System.mapLibraryName("nio")` returns `libnio.so` at `AIX` while current `OpenJ9` returns `libnio.a` which is a library archive file, with this PR, `OpenJ9` matches RI behaviour.

Also verified that there is no test breakage with PR via personal builds.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>