### PR TITLE
AArch64: Move copyParametersToHomeLocation to OMRLinkage

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1488,55 +1488,6 @@ J9::ARM64::PrivateLinkage::saveParametersToStack(TR::Instruction *cursor)
    return cursor;
    }
 
-/**
- * A more optimal implementation of this function will be required when GRA is enabled.
- * See OpenJ9 issue #6657.  Also consider merging with loadStackParametersToLinkageRegisters.
- */
-TR::Instruction *
-J9::ARM64::PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored)
-   {
-   TR::Machine *machine = cg()->machine();
-   TR::ARM64LinkageProperties& properties = getProperties();
-   TR::RealRegister *javaSP = machine->getRealRegister(properties.getStackPointerRegister());       // x20
-
-   TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
-   ListIterator<TR::ParameterSymbol> parmIterator(&(bodySymbol->getParameterList()));
-   TR::ParameterSymbol *parmCursor;
-
-   // Store to stack all parameters passed in linkage registers
-   //
-   for (parmCursor = parmIterator.getFirst();
-        parmCursor != NULL;
-        parmCursor = parmIterator.getNext())
-      {
-      if (parmCursor->isParmPassedInRegister())
-         {
-         if (!parmsHaveBeenStored)
-            {
-            int8_t lri = parmCursor->getLinkageRegisterIndex();
-            TR::RealRegister *linkageReg;
-            TR::InstOpCode::Mnemonic op;
-
-            if (parmCursor->getDataType() == TR::Double || parmCursor->getDataType() == TR::Float)
-               {
-               linkageReg = machine->getRealRegister(properties.getFloatArgumentRegister(lri));
-               op = (parmCursor->getDataType() == TR::Double) ? TR::InstOpCode::vstrimmd : TR::InstOpCode::vstrimms;
-               }
-            else
-               {
-               linkageReg = machine->getRealRegister(properties.getIntegerArgumentRegister(lri));
-               op = TR::InstOpCode::strimmx;
-               }
-
-            TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(javaSP, parmCursor->getParameterOffset(), cg());
-            cursor = generateMemSrc1Instruction(cg(), op, NULL, stackMR, linkageReg, cursor);
-            }
-         }
-      }
-
-   return cursor;
-   }
-
 void J9::ARM64::PrivateLinkage::performPostBinaryEncoding()
    {
    // --------------------------------------------------------------------------

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.hpp
@@ -151,17 +151,6 @@ class PrivateLinkage : public J9::PrivateLinkage
    TR::Instruction *loadStackParametersToLinkageRegisters(TR::Instruction *cursor);
 
    /**
-    * @brief Stores parameters passed in linkage registers to the stack where the
-    *        method body expects to find them.
-    *
-    * @param[in] cursor : the instruction cursor to begin inserting copy instructions
-    * @param[in] parmsHaveBeenStored : true if the parameters have been stored to the stack
-    *
-    * @return The instruction cursor after copies inserted.
-    */
-   TR::Instruction *copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored);
-
-   /**
     * @brief Stores parameters passed in linkage registers to the stack. This method is used only in FSD mode.
     *
     * @param[in] cursor : the instruction cursor to begin inserting copy instructions


### PR DESCRIPTION
This commit removes `copyParametersToHomeLocation` from `ARM64PrivateLinkage`
as it is moved to `OMRLinkage`.

Depends on https://github.com/eclipse/omr/pull/5162

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>