### PR TITLE
Fix the check on the return of shouldInitiateDLT

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -885,7 +885,7 @@ void DLTLogic(J9VMThread* vmThread, TR::CompilationInfo *compInfo)
       {
       int32_t numHitsInDLTBuffer = -1;
       TR_YesNoMaybe answer = shouldInitiateDLT(dltBlock, idx, &bcRepeats, &numHitsInDLTBuffer);
-      if (answer == TR_maybe)
+      if (answer != TR_no)
          {
          // Perform another test
          if (compInfo->getDLT_HT())


### PR DESCRIPTION
The original logic on checking only `TR_maybe` after `shouldInitiateDLT()` returns, caused no DLT being performed when `shouldInitiateDLT()` returns `TR_yes`.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>