### PR TITLE
Remove the virtual function patchMTIsolatedOffset

### DIFF
--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -346,19 +346,6 @@ TR_PPCRelocationTarget::flushCache(uint8_t *codeStart, unsigned long size)
    }
 
 void
-TR_PPCRelocationTarget::patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation)
-   {
-   /* apply constant to lis and ori instructions
-      lis  r0, high_16 bits
-      ori  r0, r0, low_16 bits
-    */
-   uint16_t highBits = offset >> 16;
-   uint16_t lowBits = offset &0xffff;
-   storeUnsigned16b(highBits, reloLocation+(reloRuntime()->comp()->target().cpu.isBigEndian()?2:0));
-   storeUnsigned16b(lowBits, reloLocation+(reloRuntime()->comp()->target().cpu.isBigEndian()?6:4));
-   }
-
-void
 TR_PPC64RelocationTarget::platformAddPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr)
    {
    /*

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.hpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2008, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,8 +57,6 @@ class TR_PPCRelocationTarget : public TR_RelocationTarget
 
       virtual uint8_t *arrayCopyHelperAddress(J9JavaVM *javaVM);
       virtual void flushCache(uint8_t *codeStart, unsigned long size);
-
-      virtual void patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation);
 
    };
 

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -259,12 +259,6 @@ TR_RelocationTarget::patchNonVolatileFieldMemoryFence(J9ROMFieldShape* resolvedF
    }
 
 void
-TR_RelocationTarget::patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation)
-   {
-   TR_ASSERT(0, "Error: patchMTIsolatedOffset not implemented in relocation target base class");
-   }
-
-void
 TR_RelocationTarget::addPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr)
    {
    platformAddPICtoPatchPtrOnClassUnload(classKey, ptr);

--- a/runtime/compiler/runtime/RelocationTarget.hpp
+++ b/runtime/compiler/runtime/RelocationTarget.hpp
@@ -146,8 +146,6 @@ class TR_RelocationTarget
 
       virtual void patchNonVolatileFieldMemoryFence(J9ROMFieldShape* resolvedField, UDATA cpAddr, U_8 descriptorByte, U_8 *instructionAddress, U_8 *snippetStartAddress, J9JavaVM *javaVM);
 
-      virtual void patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation);
-
       /**
        * @brief Adds a PIC guard that will invalidate a pointer when the class it is dependant on is unloaded.  Marks metadata as having class unload assumptions.
        *

--- a/runtime/compiler/x/runtime/X86RelocationTarget.cpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.cpp
@@ -264,9 +264,3 @@ TR_X86RelocationTarget::patchNonVolatileFieldMemoryFence(J9ROMFieldShape* resolv
          }
       }
    }
-
-void
-TR_X86RelocationTarget::patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation)
-   {
-   storeUnsigned32b(offset, reloLocation);
-   }

--- a/runtime/compiler/x/runtime/X86RelocationTarget.hpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.hpp
@@ -86,7 +86,6 @@ class TR_X86RelocationTarget : public TR_RelocationTarget
 
       virtual void patchNonVolatileFieldMemoryFence(J9ROMFieldShape* resolvedField, UDATA cpAddr, U_8 descriptorByte, U_8 *instructionAddress, U_8 *snippetStartAddress, J9JavaVM *javaVM);
 
-      virtual void patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation);
    };
 
 class TR_AMD64RelocationTarget : public TR_X86RelocationTarget

--- a/runtime/compiler/z/runtime/S390RelocationTarget.cpp
+++ b/runtime/compiler/z/runtime/S390RelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,26 +118,3 @@ TR_S390RelocationTarget::arrayCopyHelperAddress(J9JavaVM *javaVM)
    {
    return (uint8_t *)javaVM->memoryManagerFunctions->referenceArrayCopy;
    }
-
-void
-TR_S390RelocationTarget::patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation)
-  {
-   /* for Z platform, isolated field row/col offset is recorded in long displacement
-      Long displacement Format
-       ________ ____ ____ ____ __ ________ ____________ _______
-      |Op Code | R1 | X2 | B2 |DL2        | DH2        |Op Code|
-      |________|____|____|____|___________|____________|_______|
-      0         8   12   16   20          32           40      47
-
-      put new offset into DL2 and DH2
-   */
-   TR_ASSERT(offset < 0x7FFFF, "new offset excceed Z long displacmet range\n");
-   uint32_t tmpOffset = loadUnsigned32b(reloLocation);
-   // clear DL2 and DH2 bits
-   tmpOffset = tmpOffset & 0xf00000ff;
-   // add DL2
-   tmpOffset = tmpOffset | ((offset & 0xfff) << 16);
-   // add DH2
-   tmpOffset = tmpOffset | ((offset & 0xff000) >>4);
-   storeUnsigned32b(tmpOffset, reloLocation);
-  }

--- a/runtime/compiler/z/runtime/S390RelocationTarget.hpp
+++ b/runtime/compiler/z/runtime/S390RelocationTarget.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,6 @@ class TR_S390RelocationTarget : public TR_RelocationTarget
 
       virtual bool useTrampoline(uint8_t * helperAddress, uint8_t *baseLocation);
       virtual uint8_t *arrayCopyHelperAddress(J9JavaVM *javaVM);
-      virtual void patchMTIsolatedOffset(uint32_t offset, uint8_t *reloLocation);
    };
 
 #endif   // S390RELOCATION_TARGET_INCL


### PR DESCRIPTION
Remove the virtual function patchMTIsolatedOffset from all code generators, since multitenancy is depreciated. 

Closes: #9035