### PR TITLE
HeapSampling not available for GC policies Metronome/Balanced

### DIFF
--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,7 +174,10 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 	}
 
 #if JAVA_SPEC_VERSION >= 11
-	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)) {
+	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)
+		&& (J9_GC_POLICY_METRONOME != vm->gcPolicy)
+		&& (J9_GC_POLICY_BALANCED != vm->gcPolicy)
+	) {
 		rv_capabilities.can_generate_sampled_object_alloc_events = 1;
 	}
 #endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -136,22 +136,29 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilitie
 	getCapabilities(&initialCapabilities, &availableCount, &unavailableCount);
 
 	if (!initialCapabilities.can_retransform_any_class) {
-		unavailableCount--;
+		unavailableCount -= 1;
 	}
 	
 	if (!initialCapabilities.can_redefine_any_class) {
-		unavailableCount--;
+		unavailableCount -= 1;
 	}
 	
 	/* s390 thread/port lib does not support this functionality */
 	if (!initialCapabilities.can_get_current_thread_cpu_time) {
-		unavailableCount--;
+		unavailableCount -= 1;
 	}
 	
 	/* s390 thread/port lib does not support this functionality */
 	if (!initialCapabilities.can_get_thread_cpu_time) {
-		unavailableCount--;
+		unavailableCount -= 1;
 	}
+
+#if JAVA_SPEC_VERSION >= 11
+	/* GC policies Metronome & Balanced don't support this event */
+	if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
+		unavailableCount -= 1;
+	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (unavailableCount != 0) {
 		error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of unavailable capabilities. Expected 0", unavailableCount);
@@ -166,12 +173,6 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilitie
 		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should be available in onload phase.");
 		result = JNI_FALSE;
 	}
-#if JAVA_SPEC_VERSION >= 11
-	else if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
-		error(env, JVMTI_ERROR_INTERNAL, "can_generate_sampled_object_alloc_events should be available in onload phase.");
-		result = JNI_FALSE;
-	}
-#endif /* JAVA_SPEC_VERSION >= 11 */
 #endif /* JAVA_SPEC_VERSION >= 9 */
 
 	return result;

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,28 +42,38 @@ soae001(agentEnv *agent_env, char *args)
 	jvmtiCapabilities capabilities;
 	jvmtiError err = JVMTI_ERROR_NONE;
 	jint result = JNI_OK;
+	jvmtiCapabilities initialCapabilities = {0};
 
 	env = agent_env;
 
-	/* Set the JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event callback */
-	memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
-	callbacks.SampledObjectAlloc = sampledObjectAlloc;
-	err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
+	err = (*jvmti_env)->GetPotentialCapabilities(jvmti_env, &initialCapabilities);
 	if (JVMTI_ERROR_NONE != err) {
-		error(agent_env, err, "Failed to set callback for JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
+		error(env, err, "Failed to GetPotentialCapabilities");
+		result = JNI_ERR;
+	} else if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
+		error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "can_generate_sampled_object_alloc_events should be available in onload phase");
 		result = JNI_ERR;
 	} else {
-		/* we require the can_generate_sampled_object_alloc_events capability if we want to enable allocation callbacks */
-		memset(&capabilities, 0, sizeof(jvmtiCapabilities));
-		capabilities.can_generate_sampled_object_alloc_events = 1;
-		err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+		/* Set the JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event callback */
+		memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
+		callbacks.SampledObjectAlloc = sampledObjectAlloc;
+		err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
 		if (JVMTI_ERROR_NONE != err) {
-			error(agent_env, err, "Failed to add capabilities can_generate_sampled_object_alloc_events");
+			error(agent_env, err, "Failed to set callback for JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
 			result = JNI_ERR;
+		} else {
+			/* we require the can_generate_sampled_object_alloc_events capability if we want to enable allocation callbacks */
+			memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+			capabilities.can_generate_sampled_object_alloc_events = 1;
+			err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+			if (JVMTI_ERROR_NONE != err) {
+				error(agent_env, err, "Failed to add capabilities can_generate_sampled_object_alloc_events");
+				result = JNI_ERR;
+			}
 		}
 	}
 	
-	return JNI_OK;
+	return result;
 }
 
 static void JNICALL


### PR DESCRIPTION
**HeapSampling not available for GC policies Metronome & Balanced**

Not enable  `jvmtiCapabilities` `can_generate_sampled_object_alloc_events` when the `GC` policy is `Metronome` or `Balanced`;
Moved the test for `initialCapabilities.can_generate_sampled_object_alloc_events` to `soae001.c`.

This is a known limitation as per https://www.eclipse.org/openj9/docs/version0.15/
```
 Restrictions: JEP 331 is implemented for OpenJ9 with the following limitations:
    The balanced and metronome garbage collection policies are not supported.
```
Currently following GC policies are tested https://github.com/eclipse/openj9/blob/958d2f9b581efc1ddf774753520d709e64c7d6e7/test/functional/cmdLineTests/jvmtitests/playlist.xml#L640-L643

Note: this is #9131 with a fix for Java 8 compilation failure:
```
17:44:07  com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c: In function ‘Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilities’:
17:44:07  com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c:157:27: error: ‘jvmtiCapabilities {aka struct <anonymous>}’ has no member named ‘can_generate_sampled_object_alloc_events’; did you mean ‘can_generate_vm_object_alloc_events’?
17:44:07    if (!initialCapabilities.can_generate_sampled_object_alloc_events) {
17:44:07                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
17:44:07                             can_generate_vm_object_alloc_events
17:44:07  ../../../makelib/targets.mk:282: recipe for target 'com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.o' failed
```
`initialCapabilities.can_generate_sampled_object_alloc_events` has to be decorated with `#if JAVA_SPEC_VERSION >= 11`.
Tested with a personal build for `JDK 8/11` (last time only with `JDK 11`).

closes: #9045 

Reviewer: @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>