### PR TITLE
Warn when opening a truncated core file

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/ICore.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/ICore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,7 +68,14 @@ public interface ICore
 	 * @return Property set for this core
 	 */
 	public Properties getProperties();
-	
+
+	/**
+	 * Is this core file truncated (i.e. incomplete)?
+	 */
+	public default boolean isTruncated() {
+		return false;
+	}
+
 	/**
 	 * Close the handle to the core file and release any resources
 	 */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImage.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,51 +54,41 @@ public class J9DDRImage implements ManagedImage {
 	private boolean machineDataSet = false;
 	private final URI source;
 	private ManagedImageSource imageSource = null;
-	private ImageInputStream meta = null;		//meta data, although DDR does nothing with it, it still has to close it
-	private boolean closed = false;				//flag to indicate if the image has been closed
-	
-	public J9DDRImage(ICore coreFile)
-	{
-		this.coreFile = coreFile;
-		source = null;
-		
-		if (coreFile instanceof ILibraryDependentCore) {
-			//Figure out and pass-back the executable PATH.
-			//It may not be able to figure it out from the core file header
-			passBackExecutablePath((ILibraryDependentCore)coreFile);
-		}
+	private final ImageInputStream meta; // meta data, although DDR does nothing with it, it still has to close it
+	private boolean closed = false; // flag to indicate if the image has been closed
+
+	public J9DDRImage(ICore coreFile) {
+		this(null, coreFile, null);
 	}
-	
-	public J9DDRImage(URI source, ICore coreFile, ImageInputStream meta)
-	{
+
+	public J9DDRImage(URI source, ICore coreFile, ImageInputStream meta) {
 		this.coreFile = coreFile;
 		this.source = source;
 		this.meta = meta;
-		
+
 		if (coreFile instanceof ILibraryDependentCore) {
 			//Figure out and pass-back the executable PATH.
 			//It may not be able to figure it out from the core file header
-			passBackExecutablePath((ILibraryDependentCore)coreFile);
+			passBackExecutablePath((ILibraryDependentCore) coreFile);
 		}
 	}
 
 	public ICore getCore() {
 		return coreFile;
 	}
-	
+
 	public URI getSource() {
 		return source;
 	}
 
-	private void passBackExecutablePath(ILibraryDependentCore core)
-	{
+	private void passBackExecutablePath(ILibraryDependentCore core) {
 		Iterator<J9DDRImageAddressSpace> addressSpacesIt = getAddressSpaces();
-		
+
 		while (addressSpacesIt.hasNext()) {
 			J9DDRImageAddressSpace thisAS = addressSpacesIt.next();
-			
+
 			J9DDRImageProcess proc = thisAS.getCurrentProcess();
-			
+
 			String executablePath = proc.getExecutablePath();
 			if (executablePath != null) {
 				core.executablePathHint(executablePath);
@@ -106,23 +96,22 @@ public class J9DDRImage implements ManagedImage {
 		}
 	}
 
-	private void checkJ9RASMachineData()
-	{
-		if (! machineDataSet) {
+	private void checkJ9RASMachineData() {
+		if (!machineDataSet) {
 			j9MachineData = J9RASImageDataFactory.getMachineData(coreFile);
 			machineDataSet = true;
 		}
 	}
-	
+
 	public Iterator<J9DDRImageAddressSpace> getAddressSpaces() {
 		Collection<? extends IAddressSpace> addressSpaces = coreFile.getAddressSpaces();
-		
+
 		List<J9DDRImageAddressSpace> dtfjList = new LinkedList<J9DDRImageAddressSpace>();
-		
+
 		for (IAddressSpace thisAs : addressSpaces) {
 			dtfjList.add(new J9DDRImageAddressSpace(thisAs));
 		}
-		
+
 		return dtfjList.iterator();
 	}
 
@@ -345,11 +334,20 @@ public class J9DDRImage implements ManagedImage {
 	}
 
 	@Override
+	public boolean isTruncated() {
+		if (coreFile == null) {
+			return true;
+		}
+
+		return coreFile.isTruncated();
+	}
+
+	@Override
 	public boolean equals(Object o) {
-		if(o == null) {
+		if (o == null) {
 			return false;
 		}
-		if(!(o instanceof J9DDRImage)) {
+		if (!(o instanceof J9DDRImage)) {
 			return false;
 		}
 		J9DDRImage compareto = (J9DDRImage) o;

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/Image.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/Image.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -185,4 +185,12 @@ public interface Image {
 	 * @since 1.12
 	 */
 	public long getCreationTimeNanos() throws DataUnavailable, CorruptDataException;
+
+	/**
+	 * Is this image truncated (i.e. incomplete)?
+	 */
+	public default boolean isTruncated() {
+		return false;
+	}
+
 }

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
@@ -50,7 +50,6 @@ import com.ibm.java.diagnostics.utils.IContext;
 import com.ibm.java.diagnostics.utils.commands.CommandException;
 import com.ibm.jvm.dtfjview.CombinedContext;
 import com.ibm.jvm.dtfjview.JdmpviewContextManager;
-import com.ibm.jvm.dtfjview.Session;
 import com.ibm.jvm.dtfjview.SessionProperties;
 import com.ibm.jvm.dtfjview.Version;
 import com.ibm.jvm.dtfjview.spi.ISession;
@@ -70,20 +69,20 @@ public class OpenCommand extends BaseJdmpviewCommand {
 	}
 	
 	public void run(String command, String[] args, IContext context, PrintStream out) throws CommandException {
-		if(initCommand(command, args, context, out)) {
-			return;		//processing already handled by super class
+		if (initCommand(command, args, context, out)) {
+			return; // processing already handled by super class
 		}
-		switch(args.length) {
-			case 0 :		//print out the version information for the factory
-				out.println(Version.getAllVersionInfo(factory));
-				return;
-			case 1:
-			case 2:
-				imagesFromCommandLine(args);
-				break;
-			default :
-				out.println("The open command requires at least one and at most two parameters. See 'help open'.");
-				return;
+		switch (args.length) {
+		case 0: // print out the version information for the factory
+			out.println(Version.getAllVersionInfo(factory));
+			return;
+		case 1:
+		case 2:
+			imagesFromCommandLine(args);
+			break;
+		default:
+			out.println("The open command requires at least one and at most two parameters. See 'help open'.");
+			return;
 		}
 	}
 
@@ -98,7 +97,6 @@ public class OpenCommand extends BaseJdmpviewCommand {
 		out.println("Loading image from DTFJ...\n");
 		
 		try {
-			Image[] images = new Image[1];		//default to a single image
 			if (ctx.hasPropertyBeenSet(VERBOSE_MODE_PROPERTY)) {
 				// If we are using DDR this will enable warnings.
 				// (If not it's irrelevant.)
@@ -107,8 +105,9 @@ public class OpenCommand extends BaseJdmpviewCommand {
 			//at this point the existence of either -core or -zip has been checked
 			long current = System.currentTimeMillis();
 			File file1 = new File(args[0]);
-			if(args.length == 1) {
-				if (FileManager.isArchive(file1) && !ctx.hasPropertyBeenSet(LEGACY_ZIP_MODE_PROPERTY) ) {
+			Image[] images = new Image[1]; // default to a single image
+			if (args.length == 1) {
+				if (FileManager.isArchive(file1) && !ctx.hasPropertyBeenSet(LEGACY_ZIP_MODE_PROPERTY)) {
 					images = factory.getImagesFromArchive(file1, ctx.hasPropertyBeenSet(EXTRACT_PROPERTY));
 				} else {
 					images[0] = factory.getImage(file1);
@@ -118,7 +117,7 @@ public class OpenCommand extends BaseJdmpviewCommand {
 				images[0] = factory.getImage(file1, file2);
 			}
 			logger.fine(String.format("Time taken to load image %d ms", System.currentTimeMillis() - current));
-			for(Image image : images) {
+			for (Image image : images) {
 				createContexts(image, args[0]);
 			}
 		} catch (IOException e) {
@@ -128,23 +127,26 @@ public class OpenCommand extends BaseJdmpviewCommand {
 			}
 		}
 	}
-	
+
 	private ImageFactory getFactory() {
-		if(factory != null) {
+		if (factory != null) {
 			return factory;
 		}
 		try {
 			Class<?> factoryClass = Class.forName(factoryName);
-			factory = (ImageFactory)factoryClass.newInstance();
+			factory = (ImageFactory) factoryClass.newInstance();
 		} catch (ClassNotFoundException e) {
 			out.println("ClassNotFoundException while getting ImageFactory: " + e.getMessage());
 			out.println("Use -D" + SYSPROP_FACTORY + "=<classname> to change the ImageFactory");
 			System.exit(JDMPVIEW_SYNTAX_ERROR);
-		} catch (InstantiationException e) {
-			out.println("InstantiationException while getting ImageFactory: " + e.getMessage());
+		} catch (ClassCastException e) {
+			out.println("ClassCastException while getting ImageFactory: " + e.getMessage());
 			System.exit(JDMPVIEW_SYNTAX_ERROR);
 		} catch (IllegalAccessException e) {
 			out.println("IllegalAccessException while getting ImageFactory: " + e.getMessage());
+			System.exit(JDMPVIEW_SYNTAX_ERROR);
+		} catch (InstantiationException e) {
+			out.println("InstantiationException while getting ImageFactory: " + e.getMessage());
 			System.exit(JDMPVIEW_SYNTAX_ERROR);
 		}
 		return factory;
@@ -152,76 +154,87 @@ public class OpenCommand extends BaseJdmpviewCommand {
 	
 	
 	private void createContexts(Image loadedImage, String coreFilePath) {
-		if(loadedImage == null) {
-			//cannot create any contexts as an image has not been obtained
+		if (loadedImage == null) {
+			// cannot create any contexts as an image has not been obtained
 			return;
 		}
 		boolean hasContexts = false;
 		Iterator<?> spaces = loadedImage.getAddressSpaces();
-		while(spaces.hasNext()) {
+		while (spaces.hasNext()) {
 			Object o = spaces.next();
-			if(o instanceof ImageAddressSpace) {
-				ImageAddressSpace space = (ImageAddressSpace) o;
-				Iterator<?> procs = space.getProcesses();
-				if(procs.hasNext()) {
-					while(procs.hasNext()) {
-						o = procs.next();
-						if(o instanceof ImageProcess) {
-							ImageProcess proc = (ImageProcess) o;
-							Iterator<?> runtimes = proc.getRuntimes();
-							if(runtimes.hasNext()) {
-								while(runtimes.hasNext()) {
-									o = runtimes.next();
-									if(o instanceof JavaRuntime) {
-										createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, (JavaRuntime)o, coreFilePath);
-										hasContexts = true;
-									} else if (o instanceof CorruptData) {
-										logger.fine("CorruptData encountered in ImageProcess.getRuntimes(): " + ((CorruptData)o).toString());
-										createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, null, coreFilePath);
-										hasContexts = true;
-									} else {
-										logger.fine("Unexpected class encountered in ImageProcess.getRuntimes()");
-										createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, null, coreFilePath);
-										hasContexts = true;
-									}
-								}
-							} else {
-								//there are no runtimes so create a context for this process
-								createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, null, coreFilePath);
-								hasContexts = true;
-							}
-						}
-					}
-				} else {
-					//context with only an address space
-					createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, null, null, coreFilePath);
-					hasContexts = true;
-				}
-			} else {
-				//need a representation of a corrupt context
+			if (!(o instanceof ImageAddressSpace)) {
+				// need a representation of a corrupt context
 				logger.fine("Skipping corrupt ImageAddress space");
+				continue;
+			}
+
+			ImageAddressSpace space = (ImageAddressSpace) o;
+			Iterator<?> procs = space.getProcesses();
+			if (!procs.hasNext()) {
+				// context with only an address space
+				createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, null, null, coreFilePath);
+				hasContexts = true;
+				continue;
+			}
+
+			while (procs.hasNext()) {
+				o = procs.next();
+				if (!(o instanceof ImageProcess)) {
+					continue;
+				}
+
+				ImageProcess proc = (ImageProcess) o;
+				Iterator<?> runtimes = proc.getRuntimes();
+
+				if (!runtimes.hasNext()) {
+					// there are no runtimes so create a context for this process
+					createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, null, coreFilePath);
+					hasContexts = true;
+					continue;
+				}
+
+				while (runtimes.hasNext()) {
+					o = runtimes.next();
+					if (o instanceof JavaRuntime) {
+						createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, (JavaRuntime) o, coreFilePath);
+						hasContexts = true;
+					} else if (o instanceof CorruptData) {
+						logger.fine("CorruptData encountered in ImageProcess.getRuntimes(): " + o);
+						createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, null, coreFilePath);
+						hasContexts = true;
+					} else {
+						logger.fine("Unexpected class encountered in ImageProcess.getRuntimes()");
+						createCombinedContext(loadedImage, apiLevelMajor, apiLevelMinor, space, proc, null, coreFilePath);
+						hasContexts = true;
+					}
+				}
 			}
 		}
-		if(!hasContexts) {
-			if(ctx.hasPropertyBeenSet(VERBOSE_MODE_PROPERTY)) {
-				out.println("Warning : no contexts were found, is this a valid core file ?");
+		if (!hasContexts) {
+			if (ctx.hasPropertyBeenSet(VERBOSE_MODE_PROPERTY)) {
+				out.println("Warning: no contexts were found, is this a valid core file?");
+			}
+		} else {
+			if (loadedImage.isTruncated()) {
+				out.println("Warning: dump file is truncated. Extracted information may be incomplete.");
+				out.println();
 			}
 		}
 	}
 	
 	private void createCombinedContext(final Image loadedImage, final int major, final int minor, final ImageAddressSpace space, final ImageProcess proc, final JavaRuntime rt, String coreFilePath) {
-		//take the DTFJ context and attempt to combine it with a DDR interactive one
+		// take the DTFJ context and attempt to combine it with a DDR interactive one
 		Object obj = ctx.getProperties().get(SessionProperties.SESSION_PROPERTY);
-		if(obj == null) {
+		if (obj == null) {
 			logger.fine("Could not create a new context as the session property has not been set");
 			return;
 		}
-		if(!(obj instanceof Session)) {
+		if (!(obj instanceof ISession)) {
 			logger.fine("Could not create a new context as the session type was not recognised [" + obj.getClass().getName() + "]");
 			return;
 		}
-		JdmpviewContextManager mgr = (JdmpviewContextManager)((ISession)obj).getContextManager();
-		CombinedContext cc = (CombinedContext)mgr.createContext(loadedImage, major, minor, space, proc, rt);
+		JdmpviewContextManager mgr = (JdmpviewContextManager) ((ISession) obj).getContextManager();
+		CombinedContext cc = (CombinedContext) mgr.createContext(loadedImage, major, minor, space, proc, rt);
 		cc.startDDRInteractiveSession(loadedImage, out);
 		cc.getProperties().put(CORE_FILE_PATH_PROPERTY, coreFilePath);
 		cc.getProperties().put(IMAGE_FACTORY_PROPERTY, getFactory());
@@ -230,36 +243,35 @@ public class OpenCommand extends BaseJdmpviewCommand {
 		}
 		
 		try {
-			boolean hasLibError = true;		//flag to indicate if native libs are required but not present
+			boolean hasLibError = true; // flag to indicate if native libs are required but not present
 			String os = cc.getImage().getSystemType().toLowerCase();
-			if(os.contains("linux") || (os.contains("aix"))) {
-				if(cc.getProcess() != null) {
+			if (os.contains("linux") || os.contains("aix")) {
+				if (cc.getProcess() != null) {
 					Iterator<?> modules = cc.getProcess().getLibraries();
-					if(modules.hasNext()) {
+					if (modules.hasNext()) {
 						obj = modules.next();
-						if(obj instanceof ImageModule) {
-							hasLibError = false;		//there is at least one native lib available
+						if (obj instanceof ImageModule) {
+							hasLibError = false; // there is at least one native lib available
 						}
 					}
 				}
 			} else {
 				hasLibError = false;
 			}
-			if(hasLibError) {
-				out.println("Warning : native libraries are not available for " + coreFilePath);
+			if (hasLibError) {
+				out.println("Warning: native libraries are not available for " + coreFilePath);
 			}
 		} catch (DataUnavailable e) {
-			logger.log(Level.FINE, "Warning : native libraries are not available for " + coreFilePath);
-		}
-		catch (Exception e) {
+			logger.log(Level.FINE, "Warning: native libraries are not available for " + coreFilePath);
+		} catch (Exception e) {
 			logger.log(Level.FINE, "Error determining if native libraries are required for " + coreFilePath, e);
 		}
 	}
-	
+
 	@Override
 	public void printDetailedHelp(PrintStream out) {
-		out.println("Opens a core file or zip file and loads it into jdmpview ready for further analysis. Any resultant contexts are added to the " +
-				" list of currently available contexts");
+		out.println("Opens a core file or zip file and loads it into jdmpview ready for further analysis.");
+		out.println("Any resultant contexts are added to the list of currently available contexts.");
 	}
 
 }


### PR DESCRIPTION
With this, `jdmpview` will, like `jextract` warn about truncated core files:
```
$ jdmpview -core aix.core.dmp
DTFJView version 4.29.5, using DTFJ version 1.12.29003
Loading image from DTFJ...

Warning: dump file is truncated. Extracted information may be incomplete.
For a list of commands, type "help"; for how to use "help", type "help help"
Available contexts (* = currently selected context) : 

Source : file:///home/keithc/space/openj9/jdmpview/aix.core.dmp
	*0 : PID: 8323202 : No JRE

> 
```