### PR TITLE
Set extraTestLabels blank if TEST_NODE is set

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -676,6 +676,10 @@ def set_test_misc() {
         TESTS.each { id, target ->
             target['extraTestLabels'] = buildspec.getVectorField("extra_test_labels", target).join('&&') ?: ''
         }
+    } else {
+        TESTS.each { id, target ->
+            target['extraTestLabels'] = ''
+        }
     }
 
     def buildspec = buildspec_manager.getSpec(SPEC)


### PR DESCRIPTION
- Null check so Test build doesn't fall over.

Related #9107 #8980 #8659
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>