### PR TITLE
Replace CPU APIs on x86

### DIFF
--- a/runtime/compiler/env/J9CompilerEnv.cpp
+++ b/runtime/compiler/env/J9CompilerEnv.cpp
@@ -37,7 +37,6 @@ J9::CompilerEnv::CompilerEnv(J9JavaVM *vm, TR::RawAllocator raw, const TR::Persi
    {
    }
 
-
 void
 J9::CompilerEnv::initializeTargetEnvironment()
    {

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -177,7 +177,7 @@ class HeapProperties
    };
 
 template <TR::HeapTypes::Type HEAP_TYPE, bool is64Bit>
-uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuffer, TR_X86ProcessorInfo &cpuInfo)
+uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuffer, TR::Compilation* comp)
    {
 
    typedef HeapProperties<HEAP_TYPE> HeapTraits;
@@ -232,8 +232,9 @@ uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuf
    //
    for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset)
       {
+      TR_ASSERT_FATAL(TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
       prefetchSnippetBuffer[0] = 0x0F;
-      if (cpuInfo.isAMD15h())
+      if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H))
          prefetchSnippetBuffer[1] = 0x0D;
       else
          prefetchSnippetBuffer[1] = 0x18;
@@ -319,17 +320,17 @@ void TR::createCCPreLoadedCode(uint8_t *CCPreLoadedCodeBase, uint8_t *CCPreLoade
 
    CCPreLoadedCodeTable[TR_CCPreLoadedCode::TR_AllocPrefetch] = static_cast<void *>(cursor);
    if (cg->comp()->target().is64Bit())
-      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::ZeroedHeap, true>(cursor, cg->getX86ProcessorInfo());
+      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::ZeroedHeap, true>(cursor, cg->comp());
    else
-      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::ZeroedHeap, false>(cursor, cg->getX86ProcessorInfo());
+      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::ZeroedHeap, false>(cursor, cg->comp());
 
    cursor = static_cast<uint8_t *>( TR::alignAllocation<32>(cursor) );
 
    CCPreLoadedCodeTable[TR_CCPreLoadedCode::TR_NonZeroAllocPrefetch] = static_cast<void *>(cursor);
    if (cg->comp()->target().is64Bit())
-      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::NonZeroedHeap, true>(cursor, cg->getX86ProcessorInfo());
+      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::NonZeroedHeap, true>(cursor, cg->comp());
    else
-      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::NonZeroedHeap, false>(cursor, cg->getX86ProcessorInfo());
+      cursor = TR::X86AllocPrefetchSnippet::emitSharedBody<TR::HeapTypes::NonZeroedHeap, false>(cursor, cg->comp());
 
    cursor = static_cast<uint8_t *>( TR::alignAllocation<32>(cursor) );
 

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.hpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,7 +107,7 @@ class X86AllocPrefetchSnippet  : public TR::X86RestartSnippet
 
    static TR_X86AllocPrefetchGeometry generatePrefetchGeometry();
    template <TR::HeapTypes::Type HEAP_TYPE, bool is64Bit> static int32_t sizeOfSharedBody();
-   template <TR::HeapTypes::Type HEAP_TYPE, bool is64Bit> static uint8_t* emitSharedBody(uint8_t *, TR_X86ProcessorInfo &);
+   template <TR::HeapTypes::Type HEAP_TYPE, bool is64Bit> static uint8_t* emitSharedBody(uint8_t *, TR::Compilation*);
 
    friend void TR::createCCPreLoadedCode(uint8_t *CCPreLoadedCodeBase, uint8_t *CCPreLoadedCodeTop, void ** CCPreLoadedCodeTable, TR::CodeGenerator *cg);
    friend uint32_t TR::getCCPreLoadedCodeSize();

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -85,19 +85,23 @@ J9::X86::CodeGenerator::CodeGenerator() :
    cg->setSupportsPartialInlineOfMethodHooks();
    cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsNewInstanceImplOpt();
-   if (cg->getX86ProcessorInfo().supportsSSE4_1() &&
+   
+   TR_ASSERT_FATAL(comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
+   TR_ASSERT_FATAL(comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
+   
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringCaseConv) &&
        !TR::Compiler->om.canGenerateArraylets())
       cg->setSupportsInlineStringCaseConversion();
 
-   if (cg->getX86ProcessorInfo().supportsSSSE3() &&
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) &&
        !comp->getOption(TR_DisableFastStringIndexOf) &&
        !TR::Compiler->om.canGenerateArraylets())
       {
       cg->setSupportsInlineStringIndexOf();
       }
 
-   if (cg->getX86ProcessorInfo().supportsSSE4_1() &&
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringHashCode) &&
        !TR::Compiler->om.canGenerateArraylets())
       {
@@ -375,7 +379,8 @@ J9::X86::CodeGenerator::nopsAlsoProcessedByRelocations()
 bool
 J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    {
-   if (TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
+   TR_ASSERT_FATAL(self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
+   if (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
       return true;
    else
       return false;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -573,7 +573,8 @@ static TR::Instruction *generatePrefetchAfterHeaderAccess(TR::Node              
    TR::Instruction *instr = NULL;
 
    static const char *prefetch = feGetEnv("TR_EnableSoftwarePrefetch");
-   if (prefetch && cg->comp()->getMethodHotness()>=scorching && cg->getX86ProcessorInfo().isIntelCore2())
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
+   if (prefetch && cg->comp()->getMethodHotness()>=scorching && cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2))
       {
       int32_t fieldOffset = 0;
       if (TR::TreeEvaluator::loadLookaheadAfterHeaderAccess(node, fieldOffset, cg))
@@ -4643,7 +4644,8 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
          }
       }
 
-   if (cg->comp()->target().is64Bit() && cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed\n");
+   if (cg->comp()->target().is64Bit() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
       {
       TR::LabelSymbol *JITMonitorEntrySnippetLabel = generateLabelSymbol(cg);
       TR::TreeEvaluator::transactionalMemoryJITMonitorEntry(node, cg, startLabel, snippetLabel, JITMonitorEntrySnippetLabel, objectReg, lwOffset);
@@ -4698,13 +4700,15 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    if (cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord())
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG8MemReg : CMPXCHG8MemReg;
-      if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG8MemReg : XACMPXCHG8MemReg;
       }
    else
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG4MemReg : CMPXCHG4MemReg;
-      if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG4MemReg : XACMPXCHG4MemReg;
       }
 
@@ -5530,7 +5534,8 @@ TR::Register
 
    if (!node->isReadMonitor() && !reservingLock)
       {
-      if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
       else
@@ -9095,7 +9100,8 @@ static TR::Register* inlineStringHashCode(TR::Node* node, bool isCompressed, TR:
       generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
       auto mr = generateX86MemoryReference(tmp, index, shift, 0, cg);
-      if (cg->getX86ProcessorInfo().supportsAVX())
+      TR_ASSERT_FATAL(cg->getX86ProcessorInfo().supportsAVX() == cg->comp()->target().cpu.supportsAVX(), "supportsAVX() failed\n");
+      if (cg->comp()->target().cpu.supportsAVX())
          {
          generateRegMemInstruction(PANDRegMem, node, hashXMM, mr, cg);
          }
@@ -9504,7 +9510,8 @@ inlineCompareAndSwapNative(
       }
    else
       {
-      if (!cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction())
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
+      if (!cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8))
          return false;
 
       op = LCMPXCHG8BMem;
@@ -9925,7 +9932,8 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderAccesses:
             {
-            if (cg->getX86ProcessorInfo().supportsMFence())
+            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
+            if (cg->comp()->target().cpu.supportsMFence())
                {
                TR_X86OpCode fenceOp;
                fenceOp.setOpCodeValue(MFENCE);
@@ -9938,8 +9946,11 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderReads:
             {
-            if (cg->getX86ProcessorInfo().requiresLFENCE() &&
-                cg->getX86ProcessorInfo().supportsLFence())
+            TR_ASSERT_FATAL(cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
+
+            if (cg->comp()->target().cpu.requiresLFence() &&
+                cg->comp()->target().cpu.supportsLFence())
                {
                TR_X86OpCode fenceOp;
                fenceOp.setOpCodeValue(LFENCE);
@@ -9952,7 +9963,9 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderWrites:
             {
-            if (cg->getX86ProcessorInfo().supportsSFence())
+            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
+            
+            if (cg->comp()->target().cpu.supportsSFence())
                {
                TR_X86OpCode fenceOp;
                fenceOp.setOpCodeValue(SFENCE);

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -63,12 +63,6 @@ CPU::getProcessorSignature()
    }
 
 bool
-CPU::testOSForSSESupport()
-   {
-   return true; // VM guarantees SSE/SSE2 are available
-   }
-
-bool
 CPU::hasPopulationCountInstruction()
    {
    if ((self()->getX86ProcessorFeatureFlags2() & TR_POPCNT) != 0x00000000)

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -71,8 +71,8 @@ public:
    const char * getProcessorVendorId();
    uint32_t getProcessorSignature();
 
-   bool testOSForSSESupport();
    bool hasPopulationCountInstruction();
+   bool testOSForSSESupport() { return true; }
 
    TR_ProcessorFeatureFlags getProcessorFeatureFlags();
    bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);


### PR DESCRIPTION
- Replace old processor APIs with new APIs from the CPU class 
- Replace TR::Compiler target with per comp target 

depends on: eclipse/omr#5151
depends on: eclipse/omr#5153

Signed-off-by: Harry Yu <harryyu1994@gmail.com>