### PR TITLE
Guard unloading class events and compilations with RWMutex

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -184,8 +184,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->writeError(JITServer::MessageType::compilationInterrupted, 0 /* placeholder */);
 
       if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Interrupting remote compilation (interruptReason %u) in handleServerMessage of %s @ %s", 
-                                                          interruptReason, comp->signature(), comp->getHotnessName());
+         TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE, "Interrupting remote compilation (interruptReason %u) in handleServerMessage(%s) for %s @ %s",
+                                                          interruptReason, JITServer::messageNames[response], comp->signature(), comp->getHotnessName());
+
       comp->failCompilation<TR::CompilationInterrupted>("Compilation interrupted in handleServerMessage");
       }
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -632,7 +632,14 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
 #endif
    // The following call will return with compilation monitor in hand
    //
+   stream->setClientData(clientSession);
+   getClientData()->readAcquireClassUnloadRWMutex();
+
    void *startPC = compile(compThread, &entry, scratchSegmentProvider);
+
+   getClientData()->readReleaseClassUnloadRWMutex();
+   stream->setClientData(NULL);
+
    if (entry._compErrCode == compilationStreamFailure)
       {
       if (!enableJITServerPerCompConn)

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -38,7 +38,8 @@ getJ9ClassInfo(TR::CompilationInfoPerThread *threadCompInfo, J9Class *clazz)
    // Do not use it otherwise
    auto &classMap = threadCompInfo->getClientData()->getROMClassMap();
    auto it = classMap.find(clazz);
-   TR_ASSERT(it != classMap.end(), "ClassInfo is not in the class map");
+   TR_ASSERT_FATAL(it != classMap.end(),"compThreadID %d, ClientData %p, clazz %p: ClassInfo is not in the class map %p!!\n",
+      threadCompInfo->getCompThreadId(), threadCompInfo->getClientData(), clazz, &classMap);
    return it->second;
    }
 

--- a/runtime/compiler/net/ServerStream.cpp
+++ b/runtime/compiler/net/ServerStream.cpp
@@ -32,5 +32,6 @@ ServerStream::ServerStream(int connfd, BIO *ssl)
    {
    initStream(connfd, ssl);
    _numConnectionsOpened++;
+   _pClientSessionData = NULL;
    }
 }

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -26,7 +26,9 @@
 #include "net/RawTypeConvert.hpp"
 #include "net/CommunicationStream.hpp"
 #include "env/VerboseLog.hpp"
+#include "control/CompilationThread.hpp" // for TR::compInfoPT->getCompThreadId()
 #include "control/Options.hpp"
+#include "runtime/JITClientSession.hpp"
 #include <openssl/ssl.h>
 
 class SSLOutputStream;
@@ -73,17 +75,30 @@ public:
    virtual ~ServerStream()
       {
       _numConnectionsClosed++;
+      _pClientSessionData = NULL;
       }
 
    /**
       @brief Send a message to the client
 
       @param [in] type Message type to be sent
-      @param [in] args Variable number of additional paramaters to be sent
+      @param [in] args Variable number of additional parameters to be sent
    */
    template <typename ...Args>
    void write(MessageType type, Args... args)
       {
+      if (isReadingClassUnload() &&
+          isClassUnloadingAttempted() &&
+          (MessageType::compilationFailure != type) &&
+          (MessageType::compilationCode != type))
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d MessageType[%u] %s: throw TR::CompilationInterrupted",
+               TR::compInfoPT->getCompThreadId(), type, messageNames[type]);
+
+         throw TR::CompilationInterrupted();
+         }
+
       _sMsg.setType(type);
       setArgsRaw<Args...>(_sMsg, args...);
       writeMessage(_sMsg);
@@ -207,7 +222,8 @@ public:
       try
          {
          if (TR::Options::getVerboseOption(TR_VerboseJITServer))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "MessageType::compilationFailure: statusCode %u", statusCode);
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d MessageType::compilationFailure: statusCode %u",
+                  TR::compInfoPT->getCompThreadId(), statusCode);
          write(MessageType::compilationFailure, statusCode);
          }
       catch (std::exception &e)
@@ -226,6 +242,20 @@ public:
       return _clientId;
       }
 
+   void setClientData(ClientSessionData *pClientData)
+      {
+      _pClientSessionData = pClientData;
+      }
+
+   volatile bool isReadingClassUnload()
+      {
+      return (_pClientSessionData) ? _pClientSessionData->isReadingClassUnload() : false;
+      }
+
+   volatile bool isClassUnloadingAttempted()
+      {
+      return (_pClientSessionData) ? _pClientSessionData->isClassUnloadingAttempted() : false;
+      }
 
    // Statistics
    static int getNumConnectionsOpened() { return _numConnectionsOpened; }
@@ -235,6 +265,7 @@ private:
    static int _numConnectionsOpened;
    static int _numConnectionsClosed;
    uint64_t _clientId;  // UID of client connected to this communication stream
+   ClientSessionData *_pClientSessionData;
    };
 
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -406,6 +406,14 @@ class ClientSessionData
    J9SharedClassCacheDescriptor * reconstructJ9SharedClassCacheDescriptorList(const std::vector<uintptr_t> &listOfCacheStartAddress, const std::vector<uintptr_t> &listOfCacheSizeBytes);
    void destroyJ9SharedClassCacheDescriptorList();
 
+   volatile bool isClassUnloadingAttempted() const { return _bClassUnloadingAttempt; }
+   volatile bool isReadingClassUnload() { return !omrthread_rwmutex_is_writelocked(_classUnloadRWMutex); }
+
+   void readAcquireClassUnloadRWMutex();
+   void readReleaseClassUnloadRWMutex();
+   void writeAcquireClassUnloadRWMutex();
+   void writeReleaseClassUnloadRWMutex();
+
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -450,6 +458,9 @@ class ClientSessionData
    TR::Monitor *_thunkSetMonitor;
    PersistentUnorderedMap<std::pair<std::string, bool>, void *> _registeredJ2IThunksMap; // stores a map of J2I thunks created for this client
    PersistentUnorderedSet<std::pair<std::string, bool>> _registeredInvokeExactJ2IThunksSet; // stores a set of invoke exact J2I thunks created for this client
+
+   omrthread_rwmutex_t _classUnloadRWMutex;
+   volatile bool _bClassUnloadingAttempt;
    }; // class ClientSessionData
 
 


### PR DESCRIPTION
Use RWMutex to guard access to the client session data during the compilation to prevent the race condition in accessing the caches related to the unloaded classes at the server. `TR::CompilationInterrupt` exception is thrown at the server if one compilation tries to do 
a read access to the client session cache while another compilation just attempted a write access to the same client session data.  It results in a `compilationFailure` message along 
with statusCode=`compilationInterrupted` being sent to the client. 

Implements #9212.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>