### PR TITLE
Update to OpenSSL 1.1.1f

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -132,7 +132,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '--openssl-version=1.1.1e'
+  extra_getsource_options: '--openssl-version=1.1.1f'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Note only OSX uses the updated openssl, the other platforms except Windows only compile against it.
Windows will be done separately via #9089 as the new binary needs to be created.