### PR TITLE
Suppress warnings about trailing digit in 'openj9' module names

### DIFF
--- a/jcl/src/openj9.cuda/share/classes/module-info.java
+++ b/jcl/src/openj9.cuda/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
  * <p>
  * A wealth of background information on CUDA is available <a href="http://www.nvidia.com/object/cuda_home.html">here</a>.
  */
+@SuppressWarnings("module")
 module openj9.cuda {
   requires java.base;
   exports com.ibm.cuda;

--- a/jcl/src/openj9.dataaccess/share/classes/module-info.java
+++ b/jcl/src/openj9.dataaccess/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
  * for packed decimal data. Convert between decimal data types stored in byte arrays and Java binary types.
  * Marshall Java binary types to and from byte arrays.
  */
+@SuppressWarnings("module")
 module openj9.dataaccess {
   exports com.ibm.dataaccess;
 }

--- a/jcl/src/openj9.dtfj/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfj/share/classes/module-info.java
@@ -30,6 +30,7 @@
  * programming interface (API) used to support the building of Java diagnostic
  * tools. DTFJ works with data from a system dump or a Javadump.
  */
+@SuppressWarnings("module")
 module openj9.dtfj {
   requires transitive java.desktop;
   requires transitive java.logging;

--- a/jcl/src/openj9.dtfjview/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfjview/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 /** 
  * Defines the jdmpview tool for reading system core and java core diagnostic files.
  */
+@SuppressWarnings("module")
 module openj9.dtfjview {
   requires openj9.dtfj;
   requires java.logging;

--- a/jcl/src/openj9.gpu/share/classes/module-info.java
+++ b/jcl/src/openj9.gpu/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
  * Defines API to perform certain operations using any connected CUDA capable GPU,
  * such as sorting arrays of natives types.
  */
+@SuppressWarnings("module")
 module openj9.gpu {
   requires java.base;
   requires openj9.cuda;

--- a/jcl/src/openj9.jvm/share/classes/module-info.java
+++ b/jcl/src/openj9.jvm/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
  * Defines API for creating diagnostic dump files, querying and controlling OS logging,
  * querying Java heap and OS memory stats, and controlling and logging trace file output. 
  */
+@SuppressWarnings("module")
 module openj9.jvm {
   exports com.ibm.jvm;
 }

--- a/jcl/src/openj9.sharedclasses/share/classes/module-info.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
  * Defines the shared class cache API. Used to add shared class caching to a ClassLoader implementation.
  * Obtain information about the current shared class cache, available shared class caches, or destroy caches.
  */
+@SuppressWarnings("module")
 module openj9.sharedclasses {
   requires java.base;
   exports com.ibm.oti.shared;

--- a/jcl/src/openj9.traceformat/share/classes/module-info.java
+++ b/jcl/src/openj9.traceformat/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 /**
  *  Provides the traceformat utility for formatting binary trace files.
  */
+@SuppressWarnings("module")
 module openj9.traceformat {
   exports com.ibm.jvm.trace.format.api;
 }

--- a/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
+++ b/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 /**
  * Provides the ConditionException class for z/OS Language Environment condition handling.
  */
+@SuppressWarnings("module")
 module openj9.zosconditionhandling {
   exports com.ibm.le.conditionhandling;
 }


### PR DESCRIPTION
The java compiler issues warnings like:
```
warning: [module] module name component openj9 should avoid terminal digits
module openj9.cuda {
       ^
```
It isn't likely that the compiler will change, and module names beginning with `openj9` seem reasonable for the OpenJ9 project, so suppressing such warnings appears to be our only option.

This becomes more important in jdknext which wants to compile java code with `-Werror`; ibmruntimes/openj9-openjdk-jdk#201 suppresses that option, but we should work toward removing that suppression.