### PR TITLE
Revert "Enable UNB Artifactory server"

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -52,7 +52,7 @@ artifactory:
   defaultGeo: 'osu'
   server:
     osu: 'ci-eclipse-openj9'
-    unb: 'ci-eclipse-openj9-unb'
+    #unb: 'ci-eclipse-openj9-unb' TEMP DISABLE. See #8817
   repo: 'ci-eclipse-openj9'
   numArtifacts:
     osu: 30


### PR DESCRIPTION
Reverts eclipse/openj9#9258

Some xlinux JVMs fail to upload for unexplained reasons, blocking testing and build promotions.

https://ci.eclipse.org/openj9/job/Build_JDK11_x86-64_linux_cm_OMR/556/
https://ci.eclipse.org/openj9/job/Build_JDK11_x86-64_linux_Nightly/353/
https://ci.eclipse.org/openj9/job/Build_JDK11_x86-64_linux_cm_Nightly/347/
https://ci.eclipse.org/openj9/job/Build_JDK11_x86-64_linux_cm_OMR/557/