### PR TITLE
Fix typo in function name containesZeroOrOneConcreteClass

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -712,3 +712,62 @@ J9::ClassEnv::containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Per
       }
    return true;
    }
+
+bool 
+J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses)
+   {
+   int count = 0;
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isOutOfProcessCompilation())
+      {
+      ListIterator<TR_PersistentClassInfo> j(subClasses);
+      TR_ScratchList<TR_PersistentClassInfo> subClassesNotCached(comp->trMemory());
+   
+      // Process classes cached at the server first
+      ClientSessionData * clientData = TR::compInfoPT->getClientData();
+      for (TR_PersistentClassInfo *ptClassInfo = j.getFirst(); ptClassInfo; ptClassInfo = j.getNext())
+         {
+         TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
+         J9Class *j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+         auto romClass = JITServerHelpers::getRemoteROMClassIfCached(clientData, j9clazz);
+         if (romClass == NULL)
+            {
+            subClassesNotCached.add(ptClassInfo);
+            }
+         else
+            {
+            if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+               {
+               if (++count > 1)
+                  return false;
+               }
+            }
+         }
+      // Traverse through classes that are not cached on server
+      ListIterator<TR_PersistentClassInfo> i(&subClassesNotCached);
+      for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
+         {
+         TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
+         if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+            {
+            if (++count > 1)
+               return false;
+            }
+         }
+      }
+   else // non-jitserver
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      ListIterator<TR_PersistentClassInfo> i(subClasses);
+      for (TR_PersistentClassInfo *ptClassInfo = i.getFirst(); ptClassInfo; ptClassInfo = i.getNext())
+         {
+         TR_OpaqueClassBlock *clazz = ptClassInfo->getClassId();
+         if (!TR::Compiler->cls.isInterfaceClass(comp, clazz) && !TR::Compiler->cls.isAbstractClass(comp, clazz))
+            {
+            if (++count > 1)
+               return false;
+            }
+         }
+      }
+   return true;
+   }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -180,6 +180,15 @@ public:
     * 2 concrete classses and false otherwise.
     */
    bool containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
+
+   /**
+    * @brief Determine if a list of classes contains less than two concrete classes.
+    * A class is considered concrete if it is not an interface or an abstract class
+    * @param subClasses List of subclasses to be checked.
+    * @return Returns 'true' if the given list of classes contains less than 
+    * 2 concrete classses and false otherwise.
+    */
+   bool containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
    };
 
 }


### PR DESCRIPTION
This PR duplicates the function `containesZeroOrOneConcreteClass` with the correct name, another PR will be opened for removing function with current name once OMR PR has been merged.

Reference: https://github.com/eclipse/omr/issues/5037

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>