### PR TITLE
Remove use of '--enable-OMR_ENV_GCC'

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
@@ -47,7 +47,6 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_GCC \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
@@ -89,7 +88,6 @@ ifeq (linux_ppc-64_le_gcc, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_DOUBLE_MAP_ARRAYLETS \
-		--enable-OMR_ENV_GCC \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \


### PR DESCRIPTION
Once #9320 is merged, OpenJ9 will no longer have any references to `OMR_ENV_GCC`.