### PR TITLE
Enable if present, the miscellaneous-instruction-extention facility 2

### DIFF
--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -269,6 +269,11 @@ CPU::initializeS390ProcessorFeatures()
 
    if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14))
       {
+      if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_2))
+         {
+         TR::Compiler->target.cpu.setSupportsMiscellaneousInstructionExtensions2Facility(true);
+         }
+
       if (j9sysinfo_processor_has_feature(processorDesc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL))
          {
          TR::Compiler->target.cpu.setSupportsVectorPackedDecimalFacility(true);


### PR DESCRIPTION
z14 systems have a multiple facilities for miscellaneous-instruction-extensions (MIE).
This commit looks for the presence of the MIE-2 facility and if available,
sets the associated flag. 

Signed-off-by: Pushkar Bettadpur <pushkar.bettadpur@gmail.com>