### PR TITLE
Implement JVM_GetRandomSeedForCDSDump

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -351,6 +351,13 @@ if(NOT JAVA_SPEC_VERSION LESS 14)
 	)
 endif()
 
+if(NOT JAVA_SPEC_VERSION LESS 15)
+	jvm_add_exports(jvm
+		# Additions for Java 15 (General)
+		JVM_GetRandomSeedForCDSDump
+	)
+endif()
+
 if(J9VM_OPT_JITSERVER)
 	jvm_add_exports(jvm
 		JITServer_CreateServer

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -338,10 +338,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_InitClassName"/>
 		<export name="JVM_InitializeFromArchive"/>
 	</exports>
-	
+
 	<exports group="jdk14">
 		<!-- Additions for Java 14 (General) -->
 		<export name="JVM_GetExtendedNPEMessage"/>
+	</exports>
+
+	<exports group="jdk15">
+		<!-- Additions for Java 15 (General) -->
+		<export name="JVM_GetRandomSeedForCDSDump"/>
 	</exports>
 
 </exportlists>

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -33,6 +33,7 @@
 #include "jvminit.h"
 #include "util_api.h"
 #include "j9vmnls.h"
+#include "j9version.h"
 
 #define J9TIME_NANOSECONDS_PER_SECOND         ((jlong) 1000000000)
 /* Need to do a |currentSecondsTime - secondsOffset| < (2^32) check to ensure that the
@@ -40,7 +41,7 @@
  * |currentNanoTime - nanoTimeOffset| <  4294967295000000000.
  */
 #define TIME_LONG_MAX     ((jlong) 4294967295000000000LL)
-#define TIME_LONG_MIN     ((jlong) -4294967295000000000LL)
+#define TIME_LONG_MIN     ((jlong)-4294967295000000000LL)
 #define OFFSET_MAX        ((jlong) 0x225C17D04LL)         /*  2^63/10^9 */
 #define OFFSET_MIN        ((jlong) 0xFFFFFFFDDA3E82FCLL)  /* -2^63/10^9 */
 
@@ -1570,3 +1571,12 @@ done:
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 }
 #endif /* JAVA_SPEC_VERSION >= 11 */
+
+#if JAVA_SPEC_VERSION >= 15
+JNIEXPORT jlong JNICALL
+JVM_GetRandomSeedForCDSDump()
+{
+	/* OpenJ9 does not support -Xshare:dump, so we return zero unconditionally. */
+	return 0;
+}
+#endif /* JAVA_SPEC_VERSION >= 15 */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -61,6 +61,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk14">
 				<include-if condition="spec.java14"/>
 			</group>
+			<group name="jdk15">
+				<include-if condition="spec.java15"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -313,4 +313,6 @@ _IF([JAVA_SPEC_VERSION >= 11],
 _IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_InitializeFromArchive, JNICALL, false, void, JNIEnv *env, jclass clz)])
 _IF([JAVA_SPEC_VERSION >= 14],
-		[_X(JVM_GetExtendedNPEMessage, JNICALL, false, jstring, JNIEnv *env, jthrowable throwableObj)])
+	[_X(JVM_GetExtendedNPEMessage, JNICALL, false, jstring, JNIEnv *env, jthrowable throwableObj)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_GetRandomSeedForCDSDump, JNICALL, false, jlong)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2007, 2019 IBM Corp. and others
+Copyright (c) 2007, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,6 +61,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</group>
 			<group name="jdk14">
 				<include-if condition="spec.java14"/>
+			</group>
+			<group name="jdk15">
+				<include-if condition="spec.java15"/>
 			</group>
 		</exports>
 		<includes>


### PR DESCRIPTION
This implements the new JVM function `jlong JVM_GetRandomSeedForCDSDump();` required for jdknext since:

> 8241071: Generation of classes.jsa with -Xshare:dump is not deterministic