### PR TITLE
Reduce number of VM_getClassFromSignature messages

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -285,11 +285,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          break;
       case MessageType::VM_getClassFromSignature:
          {
+         // Need to get a non-AOT frontend because the AOT frontend also
+         // performs some class validation which we want to do at the server
+         TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
          auto recv = client->getRecvData<std::string, TR_OpaqueMethodBlock *, bool>();
          std::string sig = std::get<0>(recv);
          auto method = std::get<1>(recv);
          bool isVettedForAOT = std::get<2>(recv);
-         auto clazz = fe->getClassFromSignature(sig.c_str(), sig.length(), method, isVettedForAOT);
+         auto clazz = fej9->getClassFromSignature(sig.c_str(), sig.length(), method, isVettedForAOT);
          client->write(response, clazz);
          }
          break;


### PR DESCRIPTION
JITServer employs a cache to reduce the number of
VM_getClassFromSignature messages, but this not entirely
efficient for AOT compilations because the AOT frontend
also performs some validation of the class found. If the
validation fails getClassFromSignature() return NULL
and the caching is not going to be performed at the server.
In this commit the client will call the TR_J9VM version of
getClassFromSignature() irrespective of the type of frontend.
The class that is found is sent to server which caches it
and then proceeds to perform the validation.

Issue: #9116

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>