### PR TITLE
Add query method for class whose instances are zero initializable

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -626,3 +626,9 @@ J9::ClassEnv::isValueTypeClass(TR_OpaqueClassBlock *clazz)
    J9Class *j9class = reinterpret_cast<J9Class*>(clazz);
    return J9_IS_J9CLASS_VALUETYPE(j9class);
    }
+
+bool
+J9::ClassEnv::isZeroInitializable(TR_OpaqueClassBlock *clazz)
+   {
+   return (self()->classFlagsValue(clazz) & J9ClassContainsUnflattenedFlattenables) == 0;
+   }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -89,6 +89,24 @@ public:
    bool isAbstractClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isValueTypeClass(TR_OpaqueClassBlock *);
+
+   /**
+    * \brief
+    *    Checks whether instances of the specified class can be trivially initialized by
+    *    "zeroing" their fields.
+    *    In the case of OpenJ9, this tests whether any field is of a value type that has not been
+    *    "flattened" (that is, had the value type's fields inlined into this class).  Such a value
+    *    type field must be initialized with the default value of the type.
+    *
+    * \param clazz
+    *    The class that is to be checked
+    *
+    * \return
+    *    `true` if instances of the specified class can be initialized by zeroing their fields;
+    *    `false` otherwise (that is, if the class has value type fields whose fields have not
+    *    been inlined)
+    */
+   bool isZeroInitializable(TR_OpaqueClassBlock *clazz);
    bool isEnumClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer, TR_ResolvedMethod *method);
    bool isPrimitiveClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);
    bool isAnonymousClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);


### PR DESCRIPTION
Define an `isZeroInitializable` method that indicates whether a class's instances have fields that can be trivially initialized by zeroing memory.

For prototype support of value types, a class with a value type field that has not been inlined into the class must have that value type field of its instances initialized with the default value for the value type.  The implementation of `isZeroInitializable` is introduced to detect that case.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>