### PR TITLE
AArch64: Fix loadStackParametersToLinkageRegisters

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1426,16 +1426,17 @@ J9::ARM64::PrivateLinkage::loadStackParametersToLinkageRegisters(TR::Instruction
          int8_t lri = parmCursor->getLinkageRegisterIndex();
          TR::RealRegister *linkageReg;
          TR::InstOpCode::Mnemonic op;
+         TR::DataType dataType = parmCursor->getDataType();
 
-         if (parmCursor->getDataType() == TR::Double || parmCursor->getDataType() == TR::Float)
+         if (dataType == TR::Double || dataType == TR::Float)
             {
             linkageReg = machine->getRealRegister(properties.getFloatArgumentRegister(lri));
-            op = (parmCursor->getDataType() == TR::Double) ? TR::InstOpCode::vldrimmd : TR::InstOpCode::vldrimms;
+            op = (dataType == TR::Double) ? TR::InstOpCode::vldrimmd : TR::InstOpCode::vldrimms;
             }
          else
             {
             linkageReg = machine->getRealRegister(properties.getIntegerArgumentRegister(lri));
-            op = TR::InstOpCode::ldrimmx;
+            op = (dataType == TR::Int64 || dataType == TR::Address) ? TR::InstOpCode::ldrimmx : TR::InstOpCode::ldrimmw;
             }
 
          TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(javaSP, parmCursor->getParameterOffset(), cg());


### PR DESCRIPTION
When interger parameters are passed by interpreted methods,
the higher 32bits of stack slots of those parameters are not zeroed out
in some cases.
This commit changes `loadStackParametersToLinkageRegisters` to load
only lower 32bits for integer parameters.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>