### PR TITLE
WIP: Fix patching on class unloading at the server

### DIFF
--- a/runtime/compiler/p/runtime/PPCRelocationTarget.hpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.hpp
@@ -75,7 +75,7 @@ class TR_PPC64RelocationTarget : public TR_PPCRelocationTarget
          }
 
    private:
-         virtual void platformAddPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr);
+         virtual void platformAddPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr, void *metaDataBasePtr = NULL);
 
    };
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2225,7 +2225,7 @@ TR_RelocationRecordInlinedMethod::fixInlinedSiteInfo(TR_RelocationRuntime *reloR
    TR_OpaqueClassBlock *classOfInlinedMethod = reloRuntime->fej9()->getClassFromMethodBlock(inlinedMethod);
    if ( reloRuntime->fej9()->isUnloadAssumptionRequired( classOfInlinedMethod, reloRuntime->comp()->getCurrentMethod() ) )
       {
-      reloTarget->addPICtoPatchPtrOnClassUnload(classOfInlinedMethod, &(inlinedCallSite->_methodInfo));
+      reloTarget->addPICtoPatchPtrOnClassUnload(classOfInlinedMethod, &(inlinedCallSite->_methodInfo), (void *)reloRuntime->exceptionTable());
       }
    }
 

--- a/runtime/compiler/runtime/RelocationTarget.hpp
+++ b/runtime/compiler/runtime/RelocationTarget.hpp
@@ -152,9 +152,9 @@ class TR_RelocationTarget
        * @param classKey The class upon which the pointer to be updated is dependant.
        * @param ptr The address to be updated.
        */
-      void addPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr);
+      void addPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr, void *metaDataBasePtr = NULL);
    private:
-      virtual void platformAddPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr);
+      virtual void platformAddPICtoPatchPtrOnClassUnload(TR_OpaqueClassBlock *classKey, void *ptr, void *metaDataBasePtr = NULL);
       TR_RelocationRuntime *_reloRuntime;
    };
 


### PR DESCRIPTION
Depends on #9559. 

Add `TR_InlinedCallSite::_methodInfo` in fixInlinedSiteInfo() to class unloading assumption list at the server.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>