### PR TITLE
Add the check of BCV_SPECIAL in generating stackmaps

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -954,8 +954,15 @@ mergeStacks (J9BytecodeVerificationData * verifyData, UDATA target)
 					/* Merge when either the source or target not an object */
 					if ((sourceItem | targetItem) & (BCV_BASE_OR_SPECIAL)) {
 
-						/* Mismatch results in undefined local - rewalk if modified stack */
-						if (*targetStackPtr != (UDATA) (BCV_BASE_TYPE_TOP)) {
+						/* Mismatch results in undefined local - rewalk if modified stack
+						 * Note: BCV_SPECIAL (specifically BCV_SPECIAL_INIT) must be reserved
+						 * to flag the uninitialized_this object existing in the stackmap frame
+						 * when invoking setInitializedThisStatus() after the stackmaps is
+						 * successfully built.
+						 */
+						if ((targetItem != (UDATA) (BCV_BASE_TYPE_TOP))
+						&& ((targetItem & BCV_SPECIAL) == 0)
+						) {
 							*targetStackPtr = (UDATA) (BCV_BASE_TYPE_TOP);
 							rewalk = TRUE;
 						}

--- a/runtime/bcverify/j9bcverify.tdf
+++ b/runtime/bcverify/j9bcverify.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2019 IBM Corp. and others
+// Copyright (c) 2006, 2020 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -212,3 +212,5 @@ TraceExit=Trc_RTV_findClassRelationship_Exit Overhead=1 Level=3 Template="findCl
 TraceEntry=Trc_RTV_freeClassRelationshipParentNodes_Entry Overhead=1 Level=3 Template="freeClassRelationshipParentNodes - class: %.*s"
 TraceEvent=Trc_RTV_freeClassRelationshipParentNodes_Parent Overhead=1 Level=3 Template="freeClassRelationshipParentNodes - parent: %.*s"
 TraceExit=Trc_RTV_freeClassRelationshipParentNodes_Exit Overhead=1 Level=3 Template="freeClassRelationshipParentNodes - returning"
+
+TraceException=Trc_RTV_matchStack_PrimitiveOrSpecialMismatchException Overhead=1 Level=1 Template="matchStack - %.*s %.*s%.*s incompatible primitives or special at offset %i, live = 0x%X, target = 0x%X"


### PR DESCRIPTION
The change is to add the check of BCV_SPECIAL when 
merging & matching stacks to ensure the uninitializedThis 
flag is correctly set up during the generation of stackmaps
so as to match the  RI's behavior at runtime verification.

Fixes: #9385

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>