### PR TITLE
Disable upgrades/downgrades on jitdump compilations

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -598,7 +598,7 @@ bool TR::CompilationInfo::shouldDowngradeCompReq(TR_MethodToBeCompiled *entry)
    if (!isCompiled(method) &&
        entry->_optimizationPlan->getOptLevel() == warm && // only warm compilations are subject to downgrades
        !methodDetails.isMethodInProgress() &&
-       !methodDetails.isDumpMethod() &&
+       !methodDetails.isJitDumpMethod() &&
        !TR::Options::getCmdLineOptions()->getOption(TR_DontDowngradeToCold))
       {
       TR::PersistentInfo *persistentInfo = getPersistentInfo();
@@ -5722,7 +5722,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
    //
    if (!details.isMethodInProgress())
       startPC = startPCIfAlreadyCompiled(vmThread, details, oldStartPC);
-   if (startPC && !details.isDumpMethod() &&
+   if (startPC && !details.isJitDumpMethod() &&
       !optimizationPlan->isGPUCompilation())
       {
       // Release the compilation lock and return
@@ -5742,7 +5742,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread * vmThread, TR::Il
          (
             getPersistentInfo()->getDisableFurtherCompilation() &&
             oldStartPC == 0 &&
-            !details.isDumpMethod()
+            !details.isJitDumpMethod()
          )
       )
       {
@@ -7666,7 +7666,7 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
             // inside the compile request. For log compilations, simply return.
             //
             UDATA protectedResult;
-            if (entry->getMethodDetails().isDumpMethod())
+            if (entry->getMethodDetails().isJitDumpMethod())
                {
                // NOTE:
                //       for intentional crashes, intentional traps cause the dump, and we

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7672,7 +7672,7 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
                //       for intentional crashes, intentional traps cause the dump, and we
                //       are not protected against them (flag: J9PORT_SIG_FLAG_SIGTRAP)
                protectedResult = j9sig_protect((j9sig_protected_fn)wrappedCompile, static_cast<void *>(&compParam),
-                                                  (j9sig_handler_fn)  blankDumpSignalHandler, vmThread,
+                                                  (j9sig_handler_fn)  jitDumpSignalHandler, vmThread,
                                                   flags, &result);
                }
             else

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -37,10 +37,9 @@
 #endif
 
 UDATA
-blankDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg)
+jitDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg)
    {
-   J9VMThread *vmThread = (J9VMThread *) arg;
-   TR_VerboseLog::writeLineLocked(TR_Vlog_JITDUMP, "vmThread=%p Recursive crash occurred. Aborting JIT dump.", vmThread);
+   TR_VerboseLog::writeLineLocked(TR_Vlog_JITDUMP, "vmThread = %p Recursive crash occurred. Aborting JIT dump.", reinterpret_cast<J9VMThread*>(arg));
 
    // Returning J9PORT_SIG_EXCEPTION_RETURN will make us come back to the same crashing instruction over and over
    //

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -326,7 +326,7 @@ static TR_CompilationErrorCode recompileMethodForLog(
    // TODO: this is indiscriminately compiling as J9::DumpMethodRequest, which is wrong;
    //       should be fixed by checking if the method is indeed DLT, and compiling DLT if so
       {
-      J9::DumpMethodDetails details( ramMethod);
+      J9::JitDumpMethodDetails details(ramMethod);
       compInfo->compileMethod(vmThread, details, oldStartPC, TR_no, &compErrCode, &successfullyQueued, plan);
       }
 

--- a/runtime/compiler/control/JitDump.hpp
+++ b/runtime/compiler/control/JitDump.hpp
@@ -19,11 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+#ifndef TR_JITDUMP_INCL
+#define TR_JITDUMP_INCL
+
 #include "j9.h"
 #include "j9nonbuilder.h"
 
 extern J9_CFUNC UDATA
-blankDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg);
+jitDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg);
 
 extern J9_CFUNC intptr_t
 dumpJitInfo(J9VMThread * currentThread, char *label, J9RASdumpContext *context);
+
+#endif

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4043,7 +4043,7 @@ TR_J9VMBase::methodMayHaveBeenInterpreted(TR::Compilation *comp)
 bool
 TR_J9VMBase::canRecompileMethodWithMatchingPersistentMethodInfo(TR::Compilation *comp)
    {
-   return (comp->ilGenRequest().details().isDumpMethod() || // for a log recompilation, it's okay to compile at the same level
+   return (comp->ilGenRequest().details().isJitDumpMethod() || // for a log recompilation, it's okay to compile at the same level
            comp->getOption(TR_EnableHCR)
           );                     // TODO: Why does this assume sometimes fail in HCR mode?
    }

--- a/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
@@ -71,12 +71,12 @@ public:
    virtual const char * name()     const { return "DumpMethod"; }
 
    virtual bool isOrdinaryMethod() const { return false; }
-   virtual bool isDumpMethod()     const { return true; }
+   virtual bool isJitDumpMethod()     const { return true; }
 
 
    virtual bool sameAs(TR::IlGeneratorMethodDetails & other, TR_FrontEnd *fe)
       {
-      return other.isDumpMethod() && sameMethod(other);
+      return other.isJitDumpMethod() && sameMethod(other);
       }
 
    virtual bool supportsInvalidation() { return false; }

--- a/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
@@ -60,13 +60,13 @@ public:
 namespace J9
 {
 
-class DumpMethodDetails : public TR::IlGeneratorMethodDetails
+class JitDumpMethodDetails : public TR::IlGeneratorMethodDetails
    {
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   DumpMethodDetails(J9Method* method) : TR::IlGeneratorMethodDetails(method) { }
-   DumpMethodDetails(const DumpMethodDetails& other) : TR::IlGeneratorMethodDetails(other.getMethod()) { }
+   JitDumpMethodDetails(J9Method* method) : TR::IlGeneratorMethodDetails(method) { }
+   JitDumpMethodDetails(const JitDumpMethodDetails& other) : TR::IlGeneratorMethodDetails(other.getMethod()) { }
 
    virtual const char * name()     const { return "DumpMethod"; }
 

--- a/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/IlGeneratorMethodDetails.hpp
@@ -43,7 +43,7 @@ public:
    IlGeneratorMethodDetails() :
       J9::IlGeneratorMethodDetailsConnector() {}
 
-   IlGeneratorMethodDetails(J9Method * const method) :
+   IlGeneratorMethodDetails(J9Method* method) :
       J9::IlGeneratorMethodDetailsConnector(method) {}
 
    IlGeneratorMethodDetails(TR_ResolvedMethod *method) :
@@ -65,9 +65,8 @@ class DumpMethodDetails : public TR::IlGeneratorMethodDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   DumpMethodDetails(J9Method * const method) : TR::IlGeneratorMethodDetails(method) { }
-   DumpMethodDetails(TR_ResolvedMethod *method) : TR::IlGeneratorMethodDetails(method) { }
-   DumpMethodDetails(const DumpMethodDetails & other) : TR::IlGeneratorMethodDetails(other.getMethod()) { }
+   DumpMethodDetails(J9Method* method) : TR::IlGeneratorMethodDetails(method) { }
+   DumpMethodDetails(const DumpMethodDetails& other) : TR::IlGeneratorMethodDetails(other.getMethod()) { }
 
    virtual const char * name()     const { return "DumpMethod"; }
 
@@ -89,7 +88,7 @@ class MethodInProgressDetails : public TR::IlGeneratorMethodDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   MethodInProgressDetails(J9Method * const method, int32_t byteCodeIndex) :
+   MethodInProgressDetails(J9Method* method, int32_t byteCodeIndex) :
       TR::IlGeneratorMethodDetails(method)
       {
       _data._byteCodeIndex = byteCodeIndex;
@@ -141,7 +140,7 @@ class NewInstanceThunkDetails : public TR::IlGeneratorMethodDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   NewInstanceThunkDetails(J9Method * const method, J9Class *clazz) :
+   NewInstanceThunkDetails(J9Method* method, J9Class *clazz) :
       TR::IlGeneratorMethodDetails(method)
       {
       _data._class = clazz;
@@ -186,7 +185,7 @@ class ArchetypeSpecimenDetails : public TR::IlGeneratorMethodDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   ArchetypeSpecimenDetails(J9Method * const method) : TR::IlGeneratorMethodDetails(method) { }
+   ArchetypeSpecimenDetails(J9Method* method) : TR::IlGeneratorMethodDetails(method) { }
    ArchetypeSpecimenDetails(TR_ResolvedMethod *method) : TR::IlGeneratorMethodDetails(method) { }
    ArchetypeSpecimenDetails(const ArchetypeSpecimenDetails &other) : TR::IlGeneratorMethodDetails(other) { }
 
@@ -215,7 +214,7 @@ class MethodHandleThunkDetails : public ArchetypeSpecimenDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   MethodHandleThunkDetails(J9Method * const method, uintptr_t *handleRef, uintptr_t *argRef) :
+   MethodHandleThunkDetails(J9Method* method, uintptr_t *handleRef, uintptr_t *argRef) :
       ArchetypeSpecimenDetails(method)
       {
       _data._methodHandleData._handleRef = handleRef;
@@ -267,7 +266,7 @@ class ShareableInvokeExactThunkDetails : public MethodHandleThunkDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   ShareableInvokeExactThunkDetails(J9Method * const method, uintptr_t *handleRef, uintptr_t *argRef) :
+   ShareableInvokeExactThunkDetails(J9Method* method, uintptr_t *handleRef, uintptr_t *argRef) :
       MethodHandleThunkDetails(method, handleRef, argRef) { }
    ShareableInvokeExactThunkDetails(TR_ResolvedMethod *method, uintptr_t *handleRef, uintptr_t *argRef) :
       MethodHandleThunkDetails(method, handleRef, argRef) { }
@@ -288,7 +287,7 @@ class CustomInvokeExactThunkDetails : public MethodHandleThunkDetails
    // Objects cannot hold data of its own: must store in the _data union in TR::IlGeneratorMethodDetails
 
 public:
-   CustomInvokeExactThunkDetails(J9Method * const method, uintptr_t *handleRef, uintptr_t *argRef) :
+   CustomInvokeExactThunkDetails(J9Method* method, uintptr_t *handleRef, uintptr_t *argRef) :
       MethodHandleThunkDetails(method, handleRef, argRef) { }
    CustomInvokeExactThunkDetails(TR_ResolvedMethod *method, uintptr_t *handleRef, uintptr_t *argRef) :
       MethodHandleThunkDetails(method, handleRef, argRef) { }

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -49,7 +49,7 @@ IlGeneratorMethodDetails::clone(TR::IlGeneratorMethodDetails &storage, const TR:
 
    if (other.isOrdinaryMethod())
       return new (&storage) TR::IlGeneratorMethodDetails(static_cast<const TR::IlGeneratorMethodDetails &>(other));
-   else if (other.isDumpMethod())
+   else if (other.isJitDumpMethod())
       return new (&storage) JitDumpMethodDetails(static_cast<const JitDumpMethodDetails &>(other));
    else if (other.isNewInstanceThunk())
       return new (&storage) NewInstanceThunkDetails(static_cast<const NewInstanceThunkDetails &>(other));
@@ -126,7 +126,7 @@ IlGeneratorMethodDetails::getType() const
    {
    int type = EMPTY;
    if (self()->isOrdinaryMethod()) type |= ORDINARY_METHOD;
-   if (self()->isDumpMethod()) type |= DUMP_METHOD;
+   if (self()->isJitDumpMethod()) type |= DUMP_METHOD;
    if (self()->isNewInstanceThunk()) type |= NEW_INSTANCE_THUNK;
    if (self()->isMethodInProgress()) type |= METHOD_IN_PROGRESS;
    if (self()->isArchetypeSpecimen()) type |= ARCHETYPE_SPECIMEN;

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.cpp
@@ -50,7 +50,7 @@ IlGeneratorMethodDetails::clone(TR::IlGeneratorMethodDetails &storage, const TR:
    if (other.isOrdinaryMethod())
       return new (&storage) TR::IlGeneratorMethodDetails(static_cast<const TR::IlGeneratorMethodDetails &>(other));
    else if (other.isDumpMethod())
-      return new (&storage) DumpMethodDetails(static_cast<const DumpMethodDetails &>(other));
+      return new (&storage) JitDumpMethodDetails(static_cast<const JitDumpMethodDetails &>(other));
    else if (other.isNewInstanceThunk())
       return new (&storage) NewInstanceThunkDetails(static_cast<const NewInstanceThunkDetails &>(other));
    else if (other.isMethodInProgress())
@@ -78,7 +78,7 @@ IlGeneratorMethodDetails::clone(TR::IlGeneratorMethodDetails &storage, const TR:
    if (type & ORDINARY_METHOD)
       return new (&storage) TR::IlGeneratorMethodDetails(static_cast<const TR::IlGeneratorMethodDetails &>(other));
    else if (type & DUMP_METHOD)
-      return new (&storage) DumpMethodDetails(static_cast<const DumpMethodDetails &>(other));
+      return new (&storage) JitDumpMethodDetails(static_cast<const JitDumpMethodDetails &>(other));
    else if (type & NEW_INSTANCE_THUNK)
       return new (&storage) NewInstanceThunkDetails(static_cast<const NewInstanceThunkDetails &>(other));
    else if (type & METHOD_IN_PROGRESS)

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
@@ -81,7 +81,7 @@ public:
       _method = NULL;
       }
 
-   IlGeneratorMethodDetails(J9Method * const method) :
+   IlGeneratorMethodDetails(J9Method* method) :
       OMR::IlGeneratorMethodDetailsConnector(),
       _method(method)
    { }

--- a/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
+++ b/runtime/compiler/ilgen/J9IlGeneratorMethodDetails.hpp
@@ -104,7 +104,7 @@ public:
    virtual const char * name() const { return "OrdinaryMethod"; }
 
    virtual bool isOrdinaryMethod()     const { return true; }
-   virtual bool isDumpMethod()         const { return false; }
+   virtual bool isJitDumpMethod()      const { return false; }
    virtual bool isNewInstanceThunk()   const { return false; }
    virtual bool isMethodInProgress()   const { return false; }
    virtual bool isArchetypeSpecimen()  const { return false; }


### PR DESCRIPTION
When a jitdump recompilation is requested we want to reproduce the
exact same compilation which happened previously. This means we do not
want the normal JIT logic for upgrading or downgrading requested
optimization levels based on the state of the environment at the time
of the compilation request to affect our optimization level request.

We disable the path which upgrades/downgrades compilations if we
encounter a jitdump compilation request.

Fixes: #9201

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>