### PR TITLE
AArch64: Return 64 as L1 data cache line size when info unavailable

### DIFF
--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -1675,8 +1675,15 @@ j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, const J9CacheInfoQue
 	) {
 		/* L1 data cache line size */
 		int32_t rc = (int32_t)sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
-		if (rc >= 0) {
+		if (rc > 0) {
 			result = rc;
+		} else if (rc == 0) {
+			/*
+			 * Cache line size is unavailable on some systems
+			 * Use 64 as the default value because Arm Cortex ARMv8-A cores
+			 * have L1 data cache lines of that size
+			 */
+			result = 64;
 		}
 	}
 #endif


### PR DESCRIPTION
sysconf(_SC_LEVEL1_DCACHE_LINESIZE) returns 0 on some systems.
This commit changes j9sysinfo_get_cache_info() to return 64 as the
L1 data cache line size for AArch64 on such systems.

Fixes #8969

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>