### PR TITLE
CMake: disable buffer security checks for jit helpers on windows

### DIFF
--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -126,6 +126,17 @@ add_library(j9vm SHARED
 )
 
 
+# JIT helper methods require us to disable buffer security checks on Windows
+# See https://github.com/eclipse/openj9/pull/1494 for rationale
+if(OMR_OS_WINDOWS AND (OMR_TOOLCONFIG STREQUAL "msvc"))
+	set_property(
+		SOURCE
+			cnathelp.cpp
+			SharedService.c
+		APPEND PROPERTY COMPILE_FLAGS "/GS-"
+	)
+endif()
+
 if(OMR_ARCH_X86)
 	j9vm_gen_asm(xcinterp.m4)
 


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>