### PR TITLE
Move FrontEnd containesZeroOrOneConcreteClass into ClassEnv

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -43,6 +43,8 @@ namespace J9 { typedef J9::ClassEnv ClassEnvConnector; }
 namespace TR { class SymbolReference; }
 namespace TR { class TypeLayout; }
 namespace TR { class Region; }
+class TR_PersistentClassInfo;
+template <typename ListKind> class List;
 
 namespace J9
 {
@@ -169,6 +171,15 @@ public:
    intptr_t getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset);
    uint8_t *getROMClassRefName(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, uint32_t cpIndex, int &classRefLen);
    J9ROMConstantPoolItem *getROMConstantPool(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);
+
+   /**
+    * @brief Determine if a list of classes contains less than two concrete classes.
+    * A class is considered concrete if it is not an interface or an abstract class
+    * @param subClasses List of subclasses to be checked.
+    * @return Returns 'true' if the given list of classes contains less than 
+    * 2 concrete classses and false otherwise.
+    */
+   bool containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
    };
 
 }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8351,28 +8351,6 @@ TR_J9VM::getROMMethodFromRAMMethod(J9Method *ramMethod)
    return J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
    }
 
-bool 
-TR_J9VM::noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses)
-   {
-   TR::Compilation *comp = _compInfoPT->getCompilation();
-   int count = 0;
-   ListIterator<TR_PersistentClassInfo> i(subClasses);
-   for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
-      {
-      TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-      if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
-         {
-         count++;
-         }
-      if (count > 1)
-         {
-         return false;
-         }
-      }
-
-   return true;
-   }
-
 //////////////////////////////////////////////////////////
 // TR_J9SharedCacheVM
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1127,8 +1127,6 @@ public:
 
    TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 
-   virtual bool noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses);
-
 private:
    void transformJavaLangClassIsArrayOrIsPrimitive( TR::Compilation *, TR::Node * callNode,  TR::TreeTop * treeTop, int32_t andMask);
    void transformJavaLangClassIsArray( TR::Compilation *, TR::Node * callNode,  TR::TreeTop * treeTop);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1837,55 +1837,6 @@ TR_J9ServerVM::getObjectSizeClass(uintptr_t objectSize)
    return 0;
    }
 
-bool 
-TR_J9ServerVM::noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses)
-   {
-   TR::Compilation *comp = _compInfoPT->getCompilation();
-   int count = 0;
-   TR_ScratchList<TR_PersistentClassInfo> subClassesNotCached(comp->trMemory());
-
-   // Process classes caches at the server first
-   ListIterator<TR_PersistentClassInfo> i(subClasses);
-   for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
-      {
-      TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-      J9Class *j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
-      auto romClass = JITServerHelpers::getRemoteROMClassIfCached(_compInfoPT->getClientData(), j9clazz);
-      if (romClass == NULL)
-         {
-         subClassesNotCached.add(ptClassInfo);
-         }
-      else
-         {
-         if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
-            {
-            count++;
-            }
-         if (count > 1)
-            {
-            return false;
-            }
-         }
-      }
-
-   // Traverse though classes that are not cached on server
-   ListIterator<TR_PersistentClassInfo> j(&subClassesNotCached);
-   for (TR_PersistentClassInfo *ptClassInfo = j.getFirst(); ptClassInfo; ptClassInfo = j.getNext())
-      {
-      TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-      if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
-         {
-         count++;
-         }
-      if (count > 1)
-         {
-         return false;
-         }
-      }
-
-   return true;
-   }
-
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -187,7 +187,6 @@ public:
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod) override;
    virtual bool getReportByteCodeInfoAtCatchBlock() override;
    virtual void *getInvokeExactThunkHelperAddress(TR::Compilation *comp, TR::SymbolReference *glueSymRef, TR::DataType dataType) override;
-   virtual bool noMultipleConcreteClasses(List<TR_PersistentClassInfo>* subClasses) override;
 
    virtual uintptr_t getCellSizeForSizeClass(uintptr_t) override;
    virtual uintptr_t getObjectSizeClass(uintptr_t) override;


### PR DESCRIPTION
This PR contains two parts, add `noMultipleConcreteClasses` into ClassEnv, and remove `noMultipleConcreteClasses` from FrontEnd.

Previous OpenJ9 PR: https://github.com/eclipse/openj9/pull/8933
OMR PR: https://github.com/eclipse/omr/pull/4959
Reference: https://github.com/eclipse/openj9/issues/8699

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>