### PR TITLE
Include sanity.openjdk for XL platforms

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -199,10 +199,8 @@ ppc64le_linux_xl:
   extends: ['ppc64le_linux', 'largeheap']
   excluded_tests:
     8:
-      - sanity.openjdk
       - special.system
     11:
-      - sanity.openjdk
       - special.system
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers /w JITSERVER
@@ -237,10 +235,7 @@ s390x_linux:
 s390x_linux_xl:
   extends: ['s390x_linux', 'largeheap']
   excluded_tests:
-    8:
-      - sanity.openjdk
-    11:
-      - sanity.openjdk
+     11:
       - special.system
 #========================================#
 # Linux S390 64bits Compressed Pointers /w JITSERVER
@@ -319,10 +314,7 @@ x86-64_linux_xl:
   extends: ['x86-64_linux', 'largeheap']
   excluded_tests:
     8:
-      - sanity.openjdk
       - special.system
-    11:
-      - sanity.openjdk
 #========================================#
 # Linux x86 64bits Compressed Pointers / Valhalla
 #========================================#


### PR DESCRIPTION
There may be machine capacity to do runs of sanity.openjdk on the
remaining platforms. Remove the excludes from the x, p, z linux XL
platforms.

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>