### PR TITLE
CMake: Disable -Wall for the j9util library.

### DIFF
--- a/runtime/util/CMakeLists.txt
+++ b/runtime/util/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(hshelp.tdf j9hshelp)
 add_tracegen(util.tdf j9util)
 add_tracegen(vmutil.tdf j9vmutil)


### PR DESCRIPTION
Note that in this case the matching uma side of things is the absence of
`<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>` in the module.xml

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>