### PR TITLE
Enable JIT testing for value types tests

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -51,6 +51,39 @@
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
-		 </impls>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>ValueTypeTestsJIT</testCaseName>
+		<variations>
+			<!--
+			  - -Xjit:count=0 temporarily disabled due to intermittent failures
+			  -
+			  -	<variation>-Xjit:count=0</variation>
+			  -->
+			<variation>-Xjit:count=1,disableAsyncCompilation</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-Xverify:none \
+		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		-XX:+EnableValhalla \
+		-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTestsJIT \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>Valhalla</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 </playlist>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -51,7 +51,7 @@ import org.testng.annotations.BeforeClass;
  * 11) make -f run_configure.mk && make compile && make _sanity
  */
 
-@Test(groups = { "level.sanity" })
+@Test(groups = { "level.sanity" }, invocationCount = 2)
 public class ValueTypeTests {
 	static Lookup lookup = MethodHandles.lookup();
 	static Unsafe myUnsafe = null;

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,11 @@
 	<test name="ValueTypeTests">
 		<classes>
 			<class name="org.openj9.test.lworld.ValueTypeTests" />
+		</classes>
+	</test>
+	<test name="ValueTypeTestsJIT">
+		<classes>
+			<class name="org.openj9.test.lworld.ValueTypeTests"/>
 		</classes>
 	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
This change adds a variation to test with JIT compilation forced on with count=1,disableAsyncCompilation.

~~This is marked as  a work-in-progress as tests that~~ depends on pull request #8922 and pull request #9128 currently fail:
- [x] Pull request #8922
- [x] Pull request #9128