### PR TITLE
Check if class has static final field modified before folding

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1252,15 +1252,21 @@ bool J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(TR::Optimization* opt
       return false;
       }
 
+   int32_t cpIndex = symRef->getCPIndex();
+   TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp)->getClassFromFieldOrStatic(comp, cpIndex);
+   if (J9::TransformUtil::canFoldStaticFinalField(comp, node) != TR_maybe
+       || !declaringClass
+       || TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
+      {
+      return false;
+      }
+
    if (skipFinalFieldFoldingInBlock(comp, currentTree->getEnclosingBlock())
-       || J9::TransformUtil::canFoldStaticFinalField(comp, node) != TR_maybe
        || safeToAddFearPointAt(opt, currentTree) != TR_yes)
       {
       return false;
       }
 
-   int32_t cpIndex = symRef->getCPIndex();
-   TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp)->getClassFromFieldOrStatic(comp, cpIndex);
    int32_t fieldNameLen;
    char* fieldName = symRef->getOwningMethod(comp)->fieldName(cpIndex, fieldNameLen, comp->trMemory(), stackAlloc);
    int32_t fieldSigLength;


### PR DESCRIPTION
Can't fold a static final field if its declaring class already has one
or more static final field modified.

Related to #8353 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>