### PR TITLE
Revert "Warn when opening a truncated core file"

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/ICore.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/ICore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corp. and others
+ * Copyright (c) 2009, 2014 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,14 +68,7 @@ public interface ICore
 	 * @return Property set for this core
 	 */
 	public Properties getProperties();
-
-	/**
-	 * Is this core file truncated (i.e. incomplete)?
-	 */
-	public default boolean isTruncated() {
-		return false;
-	}
-
+	
 	/**
 	 * Close the handle to the core file and release any resources
 	 */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/aix/AIXDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/aix/AIXDumpReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,15 +71,17 @@ public abstract class AIXDumpReader extends AbstractCoreReader implements ILibra
 {
 	private static final Logger logger = Logger.getLogger(com.ibm.j9ddr.corereaders.ICoreFileReader.J9DDR_CORE_READERS_LOGGER_NAME);
 	
-	private static final int FAULTING_THREAD_OFFSET = 216; // offsetof(core_dumpx, c_flt)
-	protected static final int S64BIT = 0x00000001; // indicates a 64-bit process
-
-	private static final int CORE_FILE_VERSION_OFFSET = 4;
-
-	// see /usr/include/core.h on an AIX box for the core structures
+	private static final long FAULTING_THREAD_OFFSET = 216; // offsetof(core_dumpx,
+															// c_flt)
+	protected static final int S64BIT = 0x00000001; // indicates a 64-bit
+													// process
+	
+	private static final long CORE_FILE_VERSION_OFFSET = 4;
+	
+	//See /usr/include/core.h on an AIX box for the core structures
 	private static final int CORE_DUMP_XX_VERSION = 0xFEEDDB2;
 	private static final int CORE_DUMP_X_VERSION = 0xFEEDDB1;
-	private static final int CORE_DUMP_X_PI_FLAGS_2_OFFSET = 0x420;
+	private static final long CORE_DUMP_X_PI_FLAGS_2_OFFSET = 0x420;
 
 	private static final int POWER_RS1 = 0x0001;
 	private static final int POWER_RSC = 0x0002;
@@ -132,27 +134,20 @@ public abstract class AIXDumpReader extends AbstractCoreReader implements ILibra
 
 	private boolean _isTruncated = false;
 
-	private ILibraryResolver resolver = null; // LibraryResolverFactory.getResolverForCoreFile(this.coreFile);
+	private ILibraryResolver resolver = null; 	//LibraryResolverFactory.getResolverForCoreFile(this.coreFile);
 	private ArrayList<XCOFFReader> openFileTracker = new ArrayList<XCOFFReader>();
 	
 	protected static boolean isAIXDump(ClosingFileReader f) throws IOException
 	{
 		// There are no magic signatures in an AIX dump header. Some simple
-		// validation of the header allows a best guess about validity of the file.
-		f.seek(CORE_FILE_VERSION_OFFSET);
-		int version = f.readInt();
-		if ((version != CORE_DUMP_X_VERSION) && (version != CORE_DUMP_XX_VERSION)) {
-			return false; // unrecognised core file version
-		}
+		// validation of the header
+		// allows a best guess about validity of the file.
+		f.seek(8);
 		long fdsinfox = f.readLong();
 		long loader = f.readLong();
 		long filesize = f.length();
-		return fdsinfox > 0 && loader > 0 && loader > fdsinfox && fdsinfox < filesize && loader < filesize;
-	}
-
-	@Override
-	public boolean isTruncated() {
-		return _isTruncated;
+		return fdsinfox > 0 && loader > 0 && loader > fdsinfox
+				&& fdsinfox < filesize && loader < filesize;
 	}
 
 	public boolean validDump(byte[] data, long filesize)
@@ -878,9 +873,9 @@ public abstract class AIXDumpReader extends AbstractCoreReader implements ILibra
 	
 	public static boolean isAIXDump(byte[] data, long filesize)
 	{
-		int version = readInt(data, CORE_FILE_VERSION_OFFSET);
-		if ((version != CORE_DUMP_X_VERSION) && (version != CORE_DUMP_XX_VERSION)) {
-			return false; // unrecognised core file version
+		int version = readInt(data, (int)CORE_FILE_VERSION_OFFSET);
+		if((version != CORE_DUMP_X_VERSION) && (version != CORE_DUMP_XX_VERSION)) {
+			return false;		//unrecognised core file version
 		}
 		long fdsinfox = readLong(data, 8);
 		long loader = readLong(data, 16);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImage.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2015 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,41 +54,51 @@ public class J9DDRImage implements ManagedImage {
 	private boolean machineDataSet = false;
 	private final URI source;
 	private ManagedImageSource imageSource = null;
-	private final ImageInputStream meta; // meta data, although DDR does nothing with it, it still has to close it
-	private boolean closed = false; // flag to indicate if the image has been closed
-
-	public J9DDRImage(ICore coreFile) {
-		this(null, coreFile, null);
-	}
-
-	public J9DDRImage(URI source, ICore coreFile, ImageInputStream meta) {
+	private ImageInputStream meta = null;		//meta data, although DDR does nothing with it, it still has to close it
+	private boolean closed = false;				//flag to indicate if the image has been closed
+	
+	public J9DDRImage(ICore coreFile)
+	{
 		this.coreFile = coreFile;
-		this.source = source;
-		this.meta = meta;
-
+		source = null;
+		
 		if (coreFile instanceof ILibraryDependentCore) {
 			//Figure out and pass-back the executable PATH.
 			//It may not be able to figure it out from the core file header
-			passBackExecutablePath((ILibraryDependentCore) coreFile);
+			passBackExecutablePath((ILibraryDependentCore)coreFile);
+		}
+	}
+	
+	public J9DDRImage(URI source, ICore coreFile, ImageInputStream meta)
+	{
+		this.coreFile = coreFile;
+		this.source = source;
+		this.meta = meta;
+		
+		if (coreFile instanceof ILibraryDependentCore) {
+			//Figure out and pass-back the executable PATH.
+			//It may not be able to figure it out from the core file header
+			passBackExecutablePath((ILibraryDependentCore)coreFile);
 		}
 	}
 
 	public ICore getCore() {
 		return coreFile;
 	}
-
+	
 	public URI getSource() {
 		return source;
 	}
 
-	private void passBackExecutablePath(ILibraryDependentCore core) {
+	private void passBackExecutablePath(ILibraryDependentCore core)
+	{
 		Iterator<J9DDRImageAddressSpace> addressSpacesIt = getAddressSpaces();
-
+		
 		while (addressSpacesIt.hasNext()) {
 			J9DDRImageAddressSpace thisAS = addressSpacesIt.next();
-
+			
 			J9DDRImageProcess proc = thisAS.getCurrentProcess();
-
+			
 			String executablePath = proc.getExecutablePath();
 			if (executablePath != null) {
 				core.executablePathHint(executablePath);
@@ -96,22 +106,23 @@ public class J9DDRImage implements ManagedImage {
 		}
 	}
 
-	private void checkJ9RASMachineData() {
-		if (!machineDataSet) {
+	private void checkJ9RASMachineData()
+	{
+		if (! machineDataSet) {
 			j9MachineData = J9RASImageDataFactory.getMachineData(coreFile);
 			machineDataSet = true;
 		}
 	}
-
+	
 	public Iterator<J9DDRImageAddressSpace> getAddressSpaces() {
 		Collection<? extends IAddressSpace> addressSpaces = coreFile.getAddressSpaces();
-
+		
 		List<J9DDRImageAddressSpace> dtfjList = new LinkedList<J9DDRImageAddressSpace>();
-
+		
 		for (IAddressSpace thisAs : addressSpaces) {
 			dtfjList.add(new J9DDRImageAddressSpace(thisAs));
 		}
-
+		
 		return dtfjList.iterator();
 	}
 
@@ -334,20 +345,11 @@ public class J9DDRImage implements ManagedImage {
 	}
 
 	@Override
-	public boolean isTruncated() {
-		if (coreFile == null) {
-			return true;
-		}
-
-		return coreFile.isTruncated();
-	}
-
-	@Override
 	public boolean equals(Object o) {
-		if (o == null) {
+		if(o == null) {
 			return false;
 		}
-		if (!(o instanceof J9DDRImage)) {
+		if(!(o instanceof J9DDRImage)) {
 			return false;
 		}
 		J9DDRImage compareto = (J9DDRImage) o;

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/Image.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/Image.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corp. and others
+ * Copyright (c) 2004, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -185,12 +185,4 @@ public interface Image {
 	 * @since 1.12
 	 */
 	public long getCreationTimeNanos() throws DataUnavailable, CorruptDataException;
-
-	/**
-	 * Is this image truncated (i.e. incomplete)?
-	 */
-	public default boolean isTruncated() {
-		return false;
-	}
-
 }


### PR DESCRIPTION
Reverts eclipse/openj9#9199

Causing a compile problem.
```
    [javac] Compiling 378 source files to /tmp/bld_443712/job_638887358/debugtools/DDR_VM/output/bin/j9_core
    [javac] /tmp/bld_443712/job_638887358/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImage.java:336: error: method does not override or implement a method from a supertype
    [javac] 	@Override
    [javac] 	^
```