### PR TITLE
Minor inliner improvements

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2481,6 +2481,10 @@ TR_J9InlinerPolicy::skipHCRGuardForCallee(TR_ResolvedMethod *callee)
        && !callee->isPublic())
       return true;
 
+   J9Class* clazz = TR::Compiler->cls.convertClassOffsetToClassPtr((callee->classOfMethod()));
+   if (J9ROMCLASS_IS_UNMODIFIABLE(clazz->romClass))
+      return true;
+
    return false;
    }
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5209,6 +5209,14 @@ TR_PrexArgInfo* TR_PrexArgInfo::buildPrexArgInfoForMethodSymbol(TR::ResolvedMeth
       if (*sig == 'L')
          {
          TR_OpaqueClassBlock *clazz = comp->fe()->getClassFromSignature(sig, len, feMethod);
+         // Anonymous classes including lambda classes can't be referenced by name
+         // When clazz is NULL and the method is not static, we can get the receiver
+         // type from the method
+         if (!clazz && index == 0 && !feMethod->isStatic())
+            {
+            clazz = feMethod->classOfMethod();
+            }
+
          if (clazz)
             {
             argInfo->set(index, new (comp->trHeapMemory()) TR_PrexArgument(TR_PrexArgument::ClassIsPreexistent, clazz));


### PR DESCRIPTION
This PR contains two small improvements in inliner. One is to get the receiver class for anonymous class. The other is to emit HCR guard for non-modifiable classes.