### PR TITLE
Fix testSCCacheManagement failure on zos

### DIFF
--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
 		    	fail("iterateSharedCacheFunction failed with dir " + dir);
 		    }
 	    	
-	    	if (dir == null && false == isWindows() && false == isMVS() && isOpenJ9()) {
+	    	if (dir == null && false == isWindows() && isOpenJ9()) {
 	    		dirGroupAccess = getCacheDir("Foo_groupaccess", false);
 	    		dirRemoveJavaSharedResources = removeJavaSharedResourcesDir(dirGroupAccess);
 	    		oldCacheGroupAccessCount = iterateSharedCache(dirGroupAccess, NO_FLAGS, false) + iterateSharedCache(dirRemoveJavaSharedResources, NO_FLAGS, false);


### PR DESCRIPTION
- Fix testSCCacheManagement failure on zos
[ci skip]

Issue: runtimes/backlog/306

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>