### PR TITLE
AArch64: Add HeapAllocSnippet

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9ARM64Snippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9ARM64Snippet.cpp
@@ -22,9 +22,13 @@
 
 #include "j9.h"
 
-#include "codegen/CodeGenerator.hpp"
 #include "codegen/ARM64Instruction.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/GCStackAtlas.hpp"
 #include "codegen/J9ARM64Snippet.hpp"
+#include "codegen/Relocation.hpp"
+#include "codegen/SnippetGCMap.hpp"
+#include "runtime/CodeCacheManager.hpp"
 
 TR::ARM64MonitorEnterSnippet::ARM64MonitorEnterSnippet(
    TR::CodeGenerator *codeGen,
@@ -245,4 +249,113 @@ int32_t TR::ARM64MonitorExitSnippet::setEstimatedCodeLocation(int32_t estimatedS
    _decLabel->setEstimatedCodeLocation(estimatedSnippetStart);
    getSnippetLabel()->setEstimatedCodeLocation(estimatedSnippetStart + 6 * ARM64_INSTRUCTION_LENGTH);
    return estimatedSnippetStart;
+   }
+
+TR::ARM64HeapAllocSnippet::ARM64HeapAllocSnippet(
+   TR::CodeGenerator   *codeGen,
+   TR::Node            *node,
+   TR::LabelSymbol     *snippetLabel,
+   TR::SymbolReference *destination,
+   TR::LabelSymbol     *restartLabel)
+   : _restartLabel(restartLabel), _destination(destination),
+     TR::Snippet(codeGen, node, snippetLabel, destination->canCauseGC())
+   {
+   if (destination->canCauseGC())
+      {
+      // Helper call, preserves all registers
+      //
+      gcMap().setGCRegisterMask(0xFFFFFFFF);
+      }
+   }
+
+uint8_t *
+TR::ARM64HeapAllocSnippet::emitSnippetBody()
+   {
+   uint8_t *cursor = cg()->getBinaryBufferCursor();
+   // heap allocation snippet:
+   // x0: class
+   // x1: element size (if array)
+   //    snippetLabel:
+   //      bl     jitNewXXXX
+   //      movx   resReg, x0
+   //      b      restartLabel
+
+   TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
+   TR::RealRegister *callRetReg  = cg()->machine()->getRealRegister(TR::RealRegister::x0);
+   TR::RealRegister *zeroReg  = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+   TR::RealRegister *resultReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());   // Refer to VMnewEvaluator
+
+   getSnippetLabel()->setCodeLocation(cursor);
+   *reinterpret_cast<uint32_t *>(cursor) = cg()->encodeHelperBranchAndLink(getDestination(), cursor, getNode());
+
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   // Reset register map for resultReg because resultReg contains non-object value before calling out to VM helper.
+   if (gcMap().getStackMap() != NULL)
+      gcMap().getStackMap()->resetRegistersBits(cg()->registerBitMask(resultReg->getRegisterNumber()));
+   gcMap().registerStackMap(cursor, cg());
+
+   *reinterpret_cast<uint32_t *>(cursor) = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::orrx);
+
+   callRetReg->setRegisterFieldRM(reinterpret_cast<uint32_t *>(cursor));
+   zeroReg->setRegisterFieldRN(reinterpret_cast<uint32_t *>(cursor));
+   resultReg->setRegisterFieldRD(reinterpret_cast<uint32_t *>(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   *reinterpret_cast<uint32_t *>(cursor)= TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::b);
+   intptr_t destination = (intptr_t)getRestartLabel()->getCodeLocation();
+   TR_ASSERT(!cg()->directCallRequiresTrampoline(destination, reinterpret_cast<intptr_t>(cursor)), "Jump target too far away.");
+   intptr_t distanceToRestart = destination - reinterpret_cast<intptr_t>(cursor);
+   *reinterpret_cast<uint32_t *>(cursor) |= ((distanceToRestart >> 2) & 0x3FFFFFF); // imm26
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   return cursor;
+   }
+
+uint32_t
+TR::ARM64HeapAllocSnippet::getLength(int32_t estimatedSnippetStart)
+   {
+   return ARM64_INSTRUCTION_LENGTH * 3;
+   }
+
+void
+TR::ARM64HeapAllocSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
+   {
+   uint8_t *cursor = getSnippetLabel()->getCodeLocation();
+   debug->printSnippetLabel(pOutFile, getSnippetLabel(), cursor, "Heap Allocation Snippet");
+
+   TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
+   TR::Machine *machine = cg()->machine();
+   TR::RealRegister *callRetReg  = machine->getRealRegister(TR::RealRegister::x0);
+   TR::RealRegister *zeroReg  = machine->getRealRegister(TR::RealRegister::xzr);
+   TR::RealRegister *resultReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());   // Refer to VMnewEvaluator
+
+   TR::SymbolReference *symRef = getDestination();
+   int32_t  distance;
+   intptr_t target = reinterpret_cast<intptr_t>(symRef->getMethodAddress());
+   char    *info = "";
+   if (debug->isBranchToTrampoline(symRef, cursor, distance))
+      {
+      target = static_cast<intptr_t>(distance) + reinterpret_cast<intptr_t>(cursor);
+      info = " Through trampoline";
+      }
+
+   debug->printPrefix(pOutFile, NULL, cursor, 4);
+   trfprintf(pOutFile, "bl \t" POINTER_PRINTF_FORMAT "\t\t;%s%s", target, debug->getName(symRef), info);
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   debug->printPrefix(pOutFile, NULL, cursor, 4);
+   trfprintf(pOutFile, "orrx \t");
+   debug->print(pOutFile, resultReg, TR_WordReg);
+   trfprintf(pOutFile, ", ");
+   debug->print(pOutFile, zeroReg, TR_WordReg);
+   trfprintf(pOutFile, ", ");
+   debug->print(pOutFile, callRetReg, TR_WordReg);
+   cursor += ARM64_INSTRUCTION_LENGTH;
+
+   intptr_t destination = reinterpret_cast<intptr_t>(getRestartLabel()->getCodeLocation());
+   // assuming that the distance to the destination is in the range +/- 128MB
+   debug->printPrefix(pOutFile, NULL, cursor, 4);
+   trfprintf(pOutFile, "b \t" POINTER_PRINTF_FORMAT "\t\t; Back to ", destination);
+   debug->print(pOutFile, getRestartLabel());
    }

--- a/runtime/compiler/aarch64/codegen/J9ARM64Snippet.hpp
+++ b/runtime/compiler/aarch64/codegen/J9ARM64Snippet.hpp
@@ -133,6 +133,63 @@ class ARM64MonitorExitSnippet : public TR::ARM64HelperCallSnippet
    TR::LabelSymbol *getDecLabel() { return _decLabel; }
    };
 
+class ARM64HeapAllocSnippet : public TR::Snippet
+   {
+   TR::LabelSymbol     *_restartLabel;
+   TR::SymbolReference *_destination;
+
+   public:
+
+   /**
+    * @brief Constructs Heap Alloc Snippet
+    *
+    * @param codeGen      code generator
+    * @param node         node
+    * @param snippetLabel label of the snippet
+    * @param destination  symbol reference of allocation helper (jitNew/jitNewArray/jitANewArray)
+    * @param restartLabel label to return
+    */
+   ARM64HeapAllocSnippet(TR::CodeGenerator *codeGen,
+                       TR::Node            *node,
+                       TR::LabelSymbol     *snippetLabel,
+                       TR::SymbolReference *destination,
+                       TR::LabelSymbol     *restartLabel);
+
+   /**
+    * @brief Answers the Snippet kind
+    * @return Snippet kind
+    */
+   virtual Kind getKind() { return IsHeapAlloc; }
+
+   /**
+    * @brief Prints the Snippet
+    */
+   virtual void print(TR::FILE *, TR_Debug*);
+
+   /**
+    * @brief Emits the Snippet body
+    * @return instruction cursor
+    */
+   virtual uint8_t *emitSnippetBody();
+
+   /**
+    * @brief Answers the Snippet length
+    * @return Snippet length
+    */
+   virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+   /**
+    * @brief Returns the label to restart
+    * @return restart label
+    */
+   TR::LabelSymbol     *getRestartLabel() { return _restartLabel; }
+
+   /**
+    * @brief Returns the symbol reference of helper
+    * @return the symbol reference of helper
+    */
+   TR::SymbolReference *getDestination() { return _destination; }
+   };
 }
 
 #endif

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -668,7 +668,9 @@ J9::ARM64::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    // 4. Allocate object/array on heap
    genHeapAlloc(node, cg, allocateSize, resultReg, tempReg1, tempReg2, callLabel);
 
-   // TODO 5. Setup HeapAllocSnippet for slowpath
+   // 5. Setup HeapAllocSnippet for slowpath
+   TR::Snippet *snippet = new (cg->trHeapMemory()) TR::ARM64HeapAllocSnippet(cg, node, callLabel, node->getSymbolReference(), doneLabel);
+   cg->addSnippet(snippet);
 
    // 6. Initialize the allocated memory area with zero
    // TODO selectively initialize necessary slots


### PR DESCRIPTION
This commit adds `HeapAllocSnippet`, which is used for slow path
in `VMnewEvaluator`.

Depends on:
- https://github.com/eclipse/openj9/pull/9605
- https://github.com/eclipse/omr/pull/5208
- https://github.com/eclipse/omr/pull/5209

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>