### PR TITLE
CMake: Fix missing exports in jniargtests

### DIFF
--- a/runtime/tests/jniarg/exports.cmake
+++ b/runtime/tests/jniarg/exports.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,9 @@
 ################################################################################
 
 omr_add_exports(jniargtests
+	Java_JniArgTests_logRetValError
+	Java_JniArgTests_summary
+
 	Java_JniArgTests_nativeBBrB
 	Java_JniArgTests_nativeBBBBrB
 	Java_JniArgTests_nativeBSrB


### PR DESCRIPTION
Fixes test failure in functional.sanity
```
        ===============================================
        Running test jniargtests_0 ...
        ===============================================
        jniargtests_0 Start Time: Mon May  4 16:47:54 2020 Epoch Time (ms): 1588625274853
        variation: -Xint
        JVM_OPTIONS:  -Xint
        Exception in thread "main" java.lang.UnsatisfiedLinkError: JniArgTests.summary()I
        	at JniArgTests.main(JniArgTests.java:61)

        jniargtests_0_FAILED
```

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>