### PR TITLE
Refactoring the code of setting assertion status in ClassLoader

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1975,6 +1975,10 @@ static void loadLibrary(Class<?> caller, String libName) {
  * @since 1.4
  */
 public void setClassAssertionStatus(String cname, boolean enable) {
+	setClassAssertionStatusImpl(cname, enable);
+}
+
+private void setClassAssertionStatusImpl(String cname, boolean enable) {
 	if (!isParallelCapable) {
 		synchronized(this) {
 			setClassAssertionStatusHelper(cname, enable);
@@ -2002,6 +2006,10 @@ private void setClassAssertionStatusHelper(final String cname, final boolean ena
  * @since 1.4
  */
 public void setPackageAssertionStatus(String pname, boolean enable) {
+	setPackageAssertionStatusImpl(pname, enable);
+}
+
+private void setPackageAssertionStatusImpl(String pname, boolean enable) {
 	if (!isParallelCapable) {
 		synchronized(this) {
 			setPackageAssertionStatusHelper(pname, enable);
@@ -2012,7 +2020,6 @@ public void setPackageAssertionStatus(String pname, boolean enable) {
 		}
 	}
 }
-
 
 private void setPackageAssertionStatusHelper(final String pname, final boolean enable) {
 	if (packageAssertionStatus == null ) {
@@ -2030,6 +2037,10 @@ private void setPackageAssertionStatusHelper(final String pname, final boolean e
  * @since 1.4
  */
 public void setDefaultAssertionStatus(boolean enable){
+	setDefaultAssertionStatusImpl(enable);
+}
+
+private void setDefaultAssertionStatusImpl(boolean enable){
 	if (!isParallelCapable) {
 		synchronized(this) {
 			defaultAssertionStatus = enable;
@@ -2217,16 +2228,16 @@ private void initializeClassLoaderAssertStatus() {
 					if (bootLoader) {
 						continue;
 					}
-					setDefaultAssertionStatus(def);
+					setDefaultAssertionStatusImpl(def);
 				} else {
 					String str = vmargExtraInfo;
 					int len = str.length();
 					if ( len > 3 && str.charAt(len-1) == '.'  && 
 						str.charAt(len-2) == '.' && str.charAt(len-3) == '.') {
 						str = str.substring(0,len-3);
-						setPackageAssertionStatus(str, def);
+						setPackageAssertionStatusImpl(str, def);
 					} else {
-						setClassAssertionStatus(str, def);
+						setClassAssertionStatusImpl(str, def);
 					}
 				}
 		} else if ( vmargOptions.compareTo("-esa") == 0  //$NON-NLS-1$
@@ -2236,7 +2247,7 @@ private void initializeClassLoaderAssertStatus() {
 		) {
 			if (bootLoader) {
 				boolean def = vmargOptions.charAt(1) == 'e';
-				setDefaultAssertionStatus(def);
+				setDefaultAssertionStatusImpl(def);
 			}
 		}
 

--- a/test/functional/cmdLineTests/classLoaderTest/build.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/build.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="EnableAssertionStatusTest" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests_EnableAssertionStatusTest
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/classLoaderTest" />
+	<property name="PROJECT_ROOT" location="." />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"/>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/classloadertest.jar" filesonly="true">
+			<fileset dir="${build}"/>
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml,*.mk" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/classLoaderTest/classloadertest.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/classloadertest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="Enable Assertion Status Tests in ClassLoder" timeout="300">
+
+	<variable name="CLASSPATH" value="-cp $Q$$TEST_RESROOT$$Q$classloadertest.jar" />
+
+	<test id="test with multiple -ea options to enable all types of assertion status in initialization">
+		<command>$EXE$ -ea  -ea:pkgname... -ea:classname $CLASSPATH$ org.openj9.test.assertionstatus.EnableAssertionStatusTest</command>
+		<output regex="no" type="success" caseSensitive="no">EnableAssertionStatusTest PASSED</output>
+		<output regex="no" type="failure" caseSensitive="no">EnableAssertionStatusTest FAILED</output>
+		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setDefaultAssertionStatus</output>
+		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setPackageAssertionStatus</output>
+		<output regex="no" type="failure" caseSensitive="no">InnerClassLoader.setClassAssertionStatus</output>
+		<output regex="no" type="failure" caseSensitive="no">java.lang.Throwable</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/classLoaderTest/playlist.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/playlist.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_EnableAssertionStatusTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)classloadertest.xml$(Q) \
+		-verbose -explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/assertionstatus/EnableAssertionStatusTest.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/assertionstatus/EnableAssertionStatusTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.assertionstatus;
+
+/* The intention of this test is to verify whether these public methods (overridden by
+ * the inner class loader) are not directly invoked during the initialization so as to
+ * match the behavior of RI. 
+ */
+
+class SubClassLoader extends ClassLoader {
+	
+	class InnerClassLoader extends SubClassLoader {
+		private boolean setDefaultAssertionStatusMethodCalled;
+		private boolean setPackageAssertionStatusMethodCalled;
+		private boolean setClassAssertionStatusMethodCalled;
+		
+		public boolean isAssertionStatusPublicMethodCalled() {
+			return (setDefaultAssertionStatusMethodCalled || setPackageAssertionStatusMethodCalled || setClassAssertionStatusMethodCalled);
+		}
+		
+		public void setDefaultAssertionStatus(boolean enable) {
+			setDefaultAssertionStatusMethodCalled = true;
+			new Throwable().printStackTrace();
+		}
+		
+		public void setPackageAssertionStatus(String pname, boolean enable) {
+			setPackageAssertionStatusMethodCalled = true;
+			new Throwable().printStackTrace();
+		}
+		
+		public void setClassAssertionStatus(String cname, boolean enable) {
+			setClassAssertionStatusMethodCalled = true;
+			new Throwable().printStackTrace();
+		}
+	}
+}
+
+public class EnableAssertionStatusTest {
+	
+	public static void main(String[] args) throws Throwable {
+		SubClassLoader subCldr = new SubClassLoader();
+		SubClassLoader.InnerClassLoader innerCldr = subCldr.new InnerClassLoader();
+		
+		if (innerCldr.isAssertionStatusPublicMethodCalled()) {
+			System.out.println("EnableAssertionStatusTest FAILED");
+		} else {
+			System.out.println("EnableAssertionStatusTest PASSED");
+		}
+	}
+}


### PR DESCRIPTION
the change is to match the behavior of RI by replacing
all public methods (used for setting assertion status)
with private methods when calling in
initializeClassLoaderAssertStatus() given that these
public methods overridden by sub-classloaders will be
invoked during the  initialization of sub-classloaders.

Fixes: #9058

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>