### PR TITLE
Cut number of SharedCache_getClassChainOffsetInSharedCache messages

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -51,7 +51,8 @@ class JITServerHelpers
       CLASSINFO_REMOTE_ROM_CLASS,
       CLASSINFO_CLASS_FLAGS,
       CLASSINFO_METHODS_OF_CLASS,
-      CLASSINFO_CONSTANT_POOL
+      CLASSINFO_CONSTANT_POOL,
+      CLASSINFO_CLASS_CHAIN_OFFSET,
       };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
@@ -61,12 +62,13 @@ class JITServerHelpers
       TR_OpaqueClassBlock *, int32_t,                                // 2:  _baseComponentClass     3:  _numDimensions
       TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>,     // 4:  _parentClass            5:  _tmpInterfaces
       std::vector<uint8_t>, bool,                                    // 6:  _methodTracingInfo      7:  _classHasFinalFields
-      uintptr_t, bool,                                              // 8:  _classDepthAndFlags     9:  _classInitialized
+      uintptr_t, bool,                                               // 8:  _classDepthAndFlags     9:  _classInitialized
       uint32_t, TR_OpaqueClassBlock *,                               // 10: _byteOffsetToLockword   11: _leafComponentClass
       void *, TR_OpaqueClassBlock *,                                 // 12: _classLoader            13: _hostClass
       TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: _componentClass         15: _arrayClass
-      uintptr_t, J9ROMClass *,                                      // 16: _totalInstanceSize      17: _remoteRomClass
-      uintptr_t, uintptr_t                                         // 18: _constantPool           19: _classFlags
+      uintptr_t, J9ROMClass *,                                       // 16: _totalInstanceSize      17: _remoteRomClass
+      uintptr_t, uintptr_t,                                          // 18: _constantPool           19: _classFlags
+      uintptr_t                                                      // 20: _classChainOffsetOfIdentifyingLoaderForClazz
       >;
 
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -136,6 +136,16 @@ public:
 
    virtual uintptr_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR_OpaqueClassBlock *clazz);
 
+   #if defined(J9VM_OPT_JITSERVER)
+   /**
+     * \brief Finds the offset in SCC of the class chain identifying the class loader of the given class.
+     *        This is very similar to getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache
+     *        except that it will not fail the compilation if the offset is not valid.
+     * \return Returns the offset of the class chain that identifies given class or 0 is such offset is not valid.
+    */
+   uintptr_t getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCacheNoFail(TR_OpaqueClassBlock *clazz);
+   #endif
+
    virtual const void *storeSharedData(J9VMThread *vmThread, char *key, J9SharedDataDescriptor *descriptor);
 
    enum TR_J9SharedCacheDisabledReason

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -302,6 +302,7 @@ ClientSessionData::ClassInfo::ClassInfo() :
    _totalInstanceSize(0),
    _constantPool(NULL),
    _classFlags(0),
+   _classChainOffsetOfIdentifyingLoaderForClazz(0),
    _remoteROMStringsCache(decltype(_remoteROMStringsCache)::allocator_type(TR::Compiler->persistentAllocator())),
    _fieldOrStaticNameCache(decltype(_fieldOrStaticNameCache)::allocator_type(TR::Compiler->persistentAllocator())),
    _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(TR::Compiler->persistentAllocator())),

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -252,6 +252,7 @@ class ClientSessionData
       uintptr_t _totalInstanceSize;
       J9ConstantPool *_constantPool;
       uintptr_t _classFlags;
+      uintptr_t _classChainOffsetOfIdentifyingLoaderForClazz;
       PersistentUnorderedMap<TR_RemoteROMStringKey, std::string> _remoteROMStringsCache; // cached strings from the client
       PersistentUnorderedMap<int32_t, std::string> _fieldOrStaticNameCache;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _classOfStaticCache;


### PR DESCRIPTION
Many such messages are issued from:
TR_J9JITServerSharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache()
This commit reduces the occurences of such messages by caching the mapping
{j9class -> classChainOffsetOfIdentifyingLoaderForClazz}
JITServer already maintains a mapping {j9class -> ClassInfo} so the work
here involves extending the struct `ClassInfo` with an additional field.
One problem that needs to be taken care of is that
`classChainOffsetOfIdentifyingLoaderForClazz` may not be available when
`ClassInfo` for a j9class is cached. Thus, we need an additional check
against the cached value. If that turns out to be 0 we need to issue a
message to the client to find the proper value.

Closes: #8959

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>