### PR TITLE
Disable GCR for hot compilations

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8332,9 +8332,10 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                      options->setOption(TR_UseSymbolValidationManager, false);
                   }
 
-               // See if we need to inset GCR trees
-               if (!details.supportsInvalidation())
-                  {
+               // See if we need to insert GCR trees
+               if (!details.supportsInvalidation() ||
+                   options->getOptLevel() >= hot) // Workaround for a bug with GCR inserted in hot bodies. See #4549 for details.
+                  {                               // Upgrades hot-->scorching should be done through sampling, not GCR
                   options->setOption(TR_DisableGuardedCountingRecompilations);
                   }
                else if (vm->isAOT_DEPRECATED_DO_NOT_USE() || (options->getOptLevel() < warm &&


### PR DESCRIPTION
GCR (guarded counting recompilations is a mechanism that is supposed
to upgrade cold or AOT compilations to warm opt level. In theory
it should work with any opt level, but due to a bug it seems that
GCR is incompatible with hot compilations.
To allow stress testing with hot compilations this commit disables
GCR for hot compilations. This should have no bearing on behavior
in production because the natural way of upgrading hot compilations
to scorching is through sampling.

Fixes: #4445 #8064

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>