### PR TITLE
Add --with-boot-jdk and other improvements to Linux build instructions

### DIFF
--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -569,7 +569,7 @@ bootjdk_url() {
 }
 
 install_bootjdks() {
-  local versions="8 11 13 14"
+  local versions="8 11 14"
   echo ""
   echo "# Download and install boot JDKs from AdoptOpenJDK."
   echo "RUN cd /tmp \\"

--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -64,30 +64,17 @@ If you want to build a binary by using a Docker container, follow these steps to
 
 1. The first thing you need to do is install Docker. You can download the free Community edition from [here](https://docs.docker.com/engine/installation/), which also contains instructions for installing Docker on your system.  You should also read the [Getting started](https://docs.docker.com/get-started/) guide to familiarise yourself with the basic Docker concepts and terminology.
 
-2. Obtain the [Linux on 64-bit x86 systems Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile) to build and run a container that has all the correct software pre-requisites.
+2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
 
-    :pencil: Dockerfiles are also available for the following Linux architectures: [Linux on 64-bit Power systems&trade;](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile) and [Linux on 64-bit z Systems&trade;](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile)
+Download the docker build script to your local system or copy and paste the following command:```
 
-    Either download one of these Dockerfiles to your local system or copy and paste one of the following commands:
-
-  - For Linux on 64-bit x86 systems, run:
 ```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
-```
-
-  - For Linux on 64-bit Power systems, run:
-```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
-```
-
-  - For Linux on 64-bit z Systems, run:
-```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
+wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh
 ```
 
 3. Next, run the following command to build a Docker image, called **openj9**:
 ```
-docker build -t openj9 -f Dockerfile .
+bash mkdocker.sh --tag=openj9 --dist=ubuntu --version=16.04 --build
 ```
 
 4. Start a Docker container from the **openj9** image with the following command, where `-v` maps any directory, `<host_directory>`,
@@ -102,12 +89,11 @@ Now that you have the Docker image running, you are ready to move to the next st
 
 #### Setting up your build environment without Docker
 
-If you don't want to user Docker, you can still build an **OpenJDK V11** with OpenJ9 directly on your Ubuntu system or in a Ubuntu virtual machine. Use the
-[Linux on x86 Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile) like a recipe card to determine the software dependencies
-that must be installed on the system, plus a few configuration steps.
+If you don't want to user Docker, you can still build directly on your Ubuntu system or in a Ubuntu virtual machine. Use the output of the following command like a recipe card to determine the software dependencies that must be installed on the system, plus a few configuration steps.
 
-:pencil:
-Not on x86? We also have Dockerfiles for the following Linux architectures: [Linux on Power systems](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile) and [Linux on z Systems](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile).
+```
+bash mkdocker.sh --tag=openj9 --dist=ubuntu --version=16.04 --print
+```
 
 1. Install the list of dependencies that can be obtained with the `apt-get` command from the following section of the Dockerfile:
 ```
@@ -185,7 +171,8 @@ Now you're ready to build **OpenJDK V11** with OpenJ9:
 ```
 make all
 ```
-:warning: If you just type `make`, rather than `make all` your build will fail, because the default `make` target is `exploded-image`. If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script. For more information, read this [issue](https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/34).
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -291,7 +278,7 @@ bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar \
                --with-cups-include=<cups_include_path> \
                --disable-warnings-as-errors
 ```
-where `<my_home_dir>` is the location where you stored **freemarker.jar** and `<cups_include_path>` is the absolute path to CUPS. For example `/opt/freeware/include`.
+where `<my_home_dir>` is the location where you stored **freemarker.jar** and `<cups_include_path>` is the absolute path to CUPS. For example, `/opt/freeware/include`.
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.
 
@@ -311,7 +298,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
-:warning: If you just type `make`, rather than `make all` your build will fail, because the default `make` target is `exploded-image`. If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script. For more information, read this [issue](https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/34).
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -461,6 +449,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -596,6 +586,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 Two builds of OpenJDK with Eclipse OpenJ9 are built and stored in the following directories:
 
@@ -742,6 +734,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -1172,6 +1166,8 @@ Generate the build-JDK intended for later cross-compilation:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 :bulb:
 Please move the generated build-JDK at `build/linux-x86_64-normal-server-release/images` to an appropriate directory as the `build` directory will be removed for cross-compilation in the following step.
@@ -1230,6 +1226,8 @@ Now you're ready to cross-build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (JDK without DDR support) is built and stored in the following directory:
 

--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -113,21 +113,14 @@ Not on x86? We also have Dockerfiles for the following Linux architectures: [Lin
 ```
 apt-get update \
   && apt-get install -qq -y --no-install-recommends \
-    gcc-7 \
-    g++-7 \
-    autoconf \
-    ca-certificates \
     ...
 ```
 
-2. This build uses the same gcc and g++ compiler levels as OpenJDK, which might be
-backlevel compared with the versions you use on your system. Create links for
-the compilers with the following commands:
+2. The previous step installed g++-7 and gcc-7 packages, which might be different
+than the default version installed on your system. Export variables to set the 
+version used in the build.
 ```
-ln -s g++ /usr/bin/c++
-ln -s g++-7 /usr/bin/g++
-ln -s gcc /usr/bin/cc
-ln -s gcc-7 /usr/bin/gcc
+export CC=gcc-7 CXX=g++-7
 ```
 
 3. Download and setup **freemarker.jar** into a directory.
@@ -141,13 +134,10 @@ rm -f freemarker.tgz
 4. Download and setup the boot JDK using the latest AdoptOpenJDK v11 build.
 ```
 cd /<my_home_dir>
-wget -O bootjdk11.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
+wget -O bootjdk11.tar.gz "https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/openj9/normal/adoptopenjdk"
 tar -xzf bootjdk11.tar.gz
 rm -f bootjdk11.tar.gz
-mv $(ls | grep -i jdk) bootjdk11
-
-export JAVA_HOME="/<my_home_dir>/bootjdk11"
-export PATH="${JAVA_HOME}/bin:${PATH}"
+mv $(ls | grep -i jdk-11) bootjdk11
 ```
 
 ### 2. Get the source
@@ -171,9 +161,11 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar
+bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar --with-boot-jdk=/usr/lib/adoptojdk-java-11
 ```
 :warning: You must give an absolute path to freemarker.jar
+
+:warning: The path in the example --with-boot-jdk= option is appropriate for the Docker installation. If not using the Docker environment, set the path appropriate for your setup, such as "/<my_home_dir>/bootjdk11" as setup in the previous instructions.
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.
 

--- a/doc/build-instructions/Build_Instructions_V14.md
+++ b/doc/build-instructions/Build_Instructions_V14.md
@@ -62,30 +62,17 @@ If you want to build a binary by using a Docker container, follow these steps to
 
 1. The first thing you need to do is install Docker. You can download the free Community edition from [here](https://docs.docker.com/engine/installation/), which also contains instructions for installing Docker on your system.  You should also read the [Getting started](https://docs.docker.com/get-started/) guide to familiarise yourself with the basic Docker concepts and terminology.
 
-2. Obtain the [Linux on 64-bit x86 systems Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk14/x86_64/ubuntu16/Dockerfile) to build and run a container that has all the correct software pre-requisites.
+2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
 
-    :pencil: Dockerfiles are also available for the following Linux architectures: [Linux on 64-bit Power systems&trade;](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk14/ppc64le/ubuntu16/Dockerfile) and [Linux on 64-bit z Systems&trade;](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk14/s390x/ubuntu16/Dockerfile)
+Download the docker build script to your local system or copy and paste the following command:
 
-    Either download one of these Dockerfiles to your local system or copy and paste one of the following commands:
-
-  - For Linux on 64-bit x86 systems, run:
 ```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk14/x86_64/ubuntu16/Dockerfile
-```
-
-  - For Linux on 64-bit Power systems, run:
-```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk14/ppc64le/ubuntu16/Dockerfile
-```
-
-  - For Linux on 64-bit z Systems, run:
-```
-wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk14/s390x/ubuntu16/Dockerfile
+wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh
 ```
 
 3. Next, run the following command to build a Docker image, called **openj9**:
 ```
-docker build -t openj9 -f Dockerfile .
+bash mkdocker.sh --tag=openj9 --dist=ubuntu --version=16.04 --build
 ```
 
 4. Start a Docker container from the **openj9** image with the following command, where `-v` maps any directory, `<host_directory>`,
@@ -100,12 +87,11 @@ Now that you have the Docker image running, you are ready to move to the next st
 
 #### Setting up your build environment without Docker
 
-If you don't want to user Docker, you can still build an **OpenJDK V14** with OpenJ9 directly on your Ubuntu system or in a Ubuntu virtual machine. Use the
-[Linux on x86 Dockerfile](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk14/x86_64/ubuntu16/Dockerfile) like a recipe card to determine the software dependencies
-that must be installed on the system, plus a few configuration steps.
+If you don't want to user Docker, you can still build directly on your Ubuntu system or in a Ubuntu virtual machine. Use the output of the following command like a recipe card to determine the software dependencies that must be installed on the system, plus a few configuration steps.
 
-:pencil:
-Not on x86? We also have Dockerfiles for the following Linux architectures: [Linux on Power systems](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk14/ppc64le/ubuntu16/Dockerfile) and [Linux on z Systems](https://github.com/eclipse/openj9/blob/master/buildenv/docker/jdk14/s390x/ubuntu16/Dockerfile).
+```
+bash mkdocker.sh --tag=openj9 --dist=ubuntu --version=16.04 --print
+```
 
 1. Install the list of dependencies that can be obtained with the `apt-get` command from the following section of the Dockerfile:
 ```
@@ -183,7 +169,8 @@ Now you're ready to build **OpenJDK V14** with OpenJ9:
 ```
 make all
 ```
-:warning: If you just type `make`, rather than `make all` your build will fail, because the default `make` target is `exploded-image`. If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script. For more information, read this [issue](https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/34).
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -290,7 +277,7 @@ bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar \
                --with-cups-include=<cups_include_path> \
                --disable-warnings-as-errors
 ```
-where `<my_home_dir>` is the location where you stored **freemarker.jar** and `<cups_include_path>` is the absolute path to CUPS. For example `/opt/freeware/include`.
+where `<my_home_dir>` is the location where you stored **freemarker.jar** and `<cups_include_path>` is the absolute path to CUPS. For example, `/opt/freeware/include`.
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.
 
@@ -310,7 +297,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
-:warning: If you just type `make`, rather than `make all` your build will fail, because the default `make` target is `exploded-image`. If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script. For more information, read this [issue](https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/34).
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -454,6 +442,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 A binary for the full developer kit (jdk) is built and stored in the following directory:
 
@@ -589,6 +579,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 Two builds of OpenJDK with Eclipse OpenJ9 are built and stored in the following directories:
 

--- a/doc/build-instructions/Build_Instructions_V14.md
+++ b/doc/build-instructions/Build_Instructions_V14.md
@@ -111,21 +111,14 @@ Not on x86? We also have Dockerfiles for the following Linux architectures: [Lin
 ```
 apt-get update \
   && apt-get install -qq -y --no-install-recommends \
-    gcc-7 \
-    g++-7 \
-    autoconf \
-    ca-certificates \
     ...
 ```
 
-2. This build uses the same gcc and g++ compiler levels as OpenJDK, which might be
-backlevel compared with the versions you use on your system. Create links for
-the compilers with the following commands:
+2. The previous step installed g++-7 and gcc-7 packages, which might be different
+than the default version installed on your system. Export variables to set the 
+version used in the build.
 ```
-ln -s g++ /usr/bin/c++
-ln -s g++-7 /usr/bin/g++
-ln -s gcc /usr/bin/cc
-ln -s gcc-7 /usr/bin/gcc
+export CC=gcc-7 CXX=g++-7
 ```
 
 3. Download and setup **freemarker.jar** into a directory.
@@ -136,16 +129,13 @@ tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2
 rm -f freemarker.tgz
 ```
 
-4. Download and setup the boot JDK using the latest AdoptOpenJDK v13 build.
+4. Download and setup the boot JDK using the latest AdoptOpenJDK v14 build.
 ```
 cd /<my_home_dir>
-wget -O bootjdk13.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
-tar -xzf bootjdk13.tar.gz
-rm -f bootjdk13.tar.gz
-mv $(ls | grep -i jdk) bootjdk13
-
-export JAVA_HOME="/<my_home_dir>/bootjdk13"
-export PATH="${JAVA_HOME}/bin:${PATH}"
+wget -O bootjdk14.tar.gz "https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/openj9/normal/adoptopenjdk"
+tar -xzf bootjdk14.tar.gz
+rm -f bootjdk14.tar.gz
+mv $(ls | grep -i jdk-14) bootjdk14
 ```
 
 ### 2. Get the source
@@ -169,9 +159,11 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar --with-boot-jdk=<path_to_boot_JDK13>
+bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar --with-boot-jdk=/usr/lib/adoptojdk-java-14
 ```
 :warning: You must give an absolute path to freemarker.jar
+
+:warning: The path in the example --with-boot-jdk= option is appropriate for the Docker installation. If not using the Docker environment, set the path appropriate for your setup, such as "/<my_home_dir>/bootjdk14" as setup in the previous instructions.
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.
 

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -63,7 +63,7 @@ If you want to build a binary by using a Docker container, follow these steps to
 
 1. The first thing you need to do is install Docker. You can download the free Community edition from [here](https://docs.docker.com/engine/installation/), which also contains instructions for installing Docker on your system.  You should also read the [Getting started](https://docs.docker.com/get-started/) guide to familiarise yourself with the basic Docker concepts and terminology.
 
-2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
+2. Obtain the [docker build script](https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh) to build and run a container that has all the correct software pre-requisites.
 
 Download the docker build script to your local system or copy and paste the following command:
 
@@ -99,17 +99,31 @@ bash mkdocker.sh --tag=openj9 --dist=ubuntu --version=16.04 --print
 ```
 apt-get update \
  && apt-get install -qq -y --no-install-recommends \
-   autoconf \
-   ca-certificates \
    ...
 ```
 
-2. Download and setup **freemarker.jar** into a directory. The example commands use `/root` to be consistent with the Docker instructions. If you aren't using Docker, you probably want to store the **freemarker.jar** in your home directory.
+2. The previous step installed g++-7 and gcc-7 packages, which might be different
+than the default version installed on your system. Export variables to set the 
+version used in the build.
+```
+export CC=gcc-7 CXX=g++-7
+```
+
+3. Download and setup **freemarker.jar** into a directory. The example commands use `/root` to be consistent with the Docker instructions. If you aren't using Docker, you probably want to store the **freemarker.jar** in your home directory.
 ```
 cd /root
 wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz
 tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2
 rm -f freemarker.tgz
+```
+
+4. Download and setup the boot JDK using the latest AdoptOpenJDK v8 build.
+```
+cd /<my_home_dir>
+wget -O bootjdk8.tar.gz "https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/openj9/normal/adoptopenjdk"
+tar -xzf bootjdk8.tar.gz
+rm -f bootjdk8.tar.gz
+mv $(ls | grep -i jdk8) bootjdk8
 ```
 
 ### 2. Get the source
@@ -133,9 +147,11 @@ bash get_source.sh
 :penguin:
 When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
 ```
-bash configure --with-freemarker-jar=/root/freemarker.jar
+bash configure --with-freemarker-jar=/root/freemarker.jar --with-boot-jdk=/usr/lib/adoptojdk-java-80
 ```
 :warning: You must give an absolute path to freemarker.jar
+
+:warning: The path in the example --with-boot-jdk= option is appropriate for the Docker installation. If not using the Docker environment, set the path appropriate for your setup, such as "/<my_home_dir>/bootjdk8" as setup in the previous instructions.
 
 :pencil: **Non-compressed references support:** If you require a heap size greater than 57GB, enable a noncompressedrefs build with the `--with-noncompressedrefs` option during this step.
 

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -88,7 +88,7 @@ Now that you have the Docker image running, you are ready to move to the next st
 
 #### Setting up your build environment without Docker
 
-If you don't want to user Docker, you can still build an OpenJDK V8 with OpenJ9 directly on your Ubuntu system or in a Ubuntu virtual machine. Use the output of this command like a recipe card to determine the software dependencies that must be installed on the system, plus a few configuration steps.
+If you don't want to user Docker, you can still build directly on your Ubuntu system or in a Ubuntu virtual machine. Use the output of the following command like a recipe card to determine the software dependencies that must be installed on the system, plus a few configuration steps.
 
 ```
 bash mkdocker.sh --tag=openj9 --dist=ubuntu --version=16.04 --print
@@ -472,6 +472,8 @@ Now you're ready to build OpenJDK with OpenJ9:
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 Two Java builds are produced: a full developer kit (jdk) and a runtime environment (jre)
 1) Win 64-bit
@@ -642,6 +644,8 @@ Now you're ready to build OpenJDK with OpenJ9.
 ```
 make all
 ```
+:warning: If you just type `make`, rather than `make all` your build will be incomplete, because the default `make` target is `exploded-image`.
+If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script.
 
 :pencil: Because `make all` does not provide sufficient details for debugging, a more verbose build can be produced by running the command `make LOG=trace all 2>&1 | tee make_all.log`.
 


### PR DESCRIPTION
Also modify mkdocker.sh to stop installing jdk13 since the instructions
no longer refer to this version.

Closes #9375