### PR TITLE
AArch64: Implement genZeroInitObject for VMnewEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <cmath>
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64JNILinkage.hpp"
 #include "codegen/ARM64OutOfLineCodeSection.hpp"
@@ -583,7 +584,75 @@ static void
 genZeroInitObject(TR::Node *node, TR::CodeGenerator *cg, uint32_t objectSize, uint32_t headerSize, TR::Register *objectReg, TR::Register *zeroReg,
    TR::Register *tempReg1, TR::Register *tempReg2)
    {
-   TR_UNIMPLEMENTED();
+   /*
+    * Instructions for clearing allocate memory
+    * We assume that the objectSize is multiple of 4.
+    *
+    * // Adjust tempReg1 so that (tempReg1 + 16) points to
+    * // the memory area beyond the object header
+    * subimmx tempReg1, resultReg, (16 - #headerSize)
+    * movzx   tempReg2, loopCount
+    * loop:
+    * stpimmx xzr, xzr, [tempReg1, #16]
+    * stpimmx xzr, xzr, [tempReg1, #32]
+    * stpimmx xzr, xzr, [tempReg1, #48]
+    * stpimmx xzr, xzr, [tempReg1, #64]! // pre index
+    * subsimmx tempReg2, tempReg2, #1
+    * b.ne    loop
+    * // write residues
+    * stpimmx xzr, xzr [tempReg1, #16]
+    * stpimmx xzr, xzr [tempReg1, #32]
+    * stpimmx xzr, xzr [tempReg1, #48]
+    * strimmx xzr, [tempReg1, #64]
+    * strimmw xzr, [tempReg1, #72]
+    *
+    */
+   // TODO align tempReg1 to 16-byte boundary if objectSize is large
+   // TODO use vector register
+   // TODO use dc zva
+   const int32_t unrollFactor = 4;
+   const int32_t width = 16; // use stp to clear 16 bytes
+   const int32_t loopCount = (objectSize - headerSize) / (unrollFactor * width);
+   const int32_t res1 = (objectSize - headerSize) % (unrollFactor * width);
+   const int32_t residueCount = res1 / width;
+   const int32_t res2 = res1 % width;
+   TR::LabelSymbol *loopStart = generateLabelSymbol(cg);
+
+   generateTrg1Src1ImmInstruction(cg, (headerSize > 16) ? TR::InstOpCode::addimmx : TR::InstOpCode::subimmx,
+         node, tempReg1, objectReg, std::abs(static_cast<int>(headerSize - 16)));
+
+   if (loopCount > 0)
+      {
+      if (loopCount > 1)
+         {
+         loadConstant64(cg, node, loopCount, tempReg2);
+         generateLabelInstruction(cg, TR::InstOpCode::label, node, loopStart);
+         }
+      for (int i = 1; i < unrollFactor; i++)
+         {
+         generateMemSrc2Instruction(cg, TR::InstOpCode::stpoffx, node, new (cg->trHeapMemory()) TR::MemoryReference(tempReg1, i * width, cg), zeroReg, zeroReg);
+         }
+      generateMemSrc2Instruction(cg, TR::InstOpCode::stpprex, node, new (cg->trHeapMemory()) TR::MemoryReference(tempReg1, unrollFactor * width, cg), zeroReg, zeroReg);
+      if (loopCount > 1)
+         {
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, tempReg2, tempReg2, 1);
+         generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, loopStart, TR::CC_NE);
+         }
+      }
+   for (int i = 0; i < residueCount; i++)
+      {
+      generateMemSrc2Instruction(cg, TR::InstOpCode::stpoffx, node, new (cg->trHeapMemory()) TR::MemoryReference(tempReg1, (i + 1) * width, cg), zeroReg, zeroReg);
+      }
+   int offset = (residueCount + 1) * width;
+   if (res2 >= 8)
+      {
+      generateMemSrc1Instruction(cg, TR::InstOpCode::strimmx, node, new (cg->trHeapMemory()) TR::MemoryReference(tempReg1, offset, cg), zeroReg);
+      offset += 8;
+      }
+   if ((res2 & 4) > 0)
+      {
+      generateMemSrc1Instruction(cg, TR::InstOpCode::strimmw, node, new (cg->trHeapMemory()) TR::MemoryReference(tempReg1, offset, cg), zeroReg);
+      }
    }
 
 /**


### PR DESCRIPTION
Implement `genZeroInitObject` helper method used by `VMnewEvaluator`.

Depends on:
- https://github.com/eclipse/openj9/pull/9605
- https://github.com/eclipse/omr/pull/5205

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>