### PR TITLE
Fix instanceOf's dynamicCache sequence on IBM Z

### DIFF
--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -219,9 +219,11 @@ J9JITConfig * codert_onload(J9JavaVM * javaVM)
    /* Should use portlib */
 #if defined(TR_HOST_X86)
    jitConfig->codeCacheAlignment = 32;
-#elif defined(TR_HOST_64BIT) || defined(TR_HOST_S390)
-   // 390 31-bit may generate 64-bit instruction (i.e. CGRL) which requires
-   // doubleword alignment for its operands
+#elif defined(TR_HOST_S390)
+   // On IBM Z, it can generate load and store quadword instructions from 
+   // Snippet. This requires quadword alignment.
+   jitConfig->codeCacheAlignment = 16;
+#elif defined(TR_HOST_64BIT)
    jitConfig->codeCacheAlignment = 8;
 #else
    jitConfig->codeCacheAlignment = 4;


### PR DESCRIPTION
On IBM Z, for instanceOf node, we have a codegen optimization which caches the encountered classes for which it failed all the inline tests and has to call JIT helper to get the result. This cache is first tested to avoid a call to JIT helper. There was a bug in case we have to cache class of of child when cast class child of the node is runtime variable. We were loading and storing associated fields using two load and store instructions. This causes a potential data race condition which was exploited by highly parallel application where more than 500 threads were running same method and all were trying to update the cache, leaving with the classes in the cache which were not related and in the code which later can cause incorrect result for instanceof.

Fixes: #9457

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>