### PR TITLE
Add guards to unguarded traces

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7742,7 +7742,8 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          //
          char *targetSig = methodDescriptor+1; // skip parenthesis
          int firstArgSlot = _methodSymbol->isStatic()? 0 : 1;
-         traceMsg(comp(), "sourceSig %s targetSig %.*s\n", sourceSig, methodDescriptorLength, methodDescriptor);
+         if (trace())
+            traceMsg(comp(), "sourceSig %s targetSig %.*s\n", sourceSig, methodDescriptorLength, methodDescriptor);
 
          for (
             int32_t argIndex = 0;

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -205,7 +205,8 @@ J9::Symbol::searchRecognizedField(TR::Compilation * comp, TR_ResolvedMethod * ow
           && comp->fej9()->isClassInitialized(declaringClass)
           && strncmp(&(fieldName[totalLen - 22]), assertionsDisabledStr, 21) == 0)
          {
-         traceMsg(comp, "Matched $assertionsDisabled Z\n");
+         if (comp->getOption(TR_TraceCG))
+            traceMsg(comp, "Matched $assertionsDisabled Z\n");
          return assertionsDisabled;
          }
       }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3777,7 +3777,8 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
 
 #define DAA_PRINT(a) \
 case a: \
-   traceMsg(comp(), "DAA Method found: %s\n", #a); \
+   if(trace()) \
+      traceMsg(comp(), "DAA Method found: %s\n", #a); \
 break
 
 

--- a/runtime/compiler/optimizer/DataAccessAccelerator.hpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/DataAccessAccelerator.hpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.hpp
@@ -243,14 +243,16 @@ class TR_DataAccessAccelerator : public TR::Optimization
 
    bool printInliningStatus(bool status, TR::Node* node, const char* reason = "")
       {
-      if (status)
-         traceMsg(comp(), "DataAccessAccelerator: Intrinsics on node %p : SUCCESS\n", node);
-      else
+      if (trace()) 
          {
-         traceMsg(comp(), "DataAccessAccelerator: Intrinsics on node %p : FAILED\n", node);
-         traceMsg(comp(), "DataAccessAccelerator:     Reason : %s\n", reason);
+            if (status)
+               traceMsg(comp(), "DataAccessAccelerator: Intrinsics on node %p : SUCCESS\n", node);
+            else
+               {
+               traceMsg(comp(), "DataAccessAccelerator: Intrinsics on node %p : FAILED\n", node);
+               traceMsg(comp(), "DataAccessAccelerator:     Reason : %s\n", reason);
+               }
          }
-
       return status;
       }
    };

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -5170,7 +5170,8 @@ int32_t TR_EscapeAnalysis::sniffCall(TR::Node *callNode, TR::ResolvedMethodSymbo
        */
       if (ilgenFailed)
          {
-         traceMsg(comp(), "   (IL generation failed)\n");
+         if (trace())
+            traceMsg(comp(), "   (IL generation failed)\n");
          static char *disableHCRCallPeeking = feGetEnv("TR_disableEAHCRCallPeeking");
          if (!isPeekableCall
              && disableHCRCallPeeking == NULL

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -846,23 +846,26 @@ usedInLoopTest(TR::Compilation *comp, TR::Node *loopTestNode, TR::SymbolReferenc
    }
 
 static bool
-indexContainsArray(TR::Compilation *comp, TR::Node *index, vcount_t visitCount)
+indexContainsArray(TR::Compilation *comp, TR::Node *index, vcount_t visitCount, bool shouldTrace)
    {
    if (index->getVisitCount() == visitCount)
       return false;
 
    index->setVisitCount(visitCount);
 
-   traceMsg(comp, "analyzing node %p\n", index);
+   if (shouldTrace)
+      traceMsg(comp, "analyzing node %p\n", index);
+   
    if (index->getOpCode().hasSymbolReference() &&
          index->getSymbolReference()->getSymbol()->isArrayShadowSymbol())
       {
-      traceMsg(comp, "found array node %p\n", index);
+      if (shouldTrace)
+         traceMsg(comp, "found array node %p\n", index);
       return true;
       }
 
    for (int32_t i = 0; i < index->getNumChildren(); i++)
-      if (indexContainsArray(comp, index->getChild(i), visitCount))
+      if (indexContainsArray(comp, index->getChild(i), visitCount, shouldTrace))
          return true;
 
    return false;
@@ -870,9 +873,11 @@ indexContainsArray(TR::Compilation *comp, TR::Node *index, vcount_t visitCount)
 
 
 static bool
-indexContainsArrayAccess(TR::Compilation *comp, TR::Node *aXaddNode)
+indexContainsArrayAccess(TR::Compilation *comp, TR::Node *aXaddNode, bool shouldTrace)
    {
-   traceMsg(comp, "axaddnode %p\n", aXaddNode);
+   if (shouldTrace)
+      traceMsg(comp, "axaddnode %p\n", aXaddNode);
+   
    TR::Node *loadNode1, *loadNode2, *topLevelIndex;
    findIndexLoad(aXaddNode, loadNode1, loadNode2, topLevelIndex);
    // topLevelIndex now contains the actual expression q in a[q]
@@ -880,10 +885,11 @@ indexContainsArrayAccess(TR::Compilation *comp, TR::Node *aXaddNode)
    // this loop into an arraycopy
    // ie. a[b[i]] do not represent linear array accesses
    //
-   traceMsg(comp, "aXaddNode %p topLevelIndex %p\n", aXaddNode, topLevelIndex);
+   if (shouldTrace)
+      traceMsg(comp, "aXaddNode %p topLevelIndex %p\n", aXaddNode, topLevelIndex);
    vcount_t visitCount = comp->incOrResetVisitCount();
    if (topLevelIndex)
-      return indexContainsArray(comp, topLevelIndex, visitCount);
+      return indexContainsArray(comp, topLevelIndex, visitCount, shouldTrace);
    return false;
    }
 
@@ -966,20 +972,23 @@ static TR::Node* getArrayBase(TR::Node *node)
    }
 
 static bool
-areArraysInvariant(TR::Compilation *comp, TR::Node *inputNode, TR::Node *outputNode, TR_CISCGraph *T)
+areArraysInvariant(TR::Compilation *comp, TR::Node *inputNode, TR::Node *outputNode, TR_CISCGraph *T, bool shouldTrace)
    {
    if (T)
       {
       TR::Node *aNode = getArrayBase(inputNode);
       TR::Node *bNode = getArrayBase(outputNode);
 
-      traceMsg(comp, "aNode = %p bNode = %p\n", aNode, bNode);
+      if (shouldTrace)
+         traceMsg(comp, "aNode = %p bNode = %p\n", aNode, bNode);
       if (aNode && aNode->getOpCode().isLoadDirect() &&
             bNode && bNode->getOpCode().isLoadDirect())
          {
          TR_CISCNode *aCNode = T->getCISCNode(aNode);
          TR_CISCNode *bCNode = T->getCISCNode(bNode);
-         traceMsg(comp, "aC = %p %d bC = %p %d\n", aCNode, aCNode->getID(), bCNode, bCNode->getID());
+
+         if (shouldTrace)
+            traceMsg(comp, "aC = %p %d bC = %p %d\n", aCNode, aCNode->getID(), bCNode, bCNode->getID());
          if (aCNode && bCNode)
             {
             ListIterator<TR_CISCNode> aDefI(aCNode->getChains());
@@ -1086,7 +1095,7 @@ findIndVarLoads(TR::Node *node, TR::Node *indVarStoreNode, bool &storeFound,
    }
 
 static int32_t
-checkForPostIncrement(TR::Compilation *comp, TR::Block *loopHeader, TR::Node *loopCmpNode, TR::Symbol *ivSym)
+checkForPostIncrement(TR::Compilation *comp, TR::Block *loopHeader, TR::Node *loopCmpNode, TR::Symbol *ivSym, bool shouldTrace)
    {
    TR::TreeTop *startTree = loopHeader->getFirstRealTreeTop();
    TR::Node *indVarStoreNode = NULL;
@@ -1117,7 +1126,8 @@ checkForPostIncrement(TR::Compilation *comp, TR::Block *loopHeader, TR::Node *lo
    if (storeIvLoad->getOpCode().isAdd() || storeIvLoad->getOpCode().isSub())
       storeIvLoad = storeIvLoad->getFirstChild();
 
-   traceMsg(comp, "found storeIvload %p cmpFirstChild %p\n", storeIvLoad, cmpFirstChild);
+   if(shouldTrace)
+      traceMsg(comp, "found storeIvload %p cmpFirstChild %p\n", storeIvLoad, cmpFirstChild);
    // simple case
    // the loopCmp uses the un-incremented value
    // of the iv
@@ -5605,6 +5615,7 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
    List<TR_CISCNode> *P2T = trans->getP2T();
    TR::Compilation *comp = trans->comp();
    bool isDecrement = trans->isMEMCPYDec();
+   const bool disptrace = DISPTRACE(trans);
 
    TR_ASSERT(trans->isEmptyAfterInsertionIdiomList(0) && trans->isEmptyAfterInsertionIdiomList(1), "Not implemented yet!");
    if (!trans->isEmptyAfterInsertionIdiomList(0) || !trans->isEmptyAfterInsertionIdiomList(1)) return false;
@@ -5664,8 +5675,8 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
    if ((statusArrayStore = checkArrayStore(comp, inputNode, outputNode, elementSize, !isDecrement)) == ABANDONING_REDUCTION)
       return false;
 
-   if (indexContainsArrayAccess(comp, inLoadNode->getFirstChild()) ||
-         indexContainsArrayAccess(comp, inStoreNode->getFirstChild()))
+   if (indexContainsArrayAccess(comp, inLoadNode->getFirstChild(), disptrace) ||
+         indexContainsArrayAccess(comp, inStoreNode->getFirstChild(), disptrace))
       {
       traceMsg(comp, "inputNode %p or outputnode %p contains another arrayaccess, no reduction\n", inLoadNode, inStoreNode);
       return false;
@@ -5722,8 +5733,10 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
    variableORconstRepNode = convertStoreToLoad(comp, variableORconstRepNode);
 
 
-   int32_t postIncrement = checkForPostIncrement(comp, block, cmpIfAllCISCNode->getHeadOfTrNodeInfo()->_node, exitVarSymRef->getSymbol());
-   traceMsg(comp, "detected postIncrement %d modLength %d modStartIdx %d\n", postIncrement, modLength, modStartIdx);
+   int32_t postIncrement = checkForPostIncrement(comp, block, cmpIfAllCISCNode->getHeadOfTrNodeInfo()->_node, exitVarSymRef->getSymbol(), disptrace);
+   
+   if (disptrace)
+      traceMsg(comp, "detected postIncrement %d modLength %d modStartIdx %d\n", postIncrement, modLength, modStartIdx);
 
    TR::Node * lengthNode;
    if (isDecrement)
@@ -9158,7 +9171,8 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       int32_t index1SymRefNum = inStoreSrc1->getSymbolReference()->getReferenceNumber();
       int32_t index2SymRefNum = inStoreSrc2->getSymbolReference()->getReferenceNumber();
 
-      traceMsg(comp, "searching for stores to loop indices between preheader first tree %p and first matching tree %p, looking for symrefnum %d %d\n", preHeader->getFirstRealTreeTop()->getNode(),trTreeTop->getNode(),index1SymRefNum,index2SymRefNum);
+      if (disptrace)
+         traceMsg(comp, "searching for stores to loop indices between preheader first tree %p and first matching tree %p, looking for symrefnum %d %d\n", preHeader->getFirstRealTreeTop()->getNode(),trTreeTop->getNode(),index1SymRefNum,index2SymRefNum);
 
 
       TR::Node * tempNode;
@@ -9338,7 +9352,7 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       return false;
       }
 
-   if (!areArraysInvariant(comp, inSrc1Node, inSrc2Node, T))
+   if (!areArraysInvariant(comp, inSrc1Node, inSrc2Node, T, disptrace))
       {
       traceMsg(comp, "input array bases %p and %p are not invariant, no reduction\n", inSrc1Node, inSrc2Node);
       return false;
@@ -9411,7 +9425,8 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       end1Idx = convertStoreToLoad(comp, src1IdxRepNode);
       start1Idx = createOP2(comp, TR::isub, end1Idx, diff2);
 
-      traceMsg(comp, "isDecrement start1Idx %p start2Idx %p end1Idx %p end2Idx %p\n", start1Idx, start2Idx, end1Idx, end2Idx);
+      if (disptrace)
+         traceMsg(comp, "isDecrement start1Idx %p start2Idx %p end1Idx %p end2Idx %p\n", start1Idx, start2Idx, end1Idx, end2Idx);
       startNode = start2Idx->duplicateTree();
       endNode = useSrc1 ? end1Idx->duplicateTree() : end2Idx->duplicateTree();
 
@@ -9428,7 +9443,8 @@ CISCTransform2ArrayCmp(TR_CISCTransformer *trans)
       start1Idx = convertStoreToLoad(comp, src1IdxRepNode);
       end1Idx = needVersioned ? createOP2(comp, TR::iadd, start1Idx, diff2) : NULL;
 
-      traceMsg(comp, "start1Idx %p start2Idx %p end1Idx %p end2Idx %p\n", start1Idx, start2Idx, end1Idx, end2Idx);
+      if (disptrace)
+         traceMsg(comp, "start1Idx %p start2Idx %p end1Idx %p end2Idx %p\n", start1Idx, start2Idx, end1Idx, end2Idx);
       startNode = useSrc1 ? start1Idx->duplicateTree() : start2Idx->duplicateTree();
       endNode = end2Idx->duplicateTree();
 

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1549,10 +1549,11 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                      {
                      ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);
                      calltarget->_calleeMethod->setWarmCallGraphTooBig( newBCInfo.getByteCodeIndex(), comp());
-                     traceMsg(comp(), "set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo.getByteCodeIndex());
+                     heuristicTrace(tracer(), "set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo.getByteCodeIndex());
                      //_optimisticSize = origOptimisticSize;
                      //_realSize = origRealSize;
                      calltargetSetTooBig = true;
+                        
                      }
                   }
 

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -3181,12 +3181,14 @@ bool TR_SPMDKernelParallelizer::processGPULoop(TR_RegionStructure *loop, TR_SPMD
    TR::Node *lastNode = loopInvariantBlock->getLastRealTreeTop()->getNode();
    if (lastNode->getOpCode().isGoto())
       {
-      traceMsg(comp(), "Changing destination of goto at the end of block_%d\n", loopInvariantBlock->getNumber());
+      if (trace())
+         traceMsg(comp(), "Changing destination of goto at the end of block_%d\n", loopInvariantBlock->getNumber());
       lastNode->setBranchDestination(blockAfterLoop->getEntry());
       }
    else
       {
-      traceMsg(comp(), "Inserting goto at the end of block_%d\n", loopInvariantBlock->getNumber());
+      if (trace())
+         traceMsg(comp(), "Inserting goto at the end of block_%d\n", loopInvariantBlock->getNumber());
       TR::Node *gotoNode = TR::Node::create(firstNode, TR::Goto, 0, blockAfterLoop->getEntry());
       TR::TreeTop *gotoTreeTop = TR::TreeTop::create(comp(), gotoNode);
       loopInvariantBlock->append(gotoTreeTop);
@@ -3338,7 +3340,8 @@ bool TR_SPMDKernelParallelizer::processGPULoop(TR_RegionStructure *loop, TR_SPMD
 
    if(!(_reversedBranchNodes->isSet(ibmTryGPUNode->getGlobalIndex()))) //check if not set
       {
-      traceMsg(comp(), "Reversing branch in node %p, Global Index %u\n", ibmTryGPUNode, ibmTryGPUNode->getGlobalIndex());
+      if (trace())
+         traceMsg(comp(), "Reversing branch in node %p, Global Index %u\n", ibmTryGPUNode, ibmTryGPUNode->getGlobalIndex());
       ibmTryGPUNode->reverseBranch(ibmTryGPUNode->getBranchDestination());
       _reversedBranchNodes->set(ibmTryGPUNode->getGlobalIndex());
       }
@@ -3483,7 +3486,8 @@ bool TR_SPMDKernelParallelizer::visitCPUNode(TR::Node *node, int32_t visitCount,
        node->getOpCodeValue() == TR::arraycopy ||
        opcode.isCall())
       {
-      traceMsg(comp(), "Found %s in non-cold CPU node %p\n", opcode.isCall() ? "a call" : "array access", node);
+      if (trace())
+         traceMsg(comp(), "Found %s in non-cold CPU node %p\n", opcode.isCall() ? "a call" : "array access", node);
 
       TR_ResolvedMethod  *method;
 
@@ -3501,8 +3505,9 @@ bool TR_SPMDKernelParallelizer::visitCPUNode(TR::Node *node, int32_t visitCount,
 
       if (method)
          {
-         traceMsg(comp(), "inside IntPipeline%s.forEach\n",
-             method->getRecognizedMethod() == TR::java_util_stream_IntPipelineHead_forEach ? "$Head" : "");
+         if (trace()) 
+            traceMsg(comp(), "inside IntPipeline%s.forEach\n",
+               method->getRecognizedMethod() == TR::java_util_stream_IntPipelineHead_forEach ? "$Head" : "");
 
          traceMsg(comp(), "need to insert flush\n");
          flushGPUBlocks->set(block->getNumber());
@@ -3514,25 +3519,29 @@ bool TR_SPMDKernelParallelizer::visitCPUNode(TR::Node *node, int32_t visitCount,
              !node->getSymbolReference()->getSymbol()->castToMethodSymbol() ||
              !node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod())
             {
-            traceMsg(comp(), "can't hoist due to a call\n");
+            if (trace())
+               traceMsg(comp(), "can't hoist due to a call\n");
             return false;
             }
 
          TR::Method * method = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod();
          const char * signature = method->signature(comp()->trMemory(), stackAlloc);
-
-         traceMsg(comp(), "signature: %s\n", signature ? signature : "NULL");
+         
+         if (trace())
+            traceMsg(comp(), "signature: %s\n", signature ? signature : "NULL");
 
          if (!(signature && strlen(signature) >= 10 && strncmp(signature, "java/lang/", 10) == 0) &&
              !(signature && strlen(signature) >= 10 && strncmp(signature, "java/util/", 10) == 0))
             {
-            traceMsg(comp(), "can't hoist due to a call\n");
+            if (trace())
+               traceMsg(comp(), "can't hoist due to a call\n");
             return false;
             }
          }
       else
          {
-         traceMsg(comp(), "can't hoist due do array access\n");
+         if (trace())
+            traceMsg(comp(), "can't hoist due do array access\n");
          return false;
          }
       }
@@ -3614,7 +3623,8 @@ TR_SPMDKernelParallelizer::analyzeGPUScope(TR_SPMDScopeInfo* pScopeInfo)
 
     for (kernel = kit.getFirst(); kernel; kernel = kit.getNext())
        {
-       traceMsg(comp(), "GPU kernel: %d\n", kernel->getNumber());
+       if (trace())
+         traceMsg(comp(), "GPU kernel: %d\n", kernel->getNumber());
        kernel->getBlocks(&kernelBlocks);
        }
 
@@ -3631,7 +3641,8 @@ TR_SPMDKernelParallelizer::analyzeGPUScope(TR_SPMDScopeInfo* pScopeInfo)
 
    for (TR_RegionStructure *loop = lit.getFirst(); loop; loop = lit.getNext())
       {
-      traceMsg(comp(), "cold loop: %d\n", loop->getNumber());
+      if (trace())
+         traceMsg(comp(), "cold loop: %d\n", loop->getNumber());
       loop->getBlocks(&coldLoopBlocks);
       }
 
@@ -3646,7 +3657,8 @@ TR_SPMDKernelParallelizer::analyzeGPUScope(TR_SPMDScopeInfo* pScopeInfo)
    for (nbit.SetToFirstOne(); nbit.Valid(); nbit.SetToNextOne())
       {
       TR::Block *nextBlock = _origCfgBlocks[nbit];
-      traceMsg(comp(), "non-cold CPU block %d\n", nextBlock->getNumber());
+      if (trace())
+         traceMsg(comp(), "non-cold CPU block %d\n", nextBlock->getNumber());
 
       for (TR::TreeTop *tt = nextBlock->getEntry() ; tt != nextBlock->getExit() ; tt = tt->getNextTreeTop())
          {
@@ -3847,7 +3859,8 @@ bool TR_SPMDKernelParallelizer::checkDataLocality(TR_RegionStructure *loop, CS2:
 
    for (int32_t idx = 0; idx < _pivList.NumberOfElements(); idx++)
       {
-      traceMsg(comp, "   iv = %d\n", _pivList[idx]->getSymRef()->getReferenceNumber());
+      if (trace())
+         traceMsg(comp, "   iv = %d\n", _pivList[idx]->getSymRef()->getReferenceNumber());
       }
 
    setLoopDataType(loop,comp);
@@ -4082,7 +4095,8 @@ bool TR_SPMDKernelParallelizer::checkConstantDistanceDependence(TR_RegionStructu
 
 bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_UseDefInfo *useDefInfo, CS2::ArrayOf<TR::Node *, TR::Allocator> &useNodesOfDefsInLoop, SharedSparseBitVector &defsInLoop, TR::Compilation *comp)
    {
-   traceMsg(comp, "Checking independence in loop %d piv = %d\n", loop->getNumber(), loop->getPrimaryInductionVariable()->getSymRef()->getReferenceNumber());
+   if (trace())
+      traceMsg(comp, "Checking independence in loop %d piv = %d\n", loop->getNumber(), loop->getPrimaryInductionVariable()->getSymRef()->getReferenceNumber());
    CS2::ArrayOf<TR::Node *, TR::Allocator> defs(comp->allocator(), NULL);
    CS2::ArrayOf<TR::Node *, TR::Allocator> uses(comp->allocator(), NULL);
 
@@ -4110,7 +4124,9 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
          if (defs[dc2]->getOpCode().hasSymbolReference() &&
              defs[dc]->mayKill().contains(defs[dc2]->getSymbolReference(), comp))
             {
-            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: Testing (def %p, def %p) for dependence\n", defs[dc], defs[dc2]);
+            if (trace())
+               traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: Testing (def %p, def %p) for dependence\n", defs[dc], defs[dc2]);
+            
             if (!loop->isExprInvariant(defs[dc]->getFirstChild()) &&
                 !loop->isExprInvariant(defs[dc2]->getFirstChild()) &&
                 areNodesEquivalent(comp,defs[dc]->getFirstChild(), defs[dc2]->getFirstChild()))
@@ -4123,8 +4139,12 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
                continue;
                }
 
-            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: def %p and def %p are dependent\n", defs[dc], defs[dc2]);
-            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n");
+            if (trace())
+               {
+               traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: def %p and def %p are dependent\n", defs[dc], defs[dc2]);
+               traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: will not vectorize\n");
+               }
+            
             return false;
             }
          }
@@ -4135,7 +4155,8 @@ bool TR_SPMDKernelParallelizer::checkIndependence(TR_RegionStructure *loop, TR_U
          if (uses[uc]->getOpCode().hasSymbolReference() &&
              defs[dc]->mayKill().contains(uses[uc]->getSymbolReference(), comp))
             {
-            traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: Testing (def %p, use %p) for dependence\n", defs[dc], uses[uc]);
+            if (trace())
+               traceMsg(comp, "SPMD DEPENDENCE ANALYSIS: Testing (def %p, use %p) for dependence\n", defs[dc], uses[uc]);
             if (!loop->isExprInvariant(defs[dc]->getFirstChild()) &&
                 !loop->isExprInvariant(uses[uc]->getFirstChild()) &&
                 areNodesEquivalent(comp,defs[dc]->getFirstChild(),uses[uc]->getFirstChild()))

--- a/runtime/compiler/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/optimizer/SPMDPreCheck.cpp
@@ -29,11 +29,13 @@
 
 bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *loop)
    {
- 
+   bool trace = comp->getOption(TR_TraceAll);
+
    if (!loop->isNaturalLoop())
       {
-      traceMsg(comp, "SPMD PRE-CHECK FAILURE: region %d is not a natural loop and is discounted as an SPMD candidate\n", loop->getNumber());
-       }
+      if (trace)
+         traceMsg(comp, "SPMD PRE-CHECK FAILURE: region %d is not a natural loop and is discounted as an SPMD candidate\n", loop->getNumber());
+      }
 
    TR_ScratchList<TR::Block> blocksInLoopList(comp->trMemory());
    loop->getBlocks(&blocksInLoopList);
@@ -68,12 +70,14 @@ bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *lo
              TR::ILOpCodes vectorOp = TR::ILOpCode::convertScalarToVector(opcode.getOpCodeValue());
              if (vectorOp == TR::BadILOp)
                 {
-                traceMsg(comp, "SPMD PRE-CHECK FAILURE: store op code %s does not have a vector equivalent - skipping consideration of loop %d\n", comp->getDebug()->getName(opcode.getOpCodeValue()), loop->getNumber());
+                if (trace)
+                  traceMsg(comp, "SPMD PRE-CHECK FAILURE: store op code %s does not have a vector equivalent - skipping consideration of loop %d\n", comp->getDebug()->getName(opcode.getOpCodeValue()), loop->getNumber());
                 return false;
                 }
              if (!comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOp, node->getDataType()))
                 {
-                traceMsg(comp, "SPMD PRE-CHECK FAILURE: vector op code %s is not supported on the current platform - skipping consideration of loop %d\n", comp->getDebug()->getName(vectorOp), loop->getNumber());
+                if (trace)
+                  traceMsg(comp, "SPMD PRE-CHECK FAILURE: vector op code %s is not supported on the current platform - skipping consideration of loop %d\n", comp->getDebug()->getName(vectorOp), loop->getNumber());
                 return false;
                 }
            
@@ -81,7 +85,8 @@ bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *lo
              }
 
           // unsafe opcode - we will skip LAR and SPMD
-          traceMsg(comp, "SPMD PRE-CHECK FAILURE: found disallowed treetop opcode %s at node %p in loop %d\n", comp->getDebug()->getName(node->getOpCodeValue()), node, loop->getNumber());
+          if (trace)
+            traceMsg(comp, "SPMD PRE-CHECK FAILURE: found disallowed treetop opcode %s at node %p in loop %d\n", comp->getDebug()->getName(node->getOpCodeValue()), node, loop->getNumber());
           return false;
           }
        }

--- a/runtime/compiler/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/optimizer/SPMDPreCheck.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 
 bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *loop)
    {
-   bool trace = comp->getOption(TR_TraceAll);
+   bool trace = comp->getOption(TR_TraceAll) || comp->trace(OMR::SPMDKernelParallelization);
 
    if (!loop->isNaturalLoop())
       {

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12875,7 +12875,8 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          break;
 
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
-         traceMsg(comp, "In evaluator for compareAndSwapLong. node = %p node->isSafeForCGToFastPathUnsafeCall = %p\n", node, node->isSafeForCGToFastPathUnsafeCall());
+         if (comp->getOption(TR_TraceCG))
+            traceMsg(comp, "In evaluator for compareAndSwapLong. node = %p node->isSafeForCGToFastPathUnsafeCall = %p\n", node, node->isSafeForCGToFastPathUnsafeCall());
          // As above, we only want to inline the JNI methods, so add an explicit test for isNative()
          if (!methodSymbol->isNative())
             break;

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1748,7 +1748,7 @@ TR_BlockFrequencyInfo::getFrequencyInfo(
       bci.setCallerIndex(comp->getCurrentInlinedSiteIndex());
       normalizeForCallers = false;
       }
-   int32_t frequency = getFrequencyInfo(bci, comp, normalizeForCallers, true);
+   int32_t frequency = getFrequencyInfo(bci, comp, normalizeForCallers, comp->getOption(TR_TraceBFGeneration));
    if (comp->getOption(TR_TraceBFGeneration))
       traceMsg(comp, "@@ block_%d [%d,%d] has raw count %d\n", block->getNumber(), bci.getCallerIndex(), bci.getByteCodeIndex(), frequency);
    return frequency;
@@ -1764,7 +1764,8 @@ TR_BlockFrequencyInfo::getFrequencyInfo(
    int64_t maxCount = normalizeForCallers ? getMaxRawCount() : getMaxRawCount(bci.getCallerIndex());
    int32_t callerIndex = bci.getCallerIndex();
    int32_t frequency = getRawCount(callerIndex < 0 ? comp->getMethodSymbol() : comp->getInlinedResolvedMethodSymbol(callerIndex), bci, _callSiteInfo, maxCount, comp);
-   traceMsg(comp,"raw frequency on outter level was %d for bci %d:%d\n", frequency, bci.getCallerIndex(), bci.getByteCodeIndex());
+   if (trace)
+      traceMsg(comp,"raw frequency on outter level was %d for bci %d:%d\n", frequency, bci.getCallerIndex(), bci.getByteCodeIndex());
    if (frequency > -1 || _counterDerivationInfo == NULL)
       return frequency;
 
@@ -1805,7 +1806,8 @@ TR_BlockFrequencyInfo::getFrequencyInfo(
          // we have found a frame where we don't have profiling info
          if (callerFrequency < 0)
             {
-            traceMsg(comp, "  found frame for %s with no outter profiling info\n", resolvedMethodSymbol->signature(comp->trMemory()));
+            if (trace)
+               traceMsg(comp, "  found frame for %s with no outter profiling info\n", resolvedMethodSymbol->signature(comp->trMemory()));
             // has this method been compiled so we might have had a chance to profile it?
             if (!resolvedMethod->isInterpretedForHeuristics()
                 && !resolvedMethod->isNative()
@@ -1817,7 +1819,8 @@ TR_BlockFrequencyInfo::getFrequencyInfo(
                    && info->getBlockFrequencyInfo()
                    && info->getBlockFrequencyInfo()->_counterDerivationInfo)
                   {
-                  traceMsg(comp, "  method has profiling\n");
+                  if (trace)
+                     traceMsg(comp, "  method has profiling\n");
                   int32_t effectiveCallerIndex = -1;
                   TR_BlockFrequencyInfo *bfi = info->getBlockFrequencyInfo();
                   if (callStack.empty() || info->getCallSiteInfo()->computeEffectiveCallerIndex(comp, callStack, effectiveCallerIndex))


### PR DESCRIPTION
This is continuation to #6073, starting form that PR's commit.
This was also solved and merged in eclipse/omr#3975

> In the code there are places where unguarded tracing occurs causing
> an output into a log file when no trace flags are specified.
> This commit adds guards to stop the unguarded tracing.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>