### PR TITLE
JVM_LoadLibrary acquires VM Access before exit VM to JNI

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -3597,7 +3597,7 @@ JVM_LoadLibrary(const char* libName)
 	if (vmFuncs->registerBootstrapLibrary(currentThread, libName, &nativeLibrary, FALSE) == J9NATIVELIB_LOAD_OK) {
 		result = (void*)nativeLibrary->handle;
 	}
-	/* No need to acquire VM access since next is to exit VM */
+	vmFuncs->internalAcquireVMAccess(currentThread);
 	vmFuncs->internalExitVMToJNI(currentThread);
 
 	Trc_SC_LoadLibrary_Exit(result);


### PR DESCRIPTION
**JVM_LoadLibrary acquires VM Access before exit VM to JNI**

Added `internalAcquireVMAccess()` before `internalExitVMToJNI()`.
This is required when `J9VM_INTERP_ATOMIC_FREE_JNI` is not defined and `internalExitVMToJNI()` is equivalent to `internalReleaseVMAccess()` which checks `Assert_VM_mustHaveVMAccess(vmThread)` as following native stacktrace.
```
    frame #16: 0x000000000f2723aa libj9vm29.dylib`::internalReleaseVMAccessNoMutex(J9VMThread *) [inlined] internalReleaseVMAccessNoMutexNoCheck(vmThread=0x00000000173a7a00) at VMAccess.cpp:0 [opt]
    frame #17: 0x000000000f272377 libj9vm29.dylib`::internalReleaseVMAccessNoMutex(vmThread=0x00000000173a7a00) at VMAccess.cpp:479 [opt]
    frame #18: 0x000000000f2713c7 libj9vm29.dylib`::internalReleaseVMAccess(J9VMThread *) [inlined] VM_VMAccess::inlineReleaseVMAccess(vmThread=0x00000000173a7a00) at VMAccess.hpp:189:3 [opt]
    frame #19: 0x000000000f27139e libj9vm29.dylib`::internalReleaseVMAccess(currentThread=0x00000000173a7a00) at VMAccess.cpp:78 [opt]
    frame #20: 0x000000000e17255e libjvm.dylib`JVM_LoadLibrary(libName="./openj9-openjdk-jdk/build/macosx-x86_64-server-release/images/jdk/lib/libzip.dylib") at jvm.c:3607:2 [opt]
```

Verified that this fixes the failure #8921 .

Additional note: this is an `OSX` specific problem which is the only non-embedded platform without `J9VM_INTERP_ATOMIC_FREE_JNI` enabled. It seems not straightforward to enable it for `OSX`, will leave it in another PR instead.

closes: #8921 

Reviewer: @gacholio 
FYI: @DanHeidinga @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>