### PR TITLE
AArch64: Enable Linkage Register Allocation

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2634,13 +2634,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    // OpenJ9 issue #6538 tracks the work to enable.
    //
    self()->setOption(TR_DisableEDO);
-
-   // Support for shuffling linkage registers to GRA registers is not
-   // available on AArch64 yet.
-   //
-   // OpenJ9 issue #6657 tracks the work to enable.
-   //
-   self()->setOption(TR_DisableLinkageRegisterAllocation);
 #endif
 
    return true;


### PR DESCRIPTION
Enable Linkage Register Allocation for aarch64.

Depends on:
https://github.com/eclipse/openj9/pull/9468
https://github.com/eclipse/openj9/pull/9469
https://github.com/eclipse/omr/pull/5164

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>