### PR TITLE
Use OMR::align() in compiler

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -375,7 +375,6 @@ JIT_PRODUCT_SOURCE_FILES+=\
     omr/compiler/env/OMRCompilerEnv.cpp \
     omr/compiler/env/OMRIO.cpp \
     omr/compiler/env/OMRKnownObjectTable.cpp \
-    omr/compiler/runtime/Alignment.cpp \
     omr/compiler/runtime/CodeCacheTypes.cpp \
     omr/compiler/runtime/OMRCodeCache.cpp \
     omr/compiler/runtime/OMRCodeCacheConfig.cpp \

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9096,9 +9096,6 @@ TR_J9SharedCacheVM::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolRefe
    return 0;
    }
 
-
-extern U_8 *align(U_8 *ptr, U_32 alignment);
-
 // Multiple codeCache support
 TR::CodeCache *
 TR_J9SharedCacheVM::getDesignatedCodeCache(TR::Compilation *comp)
@@ -9112,7 +9109,7 @@ TR_J9SharedCacheVM::getDesignatedCodeCache(TR::Compilation *comp)
    // For AOT we need some alignment
    if (codeCache)
       {
-      codeCache->alignWarmCodeAlloc(_jitConfig->codeCacheAlignment - 1);
+      codeCache->alignWarmCodeAlloc(_jitConfig->codeCacheAlignment);
 
       // For AOT we must install the beginning of the code cache
       comp->setRelocatableMethodCodeStart((uint32_t *)codeCache->getWarmCodeAlloc());

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -100,7 +100,7 @@ TR_J9ServerVM::isSameOrSuperClass(J9Class *superClass, J9Class *subClass)
    while (classPtr)
       {
       // getSuperClass might invoke a remote call with a very low probability
-      classPtr = getSuperClass(classPtr); 
+      classPtr = getSuperClass(classPtr);
       if (classPtr == candidateSuperClassPtr)
          return true;
       }
@@ -155,7 +155,7 @@ TR_J9ServerVM::createResolvedMethodWithSignature(TR_Memory * trMemory, TR_Opaque
 
 TR_YesNoMaybe
 TR_J9ServerVM::isInstanceOf(TR_OpaqueClassBlock *a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed, bool optimizeForAOT)
-   { 
+   {
    // use instanceOfOrCheckCast to get the result, because
    // their logic is mostly the same, remote call might be made from there
    J9Class * objectClass   = (J9Class *) a;
@@ -448,7 +448,7 @@ TR_J9ServerVM::jitStaticsAreSame(TR_ResolvedMethod *method1, I_32 cpIndex1, TR_R
    TR_ResolvedJ9JITServerMethod *serverMethod2 = static_cast<TR_ResolvedJ9JITServerMethod*>(method2);
    TR_ResolvedMethod *clientMethod1 = serverMethod1->getRemoteMirror();
    TR_ResolvedMethod *clientMethod2 = serverMethod2->getRemoteMirror();
-   
+
    bool result = false;
 
    bool sigSame = true;
@@ -460,7 +460,7 @@ TR_J9ServerVM::jitStaticsAreSame(TR_ResolvedMethod *method1, I_32 cpIndex1, TR_R
       {
       if (sigSame)
          {
-         // if name and signature comparison is inconclusive, make a remote call 
+         // if name and signature comparison is inconclusive, make a remote call
          stream->write(JITServer::MessageType::VM_jitStaticsAreSame, clientMethod1, cpIndex1, clientMethod2, cpIndex2);
          result = std::get<0>(stream->read<bool>());
          }
@@ -494,7 +494,7 @@ TR_J9ServerVM::classHasBeenExtended(TR_OpaqueClassBlock *clazz)
    uintptr_t classDepthAndFlags = 0;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    bool dataFromCache = JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_DEPTH_AND_FLAGS, (void *)&classDepthAndFlags);
-   
+
    if(dataFromCache)
       {
       // Check if flag is set, since once set it can not be removed
@@ -1096,7 +1096,7 @@ TR::CodeCache *
 TR_J9ServerVM::getDesignatedCodeCache(TR::Compilation *comp)
    {
    TR::CodeCache * codeCache = TR_J9VMBase::getDesignatedCodeCache(comp);
-   
+
    if (codeCache)
       {
       // memorize the allocation pointers
@@ -1575,7 +1575,7 @@ TR_J9ServerVM::instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* cast
       if (it != _compInfoPT->getClientData()->getROMClassMap().end())
          {
          TR_OpaqueClassBlock *instanceClassOffset = (TR_OpaqueClassBlock *) instanceClass;
-         TR_OpaqueClassBlock *castClassOffset = (TR_OpaqueClassBlock *) castClass; 
+         TR_OpaqueClassBlock *castClassOffset = (TR_OpaqueClassBlock *) castClass;
 
          // this sometimes results in remote messages, but it happens relatively infrequently
          for (TR_OpaqueClassBlock *clazz = getSuperClass(instanceClassOffset); clazz; clazz = getSuperClass(clazz))
@@ -1592,11 +1592,11 @@ TR_J9ServerVM::instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* cast
             {
             int instanceNumDims = 0, castNumDims = 0;
             // these are the leaf classes of the arrays, unless the leaf class is primitive.
-            // in that case, return values are one-dimensional arrays, and 
+            // in that case, return values are one-dimensional arrays, and
             // instanceNumDims is 1 less than the actual number of array dimensions
             instanceClassOffset = getBaseComponentClass(instanceClassOffset, instanceNumDims);
             castClassOffset = getBaseComponentClass(castClassOffset, castNumDims);
-                       
+
             if (instanceNumDims < castNumDims)
                return false;
             if (instanceNumDims != 0 && instanceNumDims == castNumDims)
@@ -2354,7 +2354,7 @@ TR_J9SharedCacheServerVM::getClassFlagsValue(TR_OpaqueClassBlock * classPointer)
 
    bool validated = false;
    uintptr_t classFlags = TR_J9ServerVM::getClassFlagsValue(classPointer);
-   
+
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       SVM_ASSERT_ALREADY_VALIDATED(comp->getSymbolValidationManager(), classPointer);
@@ -2436,7 +2436,7 @@ TR_J9SharedCacheServerVM::getDesignatedCodeCache(TR::Compilation *comp)
    // For AOT we need some alignment
    if (codeCache)
       {
-      codeCache->alignWarmCodeAlloc(_jitConfig->codeCacheAlignment - 1);
+      codeCache->alignWarmCodeAlloc(_jitConfig->codeCacheAlignment);
 
       // For AOT we must install the beginning of the code cache
       comp->setRelocatableMethodCodeStart((uint32_t *)codeCache->getWarmCodeAlloc());

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ namespace J9 { typedef CodeCache CodeCacheConnector; }
 #include "runtime/OMRCodeCache.hpp"
 #include "env/IO.hpp"
 #include "env/VMJ9.h"
+#include "OMR/Bytes.hpp" // Temporary
 
 struct J9MemorySegment;
 struct J9ClassLoader;
@@ -100,6 +101,9 @@ public:
 
    OMR::CodeCacheHashEntry *  findUnresolvedMethod(void *constPool, int32_t constPoolIndex);
 
+   // Temporary
+   void alignWarmCodeAlloc(uint32_t round)  { _warmCodeAlloc = reinterpret_cast<uint8_t *>(OMR::align(reinterpret_cast<size_t>(_warmCodeAlloc), round)); }
+   void alignColdCodeAlloc(uint32_t round)  { _coldCodeAlloc = reinterpret_cast<uint8_t *>(OMR::align(reinterpret_cast<size_t>(_coldCodeAlloc), round)); }
 
   /**
    * @brief Restore warmCodeAlloc/coldCodeAlloc and trampoline pointers to their initial positions

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -362,12 +362,12 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
       if (someJitLibraryAddress > MAX_DISTANCE_NEAR_JITLIBRARY_TO_AVOID_TRAMPOLINE)
          {
          // align the startAddress to page boundary
-         vmemParams.startAddress = (void *)align((uint8_t *)(someJitLibraryAddress - MAX_DISTANCE_NEAR_JITLIBRARY_TO_AVOID_TRAMPOLINE), alignment - 1);
+         vmemParams.startAddress = (void *)OMR::align((size_t)(someJitLibraryAddress - MAX_DISTANCE_NEAR_JITLIBRARY_TO_AVOID_TRAMPOLINE), alignment);
          vmemParams.endAddress = preferredStartAddress;
          }
       else
          {
-         vmemParams.startAddress = (void *)align((uint8_t *)(someJitLibraryAddress + SAFE_DISTANCE_REPOSITORY_JITLIBRARY), alignment -1);
+         vmemParams.startAddress = (void *)OMR::align((size_t)(someJitLibraryAddress + SAFE_DISTANCE_REPOSITORY_JITLIBRARY), alignment);
          vmemParams.endAddress = (void *)(someJitLibraryAddress + MAX_DISTANCE_NEAR_JITLIBRARY_TO_AVOID_TRAMPOLINE);
          }
       // unset STRICT_ADDRESS and ADDRESS_HINT
@@ -540,7 +540,7 @@ J9::CodeCacheManager::chooseCacheStartAddress(size_t repositorySize)
             // otherwise move back some space larger than the VM DLL footprint
             startAddress = (void *)(((uint8_t *)someFunctionPointer) - safeDistance);
             // align so that port library returns exactly what we wanted
-            startAddress = (void *) align((uint8_t *)startAddress, alignment - 1);
+            startAddress = (void *)OMR::align((size_t)startAddress, alignment);
             }
          }
       }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1500,7 +1500,7 @@ createMethodMetaData(
       if (!comp->isOutOfProcessCompilation())
 #endif
          /* Align code caches */
-         codeCache->alignWarmCodeAlloc(3);
+         codeCache->alignWarmCodeAlloc(4);
 
       J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)comp->getAotMethodDataStart();
       TR_AOTMethodHeader *aotMethodHeaderEntry =  (TR_AOTMethodHeader *)(aotMethodHeader + 1);

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -57,18 +57,13 @@
 #include "x/codegen/FPTreeEvaluator.hpp"
 #include "runtime/J9Profiler.hpp"
 #include "runtime/J9ValueProfiler.hpp"
+#include "OMR/Bytes.hpp"
 
 #ifdef TR_TARGET_64BIT
 #include "x/amd64/codegen/AMD64GuardedDevirtualSnippet.hpp"
 #else
 #include "x/codegen/GuardedDevirtualSnippet.hpp"
 #endif
-
-inline uint32_t align(uint32_t number, uint32_t requirement)
-   {
-   TR_ASSERT(requirement && ((requirement & (requirement -1)) == 0), "INCORRECT ALIGNMENT");
-   return (number + requirement - 1) & ~(requirement - 1);
-   }
 
 inline uint32_t gcd(uint32_t a, uint32_t b)
    {
@@ -635,7 +630,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
       {
       int32_t frameSize = localSize + preservedRegsSize + ( _properties.getReservesOutgoingArgsInPrologue()? outgoingArgSize : 0 );
       uint32_t stackSize = frameSize + _properties.getRetAddressWidth();
-      uint32_t adjust = align(stackSize, _properties.getOutgoingArgAlignment()) - stackSize;
+      uint32_t adjust = OMR::align(stackSize, _properties.getOutgoingArgAlignment()) - stackSize;
       cg()->setStackFramePaddingSizeInBytes(adjust);
       cg()->setFrameSizeInBytes(frameSize + adjust);
       if (trace)


### PR DESCRIPTION
This patch replaces

1) the use of ::align() in J9::CodeCache
2) a private align() in the x86 codegen

with OMR::align().

It (temporarily) overrides align{Warm/Cold}CodeAlloc() from
OMR::CodeCache in order to eliminate ::align() until the same
change can be made upstream, after which the overrides will
be removed.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>