### PR TITLE
Turn `interp_useUnsafeHelper` on for aarch specs

### DIFF
--- a/buildspecs/linux_aarch64.spec
+++ b/buildspecs/linux_aarch64.spec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildspecs/linux_aarch64.spec
+++ b/buildspecs/linux_aarch64.spec
@@ -144,6 +144,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/linux_aarch64_cmprssptrs.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs.spec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildspecs/linux_aarch64_cmprssptrs.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs.spec
@@ -145,6 +145,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/linux_aarch64_cmprssptrs_cross.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs_cross.spec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildspecs/linux_aarch64_cmprssptrs_cross.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs_cross.spec
@@ -146,6 +146,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/linux_aarch64_cross.spec
+++ b/buildspecs/linux_aarch64_cross.spec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2019, 2019 IBM Corp. and others
+Copyright (c) 2019, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/buildspecs/linux_aarch64_cross.spec
+++ b/buildspecs/linux_aarch64_cross.spec
@@ -145,6 +145,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>


### PR DESCRIPTION
This is required to allow the VM to intercept bus errors
and convert them into InternalErrors

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>