### PR TITLE
Fix casts

### DIFF
--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -312,7 +312,7 @@ done:
 	static VMINLINE UDATA
 	enterObjectMonitor(J9VMThread *currentThread, j9object_t object)
 	{
-		UDATA rc = (IDATA)object;
+		UDATA rc = (UDATA)object;
 		if (!inlineFastObjectMonitorEnter(currentThread, object)) {
 			rc = J9_VM_FUNCTION(currentThread, objectMonitorEnterNonBlocking)(currentThread, object);
 			if (J9_OBJECT_MONITOR_BLOCKING == rc) {

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1123,7 +1123,7 @@ obj:;
 	VMINLINE IDATA
 	enterObjectMonitor(REGISTER_ARGS_LIST, j9object_t obj)
 	{
-		UDATA rc = (IDATA)obj;
+		UDATA rc = (UDATA)obj;
 		if (!VM_ObjectMonitor::inlineFastObjectMonitorEnter(_currentThread, obj)) {
 			rc = objectMonitorEnterNonBlocking(_currentThread, obj);
 			if (J9_OBJECT_MONITOR_BLOCKING == rc) {


### PR DESCRIPTION
Assignment of `IDATA` to `UDATA` is likely to yield warnings, breaking builds.