### PR TITLE
Only specify base address for 32-bit JIT dll

### DIFF
--- a/runtime/compiler/build/rules/win-msvc/common.mk
+++ b/runtime/compiler/build/rules/win-msvc/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ jit: $(JIT_PRODUCT_SONAME)
 $(JIT_PRODUCT_SONAME): $(JIT_PRODUCT_OBJECTS) | jit_createdirs
 	$(call RM,$@.objlist)
 	$(call GENLIST,$@.objlist,$(SOLINK_PRE_OBJECTS) $(JIT_PRODUCT_OBJECTS) $(SOLINK_POST_OBJECTS))
-	$(SOLINK_CMD) -DLL -subsystem:windows $(SOLINK_FLAGS) $(patsubst %,-libpath:%,$(call FIXPATH,$(SOLINK_LIBPATH))) -OUT:$(call FIXPATH,$@) -MAP:$(call FIXPATH,$@.map) -BASE:$(SOLINK_ORG) -DEF:$(call FIXPATH,$(SOLINK_DEF)) @$(call FIXPATH,$@.objlist) $(call FIXPATH,$(patsubst %,%.lib,$(SOLINK_SLINK))) $(SOLINK_EXTRA_ARGS)
+	$(SOLINK_CMD) -DLL -subsystem:windows $(SOLINK_FLAGS) $(patsubst %,-libpath:%,$(call FIXPATH,$(SOLINK_LIBPATH))) -OUT:$(call FIXPATH,$@) -MAP:$(call FIXPATH,$@.map) $(if $(SOLINK_ORG),-BASE:$(SOLINK_ORG)) -DEF:$(call FIXPATH,$(SOLINK_DEF)) @$(call FIXPATH,$@.objlist) $(call FIXPATH,$(patsubst %,%.lib,$(SOLINK_SLINK))) $(SOLINK_EXTRA_ARGS)
 	$(call RM,$@.objlist)
 
 JIT_DIR_LIST+=$(dir $(JIT_PRODUCT_SONAME))

--- a/runtime/compiler/build/toolcfg/win-msvc/common.mk
+++ b/runtime/compiler/build/toolcfg/win-msvc/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -223,10 +223,10 @@ else
 endif
 
 SOLINK_DEF?=$(JIT_SCRIPT_DIR)/j9jit.def
-SOLINK_ORG?=0x12900000
 
 ifeq ($(HOST_BITS),32)
     SOLINK_FLAGS+=-machine:i386 -safeseh
+    SOLINK_ORG?=0x12900000
 endif
 
 ifeq ($(HOST_BITS),64)


### PR DESCRIPTION
Suggested by link warning:
```
LINK : warning LNK4281: undesirable base address 0x12900000 for x64 image; set base address above 4GB for best ASLR optimization
```