### PR TITLE
Cache result of class chain validation

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1908,6 +1908,10 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
          }
 
+      if (TR::Options::sharedClassCache() && TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching))
+         if (!TR_J9SharedCache::initCCVCaching())
+            return -1;
+
       if (TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT))
          {
          javaVM->sharedClassConfig->runtimeFlags &= ~J9SHR_RUNTIMEFLAG_ENABLE_AOT;

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -52,6 +52,8 @@ TR_J9SharedCache::TR_J9SharedCacheDisabledReason TR_J9SharedCache::_sharedCacheS
 TR_YesNoMaybe TR_J9SharedCache::_sharedCacheDisabledBecauseFull = TR_maybe;
 UDATA TR_J9SharedCache::_storeSharedDataFailedLength = 0;
 
+TR::Monitor * TR_J9SharedCache::_classChainValidationMutex = NULL;
+
 TR_YesNoMaybe TR_J9SharedCache::isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo)
    {
    if (_sharedCacheDisabledBecauseFull == TR_maybe)
@@ -96,6 +98,15 @@ TR_YesNoMaybe TR_J9SharedCache::isSharedCacheDisabledBecauseFull(TR::Compilation
    return _sharedCacheDisabledBecauseFull;
    }
 
+bool
+TR_J9SharedCache::initCCVCaching()
+   {
+   if (!_classChainValidationMutex)
+      {
+      if (!(_classChainValidationMutex = TR::Monitor::create("JIT-ClassChainValidationMutex")))
+         return false;
+      }
+   }
 
 TR_J9SharedCache::TR_J9SharedCache(TR_J9VMBase *fe)
    {

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -170,6 +170,11 @@ public:
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo);
    static void setStoreSharedDataFailedLength(UDATA length) {_storeSharedDataFailedLength = length; }
 
+   /**
+    * @brief Initializes the monitor and map used to cache the result of a class chain validation
+    *
+    * @return true if initialization succeeded, false otherwise
+    */
    static bool initCCVCaching();
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
@@ -216,13 +221,52 @@ private:
    bool romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & chainPtr, UDATA *chainEnd);
    UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength);
 
+   /**
+    * @brief Validates the provided class chain. This method modifies the chainPtr arg.
+    *
+    * @param romClass The J9ROMClass of the class whose chain is to be validated
+    * @param clazz The TR_OpaqueClassBlock of the class whose chain is to be validated
+    * @param chainPtr Pointer to the start of the class chain passed by reference
+    * @param chainEnd Pointer to the end of the class chain
+    * @return true if validation succeeded, false otherwise.
+    */
    bool validateClassChain(J9ROMClass *romClass, TR_OpaqueClassBlock *clazz, UDATA * & chainPtr, UDATA *chainEnd);
+
+   /**
+    * @brief Validates the super classes portion of the class chain. This method modifies the chainPtr arg.
+    *
+    * @param clazz The TR_OpaqueClassBlock of the class whose chain is to be validated
+    * @param chainPtr Pointer to the start of super classes portion of the class chain passed by reference
+    * @param chainEnd Pointer to the end of the class chain
+    * @return true if validation succeeded, false otherwise.
+    */
    bool validateSuperClassesInClassChain(TR_OpaqueClassBlock *clazz, UDATA * & chainPtr, UDATA *chainEnd);
+
+   /**
+    * @brief Validates the interfaces portion of the class chain. This method modifies the chainPtr arg.
+    *
+    * @param clazz The TR_OpaqueClassBlock of the class whose chain is to be validated
+    * @param chainPtr Pointer to the start of interfaces portion of the class chain passed by reference
+    * @param chainEnd Pointer to the end of the class chain
+    * @return true if validation succeeded, false otherwise.
+    */
    bool validateInterfacesInClassChain(TR_OpaqueClassBlock *clazz, UDATA * & chainPtr, UDATA *chainEnd);
 
    static bool isPointerInCache(const J9SharedClassCacheDescriptor *cacheDesc, void *ptr);
 
+   /**
+    * @brief Gets the cached result of a prior class chain validation
+    * @param classOffsetInCache Offset into the SCC of the class to be validated
+    * @return The CCVResult stored in the map; CCVResult::notYetValidated if result does not exist.
+    */
    static CCVResult getCachedCCVResult(uintptr_t classOffsetInCache);
+
+   /**
+    * @brief Caches the result of a class chain validation
+    * @param classOffsetInCache Offset into the SCC of the class to be validated
+    * @param result The result represented as a CCVResult
+    * @return The result of the insertion.
+    */
    static bool cacheCCVResult(uintptr_t classOffsetInCache, CCVResult result);
 
    uint16_t _initialHintSCount;

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -216,6 +216,10 @@ private:
    bool romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & chainPtr, UDATA *chainEnd);
    UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength);
 
+   bool validateClassChain(J9ROMClass *romClass, TR_OpaqueClassBlock *clazz, UDATA * & chainPtr, UDATA *chainEnd);
+   bool validateSuperClassesInClassChain(TR_OpaqueClassBlock *clazz, UDATA * & chainPtr, UDATA *chainEnd);
+   bool validateInterfacesInClassChain(TR_OpaqueClassBlock *clazz, UDATA * & chainPtr, UDATA *chainEnd);
+
    static bool isPointerInCache(const J9SharedClassCacheDescriptor *cacheDesc, void *ptr);
 
    static CCVResult getCachedCCVResult(uintptr_t classOffsetInCache);

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -168,6 +168,9 @@ public:
    static TR_J9SharedCacheDisabledReason getSharedCacheDisabledReason() { return _sharedCacheState; }
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo);
    static void setStoreSharedDataFailedLength(UDATA length) {_storeSharedDataFailedLength = length; }
+
+   static bool initCCVCaching();
+
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList();
 
 private:
@@ -225,6 +228,8 @@ private:
    static TR_J9SharedCacheDisabledReason _sharedCacheState;
    static TR_YesNoMaybe                  _sharedCacheDisabledBecauseFull;
    static UDATA                          _storeSharedDataFailedLength;
+
+   static TR::Monitor                   *_classChainValidationMutex;
    };
 
 


### PR DESCRIPTION
Depends on https://github.com/eclipse/omr/pull/5143

This PR introduces an optimization to the Class Chain Validation performed when loading an AOT compiled body from the SCC. For specifics on the Class Chain see [1]. The high level idea is that the Class Chain does not validate visibility, but rather is used to validate that the shape of the class seen in the previous run is the same in the current run. It does so by comparing the chain of romclasses that make up its inheritance and interface hierarchy. Therefore, once the class chain validation has succeeded for a given class, that remains true for the remainder of the run and there is no need to run class chain validations again.

Currently, class chain validations are implemented as validation records, which exist per method. Therefore, a class could have its class chain validated several times. This PR caches the result of a validation. It does so by maintaining two bit vectors (one for success and one for failure). The key of the bit vector is the offset of the romclass in the SCC.

The caching is guarded by the option `-Xaot:enableClassChainValidationCaching` (hence the dependence on OMR).

This PR is motivated by changes in validation that will likely be required when Project Valhalla lands. With flattened types, the class chains will likely need to be modified. Additionally the time required to validate flattened types will likely be much higher.

fyi @andrewcraik 

<hr/>

## Questions

@mpirvu Each of the bit vectors are initialized with `1024*1204` bits. This equates to 128KiB each, so a total of 256KiB. The bit vectors are growable, but I chose `1024*1024` as a reasonable soft upper bound of the number classes that would be loaded in most cases. Do you think that initial number is too big and do you think this will have an impact on footprint when enabled?

@mstoodle I know that if a class chain validation succeeds, that is now an invariant during the run. However, if a class chain validation fails, is it possible for it to succeed later? I don't think it can but I wanted to double check with you.

@andrewcraik how does HCR affect a romclass? When a class gets redefined, does it get a different romclass?

<hr/>

## Local Tests

### Successful validation
Default:
```
TR_J9SC:classMatchesCachedVersion class 0000000000805500 java/lang/String
TR_J9SC:        found chain: 00007FCB62722670 with length 48
TR_J9SC:                Examining romclass 00007FCB514695C0 (java/lang/String) offset 431312, comparing to 431312
TR_J9SC:                Examining romclass 00007FCB51459000 (java/lang/Object) offset 364304, comparing to 364304
TR_J9SC:                Examining romclass 00007FCB51468780 (java/io/Serializable) offset 427664, comparing to 427664
TR_J9SC:                Examining romclass 00007FCB51471FD8 (java/lang/Comparable) offset 466664, comparing to 466664
TR_J9SC:                Examining romclass 00007FCB514720F0 (java/lang/CharSequence) offset 466944, comparing to 466944
TR_J9SC:        Match!  return true
...
TR_J9SC:classMatchesCachedVersion class 0000000000805500 java/lang/String
TR_J9SC:        found chain: 00007FCB62722670 with length 48
TR_J9SC:                Examining romclass 00007FCB514695C0 (java/lang/String) offset 431312, comparing to 431312
TR_J9SC:                Examining romclass 00007FCB51459000 (java/lang/Object) offset 364304, comparing to 364304
TR_J9SC:                Examining romclass 00007FCB51468780 (java/io/Serializable) offset 427664, comparing to 427664
TR_J9SC:                Examining romclass 00007FCB51471FD8 (java/lang/Comparable) offset 466664, comparing to 466664
TR_J9SC:                Examining romclass 00007FCB514720F0 (java/lang/CharSequence) offset 466944, comparing to 466944
TR_J9SC:        Match!  return true
```
enableClassChainValidationCaching:
```
TR_J9SC:classMatchesCachedVersion class 000000000222C500 java/lang/String
TR_J9SC:        found chain: 00007F21BE722670 with length 48
TR_J9SC:                Examining romclass 00007F21AD4695C0 (java/lang/String) offset 431312, comparing to 431312
TR_J9SC:                Examining romclass 00007F21AD459000 (java/lang/Object) offset 364304, comparing to 364304
TR_J9SC:                Examining romclass 00007F21AD468780 (java/io/Serializable) offset 427664, comparing to 427664
TR_J9SC:                Examining romclass 00007F21AD471FD8 (java/lang/Comparable) offset 466664, comparing to 466664
TR_J9SC:                Examining romclass 00007F21AD4720F0 (java/lang/CharSequence) offset 466944, comparing to 466944
TR_J9SC:        Match!  return true
...
TR_J9SC:classMatchesCachedVersion class 000000000222C500 java/lang/String
TR_J9SC:        cached result: validation succeeded
```

### Unsuccessful validation
Failure simulated by doing:
```
diff --git a/runtime/compiler/env/J9SharedCache.cpp b/runtime/compiler/env/J9SharedCache.cpp
index 6b73cc91d6..a8b8b37916 100644
--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -960,6 +960,7 @@ TR_J9SharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
 
    /* Perform class chain validation */
    bool validationSucceeded = validateClassChain(romClass, clazz, chainPtr, chainEnd);
+   validationSucceeded = false;
    if (validationSucceeded)
       LOG(1, "\tMatch!  return true\n");
```

Default:
```
TR_J9SC:classMatchesCachedVersion class 0000000000BEC500 java/lang/String
TR_J9SC:        found chain: 00007F09C27224E4 with length 48
TR_J9SC:                Examining romclass 00007F09B14695C0 (java/lang/String) offset 431312, comparing to 431312
TR_J9SC:                Examining romclass 00007F09B1459000 (java/lang/Object) offset 364304, comparing to 364304
TR_J9SC:                Examining romclass 00007F09B1468780 (java/io/Serializable) offset 427664, comparing to 427664
TR_J9SC:                Examining romclass 00007F09B1471FD8 (java/lang/Comparable) offset 466664, comparing to 466664
TR_J9SC:                Examining romclass 00007F09B14720F0 (java/lang/CharSequence) offset 466944, comparing to 466944
                applyRelocation: could not verify class
...
TR_J9SC:classMatchesCachedVersion class 0000000000BEC500 java/lang/String
TR_J9SC:        found chain: 00007F09C27224E4 with length 48
TR_J9SC:                Examining romclass 00007F09B14695C0 (java/lang/String) offset 431312, comparing to 431312
TR_J9SC:                Examining romclass 00007F09B1459000 (java/lang/Object) offset 364304, comparing to 364304
TR_J9SC:                Examining romclass 00007F09B1468780 (java/io/Serializable) offset 427664, comparing to 427664
TR_J9SC:                Examining romclass 00007F09B1471FD8 (java/lang/Comparable) offset 466664, comparing to 466664
TR_J9SC:                Examining romclass 00007F09B14720F0 (java/lang/CharSequence) offset 466944, comparing to 466944
                applyRelocation: could not verify class
```

enableClassChainValidationCaching:
```
TR_J9SC:classMatchesCachedVersion class 00000000014F2500 java/lang/String
TR_J9SC:        found chain: 00007FB31A722670 with length 48
TR_J9SC:                Examining romclass 00007FB3094695C0 (java/lang/String) offset 431312, comparing to 431312
TR_J9SC:                Examining romclass 00007FB309459000 (java/lang/Object) offset 364304, comparing to 364304
TR_J9SC:                Examining romclass 00007FB309468780 (java/io/Serializable) offset 427664, comparing to 427664
TR_J9SC:                Examining romclass 00007FB309471FD8 (java/lang/Comparable) offset 466664, comparing to 466664
TR_J9SC:                Examining romclass 00007FB3094720F0 (java/lang/CharSequence) offset 466944, comparing to 466944
                preparePrivateData: clazz 0000000000000000
...
TR_J9SC:classMatchesCachedVersion class 00000000014F2500 java/lang/String
TR_J9SC:        cached result: validation failed
```

<hr/>

[1] https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/ClassChains.md