### PR TITLE
AArch64: Enable omrsigSupport

### DIFF
--- a/buildspecs/linux_aarch64.spec
+++ b/buildspecs/linux_aarch64.spec
@@ -222,7 +222,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="opt_zipSupport" value="true"/>
 		<flag id="opt_zlibCompression" value="true"/>
 		<flag id="opt_zlibSupport" value="true"/>
-		<flag id="port_omrsigSupport" value="false"/>
+		<flag id="port_omrsigSupport" value="true"/>
 		<flag id="port_signalSupport" value="true"/>
 		<flag id="prof_eventReporting" value="true"/>
 		<flag id="ras_dumpAgents" value="true"/>

--- a/buildspecs/linux_aarch64_cmprssptrs.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs.spec
@@ -223,7 +223,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="opt_zipSupport" value="true"/>
 		<flag id="opt_zlibCompression" value="true"/>
 		<flag id="opt_zlibSupport" value="true"/>
-		<flag id="port_omrsigSupport" value="false"/>
+		<flag id="port_omrsigSupport" value="true"/>
 		<flag id="port_signalSupport" value="true"/>
 		<flag id="prof_eventReporting" value="true"/>
 		<flag id="ras_dumpAgents" value="true"/>


### PR DESCRIPTION
This commit enables omrsigSupport in spec files for AArch64 Linux.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>