### PR TITLE
AArch64: Add register allocation order list to private linkage

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -20,6 +20,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <algorithm>
+#include <iterator>
+
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64PrivateLinkage.hpp"
 #include "codegen/CallSnippet.hpp"
@@ -44,6 +47,74 @@
 #include "il/SymbolReference.hpp"
 #include "infra/Assert.hpp"
 #include "infra/List.hpp"
+
+uint32_t J9::ARM64::PrivateLinkage::_globalRegisterNumberToRealRegisterMap[] =
+   {
+   // GPRs
+   TR::RealRegister::x15,
+   TR::RealRegister::x14,
+   TR::RealRegister::x13,
+   TR::RealRegister::x12,
+   TR::RealRegister::x11,
+   TR::RealRegister::x10,
+   TR::RealRegister::x9,
+   TR::RealRegister::x8, // indirect result location register
+   TR::RealRegister::x18, // platform register
+   // callee-saved registers
+   TR::RealRegister::x28,
+   TR::RealRegister::x27,
+   TR::RealRegister::x26,
+   TR::RealRegister::x25,
+   TR::RealRegister::x24,
+   TR::RealRegister::x23,
+   TR::RealRegister::x22,
+   TR::RealRegister::x21,
+   // parameter registers
+   TR::RealRegister::x7,
+   TR::RealRegister::x6,
+   TR::RealRegister::x5,
+   TR::RealRegister::x4,
+   TR::RealRegister::x3,
+   TR::RealRegister::x2,
+   TR::RealRegister::x1,
+   TR::RealRegister::x0,
+
+   // FPRs
+   TR::RealRegister::v31,
+   TR::RealRegister::v30,
+   TR::RealRegister::v29,
+   TR::RealRegister::v28,
+   TR::RealRegister::v27,
+   TR::RealRegister::v26,
+   TR::RealRegister::v25,
+   TR::RealRegister::v24,
+   TR::RealRegister::v23,
+   TR::RealRegister::v22,
+   TR::RealRegister::v21,
+   TR::RealRegister::v20,
+   TR::RealRegister::v19,
+   TR::RealRegister::v18,
+   TR::RealRegister::v17,
+   TR::RealRegister::v16,
+   // callee-saved registers
+   TR::RealRegister::v15,
+   TR::RealRegister::v14,
+   TR::RealRegister::v13,
+   TR::RealRegister::v12,
+   TR::RealRegister::v11,
+   TR::RealRegister::v10,
+   TR::RealRegister::v9,
+   TR::RealRegister::v8,
+   // parameter registers
+   TR::RealRegister::v7,
+   TR::RealRegister::v6,
+   TR::RealRegister::v5,
+   TR::RealRegister::v4,
+   TR::RealRegister::v3,
+   TR::RealRegister::v2,
+   TR::RealRegister::v1,
+   TR::RealRegister::v0
+   };
 
 J9::ARM64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
    : J9::PrivateLinkage(cg),
@@ -116,6 +187,8 @@ J9::ARM64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
    _properties._argumentRegisters[13] = TR::RealRegister::v5;
    _properties._argumentRegisters[14] = TR::RealRegister::v6;
    _properties._argumentRegisters[15] = TR::RealRegister::v7;
+
+   std::copy(std::begin(_globalRegisterNumberToRealRegisterMap), std::end(_globalRegisterNumberToRealRegisterMap), std::begin(_properties._allocationOrder));
 
    _properties._firstIntegerReturnRegister = 0;
    _properties._firstFloatReturnRegister   = 1;

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -266,6 +266,10 @@ class PrivateLinkage : public J9::PrivateLinkage
     */
    TR::Instruction *_jittedMethodEntryPoint;
 
+   private:
+
+   // Tactical GRA
+   static uint32_t _globalRegisterNumberToRealRegisterMap[];
    };
 
 


### PR DESCRIPTION
Add register allocation order list to `ARM64PrivateLinkage`.

Depends on https://github.com/eclipse/omr/pull/5109

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>