### PR TITLE
Abort AOT when symbol owning method is not inlined

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2143,6 +2143,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationSymbolValidationManagerFailure:
             case compilationAOTNoSupportForAOTFailure:
             case compilationAOTValidateTMFailure:
+            case compilationAOTRelocationRecordGenerationFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;
@@ -11095,6 +11096,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTNoSupportForAOTFailure &e)
       {
       _methodBeingCompiled->_compErrCode = compilationAOTNoSupportForAOTFailure;
+      }
+   catch (const J9::AOTRelocationRecordGenerationFailure &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationAOTRelocationRecordGenerationFailure;
       }
    catch (const J9::ClassChainPersistenceFailure &e)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -205,12 +205,13 @@ char *compilationErrorNames[]={
    "compilationAOTNoSupportForAOTFailure", //51
    "compilationAOTValidateTMFailure", //52
    "compilationILGenUnsupportedValueTypeOperationFailure", //53
+   "compilationAOTRelocationRecordGenerationFailure", //54
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure", //54
-   "compilationStreamLostMessage", // 55
-   "compilationStreamMessageTypeMismatch", // 56
-   "compilationStreamVersionIncompatible", // 57
-   "compilationStreamInterrupted", // 58
+   "compilationStreamFailure", //55
+   "compilationStreamLostMessage", // 56
+   "compilationStreamMessageTypeMismatch", // 57
+   "compilationStreamVersionIncompatible", // 58
+   "compilationStreamInterrupted", // 59
 #endif /* defined(J9VM_OPT_JITSERVER) */
    "compilationMaxError"
 };

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -77,6 +77,7 @@ typedef enum {
    compilationAOTNoSupportForAOTFailure            = 51,
    compilationAOTValidateTMFailure                 = 52,
    compilationILGenUnsupportedValueTypeOperationFailure = 53,
+   compilationAOTRelocationRecordGenerationFailure = 54,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,

--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -118,6 +118,15 @@ class AOTNoSupportForAOTFailure : public virtual TR::CompilationException
    virtual const char* what() const throw() { return "This code doesn't support AOT"; }
    };
 
+/**
+ * AOT Relocation Record Generation Failure exception type.
+ *
+ * Thrown when an AOT compilation fails in relocation record generation phase.
+ */
+class AOTRelocationRecordGenerationFailure: public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "AOT Relocation Record Generation Failed"; }
+   };
 }
 
 #endif // AOT_FAILURE_HPP


### PR DESCRIPTION
Sometimes a symRef's owning method might not be inlined. Currently
AOT can't handle this case. A new AOT exception type called
`AOTRelocationRecordGenerationFailure` is added so that
compiler will retry compiling the current method without AOT when
detecting something goes wrong while generating relocation records.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>