### PR TITLE
AArch64: Add symbols for recompilation helpers

### DIFF
--- a/runtime/compiler/aarch64/runtime/Recompilation.spp
+++ b/runtime/compiler/aarch64/runtime/Recompilation.spp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,8 +23,12 @@
 	.file "Recompilation.s"
 
 	.globl	_countingRecompileMethod
-	.globl	_initialInvokeExactThunkGlue
+	.globl	_samplingRecompileMethod
+	.globl	_countingPatchCallSite
+	.globl	_samplingPatchCallSite
+	.globl	_induceRecompilation
 	.globl	_revertToInterpreterGlue
+	.globl	_initialInvokeExactThunkGlue
 
 	.extern	initialInvokeExactThunk_unwrapper
 	.extern	jitCallCFunction
@@ -33,6 +37,21 @@
 #define J9SP x20
 
 _countingRecompileMethod:
+	hlt	#0	// Not implemented yet
+
+_samplingRecompileMethod:
+	hlt	#0	// Not implemented yet
+
+_countingPatchCallSite:
+	hlt	#0	// Not implemented yet
+
+_samplingPatchCallSite:
+	hlt	#0	// Not implemented yet
+
+_induceRecompilation:
+	hlt	#0	// Not implemented yet
+
+_revertToInterpreterGlue:
 	hlt	#0	// Not implemented yet
 
 // _initialInvokeExactThunkGlue
@@ -56,6 +75,3 @@ _initialInvokeExactThunkGlue:
 	.align	3
 const_initialInvokeExactThunk_unwrapper:
 	.dword	initialInvokeExactThunk_unwrapper
-
-_revertToInterpreterGlue:
-	hlt	#0	// Not implemented yet

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1164,6 +1164,11 @@ JIT_HELPER(_induceRecompilation);
 JIT_HELPER(_revertToInterpreterGlue);
 
 #elif defined(TR_HOST_ARM64)
+JIT_HELPER(_countingRecompileMethod);
+JIT_HELPER(_samplingRecompileMethod);
+JIT_HELPER(_countingPatchCallSite);
+JIT_HELPER(_samplingPatchCallSite);
+JIT_HELPER(_induceRecompilation);
 JIT_HELPER(_revertToInterpreterGlue);
 
 #elif defined(TR_HOST_S390)
@@ -1279,7 +1284,12 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_ARMrevertToInterpreterGlue,           (void *)_revertToInterpreterGlue, TR_Helper);
 
 #elif defined(TR_HOST_ARM64)
-   SET(TR_ARM64revertToInterpreterGlue,           (void *)_revertToInterpreterGlue, TR_Helper);
+   SET(TR_ARM64countingRecompileMethod,         (void *)_countingRecompileMethod, TR_Helper);
+   SET(TR_ARM64samplingRecompileMethod,         (void *)_samplingRecompileMethod, TR_Helper);
+   SET(TR_ARM64countingPatchCallSite,           (void *)_countingPatchCallSite,   TR_Helper);
+   SET(TR_ARM64samplingPatchCallSite,           (void *)_samplingPatchCallSite,   TR_Helper);
+   SET(TR_ARM64induceRecompilation,             (void *)_induceRecompilation,     TR_Helper);
+   SET(TR_ARM64revertToInterpreterGlue,         (void *)_revertToInterpreterGlue, TR_Helper);
 
 #elif defined(TR_HOST_S390)
    SET(TR_S390samplingRecompileMethod,          (void *)_samplingRecompileMethod,   TR_Helper);


### PR DESCRIPTION
This commit adds symbols for recompilation helpers for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>