### PR TITLE
CMake: Add j9vm_add_library and j9vm_add_executable

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -59,6 +59,7 @@ if(J9VM_IS_NON_STAGING)
 else()
 	set(OMR_TRACE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
+include(cmake/J9vmTargetSupport.cmake)
 include(OmrTracegen)
 include(OmrDDRSupport)
 include(cmake/build_tags.cmake)
@@ -255,7 +256,7 @@ endif()
 
 # j9vm_interface is used to hold properties we want to apply to everyone.
 # e.g. adding oti/ to the include path etc.
-add_library(j9vm_interface INTERFACE)
+j9vm_add_library(j9vm_interface INTERFACE)
 target_include_directories(j9vm_interface
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/oti
@@ -288,7 +289,7 @@ add_dependencies(j9vm_interface
 )
 
 # j9vm_gc_includes is used to track the include directories that are consumed by the various gc components
-add_library(j9vm_gc_includes INTERFACE)
+j9vm_add_library(j9vm_gc_includes INTERFACE)
 target_include_directories(j9vm_gc_includes
 	INTERFACE
 		# Pull in the public include paths exposed by the omrgc library
@@ -302,7 +303,7 @@ target_include_directories(j9vm_gc_includes
 )
 
 # Stub library to simplify programs which use makelib/cmain.c to provide a signal protected main
-add_library(j9vm_main_wrapper INTERFACE)
+j9vm_add_library(j9vm_main_wrapper INTERFACE)
 target_sources(j9vm_main_wrapper INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/makelib/cmain.c)
 target_link_libraries(j9vm_main_wrapper
 	INTERFACE

--- a/runtime/bcutil/CMakeLists.txt
+++ b/runtime/bcutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@ omr_add_tracegen(j9bcu.tdf)
 
 # We define an interface library containing all the sources here
 # this is to avoid having to retype the entire sources list for test/recompiled
-add_library(j9dyn_sources INTERFACE)
+j9vm_add_library(j9dyn_sources INTERFACE)
 target_sources(j9dyn_sources
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/bcutil.c
@@ -69,7 +69,7 @@ target_link_libraries(j9dyn_sources
 # also add explicit dependency on running tracegen, because cmake wont pick this up outside of this dir
 add_dependencies(j9dyn_sources trc_j9bcu)
 
-add_library(j9dyn STATIC)
+j9vm_add_library(j9dyn STATIC)
 target_compile_definitions(j9dyn PRIVATE J9_INTERNAL_TO_VM)
 
 target_include_directories(j9dyn

--- a/runtime/bcutil/test/dyntest/CMakeLists.txt
+++ b/runtime/bcutil/test/dyntest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 set_source_files_properties(${j9vm_BINARY_DIR}/bcutil/ut_j9bcu.c PROPERTIES GENERATED TRUE)
 
-add_executable(dyntest
+j9vm_add_executable(dyntest
 	intern_tests.cpp
 	lineNumber_tests.c
 	localVariableTable_tests.c

--- a/runtime/bcutil/test/natives/CMakeLists.txt
+++ b/runtime/bcutil/test/natives/CMakeLists.txt
@@ -24,7 +24,7 @@
 # We dont want to suffix vm version to bcuwhite_test
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(bcuwhite_test SHARED
+j9vm_add_library(bcuwhite_test SHARED
 	bcunatives.c
 )
 

--- a/runtime/bcutil/test/recompiled/CMakeLists.txt
+++ b/runtime/bcutil/test/recompiled/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
 set_source_files_properties(${j9vm_BINARY_DIR}/bcutil/ut_j9bcu.c PROPERTIES GENERATED TRUE)
-add_library(j9dyn_generic_test STATIC
+j9vm_add_library(j9dyn_generic_test STATIC
 
 	${j9vm_BINARY_DIR}/vm/ut_j9vm.c
 	${j9vm_SOURCE_DIR}/vm/stringhelpers.cpp

--- a/runtime/bcverify/CMakeLists.txt
+++ b/runtime/bcverify/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 
 add_tracegen(j9bcverify.tdf)
 
-add_library(j9bcv STATIC
+j9vm_add_library(j9bcv STATIC
 	bcverify.c
 	classrelationships.c
 	clconstraints.c

--- a/runtime/cassume/CMakeLists.txt
+++ b/runtime/cassume/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(ctest
+j9vm_add_executable(ctest
 	basesize.c
 	ctest.c
 	vatest.c

--- a/runtime/cfdumper/CMakeLists.txt
+++ b/runtime/cfdumper/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 ################################################################################
 
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
-add_executable(cfdump
+j9vm_add_executable(cfdump
 	main.c
 	pvdump.c
 	romdump.c

--- a/runtime/cmake/J9vmTargetSupport.cmake
+++ b/runtime/cmake/J9vmTargetSupport.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2020, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,53 +20,17 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-omr_add_tracegen(j9shr.tdf)
+include(OmrTargetSupport)
 
-j9vm_add_library(j9shrcommon STATIC
-	AttachedDataManagerImpl.cpp
-	ByteDataManagerImpl.cpp
-	CacheLifecycleManager.cpp
-	CacheMap.cpp
-	ClassDebugDataProvider.cpp
-	ClasspathItem.cpp
-	ClasspathManagerImpl2.cpp
-	CompiledMethodManagerImpl.cpp
-	CompositeCache.cpp
-	hookhelpers.cpp
-	Manager.cpp
-	ManagerHintTable.cpp
-	Managers.cpp
-	OSCache.cpp
-	OSCacheFile.cpp
-	OSCachemmap.cpp
-	OSCachesysv.cpp
-	OSCachevmem.cpp
-	ROMClassManagerImpl.cpp
-	ROMClassResourceManager.cpp
-	SCImplementedAPI.cpp
-	ScopeManagerImpl.cpp
-	shrinit.cpp
-	TimestampManagerImpl.cpp
-	${CMAKE_CURRENT_BINARY_DIR}/ut_j9shr.c
-)
-target_include_directories(j9shrcommon
-	PRIVATE
-		${j9vm_SOURCE_DIR}/shared
-		${j9vm_SOURCE_DIR}/shared_util
-		${j9vm_SOURCE_DIR}/verbose
-	PUBLIC
-		${CMAKE_CURRENT_BINARY_DIR}
-		include
-		.
-)
-target_link_libraries(j9shrcommon
-	PRIVATE
-		j9vm_interface
-		j9pool
-		j9hashtable
-		j9utilcore
-		j9util
-)
+# Currently j9vm_add_library and j9vm_add_executable just call
+# omr_add_library and omr_add_executable, but have them so that we can add
+# functionality in the future, without having to hunt down all the 
+# add_library/add_executable calls.
 
-target_enable_ddr(j9shrcommon GLOB_HEADERS)
-ddr_set_add_targets(j9ddr j9shrcommon)
+function(j9vm_add_library name)
+	omr_add_library("${name}" ${ARGN})
+endfunction()
+
+function(j9vm_add_executable name)
+	omr_add_executable("${name}" ${ARGN})
+endfunction()

--- a/runtime/cmake/compiler_config.cmake
+++ b/runtime/cmake/compiler_config.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 # used by the jit components.
 
 # TODO should probably rename to j9vm_jit_defines for less ambiguity
-add_library(j9vm_compiler_defines INTERFACE)
+j9vm_add_library(j9vm_compiler_defines INTERFACE)
 
 if(OMR_ENV_DATA64)
 	target_compile_definitions(j9vm_compiler_defines INTERFACE TR_64bit TR_HOST_64BIT TR_TARGET_64BIT)

--- a/runtime/codert_vm/CMakeLists.txt
+++ b/runtime/codert_vm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 ################################################################################
 
 add_tracegen(j9codertvm.tdf)
-add_library(j9codert_vm STATIC 
+j9vm_add_library(j9codert_vm STATIC
 	cache.c
 	cnathelp.cpp
 	CodertVMHelpers.cpp

--- a/runtime/cuda/CMakeLists.txt
+++ b/runtime/cuda/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 add_tracegen(cuda4j.tdf)
 
-add_library(cuda4j SHARED
+j9vm_add_library(cuda4j SHARED
 	CudaBuffer.cpp
 	CudaCommon.cpp
 	CudaDevice.cpp

--- a/runtime/dbgext/CMakeLists.txt
+++ b/runtime/dbgext/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9dbgext STATIC
+j9vm_add_library(j9dbgext STATIC
 	dbgpool.c
 	j9dbgext.c
 	trdbgext.c

--- a/runtime/ddr/CMakeLists.txt
+++ b/runtime/ddr/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9ddr_misc SHARED
+j9vm_add_library(j9ddr_misc SHARED
 	algorithm_versions.c
 	gcddr.cpp
 	jitflagsddr.c

--- a/runtime/dfix/test/CMakeLists.txt
+++ b/runtime/dfix/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(dfixtest
+j9vm_add_executable(dfixtest
 	main.cpp
 )
 

--- a/runtime/exelib/CMakeLists.txt
+++ b/runtime/exelib/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9exelib STATIC
+j9vm_add_library(j9exelib STATIC
 	common/libargs.c
 	common/libhlp.c
 	common/strbuf.c

--- a/runtime/gc/CMakeLists.txt
+++ b/runtime/gc/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gc SHARED
+j9vm_add_library(j9gc SHARED
 	dllinit.c
 	gctable.c
 

--- a/runtime/gc_api/CMakeLists.txt
+++ b/runtime/gc_api/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcapi STATIC
+j9vm_add_library(j9gcapi STATIC
 	GuaranteedNurseryRange.cpp
 	HeapIteratorAPI.cpp
 	HeapIteratorAPIBufferedIterator.cpp

--- a/runtime/gc_base/CMakeLists.txt
+++ b/runtime/gc_base/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcbase STATIC
+j9vm_add_library(j9gcbase STATIC
 	accessBarrier.cpp
 	AsyncCallbackHandler.cpp
 	ClassLoaderLinkedListIterator.cpp

--- a/runtime/gc_check/CMakeLists.txt
+++ b/runtime/gc_check/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gccheck STATIC
+j9vm_add_library(j9gccheck STATIC
 	Check.cpp
 	CheckClassHeap.cpp
 	CheckClassLoaders.cpp

--- a/runtime/gc_glue_java/CMakeLists.txt
+++ b/runtime/gc_glue_java/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9vm_gc_glue INTERFACE)
+j9vm_add_library(j9vm_gc_glue INTERFACE)
 target_sources(j9vm_gc_glue
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/ArrayletObjectModel.cpp
@@ -64,7 +64,7 @@ target_include_directories(j9vm_gc_glue
 		${j9vm_SOURCE_DIR}/gc_trace
 		${j9vm_SOURCE_DIR}/gc_vlhgc
 )
-add_library(j9vm_util_glue INTERFACE)
+j9vm_add_library(j9vm_util_glue INTERFACE)
 target_sources(j9vm_util_glue
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/UtilGlue.c
@@ -74,7 +74,7 @@ target_link_libraries(j9vm_util_glue
 		j9vm_interface
 )
 
-add_library(j9vm_core_glue INTERFACE)
+j9vm_add_library(j9vm_core_glue INTERFACE)
 target_sources(j9vm_core_glue
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/LanguageVMGlue.c
@@ -86,5 +86,5 @@ target_link_libraries(j9vm_core_glue
 )
 
 # Note: we dont actually need to add any glue for the vm or ras components
-add_library(j9vm_vm_glue INTERFACE)
-add_library(j9vm_ras_glue INTERFACE)
+j9vm_add_library(j9vm_vm_glue INTERFACE)
+j9vm_add_library(j9vm_ras_glue INTERFACE)

--- a/runtime/gc_modron_standard/CMakeLists.txt
+++ b/runtime/gc_modron_standard/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9modronstandard STATIC
+j9vm_add_library(j9modronstandard STATIC
 	ConcurrentSweepGC.cpp
 	OwnableSynchronizerObjectBufferStandard.cpp
 	ReadBarrierVerifier.cpp

--- a/runtime/gc_modron_startup/CMakeLists.txt
+++ b/runtime/gc_modron_startup/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9modronstartup STATIC
+j9vm_add_library(j9modronstartup STATIC
 	arrayCopy.cpp
 	gcmspace.cpp
 	GCVerboseInterface.cpp

--- a/runtime/gc_realtime/CMakeLists.txt
+++ b/runtime/gc_realtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9realtime STATIC
+j9vm_add_library(j9realtime STATIC
 	AllocationContextRealtime.cpp
 	ConfigurationRealtime.cpp
 	EnvironmentRealtime.cpp

--- a/runtime/gc_stats/CMakeLists.txt
+++ b/runtime/gc_stats/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcstats STATIC 
+j9vm_add_library(j9gcstats STATIC
 	CopyForwardStats.cpp
 	FrequentObjectsStats.cpp
 	MarkJavaStats.cpp

--- a/runtime/gc_structs/CMakeLists.txt
+++ b/runtime/gc_structs/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcstructs STATIC
+j9vm_add_library(j9gcstructs STATIC
 	ArrayletLeafIterator.cpp
 	CallSitesIterator.cpp
 	ClassArrayClassSlotIterator.cpp

--- a/runtime/gc_tests/hooktests/CMakeLists.txt
+++ b/runtime/gc_tests/hooktests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(hooktests SHARED
+j9vm_add_library(hooktests SHARED
 	gc_hooktests.c
 )
 

--- a/runtime/gc_tests/rwlocktests/CMakeLists.txt
+++ b/runtime/gc_tests/rwlocktests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(gc_rwlocktest
+j9vm_add_executable(gc_rwlocktest
 	gc_rwlocktest.cpp
 	main.cpp
 )

--- a/runtime/gc_trace/CMakeLists.txt
+++ b/runtime/gc_trace/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gctrc STATIC
+j9vm_add_library(j9gctrc STATIC
 	Tgc.cpp
 	TgcAllocation.cpp
 	TgcAllocationContext.cpp

--- a/runtime/gc_trace_standard/CMakeLists.txt
+++ b/runtime/gc_trace_standard/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gctrcstandard STATIC
+j9vm_add_library(j9gctrcstandard STATIC
 	TgcCompaction.cpp
 	TgcFreeListSummary.cpp
 	TgcLargeAllocation.cpp

--- a/runtime/gc_trace_vlhgc/CMakeLists.txt
+++ b/runtime/gc_trace_vlhgc/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gctrcvlhgc STATIC
+j9vm_add_library(j9gctrcvlhgc STATIC
 	TgcDynamicCollectionSet.cpp
 	TgcIntelligentCompact.cpp
 	TgcInterRegionReferences.cpp

--- a/runtime/gc_verbose_handler_realtime/CMakeLists.txt
+++ b/runtime/gc_verbose_handler_realtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvrbhdlrrealtime STATIC
+j9vm_add_library(j9gcvrbhdlrrealtime STATIC
 	VerboseHandlerOutputRealtime.cpp
 	VerboseHandlerRealtime.cpp
 )

--- a/runtime/gc_verbose_handler_standard_java/CMakeLists.txt
+++ b/runtime/gc_verbose_handler_standard_java/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvrbhdlrstandardjava STATIC
+j9vm_add_library(j9gcvrbhdlrstandardjava STATIC
 	VerboseHandlerOutputStandardJava.cpp
 )
 

--- a/runtime/gc_verbose_handler_vlhgc/CMakeLists.txt
+++ b/runtime/gc_verbose_handler_vlhgc/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvrbhdlrvlhgc STATIC
+j9vm_add_library(j9gcvrbhdlrvlhgc STATIC
 	VerboseHandlerOutputVLHGC.cpp
 	VerboseHandlerPlaceholder_vlhgc.cpp
 )

--- a/runtime/gc_verbose_java/CMakeLists.txt
+++ b/runtime/gc_verbose_java/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvrbjava STATIC
+j9vm_add_library(j9gcvrbjava STATIC
 	VerboseHandlerJava.cpp
 	VerboseJava.cpp
 	VerboseManagerJava.cpp

--- a/runtime/gc_verbose_old/CMakeLists.txt
+++ b/runtime/gc_verbose_old/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvrbold STATIC
+j9vm_add_library(j9gcvrbold STATIC
 	VerboseEventStream.cpp
 	VerboseFileLoggingOutput.cpp
 	VerboseManagerOld.cpp

--- a/runtime/gc_verbose_old_events/CMakeLists.txt
+++ b/runtime/gc_verbose_old_events/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvrbevents STATIC
+j9vm_add_library(j9gcvrbevents STATIC
 	VerboseEvent.cpp
 	VerboseEventAFEnd.cpp
 	VerboseEventClassUnloadingEnd.cpp

--- a/runtime/gc_vlhgc/CMakeLists.txt
+++ b/runtime/gc_vlhgc/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcvlhgc STATIC
+j9vm_add_library(j9gcvlhgc STATIC
 	AllocationContextBalanced.cpp
 	AllocationContextTarok.cpp
 	CardListFlushTask.cpp

--- a/runtime/gcchk/CMakeLists.txt
+++ b/runtime/gcchk/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9gcchk SHARED
+j9vm_add_library(j9gcchk SHARED
 	gcchk.cpp
 )
 

--- a/runtime/hookable/CMakeLists.txt
+++ b/runtime/hookable/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9hookable SHARED
+j9vm_add_library(j9hookable SHARED
 	# We just pull in the hookable objects built as part of OMR
 	# TODO: Do we want to just make omr build a shared lib and use that?
 	$<TARGET_OBJECTS:j9hook_obj>

--- a/runtime/j9vm/CMakeLists.txt
+++ b/runtime/j9vm/CMakeLists.txt
@@ -27,7 +27,7 @@ add_tracegen(j9scar.tdf)
 
 # Note we add all the actual sources to this interface library.
 # This is so that we can reuse them in jvm_b150/jvm_b156 without having to explicitly re-list all the files
-add_library(jvm_common INTERFACE)
+j9vm_add_library(jvm_common INTERFACE)
 target_sources(jvm_common INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/j7verify.c
 	${CMAKE_CURRENT_SOURCE_DIR}/j7vmi.c
@@ -62,7 +62,7 @@ target_include_directories(jvm_common
 		../jcl/
 )
 
-add_library(jvm SHARED ${CMAKE_CURRENT_BINARY_DIR}/ut_j9scar.c)
+j9vm_add_library(jvm SHARED ${CMAKE_CURRENT_BINARY_DIR}/ut_j9scar.c)
 target_link_libraries(jvm
 	PRIVATE
 		jvm_common

--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -24,7 +24,7 @@ set(J9VM_JCL_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 add_tracegen(j9jcl.tdf)
 
-add_library(jclse SHARED
+j9vm_add_library(jclse SHARED
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9jcl.c
 )
 

--- a/runtime/jextractnatives/CMakeLists.txt
+++ b/runtime/jextractnatives/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 # Don't append version suffix to j9jextract
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(j9jextract SHARED
+j9vm_add_library(j9jextract SHARED
 	jextractglue.c
 	jextractnatives.c
 	

--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(constgen
+j9vm_add_executable(constgen
     jilconsts.c
 )
 

--- a/runtime/jit_vm/CMakeLists.txt
+++ b/runtime/jit_vm/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9jit_vm STATIC
+j9vm_add_library(j9jit_vm STATIC
 	artifact.c
 	cthelpers.cpp
 	ctsupport.cpp

--- a/runtime/jitserver_launcher/CMakeLists.txt
+++ b/runtime/jitserver_launcher/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(jitserver
+j9vm_add_executable(jitserver
 	jitserver.c
 )
 

--- a/runtime/jnichk/CMakeLists.txt
+++ b/runtime/jnichk/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 add_tracegen(j9jni.tdf)
 
-add_library(j9jnichk SHARED
+j9vm_add_library(j9jnichk SHARED
 	jnicbuf.c
 	jnicheck.c
 	jnicmem.c

--- a/runtime/jniinv/CMakeLists.txt
+++ b/runtime/jniinv/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(invtest
+j9vm_add_executable(invtest
 	main.c
 )
 

--- a/runtime/jsigWrapper/CMakeLists.txt
+++ b/runtime/jsigWrapper/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 # We dont want to suffix vm version to shared libs
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(jsig SHARED
+j9vm_add_library(jsig SHARED
 	jsig.c
 )
 

--- a/runtime/jvmti/CMakeLists.txt
+++ b/runtime/jvmti/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 omr_add_tracegen(j9jvmti.tdf)
 
-add_library(j9jvmti SHARED
+j9vm_add_library(j9jvmti SHARED
 	jvmtiBreakpoint.c
 	jvmtiCapability.c
 	jvmtiClass.c

--- a/runtime/libffi/CMakeLists.txt
+++ b/runtime/libffi/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(ffi STATIC
+j9vm_add_library(ffi STATIC
 	closures.c
 	debug.c
 	java_raw_api.c

--- a/runtime/mgmt/CMakeLists.txt
+++ b/runtime/mgmt/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(management_ext SHARED
+j9vm_add_library(management_ext SHARED
 	mgmtinit.c
 )
 

--- a/runtime/port/CMakeLists.txt
+++ b/runtime/port/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 # we have to actually resolve the full paths to the source files (via omr_find_files and output in resolvedPaths)
 
 add_tracegen(common/j9prt.tdf)
-add_library(j9prt SHARED
+j9vm_add_library(j9prt SHARED
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9prt.c
 
 	# Pull in the objects compiled as part of the OMR port library

--- a/runtime/rasdump/CMakeLists.txt
+++ b/runtime/rasdump/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 ################################################################################
 
 add_tracegen(j9dmp.tdf)
-add_library(j9dmp SHARED
+j9vm_add_library(j9dmp SHARED
 	dmpagent.c
 	dmpmap.c
 	dmpqueue.c

--- a/runtime/rastrace/CMakeLists.txt
+++ b/runtime/rastrace/CMakeLists.txt
@@ -25,7 +25,7 @@ add_tracegen(j9trc.tdf)
 add_tracegen(j9trc_aux.tdf)
 add_tracegen(mt.tdf)
 
-add_library(j9trc SHARED
+j9vm_add_library(j9trc SHARED
 	method_trace.c
 	method_trigger.c
 	trccomponent.c

--- a/runtime/redirector/CMakeLists.txt
+++ b/runtime/redirector/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/generated.c" PROPERTIES
 ################################################################################
 # Redirector
 ################################################################################
-add_library(jvm_redirect SHARED
+j9vm_add_library(jvm_redirect SHARED
 	"${CMAKE_CURRENT_BINARY_DIR}/generated.c"
 	redirector.c
 )

--- a/runtime/runtimetools/agentbase/CMakeLists.txt
+++ b/runtime/runtimetools/agentbase/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(tools_agentbase STATIC
+j9vm_add_library(tools_agentbase STATIC
 	RuntimeToolsAgentBase.cpp
 	RuntimeToolsIntervalAgent.cpp
 )

--- a/runtime/runtimetools/balloon/CMakeLists.txt
+++ b/runtime/runtimetools/balloon/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(balloon SHARED
+j9vm_add_library(balloon SHARED
 	BalloonAgent.cpp
 )
 target_link_libraries(balloon

--- a/runtime/runtimetools/javacoregen/CMakeLists.txt
+++ b/runtime/runtimetools/javacoregen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(jcoregen SHARED
+j9vm_add_library(jcoregen SHARED
 	JavacoreGenAgent.cpp
 )
 

--- a/runtime/runtimetools/jlm/CMakeLists.txt
+++ b/runtime/runtimetools/jlm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(jlmagent SHARED
+j9vm_add_library(jlmagent SHARED
 	JLMAgent.cpp
 )
 

--- a/runtime/runtimetools/memorywatcher/CMakeLists.txt
+++ b/runtime/runtimetools/memorywatcher/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(memorywatcher SHARED
+j9vm_add_library(memorywatcher SHARED
 	MemoryWatcherAgent.cpp
 )
 

--- a/runtime/runtimetools/migration/CMakeLists.txt
+++ b/runtime/runtimetools/migration/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 # Dont append version suffix
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(migration SHARED
+j9vm_add_library(migration SHARED
 	MigrationAgent.cpp
 )
 

--- a/runtime/runtimetools/osmemory/CMakeLists.txt
+++ b/runtime/runtimetools/osmemory/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(osmemory SHARED
+j9vm_add_library(osmemory SHARED
 	OSMemoryAgent.cpp
 )
 

--- a/runtime/runtimetools/softmxtest/CMakeLists.txt
+++ b/runtime/runtimetools/softmxtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 # Dont append version suffix
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(softmxtest SHARED
+j9vm_add_library(softmxtest SHARED
 	SoftMxTest.cpp
 )
 

--- a/runtime/runtimetools/vmruntimestateagent/CMakeLists.txt
+++ b/runtime/runtimetools/vmruntimestateagent/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(vmruntimestateagent SHARED
+j9vm_add_library(vmruntimestateagent SHARED
 	VMRuntimeStateAgent.cpp
 )
 

--- a/runtime/shared/CMakeLists.txt
+++ b/runtime/shared/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9shr SHARED
+j9vm_add_library(j9shr SHARED
 	shrclssup.c
 )
 target_link_libraries(j9shr

--- a/runtime/shared_util/CMakeLists.txt
+++ b/runtime/shared_util/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9shrutil STATIC
+j9vm_add_library(j9shrutil STATIC
 	classpathcache.c
 	shcdatautils.c
 )

--- a/runtime/simplepool/CMakeLists.txt
+++ b/runtime/simplepool/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 add_tracegen(simplepool.tdf)
 
-add_library(j9simplepool STATIC
+j9vm_add_library(j9simplepool STATIC
 	simplepool.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_simplepool.c
 )

--- a/runtime/stackmap/CMakeLists.txt
+++ b/runtime/stackmap/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 add_tracegen(map.tdf)
 
-add_library(j9stackmap STATIC
+j9vm_add_library(j9stackmap STATIC
 	debuglocalmap.c
 	fixreturns.c
 	localmap.c

--- a/runtime/sunvmi/CMakeLists.txt
+++ b/runtime/sunvmi/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 add_tracegen(sunvmi.tdf)
 
-add_library(sunvmi STATIC
+j9vm_add_library(sunvmi STATIC
 	sunvmi.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_sunvmi.c
 )

--- a/runtime/tests/algorithm/CMakeLists.txt
+++ b/runtime/tests/algorithm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(algotest
+j9vm_add_executable(algotest
 	algotest.c
 	argscantest.c
 	primenumberhelpertest.c

--- a/runtime/tests/bcprof/CMakeLists.txt
+++ b/runtime/tests/bcprof/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(bcproftest SHARED
+j9vm_add_library(bcproftest SHARED
 	bcproftest.c
 )
 target_link_libraries(bcproftest

--- a/runtime/tests/bcverify/CMakeLists.txt
+++ b/runtime/tests/bcverify/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 ################################################################################
 
 set_source_files_properties(${j9vm_BINARY_DIR}/bcverify/ut_j9bcverify.c PROPERTIES GENERATED TRUE)
-add_library(bcuwhite SHARED
+j9vm_add_library(bcuwhite SHARED
 	natives/bcvnatives.c
 
 	#TODO do we really need to recompile these sources,
@@ -70,7 +70,7 @@ omr_add_exports(bcuwhite
 	Java_com_ibm_j9_test_bcverify_TestNatives_bcvCheckMethodName
 )
 
-add_library(bcvrelationships SHARED
+j9vm_add_library(bcvrelationships SHARED
 	relationships/bcvrelationships.c
 )
 

--- a/runtime/tests/cutest/CMakeLists.txt
+++ b/runtime/tests/cutest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(cutest STATIC
+j9vm_add_library(cutest STATIC
 	CuTest.c
 	parser.c
 	XMLBenchOutputWriter.cpp

--- a/runtime/tests/gp/CMakeLists.txt
+++ b/runtime/tests/gp/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 add_tracegen(gptest.tdf)
 
-add_library(gptest SHARED
+j9vm_add_library(gptest SHARED
 	gptest.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_gptest.c
 )

--- a/runtime/tests/j9vm/CMakeLists.txt
+++ b/runtime/tests/j9vm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9vmtest SHARED
+j9vm_add_library(j9vmtest SHARED
 	jvmjni.c
 )
 

--- a/runtime/tests/jni/CMakeLists.txt
+++ b/runtime/tests/jni/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9ben SHARED
+j9vm_add_library(j9ben SHARED
 	critical.c
 	DeadlockNativeTest.c
 	jnibench.c

--- a/runtime/tests/jniarg/CMakeLists.txt
+++ b/runtime/tests/jniarg/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(jniargtests SHARED
+j9vm_add_library(jniargtests SHARED
 	args_01.c
 	args_02.c
 	args_03.c

--- a/runtime/tests/jsig/CMakeLists.txt
+++ b/runtime/tests/jsig/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(jsigjnitest main.c)
+j9vm_add_executable(jsigjnitest main.c)
 
 target_link_libraries(jsigjnitest
     PRIVATE

--- a/runtime/tests/jvmtitests/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018, 2019 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,13 +20,13 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9vm_jvmtitest_includes INTERFACE)
+j9vm_add_library(j9vm_jvmtitest_includes INTERFACE)
 target_include_directories(j9vm_jvmtitest_includes
 	INTERFACE
 		"${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
-add_library(jvmtitest SHARED
+j9vm_add_library(jvmtitest SHARED
 	fakeref.c
 )
 target_link_libraries(jvmtitest

--- a/runtime/tests/jvmtitests/agent/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/agent/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(jvmti_test_agent STATIC
+j9vm_add_library(jvmti_test_agent STATIC
 	agent.c
 	args.c
 	error.c

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(jvmti_test_src STATIC
+j9vm_add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/addToBootstrapClassLoaderSearch/abcl001.c
 	com/ibm/jvmti/tests/addToBootstrapClassLoaderSearch/abcl002.c
 	com/ibm/jvmti/tests/addToBootstrapClassLoaderSearch/abcl003.c

--- a/runtime/tests/lazyclassload/CMakeLists.txt
+++ b/runtime/tests/lazyclassload/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9lazyClassLoad SHARED
+j9vm_add_library(j9lazyClassLoad SHARED
 	lazycloassload.c
 )
 target_link_libraries(j9lazyClassLoad

--- a/runtime/tests/loadLibraryTest/CMakeLists.txt
+++ b/runtime/tests/loadLibraryTest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(loadLibraryTest SHARED legacyLibraryName.c)
+j9vm_add_library(loadLibraryTest SHARED legacyLibraryName.c)
 
 set_target_properties(loadLibraryTest PROPERTIES SUFFIX ".jnilib")
 

--- a/runtime/tests/port/CMakeLists.txt
+++ b/runtime/tests/port/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(pltest
+j9vm_add_executable(pltest
 	j9cudaTest.c
 	j9dumpTest.c
 	j9errorTest.c

--- a/runtime/tests/props/CMakeLists.txt
+++ b/runtime/tests/props/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(propstest
+j9vm_add_executable(propstest
 	main.c
 	suite.c
 )

--- a/runtime/tests/redirector/genericlauncher/CMakeLists.txt
+++ b/runtime/tests/redirector/genericlauncher/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(glaunch genlauncher.c)
+j9vm_add_executable(glaunch genlauncher.c)
 
 target_link_libraries(glaunch
     PRIVATE

--- a/runtime/tests/redirector/jep178/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ elseif(OMR_OS_AIX)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -qpic -brtl -bexpall")
 endif()
 
-add_executable(testjep178_static
+j9vm_add_executable(testjep178_static
     static_agents.c
     static_libraries.c
     testjep178.c
@@ -48,7 +48,7 @@ target_link_libraries(testjep178_static
         ${CMAKE_DL_LIBS}
 )
 
-add_executable(testjep178_dynamic
+j9vm_add_executable(testjep178_dynamic
     testjep178.c
 )
 target_link_libraries(testjep178_dynamic

--- a/runtime/tests/redirector/jep178/testjvmtiA/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/testjvmtiA/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(testjvmtiA SHARED testjvmtiA.c)
+j9vm_add_library(testjvmtiA SHARED testjvmtiA.c)
 target_link_libraries(testjvmtiA PRIVATE j9vm_interface)
 omr_add_exports(testjvmtiA
     Agent_OnLoad

--- a/runtime/tests/redirector/jep178/testjvmtiB/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/testjvmtiB/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(testjvmtiB SHARED testjvmtiB.c)
+j9vm_add_library(testjvmtiB SHARED testjvmtiB.c)
 target_link_libraries(testjvmtiB PRIVATE j9vm_interface)
 omr_add_exports(testjvmtiB
     Agent_OnLoad

--- a/runtime/tests/redirector/jep178/testlibA/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/testlibA/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(testlibA SHARED testlibA.c)
+j9vm_add_library(testlibA SHARED testlibA.c)
 target_link_libraries(testlibA PRIVATE j9vm_interface)
 
 omr_add_exports(testlibA

--- a/runtime/tests/redirector/jep178/testlibB/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/testlibB/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(testlibB SHARED testlibB.c)
+j9vm_add_library(testlibB SHARED testlibB.c)
 target_link_libraries(testlibB PRIVATE j9vm_interface)
 
 omr_add_exports(testlibB

--- a/runtime/tests/redirector/nativevmargs/CMakeLists.txt
+++ b/runtime/tests/redirector/nativevmargs/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(nativevmargs testnativevmargs.c)
+j9vm_add_executable(nativevmargs testnativevmargs.c)
 
 target_link_libraries(nativevmargs
     PRIVATE

--- a/runtime/tests/shared/CMakeLists.txt
+++ b/runtime/tests/shared/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(shrtest
+j9vm_add_executable(shrtest
 	AOTDataMinMaxTest.cpp
 	AttachedDataMinMaxTest.cpp
 	AttachedDataTest.cpp
@@ -81,7 +81,7 @@ target_compile_definitions(shrtest
 		-DJ9VM_SHRTEST
 )
 
-add_library(SharedClassesNativeAgent SHARED
+j9vm_add_library(SharedClassesNativeAgent SHARED
 	jvmti/SharedClassesNativeAgent.c
 )
 

--- a/runtime/tests/shared_service/CMakeLists.txt
+++ b/runtime/tests/shared_service/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(servicetest
+j9vm_add_executable(servicetest
 	SharedService.c
 )
 

--- a/runtime/tests/thread/CMakeLists.txt
+++ b/runtime/tests/thread/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #re-enable version num suffix
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_SHARED_LIBRARY_SUFFIX})
 
-add_library(thread_cutest_harness STATIC
+j9vm_add_library(thread_cutest_harness STATIC
 	cuharness/CuTest.c
 	cuharness/parser.c
 )
@@ -44,7 +44,7 @@ target_link_libraries(thread_cutest_harness
 )
 
 
-add_library(j9thrtestnatives SHARED
+j9vm_add_library(j9thrtestnatives SHARED
 	testnatives/testnatives.c
 )
 
@@ -80,7 +80,7 @@ omr_add_exports(j9thrtestnatives
 	Java_j9vm_test_softmx_TestNatives_setAggressiveGCPolicy
 )
 
-add_library(j9thrnumanatives SHARED
+j9vm_add_library(j9thrnumanatives SHARED
 	thrnumanatives/thrnumanatives.c
 )
 
@@ -93,7 +93,7 @@ omr_add_exports(j9thrnumanatives
 	Java_com_ibm_j9_numa_NumaTest_getUsableNodeCount
 )
 
-add_executable(thrstatetest
+j9vm_add_executable(thrstatetest
 	thrstate/runtest.c
 	thrstate/testcases1.c
 	thrstate/testcases2.c

--- a/runtime/tests/vm/CMakeLists.txt
+++ b/runtime/tests/vm/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
-add_executable(vmtest
+j9vm_add_executable(vmtest
 	resolvefield_tests.c
 	testHelpers.c
 	vmstubs.c

--- a/runtime/tests/vm_lifecycle/CMakeLists.txt
+++ b/runtime/tests/vm_lifecycle/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_executable(vmLifecycleTests
+j9vm_add_executable(vmLifecycleTests
 	main.c
 )
 

--- a/runtime/thread/CMakeLists.txt
+++ b/runtime/thread/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 # Note: We just take the objects provided by omr.
 # TODO: Do we just want to make omr build a shared lib?
-add_library(j9thr SHARED
+j9vm_add_library(j9thr SHARED
 	$<TARGET_OBJECTS:j9thr_obj>
 )
 target_link_libraries(j9thr

--- a/runtime/thrtrace/CMakeLists.txt
+++ b/runtime/thrtrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 # Dont append version suffix
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-add_library(thrtrace SHARED
+j9vm_add_library(thrtrace SHARED
 	thrtrace.c
 )
 

--- a/runtime/util/CMakeLists.txt
+++ b/runtime/util/CMakeLists.txt
@@ -28,7 +28,7 @@ add_tracegen(srphashtable.tdf)
 
 j9vm_gen_asm(fpusup.m4)
 
-add_library(j9util STATIC
+j9vm_add_library(j9util STATIC
 	alignedmemcpy.c
 	annhelp.c
 	argbits.c

--- a/runtime/util_core/CMakeLists.txt
+++ b/runtime/util_core/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9utilcore STATIC
+j9vm_add_library(j9utilcore STATIC
 	j9argscan.c
 	j9shchelp.c
 	vmargs_core.c

--- a/runtime/verbose/CMakeLists.txt
+++ b/runtime/verbose/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 add_tracegen(j9vrb.tdf)
 
-add_library(j9vrb SHARED
+j9vm_add_library(j9vrb SHARED
 	errormessage_internal.c
 	errormessagebuffer.c
 	errormessageframeworkcfr.c

--- a/runtime/verutil/CMakeLists.txt
+++ b/runtime/verutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9verutil STATIC
+j9vm_add_library(j9verutil STATIC
 	cfrerr.c
 	chverify.c
 	sigverify.c

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -21,7 +21,7 @@
 ################################################################################
 
 omr_add_tracegen(j9vm.tdf)
-add_library(j9vm SHARED
+j9vm_add_library(j9vm SHARED
 	annsup.c
 	AsyncMessageHandler.cpp
 	bchelper.c

--- a/runtime/vmchk/CMakeLists.txt
+++ b/runtime/vmchk/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 add_tracegen(j9vmchk.tdf)
 
-add_library(j9vmchk SHARED
+j9vm_add_library(j9vmchk SHARED
 	checkclasses.c
 	checkclconstraints.c
 	checkinterntable.c

--- a/runtime/zip/CMakeLists.txt
+++ b/runtime/zip/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9zip STATIC
+j9vm_add_library(j9zip STATIC
 	zcpool.c
 	zipalloc.c
 	zipcache.c

--- a/runtime/zlib/CMakeLists.txt
+++ b/runtime/zlib/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-add_library(j9zlib SHARED
+j9vm_add_library(j9zlib SHARED
 	adler32.c
 	compress.c
 	crc32.c


### PR DESCRIPTION
Functions call their omr equivalents to ensure that targets get split
debug info.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>