### PR TITLE
Support tracing allocation bytes

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -187,6 +187,8 @@ public:
 	double maxRAMPercent; /**< Value of -XX:MaxRAMPercentage specified by the user */
 	double initialRAMPercent; /**< Value of -XX:InitialRAMPercentage specified by the user */
 
+	UDATA objectSamplingBytesGranularity; /**< How often (in bytes) we do an allocation trace (for triggering J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING) */
+
 protected:
 private:
 protected:
@@ -317,6 +319,7 @@ public:
 #endif
 		, maxRAMPercent(0.0) /* this would get overwritten by user specified value */
 		, initialRAMPercent(0.0) /* this would get overwritten by user specified value */
+		, objectSamplingBytesGranularity(512 * 1024) /* default 512KB */
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_glue_java/ConfigurationDelegate.hpp
+++ b/runtime/gc_glue_java/ConfigurationDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -325,7 +325,8 @@ public:
 			vmThread->cardTableShiftSize = 0;
 		}
 
-		if (extensions->fvtest_disableInlineAllocation) {
+		if ((extensions->fvtest_disableInlineAllocation) || (extensions->disableInlineAllocationForSamplingBytesGranularity)) {
+			env->disableInlineTLHAllocate();
 			env->_objectAllocationInterface->disableCachedAllocations(env);
 		}
 

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -381,10 +381,7 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 				goto fail;
 			}
 
-			/* Initial sampling interval is MM_GCExtensions::oolObjectSamplingBytesGranularity which is 16M by default
-			 * or set by command line option -Xgc:allocationSamplingGranularity.
-			 * Set it to 512KB which is default sampling interval as per JEP 331 specification.
-			 */
+			/* Initial sampling interval is MM_GCExtensions::objectSamplingBytesGranularity which is 512KB by default. */
 			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, 512 * 1024);
 			jvmtiData->flags |= J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED;
 		}


### PR DESCRIPTION
Keep env->`_oolTraceAllocationBytes` and exts->`oolObjectSamplingBytesGranularity `
(default = 16MB, can be changedvia jvm option `-Xgc:allocationSamplingGranularity=xxx`) 
for triggering tracepoint `Trc_MM_J9AllocateIndexableObject_outOfLineObjectAllocation`
and `Trc_MM_J9AllocateObject_outOfLineObjectAllocation`, which are used by Health Center.
The default of triggering the tracepoints is on, can be enabled/disabled by
`-Xgc:allocationSamplingEnable/allocationSamplingDisable`.
_Allocation bytes for triggering the tracepoints are counted for out of line allocation only._

New env->`_traceAllocationBytes` and ext->`objectSamplingBytesGranularity`
(default = 512KB, can be set by J9MemoryManagerFunction `j9gc_set_allocation_sampling_interval()`) for triggering jvmti event
`JVMTI_EVENT_SAMPLED_OBJECT_ALLOC`.
The default of triggering jvmti event `JVMTI_EVENT_SAMPLED_OBJECT_ALLOC`
is off, can be enabled/disabled via `j9gc_set_allocation_sampling_interval()`.
_Allocation bytes for triggering `JVMTI_EVENT_SAMPLED_OBJECT_ALLOC` are counted both inline and out of line allocation._

depends on https://github.com/eclipse/omr/pull/5071

Signed-off-by: Lin Hu <linhu@ca.ibm.com>