### PR TITLE
AArch64: Enable DLT

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1726,11 +1726,6 @@ onLoadInternal(
 #endif
 
 #if defined(TR_HOST_ARM64)
-   // DLT support is not available in AArch64 yet.
-   // OpenJ9 issue #5917 tracks the work to enable.
-   //
-   TR::Options::getCmdLineOptions()->setOption(TR_DisableDynamicLoopTransfer);
-
    // ArrayCopy transformations are not available in AArch64 yet.
    // OpenJ9 issue #6438 tracks the work to enable.
    //


### PR DESCRIPTION
This commit enables dynamic loop transfer (DLT) on AArch64.

Closes: #5917

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>