### PR TITLE
Set java.base module for anonymous classes loaded at bootup stage

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -810,6 +810,21 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 								clazz = vmFuncs->allClassesNextDo(&classWalkState);
 							}
 							vmFuncs->allClassesEndDo(&classWalkState);
+
+							if (vm->anonClassCount > 0) {
+								J9ClassWalkState classWalkStateAnon = {0};
+								J9Class *clazzAnon = NULL;
+
+								Assert_SC_notNull(vm->anonClassLoader);
+								clazzAnon = vmFuncs->allClassesStartDo(&classWalkStateAnon, vm, vm->anonClassLoader);
+								while (NULL != clazzAnon) {
+									Assert_SC_true(clazzAnon->module == vm->javaBaseModule);
+									J9VMJAVALANGCLASS_SET_MODULE(currentThread, clazzAnon->classObject, modObj);
+									clazzAnon = vmFuncs->allClassesNextDo(&classWalkStateAnon);
+								}
+								vmFuncs->allClassesEndDo(&classWalkStateAnon);
+							}
+
 							vm->runtimeFlags |= J9_RUNTIME_JAVA_BASE_MODULE_CREATED;
 							TRIGGER_J9HOOK_JAVA_BASE_LOADED(vm->hookInterface, currentThread);
 							Trc_MODULE_defineModule(currentThread, "java.base", j9mod);


### PR DESCRIPTION
**Set java.base module for anonymous classes loaded at bootup stage**

For those anonymous classes loaded before the module `java.base` is created, set `java.base` module for such classes when `java.base` is just created.

Note: This issue described in #9183 can be demonstrated by making modification in `java.lang.ClassLoader.java`.
Add a helper method:
```
	protected static byte[] createDummyClass(String packageName) {
		ClassWriter cw = new ClassWriter(0);
		MethodVisitor mv = null;
		String className = "DummyClass";
		if (packageName != null) {
			className = packageName + "/" + className;
		}
		cw.visit(52, ACC_PUBLIC, className, null, "java/lang/Object", null);
		mv = cw.visitMethod(ACC_PUBLIC, "bar", "()V", null, null);
		mv.visitCode();
		mv.visitInsn(RETURN);
		mv.visitMaxs(2, 1);
		mv.visitEnd();
		cw.visitEnd();
		return cw.toByteArray();
	}
```
Put following code right before https://github.com/eclipse/openj9/blob/ea159ff8388e3d2ea0d65c56fdac047d8035085b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java#L294
```
	byte[] bytes = createDummyClass(null);
	Class<?> anon = Unsafe.getUnsafe().defineAnonymousClass(Object.class, bytes, null);		
	bytes = createDummyClass("java/lang");
	anon = Unsafe.getUnsafe().defineAnonymousClass(Object.class, bytes, null);
```
These anonymous classes are loaded by `vm->anonClassLoader` and the `module` field in these class objects are `null`.
This PR sets `java.base` module for those class objects.
Tested in a personal build (`JDK 8/11 xa64`).

closes: #9183 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>