### PR TITLE
Register assumptions for static final field modifications

### DIFF
--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -844,6 +844,11 @@ TR_CHTable::computeDataForCHTableCommit(TR::Compilation *comp)
    for (int i = 0; i < compClassesForOSRRedefinition->size(); ++i)
       classesForOSRRedefinition[i] = (*compClassesForOSRRedefinition)[i];
 
+   auto *compClassesForStaticFinalFieldModification = comp->getClassesForStaticFinalFieldModification();
+   std::vector<TR_OpaqueClassBlock*> classesForStaticFinalFieldModification(compClassesForStaticFinalFieldModification->size());
+   for (int i = 0; i < compClassesForStaticFinalFieldModification->size(); ++i)
+      classesForStaticFinalFieldModification[i] = (*compClassesForStaticFinalFieldModification)[i];
+
    uint8_t *startPC = comp->cg()->getCodeStart();
 
    return std::make_tuple(classes,
@@ -854,6 +859,7 @@ TR_CHTable::computeDataForCHTableCommit(TR::Compilation *comp)
                           compClassesThatShouldNotBeLoaded,
                           compClassesThatShouldNotBeNewlyExtended,
                           classesForOSRRedefinition,
+                          classesForStaticFinalFieldModification,
                           startPC);
    }
 #endif

--- a/runtime/compiler/env/JITServerCHTable.hpp
+++ b/runtime/compiler/env/JITServerCHTable.hpp
@@ -76,6 +76,7 @@ using CHTableCommitData = std::tuple<
       FlatClassLoadCheck, // comp->getClassesThatShouldNotBeLoaded
       FlatClassExtendCheck, // comp->getClassesThatShouldNotBeNewlyExtended
       std::vector<TR_OpaqueClassBlock*>, // classesForOSRRedefinition
+      std::vector<TR_OpaqueClassBlock*>, // classesForStaticFinalFieldModification
       uint8_t*>; // startPC
 
 /** 


### PR DESCRIPTION
This change serializes the list of final field folded classes
collected on the server during compilation and sends them over
to the client. Upon receiving the list of final field folded classes
from the server, the client checks for static field modifications
in the list of classes and fail the compilation if any of the classes
has its static field modified. If none has its static field modified,
then the client will proceed to create runtime assumptions and commit
them to the CHTable (done in JITClientCHTableCommit)

Issue: #9364

Signed-off-by: Harry Yu <harryyu1994@gmail.com>