### PR TITLE
(0.20.0) AArch64: Issue memory barrier after calling jitResolveInterfaceMethod

### DIFF
--- a/runtime/compiler/aarch64/runtime/PicBuilder.spp
+++ b/runtime/compiler/aarch64/runtime/PicBuilder.spp
@@ -735,6 +735,7 @@ L_callResolve:
 	add	x0, x30, #J9TR_UICSnippet_CP			// get CP/index pair pointer
 	mov	x1, x10						// get code cache RA
 	bl	jitResolveInterfaceMethod			// call the helper
+	dmb	ishst						// make sure interface class and iTable offset are visible if `bl` instruction is rewritten.
 	cbz	x0, L_commonLookupException			// if resolve failed, throw the exception
 	ldr	x0, [x7, #J9TR_ICSnippet_ITableIndex]		// Load ITable Index
 	tst	x0, #J9TR_J9_ITABLE_OFFSET_DIRECT		// Check if J9TR_J9_ITABLE_OFFSET_DIRECT flag is set


### PR DESCRIPTION
Memory barrier is required after returning from `jitResolveInterfaceMethod`
as `indexAndLiteralsEA` is updated  and other threads might see
old values if they execute `_interfaceCallHelper` at the certain timing.

Master PR: https://github.com/eclipse/openj9/pull/9223

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>