### PR TITLE
Fix for 16bit load on Z with balanced GC policy (Arraylets)

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -4662,21 +4662,11 @@ J9::Z::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node, TR::CodeGenera
                             else
                                op = (cg->comp()->target().is64Bit() ? TR::InstOpCode::LGB : TR::InstOpCode::LB);
                             break;
-            case TR::Int16:  if (actualLoadOrStoreChild->getOpCode().isShort())
-                               {
-                               op = TR::InstOpCode::getLoadHalfWordOpCode();
-                               }
+            case TR::Int16:
+                            if (loadOrStoreChild->isZeroExtendedAtSource())
+                               op = (cg->comp()->target().is64Bit() ? TR::InstOpCode::LLGH : TR::InstOpCode::LLH);
                             else
-                               {
-                               if (cg->comp()->target().is64Bit())
-                                  {
-                                  op = TR::InstOpCode::LLGH;
-                                  }
-                               else
-                                  {
-                                  op = TR::InstOpCode::LLH;
-                                  }
-                               }
+                               op = (cg->comp()->target().is64Bit() ? TR::InstOpCode::LGH : TR::InstOpCode::LH);
                             break;
             case TR::Int32:
                             if (loadOrStoreChild->isZeroExtendedAtSource())


### PR DESCRIPTION
When loading a 16bit value from memory while using the balanced
gc policy the Z code generator might generate a "LGH" rather then
a "LLH" instruction in some cases. This would result in an unintended
sign extend of the loaded value. This change will make the 16bit
loads work in a similar way as the 8bit and 32bit load operations
do when using arraylets.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>