### PR TITLE
Match number of artifacts to number of build logs

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -540,7 +540,7 @@ def build_all() {
                         cleanWs()
                         add_node_to_description()
                         // Setup Artifactory now that we are on a node. This determines which server(s) we push to.
-                        variableFile.set_artifactory_config()
+                        variableFile.set_artifactory_config(BUILD_IDENTIFIER)
                         get_source()
                         build()
                         archive_sdk()

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -707,7 +707,7 @@ def set_slack_channel() {
     }
 }
 
-def set_artifactory_config() {
+def set_artifactory_config(id="Nightly") {
     ARTIFACTORY_CONFIG = [:]
     echo "Configure Artifactory..."
 
@@ -721,7 +721,11 @@ def set_artifactory_config() {
         for (geo in ARTIFACTORY_CONFIG['geos']) {
             ARTIFACTORY_CONFIG[geo] = [:]
             ARTIFACTORY_CONFIG[geo]['server'] = get_value(VARIABLES.artifactory.server, geo)
-            ARTIFACTORY_CONFIG[geo]['numArtifacts'] = get_value(VARIABLES.artifactory.numArtifacts, geo).toInteger()
+            def numArtifacts = get_value(VARIABLES.artifactory.numArtifacts, geo)
+            if (!numArtifacts ){
+                numArtifacts = get_value(VARIABLES.build_discarder.logs, pipelineFunctions.convert_build_identifier(id))
+            }
+            ARTIFACTORY_CONFIG[geo]['numArtifacts'] = numArtifacts.toInteger()
             ARTIFACTORY_CONFIG[geo]['daysToKeepArtifacts'] = get_value(VARIABLES.artifactory.daysToKeepArtifacts, geo).toInteger()
             ARTIFACTORY_CONFIG[geo]['manualCleanup'] = get_value(VARIABLES.artifactory.manualCleanup, geo)
             ARTIFACTORY_CONFIG[geo]['vpn'] = get_value(VARIABLES.artifactory.vpn, geo)

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -54,8 +54,8 @@ artifactory:
     osu: 'ci-eclipse-openj9'
     #unb: 'ci-eclipse-openj9-unb' TEMP DISABLE. See #8817
   repo: 'ci-eclipse-openj9'
+  # if numArtifacts not set, use build_discarder
   numArtifacts:
-    osu: 30
     unb: 5
   daysToKeepArtifacts:
     osu: 50

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -84,12 +84,12 @@ slack_channel: '#jenkins'
 build_discarder:
   logs:
     Nightly: 40
-    Release: 10
-    OMR: 20
-    OpenJDK8: 20
-    OpenJDK11: 20
-    OpenJDK14: 20
-    OpenJDK: 20
+    Release: 5
+    OMR: 15
+    OpenJDK8: 10
+    OpenJDK11: 10
+    OpenJDK14: 10
+    OpenJDK: 10
     Personal: 50
     Pipeline: 100
 restart_timeout:


### PR DESCRIPTION
- Add option to allow number of Artifactory artifacts
  to match the number of build logs we rotate. This
  will have several positive effects. The first is
  it should reduce our overall disk usage. It will
  also be more practical to have a) Same number of
  build logs and artifacts and b) Different number
  of artifacts for different builds. This can be
  enabled on a per server basis and I have enabled
  it for the main (default) OSU server.
    
[skip ci]
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

Reduce history on builds
    
- Reduce Release from 10 to 5
- Reduce OMR Acceptance from 20 to 15
- Reduce JDK Acceptances from 20 to 10