### PR TITLE
Special handling of checkcast to value type class

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -731,3 +731,11 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
       }
    return true;
    }
+
+bool
+J9::ClassEnv::isClassRefValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex)
+   {
+   J9Class * j9class = reinterpret_cast<J9Class *>(cpContextClass);
+   J9JavaVM *vm = getJ9JitConfigFromFE(comp->fej9())->javaVM;
+   return vm->internalVMFunctions->isClassRefQtype(j9class, cpIndex);
+   }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -124,16 +124,31 @@ public:
    bool isString(TR::Compilation *comp, uintptr_t objectPointer);
    bool jitStaticsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2);
    bool jitFieldsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2, int32_t isStatic);
+   /*
+    * \brief
+    *    Tells whether a class reference entry in the constant pool represents a value type class.
+    *
+    * \param cpContextClass
+    *    The class whose constant pool contains the class reference entry being looked at. In another words,
+    *    it's the class of the method referring to the class reference entry.
+    *
+    * \param cpIndex
+    *    The constant pool index of the class reference entry.
+    *
+    * \note
+    *    The class reference entry doesn't need to be resolved because the information is encoded in class name string
+    */
+   bool isClassRefValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex);
 
    /** \brief
     *	    Populates a TypeLayout object.
     *
     *  \param region
     *     The region used to allocate TypeLayout.
-    * 
+    *
     *  \param opaqueClazz
     *     Class of the type whose layout needs to be populated.
-    * 
+    *
     *  \return
     *     Returns a pointer to the TypeLayout object populated.
     */
@@ -176,7 +191,7 @@ public:
     * @brief Determine if a list of classes contains less than two concrete classes.
     * A class is considered concrete if it is not an interface or an abstract class
     * @param subClasses List of subclasses to be checked.
-    * @return Returns 'true' if the given list of classes contains less than 
+    * @return Returns 'true' if the given list of classes contains less than
     * 2 concrete classses and false otherwise.
     */
    bool containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -495,7 +495,7 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
    TR::TreeTop *currTree = _methodSymbol->getFirstTreeTop()->getNextTreeTop();
 
    List<TR::SymbolReference> autoOrParmSymRefList(comp()->trMemory());
-   TR_ScratchList<TR::TreeTop> unresolvedCheckcastTops(comp()->trMemory());
+   TR_ScratchList<TR::TreeTop> unresolvedCheckcastTopsNeedingNullGuard(comp()->trMemory());
    TR_ScratchList<TR::TreeTop> unresolvedInstanceofTops(comp()->trMemory());
    TR_ScratchList<TR::TreeTop> invokeSpecialInterfaceTops(comp()->trMemory());
    TR::NodeChecklist evaluatedInvokeSpecialCalls(comp());
@@ -564,9 +564,11 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
 
       if (currNode->getOpCodeValue() == TR::checkcast
           && currNode->getSecondChild()->getOpCodeValue() == TR::loadaddr
-          && currNode->getSecondChild()->getSymbolReference()->isUnresolved())
+          && currNode->getSecondChild()->getSymbolReference()->isUnresolved()
+          // check whether the checkcast class is valuetype. Expansion is only needed for checkcast to reference type.
+          && !TR::Compiler->cls.isClassRefValueType(comp(), method()->classOfMethod(), currNode->getSecondChild()->getSymbolReference()->getCPIndex()))
           {
-          unresolvedCheckcastTops.add(currTree);
+          unresolvedCheckcastTopsNeedingNullGuard.add(currTree);
           }
       else if (currNode->getOpCodeValue() == TR::treetop
                && currNode->getFirstChild()->getOpCodeValue() == TR::instanceof
@@ -738,7 +740,7 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
       }
 
       {
-      ListIterator<TR::TreeTop> it(&unresolvedCheckcastTops);
+      ListIterator<TR::TreeTop> it(&unresolvedCheckcastTopsNeedingNullGuard);
       for (TR::TreeTop *tree = it.getCurrent(); tree != NULL; tree = it.getNext())
          expandUnresolvedClassCheckcast(tree);
       }


### PR DESCRIPTION
Checkcast of null to value type class needs to throw
NullPointerException.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>