### PR TITLE
Static/special resolution paths should only perform interpreted dispatch

### DIFF
--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -922,22 +922,17 @@ interpreterUnresolvedStaticGlue:
       ;
       mov         rdi, rax
 
-      ; Skip code patching if the interpreter low-tag the RAM method
+      ; Skip code patching if the interpreter low-tagged the RAM method and
+      ; dispatch the interpreted method directly.
       ;
-      jc          .skippatching
+      jc          j2iTransition
 
       ; Patch the call that brought us here into a load of the resolved RAM method into RDI.
       ;
       shl         rax, 16
       xor         rax, 0bf48h                                  ; REX+MOV bytes
       mov         qword [rsi-5], rax                           ; Replaced current call with "mov rdi, 0x0000aabbccddeeff"
-      jmp         interpreterStaticAndSpecialGlue              ; The next instruction is always "jmp interpreterStaticAndSpecialGlue",
-                                                               ; jump to its target directly.
-.skippatching:
-      mov         rcx, qword [rdi+J9TR_MethodPCStartOffset]    ; rcx = interpreter entry point of the compiled method
-      test        cl, J9TR_MethodNotCompiledBit
-      jnz         j2iTransition
-      jmp         rcx
+      jmp         j2iTransition                                ; Dispatch interpreted method
 
 
       align 16
@@ -963,8 +958,7 @@ interpreterUnresolvedSpecialGlue:
       shl         rax, 16
       xor         rax, 0bf48h                                  ; REX+MOV bytes
       mov         qword [rsi-5], rax                           ; Replaced current call with "mov rdi, 0x0000aabbccddeeff"
-      jmp         interpreterStaticAndSpecialGlue              ; The next instruction is always "jmp interpreterStaticAndSpecialGlue",
-                                                               ; jump to its target directly.
+      jmp         j2iTransition                                ; Dispatch interpreted method
 
 
 ; interpreterStaticAndSpecialGlue


### PR DESCRIPTION
The AMD64 JIT's static and special unresolved paths perform the
resolution and then conclude by either dispatching to the interpreted
method or the compiled body.

However, these resolution helpers overwrite many of the linkage registers
used in JIT private linkage such that performing a dispatch to a compiled
method is incorrect.  There is a comment to that effect before each
function that seems to be unheeded.  The stack is set up to allow
interpreted dispatch only.

The most straightforward way to fix this is to always dispatch to
the interpreted method from these helpers.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>