### PR TITLE
Changing compare and branch for unresolved snippets within FieldWatch

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -988,8 +988,8 @@ J9::Power::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(TR::
    TR::Register *cndReg = cg->allocateRegister(TR_CCR);
    generateTrg1MemInstruction(cg, TR::InstOpCode::Op_load, node, scratchReg,
                      new (cg->trHeapMemory()) TR::MemoryReference(dataSnippetRegister, offsetInDataBlock, TR::Compiler->om.sizeofReferenceAddress(), cg));
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, scratchReg, scratchReg, cndReg, -1);
-   generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, unresolvedLabel, cndReg);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::Op_cmpi, node, cndReg, scratchReg, -1);
+   generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, unresolvedLabel, cndReg);
 
    generateReportOOL->swapInstructionListsWithCompilation();
 


### PR DESCRIPTION
This change impacts the PPC implementation of Field Watch. Replacing Andi. with Cmpi to branch into unresolved snippet routine.

Fixes: https://github.com/eclipse/openj9/issues/9103

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>