### PR TITLE
AArch64: Exclude testSoftMxUserScenario

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1343,7 +1343,8 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^os.zos,bits.64</platformRequirements>
+		<!-- Temporarily disable this test on AArch64; github.com/eclipse/openj9/issues/8967 -->
+		<platformRequirements>^os.zos,bits.64,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit excludes testSoftMxUserScenario from AArch64.
The test sets the -Xmx value based on the available memory on the
test server.  The AArch64 test server has 128GB memory, and that
makes the test with compressed refs build fail.

Issue #8967

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>