### PR TITLE
CMake: Ensure that jit is built with split debug info

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -303,6 +303,9 @@ create_omr_compiler_library(NAME j9jit
 	INCLUDES ${J9_INCLUDES}
 	FILTER ${REMOVED_OMR_FILES}
 )
+# Since create_omr_compiler_library doesn't go through j9vm_add_library
+# we have to manually make sure we get split debug info
+omr_process_split_debug(j9jit)
 
 add_dependencies(j9jit
 	omrgc_hookgen


### PR DESCRIPTION
Because the jit library is created via create_omr_compiler_library,
it is not possible for it to use j9vm_add_library. Instead we make sure
that it has split debug info manually.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>