### PR TITLE
Enable interp_atomicFreeJni for OSX

### DIFF
--- a/buildspecs/osx_x86-64.spec
+++ b/buildspecs/osx_x86-64.spec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2019 IBM Corp. and others
+Copyright (c) 2006, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,6 +121,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<project id="compiler"/>
 	</source>
 	<flags>
+		<flag id="interp_atomicFreeJni" value="true"/>
+		<flag id="interp_atomicFreeJniUsesFlush" value="true"/>
+		<flag id="interp_twoPassExclusive" value="true"/>
 		<flag id="arch_x86" value="true"/>
 		<flag id="build_SE6_package" value="true"/>
 		<flag id="build_dropToHursley" value="true"/>

--- a/buildspecs/osx_x86-64_cmprssptrs.spec
+++ b/buildspecs/osx_x86-64_cmprssptrs.spec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2018, 2019 IBM Corp. and others
+Copyright (c) 2018, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,6 +117,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<project id="compiler"/>
 	</source>
 	<flags>
+		<flag id="interp_atomicFreeJni" value="true"/>
+		<flag id="interp_atomicFreeJniUsesFlush" value="true"/>
+		<flag id="interp_twoPassExclusive" value="true"/>
 		<flag id="arch_x86" value="true"/>
 		<flag id="build_SE6_package" value="true"/>
 		<flag id="build_dropToHursley" value="true"/>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5126,10 +5126,10 @@ typedef struct J9JavaVM {
 	UDATA safePointResponseCount;
 	struct J9VMRuntimeStateListener vmRuntimeStateListener;
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-#if defined(LINUX) || defined(AIXPPC)
+#if defined(J9UNIX) || defined(AIXPPC)
 	J9PortVmemIdentifier exclusiveGuardPage;
 	omrthread_monitor_t flushMutex;
-#elif defined(WIN32) /* LINUX || AIXPPC  */
+#elif defined(WIN32) /* J9UNIX || AIXPPC  */
 	void *flushFunction;
 #endif /* WIN32 */
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */

--- a/runtime/vm/FlushProcessWriteBuffers.cpp
+++ b/runtime/vm/FlushProcessWriteBuffers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,12 @@
 
 #if defined(WIN32)
 #include <windows.h>
-#elif defined(LINUX) || defined(AIXPPC) /* WIN32 */
-#include <sys/mman.h>
-#endif /* LINUX || AIXPPC */
+#endif /* WIN32 */
 
 #include "vm_internal.h"
+#if defined(J9UNIX) || defined(AIXPPC)
+#include <sys/mman.h>
+#endif /* J9UNIX || AIXPPC */
 #include "ut_j9vm.h"
 #include "AtomicSupport.hpp"
 
@@ -44,7 +45,7 @@ flushProcessWriteBuffers(J9JavaVM *vm)
 	if (NULL != vm->flushFunction) {
 		((VOID (WINAPI*)(void))vm->flushFunction)();
 	}
-#elif defined(LINUX) || defined(AIXPPC) /* WIN32 */
+#elif defined(J9UNIX) || defined(AIXPPC) /* WIN32 */
 	if (NULL != vm->flushMutex) {
 		omrthread_monitor_enter(vm->flushMutex);
 		void *addr = vm->exclusiveGuardPage.address;
@@ -56,9 +57,9 @@ flushProcessWriteBuffers(J9JavaVM *vm)
 		Assert_VM_true(0 == mprotectrc);
 		omrthread_monitor_exit(vm->flushMutex);
 	}
-#else /* LINUX || AIXPPC */
+#else /* J9UNIX || AIXPPC */
 #error flushProcessWriteBuffers unimplemented
-#endif /* LINUX || AIXPPC */
+#endif /* J9UNIX || AIXPPC */
 }
 
 UDATA


### PR DESCRIPTION
`Enable interp_atomicFreeJni for OSX`

Enabled `interp_atomicFreeJni`, `interp_atomicFreeJniUsesFlush` and `interp_twoPassExclusive` for two `OSX` specs;
Defined `J9UNIX` for related code to support `OSX` Atomic-free JNI.

Tested in personal builds and no related failure observed.

Related PR: https://github.com/eclipse/openj9/pull/8971

Reviewer: @gacholio 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>