### PR TITLE
Optimize IProfiler fan-in info serialization

### DIFF
--- a/runtime/compiler/runtime/JITServerIProfiler.hpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.hpp
@@ -39,9 +39,10 @@ struct TR_ContiguousIPMethodData
 
 struct TR_ContiguousIPMethodHashTableEntry
    {
-   static TR_ContiguousIPMethodHashTableEntry serialize(TR_IPMethodHashTableEntry *entry);
+   static void serialize(TR_IPMethodHashTableEntry *entry, TR_ContiguousIPMethodHashTableEntry *serialEntry);
 
    TR_OpaqueMethodBlock *_method; // callee
+   size_t _callerCount;
    TR_ContiguousIPMethodData _callers[TR_IPMethodHashTableEntry::MAX_IPMETHOD_CALLERS]; // array of callers and their weights. null _method means EOL
    TR_DummyBucket _otherBucket;
    };


### PR DESCRIPTION
Previously, serializing `TR_IPMethodHashTableEntry` to
`TR_ContiguousIPMethodHashTableEntry` required memsetting
the contiguous entry to 0 on the client, so when
the next element in the serialized array of callers is NULL,
server would know that it reached the end.

This commit adds `_callerCount` field to the contiguous entry,
so that client doesn't have to perform a memset since server
is informed how many callers are present.