### PR TITLE
Remove use of DecimalFormatHelper in JITServer

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2081,7 +2081,6 @@ J9::Options::setupJITServerOptions()
       self()->setOption(TR_DisableProfiling); // JITServer limitation, JIT profiling data is not available to remote compiles yet
       self()->setOption(TR_DisableEDO); // JITServer limitation, EDO counters are not relocatable yet
       self()->setOption(TR_DisableMethodIsCold); // Shady heuristic; better to disable to reduce client/server traffic
-      self()->setOption(TR_DisableDecimalFormatPeephole);// JITServer decimalFormatPeephole,
       self()->setOption(TR_DisableJProfilerThread);
       self()->setOption(TR_EnableJProfiling, false);
 


### PR DESCRIPTION
Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>