### PR TITLE
AIX JDK8 System.mapLibraryNamepublic() returns libraries with .a suffix

### DIFF
--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -241,7 +241,11 @@ void mapLibraryToPlatformName(const char *inPath, char *outPath) {
 #else
 	strcpy(outPath, "lib");
 	strcat(outPath,inPath);
+#if defined(AIXPPC) && (JAVA_SPEC_VERSION == 8)
+	strcat(outPath, ".a");
+#else /* defined(AIXPPC) && (JAVA_SPEC_VERSION == 8) */
 	strcat(outPath, J9PORT_LIBRARY_SUFFIX);
+#endif /* defined(AIXPPC) && (JAVA_SPEC_VERSION == 8) */
 #endif
 }
 


### PR DESCRIPTION
**AIX JDK8 System.mapLibraryNamepublic() returns libraries with .a suffix**

Restore `AIX JDK8` previous behaviour to avoid breakage for existing applications;
Return libraries with `.so` suffic for `AIX JDK11+` onwards.

Tested in personal builds. There was a build error at `OpenJ9 JDK8 AIX` which doesn't appear related to this PR, in addition, `OpenJ9 JDK11` and internal `JDK8` worked.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>