### PR TITLE
Support PR builds from non-default repos

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -714,14 +714,19 @@ def setup_pull_request_single_comment(parsedComment) {
     // Setup JDK VERSIONS
     switch (ghprbGhRepository) {
         case ~/.*openj9-openjdk-jdk.*/:
+            // <org>/openj9-openjdk-jdk<version>(-zos)?
             def tmp_version = ghprbGhRepository.substring(ghprbGhRepository.indexOf('-jdk')+4)
             if ("${tmp_version}" == "") {
                 tmp_version = 'next'
             }
+            if (tmp_version.contains('-')) {
+                // Strip off '-zos'
+                tmp_version = tmp_version.substring(0, tmp_version.indexOf('-'))
+            }
             RELEASES.add(tmp_version)
             minCommentSize = 3
             break
-        case "eclipse/openj9":
+        case ~/.*\/openj9(-omr)?/:
             def tmpVersions = parsedComment[3+offset].tokenize(',')
             tmpVersions.each { version ->
                 echo "VERSION:'${version}'"

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -135,7 +135,8 @@ SHORT_NAMES = ['all' : ['ppc64le_linux','ppc64le_linux_xl','s390x_linux','s390x_
             'osxxl' : ['x86-64_mac_xl'],
             'alinux64' : ['aarch64_linux'],
             'alinux64xl' : ['aarch64_linux_xl'],
-            'alinux64largeheap' : ['aarch64_linux_xl']]
+            'alinux64largeheap' : ['aarch64_linux_xl'],
+            'zos' : ['s390x_zos']]
 
 // Initialize all PARAMETERS (params) to Groovy Variables even if they are not passed
 echo "Initialize all PARAMETERS..."
@@ -191,14 +192,14 @@ echo "SCM_REPO:'${SCM_REPO}'"
 SCM_BRANCH = 'refs/heads/master'
 if (params.SCM_BRANCH) {
     SCM_BRANCH = params.SCM_BRANCH
-} else if (ghprbPullId && ghprbGhRepository == 'eclipse/openj9') {
+} else if (ghprbPullId && ghprbGhRepository ==~ /.*\/openj9/) {
     SCM_BRANCH = sha1
 }
 echo "SCM_BRANCH:'${SCM_BRANCH}'"
 SCM_REFSPEC = ''
 if (params.SCM_REFSPEC) {
     SCM_REFSPEC = params.SCM_REFSPEC
-} else if (ghprbPullId && ghprbGhRepository == 'eclipse/openj9') {
+} else if (ghprbPullId && ghprbGhRepository ==~ /.*\/openj9/) {
     SCM_REFSPEC = "+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge"
 }
 echo "SCM_REFSPEC:'${SCM_REFSPEC}'"


### PR DESCRIPTION
- In order to support PR builds from other GitHub
  servers and other GH orgs a few changes were required.
- Trim characters from version when reponame ends with 'jdk-*'
- Accept any GH org name.
- Support 'zos' as a PR shortname.
- Pass all OpenJ9 and OMR variables to get_source.sh. This
  ensures we are getting the intended repo and branch,
  even if we further checkout something else afterwards.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>