### PR TITLE
Revert "HeapSampling not available for GC policies Metronome & Balanced"

### DIFF
--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,10 +174,7 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 	}
 
 #if JAVA_SPEC_VERSION >= 11
-	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)
-		&& (J9_GC_POLICY_METRONOME != vm->gcPolicy)
-		&& (J9_GC_POLICY_BALANCED != vm->gcPolicy)
-	) {
+	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)) {
 		rv_capabilities.can_generate_sampled_object_alloc_events = 1;
 	}
 #endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -136,26 +136,21 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilitie
 	getCapabilities(&initialCapabilities, &availableCount, &unavailableCount);
 
 	if (!initialCapabilities.can_retransform_any_class) {
-		unavailableCount -= 1;
+		unavailableCount--;
 	}
 	
 	if (!initialCapabilities.can_redefine_any_class) {
-		unavailableCount -= 1;
+		unavailableCount--;
 	}
 	
 	/* s390 thread/port lib does not support this functionality */
 	if (!initialCapabilities.can_get_current_thread_cpu_time) {
-		unavailableCount -= 1;
+		unavailableCount--;
 	}
 	
 	/* s390 thread/port lib does not support this functionality */
 	if (!initialCapabilities.can_get_thread_cpu_time) {
-		unavailableCount -= 1;
-	}
-
-	/* GC policies Metronome & Balanced don't support this event */
-	if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
-		unavailableCount -= 1;
+		unavailableCount--;
 	}
 
 	if (unavailableCount != 0) {
@@ -171,6 +166,12 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilitie
 		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should be available in onload phase.");
 		result = JNI_FALSE;
 	}
+#if JAVA_SPEC_VERSION >= 11
+	else if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
+		error(env, JVMTI_ERROR_INTERNAL, "can_generate_sampled_object_alloc_events should be available in onload phase.");
+		result = JNI_FALSE;
+	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #endif /* JAVA_SPEC_VERSION >= 9 */
 
 	return result;


### PR DESCRIPTION
Reverts eclipse/openj9#9131

Getting a compile error on zlinux jdk8.

https://ci.eclipse.org/openj9/job/Build_JDK8_s390x_linux_OMR/546/
```
17:44:07  com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c: In function ‘Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilities’:
17:44:07  com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c:157:27: error: ‘jvmtiCapabilities {aka struct <anonymous>}’ has no member named ‘can_generate_sampled_object_alloc_events’; did you mean ‘can_generate_vm_object_alloc_events’?
17:44:07    if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
17:44:07                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
17:44:07                             can_generate_vm_object_alloc_events
17:44:07  ../../../makelib/targets.mk:282: recipe for target 'com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.o' failed
```