### PR TITLE
Incomplete tactical implementation for -XX:+PrintFlagsFinal

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -542,6 +542,9 @@ enum INIT_STAGE {
 #define VMOPT_XXSHOW_EXTENDED_NPE_MESSAGE "-XX:+ShowCodeDetailsInExceptionMessages"
 #define VMOPT_XXNOSHOW_EXTENDED_NPE_MESSAGE "-XX:-ShowCodeDetailsInExceptionMessages"
 
+#define VMOPT_XXPRINTFLAGSFINALENABLE "-XX:+PrintFlagsFinal"
+#define VMOPT_XXPRINTFLAGSFINALDISABLE "-XX:-PrintFlagsFinal"
+
 /* Modularity command line options */
 #define VMOPT_MODULE_UPGRADE_PATH "--upgrade-module-path"
 #define VMOPT_MODULE_PATH "--module-path"

--- a/test/functional/cmdLineTests/xxargtest/XXArgumentTesting.xml
+++ b/test/functional/cmdLineTests/xxargtest/XXArgumentTesting.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2011, 2018 IBM Corp. and others
+  Copyright (c) 2011, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,4 +72,23 @@
 		<output type="required" caseSensitive="no" regex="no">-Xms11M</output>
 	</test>
 	
+	<test id="Verify -XX:+PrintFlagsFinal">
+		<command>$EXE$ -XX:+PrintFlagsFinal -version</command>
+		<output type="success" caseSensitive="no" regex="no">[Global flags]</output>
+		<output type="required" caseSensitive="no" regex="no">MaxHeapSize</output>
+		<output type="required" caseSensitive="no" regex="no">MaxDirectMemorySize</output>
+	</test>
+
+	<test id="Verify rightmost -XX:+PrintFlagsFinal overrides earlier -XX:-PrintFlagsFinal">
+		<command>$EXE$ -XX:-PrintFlagsFinal -XX:+PrintFlagsFinal -version</command>
+		<output type="success" caseSensitive="no" regex="no">[Global flags]</output>
+		<output type="required" caseSensitive="no" regex="no">MaxHeapSize</output>
+		<output type="required" caseSensitive="no" regex="no">MaxDirectMemorySize</output>
+	</test>
+
+	<test id="Verify rightmost -XX:-PrintFlagsFinal overrides earlier -XX:+PrintFlagsFinal">
+		<command>$EXE$ -XX:+PrintFlagsFinal -XX:-PrintFlagsFinal -version</command>
+		<output type="success" caseSensitive="no" regex="no">Runtime Environment</output>
+		<output type="failure" caseSensitive="no" regex="no">[Global flags]</output>
+	</test>
 </suite>


### PR DESCRIPTION
An incomplete implementation of VM options that produces the
-XX:+PrintFlagsFinal output for two specific options required by
the elasticsearch project. This code is expected to be temporary
until a more comprehensive solution can be architected. For this
reason, this change is very straight-forward and localized so
it can be easily removed.

The two options whose values will be printed are for
`-XX:MaxHeapSize=` and `-XX:MaxDirectMemorySize=` .

With this change, elasticsearch no longer NPEs on startup and,
in my local testing, all their tests pass on OpenJ9.

I tried to match, as closely as possible, the output Hotspot
generates when one uses -XX:+PrintFlagsFinal, which includes the
names used for types (e.g. size_t or uint64_t), the option names,
the option category (e.g. {product} for these two options), the
way the option is set (e.g. {ergonomic} or {command line} for
these two options), and the field widths produced by a JDK11
Hotspot build.

I added 3 command-line tests :

1) that two options (MaxHeapSize, MaxDirectMemorySize) are present
when -XX:+PrintFlagsFinal option is specified.

2) that -XX:+PrintFlagsFinal overrides earlier -XX:-PrintFlagsFinal.

3) that -XX:-PrintFlagsFinal overrides earlier -XX:+PrintFlagsFinal.

Fixes: #7764

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>