### PR TITLE
Resolve classref in checkcast if Qtype

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -39,6 +39,9 @@
 
 extern "C" {
 
+void* J9FASTCALL
+old_slow_jitThrowNullPointerException(J9VMThread *currentThread);
+
 J9_EXTERN_BUILDER_SYMBOL(throwCurrentExceptionFromJIT);
 J9_EXTERN_BUILDER_SYMBOL(handlePopFramesFromJIT);
 #define J9_JITHELPER_ACTION_THROW		J9_BUILDER_SYMBOL(throwCurrentExceptionFromJIT)
@@ -1068,7 +1071,7 @@ old_fast_jitCheckCast(J9VMThread *currentThread)
 	OLD_JIT_HELPER_PROLOGUE(2);
 	DECLARE_JIT_CLASS_PARM(castClass, 1);
 	DECLARE_JIT_PARM(j9object_t, object, 2);
-	/* null can be cast to anything */
+	/* null can be cast to anything, except if castClass is a VT */
 	if (NULL != object) {
 		J9Class *instanceClass = J9OBJECT_CLAZZ(currentThread, object);
 		if (!VM_VMHelpers::inlineCheckCast(instanceClass, castClass)) {
@@ -1077,6 +1080,11 @@ old_fast_jitCheckCast(J9VMThread *currentThread)
 			slowPath = (void*)old_slow_jitCheckCast;
 		}
 	}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	else if (J9_IS_J9CLASS_VALUETYPE(castClass)) {
+		slowPath = (void*)old_slow_jitThrowNullPointerException;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	return slowPath;
 }
 
@@ -1095,13 +1103,18 @@ old_fast_jitCheckCastForArrayStore(J9VMThread *currentThread)
 	OLD_JIT_HELPER_PROLOGUE(2);
 	DECLARE_JIT_CLASS_PARM(castClass, 1);
 	DECLARE_JIT_PARM(j9object_t, object, 2);
-	/* null can be cast to anything */
+	/* null can be cast to anything, except if castClass is a VT */
 	if (NULL != object) {
 		J9Class *instanceClass = J9OBJECT_CLAZZ(currentThread, object);
 		if (!VM_VMHelpers::inlineCheckCast(instanceClass, castClass)) {
 			slowPath = (void*)old_slow_jitCheckCastForArrayStore;
 		}
 	}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	else if (J9_IS_J9CLASS_VALUETYPE(castClass)) {
+		slowPath = (void*)old_slow_jitThrowNullPointerException;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	return slowPath;
 }
 
@@ -3054,7 +3067,7 @@ fast_jitCheckCast(J9VMThread *currentThread, J9Class *castClass, j9object_t obje
 //	extern void* slow_jitCheckCast(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
 	void *slowPath = NULL;
-	/* null can be cast to anything */
+	/* null can be cast to anything, except if castClass is a VT */
 	if (NULL != object) {
 		J9Class *instanceClass = J9OBJECT_CLAZZ(currentThread, object);
 		if (J9_UNEXPECTED(!VM_VMHelpers::inlineCheckCast(instanceClass, castClass))) {
@@ -3064,6 +3077,11 @@ fast_jitCheckCast(J9VMThread *currentThread, J9Class *castClass, j9object_t obje
 			slowPath = (void*)old_slow_jitCheckCast;
 		}
 	}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	else if (J9_IS_J9CLASS_VALUETYPE(castClass)) {
+		slowPath = (void*)old_slow_jitThrowNullPointerException;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	return slowPath;
 }
 
@@ -3078,7 +3096,7 @@ fast_jitCheckCastForArrayStore(J9VMThread *currentThread, J9Class *castClass, j9
 //	extern void* slow_jitCheckCastForArrayStore(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
 	void *slowPath = NULL;
-	/* null can be cast to anything */
+	/* null can be cast to anything, except if castClass is a VT */
 	if (NULL != object) {
 		J9Class *instanceClass = J9OBJECT_CLAZZ(currentThread, object);
 		if (J9_UNEXPECTED(!VM_VMHelpers::inlineCheckCast(instanceClass, castClass))) {
@@ -3086,6 +3104,11 @@ fast_jitCheckCastForArrayStore(J9VMThread *currentThread, J9Class *castClass, j9
 			slowPath = (void*)old_slow_jitCheckCastForArrayStore;
 		}
 	}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	else if (J9_IS_J9CLASS_VALUETYPE(castClass)) {
+		slowPath = (void*)old_slow_jitThrowNullPointerException;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	return slowPath;
 }
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4535,6 +4535,7 @@ typedef struct J9InternalVMFunctions {
 #endif /* J9VM_OPT_JITSERVER */
 	IDATA ( *createJoinableThreadWithCategory)(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend, omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category) ;
 	BOOLEAN ( *valueTypeCapableAcmp)(struct J9VMThread *currentThread, j9object_t lhs, j9object_t rhs) ;
+	BOOLEAN ( *isClassRefQtype)(struct J9Class *cpContextClass, U_16 cpIndex) ;
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2263,6 +2263,19 @@ BOOLEAN
 valueTypeCapableAcmp(J9VMThread *currentThread, j9object_t lhs, j9object_t rhs);
 
 /**
+ * Determines if the classref c=signature is a Qtype. There is no validation performed
+ * to ensure that the cpIndex points at a classref.
+ *
+ * @param[in] cpContextClass ramClass that owns the constantpool being queried
+ * @param[in] cpIndex the CP index
+ *
+ * @return TRUE if classref is a Qtype, false otherwise
+ */
+BOOLEAN
+isClassRefQtype(J9Class *cpContextClass, U_16 cpIndex);
+
+
+/**
 * @brief Iterate over fields of the specified class in JVMTI order.
 * @param state[in/out]  the walk state that was initialized via fieldOffsetsStartDo()
 * @return J9ROMFieldOffsetWalkResult *

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7667,14 +7667,20 @@ resolve:
 			}
 		}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		else {
+		else if (VM_ValueTypeHelpers::isClassRefQtype(ramConstantPool, index)) {
+			/* Even though an NPE is going to be thrown the classref must still be resolved because
+			 * its a qtype.
+			 *
+			 * TODO in the future a different type of exception may thrown, spec for this behaviour
+			 * not currently known.
+			 */
 			if (NULL == castClass) {
 				/* Resolve the class and then check again whether it is a value type */
 				goto resolve;
-			} else if (J9_IS_J9CLASS_VALUETYPE(castClass)) {
-				rc = THROW_NPE;
-				goto done;
 			}
+
+			rc = THROW_NPE;
+			goto done;
 		}
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 		_pc += 3;

--- a/runtime/vm/ValueTypeHelpers.cpp
+++ b/runtime/vm/ValueTypeHelpers.cpp
@@ -63,4 +63,10 @@ valueTypeCapableAcmp(J9VMThread *currentThread, j9object_t lhs, j9object_t rhs)
 	MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
 	return VM_ValueTypeHelpers::acmp(currentThread, objectAccessBarrier, lhs, rhs);
 }
+
+BOOLEAN
+isClassRefQtype(J9Class *cpContextClass, U_16 cpIndex)
+{
+	return VM_ValueTypeHelpers::isClassRefQtype((J9ConstantPool *) cpContextClass->ramConstantPool, cpIndex);
+}
 } /* extern "C" */

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -236,6 +236,24 @@ public:
 		return acmpResult;
 	}
 
+	static VMINLINE bool
+	isClassRefQtype(J9ConstantPool *ramCP, U_16 cpIndex)
+	{
+		J9ROMStringRef *romStringRef = (J9ROMStringRef *)&ramCP->romConstantPool[cpIndex];
+		J9UTF8 *classNameWrapper = J9ROMSTRINGREF_UTF8DATA(romStringRef);
+		U_16 classNameLength = J9UTF8_LENGTH(classNameWrapper);
+		U_8 *classNameData = J9UTF8_DATA(classNameWrapper);
+		bool rc = false;
+
+		if ((';' == *(char *)(classNameData + (classNameLength - 1)))
+			&& ('Q' == *(char *)classNameData)
+		) {
+			rc = true;
+		}
+
+		return rc;
+	}
+
 };
 
 #endif /* VALUETYPEHELPERS_HPP_ */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -375,4 +375,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* J9VM_OPT_JITSERVER */
 	createJoinableThreadWithCategory,
 	valueTypeCapableAcmp,
+	isClassRefQtype,
 };

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -116,6 +116,8 @@ public class ValueTypeGenerator extends ClassLoader {
 				makeGeneric(cw, className, "makeValueGeneric", "makeValue", makeValueSig, makeValueGenericSig, fields, makeMaxLocal, isRef);
 			}
 		}
+		testCheckCastOnInvalidQtype(cw);
+		testCheckCastOnInvalidLtype(cw);
 		addStaticSynchronizedMethods(cw);
 		addSynchronizedMethods(cw);
 		cw.visitEnd();
@@ -338,7 +340,27 @@ public class ValueTypeGenerator extends ClassLoader {
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastValueTypeOnNull", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
-		mv.visitTypeInsn(CHECKCAST, className);
+		mv.visitTypeInsn(CHECKCAST, getSigFromSimpleName(className, false));
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 2);
+		mv.visitEnd();
+	}
+	
+	private static void testCheckCastOnInvalidQtype(ClassWriter cw) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastOnInvalidQtype", "()Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitInsn(ACONST_NULL);
+		mv.visitTypeInsn(CHECKCAST, "QClassDoesNotExist;");
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(1, 2);
+		mv.visitEnd();
+	}
+	
+	private static void testCheckCastOnInvalidLtype(ClassWriter cw) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastOnInvalidLtype", "()Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitInsn(ACONST_NULL);
+		mv.visitTypeInsn(CHECKCAST, "ClassDoesNotExist");
 		mv.visitInsn(ARETURN);
 		mv.visitMaxs(1, 2);
 		mv.visitEnd();

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -2000,6 +2000,32 @@ public class ValueTypeTests {
 	}
 
 	/*
+	 * Ensure that casting null to invalid Qtype class will throw a NoClassDef 
+	 */
+	@Test(priority=1)
+	static public void testCheckCastValueTypeOnInvalidLtype() throws Throwable {
+		try {
+			String fields[] = {"longField:J"};
+			Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastOnInvalidLtype", fields);
+			MethodHandle checkCastOnInvalidLtype = lookup.findStatic(valueClass, "testCheckCastOnInvalidLtype", MethodType.methodType(Object.class));
+			checkCastOnInvalidLtype.invoke();
+		} catch (Exception e) {
+			Assert.fail("Should not throw exception");
+		}
+	}
+	
+	/*
+	 * Ensure that casting null to invalid Qtype class will throw a NoClassDef 
+	 */
+	@Test(priority=1, expectedExceptions=NoClassDefFoundError.class)
+	static public void testCheckCastValueTypeOnInvalidQtype() throws Throwable {
+		String fields[] = {"longField:J"};
+		Class valueClass = ValueTypeGenerator.generateValueClass("TestCheckCastOnInvalidQtype", fields);
+		MethodHandle checkCastOnInvalidQtype = lookup.findStatic(valueClass, "testCheckCastOnInvalidQtype", MethodType.methodType(Object.class));
+		checkCastOnInvalidQtype.invoke();
+	}
+	
+	/*
 	 * Ensure that casting null to a value type class will throw a null pointer exception 
 	 */
 	@Test(priority=1, expectedExceptions=NullPointerException.class)


### PR DESCRIPTION
Resolve classref in checkcast if Qtype

Currently, if the receiver for a checkcast is NULL the VM does not
bother to resolve the classref and the checkcast test passes. With VTs this
behaviour is not allowed as NULL cannot be assigned to VTs. VTs will
always have Qsignatures, therefore, if the classref of a checkcast has
a qsignature it must be resolved, regardless of what the receiver is.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>