### PR TITLE
(0.20.0) Enable DDR JITExt test for AArch64 again

### DIFF
--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -118,7 +118,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-Dtest.list=$(Q)TestJITExt$(Q) -DADDITIONALEXPORTS=$(ADDEXPORTS_JDKASM_UNNAMED) -DEXTRADUMPOPT=$(Q)-Xjit:count=0$(Q) -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.zos,^arch.aarch64</platformRequirements>
+		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit enables DDR JITExt test that was disabled for AArch64 in #8569.

Original PR for master: #8764

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>