### PR TITLE
CMake: Don't link jsig against omrsig

### DIFF
--- a/runtime/jsigWrapper/CMakeLists.txt
+++ b/runtime/jsigWrapper/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(jsig
 	PRIVATE
 		j9vm_interface
 
-		omrsig
 		omrutil
 		${CMAKE_DL_LIBS}
 )


### PR DESCRIPTION
This can cause a link ordering issue which results in a deadlock when
signal() is called.

Fixes #9430

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>