### PR TITLE
Fix for Z 31-bit decompile issue

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -75,7 +75,7 @@ fixStackForSyntheticHandler(J9VMThread *currentThread)
 	J9JITDecompilationInfo *decomp = currentThread->decompilationStack;
 	if (NULL != decomp) {
 		J9SFJITResolveFrame *resolveFrame = (J9SFJITResolveFrame*)currentThread->sp;
-		void *jitPC = resolveFrame->returnAddress;
+		void *jitPC = MASK_PC(resolveFrame->returnAddress);
 		J9JITExceptionTable *metaData = jitGetExceptionTableFromPC(currentThread, (UDATA)jitPC);
 		Assert_CodertVM_false(NULL == metaData);
 		UDATA *oldSP = (UDATA*)(resolveFrame + 1);


### PR DESCRIPTION
Canonicalize the JIT PC when adjusting the resolve frame and
decompiliation record for the synthetic handler fix.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>