### PR TITLE
Removing Global GC specific method from base Collector class

### DIFF
--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -642,8 +642,7 @@ MM_ScavengerDelegate::private_shouldPercolateGarbageCollect_classUnloading(MM_En
 	bool shouldGCPercolate = false;
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-	MM_Collector *globalCollector = _extensions->getGlobalCollector();
-	shouldGCPercolate = globalCollector->isTimeForGlobalGCKickoff();
+	shouldGCPercolate = _extensions->getGlobalCollector()->isTimeForGlobalGCKickoff();
 #endif
 
 	return shouldGCPercolate;


### PR DESCRIPTION
This is change is prepare work for https://github.com/eclipse/omr/issues/5178

### Goal:
Preparing for moving `isTimeForGlobalGCKickoff()` from `MM_Collector(base)` to `MM_GlobalCollector (subclass)` so downstream projects will not invoke `isTimeForGlobalGCKickoff` against `MM_Collector`.




Signed-off-by: Enson <enson.guo@ibm.com>