### PR TITLE
Runtime compressed refs work

### DIFF
--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -687,8 +687,8 @@ MM_ScavengerDelegate::switchConcurrentForThread(MM_EnvironmentBase *env)
 		vmThread->readBarrierRangeCheckTop = (UDATA)top - 1;
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 		if (compressObjectReferences()) {
-			vmThread->readBarrierRangeCheckBaseCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckBase);
-			vmThread->readBarrierRangeCheckTopCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckTop);
+			vmThread->readBarrierRangeCheckBaseCompressed = (U_32)_extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckBase);
+			vmThread->readBarrierRangeCheckTopCompressed = (U_32)_extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckTop);
 		}
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5909,9 +5909,18 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	}
 #endif
 
+	/* Scans cmd-line arguments in order */
+	if (JNI_OK != processVMArgsFromFirstToLast(vm)) {
+		goto error;
+	}
+
+	/* At this point, the compressed/full determination has been made */
+
 #ifdef J9VM_RAS_EYECATCHERS
 	J9RASInitialize(vm);
 #endif
+
+	initializeROMClasses(vm);
 
 #ifdef J9VM_INTERP_VERBOSE
 	localVerboseLevel = vm->verboseLevel;
@@ -6089,14 +6098,6 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 	/* Default to using lazy in all but realtime */
 	vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_LAZY_SYMBOL_RESOLUTION;
-
-	/* Scans cmd-line arguments in order */
-	if (JNI_OK != processVMArgsFromFirstToLast(vm)) {
-		goto error;
-	}
-
-	/* Must be done after the compressed/full determination has been made */
-	initializeROMClasses(vm);
 
 #if !defined(WIN32)
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags,J9_EXTENDED_RUNTIME_HANDLE_SIGXFSZ)) {

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -629,8 +629,8 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 
 	Trc_VM_romFieldOffsetsStartDo_Entry( NULL, romClass, superClazz, flags );
 
-	UDATA const referenceSize = J9JAVAVM_REFERENCE_SIZE(vm);
-	UDATA const objectHeaderSize = J9JAVAVM_OBJECT_HEADER_SIZE(vm);
+	U_32 const referenceSize = J9JAVAVM_REFERENCE_SIZE(vm);
+	U_32 const objectHeaderSize = J9JAVAVM_OBJECT_HEADER_SIZE(vm);
 
 	/* init the walk state, including all counters to 0 */
 	memset( state, 0, sizeof( *state ) );


### PR DESCRIPTION
Update RAS code to properly handle mixed mode.

The issue was that AIX non-compressed was not copying the RAS structure to virtual memory, resulting in DDR taking forever (i.e. longer than the test timeout) to find the RAS structure.

Also fix some compile errors on windows (assuming fj9object_t == U_32 when the compressed compile flag is on).

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>