### PR TITLE
Avoid value type inline allocations

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -617,6 +617,8 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
 
    bool generateArraylets = self()->generateArraylets();
 
+   const bool areValueTypesEnabled = TR::Compiler->om.areValueTypesEnabled();
+
    if (node->getOpCodeValue() == TR::New)
       {
 
@@ -665,11 +667,26 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
       {
       classRef      = node->getSecondChild();
 
-      // In the case of dynamic array allocation, return 0 indicating variable dynamic array allocation
+      // In the case of dynamic array allocation, return 0 indicating variable dynamic array allocation,
+      // unless value types are enabled, in which case return -1 to prevent inline allocation
       if (classRef->getOpCodeValue() != TR::loadaddr)
          {
          classInfo = NULL;
-         return 0;
+         if (areValueTypesEnabled)
+            {
+            if (self()->getOption(TR_TraceCG))
+               {
+               traceMsg(self(), "cannot inline array allocation @ node %p because value types are enabled\n", node);
+               }
+            const char *signature = self()->signature();
+
+            TR::DebugCounter::incStaticDebugCounter(self(), TR::DebugCounter::debugCounterName(self(), "inlineAllocation/dynamicArray/failed/valueTypes/(%s)", signature));
+            return -1;
+            }
+         else
+            {
+            return 0;
+            }
          }
 
       classSymRef   = classRef->getSymbolReference();
@@ -679,8 +696,17 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
       if (clazz == NULL)
          return -1;
 
+      // Arrays of value type classes must have all their elements initialized with the
+      // default value of the component type.  For now, prevent inline allocation of them.
+      //
+      if (areValueTypesEnabled && TR::Compiler->cls.isValueTypeClass(reinterpret_cast<TR_OpaqueClassBlock*>(clazz)))
+         {
+         return -1;
+         }
+
       auto classOffset = self()->fej9()->getArrayClassFromComponentClass(TR::Compiler->cls.convertClassPtrToClassOffset(clazz));
       clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(classOffset);
+
       if (!clazz)
          return -1;
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5973,8 +5973,10 @@ TR_J9VMBase::canAllocateInlineClass(TR_OpaqueClassBlock *clazzOffset)
    if (clazz->initializeStatus != 1)
       return false;
 
-   // Can not inline the allocation if the class is an interface or abstract
-   if (clazz->romClass->modifiers & (J9AccAbstract | J9AccInterface))
+   // Can not inline the allocation if the class is an interface, abstract or identityless
+   // (a value type) or if it is a class with identityless fields
+   if ((clazz->romClass->modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType))
+       || (clazz->classFlags & J9ClassContainsUnflattenedFlattenables))
       return false;
    return true;
    }

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -876,6 +876,7 @@ bool
 TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
    {
    uint32_t modifiers = 0;
+   uintptr_t classFlags = 0;
    bool isClassInitialized = false;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_INITIALIZED, (void *)&isClassInitialized, JITServerHelpers::CLASSINFO_ROMCLASS_MODIFIERS, (void *)&modifiers);
@@ -894,10 +895,13 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
            it->second._classInitialized = isClassInitialized;
            }
         }
+
+        classFlags = TR_J9ServerVM::getClassFlagsValue(clazz);
      }
 
    if (isClassInitialized)
-      return ((modifiers & (J9AccAbstract | J9AccInterface ))?false:true);
+      return ((modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType)
+              || (classFlags & J9ClassContainsUnflattenedFlattenables)) ? false : true);
 
    return false;
    }

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -756,7 +756,7 @@ done:
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		if (J9_IS_J9CLASS_FLATTENED(arrayClass)) {
 			instance = objectAllocate->inlineAllocateIndexableValueTypeObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
-		} else
+		} else if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables))
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 		{
 			instance = objectAllocate->inlineAllocateIndexableObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);


### PR DESCRIPTION
For the prototype implementation of value types, special handling of value type classes is required in a few cases:

- If the `new` bytecode is applied to a value type class, an `InstantiationError` must be thrown;
- If an identity (that is, non-value type) class has a value type field, that field should be instantiated with the default value of the value type when an instance of the identity class is create with the `new` bytecode; and
- If an array with value type elements is created with `anewarray` or with `multianewarray`, the elements of value type are initialized with the default value for the value type.

These changes avoid inline allocation and stack allocation in such situations, as the code for inline allocation is not yet able to handle the special requirements.