### PR TITLE
Disable JProfiling and JitProfiling for JITServer

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2082,6 +2082,8 @@ J9::Options::setupJITServerOptions()
       self()->setOption(TR_DisableEDO); // JITServer limitation, EDO counters are not relocatable yet
       self()->setOption(TR_DisableMethodIsCold); // Shady heuristic; better to disable to reduce client/server traffic
       self()->setOption(TR_DisableDecimalFormatPeephole);// JITServer decimalFormatPeephole,
+      self()->setOption(TR_DisableJProfilerThread);
+      self()->setOption(TR_EnableJProfiling, false);
 
       if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
          {

--- a/runtime/compiler/control/J9Recompilation.hpp
+++ b/runtime/compiler/control/J9Recompilation.hpp
@@ -134,6 +134,7 @@ public:
 
 #if defined(J9VM_OPT_JITSERVER)
    static TR_PersistentJittedBodyInfo * persistentJittedBodyInfoFromString(const std::string &bodyInfoStr, const std::string &methodInfoStr, TR_Memory * trMemory);
+   static void resetPersistentProfileInfo(TR_PersistentMethodInfo *methodInfo);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 protected:

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -455,6 +455,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
          {
          _recompilationMethodInfo = new (PERSISTENT_NEW) TR_PersistentMethodInfo();
          memcpy(_recompilationMethodInfo, recompInfoStr.data(), sizeof(TR_PersistentMethodInfo));
+         J9::Recompilation::resetPersistentProfileInfo(_recompilationMethodInfo);
          }
       // Get the ROMClass for the method to be compiled if it is already cached
       // Or read it from the compilation request and cache it otherwise


### PR DESCRIPTION
JProfiling and JitProfiling are not supported by JITServer.
JProfiling is disabled by setting an option,
but for JitProfiling need to ensure that `TR_PersistentProfileInfo`
records do not get created and set pointers to them to NULL
on the server, if they do get created.