### PR TITLE
Ensure KEEP_REPORTDIR does not get passed as null

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -426,7 +426,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
             echo "TEST_FLAG:'${TEST_FLAG}'"
 
             def extraTestLabels = EXTRA_TEST_LABELS[target] ?: ''
-            def keepReportDir = TEST_KEEP_REPORTDIR[target]
+            def keepReportDir = TEST_KEEP_REPORTDIR[target] ?: ''
             def buildList = TEST_BUILD_LIST[target] ?: ''
             echo "Target:'${target}' extraTestLabels:'${extraTestLabels}', keepReportDir:'${keepReportDir}'"
 


### PR DESCRIPTION
- This is a temp fix to workaround a current blocker running
  aot tests. A more thorough fix is needed and will be
  followed shortly.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>