### PR TITLE
Reduce the scratch segment cache in JITClient from 16MB to 2MB

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3849,16 +3849,21 @@ TR::CompilationInfoPerThread::doSuspend()
 J9::J9SegmentCache
 TR::CompilationInfoPerThread::initializeSegmentCache(J9::J9SegmentProvider &segmentProvider)
    {
-   try
+#if defined(J9VM_OPT_JITSERVER)
+   if (_compInfo.getPersistentInfo()->getRemoteCompilationMode() != JITServer::CLIENT)
+#endif /* defined(J9VM_OPT_JITSERVER) */
       {
-      J9::J9SegmentCache segmentCache(1 << 24, segmentProvider);
-      return segmentCache;
-      }
-   catch (const std::bad_alloc &allocationFailure)
-      {
-      if (TR::Options::getVerboseOption(TR_VerbosePerformance))
+      try
          {
-         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Failed to initialize segment cache of size 1 << 24");
+         J9::J9SegmentCache segmentCache(1 << 24, segmentProvider);
+         return segmentCache;
+         }
+      catch (const std::bad_alloc &allocationFailure)
+         {
+         if (TR::Options::getVerboseOption(TR_VerbosePerformance))
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Failed to initialize segment cache of size 1 << 24");
+            }
          }
       }
    try


### PR DESCRIPTION
Remote compilations typically take longer due to network latency. This
increases the size of the compilation queue and, as a result, more
compilation threads can be activated. In order to keep the footprint
envelope low in the presence of many compilation threads we need to use
a smaller scratch segment cache. All remote compilation require less than
2MB at the JITClient so this seems like a good value.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>
