### PR TITLE
Prepare Power UnresolvedDataSnippet for OMR changes

### DIFF
--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "codegen/UnresolvedDataSnippet.hpp"
+#include "codegen/UnresolvedDataSnippet_inlines.hpp"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -66,6 +67,13 @@ J9::Power::UnresolvedDataSnippet::UnresolvedDataSnippet(
    {
    }
 
+uint8_t *J9::Power::UnresolvedDataSnippet::getAddressOfDataReference()
+   {
+   if (self()->getDataReferenceInstruction())
+      return self()->getDataReferenceInstruction()->getBinaryEncoding();
+   else
+      return self()->OMR::UnresolvedDataSnippet::getAddressOfDataReference();
+   }
 
 uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
    {

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,6 +85,8 @@ class UnresolvedDataSnippet : public J9::UnresolvedDataSnippet
    bool is32BitLong() {return _flags.testAll(TO_MASK32(Is32BitLong));}
    void setIs32BitLong() {_flags.set(TO_MASK32(Is32BitLong));}
    void resetIs32BitLong() {_flags.reset(TO_MASK32(Is32BitLong));}
+
+   uint8_t *getAddressOfDataReference();
 
    virtual uint8_t *emitSnippetBody();
 


### PR DESCRIPTION
Previously, Power's UnresolvedDataSnippet took the address of the
instruction it should patch within the binary-encoded buffer. However,
the binary encoder refactors currently happening in OMR will make
unresolved-related expansion occur before binary encoding, making it
impossible to provide this information at that time. Instead, the
TR::Instruction object of the corresponding instruction will need to be
used instead.

To avoid breaking OpenJ9, it's necessary to make sure it can handle both
methods of passing the instruction until the refactor is complete. To
accomplish this, Power's UnresolvedDataSnippet will determine which
method to use at runtime for the time being by overriding
getAddressOfDataReference. Once the refactors are complete, this hack
can be removed and the TR::Instruction method can be used
unconditionally.

Signed-off-by: Ben Thomas <ben@benthomas.ca>