### PR TITLE
AArch64: Enable inlining of jitNewObject

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -604,7 +604,7 @@ J9::ARM64::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Compilation * comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg->fe());
 
-   if (comp->getOption(TR_DisableAllocationInlining))
+   if (comp->suppressAllocationInlining())
       return NULL;
 
    if (comp->getOption(TR_DisableTarokInlineArrayletAllocation) && (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray))
@@ -756,10 +756,16 @@ J9::ARM64::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR::CodeGenera
 TR::Register *
 J9::ARM64::TreeEvaluator::newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::ILOpCodes opCode = node->getOpCodeValue();
-   TR::Node::recreate(node, TR::acall);
-   TR::Register *targetRegister = directCallEvaluator(node, cg);
-   TR::Node::recreate(node, opCode);
+   TR::Register *targetRegister = TR::TreeEvaluator::VMnewEvaluator(node, cg);
+   if (!targetRegister)
+      {
+      // Inline object allocation wasn't generated, just generate a call to the helper.
+      //
+      TR::ILOpCodes opCode = node->getOpCodeValue();
+      TR::Node::recreate(node, TR::acall);
+      targetRegister = directCallEvaluator(node, cg);
+      TR::Node::recreate(node, opCode);
+      }
    return targetRegister;
    }
 


### PR DESCRIPTION
This commit enables inlining of `jitNewObject`.
The limitation of the current implementation is:
- Supports `TR::new` only.
- Does not support `DualTLH`.
- Does not support realtime GC.

Inlining under AOT compilation is not enabled yet.

Depends on:
- https://github.com/eclipse/openj9/pull/9605
- https://github.com/eclipse/openj9/pull/9606
- https://github.com/eclipse/openj9/pull/9607
- https://github.com/eclipse/openj9/pull/9608

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>