### PR TITLE
Disable runtime assumption table on JITServer

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1315,8 +1315,14 @@ onLoadInternal(
       numCodeCachesToCreateAtStartup = 4;
 #endif
 
-   if (!persistentMemory->getPersistentInfo()->getRuntimeAssumptionTable()->init())
-      return -1;
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER)
+#endif
+      {
+      if (!persistentMemory->getPersistentInfo()->getRuntimeAssumptionTable()->init())
+         return -1;
+      }
 
    TR_PersistentClassLoaderTable *loaderTable = new (PERSISTENT_NEW) TR_PersistentClassLoaderTable(persistentMemory);
    if (loaderTable == NULL)


### PR DESCRIPTION
JITServer should not create any runtime assumptions, instead it
should buffer them and send them to the client. In order to catch
all mistakes, it's better to disable RuntimeAssumptionTable on JITServer
so any misuses will be caught by crashes.

Issue: #8029

Signed-off-by: Harry Yu <harryyu1994@gmail.com>