### PR TITLE
Fix ClassEnv::containesZeroOrOneConcreteClass implementation

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -659,52 +659,56 @@ J9::ClassEnv::containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Per
    {
    int count = 0;
 #if defined(J9VM_OPT_JITSERVER)
-   ListIterator<TR_PersistentClassInfo> j(subClasses);
-   TR_ScratchList<TR_PersistentClassInfo> subClassesNotCached(comp->trMemory());
-   
-   // Process classes cached at the server first
-   ClientSessionData * clientData = TR::compInfoPT->getClientData();
-   for (TR_PersistentClassInfo *ptClassInfo = j.getFirst(); ptClassInfo; ptClassInfo = j.getNext())
+   if (comp->isOutOfProcessCompilation())
       {
-      TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-      J9Class *j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
-      auto romClass = JITServerHelpers::getRemoteROMClassIfCached(clientData, j9clazz);
-      if (romClass == NULL)
+      ListIterator<TR_PersistentClassInfo> j(subClasses);
+      TR_ScratchList<TR_PersistentClassInfo> subClassesNotCached(comp->trMemory());
+   
+      // Process classes cached at the server first
+      ClientSessionData * clientData = TR::compInfoPT->getClientData();
+      for (TR_PersistentClassInfo *ptClassInfo = j.getFirst(); ptClassInfo; ptClassInfo = j.getNext())
          {
-         subClassesNotCached.add(ptClassInfo);
+         TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
+         J9Class *j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+         auto romClass = JITServerHelpers::getRemoteROMClassIfCached(clientData, j9clazz);
+         if (romClass == NULL)
+            {
+            subClassesNotCached.add(ptClassInfo);
+            }
+         else
+            {
+            if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+               {
+               if (++count > 1)
+                  return false;
+               }
+            }
          }
-      else
+      // Traverse through classes that are not cached on server
+      ListIterator<TR_PersistentClassInfo> i(&subClassesNotCached);
+      for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
          {
+         TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
          if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
             {
-            count++;
-            }
-         if (count > 1)
-            {
-            return false;
+            if (++count > 1)
+               return false;
             }
          }
       }
-   
-   // Traverse though classes that are not cached on server
-   // With the following for loop outside if defined block
-   ListIterator<TR_PersistentClassInfo> i(&subClassesNotCached);
-#else
-   ListIterator<TR_PersistentClassInfo> i(subClasses);
+   else // non-jitserver
 #endif /* defined(J9VM_OPT_JITSERVER) */
-
-   for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
       {
-      TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
-      if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+      ListIterator<TR_PersistentClassInfo> i(subClasses);
+      for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
          {
-         count++;
-         }
-      if (count > 1)
-         {
-         return false;
+         TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
+         if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+            {
+            if (++count > 1)
+               return false;
+            }
          }
       }
-
    return true;
    }


### PR DESCRIPTION
The implementation of ClassEnv::containesZeroOrOneConcreteClass is broken
because it allows JITServer specific code to be executed by
a non-jitserver process. We need to protect such code with a runtime
check:  `if (comp->isOutOfProcessCompilation())`

Fixes: #9144

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>