### PR TITLE
Get rid of align{Warm,Cold}CodeAlloc

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -35,7 +35,6 @@ namespace J9 { typedef CodeCache CodeCacheConnector; }
 #include "runtime/OMRCodeCache.hpp"
 #include "env/IO.hpp"
 #include "env/VMJ9.h"
-#include "OMR/Bytes.hpp" // Temporary
 
 struct J9MemorySegment;
 struct J9ClassLoader;
@@ -100,10 +99,6 @@ public:
                                                           int32_t cpIndex);
 
    OMR::CodeCacheHashEntry *  findUnresolvedMethod(void *constPool, int32_t constPoolIndex);
-
-   // Temporary
-   void alignWarmCodeAlloc(uint32_t round)  { _warmCodeAlloc = reinterpret_cast<uint8_t *>(OMR::align(reinterpret_cast<size_t>(_warmCodeAlloc), round)); }
-   void alignColdCodeAlloc(uint32_t round)  { _coldCodeAlloc = reinterpret_cast<uint8_t *>(OMR::align(reinterpret_cast<size_t>(_coldCodeAlloc), round)); }
 
   /**
    * @brief Restore warmCodeAlloc/coldCodeAlloc and trampoline pointers to their initial positions


### PR DESCRIPTION
No longer necessary; the APIs have been cleaned up in OMR.

See https://github.com/eclipse/omr/pull/4977.