### PR TITLE
Send CHTable updates with compilation requests

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -200,7 +200,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          done = true;
          break;
 
-      case MessageType::getUnloadedClassRanges:
+      case MessageType::getUnloadedClassRangesAndCHTable:
          {
          auto unloadedClasses = comp->getPersistentInfo()->getUnloadedClassAddresses();
          std::vector<TR_AddressRange> ranges;
@@ -209,7 +209,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             OMR::CriticalSection getAddressSetRanges(assumptionTableMutex);
             unloadedClasses->getRanges(ranges);
             }
-         client->write(response, ranges, unloadedClasses->getMaxRanges());
+         // Add the entire CHTable as well
+         auto table = (JITClientPersistentCHTable*)comp->getPersistentInfo()->getPersistentCHTable();
+         std::string encoded = FlatPersistentClassInfo::serializeHierarchy(table);
+
+         client->write(response, ranges, unloadedClasses->getMaxRanges(), encoded);
          break;
          }
 
@@ -3135,8 +3139,8 @@ remoteCompile(
    std::vector<TR_OpaqueClassBlock*> unloadedClasses(compInfo->getUnloadedClassesTempList()->begin(), compInfo->getUnloadedClassesTempList()->end());
    compInfo->getUnloadedClassesTempList()->clear();
    // Collect and encode the CHTable updates; this will acquire CHTable mutex
-   //auto table = (JITClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
-   //std::pair<std::string, std::string> chtableUpdates = table->serializeUpdates();
+   auto table = (JITClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+   std::pair<std::string, std::string> chtableUpdates = table->serializeUpdates();
    // Update the sequence number for these updates
    uint32_t seqNo = compInfo->getCompReqSeqNo();
    compInfo->incCompReqSeqNo();
@@ -3164,10 +3168,10 @@ remoteCompile(
             "Client sending compReq seqNo=%u to server for method %s @ %s.",
             seqNo, compiler->signature(), compiler->getHotnessName());
          }
-      client->buildCompileRequest(TR::comp()->getPersistentInfo()->getClientUID(), romMethodOffset,
-                                 method, clazz, *compInfoPT->getMethodBeingCompiled()->_optimizationPlan, detailsStr, details.getType(), unloadedClasses,
-                                 classInfoTuple, optionsStr, recompMethodInfoStr, seqNo, useAotCompilation);
-
+      client->buildCompileRequest(TR::comp()->getPersistentInfo()->getClientUID(), seqNo, romMethodOffset, method,
+                                  clazz, *compInfoPT->getMethodBeingCompiled()->_optimizationPlan, detailsStr,
+                                  details.getType(), unloadedClasses, classInfoTuple, optionsStr, recompMethodInfoStr,
+                                  chtableUpdates.first, chtableUpdates.second, useAotCompilation);
       JITServer::MessageType response;
       while(!handleServerMessage(client, compiler->fej9vm(), response));
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -287,23 +287,25 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    ClientSessionData *clientSession = NULL;
    try
       {
-      auto req = stream->readCompileRequest<uint64_t, uint32_t, J9Method *, J9Class*, TR_OptimizationPlan, std::string,
-         J9::IlGeneratorMethodDetailsType, std::vector<TR_OpaqueClassBlock*>,
-         JITServerHelpers::ClassInfoTuple, std::string, std::string, uint32_t, bool>();
+      auto req = stream->readCompileRequest<uint64_t, uint32_t, uint32_t, J9Method *, J9Class*, TR_OptimizationPlan, 
+         std::string, J9::IlGeneratorMethodDetailsType, std::vector<TR_OpaqueClassBlock*>, 
+         JITServerHelpers::ClassInfoTuple, std::string, std::string, std::string, std::string, bool>();
 
       clientId                           = std::get<0>(req);
-      uint32_t romMethodOffset           = std::get<1>(req);
-      J9Method *ramMethod                = std::get<2>(req);
-      J9Class *clazz                     = std::get<3>(req);
-      TR_OptimizationPlan clientOptPlan  = std::get<4>(req);
-      std::string detailsStr             = std::get<5>(req);
-      auto detailsType                   = std::get<6>(req);
-      auto &unloadedClasses              = std::get<7>(req);
-      auto &classInfoTuple               = std::get<8>(req);
-      std::string clientOptStr           = std::get<9>(req);
-      std::string recompInfoStr          = std::get<10>(req);
-      seqNo                              = std::get<11>(req); // Sequence number at the client
-      useAotCompilation                  = std::get<12>(req);
+      seqNo                              = std::get<1>(req); // Sequence number at the client
+      uint32_t romMethodOffset           = std::get<2>(req);
+      J9Method *ramMethod                = std::get<3>(req);
+      J9Class *clazz                     = std::get<4>(req);
+      TR_OptimizationPlan clientOptPlan  = std::get<5>(req);
+      std::string detailsStr             = std::get<6>(req);
+      auto detailsType                   = std::get<7>(req);
+      auto &unloadedClasses              = std::get<8>(req);
+      auto &classInfoTuple               = std::get<9>(req);
+      std::string clientOptStr           = std::get<10>(req);
+      std::string recompInfoStr          = std::get<11>(req);
+      const std::string &chtableUnloads  = std::get<12>(req);
+      const std::string &chtableMods     = std::get<13>(req);
+      useAotCompilation                  = std::get<14>(req);
 
       if (useAotCompilation)
          {
@@ -373,28 +375,60 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       clientSession->getSequencingMonitor()->exit();
 
       // At this point I know that all preceeding requests have been processed
-      // Free data for all classes that were unloaded for this sequence number
-      // Redefined classes are marked as unloaded, since they need to be cleared
-      // from the ROM class cache.
-      clientSession->processUnloadedClasses(stream, unloadedClasses); // this locks getROMMapMonitor()
-
-      auto chTable = (JITServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
-      // TODO: is chTable always non-null?
-      // TODO: we could send JVM info that is global and does not change together with CHTable
-      // The following will acquire CHTable monitor and VMAccess, send a message and then release them
-      bool initialized = chTable->initializeIfNeeded(_vm);
-
-      // A thread that initialized the CHTable does not have to apply the incremental update
-      if (!initialized)
+      // and only one thread can ever be present in this section
+      if (!clientSession->cachesAreCleared())
          {
+         // Free data for all classes that were unloaded for this sequence number
+         // Redefined classes are marked as unloaded, since they need to be cleared
+         // from the ROM class cache.
+         if (unloadedClasses.empty())
+            {
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d has no class to unload for clientUID %llu", 
+                  getCompThreadId(), (unsigned long long)clientId);
+            }
+          else
+            {
+            clientSession->processUnloadedClasses(unloadedClasses, true); // this locks getROMMapMonitor()
+            }
+
          // Process the CHTable updates in order
-         stream->write(JITServer::MessageType::CHTable_getClassInfoUpdates, JITServer::Void());
-         auto recv = stream->read<std::string, std::string>();
-         const std::string &chtableUnloads = std::get<0>(recv);
-         const std::string &chtableMods = std::get<1>(recv);
          // Note that applying the updates will acquire the CHTable monitor and VMAccess
+         auto chTable = (JITServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+         TR_ASSERT_FATAL(chTable->isInitialized() || (chtableUnloads.empty() && chtableMods.empty()), 
+                         "CHTable must have been initialized for clientUID=%llu", (unsigned long long)clientId);
          if (!chtableUnloads.empty() || !chtableMods.empty())
             chTable->doUpdate(_vm, chtableUnloads, chtableMods);
+         }
+      else // Internal caches are empty
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will ask for address ranges of unloaded classes and CHTable for clientUID %llu", 
+               getCompThreadId(), (unsigned long long)clientId);
+         stream->write(JITServer::MessageType::getUnloadedClassRangesAndCHTable, JITServer::Void());
+         auto response = stream->read<std::vector<TR_AddressRange>, int32_t, std::string>();
+         // TODO: we could send JVM info that is global and does not change together with CHTable
+         auto &unloadedClassRanges = std::get<0>(response);
+         auto maxRanges = std::get<1>(response);
+         std::string &serializedCHTable = std::get<2>(response);
+
+         clientSession->initializeUnloadedClassAddrRanges(unloadedClassRanges, maxRanges);
+         if (!unloadedClasses.empty())
+            {
+            // This function updates multiple caches based on the newly unloaded classes list. 
+            // Pass `false` here to indicate that we want the unloaded class ranges table cache excluded,
+            // since we just retrieved the entire table and it should therefore already be up to date.
+            clientSession->processUnloadedClasses(unloadedClasses, false);
+            }
+
+         auto chTable = (JITServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+         // Need CHTable mutex
+         TR_ASSERT_FATAL(!chTable->isInitialized(), "CHTable must be empty for clientUID=%llu", (unsigned long long)clientId);
+         if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "compThreadID=%d will initialize CHTable for clientUID %llu size=%zu", 
+               getCompThreadId(), (unsigned long long)clientId, serializedCHTable.size());
+         chTable->initializeCHTable(_vm, serializedCHTable);
+         clientSession->setCachesAreCleared(false);
          }
 
       clientSession->getSequencingMonitor()->enter();
@@ -534,9 +568,9 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
             getCompThreadId(), e.what());
 
       abortCompilation = true;
-      // If the client aborted this compilation it could have happened only while
-      // asking for CHTable updates and at that point the seqNo was not updated.
-      // We must update it now to allow for blocking threads to pass through.
+      // If the client aborted this compilation it could have happened only while asking for entire 
+      // CHTable and unloaded class address ranges and at that point the seqNo was not updated.
+      // We must update seqNo now to allow for blocking threads to pass through.
       clientSession->getSequencingMonitor()->enter();
       TR_ASSERT(seqNo == clientSession->getExpectedSeqNo(), "Unexpected seqNo");
       updateSeqNo(clientSession);

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -41,18 +41,8 @@ PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> &JITServer
    }
 
 bool
-JITServerPersistentCHTable::initializeIfNeeded(TR_J9VMBase *fej9)
+JITServerPersistentCHTable::initializeCHTable(TR_J9VMBase *fej9, const std::string &rawData)
    {
-      {
-      TR::ClassTableCriticalSection initializeIfNeeded(fej9);
-      auto& data = getData();
-      if (!data.empty())
-         return false; // this is the most frequent path
-      }
-
-   auto stream = TR::CompilationInfo::getStream();
-   stream->write(JITServer::MessageType::CHTable_getAllClassInfo, JITServer::Void());
-   std::string rawData = std::get<0>(stream->read<std::string>());
    if (rawData.length() == 0)
       return false;
    auto infos = FlatPersistentClassInfo::deserializeHierarchy(rawData);
@@ -67,7 +57,7 @@ JITServerPersistentCHTable::initializeIfNeeded(TR_J9VMBase *fej9)
          return true;
          }
       }
-      return false;
+   return false;
    }
 
 void 

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -58,7 +58,7 @@ public:
    JITServerPersistentCHTable(TR_PersistentMemory *);
 
    bool isInitialized() { return !getData().empty(); } // needs CHTable mutex in hand
-   bool initializeIfNeeded(TR_J9VMBase *fej9);
+   bool initializeCHTable(TR_J9VMBase *fej9, const std::string &rawData);
    void doUpdate(TR_J9VMBase *fej9, const std::string &removeStr, const std::string &modifyStr);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -92,7 +92,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 3;
+   static const uint16_t MINOR_NUMBER = 4;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -32,7 +32,7 @@ enum MessageType : uint16_t
    compilationFailure,
    mirrorResolvedJ9Method,
    get_params_to_construct_TR_j9method,
-   getUnloadedClassRanges,
+   getUnloadedClassRangesAndCHTable,
    compilationRequest, // type used when client sends remote compilation requests
    compilationInterrupted, // type used when client informs the server to abort the remote compilation
    clientSessionTerminate, // type used when client process is about to terminate
@@ -304,7 +304,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "compilationFailure", // 1
    "mirrorResolvedJ9Method", // 2
    "get_params_to_construct_TR_j9method", // 3
-   "getUnloadedClassRanges", // 4
+   "getUnloadedClassRangesAndCHTable", // 4
    "compilationRequest", // 5
    "compilationInterrupted", // 6
    "clientSessionTerminate", // 7

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -38,6 +38,7 @@ class TR_PersistentClassInfo;
 class J9ConstantPool;
 class TR_IPBytecodeHashTableEntry;
 class TR_MethodToBeCompiled;
+class TR_AddressRange;
 namespace JITServer { class ServerStream; }
 
 
@@ -346,14 +347,17 @@ class ClientSessionData
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> & getClassByNameMap() { return _classByNameMap; }
    PersistentUnorderedMap<J9Class *, UDATA *> & getClassChainDataCache() { return _classChainDataMap; }
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock*> & getConstantPoolToClassMap() { return _constantPoolToClassMap; }
-   void processUnloadedClasses(JITServer::ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes);
+   void initializeUnloadedClassAddrRanges(const std::vector<TR_AddressRange> &unloadedClassRanges, int32_t maxRanges);
+   void processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*> &classes, bool updateUnloadedClasses);
    TR::Monitor *getROMMapMonitor() { return _romMapMonitor; }
    TR::Monitor *getClassMapMonitor() { return _classMapMonitor; }
    TR::Monitor *getClassChainDataMapMonitor() { return _classChainDataMapMonitor; }
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry, bool isCompiled);
    VMInfo *getOrCacheVMInfo(JITServer::ServerStream *stream);
-   void clearCaches(); // destroys _chTableClassMap, _romClassMap and _J9MethodMap
+   void clearCaches(); // destroys _chTableClassMap, _romClassMap, _J9MethodMap and _unloadedClassAddresses
+   bool cachesAreCleared() const { return _requestUnloadedClasses; }
+   void setCachesAreCleared(bool b) { _requestUnloadedClasses = b; }
    TR_AddressSet& getUnloadedClassAddresses()
       {
       TR_ASSERT(_unloadedClassAddresses, "Unloaded classes address set should exist by now");


### PR DESCRIPTION
In this commit the list of unloaded classes and the serialized version
of the CHTable updates are sent to the JITServer together with the
compilation request, rather than in a separate message. This has
two advantages:
(1) Fewer messages
(2) Serialization of compilation requests is sped up because it does
not have to wait for a round trip to ask for CHTable updates.
If caches are cleared (this includes the server version of CHTable)
then JITServer will still have to ask for the entire set of ranges
of unloaded classes and the entire CHTable (not just modifications
since the last message).
All these updates are processed in order based on the seqNo sent by
the client.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>