### PR TITLE
Remove ";" from the interpreter goto statements

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -821,7 +821,7 @@ done:
 			returnPoint = jitConfig->jitExitInterpreter0;
 			break;
 		case ';':
-obj:;
+obj:
 		/* On 32-bit, object uses the "1" target (already loaded, so just break).
 		 * On 64-bit, object uses the "J" target (fall through)
 		 */
@@ -2274,7 +2274,7 @@ done:
 			*(U_32 *)_sp = (U_32)_currentThread->returnValue;
 		}
 		rc = EXECUTE_BYTECODE;
-done:;
+done:
 		return rc;
 	}
 


### PR DESCRIPTION
`;` is removed since it is not required.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>