### PR TITLE
Supporting Changes for mon(ent/exit) for value Types

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -148,7 +148,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
                                                             TR::Register *byteSrcReg, TR::Register *byteDstReg,
                                                             TR::Register *byteLenReg, TR::Node *byteLenNode,
                                                             TR_S390ScratchRegisterManager *srm, TR::LabelSymbol *mergeLabel);
-
 
 
    /*           START BCD Evaluators          */

--- a/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp
+++ b/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp
@@ -284,7 +284,9 @@ ReduceSynchronizedFieldLoad::performOnTreeTops(TR::TreeTop* startTreeTop, TR::Tr
          TR::Node* monentNode = iter.currentNode()->getOpCodeValue() == TR::monent ?
             iter.currentNode() :
             iter.currentNode()->getFirstChild();
-
+         // Locking on value types is prohibited by the spec., so this optimization can only be performed if we are certain (at compile time) the locking object is not a value type
+         if (TR::Compiler->om.areValueTypesEnabled() && cg->isMonitorValueType(monentNode) != TR_no)
+            continue;
          if (cg->comp()->getOption(TR_TraceCG))
             {
             traceMsg(cg->comp(), "Found monent [%p]\n", monentNode);
@@ -299,7 +301,6 @@ ReduceSynchronizedFieldLoad::performOnTreeTops(TR::TreeTop* startTreeTop, TR::Tr
                TR::Node* monexitNode = iter.currentNode()->getOpCodeValue() == TR::monexit ?
                   iter.currentNode() :
                   iter.currentNode()->getFirstChild();
-
                if (cg->comp()->getOption(TR_TraceCG))
                   {
                   traceMsg(cg->comp(), "Found monexit [%p]\n", monexitNode);


### PR DESCRIPTION
Add support for monitor enter/exit for value Types on IBM Z.

Closes: #9110

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>