### PR TITLE
String table read barrier

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -103,8 +103,8 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	J9MetronomeWriteBarrierJ9ClassStore,
 	J9ReadBarrier,
 	J9ReadBarrierJ9Class,
-	j9gc_objaccess_monitorTableReadObject,
-	j9gc_objaccess_monitorTableReadObjectVM,
+	j9gc_weakRoot_readObject,
+	j9gc_weakRoot_readObjectVM,
 	j9gc_ext_check_is_valid_heap_object,
 #if defined(J9VM_GC_FINALIZATION)
 	j9gc_get_objects_pending_finalization_count,

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -2013,13 +2013,13 @@ MM_ObjectAccessBarrier::preObjectRead(J9VMThread *vmThread, J9Object *srcObject,
 }
 
 bool
-MM_ObjectAccessBarrier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t *srcAddress)
+MM_ObjectAccessBarrier::preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress)
 {
 	return true;
 }
 
 bool
-MM_ObjectAccessBarrier::preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAddress)
+MM_ObjectAccessBarrier::preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress)
 {
 	return true;
 }

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -262,8 +262,8 @@ public:
 
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Object *srcObject, fj9object_t *srcAddress);
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Class *srcClass, j9object_t *srcAddress);
-	virtual bool preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
-	virtual bool preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAddress);
+	virtual bool preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
+	virtual bool preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress);
 	virtual bool postObjectRead(J9VMThread *vmThread, J9Object *srcObject, fj9object_t *srcAddress);
 	virtual bool postObjectRead(J9VMThread *vmThread, J9Class *srcClass, J9Object **srcAddress);
 

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -224,16 +224,7 @@ stringComparatorFn(struct J9AVLTree *tree, struct J9AVLTreeNode *leftNode, struc
 	stu8Ptr = *((UDATA*) (leftNode+1)); 
 
 	/* Get at the String information  */
-	right_s = *(j9object_t *)(rightNode+1);
-
-	if (!isMetronome) {
-		/* Check if string was copy-forwarded.  Only do this on non-metronome since metronome re-uses the FORWARDED bit */
-		MM_ScavengerForwardedHeader forwardedHeader(right_s, extensions);
-		J9Object* forwardedPtr = forwardedHeader.getForwardedObject();
-		if (NULL != forwardedPtr) {
-			right_s = forwardedPtr;
-		}
-	}
+	right_s = J9WEAKROOT_OBJECT_LOAD_VM(javaVM, (j9object_t *)(rightNode+1));
 
 	rightLength = J9VMJAVALANGSTRING_LENGTH_VM(javaVM, right_s);
 	right_p = J9VMJAVALANGSTRING_VALUE_VM(javaVM, right_s);
@@ -297,16 +288,7 @@ stringComparatorFn(struct J9AVLTree *tree, struct J9AVLTreeNode *leftNode, struc
 		U_32 i = 0;
 		bool leftCompressed = false;
 
-		left_s = *(j9object_t *)(leftNode+1);
-
-		if (!isMetronome) {
-			/* Check if string was copy-forwarded.  Only do this on non-metronome since metronome re-uses the FORWARDED bit */
-			MM_ScavengerForwardedHeader forwardedHeader(left_s, extensions);
-			J9Object* forwardedPtr = forwardedHeader.getForwardedObject();
-			if (NULL != forwardedPtr) {
-				left_s = forwardedPtr;
-			}
-		}
+		left_s = J9WEAKROOT_OBJECT_LOAD_VM(javaVM, (j9object_t *)(leftNode+1));
 
 		leftLength = J9VMJAVALANGSTRING_LENGTH_VM(javaVM, left_s);
 		left_p = J9VMJAVALANGSTRING_VALUE_VM(javaVM, left_s);

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -733,18 +733,18 @@ J9ReadBarrierJ9Class(J9VMThread *vmThread, j9object_t *srcAddress)
 }
 
 j9object_t
-j9gc_objaccess_monitorTableReadObject(J9VMThread *vmThread, j9object_t *srcAddress)
+j9gc_weakRoot_readObject(J9VMThread *vmThread, j9object_t *srcAddress)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread->javaVM)->accessBarrier;
-	barrier->preMonitorTableSlotRead(vmThread, srcAddress);
+	barrier->preWeakRootSlotRead(vmThread, srcAddress);
 	return *srcAddress;
 }
 
 j9object_t
-j9gc_objaccess_monitorTableReadObjectVM(J9JavaVM *vm, j9object_t *srcAddress)
+j9gc_weakRoot_readObjectVM(J9JavaVM *vm, j9object_t *srcAddress)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vm)->accessBarrier;
-	barrier->preMonitorTableSlotRead(vm, srcAddress);
+	barrier->preWeakRootSlotRead(vm, srcAddress);
 	return *srcAddress;
 }
 

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -195,8 +195,8 @@ extern J9_CFUNC void J9MetronomeWriteBarrierStore(J9VMThread *vmThread, J9Object
 extern J9_CFUNC void J9MetronomeWriteBarrierJ9ClassStore(J9VMThread *vmThread, J9Object *dstObject, J9Object **dstAddress, J9Object *srcObject);
 extern J9_CFUNC void J9ReadBarrier(J9VMThread *vmThread, fj9object_t *srcAddress);
 extern J9_CFUNC void J9ReadBarrierJ9Class(J9VMThread *vmThread, j9object_t *srcAddress);
-extern J9_CFUNC j9object_t j9gc_objaccess_monitorTableReadObject(J9VMThread *vmThread, j9object_t *srcAddress);
-extern J9_CFUNC j9object_t j9gc_objaccess_monitorTableReadObjectVM(J9JavaVM *vm, j9object_t *srcAddress);
+extern J9_CFUNC j9object_t j9gc_weakRoot_readObject(J9VMThread *vmThread, j9object_t *srcAddress);
+extern J9_CFUNC j9object_t j9gc_weakRoot_readObjectVM(J9JavaVM *vm, j9object_t *srcAddress);
 extern J9_CFUNC UDATA isStaticObjectAllocateFlags(J9JavaVM *javaVM);
 extern J9_CFUNC void J9FlushThreadLocalHeap(J9VMThread *vmContext);
 extern J9_CFUNC jvmtiIterationControl j9mm_iterate_region_objects(J9JavaVM *vm, J9PortLibrary *portLibrary, struct J9MM_IterateRegionDescriptor *region, UDATA flags, jvmtiIterationControl(*func)(J9JavaVM *vm, struct J9MM_IterateObjectDescriptor *objectDesc, void *userData), void *userData);

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.cpp
@@ -219,7 +219,7 @@ MM_ReadBarrierVerifier::preObjectRead(J9VMThread *vmThread, J9Class *srcClass, j
 }
 
 bool
-MM_ReadBarrierVerifier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t *srcAddress)
+MM_ReadBarrierVerifier::preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress)
 {
 	Assert_MM_true(vmThread->javaVM->internalVMFunctions->currentVMThread(vmThread->javaVM) == vmThread);
 	healSlot(_extensions, srcAddress);
@@ -227,7 +227,7 @@ MM_ReadBarrierVerifier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t
 }
 
 bool
-MM_ReadBarrierVerifier::preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAddress)
+MM_ReadBarrierVerifier::preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress)
 {
 	healSlot(_extensions, srcAddress);
 	return true;

--- a/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
+++ b/runtime/gc_modron_standard/ReadBarrierVerifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,8 +59,8 @@ public:
 
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Object *srcObject, fj9object_t *srcAddress);
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Class *srcClass, j9object_t *srcAddress);
-	virtual bool preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
-	virtual bool preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAddress);
+	virtual bool preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
+	virtual bool preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress);
 
 	void poisonSlot(MM_GCExtensionsBase *extensions, omrobjectptr_t *slot);
 	void poisonJniWeakReferenceSlots(MM_EnvironmentBase *env);

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -767,7 +767,7 @@ MM_StandardAccessBarrier::asConstantPoolObject(J9VMThread *vmThread, J9Object* t
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 bool
-MM_StandardAccessBarrier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t *srcAddress)
+MM_StandardAccessBarrier::preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress)
 {
 	omrobjectptr_t object = (omrobjectptr_t)*srcAddress;
 	bool const compressed = compressObjectReferences();
@@ -797,7 +797,7 @@ MM_StandardAccessBarrier::preMonitorTableSlotRead(J9VMThread *vmThread, j9object
 }
 
 bool
-MM_StandardAccessBarrier::preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAddress)
+MM_StandardAccessBarrier::preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress)
 {
 	omrobjectptr_t object = (omrobjectptr_t)*srcAddress;
 	bool const compressed = compressObjectReferences();

--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,8 +100,8 @@ public:
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Object *srcObject, fj9object_t *srcAddress);
 	/* off-heap slot (always non-compressed) */
 	virtual bool preObjectRead(J9VMThread *vmThread, J9Class *srcClass, j9object_t *srcAddress);
-	virtual bool preMonitorTableSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
-	virtual bool preMonitorTableSlotRead(J9JavaVM *vm, j9object_t *srcAddress);	
+	virtual bool preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
+	virtual bool preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress);	
 #endif	
 
 	bool preObjectStoreImpl(J9VMThread *vmThread, J9Object *destObject, fj9object_t *destAddress, J9Object *value, bool isVolatile);

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -557,18 +557,18 @@ typedef struct J9IndexableObject* mm_j9array_t;
 #endif /* defined (J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
 
 #if defined (J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
-#define J9MONITORTABLE_OBJECT_LOAD(vmThread, objectSlot) ((j9object_t)J9VMTHREAD_JAVAVM(vmThread)->memoryManagerFunctions->j9gc_objaccess_monitorTableReadObject((vmThread), (j9object_t *)(objectSlot)))
-#define J9MONITORTABLE_OBJECT_LOAD_VM(javaVM, objectSlot) ((j9object_t)(javaVM)->memoryManagerFunctions->j9gc_objaccess_monitorTableReadObjectVM(javaVM, (j9object_t *)(objectSlot)))
+#define J9WEAKROOT_OBJECT_LOAD(vmThread, objectSlot) ((j9object_t)J9VMTHREAD_JAVAVM(vmThread)->memoryManagerFunctions->j9gc_weakRoot_readObject((vmThread), (j9object_t *)(objectSlot)))
+#define J9WEAKROOT_OBJECT_LOAD_VM(javaVM, objectSlot) ((j9object_t)(javaVM)->memoryManagerFunctions->j9gc_weakRoot_readObjectVM(javaVM, (j9object_t *)(objectSlot)))
 #else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
-#define J9MONITORTABLE_OBJECT_LOAD(vmThread, objectSlot) \
+#define J9WEAKROOT_OBJECT_LOAD(vmThread, objectSlot) \
 		((J9_GC_READ_BARRIER_TYPE_NONE == (vmThread)->javaVM->gcReadBarrierType) ? \
 		(*(j9object_t *)(objectSlot)) : \
-		((j9object_t)J9VMTHREAD_JAVAVM(vmThread)->memoryManagerFunctions->j9gc_objaccess_monitorTableReadObject((vmThread), (j9object_t *)(objectSlot))))
+		((j9object_t)J9VMTHREAD_JAVAVM(vmThread)->memoryManagerFunctions->j9gc_weakRoot_readObject((vmThread), (j9object_t *)(objectSlot))))
 
-#define J9MONITORTABLE_OBJECT_LOAD_VM(javaVM, objectSlot) \
+#define J9WEAKROOT_OBJECT_LOAD_VM(javaVM, objectSlot) \
 		((J9_GC_READ_BARRIER_TYPE_NONE == (javaVM)->gcReadBarrierType) ? \
 		(*(j9object_t *)(objectSlot)) : \
-		((j9object_t)(javaVM)->memoryManagerFunctions->j9gc_objaccess_monitorTableReadObjectVM(javaVM, (j9object_t *)(objectSlot))))
+		((j9object_t)(javaVM)->memoryManagerFunctions->j9gc_weakRoot_readObjectVM(javaVM, (j9object_t *)(objectSlot))))
 
 #endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3963,8 +3963,8 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *J9MetronomeWriteBarrierJ9ClassStore)(struct J9VMThread *vmThread, J9Object *dstObject, J9Object **dstAddress, J9Object *srcObject) ;
 	void  ( *J9ReadBarrier)(struct J9VMThread *vmThread, fj9object_t *srcAddress);
 	void  ( *J9ReadBarrierJ9Class)(struct J9VMThread *vmThread, j9object_t *srcAddress);
-	j9object_t  ( *j9gc_objaccess_monitorTableReadObject)(struct J9VMThread *vmThread, j9object_t *srcAddress);
-	j9object_t  ( *j9gc_objaccess_monitorTableReadObjectVM)(struct J9JavaVM *vm, j9object_t *srcAddress);
+	j9object_t  ( *j9gc_weakRoot_readObject)(struct J9VMThread *vmThread, j9object_t *srcAddress);
+	j9object_t  ( *j9gc_weakRoot_readObjectVM)(struct J9JavaVM *vm, j9object_t *srcAddress);
 	UDATA  ( *j9gc_ext_check_is_valid_heap_object)(struct J9JavaVM *javaVM, j9object_t ptr, UDATA flags) ;
 #if defined(J9VM_GC_FINALIZATION)
 	UDATA  ( *j9gc_get_objects_pending_finalization_count)(struct J9JavaVM* vm) ;

--- a/runtime/util/jlm.c
+++ b/runtime/util/jlm.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,7 +183,7 @@ request_MonitorJlmDump(jvmtiEnv * env, J9VMJlmDump * jlmd, jint dump_format)
 			if (dump_format == COM_IBM_JLM_DUMP_FORMAT_TAGS) {
 				jlong tag = 0;
 					if (monitor->flags & J9THREAD_MONITOR_OBJECT) {
-					j9object_t object = J9MONITORTABLE_OBJECT_LOAD(vmThread, &monitor->userData);
+					j9object_t object = J9WEAKROOT_OBJECT_LOAD(vmThread, &monitor->userData);
 						/* Similar to jvmtiGetTag code, but with object being of object_t type */
 						if (object != NULL) {							
 						J9JVMTIObjectTag   entry;
@@ -314,7 +314,7 @@ GetMonitorName(J9VMThread *vmThread, J9ThreadAbstractMonitor *monitor, char *nam
 	PORT_ACCESS_FROM_VMC(vmThread);
 
 	if (monitor->flags & J9THREAD_MONITOR_OBJECT ) {
-		j9object_t object = J9MONITORTABLE_OBJECT_LOAD(vmThread, &monitor->userData);
+		j9object_t object = J9WEAKROOT_OBJECT_LOAD(vmThread, &monitor->userData);
 		J9Class *clazz;
 		char* objType;
 		J9ROMClass *romClass;

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -201,7 +201,7 @@ restart:
 			}
 			/* In a Concurrent GC where monitor object can *move* in a middle of GC cycle,
 			 * we need a proper barrier to get an up-to-date location of the monitor object */
-			j9objectmonitor_t volatile *lwEA = VM_ObjectMonitor::inlineGetLockAddress(currentThread, J9MONITORTABLE_OBJECT_LOAD(currentThread, &((J9ThreadMonitor*)monitor)->userData));
+			j9objectmonitor_t volatile *lwEA = VM_ObjectMonitor::inlineGetLockAddress(currentThread, J9WEAKROOT_OBJECT_LOAD(currentThread, &((J9ThreadMonitor*)monitor)->userData));
 			j9objectmonitor_t lockInLoop = J9_LOAD_LOCKWORD(currentThread, lwEA);
 			/* Change lockword from Learning to Flat if in Learning state. */
 			while (OBJECT_HEADER_LOCK_LEARNING == (lockInLoop & (OBJECT_HEADER_LOCK_LEARNING | OBJECT_HEADER_LOCK_INFLATED))) {


### PR DESCRIPTION
Replacing Collector (Scavenge) specific code in a middle of StringTable
code, with more generic barrier API.

Besides, the original code was not fully correct, since it was using
ForwardedHeader variant that is used for Partial GC in Balanced, that
is not aware of:
1) self forwarded pointer.
2) large object parallel copy protocol

All other code is just renaming various ReadBarrier APIs, giving them
more generic name that serves the same purpose for any kind of Weak
(Clearable) Root: just updates the slot in case object is already
forwarded, but does trigger a copy (keep it alive), even if in Evacuate
space.

This code has several more suspicious spots needing further scrutiny:
1) referring directly to Metronome and
2) reading object slots directly without using Read Barrier API
(currently, probably benign because those are pre=tenured objects not
subject to movement, but obviously not future-proof),
but the change does the bare minimum to fix a known problem.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>