### PR TITLE
AArch64: Add initial implementation of VMnewEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,16 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
     * @param dataSnippetRegister: Optional, can be used to pass the address of the snippet inside the register.  
     */
    static void generateTestAndReportFieldWatchInstructions(TR::CodeGenerator *cg, TR::Node *node, TR::Snippet *dataSnippet, bool isWrite, TR::Register *sideEffectRegister, TR::Register *valueReg, TR::Register *dataSnippetRegister);
+
+   /**
+    * @brief Generates instructions for inlining new/newarray/anewarray
+    *
+    * @param[in] node: node
+    * @param[in]   cg: code generator
+    *
+    * @return register containing allocated object, NULL if inlining is not possible
+    */
+   static TR::Register *VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 


### PR DESCRIPTION
Add `VMnewEvaluator` method to `J9TreeEvaluator.cpp`
The limitations of this implementation:
  - Supports `TR::new` only.
  - Does not support `DualTLH`.
  - Does not support realtime GC.

This implementation uses `HeapAllocSnippet` for slow path
because AArch64 code gen does not support OOL section.
`HeapAllocSnippet` will be added by another PR.

This commit also adds helper methods for `VMnewEvaluator`.
The helper methods are unimplemented yet.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>