### PR TITLE
Reduce CompInfo_isCompiled message from the server

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -120,7 +120,7 @@ handler_IProfiler_profilingSample(JITServer::ClientStream *client, TR_J9VM *fe, 
    if (wholeMethodInfo)
       {
       // Serialize all the information related to this method
-      abort = iProfiler->serializeAndSendIProfileInfoForMethod(method, comp, client, usePersistentCache);
+      abort = iProfiler->serializeAndSendIProfileInfoForMethod(method, comp, client, usePersistentCache, isCompiled);
       }
    if (!wholeMethodInfo || abort) // Send information just for this entry
       {
@@ -135,11 +135,11 @@ handler_IProfiler_profilingSample(JITServer::ClientStream *client, TR_J9VM *fe, 
             auto storage = (TR_IPBCDataStorageHeader*)&entryBytes[0];
             uintptr_t methodStartAddress = (uintptr_t)TR::Compiler->mtd.bytecodeStart(method);
             entry->serialize(methodStartAddress, storage, comp->getPersistentInfo());
-            client->write(JITServer::MessageType::IProfiler_profilingSample, entryBytes, false, usePersistentCache);
+            client->write(JITServer::MessageType::IProfiler_profilingSample, entryBytes, false, usePersistentCache, isCompiled);
             }
          else
             {
-            client->write(JITServer::MessageType::IProfiler_profilingSample, std::string(), false, usePersistentCache);
+            client->write(JITServer::MessageType::IProfiler_profilingSample, std::string(), false, usePersistentCache, isCompiled);
             }
          // Unlock the entry
          if (auto callGraphEntry = entry->asIPBCDataCallGraph())
@@ -148,7 +148,7 @@ handler_IProfiler_profilingSample(JITServer::ClientStream *client, TR_J9VM *fe, 
          }
       else // No valid info for specified bytecode index
          {
-         client->write(JITServer::MessageType::IProfiler_profilingSample, std::string(), false, usePersistentCache);
+         client->write(JITServer::MessageType::IProfiler_profilingSample, std::string(), false, usePersistentCache, isCompiled);
          }
       }
    }
@@ -2617,7 +2617,8 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto count = std::get<2>(recv);
          TR_IProfiler * iProfiler = fe->getIProfiler();
          iProfiler->setCallCount(method, bcIndex, count, comp);
-         client->write(response, JITServer::Void());
+
+         client->write(response, TR::CompilationInfo::isCompiled((J9Method *)method));
          }
          break;
       case MessageType::Recompilation_getExistingMethodInfo:

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -228,7 +228,7 @@ ClientSessionData::getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t
    }
 
 bool
-ClientSessionData::cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry)
+ClientSessionData::cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry, bool isCompiled)
    {
    OMR::CriticalSection getRemoteROMClass(getROMMapMonitor());
    // check whether info about j9method exists
@@ -240,7 +240,6 @@ ClientSessionData::cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byt
       if (!iProfilerMap)
          {
          // Check and update if method is compiled when collecting profiling data
-         bool isCompiled = TR::CompilationInfo::isCompiled((J9Method*)method);
          if (isCompiled)
             it->second._isCompiledWhenProfiling = true;
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -351,7 +351,7 @@ class ClientSessionData
    TR::Monitor *getClassMapMonitor() { return _classMapMonitor; }
    TR::Monitor *getClassChainDataMapMonitor() { return _classChainDataMapMonitor; }
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
-   bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
+   bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry, bool isCompiled);
    VMInfo *getOrCacheVMInfo(JITServer::ServerStream *stream);
    void clearCaches(); // destroys _chTableClassMap, _romClassMap and _J9MethodMap
    TR_AddressSet& getUnloadedClassAddresses()

--- a/runtime/compiler/runtime/JITServerIProfiler.hpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.hpp
@@ -142,7 +142,7 @@ public:
    // Thus, any virtual function here must call the corresponding method in
    // the base class. It may be better not to override any methods though
  
-   bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITServer::ClientStream *client, bool usePersistentCache);
+   bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITServer::ClientStream *client, bool usePersistentCache, bool isCompiled);
    std::string serializeIProfilerMethodEntry(TR_OpaqueMethodBlock *omb);
 
 private:


### PR DESCRIPTION
One frequent path on which the server sends `CompInfo_isCompiled` message is in `ClientSessionData::cacheIProfilerInfo()`. On this path, we could combine the message into other two messages:` IProfiler_setCallCount` and `IProfiler_profilingSample`.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>