### PR TITLE
Leverage CHTable at the server to check if a class is extended

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -84,6 +84,8 @@ class JITServerHelpers
 
    static void insertIntoOOSequenceEntryList(ClientSessionData *clientData, TR_MethodToBeCompiled *entry);
 
+   static uintptr_t getRemoteClassDepthAndFlagsWhenROMClassNotCached(J9Class *clazz, ClientSessionData *clientSessionData, JITServer::ServerStream *stream);
+
    // Functions used for allowing the client to compile locally when server is unavailable.
    // Should be used only on the client side.
    static void postStreamFailure(OMRPortLibrary *portLibrary);

--- a/runtime/compiler/env/JITServerPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.cpp
@@ -180,6 +180,20 @@ JITServerPersistentCHTable::findClassInfoAfterLocking(
    return classInfo;
    }
 
+/**
+ * Find persistent JIT class information for a given class.
+ * The class table lock is used to synchronize use of this method
+ */
+TR_PersistentClassInfo *
+JITServerPersistentCHTable::findClassInfoAfterLocking(
+      TR_OpaqueClassBlock *classId,
+      TR_FrontEnd *fe,
+      bool returnClassInfoForAOT)
+   {
+   TR::ClassTableCriticalSection findClassInfoAfterLocking(fe);
+   return findClassInfo(classId);
+   }
+
 std::string
 JITClientPersistentCHTable::serializeRemoves()
    {

--- a/runtime/compiler/env/JITServerPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITServerPersistentCHTable.hpp
@@ -63,6 +63,7 @@ public:
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId) override;
    virtual TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false) override;
+   virtual TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR_FrontEnd *, bool returnClassInfoForAOT = false) override;
 
 #ifdef COLLECT_CHTABLE_STATS
    // Statistical counters

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -193,6 +193,7 @@ public:
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
+   bool checkCHTableIfClassInfoExistsAndHasBeenExtended(TR_OpaqueClassBlock *clazz, bool &bClassHasBeenExtended);
 
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);


### PR DESCRIPTION
If a class has subclasses in the CHTable at the server, return true in `classHasBeenExtended()`. If not or the class info doesn't exist in the CHTable, check the ROMClass cache next. `VM_classHasBeenExtended` is only sent when the class info doesn't exist in the CHTable and the flag is not set in the cache. `ResolvedMethod_getRemoteROMClassAndMethods` is sent when the class data cannot be found in the CHTable or the ROMClass cache at the server.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>