### PR TITLE
Clarify contract of findROMClassFromPC() method

### DIFF
--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3953,7 +3953,9 @@ J9ROMMethod *
 * @brief Finds the rom class given a PC.  Also returns the classloader it belongs to.
 * @param vmThread
 * @param methodPC
-* @param resultClassLoader
+* @param resultClassLoader  This is the classLoader that owns the memory segment that the ROMClass was found in.
+*	For classes from the SharedClasses cache, this will always be the vm->systemClassLoader regardless of which
+*	J9ClassLoader actually loaded the class.
 * @return IDATA
 *
 * Returns the rom class, or NULL on failure.  resultClassLoader is filled in if non-null with the classloader associated.

--- a/runtime/vm/classseg.c
+++ b/runtime/vm/classseg.c
@@ -107,14 +107,11 @@ allocateClassMemorySegment(J9JavaVM *javaVM, UDATA requiredSize, UDATA segmentTy
 {
 	UDATA appropriateSize = 0;
 	J9MemorySegment *memorySegment = NULL;
-	omrthread_monitor_t segmentMutex = NULL;
-	
-#if defined(J9VM_THR_PREEMPTIVE)
-	segmentMutex = javaVM->classMemorySegments->segmentMutex;
+	omrthread_monitor_t segmentMutex = javaVM->classMemorySegments->segmentMutex;
+
 	if (NULL != segmentMutex) {
 		omrthread_monitor_enter(segmentMutex);
 	}
-#endif
 
 	appropriateSize = calculateAppropriateSegmentSize(javaVM, requiredSize, segmentType, classLoader, allocationIncrement);
 	memorySegment = allocateMemorySegmentInList(javaVM, javaVM->classMemorySegments, appropriateSize, segmentType, J9MEM_CATEGORY_CLASSES);
@@ -125,11 +122,9 @@ allocateClassMemorySegment(J9JavaVM *javaVM, UDATA requiredSize, UDATA segmentTy
 		classLoader->classSegments = memorySegment;
 	}
 	
-#if defined(J9VM_THR_PREEMPTIVE)
 	if (NULL != segmentMutex) {
 		omrthread_monitor_exit(segmentMutex);
 	}
-#endif
 
 	return memorySegment;
 }

--- a/runtime/vm/classseg.c
+++ b/runtime/vm/classseg.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/classseg.c
+++ b/runtime/vm/classseg.c
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2014 IBM Corp. and others
  *
@@ -108,10 +107,12 @@ allocateClassMemorySegment(J9JavaVM *javaVM, UDATA requiredSize, UDATA segmentTy
 {
 	UDATA appropriateSize = 0;
 	J9MemorySegment *memorySegment = NULL;
+	omrthread_monitor_t segmentMutex = NULL;
 	
 #if defined(J9VM_THR_PREEMPTIVE)
-	if (javaVM->classMemorySegments->segmentMutex) {
-		omrthread_monitor_enter(javaVM->classMemorySegments->segmentMutex);
+	segmentMutex = javaVM->classMemorySegments->segmentMutex;
+	if (NULL != segmentMutex) {
+		omrthread_monitor_enter(segmentMutex);
 	}
 #endif
 
@@ -125,8 +126,8 @@ allocateClassMemorySegment(J9JavaVM *javaVM, UDATA requiredSize, UDATA segmentTy
 	}
 	
 #if defined(J9VM_THR_PREEMPTIVE)
-	if (javaVM->classMemorySegments->segmentMutex) {
-		omrthread_monitor_exit(javaVM->classMemorySegments->segmentMutex);
+	if (NULL != segmentMutex) {
+		omrthread_monitor_exit(segmentMutex);
 	}
 #endif
 

--- a/runtime/vm/findmethod.c
+++ b/runtime/vm/findmethod.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/findmethod.c
+++ b/runtime/vm/findmethod.c
@@ -80,6 +80,7 @@ findROMClassFromPC(J9VMThread *vmThread, UDATA methodPC, J9ClassLoader **resultC
 	segmentForClass = findMemorySegment(javaVM, javaVM->classMemorySegments, methodPC);
 	if (segmentForClass != NULL && (segmentForClass->type & MEMORY_TYPE_ROM_CLASS) != 0) {
 		romClass = findROMClassInSegment(vmThread, segmentForClass, methodPC);
+		/* Note, for classes from the SharedClasses cache, this will *always* be the vm->systemLoader */
 		*resultClassLoader = segmentForClass->classLoader;
 	}
 


### PR DESCRIPTION
Discovered thru a painful debug session that this API will
always return the vm->systemClassLoader for any ROMClass
found in the SharedClasses cache.  This is regardless of
which classloader actually loaded the class.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>