### PR TITLE
Fix known object table update at the server

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2652,8 +2652,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          break;
       case MessageType::KnownObjectTable_getOrCreateIndexAt:
          {
-         uintptr_t *objectPointerReference = std::get<0>(client->getRecvData<uintptr_t*>());
-         client->write(response, knot->getOrCreateIndexAt(objectPointerReference));
+         uintptr_t *objectPointerReferenceServerQuery = std::get<0>(client->getRecvData<uintptr_t*>());
+         TR::KnownObjectTable::Index index = knot->getOrCreateIndexAt(objectPointerReferenceServerQuery);
+         client->write(response, index, knot->getPointerLocation(index));
          }
          break;
       case MessageType::KnownObjectTable_getPointer:

--- a/runtime/compiler/env/J9KnownObjectTable.hpp
+++ b/runtime/compiler/env/J9KnownObjectTable.hpp
@@ -104,7 +104,7 @@ public:
    uintptr_t getPointer(Index index);
 
 #if defined(J9VM_OPT_JITSERVER)
-   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocation);
+   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient);
    void getKnownObjectTableDumpInfo(std::vector<TR_KnownObjectTableDumpInfo> &knotDumpInfoList);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 


### PR DESCRIPTION
When `getIndexAt()` is called, the passed-in parameter `objectReferenceLocation` is not necessarily the reference that’s stored in the known object table. It should not be used to pass into `updateKnownObjectTableAtServer()` to update the table at the server.

Pass the reference object location from the client to `updateKnownObjectTableAtServer()` in `getOrCreateIndexAt()` instead of the one passed in from the caller of `getOrCreateIndexAt()`.

Fixes #8952

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>