### PR TITLE
Use a different cacheDir for the nameOption test

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption.bat
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption.bat
@@ -1,7 +1,7 @@
 @ echo off
 
 rem
-rem Copyright (c) 2004, 2018 IBM Corp. and others
+rem Copyright (c) 2004, 2020 IBM Corp. and others
 rem
 rem This program and the accompanying materials are made available under
 rem the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,9 +31,6 @@ rem @summary that only one cache is created and that the destroy command works
 setlocal
 
 call cmdlineConfig.bat
-
-%2\javac HelloWorld.java
-%2\javac SimpleGrep.java
 
 set TESTSCRIPT=nameOption
 set DEFAULT_CACHE_NAME=sharedcc_%TESTUSER%

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption.sh
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2018 IBM Corp. and others
+# Copyright (c) 2004, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,11 +31,8 @@ export TESTSCRIPT=nameOption
 
 export DEFAULT_CACHE_NAME="sharedcc_$TESTUSER"
 
-$2/javac HelloWorld.java
-$2/javac SimpleGrep.java
-
-$1/java -Xshareclasses HelloWorld
-$1/java -Xshareclasses:listAllCaches 2> $TESTSCRIPT.out
+$1/java -Xshareclasses:cacheDir=/tmp HelloWorld
+$1/java -Xshareclasses:cacheDir=/tmp,listAllCaches 2> $TESTSCRIPT.out
 
 if [ ! -e $TESTSCRIPT.out ]
 then
@@ -50,8 +47,8 @@ else
     fi
 fi
 
-$1/java -Xshareclasses:name="$DEFAULT_CACHE_NAME",destroy
-$1/java -Xshareclasses:name="$DEFAULT_CACHE_NAME",printStats 2> $TESTSCRIPT_2.out
+$1/java -Xshareclasses:cacheDir=/tmp,name="$DEFAULT_CACHE_NAME",destroy
+$1/java -Xshareclasses:cacheDir=/tmp,name="$DEFAULT_CACHE_NAME",printStats 2> $TESTSCRIPT_2.out
 
 if [ ! -e $TESTSCRIPT.out ]
 then


### PR DESCRIPTION
Use a non-default cacheDir for the
cmdLineTester_SCCommandLineOptionTests nameOption test. The test creates
and destroys the default cache name. When the shared cache is enabled by
default, on platforms where the default cache type is nonpersistent
(z/OS), the default cache in the default cacheDir may be in use by other
processes and cannot be destroyed.

Also remove the unnecessary javac commands, as the build.xml
pre-compiles the code.

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>