### PR TITLE
Initialize variable to fix build break on windows

### DIFF
--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp005.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp005.c
@@ -37,7 +37,7 @@ jint JNICALL
 decomp005(agentEnv * _env, char * args)
 {
 	JVMTI_ACCESS_FROM_AGENT(_env);
-	jvmtiError err;                	
+	jvmtiError err = JVMTI_ERROR_NONE;                	
 	jvmtiEventCallbacks callbacks;
 	jvmtiCapabilities capabilities;                
 


### PR DESCRIPTION
Related: #9463

fyi @gacholio @pshipton 

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>