### PR TITLE
Use front end query to check J9ClassInitSucceeded

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -730,7 +730,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                uintptr_t mhObject = comp()->fej9()->getStaticReferenceFieldAtAddress((uintptr_t)mhLocation);
                uintptr_t defc = comp()->fej9()->getReferenceFieldAtAddress(mhObject + defcOffset);
                J9Class* defcClazz = (J9Class*)TR::Compiler->cls.classFromJavaLangClass(comp(), defc);
-               if (defcClazz->initializeStatus == J9ClassInitSucceeded)
+               if (comp()->fej9()->classInitIsFinished((TR_OpaqueClassBlock*)defcClazz))
                   {
                   removeCall = true;
                   if (trace())


### PR DESCRIPTION
Use the front end query to check the `J9ClassInitSucceeded` flag.

Close: #7233

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>