### PR TITLE
Add JITServer implementation for areValueTypesEnabled

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -518,6 +518,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             else
                vmInfo._srConstructorAccessorClass = NULL;
 #endif // J9VM_OPT_SIDECAR
+         vmInfo._extendedRuntimeFlags2 = javaVM->extendedRuntimeFlags2;
          }
 
          // For multi-layered SCC support

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -103,6 +103,14 @@ J9::ObjectModel::initialize()
 bool
 J9::ObjectModel::areValueTypesEnabled()
    {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return J9_ARE_ALL_BITS_SET(vmInfo->_extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VALHALLA);
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    J9JavaVM * javaVM = TR::Compiler->javaVM;
    return javaVM->internalVMFunctions->areValueTypesEnabled(javaVM);
    }

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -330,6 +330,7 @@ class ClientSessionData
       TR_OpaqueClassBlock *_srMethodAccessorClass;
       TR_OpaqueClassBlock *_srConstructorAccessorClass;
 #endif // J9VM_OPT_SIDECAR
+      U_32 _extendedRuntimeFlags2;
       }; // struct VMInfo
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)


### PR DESCRIPTION
`ObjectModel::areValueTypesEnabled` is a recent added query, this PR added JITServer related change to this function.

`areValueTypesEnabled` uses `extendedRuntimeFlags2` variable inside VM. Thus we can cache this value on the server `VMInfo`, and query the value when `areValueTypesEnabled ` is needed.

Reference: https://github.com/eclipse/openj9/issues/9004

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>