### PR TITLE
AArch64: Enable GlobalRegisterAllocation

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2634,13 +2634,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    //
    self()->setOption(TR_DisableEDO);
 
-   // Full support for GRA is not available on AArch64 yet, mainly to
-   // work out all the subtleties with GlRegDeps.
-   //
-   // OpenJ9 issue #6606 tracks the work to enable.
-   //
-   self()->setDisabled(OMR::tacticalGlobalRegisterAllocator, true);
-
    // Support for shuffling linkage registers to GRA registers is not
    // available on AArch64 yet.
    //


### PR DESCRIPTION
Enable `GlobalRegisterAllocation` on aarch64.

Depends on:
https://github.com/eclipse/omr/pull/5091
https://github.com/eclipse/omr/pull/5092
https://github.com/eclipse/omr/pull/5093
https://github.com/eclipse/omr/pull/5094
https://github.com/eclipse/omr/pull/5095

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>