### PR TITLE
(0.20.0) Reverse Throwable writableStackTrace boolean field logic

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,7 +80,7 @@ public class Throwable implements java.io.Serializable {
 	 * The list containing the exceptions suppressed 
 	 */
 	private List<Throwable> suppressedExceptions = Collections.EMPTY_LIST;
-	private transient boolean enableWritableStackTrace = true;
+	private transient boolean disableWritableStackTrace;
 	
 /**
  * Constructs a new instance of this class with its 
@@ -165,7 +165,7 @@ protected Throwable(String detailMessage, Throwable throwable,
 	}
 	
 	if (enableWritableStackTrace == false)	{
-		this.enableWritableStackTrace = false;
+		this.disableWritableStackTrace = true;
 	} else {
 		fillInStackTrace();
 	}
@@ -237,7 +237,7 @@ public void setStackTrace(StackTraceElement[] trace) {
 		}
 	}
 	
-	if (enableWritableStackTrace == false) {
+	if (disableWritableStackTrace) {
 		return;
 	}
 	
@@ -284,7 +284,7 @@ private static int countDuplicates(StackTraceElement[] currentStack, StackTraceE
  */
 StackTraceElement[] getInternalStackTrace() {
 
-	if (!enableWritableStackTrace) {
+	if (disableWritableStackTrace) {
 		return	ZeroStackTraceElementArray;
 	}
 
@@ -429,7 +429,7 @@ private void readObject(ObjectInputStream s)
 	throws IOException, ClassNotFoundException	{
 	s.defaultReadObject();
 	
-	enableWritableStackTrace = (stackTrace != null);
+	disableWritableStackTrace = (stackTrace == null);
 	
 	if (stackTrace != null) {
 		if (stackTrace.length == 1) {

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corp. and others
+ * Copyright (c) 2002, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -427,10 +427,8 @@ JVM_FillInStackTrace(JNIEnv* env, jobject throwable)
 	vmfns->internalEnterVMFromJNI(currentThread);
 	unwrappedThrowable = J9_JNI_UNWRAP_REFERENCE(throwable);
 	if ((0 == (javaVM->runtimeFlags & J9_RUNTIME_OMIT_STACK_TRACES)) &&
-		/* If the enableWritableStackTrace field is resolved, check it. If it's false, do not create the stack trace. */
-		/* TODO should be: (0 == J9VMCONSTANTPOOL_FIELDREF_AT(javaVM, J9VMCONSTANTPOOL_JAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE)->flags) */
-		((J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(J9_CLASS_FROM_CP((javaVM)->jclConstantPool)->romClass), J9VMCONSTANTPOOL_JAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE) == J9CPTYPE_UNUSED) ||
-			J9VMJAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE(currentThread, unwrappedThrowable)))
+		/* If the disableWritableStackTrace field is true, do not create the stack trace. */
+		!J9VMJAVALANGTHROWABLE_DISABLEWRITABLESTACKTRACE(currentThread, unwrappedThrowable))
 	{
 		UDATA flags = J9_STACKWALK_CACHE_PCS | J9_STACKWALK_WALK_TRANSLATE_PC | J9_STACKWALK_VISIBLE_ONLY | J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_SKIP_INLINES;
 		J9StackWalkState* walkState = currentThread->stackWalkState;

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -192,7 +192,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/Throwable" name="detailMessage" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/Throwable" name="walkback" signature="Ljava/lang/Object;"/>
 	<fieldref class="java/lang/Throwable" name="stackTrace" signature="[Ljava/lang/StackTraceElement;"/>
-	<fieldref class="java/lang/Throwable" name="enableWritableStackTrace" signature="Z"/>
+	<fieldref class="java/lang/Throwable" name="disableWritableStackTrace" signature="Z"/>
 	<fieldref class="java/lang/ExceptionInInitializerError" name="exception" signature="Ljava/lang/Throwable;" versions="8-11"/>
 	<fieldref class="java/lang/Boolean" name="value" signature="Z"/>
 	<fieldref class="java/lang/Byte" name="value" signature="B"/>

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2937,12 +2937,10 @@ done:
 		/* Don't fill in stack traces if -XX:-StackTraceInThrowable is in effect */
 		if (0 == (_vm->runtimeFlags & J9_RUNTIME_OMIT_STACK_TRACES)) {
 			j9object_t receiver = *(j9object_t*)_sp;
-			/* If the enableWritableStackTrace field is unresolved (i.e. doesn't exist) or is set to true,
+			/* If the disableWritableStackTrace field is set to false,
 			 * continue filling in the stack trace.
 			 */
-			if (VM_VMHelpers::vmConstantPoolFieldIsResolved(_vm, J9VMCONSTANTPOOL_JAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE)
-				&& J9VMJAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE(_currentThread, receiver)
-			) {
+			if (!J9VMJAVALANGTHROWABLE_DISABLEWRITABLESTACKTRACE(_currentThread, receiver)) {
 				buildInternalNativeStackFrame(REGISTER_ARGS);
 				j9object_t walkback = (j9object_t)J9VMJAVALANGTHROWABLE_WALKBACK(_currentThread, receiver);
 				J9StackWalkState *walkState = _currentThread->stackWalkState;

--- a/runtime/vm/FastJNI_java_lang_Throwable.cpp
+++ b/runtime/vm/FastJNI_java_lang_Throwable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,12 +41,10 @@ Fast_java_lang_Throwable_fillInStackTrace(J9VMThread *currentThread, j9object_t 
 	if (0 == (vm->runtimeFlags & J9_RUNTIME_OMIT_STACK_TRACES)) {
 		MM_ObjectAllocationAPI objectAllocate(currentThread);
 		MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
-		/* If the enableWritableStackTrace field is unresolved (i.e. doesn't exist) or is set to true,
+		/* If the disableWritableStackTrace field is set to false,
 		 * continue filling in the stack trace.
 		 */
-		if (VM_VMHelpers::vmConstantPoolFieldIsResolved(vm, J9VMCONSTANTPOOL_JAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE)
-			&& J9VMJAVALANGTHROWABLE_ENABLEWRITABLESTACKTRACE(currentThread, receiver)
-		) {
+		if (!J9VMJAVALANGTHROWABLE_DISABLEWRITABLESTACKTRACE(currentThread, receiver)) {
 			j9object_t walkback = (j9object_t)J9VMJAVALANGTHROWABLE_WALKBACK(currentThread, receiver);
 			J9StackWalkState *walkState = currentThread->stackWalkState;
 			UDATA walkFlags = J9_STACKWALK_CACHE_PCS | J9_STACKWALK_WALK_TRANSLATE_PC |


### PR DESCRIPTION
The field to control Throwable writeable stack trace
enableWritableStackTrace has a default value true. The field is
transient (not included in the serialized form) as per the
specification. This logic doesn't work with Google gson, as gson doesn't
restore the field value after serialization. Rename the field to
disableWritableStackTrace, which is false by default, and reverse the
logic.

Also remove checks if the disableWritableStackTrace field exists, which
were for Java 6.

Fixes #8760

Cherry pick of #8938 for the 0.20.0 release.