### PR TITLE
(0.20.0) AArch64: Fix jitCalleeDestroyedRegisterList

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
@@ -429,7 +429,10 @@ public class JITRegMap {
 					0x11,   /* jit_r17 */
 					0x12,   /* jit_r18 */
 					0x13,   /* jit_r19 */
-					0x14    /* jit_r20 */
+					0x14,   /* jit_r20 */
+					0x1D,   /* jit_r29 */
+					0x1E,   /* jit_r30 */
+					0x1F    /* jit_r31 */
 			};
 
 			jitCalleeSavedRegisterList = new int[] {

--- a/runtime/util/jitregs.c
+++ b/runtime/util/jitregs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -389,6 +389,9 @@ U_8 jitCalleeDestroyedRegisterList[] = {
 	0x12,	/* jit_r18 */
 	0x13,	/* jit_r19 */
 	0x14,	/* jit_r20 */
+	0x1D,   /* jit_r29 */
+	0x1E,   /* jit_r30 */
+	0x1F    /* jit_r31 */
 };
 U_8 jitCalleeSavedRegisterList[] = {
 	0x15,	/* jit_r21 */


### PR DESCRIPTION
This commit adds r29-r31 to `jitCalleeDestroyedRegisterList` for aarch64
because `CLEAR_LOCAL_REGISTER_MAP_ENTRIES` expects `jitCalleeDestroyedRegisterList` to
have (`J9SW_POTENTIAL_SAVED_REGISTERS` - `J9SW_JIT_CALLEE_PRESERVED_SIZE`) elements.

Master PR: https://github.com/eclipse/openj9/pull/9179
In the comment of master PR, I wrote `jitCalleeSavedRegisterList` but it was actually `jitCalleeDestroyedRegisterList`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>