### PR TITLE
Add exit agent exclusive vm access flags

### DIFF
--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -437,7 +437,7 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 		  NULL,
 		  NULL,
 		  0,
-		  J9RAS_DUMP_DO_SUSPEND_OTHER_DUMPS,
+		  J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS,
 		  NULL }
 	}
 };


### PR DESCRIPTION
solves 1 of 2 issues for https://github.com/eclipse/openj9/issues/8552

A hang is occurring when two threads are running the `exit` xdump agent at the same time.

This can be reproduced with the instructions from the related issue with `-Xint` also set.

Stack trace from stalling threads:

 ```
(gdb) info threads
  Id   Target Id         Frame
  1    Thread 0x7f5bd655e700 (LWP 3380) "java" 0x00007f5bd5f1498d in pthread_join (threadid=140032394450688, thread_return=0x7ffd18174348) at pthread_join.c:90
  2    Thread 0x7f5bd520d700 (LWP 3381) "main" pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
  3    Thread 0x7f5bd652b700 (LWP 3382) "Signal Reporter" 0x00007f5bd5f1b827 in futex_abstimed_wait_cancelable (private=0, abstime=0x0, expected=0,
    futex_word=0x7f5bcfdf6820 <wakeUpASyncReporter>) at ../sysdeps/unix/sysv/linux/futex-internal.h:205
  4    Thread 0x7f5bc15ff700 (LWP 3383) "Common-Cleaner" pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:225
  5    Thread 0x7f5bc15be700 (LWP 3384) "Finalizer maste" pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
* 6    Thread 0x7f5bc12c6700 (LWP 3386) "Thread-2" pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
  7    Thread 0x7f5bc1285700 (LWP 3387) "Attach API wait" 0x00007f5bd5835c47 in semop () at ../sysdeps/unix/syscall-template.S:84
  8    Thread 0x7f5bc157d700 (LWP 3388) "Thread-4" pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:225
  9    Thread 0x7f5bc102e700 (LWP 3389) "Thread-5" pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
  10   Thread 0x7f5bc0fed700 (LWP 3390) "Thread-6" pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
(gdb) thread 8
[Switching to thread 8 (Thread 0x7f5bc157d700 (LWP 3388))]
#0  pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:225
225	../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S: No such file or directory.
(gdb) bt
#0  pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:225
#1  0x00007f5bd4025716 in omrthread_sleep () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9thr29.so
#2  0x00007f5bcf47a5fd in prepareForDump () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#3  0x00007f5bcf463c89 in runDumpAgent () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#4  0x00007f5bcf47b02b in triggerDumpAgents () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#5  0x00007f5bcf479794 in rasDumpHookExceptionSysthrow () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
(gdb) thread 6
[Switching to thread 6 (Thread 0x7f5bc12c6700 (LWP 3386))]
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
185	../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S: No such file or directory.
(gdb) bt
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x00007f5bd40275d7 in omrthread_monitor_wait () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9thr29.so
#2  0x00007f5bd42b465c in internalAcquireVMAccessNoMutexWithMask () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9vm29.so
#3  0x00007f5bd42b70ea in internalEnterVMFromJNI () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9vm29.so
#4  0x00007f5bd42eaa5f in exitJavaVM () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9vm29.so
#5  0x00007f5bcf460439 in doJavaVMExit () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#6  0x00007f5bcf460475 in protectedDumpFunction () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#7  0x00007f5bcfb9fdf3 in omrsig_protect () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9prt29.so
#8  0x00007f5bcf463b8b in runDumpFunction () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#9  0x00007f5bcf463d1f in runDumpAgent () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#10 0x00007f5bcf47b02b in triggerDumpAgents () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
#11 0x00007f5bcf479794 in rasDumpHookExceptionSysthrow () from /root/exitoom/jdk-11.0.6+10/lib/compressedrefs/libj9dmp29.so
```

ddr shows that Thread 4 is not giving up its vm access flag to the exiting thread.
```
> !threads flags
Attached Threads List. For more options, run !threads help

    !j9vmthread 0xc01200 publicFlags=81 privateFlags=1008 inNative=0 // main
    !j9vmthread 0xcdf500 publicFlags=80181 privateFlags=2 inNative=0 // Common-Cleaner
    !j9vmthread 0xd20100 publicFlags=81 privateFlags=2400 inNative=0 // Thread-2
    !j9vmthread 0xd27d00 publicFlags=a1 privateFlags=2 inNative=1 // Attach API wait loop
    !j9vmthread 0xd03300 publicFlags=21 privateFlags=2400 inNative=0 // Thread-4
    !j9vmthread 0xd3fa00 publicFlags=1020 privateFlags=0 inNative=0 // Thread-5
    !j9vmthread 0xd43600 publicFlags=81 privateFlags=0 inNative=0 // Thread-6
>
```

By changing the exit agents `requestMask` from J9RAS_DUMP_DO_SUSPEND_OTHER_DUMPS to J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS the second thread will be waiting to acquire vm access instead of the dump lock where it was getting stuck.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>