### PR TITLE
AArch64: Implement TR_UnloadedClassPicSite::compensate

### DIFF
--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -716,6 +716,11 @@ void TR_UnloadedClassPicSite::compensate(TR_FrontEnd *, bool isSMP, void *)
    value |= 0x03a00001;
    *((uint32_t *)_picLocation) = value;
    armCodeSync(_picLocation, 4);
+#elif defined(TR_HOST_ARM64)
+   // On aarch64, we use constant data snippet for class unloading pic site
+   extern void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize);
+   *(int64_t *)_picLocation = -1;
+   arm64CodeSync(_picLocation, 8);
 #else
    //   TR_ASSERT(0, "unloaded class PIC patching is not implemented on this platform yet");
 #endif


### PR DESCRIPTION
This commit implements `TR_UnloadedClassPicSite::compensate` for aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>