### PR TITLE
IL Generation for defaultvalue bytecode instruction

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11036,6 +11036,10 @@ TR::CompilationInfoPerThreadBase::processException(
       {
       _methodBeingCompiled->_compErrCode = compilationILGenFailure;
       }
+   catch (const TR::UnsupportedValueTypeOperation &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationILGenUnsupportedValueTypeOperationFailure;
+      }
    /* IL Gen Exceptions End */
 
    /* Runtime Failure Exceptions Start */

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -209,12 +209,13 @@ char *compilationErrorNames[]={
    "compilationSymbolValidationManagerFailure", //50
    "compilationAOTNoSupportForAOTFailure", //51
    "compilationAOTValidateTMFailure", //52
+   "compilationILGenUnsupportedValueTypeOperationFailure", //53
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", //53
-   "compilationStreamLostMessage", // 54
-   "compilationStreamMessageTypeMismatch", // 55
-   "compilationStreamVersionIncompatible", // 56
-   "compilationStreamInterrupted", // 57
+   "compilationStreamFailure", //54
+   "compilationStreamLostMessage", // 55
+   "compilationStreamMessageTypeMismatch", // 56
+   "compilationStreamVersionIncompatible", // 57
+   "compilationStreamInterrupted", // 58
 #endif /* defined(J9VM_OPT_JITSERVER) */
    "compilationMaxError"
 };

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -76,12 +76,14 @@ typedef enum {
    compilationSymbolValidationManagerFailure       = 50,
    compilationAOTNoSupportForAOTFailure            = 51,
    compilationAOTValidateTMFailure                 = 52,
+   compilationILGenUnsupportedValueTypeOperationFailure = 53,
 #if defined(J9VM_OPT_JITSERVER)
-   compilationStreamFailure                        = 53,
-   compilationStreamLostMessage                    = 54,
-   compilationStreamMessageTypeMismatch            = 55,
-   compilationStreamVersionIncompatible            = 56,
-   compilationStreamInterrupted                    = 57,
+   compilationFirstJITServerFailure,
+   compilationStreamFailure                        = compilationFirstJITServerFailure,
+   compilationStreamLostMessage                    = compilationFirstJITServerFailure+1,
+   compilationStreamMessageTypeMismatch            = compilationFirstJITServerFailure+2,
+   compilationStreamVersionIncompatible            = compilationFirstJITServerFailure+3,
+   compilationStreamInterrupted                    = compilationFirstJITServerFailure+4,
 #endif /* defined(J9VM_OPT_JITSERVER) */
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -449,7 +449,9 @@ J9::ClassEnv::enumerateFields(TR::Region& region, TR_OpaqueClassBlock * opaqueCl
             dataType = TR::Double;
             break;
             }
-         case 'L': 
+// VALHALLA_TODO:  Might require different TR::DataType for value types (Q)
+         case 'L':
+         case 'Q':
          case '[':
             {
             dataType = TR::Address;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7006,7 +7006,7 @@ TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPo
    // For a non-array class type, strip off the first 'L' and last ';' of the
    // signature
    //
-   if (* sig == 'L' && sigLength > 2)
+   if ((*sig == 'L' || *sig == 'Q') && sigLength > 2)
       {
       sig += 1;
       sigLength -= 2;

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -229,6 +229,7 @@ private:
    void         genMonitorExit(bool);
    TR_OpaqueClassBlock *loadValueClass(int32_t classCpIndex);
    void         genDefaultValue(uint16_t classCpIndex);
+   void         genDefaultValue(TR_OpaqueClassBlock *valueTypeClass);
    void         genWithField(uint16_t fieldCpIndex);
    void         genFlush(int32_t nargs);
    void         genFullFence(TR::Node *node);

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -358,14 +358,8 @@ const TR_J9ByteCode TR_J9ByteCodeIterator::_opCodeToByteCodeEnum[] =
    /* 198 */ J9BCifnull, J9BCifnonnull,
    /* 200 */ J9BCgotow, J9BCunknown,
    /* 202 */ J9BCbreakpoint,
-
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
    /* 203 */ J9BCdefaultvalue,
    /* 204 */ J9BCwithfield,
-#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-   /* 203 */ J9BCunknown,
-   /* 204 */ J9BCunknown,
-#endif
    /* 205 */ J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown,
    /* 209 */ J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown,
    /* 213 */ J9BCiincw, J9BCunknown,
@@ -826,6 +820,9 @@ const uint8_t TR_J9ByteCodeIterator::_estimatedCodeSize[] =
   25, // J9BCmonitorenter
   25, // J9BCmonitorexit
    0, // J9BCwide
+   0, // J9BCasyncCheck
+   1, // J9BCdefaultvalue
+   1, // J9BCwithfield
    0, // J9BCunknown
    };
 

--- a/runtime/jit_vm/ctsupport.cpp
+++ b/runtime/jit_vm/ctsupport.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 IBM Corp. and others
+ * Copyright (c) 2008, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -202,6 +202,9 @@ jitParseSignature (const J9UTF8 *signature, U_8 *paramBuffer, UDATA *paramElemen
 			state = returnValue;
 		} else {
 			switch (*sigChar) {
+			case 'Q':
+                                /* VALHALLA_TODO:  Need to return a J9_NATIVE_TYPE_VALUE for 'Q' in future */
+                                /* FALLTHROUGH */
 			case 'L': next = J9_NATIVE_TYPE_OBJECT; break;
 			case '[': 
 				next = J9_NATIVE_TYPE_OBJECT; 
@@ -228,7 +231,7 @@ jitParseSignature (const J9UTF8 *signature, U_8 *paramBuffer, UDATA *paramElemen
 			case 'V': next = J9_NATIVE_TYPE_VOID; break;
 			}
 			
-			if ('L' == *sigChar) {
+			if ('L' == *sigChar || 'Q' == *sigChar) {
 				/* flush the name of the class */
 				while (';' != *sigChar) {
 					++sigChar;


### PR DESCRIPTION
This change adds prototype IL generation support for the value type `defaultvalue` bytecode in the case where the class specified is resolved.  If the class is unresolved, the JIT compilation is aborted with an `UnsupportedValueTypeOperation` exception.