### PR TITLE
Removed macros related to multitenancy in PicBuilder

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -106,19 +106,6 @@
     rlwinm r3, r3, 2, 2, 31         				! r3 = col_index << 2
     addi   r3, r3, 8                                ! r3 = col_index*4 + 8
  */
-#define MT_ComputeStaticFieldAddress(TenantData, elem_shift_size) \
-    clrrdi r3, r3, 2 ;                              \
-    ld r4, TenantData(r15) ;                        \
-    ld r3, 0(r3);                                   \
-    sradi  r5, r3, 16 ;                             \
-    rlwinm r5, r5, 2, 2, 31 ;                       \
-    addi   r5, r5, 8 ;                              \
-    lwzx   r5, r5, r4 ;                             \
-    lwz    r4, 20(r7) ;                             \
-    sld    r5, r5, r4 ;                             \
-    rlwinm	r3, r3,0, 16, 31 ;                      \
-    rlwinm r3, r3, elem_shift_size, elem_shift_size, 31 ;                       \
-    addi   r3, r3, 8        ;
 
 /*
  * load jitResolveStaticField helper address into r8
@@ -131,61 +118,6 @@
     rlwinm	r4, r29,0, 5, 31				! Masking off flag bits
     bcctrl  BO_ALWAYS, CR0_LT				! Call to resolve: RTOC, r7
  */
-
-#define MT_CallHelper                                       \
-    mtspr   CTR, r8;				                        \
-    laddr	r3, 1*ALen+4(r7);   			                \
-    lwz	r29,1*ALen(r7);					                    \
-    laddr	r5, 0(r7);					                    \
-    rlwinm	r4, r29,0, 5, 31;				                \
-    bcctrl  BO_ALWAYS, CR0_LT
-
-#ifdef AIXPPC
-#define MT_ResovleStaticField                               \
-    ld      RTOC, J9TR_VMThread_jitTOC(J9VM_STRUCT);        \
-    laddr	r8, TOCjitResolveStaticField(RTOC);	            \
-    laddr	r8, 0(r8);					                    \
-    MT_CallHelper
-
-#define MT_ResovleStaticFieldSetter                         \
-    ld      RTOC, J9TR_VMThread_jitTOC(J9VM_STRUCT);        \
-    laddr	r8, TOCjitResolveStaticFieldSetter(RTOC);	    \
-    laddr	r8, 0(r8);					                    \
-    MT_CallHelper
-
-#elif defined(LINUXPPC64)
-#if defined(__LITTLE_ENDIAN__)
-#define MT_ResovleStaticField                               \
-    ld      RTOC, J9TR_VMThread_jitTOC(J9VM_STRUCT);        \
-    laddr	r8, TOCjitResolveStaticField@toc(RTOC);         \
-    MT_CallHelper
-
-#define MT_ResovleStaticFieldSetter                         \
-    ld      RTOC, J9TR_VMThread_jitTOC(J9VM_STRUCT);        \
-    laddr	r8, TOCjitResolveStaticFieldSetter@toc(RTOC);   \
-    MT_CallHelper
-#else
-#define MT_ResovleStaticField                               \
-    ld      RTOC, J9TR_VMThread_jitTOC(J9VM_STRUCT);        \
-    laddr	r8, TOCjitResolveStaticField@toc(RTOC);         \
-    laddr	r8, 0(r8);                                      \
-    MT_CallHelper
-
-#define MT_ResovleStaticFieldSetter                         \
-    ld      RTOC, J9TR_VMThread_jitTOC(J9VM_STRUCT);        \
-    laddr	r8, TOCjitResolveStaticFieldSetter@toc(RTOC);   \
-    laddr	r8, 0(r8);                                      \
-    MT_CallHelper
-#endif
-#else
-#define MT_ResovleStaticField                               \
-    laddr	r8, jitResolveStaticField@got(RTOC);            \
-    MT_CallHelper
-
-#define MT_ResovleStaticFieldSetter                               \
-    laddr	r8, jitResolveStaticFieldSetter@got(RTOC);            \
-    MT_CallHelper
-#endif
 
 #endif
 


### PR DESCRIPTION
Resolves issue #9034 raised by @0xdaryl 