### PR TITLE
Fix DDR errors cause by OMRs OMR_THR_YIELD_ALG checks

### DIFF
--- a/runtime/ddr/dummy_headers/unistd.h
+++ b/runtime/ddr/dummy_headers/unistd.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,3 +19,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+#ifndef UNISTD_H
+#define UNISTD_H
+
+/*
+ * Assume we have POSIX priority scheduling, so OMR
+ * doesn't complain it can't implement THREAD_YIELD_NEW.
+ */
+#define _POSIX_PRIORITY_SCHEDULING
+#endif


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>