### PR TITLE
Update s390x Dockerfiles to use AdoptOpenJDK API v3

### DIFF
--- a/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2019 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,7 @@ RUN cd /root \
 
 # Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
-  && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk" \
+  && wget -O bootjdk10.tar.gz https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/s390x/jdk/openj9/normal/adoptopenjdk?project=jdk \
   && tar -xzf bootjdk10.tar.gz \
   && rm -f bootjdk10.tar.gz \
   && mv $(ls | grep -i jdk) bootjdk10

--- a/buildenv/docker/jdk14/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk14/s390x/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,13 +87,13 @@ RUN cd /root \
 
 # Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
-  && wget -O bootjdk12.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk" \
-  && tar -xzf bootjdk12.tar.gz \
-  && rm -f bootjdk12.tar.gz \
-  && mv $(ls | grep -i jdk) bootjdk12
+  && wget -O bootjdk13.tar.gz https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/s390x/jdk/openj9/normal/adoptopenjdk?project=jdk \
+  && tar -xzf bootjdk13.tar.gz \
+  && rm -f bootjdk13.tar.gz \
+  && mv $(ls | grep -i jdk) bootjdk13
 
 # Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
-ENV JAVA_HOME="/root/bootjdk12"
+ENV JAVA_HOME="/root/bootjdk13"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 WORKDIR /root

--- a/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
@@ -82,10 +82,10 @@ RUN cd /root \
 
 # Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
-  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/openjdk8-openj9/releases/s390x_linux/latest/binary \
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/s390x/jdk/openj9/normal/adoptopenjdk?project=jdk \
   && tar -xzf bootjdk8.tar.gz \
   && rm -f bootjdk8.tar.gz \
-  && ls | grep -i jdk | xargs -I % sh -c 'mv % bootjdk8'
+  && mv $(ls | grep -i jdk) bootjdk8
 
 # Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
 ENV JAVA_HOME="/root/bootjdk8"

--- a/buildenv/docker/jdk8/s390x/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu18/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,15 +83,15 @@ RUN cd /root \
  && tar -xzf freemarker.tar.gz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
  && rm -f freemarker.tar.gz
 
-# Download the boot JDK from AdoptOpenJDK.
+# Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
- && wget https://api.adoptopenjdk.net/openjdk8-openj9/releases/s390x_linux/latest/binary -O bootjdk8.tar.gz \
- && tar -xzf bootjdk8.tar.gz \
- && rm -f bootjdk8.tar.gz \
- && mv $(ls | grep -i jdk) bootjdk8
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/s390x/jdk/openj9/normal/adoptopenjdk?project=jdk \
+  && tar -xzf bootjdk8.tar.gz \
+  && rm -f bootjdk8.tar.gz \
+  && mv $(ls | grep -i jdk) bootjdk8
 
-# Set JAVA_HOME, and prepend $JAVA_HOME/bin to PATH.
-ENV JAVA_HOME=/root/bootjdk8
-ENV PATH="$JAVA_HOME/bin:$PATH"
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk8"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 WORKDIR /root


### PR DESCRIPTION
According to [1] v1 and v2 APIs are now deprecated and the latter may
be removed at some point. The jdk8 Dockerfile uses the v1 API which
currently fails and we cannot build the Dockerfile properly. This
commit switches all known s390x Dockerfiles to use the v3 API.

[1] https://api.adoptopenjdk.net/

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>