### PR TITLE
(0.20.0) Update aarch64 platform to use gcc-7.5

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -308,6 +308,8 @@ aarch64_linux:
   node_labels:
     build:
       11: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
+  build_env:
+    vars: 'PATH+TOOLS=/usr/local/gcc-7.5.0/bin'
 #========================================#
 # Linux Aarch 64bits Large Heap
 #========================================#


### PR DESCRIPTION
* Resolves #9159
* [skip ci]

Cherry pick of #9238 for the 0.20.0 release.