### PR TITLE
Protect including Listener.hpp by J9VM_OPT_JITSERVER

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -30,7 +30,9 @@
 #include "env/VMJ9.h"
 #include "runtime/IProfiler.hpp"
 #include "runtime/J9Profiler.hpp"
+#if defined(J9VM_OPT_JITSERVER)
 #include "runtime/Listener.hpp"
+#endif /* J9VM_OPT_JITSERVER */
 #include "runtime/codertinit.hpp"
 #include "rossa.h"
 


### PR DESCRIPTION
Header file specific to JITServer should be protected by
J9VM_OPT_JITSERVER when including them.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>