### PR TITLE
Add support to the installed cross-compiler for RISCV

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_riscv.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_riscv.mk
@@ -23,7 +23,7 @@
 include $(CONFIG_INCL_DIR)/configure_common.mk
 
 # The riscv64 cross toolchain is used for both 32bit and 64bit
-RISCV_CROSSTOOLS_PREFIX=riscv64-unknown-linux-gnu
+RISCV_CROSSTOOLS_PREFIX ?= riscv64-unknown-linux-gnu
 
 CONFIGURE_ARGS += \
     --enable-debug \
@@ -41,7 +41,7 @@ CONFIGURE_ARGS += \
 
 ifneq (,$(findstring _riscv64, $(SPEC)))
     CONFIGURE_ARGS += \
-        --host=riscv64-unknown-linux-gnu \
+        --host=$(RISCV_CROSSTOOLS_PREFIX) \
         --enable-OMR_ENV_DATA64 \
         'OMR_TARGET_DATASIZE=64'
 endif
@@ -66,7 +66,7 @@ ifneq (,$(findstring _cross, $(SPEC)))
     OBJCOPY=$(RISCV_CROSSTOOLS_PREFIX)-objcopy
 else
     CONFIGURE_ARGS += \
-        --build=riscv64-unknown-linux-gnu
+        --build=$(RISCV_CROSSTOOLS_PREFIX)
 
     ifeq (default,$(origin AR))
         AR=ar

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -27,9 +27,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <#elseif uma.spec.processor.aarch64>
   OBJCOPY := $(OPENJ9_CC_PREFIX)-objcopy
 <#elseif uma.spec.processor.riscv64 && uma.spec.flags.env_crossbuild.enabled>
-  AR := riscv64-unknown-linux-gnu-ar
-  AS := riscv64-unknown-linux-gnu-as
-  OBJCOPY := riscv64-unknown-linux-gnu-objcopy
+  RISCV_CROSSTOOLS_PREFIX ?= riscv64-unknown-linux-gnu
+  AR := $(RISCV_CROSSTOOLS_PREFIX)-ar
+  AS := $(RISCV_CROSSTOOLS_PREFIX)-as
+  OBJCOPY := $(RISCV_CROSSTOOLS_PREFIX)-objcopy
 <#else>
   OBJCOPY := objcopy
 </#if>


### PR DESCRIPTION
The change is to ensure the installed cross-compiler
is correctly set up on the host system from OpenJ9
perspective by changing the prefix of the cross-toolchain
if users prefer the installed cross-compiler rather than
building a cross-compiler from the source.

Issue: #7421

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>