### PR TITLE
Update JITServer heuristics

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -256,6 +256,18 @@ class CompilationInfoPerThreadBase
 
    void                     setClientStream(JITServer::ClientStream *stream) { _clientStream = stream; }
    JITServer::ClientStream *getClientStream() const { return _clientStream; }
+   /**
+      @brief Heuristic that returns true if compiling a method of given size
+             and at given optimization level less is likely to consume little
+             memory relative to what the JVM has at its disposal
+    */
+   bool isMemoryCheapCompilation(uint32_t bcsz, TR_Hotness optLevel);
+   /**
+      @brief Heuristic that returns true if compiling a method of given size
+             and at given optimization level less is likely to consume little
+             CPU relative to what the JVM has at its disposal
+    */
+   bool isCPUCheapCompilation(uint32_t bcsz, TR_Hotness optLevel);
    bool shouldPerformLocalComp(const TR_MethodToBeCompiled *entry);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -127,13 +127,13 @@ void TR_MethodToBeCompiled::releaseSlotMonitor(J9VMThread *vmThread)
    }
 
 bool
-TR_MethodToBeCompiled::isCompiled()
+TR_MethodToBeCompiled::isCompiled() const
    {
    return TR::CompilationInfo::isCompiled(getMethodDetails().getMethod());
    }
 
 bool
-TR_MethodToBeCompiled::isJNINative()
+TR_MethodToBeCompiled::isJNINative() const
    {
    return TR::CompilationInfo::isJNINative(getMethodDetails().getMethod());
    }

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -59,10 +59,10 @@ struct TR_MethodToBeCompiled
    void initialize(TR::IlGeneratorMethodDetails & details, void *oldStartPC, CompilationPriority p, TR_OptimizationPlan *optimizationPlan);
 
    TR::Monitor *getMonitor() { return _monitor; }
-   TR::IlGeneratorMethodDetails & getMethodDetails(){ return *_methodDetails; }
+   TR::IlGeneratorMethodDetails & getMethodDetails() const { return *_methodDetails; }
    bool isDLTCompile()   { return getMethodDetails().isMethodInProgress(); }
-   bool isCompiled();
-   bool isJNINative();
+   bool isCompiled() const;
+   bool isJNINative() const;
    void acquireSlotMonitor(J9VMThread *vmThread);
    void releaseSlotMonitor(J9VMThread *vmThread);
    void setAotCodeToBeRelocated(const void *m);

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,6 +106,7 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
       int64_t newTotalTimeUsedByVm = vmCpuStats._systemTime + vmCpuStats._userTime;
       
       _cpuUsage = (100 * (machineCpuStats.cpuTime - _prevMachineCpuTime)) / _prevIntervalLength;
+      _cpuIdle = 100 * machineCpuStats.numberOfCpus - _cpuUsage;
       _vmCpuUsage = (100 * (newTotalTimeUsedByVm - prevTotalTimeUsedByVm)) / _prevIntervalLength;
       }
    
@@ -121,11 +122,6 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
    _prevMachineCpuTime = machineCpuStats.cpuTime;
    _prevVmSysTime      = vmCpuStats._systemTime;
    _prevVmUserTime     = vmCpuStats._userTime;
-   
-   /*
-   fprintf(stderr, "#CPUINFO: usage=%lld%%, vm-usage=%lld%%, avg-usage=%lld%%, avg-idle=%lld%%, interval=%lldms\n", 
-      _cpuUsage, _vmCpuUsage, _avgCpuUsage, _avgCpuIdle, (_prevIntervalLength / 1000000ll));
-   */
    
    return 0;
    } // updateCpuUtil
@@ -161,6 +157,7 @@ CpuUtilization::CpuUtilization(J9JITConfig *jitConfig):
    _cpuUsage    (INITIAL_USAGE),
    _vmCpuUsage  (INITIAL_USAGE),
    _avgCpuUsage (INITIAL_USAGE),
+   _cpuIdle     (INITIAL_IDLE),
    _avgCpuIdle  (INITIAL_IDLE),
    
    _prevIntervalLength (0),

--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,16 +71,17 @@ public:
 
    bool    isFunctional() const { return _isFunctional; }
    int32_t getCpuUsage() const { return _cpuUsage; }
+   int32_t getCpuIdle() const { return _cpuIdle; }
    int32_t getVmCpuUsage() const { return _vmCpuUsage; }
    int32_t getAvgCpuUsage() const { return _avgCpuUsage; }
-   int32_t getCpuIdle() const { return _avgCpuIdle; }
+   int32_t getAvgCpuIdle() const { return _avgCpuIdle; }
    int64_t getUptime() const { return _prevMachineUptime; } // in nanoseconds
    int64_t getLastMeasurementInterval() const { return _prevIntervalLength; } // in nanoseconds
    int64_t getVmTotalCpuTime() const { return _prevVmSysTime + _prevVmUserTime; }
    int32_t getCpuUtil(J9JITConfig *jitConfig, J9SysinfoCPUTime *machineCpuStats, j9thread_process_time_t *vmCpuStats);
    int32_t updateCpuUtil(J9JITConfig *jitConfig);
    void    disable() { _isFunctional = false;
-                       _cpuUsage = _vmCpuUsage = _avgCpuUsage = _avgCpuIdle = -1;
+                       _cpuUsage = _cpuIdle = _vmCpuUsage = _avgCpuUsage = _avgCpuIdle = -1;
                        disableCpuUsageCircularBuffer(); }
 
    // Circular Buffer related functions
@@ -94,9 +95,10 @@ public:
 private:
 
    int32_t _cpuUsage;    // percentage of used CPU on the whole machine for the last update interval
+   int32_t _cpuIdle;     // percentage of idle CPU on the whole machine for the last update interval
    int32_t _vmCpuUsage;  // percentage of used CPU by the VM for the last update interval
-   int32_t _avgCpuUsage; // percentage of time each processor is used on average
-   int32_t _avgCpuIdle;  // percentage of time each processor is idle on average
+   int32_t _avgCpuUsage; // percentage of time each processor is used on average (0..100)
+   int32_t _avgCpuIdle;  // percentage of time each processor is idle on average (0..100)
 
    int64_t _prevIntervalLength; // the duration (in ns) of the last update interval
 


### PR DESCRIPTION
Under -Xjit:enableJITServerHeuristics change the logic that
determines which compilations to keep local vs which ones to
send to the server based on the amount of memory and CPU
available.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>
