### PR TITLE
Avoid verifying trees during codegen crashes when generating jitdumps

### DIFF
--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -127,16 +127,16 @@ static UDATA dumpCurrentILProtected(J9PortLibrary *portLib, void * opaqueParamet
       if ( ((vmThread->omrVMThread->vmState) & bitMask) == bitMask )  // if we are in the Codegen Phase
          {
          dbg->dumpMethodInstrs(logFile, "Post Binary Instructions", false, true);
-
-         dbg->print(logFile,comp->cg()->getSnippetList(), true);  // print Warm Snippets
-         dbg->print(logFile,comp->cg()->getSnippetList(), false);
-
+         dbg->print(logFile,comp->cg()->getSnippetList());
          dbg->dumpMixedModeDisassembly();
          }
-
-      // leaving to the very end in case there is a crash before this point.
-      comp->verifyTrees(comp->getMethodSymbol());
-      comp->verifyBlocks(comp->getMethodSymbol());
+      else
+         {
+         // Tree verification is only valid during optimizations as it relies on consistent node counts which are only
+         // valid before codegen, since the codegen will decrement the node counts as part of instruction selection
+         comp->verifyTrees(comp->getMethodSymbol());
+         comp->verifyBlocks(comp->getMethodSymbol());
+         }
 
       trfprintf(logFile, "</currentIL>\n");
       }


### PR DESCRIPTION
When a jitdump is generated for a crash during codegen we want to avoid
verifying the trees, since tree verification has the assumption that
the node counts are valid. This is not the case during codegen as we
would have decremented the node counts as part of instruction selection.

This change avoids recursive crashes during printing of the IL when
generating a jitdump for a failed compilation.

Fixes: #9227

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>