### PR TITLE
Initialize field attributes with default values (0.20.0)

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1143,8 +1143,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          int32_t isStore = std::get<2>(recv);
          int32_t needAOTValidation = std::get<3>(recv);
          void *address;
-         TR::DataType type;
-         bool volatileP, isFinal, isPrivate, unresolvedInCP;
+         TR::DataType type = TR::NoType;
+         bool volatileP = true;
+         bool isFinal = false;
+         bool isPrivate = false;
+         bool unresolvedInCP;
          bool result = method->staticAttributes(comp, cpIndex, &address, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
          TR_J9MethodFieldAttributes attrs(reinterpret_cast<uintptr_t>(address), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
          client->write(response, attrs);
@@ -1193,8 +1196,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          bool isStore = std::get<2>(recv);
          bool needAOTValidation = std::get<3>(recv);
          U_32 fieldOffset;
-         TR::DataType type;
-         bool volatileP, isFinal, isPrivate, unresolvedInCP;
+         TR::DataType type = TR::NoType;
+         bool volatileP = true;
+         bool isFinal = false;
+         bool isPrivate = false;
+         bool unresolvedInCP;
          bool result = method->fieldAttributes(comp, cpIndex, &fieldOffset, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
          TR_J9MethodFieldAttributes attrs(static_cast<uintptr_t>(fieldOffset), type.getDataType(), volatileP, isFinal, isPrivate, unresolvedInCP, result);
          client->write(response, attrs);
@@ -1871,8 +1877,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          bool isStore = std::get<2>(recv);
          bool needAOTValidation = std::get<3>(recv);
          U_32 fieldOffset;
-         TR::DataType type;
-         bool volatileP, isFinal, isPrivate, unresolvedInCP;
+         TR::DataType type = TR::NoType;
+         bool volatileP = true;
+         bool isFinal = false;
+         bool isPrivate = false;
+         bool unresolvedInCP;
          bool result = method->fieldAttributes(comp, cpIndex, &fieldOffset, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());
@@ -1891,8 +1900,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          int32_t isStore = std::get<2>(recv);
          int32_t needAOTValidation = std::get<3>(recv);
          void *address;
-         TR::DataType type;
-         bool volatileP, isFinal, isPrivate, unresolvedInCP;
+         TR::DataType type = TR::NoType;
+         bool volatileP = true;
+         bool isFinal = false;
+         bool isPrivate = false;
+         bool unresolvedInCP;
          bool result = method->staticAttributes(comp, cpIndex, &address, &type, &volatileP, &isFinal, &isPrivate, isStore, &unresolvedInCP, needAOTValidation);
 
          J9ConstantPool *constantPool = (J9ConstantPool *) J9_CP_FROM_METHOD(method->ramMethod());

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7016,6 +7016,7 @@ TR_ResolvedJ9Method::fieldAttributes(TR::Compilation * comp, I_32 cpIndex, U_32 
       *fieldOffset = TR::Compiler->om.objectHeaderSizeInBytes();
       ltype = ltype << 16;
       if (isFinal) *isFinal = false;
+      if (isPrivate) *isPrivate = false;
       }
 
    *type = decodeType(ltype);
@@ -7076,6 +7077,7 @@ TR_ResolvedJ9Method::staticAttributes(TR::Compilation * comp, I_32 cpIndex, void
       resolved = false;
       *volatileP = true;
       if (isFinal) *isFinal = false;
+      if (isPrivate) *isPrivate = false;
 
          {
          TR::VMAccessCriticalSection getFieldType(fej9());


### PR DESCRIPTION
`isPrivate` is not set if the symbol is unresolved.
Initialize `isPrivate`, `isFinal`, `volatileP` with
default values before calling fieldAttributes() or
staticAttributes().

Fixes: #8839

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>