### PR TITLE
Prevent increasing the scratchSpaceLimit on low virtual memory

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -3944,10 +3944,9 @@ void lowerCompilationLimitsOnLowVirtualMemory(TR::CompilationInfo *compInfo, J9V
             }
          }
 
-      // If the scratch space limit is still the default value, then change it now
-      if (TR::Options::getScratchSpaceLimit() == (DEFAULT_SCRATCH_SPACE_LIMIT_KB * 1024))
+      // Decrease the scratch space limit
+      if (TR::Options::getScratchSpaceLimit() > TR::Options::getScratchSpaceLimitKBWhenLowVirtualMemory()*1024)
          {
-         TR_ASSERT(DEFAULT_SCRATCH_SPACE_LIMIT_KB > TR::Options::getScratchSpaceLimitKBWhenLowVirtualMemory(), "assertion failure");
          TR::Options::setScratchSpaceLimit(TR::Options::getScratchSpaceLimitKBWhenLowVirtualMemory() * 1024);
          if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
             {


### PR DESCRIPTION
When low virtual memory is detected, the JIT will decrease the
`scratchSpaceLimit` (i.e. maximum amount of memory a compilation
thread is allowed to use) to 64 MB. This is done only if the current
scratchSpaceLimit is still at the default value of 256 MB.
However, a recent commit has changed the default scratchSpaceLimit
under `-Xtune:virtualized` option to 16 MB. Thus, we may actually
increase the scratchSpaceLimit from 16 MB to 64 MB when low virtual
memory is detected.
This commit adds a check that prevents the increase of the
scratchSpaceLimit under low virtual memory conditions.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>