### PR TITLE
Forced finalize fix for CS

### DIFF
--- a/runtime/gc_base/UnfinalizedObjectList.hpp
+++ b/runtime/gc_base/UnfinalizedObjectList.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,12 @@ public:
 	 * @return the head object, or NULL if the list is empty
 	 */
 	MMINLINE j9object_t getHeadOfList() { return _head; }
+	
+	/**
+	 * Reset the current list, to look empty.
+	 */
+	void resetHeadOfList() { _head = NULL; }
+	
 
 	/**
 	 * Move the list to the prior list and reset the current list to empty.

--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -198,7 +198,14 @@ public:
 	virtual void scanRoots(MM_EnvironmentBase *env) 
 	{
 		MM_RootScanner::scanRoots(env);
-		
+		/* Determine if there is unfinalized work (any newly created finalizable objects
+		 * since last GC) to be done later during clearable phase.
+		 * In CS this will be called in first STW increment.
+		 * Doing so may conclude there is no unfinalize work, while new finalizable objects
+		 * can be created later during concurrent phase of this cycle. It's still ok,
+		 * since these objects cannot die (as any newly allocated objects during CS),
+		 * hence not subject for unfinalized processing.
+		 */ 
 		startUnfinalizedProcessing(env);
 	}
 


### PR DESCRIPTION
When VM is shutting down, we force finalization of all
objects even those that have not died. We do so by moving the content of
unfinalized list to finalizable list.

If this occurs in a middle of CS cycle, we would incorrectly leave
unfinalized _priorList head pointer non-null, which would then be later,
 in clearable pass of that CS cycle, be treated as if objects are still
in unfinalized list, while they actually belong to finalizable list.

Another problem is calling startUnfinalizedProcessing which would have
been already done at the start of this cycle, hence overwriting existing
_priorList pointer and losing the real content of unfinalized list.

Fix is to iterate the head list directly and reset the pointer after the
pass.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>