### PR TITLE
Java 14: track interrupt state when thread is dead

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,6 +80,14 @@ public class Thread implements Runnable {
 	// Instance variables
 	private long threadRef;									// Used by the VM
 	long stackSize = 0;
+	/*[IF Java14]*/
+	/* deadInterrupt tracks the thread interrupt state when threadRef has no reference (ie thread is not alive). 
+	 * Note that this value need not be updated while the thread is running since the interrupt state will be 
+	 * tracked by the vm during that time. Because of this the value should not be used over calling
+	 * isInterrupted() or interrupted().
+	 */
+	private volatile boolean deadInterrupt;
+	/*[ENDIF] Java14 */
 	private volatile boolean started;				// If !isAlive(), tells if Thread died already or hasn't even started
 	private String name;						// The Thread's name
 	private int priority = NORM_PRIORITY;			// The Thread's current priority
@@ -677,6 +685,10 @@ public final ThreadGroup getThreadGroup() {
 
 /**
  * Posts an interrupt request to the receiver
+ * 
+/*[IF Java14]
+ * From Java 14, the interrupt state for threads that are not alive is tracked.
+/*[ENDIF]
  *
  * @exception	SecurityException
  *					if <code>group.checkAccess()</code> fails with a SecurityException
@@ -700,7 +712,12 @@ public void interrupt() {
 		sun.nio.ch.Interruptible localBlockOn = blockOn;
 		if (localBlockOn != null) {
 			localBlockOn.interrupt(this);
-		}
+        }
+        /*[IF Java14]*/
+        if (!isAlive()) {
+		deadInterrupt = true;
+        }
+        /*[ENDIF] Java 14 */
 	}
 }
 
@@ -721,6 +738,10 @@ public static native boolean interrupted();
 
 /**
  * Posts an interrupt request to the receiver
+ * 
+/*[IF Java14]
+ * From Java 14, the interrupt state for threads that are not alive is tracked.
+/*[ENDIF]
  *
  * @see			Thread#interrupted
  * @see			Thread#isInterrupted 
@@ -788,6 +809,11 @@ public final boolean isDaemon() {
  */
 public boolean isInterrupted() {
 	synchronized(lock) {
+		/*[IF Java14]*/
+		if (!isAlive()) {
+			return deadInterrupt;
+		}
+		/*[ENDIF] Java14 */
 		return isInterruptedImpl();
 	}
 }
@@ -1525,6 +1551,11 @@ void uncaughtException(Throwable e) {
  * @see J9VMInternals#threadCleanup()
  */
 void cleanup() {
+/*[IF Java14]*/
+	/* Refresh deadInterrupt value so it is accurate when thread reference is removed. */	
+	deadInterrupt = interrupted();
+/*[ENDIF]*/
+
 /*[IF Java11]*/
 	if (threadLocals != null && TerminatingThreadLocal.REGISTRY.isPresent()) {
 		TerminatingThreadLocal.threadTerminated();

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -166,6 +166,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/Thread" name="threadRef" signature="J" cast="struct J9VMThread *"/>
 	<fieldref class="java/lang/Thread" name="stackSize" signature="J"/>
 	<fieldref class="java/lang/Thread" name="tid" signature="J"/>
+	<fieldref class="java/lang/Thread" name="deadInterrupt" signature="Z" versions="14-"/>
 	<fieldref class="java/lang/Thread" name="started" signature="Z"/>
 	<fieldref class="java/lang/Thread" name="name" signature="Ljava/lang/String;"/>
 

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1958,6 +1958,13 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 		J9VMJAVALANGTHREAD_SET_LOCK(currentThread, threadObject, lock);
 	}
 	J9VMJAVALANGTHREAD_SET_THREADREF(currentThread, threadObject, newThread);
+
+#if (JAVA_SPEC_VERSION >= 14)
+    /* If thread was interrupted before start, make sure interrupt flag is set for running thread. */
+    if (J9VMJAVALANGTHREAD_DEADINTERRUPT(currentThread, threadObject)) {
+        omrthread_interrupt(osThread);
+    }
+#endif
 
 	/* Allow the thread to run */
 

--- a/test/functional/Java14andUp/playlist.xml
+++ b/test/functional/Java14andUp/playlist.xml
@@ -23,28 +23,50 @@
 -->
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
-      <test>
-          <testCaseName>Jep359Tests</testCaseName>
-          <variations>
-                  <variation>NoOptions</variation>
-          </variations>
-          <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-                  --enable-preview \
-                  -cp $(Q)$(LIB_DIR)$(D)asm-7.3.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-                  org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Jep359Tests \
-                  -groups $(TEST_GROUP) \
-                  -excludegroups $(DEFAULT_EXCLUDE); \
-                  $(TEST_STATUS)
-          </command>
-          <levels>
-                  <level>sanity</level>
-          </levels>
-          <groups>
-                  <group>functional</group>
-          </groups>
-          <!-- Run for Java 14 only since this is a preview feature. -->
-          <subsets>
-                  <subset>14</subset>
-          </subsets>
-        </test>
+    <test>
+        <testCaseName>Jep359Tests</testCaseName>
+        <variations>
+            <variation>--enable-preview</variation>
+        </variations>
+        <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+            -cp $(Q)$(LIB_DIR)$(D)asm-7.3.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+            org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Jep359Tests \
+            -groups $(TEST_GROUP) \
+            -excludegroups $(DEFAULT_EXCLUDE); \
+            $(TEST_STATUS)
+        </command>
+        <levels>
+            <level>sanity</level>
+        </levels>
+        <groups>
+            <group>functional</group>
+        </groups>
+        <!-- Run for Java 14 only since this is a preview feature. -->
+        <subsets>
+            <subset>14</subset>
+        </subsets>
+    </test>
+    <test>
+        <testCaseName>ThreadInterruptImplTest</testCaseName>
+        <variations>
+            <!-- enable-preview is needed here because JEP 359 test class files will be included on the classpath. -->
+            <variation>--enable-preview</variation>
+        </variations>
+        <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+            -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+            org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ThreadInterruptImplTest \
+            -groups $(TEST_GROUP) \
+            -excludegroups $(DEFAULT_EXCLUDE); \
+            $(TEST_STATUS)
+        </command>
+        <levels>
+            <level>sanity</level>
+        </levels>
+        <groups>
+            <group>functional</group>
+        </groups>
+        <subsets>
+            <subset>14+</subset>
+        </subsets>
+    </test>
 </playlist>

--- a/test/functional/Java14andUp/src/org/openj9/test/java/lang/Test_Thread.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/java/lang/Test_Thread.java
@@ -1,0 +1,171 @@
+package org.openj9.test.java.lang;
+
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+
+/**
+ * This test is to verify matching behavior to the RI from the following implementation change
+ * discussed in the Java 14 release notes:
+ * 
+ * "The specification for java.lang.Thread::interrupt allows for an implementation to only track the 
+ * interrupt state for live threads, and previously this is what occurred. As of this release, the 
+ * interrupt state of a Thread is always available, and if you interrupt a thread t before it is started, 
+ * or after it has terminated, the query t.isInterrupted() will return true."
+ */
+
+@Test(groups = { "level.sanity" })
+public class Test_Thread {
+
+    /* interrupt thread after it has ended */
+    @Test
+    public void test_interruptAfterRun() throws Throwable {
+        String name = "interruptAfterRun: ";
+        Thread t = new Thread();
+
+        /* run thread */
+        t.start();
+        t.join();
+
+        /* Verify thread is dead and has not been interrupted */
+        AssertJUnit.assertFalse(name + "thread should not be alive", t.isAlive());
+        AssertJUnit.assertFalse(name + "interrupt flag should not be set", t.isInterrupted());
+        
+        t.interrupt();
+
+        /* Verify that the thread was successfully interrupted. */
+        AssertJUnit.assertTrue(name + "thread that has ended was was interrupted", t.isInterrupted());    
+    }
+
+    /* Verify that thread was sucessfully interrupted before it is started, and that the interrupt flag is 
+     * still set after it is run. */
+    @Test
+    public void test_interruptAtStartSetAfterRun() throws Throwable {
+        String name = "interruptAtStartSetAfterRun: ";
+        Thread t = new Thread();
+
+        /* Verify thread is dead and has not been interrupted */
+        AssertJUnit.assertFalse(name + "thread should not be alive", t.isAlive());
+        AssertJUnit.assertFalse(name + "interrupt flag should not be set", t.isInterrupted());
+
+        t.interrupt();
+
+        /* Verify that the thread was successfully interrupted. */
+        AssertJUnit.assertTrue(name + "thread that has not started should have interrupt flag set", t.isInterrupted());
+
+        /* run thread */
+        t.start();
+        t.join();
+
+        /* Verify thread is dead and has been interrupted */
+        AssertJUnit.assertFalse(name + "thread should be dead", t.isAlive());
+        AssertJUnit.assertTrue(name + "interrupt flag should be set", t.isInterrupted()); 
+    }
+
+    /* Interrupt thread during run, verify that interrupt flag is not set when thread stops running. 
+     * isInterrupted becomes false after InterruptedException is thrown. */
+    private volatile boolean bool_interruptDuringRun = false;
+    @Test
+    public void test_interruptDuringRun() throws Throwable {
+        String name = "interruptDuringRun: ";
+        Thread t = new Thread() {
+            public void run() {
+                synchronized(this) {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        /* expected */
+                        bool_interruptDuringRun = true;
+                    }
+                }
+            }
+        };
+
+        /* run thread */
+        t.start();
+        AssertJUnit.assertFalse(name + "thread not yet interrupted during run", t.isInterrupted());
+        t.interrupt();
+        t.join();
+
+        AssertJUnit.assertTrue(name + "InterruptedException was thrown during run", bool_interruptDuringRun);
+
+        /* Verify thread is dead and has not been interrupted */
+        AssertJUnit.assertFalse(name + "thread should be dead", t.isAlive());
+        AssertJUnit.assertFalse(name + "interrupt flag should not be set", t.isInterrupted()); 
+    }
+
+    /* Interrupt thread at start and during run, verify that interrupt flag is not set when thread stops running.
+     * isInterrupted becomes false after InterruptedException is thrown. */
+    private volatile boolean bool_interruptBeforeAndDuringRun = false;
+    @Test
+    public void test_interruptBeforeAndDuringRun() throws Throwable {
+        String name = "interruptBeforeAndDuringRun: ";
+        Thread t = new Thread() {
+            public void run() {
+                synchronized(this) {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        bool_interruptBeforeAndDuringRun = true;
+                    }
+                }
+            }
+        };
+
+        /* Verify thread is dead and has not been interrupted */
+        AssertJUnit.assertFalse(name + "thread should not be alive", t.isAlive());
+        AssertJUnit.assertFalse(name + "interrupt flag should not be set", t.isInterrupted());
+
+        /* run thread */
+        t.start();
+        t.interrupt();
+        t.join();
+
+        AssertJUnit.assertTrue(name + "InterruptedException was thrown during run", bool_interruptBeforeAndDuringRun);
+
+        /* Verify thread is dead and has not been interrupted */
+        AssertJUnit.assertFalse(name + "thread should be dead", t.isAlive());
+        AssertJUnit.assertFalse(name + "interrupt flag should be cleared", t.isInterrupted()); 
+    }
+
+    /* If thread is interrupted before start, Thread.interrupted is set */
+    @Test
+    public void test_interruptedStart() throws Throwable {
+        String name = "interruptedStart: ";
+        Thread t = new Thread(){
+            public void run() throws AssertionError {
+                AssertJUnit.assertTrue(Thread.interrupted());
+            }
+          };
+
+        /* interrupt before start */
+        t.interrupt();
+
+        t.start();
+        t.join();
+
+        AssertJUnit.assertFalse(name + "interrupt flag should be cleared", t.isInterrupted()); 
+    }
+}
+

--- a/test/functional/Java14andUp/testng.xml
+++ b/test/functional/Java14andUp/testng.xml
@@ -30,4 +30,9 @@
             <class name="org.openj9.test.records.RecordClassTests" />
         </classes>
     </test>
+    <test name="ThreadInterruptImplTest">
+        <classes>
+            <class name="org.openj9.test.java.lang.Test_Thread"/>
+        </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/8916

- A new private boolean is added to java.lang.Thread to track the interrupt state since a J9VMThread only exists when the thread is actually running. When a thread is started the interrupt state will be transferred from the deadInterrupt boolean to the J9VMThread and tracked in the vm. When the thread is cleaned up, the interrupt state will be transferred back to be tracked by the deadInterrupt boolean.
- Update formatting for Java14AndUp test playlist

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>