### PR TITLE
Add support for -XX:[+|-]HandleSIGABRT

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1970,3 +1970,13 @@ J9NLS_VM_PACKAGE_IS_NULL.system_action=The JVM will throw a java/lang/NullPointe
 J9NLS_VM_PACKAGE_IS_NULL.user_response=Don't pass a NULL package String.
 # END NON-TRANSLATABLE
 
+# Message to use when two incompatible options are used together
+# Arguments 1 and 2 are the incompatible command line options
+J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR=%1$s is not supported with %2$s.
+# START NON-TRANSLATABLE
+J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.sample_input_1=-XX:+HandleSIGABRT
+J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.sample_input_2=-Xrs
+J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.explanation=The two command line options are incompatible. Please refer to their documentation.
+J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.system_action=The JVM will terminate while processing the command line options.
+J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.user_response=Remove one of the incompatible command line options in order to resolve the issue.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -579,6 +579,7 @@ extern "C" {
 #define J9_JCL_FLAG_JDK_MODULE_PATCH_PROP	0x40
 
 #define J9_SIG_NO_SIG_QUIT 0x1
+#define J9_SIG_NO_SIG_ABRT 0x2
 #define J9_SIG_NO_SIG_CHAIN 0x4
 #define J9_SIG_NO_SIG_INT 0x8
 #define J9_SIG_XRS_SYNC 0x10

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -327,6 +327,8 @@ enum INIT_STAGE {
 #define VMOPT_XXDEBUGINTERPRETER "-XX:+DebugInterpreter"
 #define VMOPT_XXNOHANDLESIGXFSZ "-XX:-HandleSIGXFSZ"
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
+#define VMOPT_XXNOHANDLESIGABRT "-XX:-HandleSIGABRT"
+#define VMOPT_XXHANDLESIGABRT "-XX:+HandleSIGABRT"
 #define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
 #define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
 #define VMOPT_XDUMP_EXIT_OUTOFMEMORYERROR "-Xdump:exit:events=systhrow,filter=java/lang/OutOfMemoryError"

--- a/test/functional/cmdLineTests/sigabrtHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/build.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="sigabrtHandlingTest" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests sigabrtHandlingTest
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/sigabrtHandlingTest" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml"/>
+			<fileset dir="${src}" includes="*.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/sigabrtHandlingTest/playlist.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/playlist.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTest_sigabrtHandlingTest</testCaseName>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+	-Xint -jar $(CMDLINETESTER_JAR) \
+	-config  $(Q)$(TEST_RESROOT)$(D)sigabrtHandlingTest.xml$(Q) -verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}	</command>
+		<platformRequirements></platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<types>
+			<type>native</type>
+		</types>
+		<subsets>
+			<subset>8</subset>
+			<subset>11+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/sigabrtHandlingTest/sigabrtHandlingTest.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/sigabrtHandlingTest.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2020, 2020 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="SIGABRT Handling Tests" timeout="2400">
+ <variable name="CP" value="-cp $Q$$RESJAR$$Q$ VMBench.GPTests.GPTest" />
+ 
+ <!-- 
+   The system, JIT, snap and heap dumps are disabled to reduce the memory footprint of
+   the tests. Only a Java dump will be generated when the JVM abort handler is invoked.
+   This should be sufficient to test the -XX:[+|-]HandleSIGABRT option.
+ -->
+ <variable name="DUMP" value="-Xdump:system+heap+snap+jit:none" />
+
+ <test id="Default">
+  <command>$EXE$ $DUMP$ $CP$ abort</command>
+  <output type="success" regex="no">Processing dump event "abort"</output>
+  <output type="required" regex="no">Processed dump event "abort"</output>
+ </test>
+
+ <test id="-XX:+HandleSIGABRT">
+  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT $CP$ abort</command>
+  <output type="success" regex="no">Processing dump event "abort"</output>
+  <output type="required" regex="no">Processed dump event "abort"</output>
+ </test>
+
+ <test id="-XX:-HandleSIGABRT -XX:+HandleSIGABRT">
+  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT -XX:+HandleSIGABRT $CP$ abort</command>
+  <output type="success" regex="no">Processing dump event "abort"</output>
+  <output type="required" regex="no">Processed dump event "abort"</output>
+ </test>
+
+ <test id="-XX:-HandleSIGABRT">
+  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:+HandleSIGABRT -XX:-HandleSIGABRT">
+  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT -XX:-HandleSIGABRT $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:+HandleSIGABRT -Xrs">
+  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT -Xrs $CP$ abort</command>
+  <output type="success" regex="no">-XX:+HandleSIGABRT is not supported with -Xrs</output>
+  <output type="failure" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-XX:+HandleSIGABRT -Xrs:sync">
+  <command>$EXE$ $DUMP$ -XX:+HandleSIGABRT -Xrs:sync $CP$ abort</command>
+  <output type="success" regex="no">-XX:+HandleSIGABRT is not supported with -Xrs</output>
+  <output type="failure" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+
+ <test id="-Xrs">
+  <command>$EXE$ $DUMP$ -Xrs $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+ 
+ <test id="-XX:-HandleSIGABRT -Xrs">
+  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT -Xrs $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+ 
+ <test id="-XX:-HandleSIGABRT -Xrs:sync">
+  <command>$EXE$ $DUMP$ -XX:-HandleSIGABRT -Xrs:sync $CP$ abort</command>
+  <output type="success" regex="no">Invoking abort!</output>
+  <output type="failure" regex="no">Processing dump event "abort"</output>
+ </test>
+</suite>

--- a/test/functional/cmdline_options_testresources/src/VMBench/GPTests/GPTest.java
+++ b/test/functional/cmdline_options_testresources/src/VMBench/GPTests/GPTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,6 +104,7 @@ public void run() {
 	}
 	
 	if (arg.equalsIgnoreCase("abort")) {
+		System.out.println("Invoking abort!");
 		this.gpAbort();
 		System.err.println("Survived abort!");
 		System.exit(3);


### PR DESCRIPTION
**a) Add a tracepoint to output an error for incompatible cmdline options**

The new tracepoint takes the two incompatible cmdline options as string
inputs.

**b) Add macros to support `-XX:[+|-]HandleSIGABRT`**

**c) Parse the new cmdline option: `-XX:[+|-]HandleSIGABRT`**

```
1. default                               -> JVM abort handler enabled
2. -XX:+HandleSIGABRT                    -> JVM abort handler enabled
3. -XX:-HandleSIGABRT                    -> JVM abort handler disabled
4. -XX:-HandleSIGABRT -XX:+HandleSIGABRT -> JVM abort handler enabled
5. -XX:+HandleSIGABRT -XX:-HandleSIGABRT -> JVM abort handler disabled
6. -XX:+HandleSIGABRT -Xrs               -> not allowed, error thrown
7. ... -XX:+HandleSIGABRT -Xrs:sync      -> not allowed, error thrown
8. ... -XX:-HandleSIGABRT -Xrs...        -> JVM abort handler disabled
```
`setSignalOptions` returns an error code if incompatible command line
options are specified.

`initializeJavaVM` terminates with `JNI_ERR` if `setSignalOptions` returns an
error code.

**d) Install the JVM abort handler based on `-XX:[+|-]HandleSIGABRT`**

**e) Add tests for `-XX:[+|-]HandleSIGABRT`**

- Copied `functional/cmdLineTests/gptest` to create `sigabrtHandlingTest`
- `class GPTest` updated to output `"Invoking abort!"`
- `sigabrtHandlingTest.xml` contains testcases for `-XX:[+|-]HandleSIGABRT`

Related: https://github.com/eclipse/openj9/issues/8735, https://github.com/eclipse/openj9-docs/pull/564

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>

