### PR TITLE
Fix JITServer version incompatibility

### DIFF
--- a/runtime/compiler/net/Message.hpp
+++ b/runtime/compiler/net/Message.hpp
@@ -62,6 +62,14 @@ public:
       uint32_t _config; // includes JITServerCompatibilityFlags which must match
       MessageType _type;
       uint16_t _numDataPoints;
+
+      void init()
+         {
+         _version = 0;
+         _config = 0;
+         _type = MessageType_MAXTYPE;
+         _numDataPoints = 0;
+         }
       };
 
    /**
@@ -207,6 +215,8 @@ public:
       // These will be populated at a later time
       _buffer.reserveValue<uint32_t>(); // Reserve space for encoding the size
       _buffer.reserveValue<Message::MetaData>();
+
+      getMetaData()->init();
       }
 
    MetaData *getMetaData() const


### PR DESCRIPTION
The stream version incompatible error is caused when sending message `MessageType::clientSessionTerminate`, a new `ClientStream` is created and the `MetaData` is not properly initialized. Add an `init()` method to initialize the MetaData in Message constructor.

Fixes #9266

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>