### PR TITLE
Add null checks to aastore bytecode

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5942,10 +5942,18 @@ done:
 					rc = THROW_ARRAY_STORE;
 				} else {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-					J9Class *arrayrefClass = J9OBJECT_CLAZZ(_currentThread, arrayref);
-					if (J9_IS_J9CLASS_FLATTENED(arrayrefClass)) {
-						_objectAccessBarrier.copyObjectFieldsToFlattenedArrayElement(_currentThread, (J9ArrayClass *) arrayrefClass, value, (J9IndexableObject *) arrayref, index);
-					} else 
+					J9ArrayClass *arrayrefClass = (J9ArrayClass *) J9OBJECT_CLAZZ(_currentThread, arrayref);
+					if (J9_IS_J9CLASS_VALUETYPE(arrayrefClass->componentType)) {
+						if (NULL == value) {
+							rc = THROW_NPE;
+							goto done;
+						}
+						if (J9_IS_J9CLASS_FLATTENED(arrayrefClass)) {
+							_objectAccessBarrier.copyObjectFieldsToFlattenedArrayElement(_currentThread, arrayrefClass, value, (J9IndexableObject *) arrayref, index);
+						} else {
+							_objectAccessBarrier.inlineIndexableObjectStoreObject(_currentThread, arrayref, index, value);
+						}
+					} else
 #endif /* if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 					{
 						_objectAccessBarrier.inlineIndexableObjectStoreObject(_currentThread, arrayref, index, value);
@@ -5955,6 +5963,9 @@ done:
 				}
 			}
 		}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+done:
+#endif /* if defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		return rc;
 	}
 

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -672,7 +672,22 @@ public class ValueTypeTests {
 			Assert.fail("should throw error. Class does not exist");
 		} catch (NoClassDefFoundError e) {}
 	}
+	
+	@Test(priority=4)
+	static public void testNullWritesOnNonNullableArrays() throws Throwable {
+		Object arrayObject = Array.newInstance(point2DClass, 3);
+		try {
+			Array.set(arrayObject, 1, null);
+			Assert.fail("Should throw NPE. Cant write null to arrays of valuetypes");
+		} catch(NullPointerException e) {}
 
+		Object arrayObject2 = Array.newInstance(String.class, 3);
+		try {
+			Array.set(arrayObject2, 1, null);
+		} catch(NullPointerException e) {
+			Assert.fail("Should not throw NPE. Can write null to arrays of identity types");
+		}
+	}
 	
 	@Test(priority=2)
 	static public void testBasicACMPTestOnIdentityTypes() throws Throwable {


### PR DESCRIPTION
Add null checks to aastore bytecode

When storing a value into an array of valuetype elements the value
cannot be null since valuetypes are non-nullable.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>