### PR TITLE
Partial MethodType created by readObject can be used

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1213,6 +1213,8 @@ public final class MethodType implements Serializable
 			);
 			fReturnType.set(this, void.class);
 			fArguments.set(this, EMTPY_PARAMS);
+			methodDescriptor = "()V";
+			stackDescriptionBits = stackDescriptionBits(EMTPY_PARAMS, 0);
 			Class<?> serialReturnType = (Class<?>) in.readObject();
 			Class<?>[] serialArguments = (Class<?>[]) in.readObject();
 			deserializedFields = new DeserializedFieldsHolder(serialReturnType, serialArguments);


### PR DESCRIPTION
If the serialized MethodType contains objects which have their own readObject
method, whether from extra items in the serialized form or from the return
type or argumens fields, then the bogus MethodType object created will be
accessible from the other readObject methods, with possibly incomplete type
information.

This commit adds copies of the arguments and return type fields for use in
serialization, and sets the actual type to "()V" until readResolve is called
and creates a useable MethodType.

Set methodDescriptor string and stackDescriptionBits in case the temporary
object is accessed.