### PR TITLE
Abort ILGen for non supported features in AOT

### DIFF
--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,36 @@ class AOTHasInvokeVarHandle : public virtual TR::RecoverableILGenException
 class AOTHasInvokeSpecialInInterface : public virtual TR::RecoverableILGenException
    {
    virtual const char* what() const throw() { return "AOT Has Invoke Special in Interface"; }
+   };
+
+/**
+ * AOT Has Constant Dynamic exception type.
+ *
+ * Thrown when a method that has a constant dynamic is AOT Compiled.
+ */
+class AOTHasConstantDynamic : public virtual TR::RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "AOT Has Constant Dynamic"; }
+   };
+
+/**
+ * AOT Has Method Handle Constant exception type.
+ *
+ * Thrown when a method that has a method handle constant is AOT Compiled.
+ */
+class AOTHasMethodHandleConstant : public virtual TR::RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "AOT Has Method Handle Constant"; }
+   };
+
+/**
+ * AOT Has Method Type Constant exception type.
+ *
+ * Thrown when a method that has a method type constant is AOT Compiled.
+ */
+class AOTHasMethodTypeConstant : public virtual TR::RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "AOT Has Method Type Constant"; }
    };
 
 /**

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -5456,6 +5456,13 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
       case TR::Address:
          if (method()->isConstantDynamic(cpIndex))
             {
+            if (comp()->compileRelocatableCode())
+               {
+               if (comp()->getOption(TR_TraceILGen))
+                  traceMsg(comp(), "  Constant Dynamic not supported in AOT.\n");
+               comp()->failCompilation<J9::AOTHasConstantDynamic>("Constant Dynamic not supported in AOT.");
+               }
+
             bool isCondyUnresolved = _methodSymbol->getResolvedMethod()->isUnresolvedConstantDynamic(cpIndex);
             J9UTF8 *returnTypeUtf8 = (J9UTF8 *)_methodSymbol->getResolvedMethod()->getConstantDynamicTypeFromCP(cpIndex);
             int returnTypeUtf8Length = J9UTF8_LENGTH(returnTypeUtf8);
@@ -5678,11 +5685,23 @@ TR_J9ByteCodeIlGenerator::loadFromCP(TR::DataType type, int32_t cpIndex)
             }
          else if (method()->isMethodHandleConstant(cpIndex))
             {
+            if (comp()->compileRelocatableCode())
+               {
+               if (comp()->getOption(TR_TraceILGen))
+                  traceMsg(comp(), "  Method Handle Constant not supported in AOT.\n");
+               comp()->failCompilation<J9::AOTHasMethodHandleConstant>("Method Handle Constant not supported in AOT.");
+               }
             loadSymbol(TR::aload, symRefTab()->findOrCreateMethodHandleSymbol(_methodSymbol, cpIndex));
             }
          else
             {
             TR_ASSERT(method()->isMethodTypeConstant(cpIndex), "Address-type CP entry %d must be class, string, methodHandle, or methodType", cpIndex);
+            if (comp()->compileRelocatableCode())
+               {
+               if (comp()->getOption(TR_TraceILGen))
+                  traceMsg(comp(), "  Method Type Constant not supported in AOT.\n");
+               comp()->failCompilation<J9::AOTHasMethodTypeConstant>("Method Type Constant not supported in AOT.");
+               }
             loadSymbol(TR::aload, symRefTab()->findOrCreateMethodTypeSymbol(_methodSymbol, cpIndex));
             }
          break;


### PR DESCRIPTION
Constant Dynamic, Method Handle Constant, and Method Type Constant
 is not currently supported in AOT. Therefore, in this
PR, the compiler throws the appropriate exception in ILGen if this
condition is met. However, because all of these exceptions are a
TR::RecoverableILGenException, if the compiler is generating IL for an
inlined method, it will not abort the compile, but simply refuse to
inline that particular method.

Fixes https://github.com/eclipse/openj9/issues/6011