### PR TITLE
CMake: Add missing link libraries to gc components

### DIFF
--- a/runtime/gc_base/CMakeLists.txt
+++ b/runtime/gc_base/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,7 @@ target_link_libraries(j9gcbase
 		j9vm_interface
 		j9vm_gc_includes
 		omrgc
+		j9modronstartup
 )
 
 target_enable_ddr(j9gcbase GLOB_HEADERS)

--- a/runtime/gc_modron_standard/CMakeLists.txt
+++ b/runtime/gc_modron_standard/CMakeLists.txt
@@ -37,4 +37,5 @@ target_link_libraries(j9modronstandard
 
 		omrgc
 		j9gcbase
+		j9modronstartup
 )


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>