### PR TITLE
Assume java.base for the module of a null caller class

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2019,7 +2019,9 @@ private boolean useModularSearch(String absoluteResName, Module thisModule, Clas
 	boolean visible = false;
 
 	if (thisModule.isNamed()) {
-		final Module callerModule = callerClass.getModule();
+		// When the caller class is null, assuming it is loaded by module java.base.
+		// See https://github.com/eclipse/openj9/issues/8993 for more info.
+		final Module callerModule = callerClass == null ? Class.class.getModule() : callerClass.getModule();
 		visible = (thisModule == callerModule);
 		if (!visible) {
 			visible = absoluteResName.endsWith(".class"); //$NON-NLS-1$


### PR DESCRIPTION
**Assume java.base for the module of a null caller class**

`System.getCallerClass()` might return a `null` caller class for a caller within a `JVMTI` callback function when `walkStackFrames()/cInterpGetStackClassJEP176Iterator()` walked off the end of the stack. Refer https://github.com/eclipse/openj9/issues/8993 for more info;
In such case, assume `java.base` for the module of such callers.

Note: this matches the behaviour of `com.ibm.oti.vm.VM.getStackClassLoader(depth)`
https://github.com/eclipse/openj9/blob/a235102acaeb0cf7dee1bd9590bd714b0daf66eb/runtime/vm/BytecodeInterpreter.hpp#L4099-L4100

closes: #8993 

Reviewer: @pshipton 
FYI: @DanHeidinga @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>