### PR TITLE
Use _regionBytesAllocated to enforce scratch space limit

### DIFF
--- a/runtime/compiler/env/SystemSegmentProvider.cpp
+++ b/runtime/compiler/env/SystemSegmentProvider.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,6 +89,10 @@ J9::SystemSegmentProvider::request(size_t requiredSize)
       return recycledSegment;
       }
 
+   if (_regionBytesAllocated + roundedSize > _allocationLimit)
+      {
+      throw std::bad_alloc();
+      }
    if (remaining(_currentSystemSegment) >= roundedSize)
       {
       // Only allocate small segments from _currentSystemSegment
@@ -97,10 +101,6 @@ J9::SystemSegmentProvider::request(size_t requiredSize)
       }
 
    size_t systemSegmentSize = std::max(roundedSize, _systemSegmentSize);
-   if (_systemBytesAllocated + systemSegmentSize > _allocationLimit )
-      {
-      throw std::bad_alloc();
-      }
 
    J9MemorySegment &newSegment = _systemSegmentAllocator.request(systemSegmentSize);
    TR_ASSERT(


### PR DESCRIPTION
Currently the code uses _systemBytesAllocated when enforcing scratch
space limit. _systemBytesAllocated represents memory allocated using
J9MemorySegments which are by default 16 MB in size for scratch
segments. This causes two problems:
1. It prevents allocation of new system segment when scratch space limit
is not a multiple of system segment size(=16 MB), even though the actual
usage (_regionBytesAllocated) + requested amount is less than scratch
space limit. Eg scratch space limit is set to 30 MB, and one system segment
is allocated (of 16 MB), so _systemBytesAllocated = 16 MB.
Lets say current usage (i.e._regionBytesAllocated is 14 MB).
If we get a request of 4 MB, then we would throw std::bad_alloc even
though the usage would be well below the scratch space limit after
requested memory is allocated.
2. It allows memory usage beyond scratch space limit and upto system
segment size even when the limit is less than the systemt segment size.
Eg if scratch space limit is set to 12 MB, it would allow still allow
usage upto 16 MB.

_regionBytesAllocated represents memory allocated using
TR_MemorySegments which are currently 64 KB in size. Because of much
lower granularity, this variable is a much better approximation for
the actualy physical memory usage in scrach space segments and
therefore it should be used for imposing the scratch space limit.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>