### PR TITLE
Reduce VM_getROMMethodFromRAMMethod messages

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -68,7 +68,7 @@ class JITServerHelpers
       TR_OpaqueClassBlock *, TR_OpaqueClassBlock *,                  // 14: _componentClass         15: _arrayClass
       uintptr_t, J9ROMClass *,                                       // 16: _totalInstanceSize      17: _remoteRomClass
       uintptr_t, uintptr_t,                                          // 18: _constantPool           19: _classFlags
-      uintptr_t                                                      // 20: _classChainOffsetOfIdentifyingLoaderForClazz
+      uintptr_t, std::vector<J9ROMMethod *>                          // 20: _classChainOffsetOfIdentifyingLoaderForClazz 21. _origROMMethods
       >;
 
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, TR_Memory *trMemory);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1761,6 +1761,16 @@ TR_J9ServerVM::isStringCompressionEnabledVM()
 J9ROMMethod *
 TR_J9ServerVM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    {
+      {
+      // Check persistent cache first
+      OMR::CriticalSection J9MethodMapMonitor(_compInfoPT->getClientData()->getROMMapMonitor());
+      auto it = _compInfoPT->getClientData()->getJ9MethodMap().find(ramMethod);
+      if (it != _compInfoPT->getClientData()->getJ9MethodMap().end())
+         {
+         return it->second._origROMMethod;
+         }
+      }
+
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getROMMethodFromRAMMethod, ramMethod);
    return std::get<0>(stream->read<J9ROMMethod *>());

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -280,6 +280,7 @@ class ClientSessionData
    struct J9MethodInfo
       {
       J9ROMMethod *_romMethod; // pointer to local/server cache
+      J9ROMMethod *_origROMMethod; // pointer to the client-side method
       // The following is a hashtable that maps a bcIndex to IProfiler data
       // The hashtable is created on demand (NULL means it is missing)
       IPTable_t *_IPData;


### PR DESCRIPTION
When ROM method is requested, first check persistent cache
of `J9MethodInfo` and return ROM method from there, if found.
Only make remote call, if the method is not cached.

Resolves: #8958