### PR TITLE
CMake add missing exports for JVMTI Exception event test

### DIFF
--- a/runtime/tests/jvmtitests/exports.cmake
+++ b/runtime/tests/jvmtitests/exports.cmake
@@ -201,6 +201,8 @@ omr_add_exports(jvmtitest
 	Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat
 	Java_com_ibm_jvmti_tests_getSystemProperty_gsp001_getSystemProperty
 	Java_com_ibm_jvmti_tests_getSystemProperty_gsp001_cleanup
+	Java_com_ibm_jvmti_tests_eventException_ee001_invoke
+	Java_com_ibm_jvmti_tests_eventException_ee001_check
 )
 
 if(NOT JAVA_SPEC_VERSION LESS 9)


### PR DESCRIPTION
See #5883

Fixes test failure in sanity.functional

```
        Testing: ee001
        Test start time: 2020/05/04 15:14:19 Eastern Standard Time
        Running command: "/home/jenkins/workspace/Test_openjdk11_j9_sanity.functional_x86-64_linux_cm_Personal/openjdkbinary/j2sdk-image/bin/java"  -Xcompressedrefs -Xjit -Xgcpolicy:gencon  -Xdump    -agentlib:jvmtitest=test:ee001 -cp "/home/jenkins/workspace/Test_openjdk11_j9_sanity.functional_x86-64_linux_cm_Personal/openjdk-tests/TKG/../../jvmtest/functional/cmdLineTests/jvmtitests/jvmtitest.jar" com.ibm.jvmti.tests.util.TestRunner
        Time spent starting: 2 milliseconds
        Time spent executing: 468 milliseconds
        Test result: FAILED
        Output from test:
         [OUT] *** Testing [1/1]:	testException
         [ERR] exception thrown: null
         [ERR] java.lang.reflect.InvocationTargetException
         [ERR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
         [ERR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
         [ERR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
         [ERR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
         [ERR] 	at com.ibm.jvmti.tests.util.TestCase.run(TestCase.java:215)
         [ERR] 	at com.ibm.jvmti.tests.util.TestSuite.run(TestSuite.java:68)
         [ERR] 	at com.ibm.jvmti.tests.util.TestSuite.run(TestSuite.java:79)
         [ERR] 	at com.ibm.jvmti.tests.util.TestRunner.main(TestRunner.java:60)
         [ERR] Caused by: java.lang.UnsatisfiedLinkError: com/ibm/jvmti/tests/eventException/ee001.invoke(Ljava/lang/reflect/Method;)V
         [ERR] 	at com.ibm.jvmti.tests.eventException.ee001.testException(ee001.java:46)
         [ERR] 	... 8 more
        >> Success condition was not found: [Return code: 0]
```

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>