### PR TITLE
Enable CFG simplifier

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -34,10 +34,6 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
-   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
-   if (enableCFGSimplification == NULL)
-      return false;
-
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
           || simplifyResolvedRequireNonNull(needToDuplicateTree)
           || simplifyUnresolvedRequireNonNull(needToDuplicateTree)


### PR DESCRIPTION
CFG simplification was disabled in #8412 due to issue #8396. There appear to be bugs in the CFG simplifier patterns related to conditional stores. These problematic patterns will be disabled in https://github.com/eclipse/omr/pull/5200. Once that pull request has been merged, CFG simplification can be enabled in openj9.

While disabling the problematic patterns in OMR does not solve the problem, it allows us to enable this optimization in openj9 while we continue to investigate the root cause.

Signed-off-by: Ryan Shukla <ryans@ibm.com>