### PR TITLE
Remove discontiguous arraylet NULL pointers

### DIFF
--- a/runtime/gc_glue_java/ArrayletObjectModel.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,13 +43,21 @@ GC_ArrayletObjectModel::AssertBadElementSize()
 	Assert_MM_unreachable();
 }
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 void
-GC_ArrayletObjectModel::AssertNotEmptyArrayletLeaves(UDATA sizeInElements, UDATA arrayletLeafCount)
+GC_ArrayletObjectModel::AssertArrayletIsDiscontiguous(J9IndexableObject *objPtr)
 {
-	Assert_MM_true((0 == sizeInElements) || (arrayletLeafCount > 0));
-}
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	if (!isDoubleMappingEnabled())
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+	{
+		MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
+		UDATA arrayletLeafSize = _omrVM->_arrayletLeafSize;
+		UDATA remainderBytes = getDataSizeInBytes(objPtr) % arrayletLeafSize;
+		if (0 != remainderBytes) {
+			Assert_MM_true((getSpineSize(objPtr) + remainderBytes + extensions->getObjectAlignmentInBytes()) > arrayletLeafSize);
+		}
+	}
+}
 
 GC_ArrayletObjectModel::ArrayLayout
 GC_ArrayletObjectModel::getArrayletLayout(J9Class* clazz, UDATA dataSizeInBytes, UDATA largestDesirableSpine)

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
@@ -240,19 +240,13 @@ public:
 	 * @return the number of arraylets used for an array of dataSizeInBytes bytes
 	 */
 	MMINLINE UDATA
-	numArraylets(UDATA unadjustedDataSizeInBytes)
+	numArraylets(UDATA dataSizeInBytes)
 	{
 		UDATA leafSize = _omrVM->_arrayletLeafSize;
 		UDATA numberOfArraylets = 1;
 		if (UDATA_MAX != leafSize) {
 			UDATA leafSizeMask = leafSize - 1;
 			UDATA leafLogSize = _omrVM->_arrayletLeafLogSize;
-
-			/* We add one to unadjustedDataSizeInBytes to ensure that it's always possible to determine the address
-			 * of the after-last element without crashing. Handle the case of UDATA_MAX specially, since we use that
-			 * for any object whose size overflows the address space.
-			 */
-			UDATA dataSizeInBytes = (UDATA_MAX == unadjustedDataSizeInBytes) ? UDATA_MAX : (unadjustedDataSizeInBytes + 1);
 
 			/* CMVC 135307 : following logic for calculating the leaf count would not overflow dataSizeInBytes.
 			 * the assumption is leaf size is order of 2. It's identical to:

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -316,11 +316,11 @@ MM_VLHGCAccessBarrier::jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray
 				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
 				data = objectSlot.readReferenceFromSlot();
 			} else {
-				/* Possible to reach here if arraylet leaf has one leaf and no elements in it.
+				/* Possible to reach here if arraylet has no leaves.
 				 * Even though there are no elements in it the caller expects a non NULL value
 				 * therefore we just return the address after the object header. */
-				data = (void *)GC_SlotObject::addToSlotAddress((fomrobject_t*)arrayoidPtr, 1, env->compressObjectReferences());
-				Assert_MM_true((1 == indexableObjectModel->numArraylets(arrayObject)) && (0 == indexableObjectModel->getSizeInElements(arrayObject)));
+				data = (void *)arrayoidPtr;
+				Assert_MM_true((0 == indexableObjectModel->numArraylets(arrayObject)) && (0 == indexableObjectModel->getSizeInElements(arrayObject)));
 			}
 		} else
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
@@ -408,8 +408,8 @@ MM_VLHGCAccessBarrier::jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, ja
 				}
 				MM_JNICriticalRegion::exitCriticalRegion(vmThread, true);
 			} else {
-				/* Possible to reach here if arraylet leaf has one leaf and no elements in it */
-				Assert_MM_true((1 == indexableObjectModel->numArraylets(arrayObject)) && (0 == indexableObjectModel->getSizeInElements(arrayObject)));
+				/* Possible to reach here if arraylet has no leaves */
+				Assert_MM_true((0 == indexableObjectModel->numArraylets(arrayObject)) && (0 == indexableObjectModel->getSizeInElements(arrayObject)));
 			}
 		} else
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
@@ -511,11 +511,11 @@ MM_VLHGCAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str, j
 				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
 				data = (jchar *)objectSlot.readReferenceFromSlot();
 			} else {
-				/* Possible to reach here if arraylet leaf has one leaf and no elements in it.
+				/* Possible to reach here if arraylet has no leaves.
 				 * Even though there are no elements in it the caller expects a non NULL value
 				 * therefore we just return the address after the object header. */
-				data = (jchar *)GC_SlotObject::addToSlotAddress((fomrobject_t*)arrayoidPtr, 1, env->compressObjectReferences());
-				Assert_MM_true((1 == indexableObjectModel->numArraylets(valueObject)) && (0 == indexableObjectModel->getSizeInElements(valueObject)));
+				data = (jchar *)arrayoidPtr;
+				Assert_MM_true((0 == indexableObjectModel->numArraylets(valueObject)) && (0 == indexableObjectModel->getSizeInElements(valueObject)));
 			}
 		} else
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
@@ -588,8 +588,8 @@ MM_VLHGCAccessBarrier::jniReleaseStringCritical(J9VMThread* vmThread, jstring st
 				/* Solo arraylet leaf is contiguous so nothing to do besides exiting critical section */
 				MM_JNICriticalRegion::exitCriticalRegion(vmThread, true);
 			} else {
-				/* Possible to reach here if arraylet leaf has one leaf and no elements in it */
-				Assert_MM_true((1 == indexableObjectModel->numArraylets(valueObject)) && (0 == indexableObjectModel->getSizeInElements(valueObject)));
+				/* Possible to reach here if arraylet has no leaves */
+				Assert_MM_true((0 == indexableObjectModel->numArraylets(valueObject)) && (0 == indexableObjectModel->getSizeInElements(valueObject)));
 			}
 		} else
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */


### PR DESCRIPTION
Currently every discontiguous arraylet contains an extra
arrayoid that points to NULL, which is not required
anymore; therefore, every arraylet from now on will
contain the exact number of arrayoids/leaves it consumes

I included checks in case of discontiguous arraylets to make sure we’re dealing with discontiguous arraylets or fail otherwise. This might be overkill so wanted feedback on it. Now that we don’t have the distinction between discontiguous arraylet + `nullPtr` and normal arraylet without `nullPtr` there are 2 possibilities for discontiguous arraylet:
- Fully discontiguous arraylet where `0 == dataSize % arrayletLeafRegionSize`
- `arrayletSpineSize + lastLeafSize > arrayletLeafRegionSize`, meaning we need to allocate an entire region for this leaf since it cannot fit with the spine however `0 != dataSize % arrayletLeafSize`. 

So I tried to capture these cases with my checks but not sure if it’s overkill or not. 

Signed-off-by: Igor Braga <higorb1@gmail.com>