### PR TITLE
Jenkins: Add extra_cmake_options parameter in yaml

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -1259,6 +1259,16 @@ def set_build_extra_options(build_specs=null) {
         if (!EXTRA_MAKE_OPTIONS) {
             EXTRA_MAKE_OPTIONS = buildspec.getVectorField("extra_make_options", SDK_VERSION).join(" ")
         }
+        def cmake_opts = []
+        // Wrap each option in quotes
+        buildspec.getVectorField("extra_cmake_options", SDK_VERSION).each { opt ->
+            cmake_opts << "\"${opt}\""
+        }
+        if(cmake_opts){
+            cmake_opts = cmake_opts.join(" ")
+            // Put the cmake options at the beginning, so that user can override them with the EXTRA_MAKE_OPTIONS if needed
+            EXTRA_MAKE_OPTIONS = "'EXTRA_CMAKE_OPTIONS=${cmake_opts}' " + EXTRA_MAKE_OPTIONS
+        }
 
         OPENJDK_CLONE_DIR = params.OPENJDK_CLONE_DIR
         if (!OPENJDK_CLONE_DIR) {

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -114,7 +114,6 @@ cmake:
     all: '--with-cmake'
     14: '--disable-ddr'
     next: '--disable-ddr'
-  extra_make_options: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
   excluded_tests:
     8:
       - special.system
@@ -189,6 +188,7 @@ ppc64le_linux:
 #========================================#
 ppc64le_linux_cm:
   extends: ['ppc64le_linux', 'cmake']
+  extra_cmake_options: ['-DOMR_WARNINGS_AS_ERRORS=FALSE']
 #========================================#
 # Linux PPCLE 64bits Large Heap
 #========================================#
@@ -296,6 +296,7 @@ x86-64_linux:
 #========================================#
 x86-64_linux_cm:
   extends: ['x86-64_linux', 'cmake']
+  extra_cmake_options: ['-DOMR_WARNINGS_AS_ERRORS=FALSE']
   excluded_tests:
       - extended.functional
       - sanity.system
@@ -305,6 +306,7 @@ x86-64_linux_cm:
 #========================================#
 x86-64_linux_xl_cm:
   extends: ['x86-64_linux_xl', 'cmake']
+  extra_cmake_options: ['-DOMR_WARNINGS_AS_ERRORS=FALSE']
   excluded_tests:
       - extended.functional
       - sanity.system


### PR DESCRIPTION
Also enable warnings as errors on osx

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>