### PR TITLE
Run ref repo updater on test only nodes

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Update-Reference-Repos.groovy
@@ -26,7 +26,7 @@ if (!SETUP_LABEL) {
 
 LABEL = params.LABEL
 if (!LABEL) {
-    LABEL = 'ci.role.build'
+    LABEL = 'ci.role.build || ci.role.test'
 }
 
 CLEAN_CACHE_DIR = params.CLEAN_CACHE_DIR
@@ -129,7 +129,10 @@ timeout(time: 6, unit: 'HOURS') {
                         }
 
                         // get Eclipse OpenJ9 extensions repositories from variables file
-                        def repos = get_openjdk_repos(VARIABLES.openjdk, foundLabel)
+                        def repos = []
+                        if (nodeLabels.contains('ci.role.build')) {
+                            repos.addAll(get_openjdk_repos(VARIABLES.openjdk, foundLabel))
+                        }
 
                         if (nodeLabels.contains('ci.role.test')) {
                             // add AdoptOpenJDK/openjdk-tests repository


### PR DESCRIPTION
- In the ref repo updater we add the openjdk-tests repo
  to test nodes. There was a bug in the script where if
  the node was test-only it never made it into the list
  of machines to get a ref repo. This change makes the
  script look for all build or test nodes and will add
  ext repos for build nodes and test repo for test nodes.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>