### PR TITLE
Activate compilation threads more aggressively for JITClient

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -544,9 +544,19 @@ TR_YesNoMaybe TR::CompilationInfo::shouldActivateNewCompThread()
          if (_queueWeight > _compThreadActivationThresholds[getNumCompThreadsActive()])
             return TR_yes;
          }
+#if defined(J9VM_OPT_JITSERVER)
+      else if (getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT && JITServerHelpers::isServerAvailable())
+         {
+         // For JITClient let's be more agressive with compilation thread activation
+         // because the latencies are larger. Beyond 'numProc-1' we will use the
+         // 'starvation activation schedule', but accelerated (divide those thresholds by 2)
+         if (_queueWeight > (_compThreadActivationThresholdsonStarvation[getNumCompThreadsActive()] >> 1))
+            return TR_yes;
+         }
+#endif /* defined(J9VM_OPT_JITSERVER) */
       else if (_starvationDetected)
          {
-         // comp thread starvation; may activate threads beyond numCpu-1
+         // comp thread starvation; may activate threads beyond 'numCpu-1'
          if (_queueWeight > _compThreadActivationThresholdsonStarvation[getNumCompThreadsActive()])
             return TR_yes;
          }


### PR DESCRIPTION
To mitigate the effects of network latency which increases the
compilation time, this commit lowers the queue weight thresholds
at which suspended compilation threads are activated, effectively
increasing the degree of parallelism with respect to compilation.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>