### PR TITLE
Improve jitdump diagnostic messages and function names

### DIFF
--- a/runtime/compiler/control/JitDump.hpp
+++ b/runtime/compiler/control/JitDump.hpp
@@ -24,12 +24,13 @@
 #define TR_JITDUMP_INCL
 
 #include "j9.h"
+#include "j9dump.h"
 #include "j9nonbuilder.h"
 
 extern J9_CFUNC UDATA
 jitDumpSignalHandler(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *arg);
 
-extern J9_CFUNC intptr_t
-dumpJitInfo(J9VMThread * currentThread, char *label, J9RASdumpContext *context);
+extern J9_CFUNC omr_error_t
+runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent);
 
 #endif

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1738,7 +1738,7 @@ onLoadInternal(
 #endif
 
 #ifdef J9VM_RAS_DUMP_AGENTS
-   jitConfig->dumpJitInfo = dumpJitInfo;
+   jitConfig->runJitdump = runJitdump;
 #endif
 
    if (!TR::Compiler->target.cpu.isI386())

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -283,6 +283,7 @@ struct J9MM_IterateSpaceDescriptor;
 struct J9ObjectMonitorInfo;
 struct J9Pool;
 struct J9PortLibrary;
+struct J9RASdumpAgent;
 struct J9RASdumpContext;
 struct J9RASdumpFunctions;
 struct J9ROMClass;
@@ -3685,7 +3686,7 @@ typedef struct J9JITConfig {
 	void  ( *jitReportDynamicCodeLoadEvents)(struct J9VMThread * currentThread) ;
 	UDATA  ( *jitSignalHandler)(struct J9VMThread *vmStruct, U_32 gpType, void* gpInfo) ;
 	IDATA sampleInterruptHandlerKey;
-	IDATA  ( *dumpJitInfo)(struct J9VMThread *currentThread, char *label, struct J9RASdumpContext *context) ;
+	omr_error_t ( *runJitdump)(char *label, struct J9RASdumpContext *context, struct J9RASdumpAgent *agent);
 	void*  ( *isDLTReady)(struct J9VMThread * currentThread, struct J9Method * method, UDATA bytecodeIndex) ;
 	UDATA*  ( *jitLocalSlotAddress)(struct J9VMThread * currentThread, J9StackWalkState *walkState, UDATA slot, UDATA inlineDepth) ;
 	void  ( *jitOSRPatchMethod)(struct J9VMThread * currentThread, struct J9JITExceptionTable * metaData, U_8 * pc) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1094,8 +1094,6 @@ extern J9_CFUNC UDATA * getNextStackMapFrame(U_32 *stackMap, UDATA *previousFram
 extern J9_CFUNC void  jitResetAllUntranslateableMethods (J9VMThread *vmThread);
 #endif /* J9VM_JIT_FULL_SPEED_DEBUG &&  J9VM_INTERP_NATIVE_SUPPORT */
 
-extern J9_CFUNC IDATA dumpJitInfo(J9VMThread *thread, char *label, J9RASdumpContext *context);
-
 extern J9_CFUNC void  jitConvertStoredDoubleRegisterToSingle (U_64 * doublePtr, U_32 * singlePtr);
 #endif /* _J9VMJITDEBUGHELPERS_ */
 


### PR DESCRIPTION
- Properly report jitdump request in the same way as javacore
- Refactor functio names to have the same naming pattern as other dump agents
- Use correct return types
- Remove prefixes when printing verbose information as the `writeLineLocked` API already prints the prefix for us

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>