### PR TITLE
Eliminate storeValidationRecordIfNecessary messages

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1880,26 +1880,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, methodInfo, isRomClassForMethodInSC, sameLoaders, sameClass);
          }
          break;
-      case MessageType::ResolvedRelocatableMethod_storeValidationRecordIfNecessary:
-         {
-         auto recv = client->getRecvData<J9Method *, J9ConstantPool *, int32_t, bool, J9Class *>();
-         auto ramMethod = std::get<0>(recv);
-         auto constantPool = std::get<1>(recv);
-         auto cpIndex = std::get<2>(recv);
-         bool isStatic = std::get<3>(recv);
-         J9Class *definingClass = std::get<4>(recv);
-         J9Class *clazz = (J9Class *) J9_CLASS_FROM_METHOD(ramMethod);
-         if (!definingClass)
-            {
-            definingClass = (J9Class *) TR_ResolvedJ9Method::definingClassFromCPFieldRef(comp, constantPool, cpIndex, isStatic);
-            }
-         UDATA *classChain = NULL;
-         if (definingClass)
-            classChain = fe->sharedCache()->rememberClass(definingClass);
-
-         client->write(response, clazz, definingClass, classChain);
-         }
-         break;
       case MessageType::ResolvedRelocatableMethod_getFieldType:
          {
          auto recv = client->getRecvData<int32_t, TR_ResolvedJ9Method *>();

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -97,7 +97,6 @@ enum MessageType : uint16_t
    ResolvedMethod_definingClassFromCPFieldRef,
 
    ResolvedRelocatableMethod_createResolvedRelocatableJ9Method,
-   ResolvedRelocatableMethod_storeValidationRecordIfNecessary,
    ResolvedRelocatableMethod_fieldAttributes,
    ResolvedRelocatableMethod_staticAttributes,
    ResolvedRelocatableMethod_getFieldType,
@@ -367,7 +366,6 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ResolvedMethod_dynamicConstant", // 63
    "ResolvedMethod_definingClassFromCPFieldRef", // 64
    "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 65
-   "ResolvedRelocatableMethod_storeValidationRecordIfNecessary", // 66
    "ResolvedRelocatableMethod_fieldAttributes", // 67
    "ResolvedRelocatableMethod_staticAttributes", // 68
    "ResolvedRelocatableMethod_getFieldType", // 69


### PR DESCRIPTION
A lot of these messsages were being sent during AOT
compilations. Replacing one message that fetches
all required information with invocations of multiple
methods that return the same information significantly
reduces the total message count, since the latter methods
already do a lot of server-side caching.