### PR TITLE
Update verbose log write API calls to use new newline convention

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -309,7 +309,7 @@ J9::Compilation::allocateCompYieldStatsMatrix()
 void
 J9::Compilation::printCompYieldStats()
    {
-   TR_VerboseLog::writeLine(TR_Vlog_PERF,"max yield-to-yield time of %u usec for ", (uint32_t)_maxYieldInterval);
+   TR_VerboseLog::writeLine(TR_Vlog_PERF, "Max yield-to-yield time of %u usec for ", static_cast<uint32_t>(_maxYieldInterval));
    TR_VerboseLog::write("%s -", J9::Compilation::getContextName(_sourceContextForMaxYieldInterval));
    TR_VerboseLog::write("- %s", J9::Compilation::getContextName(_destinationContextForMaxYieldInterval));
    }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10759,11 +10759,10 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
          }
       else
          {
-         char compilationTypeString[15]={0};
+         char compilationTypeString[15] = { 0 };
          snprintf(compilationTypeString, sizeof(compilationTypeString), "%s%s",
-                 vm.isAOT_DEPRECATED_DO_NOT_USE() ? "AOT " : "",
-                 compiler->isProfilingCompilation() ? "profiled " : ""
-                );
+            vm.isAOT_DEPRECATED_DO_NOT_USE() ? "AOT " : "",
+            compiler->isProfilingCompilation() ? "profiled " : "");
 
          UDATA startPC = 0;
          UDATA endWarmPC = 0;
@@ -11312,6 +11311,14 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
    if (TR::Options::isAnyVerboseOptionSet(TR_VerbosePerformance, TR_VerboseCompileEnd, TR_VerboseCompFailure))
       {
       uintptr_t translationTime = j9time_usec_clock() - getTimeWhenCompStarted(); //get the time it took to fail the compilation
+      
+      char compilationTypeString[15] = { 0 };
+      snprintf(compilationTypeString, sizeof(compilationTypeString), "%s%s",
+         compiler->fej9()->isAOT_DEPRECATED_DO_NOT_USE() ? "AOT " : "",
+         compiler->isProfilingCompilation() ? "profiled " : "");
+
+      const char *hotnessString = compiler->getHotnessName(compiler->getMethodHotness());
+
       TR_VerboseLog::vlogAcquire();
       if (_methodBeingCompiled->_compErrCode != compilationFailure)
          {
@@ -11323,7 +11330,9 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
             uint64_t freePhysicalMemorySizeB = _compInfo.computeAndCacheFreePhysicalMemory(incomplete);
             if (freePhysicalMemorySizeB != OMRPORT_MEMINFO_NOT_AVAILABLE)
                {
-               TR_VerboseLog::write(TR_Vlog_COMPFAIL, "%s time=%dus %s memLimit=%zu KB freePhysicalMemory=%llu MB",
+               TR_VerboseLog::write(TR_Vlog_COMPFAIL, "(%s%s) %s time=%dus %s memLimit=%zu KB freePhysicalMemory=%llu MB",
+                                           compilationTypeString,
+                                           hotnessString,
                                            compiler->signature(),
                                            translationTime,
                                            compilationErrorNames[_methodBeingCompiled->_compErrCode],
@@ -11332,7 +11341,9 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
                }
             else
                {
-               TR_VerboseLog::write(TR_Vlog_COMPFAIL, "%s time=%dus %s memLimit=%zu KB",
+               TR_VerboseLog::write(TR_Vlog_COMPFAIL, "(%s%s) %s time=%dus %s memLimit=%zu KB",
+                                           compilationTypeString,
+                                           hotnessString,
                                            compiler->signature(),
                                            translationTime,
                                            compilationErrorNames[_methodBeingCompiled->_compErrCode],
@@ -11343,9 +11354,11 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
       else
          {
          uintptr_t translationTime = j9time_usec_clock() - getTimeWhenCompStarted(); //get the time it took to fail the compilation
-         TR_VerboseLog::write(TR_Vlog_COMPFAIL, "compThreadID=%d %s time=%dus <TRANSLATION FAILURE: %s>",
-                                        compiler->getCompThreadID(),
+         TR_VerboseLog::write(TR_Vlog_COMPFAIL, "(%s%s) %s compThreadID=%d time=%dus <TRANSLATION FAILURE: %s>",
+                                        compilationTypeString,
+                                        hotnessString,
                                         compiler->signature(),
+                                        compiler->getCompThreadID(),
                                         translationTime,
                                         exceptionName);
          }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5516,7 +5516,7 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
    if (verbose)
       {
       TR_VerboseLog::vlogAcquire();
-      TR_VerboseLog::writeLine(TR_Vlog_CR,"%p   Compile request %s", vmThread, details.name());
+      TR_VerboseLog::write(TR_Vlog_CR, "%p   Compile request %s", vmThread, details.name());
 
       if (newInstanceThunkDetails)
          {
@@ -5543,6 +5543,7 @@ void *TR::CompilationInfo::compileMethod(J9VMThread * vmThread, TR::IlGeneratorM
          TR_ASSERT(!fe->isAOT_DEPRECATED_DO_NOT_USE(), "Shouldn't get obsolete classes in AOT");
          TR_VerboseLog::write(" OBSOLETE class=%p -- request declined", clazz);
          }
+      TR_VerboseLog::writeLine("");
       TR_VerboseLog::vlogRelease();
       }
 
@@ -6598,7 +6599,7 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
             }
 
          TR_VerboseLog::vlogAcquire();
-         TR_VerboseLog::writeLine(TR_Vlog_COMP,"(AOT load) ");
+         TR_VerboseLog::write(TR_Vlog_COMP, "(AOT load) ");
          CompilationInfo::printMethodNameToVlog(method);
          TR_VerboseLog::write(" @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT, metaData->startPC, metaData->endWarmPC);
          TR_VerboseLog::write(" Q_SZ=%d Q_SZI=%d QW=%d j9m=%p bcsz=%u", _compInfo.getMethodQueueSize(), _compInfo.getNumQueuedFirstTimeCompilations(),
@@ -6611,6 +6612,7 @@ TR::CompilationInfoPerThreadBase::installAotCachedMethod(
          if (entry)
             TR_VerboseLog::write(" compThreadID=%d", getCompThreadId());
 
+         TR_VerboseLog::writeLine("");
          TR_VerboseLog::vlogRelease();
          }
 
@@ -7521,9 +7523,9 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
          if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompFailure))
             {
             TR_VerboseLog::vlogAcquire();
-            TR_VerboseLog::writeLine(TR_Vlog_COMP, "Method ");
+            TR_VerboseLog::write(TR_Vlog_COMP, "Method ");
             CompilationInfo::printMethodNameToVlog(method);
-            TR_VerboseLog::write(" will continue as interpreted");
+            TR_VerboseLog::writeLine(" will continue as interpreted");
             TR_VerboseLog::vlogRelease();
             }
          if (entry->_compErrCode != compilationRestrictedMethod && // do not look at methods excluded by filters
@@ -7965,12 +7967,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             options = TR::Options::getAOTCmdLineOptions();
          if (options->getVerboseOption(TR_VerboseCompileExclude))
             {
-            TR_VerboseLog::vlogAcquire();
-            if (jitConfig->runtimeFlags & J9JIT_TESTMODE)
-               TR_VerboseLog::write("\n<JIT: translating %s -- CANNOT BE TRANSLATED>\n", compilee->signature(p->trMemory()));
-            else
-               TR_VerboseLog::writeLine(TR_Vlog_COMPFAIL,"%s cannot be translated", compilee->signature(p->trMemory()));
-            TR_VerboseLog::vlogRelease();
+            TR_VerboseLog::writeLineLocked(TR_Vlog_COMPFAIL, "%s cannot be translated", compilee->signature(p->trMemory()));
             }
          Trc_JIT_noAttemptToJit(vmThread, compilee->signature(p->trMemory()));
 
@@ -9169,22 +9166,13 @@ TR::CompilationInfoPerThreadBase::compile(
 
          if (TR::Options::getVerboseOption(TR_VerboseCompilationDispatch) && !rtn)
             {
-            TR_VerboseLog::vlogAcquire();
-
-            TR_VerboseLog::writeLine(
+            TR_VerboseLog::writeLineLocked(
                TR_Vlog_DISPATCH,
-               "Successfully created compiled body [" POINTER_PRINTF_FORMAT "-",
-               compiler->cg()->getCodeStart()
-            );
-
-            TR_VerboseLog::write(
-               POINTER_PRINTF_FORMAT "] for %s @ %s",
+               "Successfully created compiled body [" POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT "] for %s @ %s",
+               compiler->cg()->getCodeStart(),
                compiler->cg()->getCodeEnd(),
                compiler->signature(),
-               compiler->getHotnessName()
-            );
-
-            TR_VerboseLog::vlogRelease();
+               compiler->getHotnessName());
             }
          }
 
@@ -10865,13 +10853,13 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
             const uint32_t bytecodeSize = TR::CompilationInfo::getMethodBytecodeSize(method);
             const bool isJniNative = compilee->isJNINative();
             TR_VerboseLog::vlogAcquire();
-            TR_VerboseLog::writeLine(TR_Vlog_COMP,"(%s%s) %s @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT,
+            TR_VerboseLog::write(TR_Vlog_COMP,"(%s%s) %s @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT,
                compilationTypeString,
                hotnessString,
                compiler->signature(),
                startPC,
-               startColdPC ? endWarmPC : endPC
-               );
+               startColdPC ? endWarmPC : endPC);
+
             if (startColdPC)
                {
                TR_VerboseLog::write("/" POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT, startColdPC, endPC);
@@ -10885,7 +10873,6 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                TR_VerboseLog::write(" %.2f%%", optimizationPlan->getPerceivedCPUUtil() / 10.0);
 
             TR_VerboseLog::write(" %c", recompReason);
-
             TR_VerboseLog::write(" Q_SZ=%d Q_SZI=%d QW=%d", _compInfo.getMethodQueueSize(),
                                  _compInfo.getNumQueuedFirstTimeCompilations(), _compInfo.getQueueWeight());
 
@@ -10926,13 +10913,12 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
             if (TR::Options::getVerboseOption(TR_VerbosePerformance))
                TR_VerboseLog::write(" time=%dus", translationTime);
 
-            if(TR::Options::getVerboseOption(TR_VerbosePerformance))
+            if (TR::Options::getVerboseOption(TR_VerbosePerformance))
                {
                TR_VerboseLog::write(
                   " mem=[region=%llu system=%llu]KB",
                   static_cast<unsigned long long>(scratchSegmentProvider.regionBytesAllocated())/1024,
-                  static_cast<unsigned long long>(scratchSegmentProvider.systemBytesAllocated())/1024
-                  );
+                  static_cast<unsigned long long>(scratchSegmentProvider.systemBytesAllocated())/1024);
                }
 
 #if defined(WINDOWS) && defined(TR_TARGET_32BIT)
@@ -10942,7 +10928,7 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
                if (j9sysinfo_get_memory_info(&memInfo) == 0 &&
                memInfo.availVirtual != J9PORT_MEMINFO_NOT_AVAILABLE)
-                  TR_VerboseLog::write( " VMemAv=%u MB", (uint32_t)(memInfo.availVirtual >> 20));
+                  TR_VerboseLog::write(" VMemAv=%u MB", static_cast<uint32_t>(memInfo.availVirtual >> 20));
                }
 #endif
             if (TR::Options::getVerboseOption(TR_VerboseRecompile))
@@ -10986,6 +10972,7 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                   TR_VerboseLog::write(" compCPU=%d%%", cpuUtil);
                }
 
+            TR_VerboseLog::writeLine("");
             TR_VerboseLog::vlogRelease();
             }
 
@@ -11329,14 +11316,14 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
       if (_methodBeingCompiled->_compErrCode != compilationFailure)
          {
          if ((_jitConfig->runtimeFlags & J9JIT_TESTMODE) && _methodBeingCompiled->_compErrCode == compilationInterrupted)
-            TR_VerboseLog::writeLine(TR_Vlog_FAILURE,"<JIT: translating %s -- Interrupted because of %s", compiler->signature(), exceptionName);
+            TR_VerboseLog::write(TR_Vlog_FAILURE, "Translating %s -- Interrupted because of %s", compiler->signature(), exceptionName);
          else
             {
             bool incomplete;
             uint64_t freePhysicalMemorySizeB = _compInfo.computeAndCacheFreePhysicalMemory(incomplete);
             if (freePhysicalMemorySizeB != OMRPORT_MEMINFO_NOT_AVAILABLE)
                {
-               TR_VerboseLog::writeLine(TR_Vlog_COMPFAIL,"%s time=%dus %s memLimit=%zu KB freePhysicalMemory=%llu MB",
+               TR_VerboseLog::write(TR_Vlog_COMPFAIL, "%s time=%dus %s memLimit=%zu KB freePhysicalMemory=%llu MB",
                                            compiler->signature(),
                                            translationTime,
                                            compilationErrorNames[_methodBeingCompiled->_compErrCode],
@@ -11345,7 +11332,7 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
                }
             else
                {
-               TR_VerboseLog::writeLine(TR_Vlog_COMPFAIL,"%s time=%dus %s memLimit=%zu KB",
+               TR_VerboseLog::write(TR_Vlog_COMPFAIL, "%s time=%dus %s memLimit=%zu KB",
                                            compiler->signature(),
                                            translationTime,
                                            compilationErrorNames[_methodBeingCompiled->_compErrCode],
@@ -11356,7 +11343,7 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
       else
          {
          uintptr_t translationTime = j9time_usec_clock() - getTimeWhenCompStarted(); //get the time it took to fail the compilation
-         TR_VerboseLog::writeLine(TR_Vlog_COMPFAIL,"compThreadID=%d %s time=%dus <TRANSLATION FAILURE: %s>",
+         TR_VerboseLog::write(TR_Vlog_COMPFAIL, "compThreadID=%d %s time=%dus <TRANSLATION FAILURE: %s>",
                                         compiler->getCompThreadID(),
                                         compiler->signature(),
                                         translationTime,
@@ -11368,9 +11355,10 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
          TR_VerboseLog::write(
             " mem=[region=%llu system=%llu]KB",
             static_cast<unsigned long long>(scratchSegmentProvider.regionBytesAllocated())/1024,
-            static_cast<unsigned long long>(scratchSegmentProvider.systemBytesAllocated())/1024
-            );
+            static_cast<unsigned long long>(scratchSegmentProvider.systemBytesAllocated())/1024);
          }
+
+      TR_VerboseLog::writeLine("");
       TR_VerboseLog::vlogRelease();
       }
 
@@ -11474,10 +11462,11 @@ TR::CompilationInfo::triggerOrderedCompiles(TR_FrontEnd * f, intptr_t tickCount)
                if (logSampling)
                   {
                   TR_VerboseLog::vlogAcquire();
-                  TR_VerboseLog::writeLine(TR_Vlog_SAMPLING,"(%d) Compiled %s.%s%s (SIMULATED) recompile at level --> %d", tickCount, filter->getClass(),
+                  TR_VerboseLog::write(TR_Vlog_SAMPLING, "(%d) Compiled %s.%s%s (SIMULATED) recompile at level --> %d", tickCount, filter->getClass(),
                            filter->getName(), filter->getSignature(), filter->getSampleLevel());
                   if (filter->getSampleProfiled())
                      TR_VerboseLog::write(", profiled");
+                  TR_VerboseLog::writeLine("");
                   TR_VerboseLog::vlogRelease();
                   }
 

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -209,7 +209,7 @@ static void reportHook(J9VMThread *curThread, char *name, char *format=NULL, ...
       || TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseHookDetails))
       {
       TR_VerboseLog::vlogAcquire();
-      TR_VerboseLog::writeLine(TR_Vlog_HK,"%x hook %s vmThread=%p ", (int)(intptr_t)curThread, name, curThread);
+      TR_VerboseLog::write(TR_Vlog_HK,"%x hook %s vmThread=%p ", (int)(intptr_t)curThread, name, curThread);
       if (format)
          {
          va_list args;
@@ -217,6 +217,7 @@ static void reportHook(J9VMThread *curThread, char *name, char *format=NULL, ...
          j9jit_vprintf(jitConfig, format, args);
          va_end(args);
          }
+      TR_VerboseLog::writeLine("");
       TR_VerboseLog::vlogRelease();
       }
    }
@@ -4945,15 +4946,19 @@ static void DoCalculateOverallCompCPUUtilization(TR::CompilationInfo *compInfo, 
    if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompilationThreads, TR_VerboseCompilationThreadsDetails))
       {
       TR_VerboseLog::vlogAcquire();
-      TR_VerboseLog::writeLine(TR_Vlog_INFO, "t=%6u TotalCompCpuUtil=%3d%%.", (uint32_t)crtTime, totalCompCPUUtilization);
+      TR_VerboseLog::write(TR_Vlog_INFO, "t=%6u TotalCompCpuUtil=%3d%%.", static_cast<uint32_t>(crtTime), totalCompCPUUtilization);
       TR::CompilationInfoPerThread * const *arrayOfCompInfoPT = compInfo->getArrayOfCompilationInfoPerThread();
       for (uint8_t i = 0; i < compInfo->getNumUsableCompilationThreads(); i++)
          {
          const CpuSelfThreadUtilization& cpuUtil = arrayOfCompInfoPT[i]->getCompThreadCPU();
          TR_VerboseLog::write(" compThr%d:%3d%% (%2d%%, %2d%%) ", i, cpuUtilizationValues[i], cpuUtil.getThreadLastCpuUtil(), cpuUtil.getThreadPrevCpuUtil());
          if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompilationThreadsDetails))
-            TR_VerboseLog::write("(%dms, %dms, lastCheckpoint=%u) ", (int32_t)cpuUtil.getLastMeasurementInterval() / 1000000, (int32_t)cpuUtil.getSecondLastMeasurementInterval() / 1000000, cpuUtil.getLowResolutionClockAtLastUpdate());
+            TR_VerboseLog::write("(%dms, %dms, lastCheckpoint=%u) ", 
+               static_cast<int32_t>(cpuUtil.getLastMeasurementInterval()) / 1000000,
+               static_cast<int32_t>(cpuUtil.getSecondLastMeasurementInterval()) / 1000000,
+               cpuUtil.getLowResolutionClockAtLastUpdate());
          }
+      TR_VerboseLog::writeLine("");
       TR_VerboseLog::vlogRelease();
       }
    }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1361,7 +1361,7 @@ J9::Options::fePreProcess(void * base)
                mRegex = TR::SimpleRegex::create(optValue);
                if (!mRegex || *optValue != 0)
                   {
-                  TR_VerboseLog::write("<JNI: Bad regular expression at --> '%s'>\n", optValue);
+                  TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", optValue);
                   }
                else
                   {
@@ -3220,13 +3220,13 @@ J9::Options::setCounts()
 
    if (!_countString)
       {
-      TR_VerboseLog::write("<JIT: Count string could not be allocated>\n");
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Count string could not be allocated");
       return dummy_string;
       }
 
    if (_initialCount == -1 || _initialBCount == -1 || _initialMILCount == -1)
       {
-      TR_VerboseLog::write("<JIT: Bad string count: %s>\n", _countString);
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad string count: '%s'", _countString);
       return _countString;
       }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1348,7 +1348,7 @@ void TR_J9VMBase::printPID()
 void TR_J9VMBase::emitNewPseudoRandomNumberVerbosePrefix()
    {
    TR_VerboseLog::vlogAcquire();
-   TR_VerboseLog::writeLine(TR_Vlog_INFO,"%s ", PSEUDO_RANDOM_NUMBER_PREFIX);
+   TR_VerboseLog::write(TR_Vlog_INFO, "%s ", PSEUDO_RANDOM_NUMBER_PREFIX);
    //vlogRelease();
    }
 
@@ -1363,6 +1363,7 @@ void TR_J9VMBase::emitNewPseudoRandomVerboseSuffix()
    {
    //vlogAcquire();
    TR_VerboseLog::write("%c ", PSEUDO_RANDOM_SUFFIX);
+   TR_VerboseLog::writeLine("");
    TR_VerboseLog::vlogRelease();
    }
 
@@ -9171,13 +9172,13 @@ TR_J9SharedCacheVM::persistThunk(char *signatureChars, uint32_t signatureLength,
 
    if (TR::Options::getAOTCmdLineOptions()->getOption(TR_TraceRelocatableDataDetailsCG))
       {
-      TR_VerboseLog::write("<relocatableDataThunksDetailsCG>\n");
+      TR_VerboseLog::writeLine("<relocatableDataThunksDetailsCG>");
 
-      TR_VerboseLog::write("%.*s\n", signatureLength, signatureChars);
-      TR_VerboseLog::write("thunkAddress: %p, thunkSize: %x\n", dataDescriptor.address, dataDescriptor.length);
-      TR_VerboseLog::write("thunkStart: %p\n", thunkStart);
-      TR_VerboseLog::write("</relocatableDataThunksDetailsCG>\n");
+      TR_VerboseLog::writeLine("%.*s", signatureLength, signatureChars);
+      TR_VerboseLog::writeLine("thunkAddress: %p, thunkSize: %x", dataDescriptor.address, dataDescriptor.length);
+      TR_VerboseLog::writeLine("thunkStart: %p", thunkStart);
 
+      TR_VerboseLog::writeLine("</relocatableDataThunksDetailsCG>");
       }
 
    const void* store= _jitConfig->javaVM->sharedClassConfig->storeSharedData(curThread, signatureChars, signatureLength, &dataDescriptor);

--- a/runtime/compiler/net/Message.cpp
+++ b/runtime/compiler/net/Message.cpp
@@ -94,10 +94,10 @@ uint32_t
 Message::DataDescriptor::print(uint32_t nestingLevel)
    {
    uint32_t numDescriptorsPrinted = 1;
-   TR_VerboseLog::writeLine(TR_Vlog_JITServer, "");
+   TR_VerboseLog::write(TR_Vlog_JITServer, "");
    for (uint32_t i = 0; i < nestingLevel; ++i)
       TR_VerboseLog::write("\t");
-   TR_VerboseLog::write("DataDescriptor[%p]: type=%d(%6s) payload_size=%u dataOffset=%u, padding=%u", 
+   TR_VerboseLog::writeLine("DataDescriptor[%p]: type=%d(%6s) payload_size=%u dataOffset=%u, padding=%u", 
                         this, getDataType(), _descriptorNames[getDataType()], getPayloadSize(), getDataOffset(), getPaddingSize());
    if (!isPrimitive())
       {
@@ -110,6 +110,7 @@ Message::DataDescriptor::print(uint32_t nestingLevel)
          }
       TR_VerboseLog::writeLine(TR_Vlog_JITServer, "DataDescriptor[%p] nested data end", this);
       }
+
    return numDescriptorsPrinted;
    }
 

--- a/runtime/compiler/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/runtime/CRuntimeImpl.cpp
@@ -177,7 +177,7 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
                if (details)
                   {
                   TR_VerboseLog::vlogAcquire();
-                  TR_VerboseLog::writeLine(TR_Vlog_OSRD, "%X     Symbol #%d osrFrameDataOffset=%d scratchBufferOffset=%d size=%d data:", (int)vmThreadArg,
+                  TR_VerboseLog::write(TR_Vlog_OSRD, "%X     Symbol #%d osrFrameDataOffset=%d scratchBufferOffset=%d size=%d data:", (int)vmThreadArg,
                      i, osrFrameDataOffset, scratchBufferOffset, symSize);
                   switch (symSize)
                      {
@@ -191,6 +191,7 @@ void _prepareForOSR(uintptr_t vmThreadArg, int32_t currentInlinedSiteIndex, int3
                         // TODO: Dump binary
                         break;
                      }
+                  TR_VerboseLog::writeLine("");
                   TR_VerboseLog::vlogRelease();
                   }
                memcpy(

--- a/runtime/compiler/runtime/DataCache.cpp
+++ b/runtime/compiler/runtime/DataCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -273,7 +273,7 @@ TR_DataCache* TR_DataCacheManager::allocateNewDataCache(uint32_t minimumSize)
                }
             else
                {
-               TR_VerboseLog::write("<JIT: non-fatal error: failed to allocate %d Kb data cache>\n", _jitConfig->dataCacheKB);
+               TR_VerboseLog::writeLine(TR_Vlog_INFO, "Failed to allocate %d Kb data cache", _jitConfig->dataCacheKB);
                j9mem_free_memory(dataCache);
                dataCache = NULL;
                _jitConfig->runtimeFlags |= J9JIT_DATA_CACHE_FULL;  // prevent future allocations
@@ -284,7 +284,7 @@ TR_DataCache* TR_DataCacheManager::allocateNewDataCache(uint32_t minimumSize)
             }
          else // cannot allocate even a bit of memory from the JVM
             {
-            TR_VerboseLog::write("<JIT: non-fatal error: failed to allocate %d bytes for data cache>\n", sizeof(TR_DataCache));
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Failed to allocate %d bytes for data cache", sizeof(TR_DataCache));
             _jitConfig->runtimeFlags |= J9JIT_DATA_CACHE_FULL;  // prevent future allocations
 #ifdef DATA_CACHE_DEBUG
             fprintf(stderr, "Memory allocation for TR_DataCache failed\n");

--- a/runtime/compiler/runtime/GPUHelpers.cpp
+++ b/runtime/compiler/runtime/GPUHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1385,11 +1385,12 @@ generatePTX(int tracing, const char *programSource, int deviceId, TR::Persistent
 
    if (detailsTrace)
       {
-      TR_VerboseLog::writeLine(TR_Vlog_GPU, "\tCompiling NVVM program with options:");
+      TR_VerboseLog::write(TR_Vlog_GPU, "\tCompiling NVVM program with options:");
       for (int i = 0; i < optionLength; i++)
          {
          TR_VerboseLog::write(" %s", options[i]);
          }
+      TR_VerboseLog::writeLine("");
       fflush(NULL);
       }
 

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -447,30 +447,27 @@ void vlogReclamation(const char * prefix, J9JITExceptionTable *metaData, size_t 
       {
 
       TR_VerboseLog::vlogAcquire();
-      TR_VerboseLog::writeLine(
-      TR_Vlog_RECLAMATION,
-      "%s %.*s.%.*s%.*s @ %s [" POINTER_PRINTF_FORMAT "-",
-      prefix,
-      J9UTF8_LENGTH(metaData->className), J9UTF8_DATA(metaData->className),
-      J9UTF8_LENGTH(metaData->methodName), J9UTF8_DATA(metaData->methodName),
-      J9UTF8_LENGTH(metaData->methodSignature), J9UTF8_DATA(metaData->methodSignature),
-      TR::Compilation::getHotnessName(TR_Hotness(metaData->hotness)),
-      metaData->startPC + bytesToSaveAtStart
-      );
+      TR_VerboseLog::write(
+         TR_Vlog_RECLAMATION,
+         "%s %.*s.%.*s%.*s @ %s [" POINTER_PRINTF_FORMAT "-",
+         prefix,
+         J9UTF8_LENGTH(metaData->className), J9UTF8_DATA(metaData->className),
+         J9UTF8_LENGTH(metaData->methodName), J9UTF8_DATA(metaData->methodName),
+         J9UTF8_LENGTH(metaData->methodSignature), J9UTF8_DATA(metaData->methodSignature),
+         TR::Compilation::getHotnessName(TR_Hotness(metaData->hotness)),
+         metaData->startPC + bytesToSaveAtStart);
 
       if (metaData->startColdPC)
          {
          TR_VerboseLog::write(
-         POINTER_PRINTF_FORMAT "] & [" POINTER_PRINTF_FORMAT "-",
-         metaData->endWarmPC,
-         metaData->startColdPC
-         );
+            POINTER_PRINTF_FORMAT "] & [" POINTER_PRINTF_FORMAT "-",
+            metaData->endWarmPC,
+            metaData->startColdPC);
          }
 
-      TR_VerboseLog::write(
-      POINTER_PRINTF_FORMAT "]",
-      metaData->endPC
-      );
+      TR_VerboseLog::writeLine(
+         POINTER_PRINTF_FORMAT "]",
+         metaData->endPC);
 
       TR_VerboseLog::vlogRelease();
       }

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1519,7 +1519,7 @@ uint8_t *compileMethodHandleThunk(j9object_t methodHandle, j9object_t arg, J9VMT
    if (verbose)
       {
       TR_VerboseLog::vlogAcquire();
-      TR_VerboseLog::writeLine(TR_Vlog_MH, "%p Starting compileMethodHandleThunk on MethodHandle %p", vmThread, methodHandle);
+      TR_VerboseLog::write(TR_Vlog_MH, "%p Starting compileMethodHandleThunk on MethodHandle %p", vmThread, methodHandle);
       if (arg)
          TR_VerboseLog::write(" arg %p", arg);
       static const char *flagNames[] = { "CUSTOM", "SYNCHRONOUS" };
@@ -1529,6 +1529,7 @@ uint8_t *compileMethodHandleThunk(j9object_t methodHandle, j9object_t arg, J9VMT
          if (flags & flag)
             TR_VerboseLog::write(" %s", flagNames[i]);
          }
+      TR_VerboseLog::writeLine("");
       TR_VerboseLog::vlogRelease();
       }
    bool disabled = false;


### PR DESCRIPTION
We perform the following changes:

- Update `write` calls to `writeLine` calls where possible
- Update newline convention to print the new line at the end
- Use the tag when printing where possible
- Add lock acquire and release where it is missed

Fixes: #8911
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>