### PR TITLE
Fix Java 15 build issues with updated JDK content

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -23,6 +23,10 @@
 package java.lang;
 
 import java.lang.annotation.Annotation;
+/*[IF Java15]*/
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+/*[ENDIF] Java15 */
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -390,6 +394,26 @@ final class Access implements JavaLangAccess {
 		System.loadLibrary(library);
 	}
 /*[ENDIF] Java14 */
+
+/*[IF Java15]*/
+	// TODO: implement support for hidden classes.
+
+	public Class<?> defineClass(ClassLoader classLoader, Class<?> clazz, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean option, int flags, Object obj) {
+		return null;
+	}
+
+	public ProtectionDomain protectionDomain(Class<?> clazz) {
+		return null;
+	}
+
+	public MethodHandle stringConcatHelper(String arg0, MethodType type) {
+		return null;
+	}
+
+	public Object classData(Class<?> clazz) {
+		return null;
+	}
+/*[ENDIF] Java15 */
 
 /*[ENDIF] Sidecar19-SE */
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4711,7 +4711,7 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 	 * For a class that is not a record, null is returned.
 	 * For a record with no components an empty array is returned.
 	 * 
-	 * @throws SecurityException 
+	 * @throws SecurityException if declared member access or package access is not allowed
 	 */
 	@CallerSensitive
 	public RecordComponent[] getRecordComponents() {
@@ -4730,4 +4730,11 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 
 	private native RecordComponent[] getRecordComponentsImpl();
 /*[ENDIF] Java14 */
+
+/*[IF Java15]*/
+	// TODO: implement support for hidden classes.
+	public boolean isHidden() {
+		return false;
+	}
+/*[ENDIF] Java15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2245,7 +2245,30 @@ public class MethodHandles {
 			return (!isWeakenedLookup() && (MODULE == (accessMode & MODULE)));
 		}
 		/*[ENDIF] Java14*/
-		/*[ENDIF]*/
+		/*[ENDIF] Sidecar19-SE */
+		
+		/*[IF Java15]*/
+		// TODO: implement support for hidden classes.
+
+		public enum ClassOption {
+			NESTMATE,
+			STRONG
+		}
+
+		static class ClassDefiner {
+			Class<?> defineClass(boolean option) {
+				return null;
+			}
+		}
+
+		public Lookup defineHiddenClass(byte[] bytes, boolean initOption, ClassOption... classOptions) {
+			return null;
+		}
+
+		ClassDefiner makeHiddenClassDefiner(String name, byte[] template) {
+			return null;
+		}
+		/*[ENDIF] Java15 */		
 	}
 	
 	static MethodHandle filterArgument(MethodHandle target, int pos, MethodHandle filter) {

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/BufferPoolMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,11 @@ import java.util.List;
 
 import javax.management.ObjectName;
 
-/*[IF Java12]*/
+/*[IF Java15]*/
+import jdk.internal.misc.VM.BufferPool;
+import jdk.internal.access.SharedSecrets;
+/*[ELSE]
+/*[IF Java12]
 import jdk.internal.access.JavaNioAccess.BufferPool;
 import jdk.internal.access.SharedSecrets;
 /*[ELSE]
@@ -38,8 +42,9 @@ import jdk.internal.misc.SharedSecrets;
 /*[ELSE]
 import sun.misc.JavaNioAccess.BufferPool;
 import sun.misc.SharedSecrets;
-/*[ENDIF]*/
-/*[ENDIF]*/
+/*[ENDIF] Sidecar19-SE */
+/*[ENDIF] Java12 */
+/*[ENDIF] Java15 */
 
 /**
  * The implementation MXBean for {@link java.lang.management.BufferPoolMXBean}.

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -84,6 +84,10 @@ static BOOLEAN isModuleJavaBase(j9object_t moduleName);
 static BOOLEAN isModuleNameGood(j9object_t moduleName);
 static UDATA allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Module * toModule);
 static void trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *j9FromMod, J9Module *j9ToMod);
+#if JAVA_SPEC_VERSION >= 15
+static void convertPackageName(char* packageName);
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 
 #if !defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
 /* These come from jvm.c */
@@ -690,6 +694,22 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
 	return retval;
 }
 
+#if JAVA_SPEC_VERSION >= 15
+/* Convert '.' to '/' in the package name. */
+static void
+convertPackageName(char* packageName)
+{
+	char ch = '\0';
+	char* p = packageName;
+	while ('\0' != (ch = *p)) {
+		if ('.' == ch) {
+			*p = '/';
+		}
+		p++;
+	}
+}
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 /**
  * Define a module containing the specified packages. It will create the module record in the  ClassLoader's module hash table and
  * create package records in the class loader's package hash table if necessary.
@@ -710,11 +730,57 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
  * @return If successful, returns a java.lang.reflect.Module object. Otherwise, returns NULL.
  */
 jobject JNICALL
+#if JAVA_SPEC_VERSION >= 15
+JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version, jstring location, jobjectArray packageArray)
+#else
 JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version, jstring location, const char* const* packages, jsize numPackages)
+#endif /* JAVA_SPEC_VERSION >= 15 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM * vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
+#if JAVA_SPEC_VERSION >= 15
+	BOOLEAN oom = FALSE;
+	BOOLEAN nullPackage = FALSE;
+	jsize numPackages = (NULL == packageArray) ? 0 : (*env)->GetArrayLength(env, packageArray);
+	PORT_ACCESS_FROM_ENV(env);
+	UDATA packagesNumBytes = sizeof(char*) * numPackages;
+	const char* * packages = (const char* *)j9mem_allocate_memory(packagesNumBytes, OMRMEM_CATEGORY_VM);
+	if ((*env)->ExceptionCheck(env)) {
+		goto cleanup;
+	}
+
+	if (NULL != packages) {
+		jsize pkgIndex = 0;
+		memset((void *)packages, 0, packagesNumBytes);
+		for (pkgIndex = 0; pkgIndex < numPackages; pkgIndex++) {
+			jobject packageObj = (*env)->GetObjectArrayElement(env, packageArray, pkgIndex);
+			if ((*env)->ExceptionCheck(env)) {
+				Assert_SC_unreachable();
+				goto cleanup;
+			}
+			if (NULL != packageObj) {
+				jboolean isCopy = JNI_FALSE;
+				const char* packageName = (*env)->GetStringUTFChars(env, packageObj, &isCopy);
+				(*env)->DeleteLocalRef(env, packageObj);
+
+				if (NULL == packageName) {
+					oom = TRUE;
+					break;
+				}
+				if (JNI_FALSE == isCopy) {
+					Assert_SC_unreachable();
+					goto cleanup;
+				}
+				convertPackageName((char*)packageName);
+				packages[pkgIndex] = packageName;
+			} else {
+				nullPackage = TRUE;
+				break;
+			}
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
@@ -722,6 +788,22 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 #else
 	f_monitorEnter(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL == packageArray) {
+		vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, J9NLS_VM_PACKAGES_IS_NULL);
+		goto done;
+	}
+	if ((NULL == packages) || oom) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+	if (nullPackage) {
+		vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, J9NLS_VM_PACKAGE_IS_NULL);
+		goto done;
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 	if (NULL == module) {
 		vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, J9NLS_VM_MODULE_IS_NULL);
 	} else {
@@ -851,6 +933,29 @@ done:
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
 	vmFuncs->internalExitVMToJNI(currentThread);
 
+#if JAVA_SPEC_VERSION >= 15
+cleanup:
+	if (NULL != packages) {
+		jsize pkgIndex = 0;
+		for (pkgIndex = 0; pkgIndex < numPackages; pkgIndex++) {
+			jobject packageObj = NULL;
+			const char* packageName = packages[pkgIndex];
+			if (NULL == packageName) {
+				break;
+			}
+
+			packageObj = (*env)->GetObjectArrayElement(env, packageArray, pkgIndex);
+			if ((*env)->ExceptionCheck(env)) {
+				Assert_SC_unreachable();
+				break;
+			}
+			(*env)->ReleaseStringUTFChars(env, packageObj, packageName);
+			(*env)->DeleteLocalRef(env, packageObj);
+		}
+		j9mem_free_memory((void *)packages);		
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 	return module;
 }
 
@@ -866,12 +971,26 @@ done:
  * 4) Package is not defined for fromModule's class loader
  * 5) Package is not in module fromModule.
  */
+#if JAVA_SPEC_VERSION >= 15
+void JNICALL
+JVM_AddModuleExports(JNIEnv * env, jobject fromModule, jstring packageObj, jobject toModule)
+#else
 void JNICALL
 JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobject toModule)
+#endif /* JAVA_SPEC_VERSION >= 15 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
+#if JAVA_SPEC_VERSION >= 15
+	jboolean isCopy = JNI_FALSE;
+	const char* package = (NULL == packageObj) ? NULL : (*env)->GetStringUTFChars(env, packageObj, &isCopy);
+	if ((NULL != package) && (JNI_FALSE == isCopy)) {
+		Assert_SC_unreachable();
+		(*env)->ReleaseStringUTFChars(env, packageObj, package);
+		package = NULL;
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
@@ -879,6 +998,19 @@ JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobj
 #else
 	f_monitorEnter(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL == packageObj) {
+		vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, J9NLS_VM_PACKAGE_IS_NULL);
+		goto done;
+	}
+	if (NULL == package) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+	convertPackageName((char*)package);
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 	if (NULL == toModule) {
 		vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, "module is null");
 	} else {
@@ -896,12 +1028,23 @@ JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobj
 			throwExceptionHelper(currentThread, rc);
 		}
 	}
+
+#if JAVA_SPEC_VERSION >= 15
+done:
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
 	omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
 #else
 	f_monitorExit(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
 	vmFuncs->internalExitVMToJNI(currentThread);
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL != package) {
+		(*env)->ReleaseStringUTFChars(env, packageObj, package);
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 }
 
 /**
@@ -913,12 +1056,26 @@ JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobj
  * 3) Package is not defined for fromModule's class loader
  * 4) Package is not in module fromModule.
  */
+#if JAVA_SPEC_VERSION >= 15
+void JNICALL
+JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, jstring packageObj)
+#else
 void JNICALL
 JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, const char *package)
+#endif /* JAVA_SPEC_VERSION >= 15 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
+#if JAVA_SPEC_VERSION >= 15
+	jboolean isCopy = JNI_FALSE;
+	const char* package = (NULL == packageObj) ? NULL : (*env)->GetStringUTFChars(env, packageObj, &isCopy);
+	if ((NULL != package) && (JNI_FALSE == isCopy)) {
+		Assert_SC_unreachable();
+		(*env)->ReleaseStringUTFChars(env, packageObj, package);
+		package = NULL;
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
@@ -926,6 +1083,19 @@ JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, const char *package)
 #else
 	f_monitorEnter(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL == packageObj) {
+		vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, J9NLS_VM_PACKAGE_IS_NULL);
+		goto done;
+	}
+	if (NULL == package) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+	convertPackageName((char*)package);
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 	{
 		UDATA rc = ERRCODE_GENERAL_FAILURE;
 
@@ -937,12 +1107,23 @@ JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, const char *package)
 			throwExceptionHelper(currentThread, rc);
 		}
 	}
+
+#if JAVA_SPEC_VERSION >= 15
+done:
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
 	omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
 #else
 	f_monitorExit(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
 	vmFuncs->internalExitVMToJNI(currentThread);
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL != package) {
+		(*env)->ReleaseStringUTFChars(env, packageObj, package);
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 }
 
 static void
@@ -1142,12 +1323,26 @@ JVM_AddModulePackage(JNIEnv * env, jobject module, const char *package)
  * 2) module is unnamed or
  * 3) package is not in module
  */
+#if JAVA_SPEC_VERSION >= 15
+void JNICALL
+JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, jstring packageObj)
+#else
 void JNICALL
 JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, const char *package)
+#endif /* JAVA_SPEC_VERSION >= 15 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
 	J9JavaVM const * const vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
+#if JAVA_SPEC_VERSION >= 15
+	jboolean isCopy = JNI_FALSE;
+	const char* package = (NULL == packageObj) ? NULL : (*env)->GetStringUTFChars(env, packageObj, &isCopy);
+	if ((NULL != package) && (JNI_FALSE == isCopy)) {
+		Assert_SC_unreachable();
+		(*env)->ReleaseStringUTFChars(env, packageObj, package);
+		package = NULL;
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
@@ -1155,6 +1350,19 @@ JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, const char *p
 #else
 	f_monitorEnter(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL == packageObj) {
+		vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, J9NLS_VM_PACKAGE_IS_NULL);
+		goto done;
+	}
+	if (NULL == package) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+	convertPackageName((char*)package);
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 	{
 		UDATA rc = ERRCODE_GENERAL_FAILURE;
 
@@ -1166,12 +1374,23 @@ JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, const char *p
 			throwExceptionHelper(currentThread, rc);
 		}
 	}
+
+#if JAVA_SPEC_VERSION >= 15
+done:
+#endif /* JAVA_SPEC_VERSION >= 15 */
+
 #if defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY)
 	omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
 #else
 	f_monitorExit(vm->classLoaderModuleAndLocationMutex);
 #endif /* defined(CALL_BUNDLED_FUNCTIONS_DIRECTLY) */
 	vmFuncs->internalExitVMToJNI(currentThread);
+
+#if JAVA_SPEC_VERSION >= 15
+	if (NULL != package) {
+		(*env)->ReleaseStringUTFChars(env, packageObj, package);
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 }
 
 jstring JNICALL

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1953,3 +1953,20 @@ J9NLS_VM_CLASS_RELATIONSHIP_INVALID.explanation=The specified child class fails 
 J9NLS_VM_CLASS_RELATIONSHIP_INVALID.system_action=The JVM will throw a java/lang/VerifyError.
 J9NLS_VM_CLASS_RELATIONSHIP_INVALID.user_response=Ensure that all class relationships are valid.
 # END NON-TRANSLATABLE
+
+# No arguments
+J9NLS_VM_PACKAGES_IS_NULL=Package array is null.
+# START NON-TRANSLATABLE
+J9NLS_VM_PACKAGES_IS_NULL.explanation=Incoming package array can't be NULL.
+J9NLS_VM_PACKAGES_IS_NULL.system_action=The JVM will throw a java/lang/NullPointerException.
+J9NLS_VM_PACKAGES_IS_NULL.user_response=Don't pass a NULL package array.
+# END NON-TRANSLATABLE
+
+# No arguments
+J9NLS_VM_PACKAGE_IS_NULL=Package String is null.
+# START NON-TRANSLATABLE
+J9NLS_VM_PACKAGE_IS_NULL.explanation=Incoming package String can't be NULL.
+J9NLS_VM_PACKAGE_IS_NULL.system_action=The JVM will throw a java/lang/NullPointerException.
+J9NLS_VM_PACKAGE_IS_NULL.user_response=Don't pass a NULL package String.
+# END NON-TRANSLATABLE
+

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2001, 2019 IBM Corp. and others
+dnl Copyright (c) 2001, 2020 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -269,18 +269,26 @@ _X(JVM_PrintStackTrace,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2)
 _X(JVM_SetField,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2, jint arg3)
 _X(JVM_SetPrimitiveField,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5)
 _X(JVM_SetNativeThreadName,JNICALL,true,void ,jint arg0, jobject arg1, jstring arg2)
-_IF([JAVA_SPEC_VERSION >= 9],
+_IF([(9 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 15)],
 	[_X(JVM_DefineModule,JNICALL,false,jobject,JNIEnv arg0, jobject arg1, jboolean arg2, jstring arg3, jstring arg4, const char* const* arg5, jsize arg6)])
-_IF([JAVA_SPEC_VERSION >= 9],
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_DefineModule,JNICALL,false,jobject,JNIEnv arg0, jobject arg1, jboolean arg2, jstring arg3, jstring arg4, jobjectArray arg5)])
+_IF([(9 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 15)],
 	[_X(JVM_AddModuleExports,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2, jobject arg3)])
-_IF([JAVA_SPEC_VERSION >= 9],
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_AddModuleExports,JNICALL,false,void,JNIEnv arg0, jobject arg1, jstring arg2, jobject arg3)])
+_IF([(9 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 15)],
 	[_X(JVM_AddModuleExportsToAll,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2, jobject arg3)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_AddModuleExportsToAll,JNICALL,false,void,JNIEnv arg0, jobject arg1, jstring arg2, jobject arg3)])
 _X(JVM_AddReadsModule,JNICALL,false,void ,JNIEnv arg0, jobject arg1, jobject arg2)
 _X(JVM_CanReadModule,JNICALL,false,jboolean ,JNIEnv arg0, jobject arg1, jobject arg2)
 _IF([JAVA_SPEC_VERSION >= 9],
 	[_X(JVM_AddModulePackage,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2)])
-_IF([JAVA_SPEC_VERSION >= 9],
+_IF([(9 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 15)],
 	[_X(JVM_AddModuleExportsToAllUnnamed,JNICALL,false,void,JNIEnv arg0, jobject arg1, const char *arg2)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_AddModuleExportsToAllUnnamed,JNICALL,false,void,JNIEnv arg0, jobject arg1, jstring arg2)])
 _X(JVM_GetSimpleBinaryName,JNICALL,false,jstring ,JNIEnv arg0, jclass arg1)
 _X(JVM_SetMethodInfo,JNICALL,false,void ,JNIEnv arg0, jobject arg1)
 _X(JVM_ConstantPoolGetNameAndTypeRefIndexAt,JNICALL,false,jint ,JNIEnv arg0, jobject arg1, jobject arg2, jint arg3)


### PR DESCRIPTION
Java 15 BufferPool class has moved to a different package.

Update Java 15 JVM_ Module functions parameters. Related to 8242452: During module definition, move conversion of packages from native to VM. The signature of JVM_DefineModule has been modified from `..., const char* const* packages, jsize numPackages` to `..., jobjectArray packages`.

Also the package parameter of following has been modified from char* to jstring.
JVM_AddModuleExports
JVM_AddModuleExportsToAllUnnamed
JVM_AddModuleExportsToAll

Stub in some initial Hidden Classes support.

Fixes #9278
Fixes: #9293