### PR TITLE
Fix JITServer allocation fence and get max heap size

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -512,6 +512,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._floatInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactF, false, false, false)->getMethodAddress();
          vmInfo._doubleInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactD, false, false, false)->getMethodAddress();
          vmInfo._interpreterVTableOffset = TR::Compiler->vm.getInterpreterVTableOffset();
+         vmInfo._maxHeapSizeInBytes = TR::Compiler->vm.maxHeapSizeInBytes();
          vmInfo._enableGlobalLockReservation = vmThread->javaVM->enableGlobalLockReservation;
          {
             TR::VMAccessCriticalSection getVMInfo(fe);

--- a/runtime/compiler/env/J9VMEnv.cpp
+++ b/runtime/compiler/env/J9VMEnv.cpp
@@ -45,6 +45,13 @@
 int64_t
 J9::VMEnv::maxHeapSizeInBytes()
    {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_maxHeapSizeInBytes;
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
    J9JavaVM *jvm = TR::Compiler->javaVM;
 
    if (!jvm)

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4596,13 +4596,13 @@ break
 
    // We disable this optimization for JITServer because TR_VMField is not supported on JITServer yet. Once we have decided how to build the data structures
    // required by this optimization efficiently, we can re-enable this optimization.
-   if (cg()->getEnforceStoreOrder() && calledMethod->isConstructor()
-      #ifdef J9VM_OPT_JITSERVER
-         && !cg()->comp()->isOutOfProcessCompilation()
-      #endif
-      )
+   if (cg()->getEnforceStoreOrder() && calledMethod->isConstructor())
       {
-      if (resolvedMethodSymbol)
+      if (resolvedMethodSymbol
+#ifdef J9VM_OPT_JITSERVER
+         && !cg()->comp()->isOutOfProcessCompilation()
+#endif /* defined(J9VM_OPT_JITSERVER) */
+         )
          {
          J9Class *methodClass = (J9Class *) resolvedMethodSymbol->getResolvedMethod()->containingClass();
          TR_VMFieldsInfo *fieldsInfoByIndex = new (comp()->trStackMemory()) TR_VMFieldsInfo(comp(), methodClass, 1, stackAlloc);

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -325,6 +325,7 @@ class ClientSessionData
       void *_floatInvokeExactThunkHelper;
       void *_doubleInvokeExactThunkHelper;
       size_t _interpreterVTableOffset;
+      int64_t _maxHeapSizeInBytes;
       J9Method *_jlrMethodInvoke;
       uint32_t _enableGlobalLockReservation;
 #if defined(J9VM_OPT_SIDECAR)


### PR DESCRIPTION
Max heap size should be retrieved from the client and stored in the ClientSessionData VMInfo at the server.

JITServer also missed some allocation fence in IlGen when the method symbol is not resolved.

Fixes #8505

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>