### PR TITLE
Fix warning in jvmti agent test

### DIFF
--- a/runtime/cmake/platform/toolcfg/msvc.cmake
+++ b/runtime/cmake/platform/toolcfg/msvc.cmake
@@ -1,0 +1,25 @@
+################################################################################
+# Copyright (c) 2020, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
+
+list(APPEND OMR_PLATFORM_DEFINITIONS
+	-D_CRT_NONSTDC_NO_WARNINGS
+)

--- a/runtime/makelib/targets.mk.win.inc.ftl
+++ b/runtime/makelib/targets.mk.win.inc.ftl
@@ -1,5 +1,5 @@
 <#-- 
-	Copyright (c) 1998, 2019 IBM Corp. and others
+	Copyright (c) 1998, 2020 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -167,6 +167,13 @@ CFLAGS+=-D_CRT_SECURE_NO_WARNINGS
 CXXFLAGS+=-D_CRT_SECURE_NO_WARNINGS
 ifdef USE_CLANG
   CLANG_CXXFLAGS+=-D_CRT_SECURE_NO_WARNINGS
+endif
+
+# We don't want warnings about deprecated POSIX function names
+CFLAGS+=-D_CRT_NONSTDC_NO_WARNINGS
+CXXFLAGS+=-D_CRT_NONSTDC_NO_WARNINGS
+ifdef USE_CLANG
+  CLANG_CFFGLAGS+=-D_CRT_NONSTDC_NO_WARNINGS
 endif
 
 CFLAGS+=-DCRTAPI1=_cdecl -DCRTAPI2=_cdecl -nologo

--- a/runtime/tests/jvmtitests/agent/error.c
+++ b/runtime/tests/jvmtitests/agent/error.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,7 +60,7 @@ throwJVMTIError(agentEnv * env, JNIEnv * jni_env, jvmtiError err)
 
 	if ((*jvmti_env)->GetErrorName(jvmti_env, err, &error) == JVMTI_ERROR_NONE) {
 		throwError(jni_env, error);
-		(*jvmti_env)->Deallocate(jvmti_env, error);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *) error);
 	} else {
 		throwError(jni_env, "Failed to retrieve JVMTI error name");
 	}

--- a/runtime/tests/jvmtitests/agent/module.xml
+++ b/runtime/tests/jvmtitests/agent/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2019 IBM Corp. and others
+  Copyright (c) 2001, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@
 			<makefilestub data="UMA_ZOS_FLAGS += -Wc,DLL,EXPORTALL">
 				<include-if condition="spec.zos_390.*"/>
 			</makefilestub>
+			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS = 1"/>
 		</makefilestubs>
 	</artifact>
 </module>


### PR DESCRIPTION
Compiler warned of passing char* to function expecting unsigned char*.
Same cast can be seen on other calls to Deallocate.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>