### PR TITLE
Ensure sanity test material is readable on z/OS

### DIFF
--- a/test/TestConfig/build.xml
+++ b/test/TestConfig/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2019, 2019 IBM Corp. and others
+  Copyright (c) 2019, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,9 +35,22 @@
 		<mkdir dir="${DEST}" />
 	</target>
 
+	<if>
+		<contains string="${SPEC}" substring="zos"/>
+		<then>
+			<property name="TEXT_ENCODING" value="IBM-1047"/>
+		</then>
+		<else>
+			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
+		</else>
+	</if>
+
 	<target name="build" depends="init">
 			<copy todir="${DEST}">
-					<fileset dir="." includes="**"/>
+					<fileset dir="." includes="**" excludes="**/*.pl"/>
+			</copy>
+			<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">
+					<fileset dir="." includes="**/*.pl"/>
 			</copy>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2019 IBM Corp. and others
+  Copyright (c) 2017, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,12 +50,22 @@
 		</javac>
 	</target>
 
+	<if>
+		<contains string="${SPEC}" substring="zos"/>
+		<then>
+			<property name="TEXT_ENCODING" value="IBM-1047"/>
+		</then>
+		<else>
+			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
+		</else>
+	</if>
+
 	<target name="dist" depends="compile" description="generate the distribution">
 		<jar jarfile="${DEST}/runtimemxbeanTests.jar" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="./" />
 		</jar>
-		<copy todir="${DEST}">
+		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">
 			<fileset dir="${src}/../" includes="*.xml,*.mk,*.pl" />
 		</copy>
 	</target>

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,8 +32,18 @@
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/sigxfszHandlingTest" />
 	<property name="src" location="." />
 
+	<if>
+		<contains string="${SPEC}" substring="zos"/>
+		<then>
+			<property name="TEXT_ENCODING" value="IBM-1047"/>
+		</then>
+		<else>
+			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
+		</else>
+	</if>
+
 	<target name="dist" description="generate the distribution">
-		<copy todir="${DEST}">
+		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">
 			<fileset dir="${src}" includes="*.xml"/>
 			<fileset dir="${src}" includes="*.mk"/>
 			<fileset dir="${src}" includes="*.sh"/>


### PR DESCRIPTION
On z/OS the following test files loose their ASCII file tagging when the
build.xml copies the files, so they are treated as EBCDIC files. Convert
them to EBCDIC when copied so they are readable.

getPidTest.pl - cmdLineTester_getPid_0
runSIGXFSZTest.sh - cmdLineTest_sigxfszHandlingTest_0
sysvcleanup.pl - shrtest_zos_0

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>