### PR TITLE
Set sampling interval to UDATA_MAX to inform GC sampling is not required

### DIFF
--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -240,7 +240,7 @@ extern J9_CFUNC void j9gc_set_memoryController(J9VMThread *vmThread, J9Object* o
 extern J9_CFUNC const char* omrgc_get_version(OMR_VM *omrVM);
 extern J9_CFUNC void j9gc_startGCIfTimeExpired(OMR_VMThread* vmThread);
 extern J9_CFUNC void j9gc_allocation_threshold_changed(J9VMThread* currentThread);
-extern J9_CFUNC void j9gc_set_allocation_sampling_interval(J9VMThread* vmThread, UDATA samplingInterval);
+extern J9_CFUNC void j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval);
 extern J9_CFUNC void j9gc_set_allocation_threshold(J9VMThread* vmThread, UDATA low, UDATA high);
 extern J9_CFUNC void j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread, J9Object *dstObject);
 extern J9_CFUNC void j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass);

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -863,20 +863,20 @@ j9gc_allocation_threshold_changed(J9VMThread *currentThread)
  * 
  * Examples:
  * 	To trigger an event whenever 4K objects have been allocated:
- *		j9gc_set_allocation_sampling_interval(vmThread, (UDATA)4096);
+ *		j9gc_set_allocation_sampling_interval(vm, (UDATA)4096);
  *	To trigger an event for every object allocation:
- *		j9gc_set_allocation_sampling_interval(vmThread, (UDATA)0);
+ *		j9gc_set_allocation_sampling_interval(vm, (UDATA)0);
  * The initial MM_GCExtensions::oolObjectSamplingBytesGranularity value is 16M
  * or set by command line option "-Xgc:allocationSamplingGranularity".
  * By default, the sampling interval is going to be set to 512 KB.
  * 
- * @parm[in] vmThread The current VM Thread
+ * @parm[in] vm The J9JavaVM
  * @parm[in] samplingInterval The allocation sampling interval.
  */
 void 
-j9gc_set_allocation_sampling_interval(J9VMThread *vmThread, UDATA samplingInterval)
+j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval)
 {
-	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(vmThread->javaVM);
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(vm);
 	if (0 == samplingInterval) {
 		/* avoid (env->_oolTraceAllocationBytes) % 0 which could be undefined. */
 		samplingInterval = 1;

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -89,7 +89,7 @@ UDATA j9gc_get_object_size_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 j9object_t j9gc_get_memoryController(J9VMThread *vmContext, j9object_t objectPtr);
 void j9gc_set_memoryController(J9VMThread *vmThread, j9object_t objectPtr, j9object_t memoryController);
-void j9gc_set_allocation_sampling_interval(J9VMThread *vmThread, UDATA samplingInterval);
+void j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval);
 void j9gc_set_allocation_threshold(J9VMThread *vmThread, UDATA low, UDATA high);
 UDATA j9gc_get_bytes_allocated_by_thread(J9VMThread *vmThread);
 void j9gc_get_CPU_times(J9JavaVM *javaVM, U_64 *masterCpuMillis, U_64 *slaveCpuMillis, U_32 *maxThreads, U_32 *currentThreads);

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -385,7 +385,7 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 			 * or set by command line option -Xgc:allocationSamplingGranularity.
 			 * Set it to 512KB which is default sampling interval as per JEP 331 specification.
 			 */
-			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(currentThread, 512 * 1024);
+			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, 512 * 1024);
 			jvmtiData->flags |= J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED;
 		}
 #endif /* JAVA_SPEC_VERSION >= 11 */
@@ -478,8 +478,9 @@ jvmtiRelinquishCapabilities(jvmtiEnv* env,
 
 #if JAVA_SPEC_VERSION >= 11
 		if (capabilities_ptr->can_generate_sampled_object_alloc_events) {
-			/* The default sampling interval is not changed. */
 			jvmtiData->flags &= ~J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED;
+			/* Set sampling interval to UDATA_MAX to inform GC that sampling is not required */
+			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, UDATA_MAX);
 		}
 #endif /* JAVA_SPEC_VERSION >= 11 */
 

--- a/runtime/jvmti/jvmtiEventManagement.c
+++ b/runtime/jvmti/jvmtiEventManagement.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -173,6 +173,14 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 					break;
  			}
 		}
+#if JAVA_SPEC_VERSION >= 11
+		else if (JVMTI_DISABLE == mode) {
+			if (JVMTI_EVENT_SAMPLED_OBJECT_ALLOC == event_type) {
+				/* Set sampling interval to UDATA_MAX to inform GC that sampling is not required */
+				vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, UDATA_MAX);
+			}
+		}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 		/* Disallow certain events at the thread level */
 

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,6 +174,8 @@ disposeEnvironment(J9JVMTIEnv * j9env, UDATA freeData)
 #if JAVA_SPEC_VERSION >= 11
 		if (j9env->capabilities.can_generate_sampled_object_alloc_events) {
 			J9JVMTI_DATA_FROM_VM(vm)->flags &= ~J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED;
+			/* Set sampling interval to UDATA_MAX to inform GC that sampling is not required */
+			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, UDATA_MAX);
 		}
 #endif /* JAVA_SPEC_VERSION >= 11 */
 

--- a/runtime/jvmti/jvmtiMemory.c
+++ b/runtime/jvmti/jvmtiMemory.c
@@ -86,7 +86,6 @@ jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
 	jint samplingInterval)
 {
 	jvmtiError rc = JVMTI_ERROR_NONE;
-	J9VMThread *currentThread = NULL;
 	J9JavaVM *vm = JAVAVM_FROM_ENV(env);
 	
 	Trc_JVMTI_jvmtiSetHeapSamplingInterval_Entry(env, samplingInterval);
@@ -95,11 +94,8 @@ jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
 	ENSURE_CAPABILITY(env, can_generate_sampled_object_alloc_events);
 	ENSURE_NON_NEGATIVE(samplingInterval);
 
-	rc = getCurrentVMThread(vm, &currentThread);
-	if ((JVMTI_ERROR_NONE == rc) && (NULL != currentThread)) {
-		/* No negative samplingInterval, and there is no data lost when jint is casted to UDATA. */
-		vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(currentThread, samplingInterval);
-	}
+	/* No negative samplingInterval, and there is no data lost when jint is casted to UDATA. */
+	vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, samplingInterval);
 
 done:
 	TRACE_JVMTI_RETURN(jvmtiSetHeapSamplingInterval);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4082,7 +4082,7 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9mm_get_guaranteed_nursery_range)(struct J9JavaVM* javaVM, void** start, void** end) ;
 	UDATA  ( *j9gc_arraylet_getLeafSize)(struct J9JavaVM* javaVM) ;
 	UDATA  ( *j9gc_arraylet_getLeafLogSize)(struct J9JavaVM* javaVM) ;
-	void  ( *j9gc_set_allocation_sampling_interval)(struct J9VMThread *vmThread, UDATA samplingInterval);
+	void  ( *j9gc_set_allocation_sampling_interval)(struct J9JavaVM *vm, UDATA samplingInterval);
 	void  ( *j9gc_set_allocation_threshold)(struct J9VMThread *vmThread, UDATA low, UDATA high) ;
 	void  ( *j9gc_objaccess_recentlyAllocatedObject)(struct J9VMThread *vmThread, J9Object *dstObject) ;
 	void  ( *j9gc_objaccess_postStoreClassToClassLoader)(struct J9VMThread* vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass) ;


### PR DESCRIPTION
**Set sampling interval to UDATA_MAX to inform GC sampling is not required**

GC need to be informed that the allocation sampling has been disabled, and turn off related GC settings;
Set sampling interval to `UDATA_MAX` in three cases:
1. `can_generate_sampled_object_alloc_events` capability is removed;
2. `JVMTI_EVENT_SAMPLED_OBJECT_ALLOC` event is disabled;
3. The `JVMTI` environment enabled `JVMTI_EVENT_SAMPLED_OBJECT_ALLOC` is disposed.

Related https://github.com/eclipse/openj9/issues/7740 https://github.com/eclipse/openj9/pull/9254 https://github.com/eclipse/omr/pull/5071

Reviewer: @DanHeidinga 
FYI: @LinHu2016 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>