### PR TITLE
Consolidate all trace CG options

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10552,8 +10552,7 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
       J9JavaVM * javaVM = _jitConfig->javaVM;
       // Dump mixed mode disassembly listing.
       //
-      if (compiler->getOutFile() != NULL &&
-          (compiler->getOption(TR_TraceAll) || compiler->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly)))
+      if (compiler->getOutFile() != NULL && compiler->getOption(TR_TraceAll))
          compiler->getDebug()->dumpMixedModeDisassembly();
 
       if (!vm.isAOT_DEPRECATED_DO_NOT_USE())

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2745,7 +2745,6 @@ J9::Options::packOptions(const TR::Options *origOptions)
    // sizeof(bool) is reserved to pack J9JIT_RUNTIME_RESOLVE
    size_t totalSize = sizeof(TR::Options) + logFileNameLength + suffixLogsFormatLength + blockShufflingSequenceLength + induceOSRLength + sizeof(bool);
 
-   addRegexStringSize(origOptions->_traceForCodeMining, totalSize);
    addRegexStringSize(origOptions->_disabledOptTransformations, totalSize);
    addRegexStringSize(origOptions->_disabledInlineSites, totalSize);
    addRegexStringSize(origOptions->_disabledOpts, totalSize);
@@ -2786,7 +2785,6 @@ J9::Options::packOptions(const TR::Options *origOptions)
    options->_customStrategy = NULL;
    options->_customStrategySize = 0;
    options->_countString = NULL;
-   appendRegex(options->_traceForCodeMining, curPos);
    appendRegex(options->_disabledOptTransformations, curPos);
    appendRegex(options->_disabledInlineSites, curPos);
    appendRegex(options->_disabledOpts, curPos);
@@ -2855,7 +2853,6 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR::Co
    // On JITServer, we store this value for each client in ClientSessionData
    bool rtResolve = (bool) *((uint8_t *) options + clientOptionsSize - sizeof(bool));
    compInfoPT->getClientData()->setRtResolve(rtResolve);
-   unpackRegex(options->_traceForCodeMining);
    unpackRegex(options->_disabledOptTransformations);
    unpackRegex(options->_disabledInlineSites);
    unpackRegex(options->_disabledOpts);

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -236,7 +236,7 @@ void J9::Z::PrivateLinkage::alignLocalsOffset(uint32_t &stackIndex, uint32_t loc
 
       atlas->setNumberOfSlotsMapped(atlas->getNumberOfSlotsMapped() + ((stackIndexBeforeAlignment - stackIndex) / TR::Compiler->om.sizeofReferenceAddress()));
 
-      if (cg()->getTraceRAOption(TR_TraceRASpillTemps))
+      if (comp()->getOption(TR_TraceRA))
          {
          traceMsg(comp(),"\nAlign stack offset before alignment = %d and after alignment = %d\n", stackIndexBeforeAlignment, stackIndex);
          }
@@ -440,7 +440,7 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
          {
          int32_t newOffset = stackIndex + pointerSize*(localCursor->getGCMapIndex()-firstLocalGCIndex);
 
-         if (cg()->getTraceRAOption(TR_TraceRASpillTemps))
+         if (comp()->getOption(TR_TraceRA))
             traceMsg(comp(), "\nmapCompactedStack: changing %s (GC index %d) offset from %d to %d",
                comp()->getDebug()->getName(localCursor), localCursor->getGCMapIndex(), localCursor->getOffset(), newOffset);
 


### PR DESCRIPTION
See eclipse/omr#5165 for details. This change was reverted in #9527, and we reinstate it now to get a proper OMR promotion through.

Issue: #9428