### PR TITLE
AArch64: Add gpu feature in build spec files

### DIFF
--- a/buildspecs/linux_aarch64.spec
+++ b/buildspecs/linux_aarch64.spec
@@ -101,6 +101,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<feature id="combogc"/>
 		<feature id="core"/>
 		<feature id="dbgext"/>
+		<feature id="gpu"/>
 		<feature id="se"/>
 		<feature id="se60_26"/>
 		<feature id="se7"/>

--- a/buildspecs/linux_aarch64_cmprssptrs.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs.spec
@@ -101,6 +101,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<feature id="combogc"/>
 		<feature id="core"/>
 		<feature id="dbgext"/>
+		<feature id="gpu"/>
 		<feature id="se"/>
 		<feature id="se60_26"/>
 		<feature id="se7"/>

--- a/buildspecs/linux_aarch64_cmprssptrs_cross.spec
+++ b/buildspecs/linux_aarch64_cmprssptrs_cross.spec
@@ -101,6 +101,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<feature id="combogc"/>
 		<feature id="core"/>
 		<feature id="dbgext"/>
+		<feature id="gpu"/>
 		<feature id="se"/>
 		<feature id="se60_26"/>
 		<feature id="se7"/>

--- a/buildspecs/linux_aarch64_cross.spec
+++ b/buildspecs/linux_aarch64_cross.spec
@@ -101,6 +101,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<feature id="combogc"/>
 		<feature id="core"/>
 		<feature id="dbgext"/>
+		<feature id="gpu"/>
 		<feature id="se"/>
 		<feature id="se60_26"/>
 		<feature id="se7"/>


### PR DESCRIPTION
This commit adds `<feature id="gpu"/>` in build spec files for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>