### PR TITLE
Remove J9VM_OPT_VALHALLA_NESTMATES

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -151,10 +151,10 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 	_doubleScalarStaticCount(0),
 	_memberAccessFlags(0),
 	_innerClassCount(0),
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	_nestMembersCount(0),
 	_nestHost(0),
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	_maxBranchCount(1), /* This is required to support buffer size calculations for stackmap support code */
 	_outerClassNameIndex(0),
 	_simpleNameIndex(0),
@@ -180,9 +180,9 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 	_typeAnnotationsAttribute(NULL),
 	_innerClasses(NULL),
 	_bootstrapMethodsAttribute(NULL),
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	_nestMembers(NULL),
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	_isClassContended(false),
 	_isClassUnmodifiable(context->isClassUnmodifiable()),
 	_isInnerClass(false),
@@ -494,7 +494,7 @@ ClassFileOracle::walkAttributes()
 			walkRecordComponents((J9CfrAttributeRecord *)attrib);
 			break;
 		}
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 		case CFR_ATTRIBUTE_NestMembers:
 			_nestMembers = (J9CfrAttributeNestMembers *)attrib;
 			_nestMembersCount = _nestMembers->numberOfClasses;
@@ -513,7 +513,7 @@ ClassFileOracle::walkAttributes()
 			markConstantUTF8AsReferenced(_nestHost);
 			break;
 		}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 		default:
 			Trc_BCU_ClassFileOracle_walkAttributes_UnknownAttribute((U_32)attrib->tag, (U_32)getUTF8Length(attrib->nameIndex), getUTF8Data(attrib->nameIndex), attrib->length);
 			break;

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -842,7 +842,7 @@ class RecordComponentIterator
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	void nestMembersDo(ConstantPoolIndexVisitor *visitor)
 	{
 		if (NULL != _nestMembers) {
@@ -853,7 +853,7 @@ class RecordComponentIterator
 			}
 		}
 	}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	/*
 	 * Iterate over the bootstrap methods and their arguments.
@@ -899,10 +899,10 @@ class RecordComponentIterator
 	U_16 getDoubleScalarStaticCount() const { return _doubleScalarStaticCount; }
 	U_16 getMemberAccessFlags() const { return _memberAccessFlags; }
 	U_16 getInnerClassCount() const { return _innerClassCount; }
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	U_16 getNestMembersCount() const { return _nestMembersCount; }
 	U_16 getNestHostNameIndex() const { return _nestHost; }
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	U_16 getMajorVersion() const { return _classFile->majorVersion; }
 	U_16 getMinorVersion() const { return _classFile->minorVersion; }
 	U_32 getMaxBranchCount() const { return _maxBranchCount; }
@@ -1025,10 +1025,10 @@ private:
 	U_16 _doubleScalarStaticCount;
 	U_16 _memberAccessFlags;
 	U_16 _innerClassCount;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	U_16 _nestMembersCount;
 	U_16 _nestHost;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	U_32 _maxBranchCount;
 	U_16 _outerClassNameIndex;
 	U_16 _simpleNameIndex;
@@ -1063,9 +1063,9 @@ private:
 	J9CfrAttributeRuntimeVisibleTypeAnnotations *_typeAnnotationsAttribute;
 	J9CfrAttributeInnerClasses *_innerClasses;
 	J9CfrAttributeBootstrapMethods *_bootstrapMethodsAttribute;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9CfrAttributeNestMembers *_nestMembers;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	void walkHeader();
 	void walkFields();

--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -63,10 +63,10 @@ DECLARE_UTF8_ATTRIBUTE_NAME(RUNTIME_VISIBLE_TYPE_ANNOTATIONS, "RuntimeVisibleTyp
 DECLARE_UTF8_ATTRIBUTE_NAME(ANNOTATION_DEFAULT, "AnnotationDefault");
 DECLARE_UTF8_ATTRIBUTE_NAME(BOOTSTRAP_METHODS, "BootstrapMethods");
 DECLARE_UTF8_ATTRIBUTE_NAME(RECORD, "Record");
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 DECLARE_UTF8_ATTRIBUTE_NAME(NEST_MEMBERS, "NestMembers");
 DECLARE_UTF8_ATTRIBUTE_NAME(NEST_HOST, "NestHost");
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 void
 ClassFileWriter::analyzeROMClass()
@@ -101,9 +101,9 @@ ClassFileWriter::analyzeROMClass()
 	U_32 * typeAnnotationsData = getClassTypeAnnotationsDataForROMClass(_romClass);
 	J9UTF8 * outerClassName = J9ROMCLASS_OUTERCLASSNAME(_romClass);
 	J9UTF8 * simpleName = getSimpleNameForROMClass(_javaVM, NULL, _romClass);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9UTF8 *nestHost = J9ROMCLASS_NESTHOSTNAME(_romClass);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	/* For a local class only InnerClasses.class[i].inner_name_index is preserved as simpleName in its J9ROMClass */
 	if ((0 != _romClass->innerClassCount) || J9_ARE_ANY_BITS_SET(_romClass->extraModifiers, J9AccClassInnerClass)) {
@@ -124,7 +124,7 @@ ClassFileWriter::analyzeROMClass()
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	/* Class can not have both a nest members and nest host attribute */
 	if (0 != _romClass->nestMemberCount) {
 		U_16 nestMemberCount = _romClass->nestMemberCount;
@@ -139,7 +139,7 @@ ClassFileWriter::analyzeROMClass()
 		addEntry((void *) &NEST_HOST, 0, CFR_CONSTANT_Utf8);
 		addClassEntry(nestHost, 0);
 	}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (NULL != enclosingObject) {
 		addEntry((void *) &ENCLOSING_METHOD, 0, CFR_CONSTANT_Utf8);
@@ -925,10 +925,10 @@ ClassFileWriter::writeAttributes()
 	J9SourceDebugExtension * sourceDebugExtension = getSourceDebugExtensionForROMClass(_javaVM, NULL, _romClass);
 	U_32 * annotationsData = getClassAnnotationsDataForROMClass(_romClass);
 	U_32 * typeAnnotationsData = getClassTypeAnnotationsDataForROMClass(_romClass);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9UTF8 *nestHost = J9ROMCLASS_NESTHOSTNAME(_romClass);
 	U_16 nestMemberCount = _romClass->nestMemberCount;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if ((0 != _romClass->innerClassCount) || J9_ARE_ANY_BITS_SET(_romClass->extraModifiers, J9AccClassInnerClass)) {
 		attributesCount += 1;
@@ -957,12 +957,12 @@ ClassFileWriter::writeAttributes()
 	if (J9_ARE_ANY_BITS_SET(_romClass->extraModifiers, J9AccRecord)) {
 		attributesCount += 1;
 	}
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	/* Class can not have both a nest members and member of nest attribute */
 	if ((0 != _romClass->nestMemberCount) || (NULL != nestHost)) {
 		attributesCount += 1;
 	}
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	writeU16(attributesCount);
 
 	if ((0 != _romClass->innerClassCount) || J9_ARE_ANY_BITS_SET(_romClass->extraModifiers, J9AccClassInnerClass)) {
@@ -1004,7 +1004,7 @@ ClassFileWriter::writeAttributes()
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	/* A class can only have one of the nest mate attributes */
 	if (0 != nestMemberCount) {
 		J9SRP *nestMembers = (J9SRP *) J9ROMCLASS_NESTMEMBERS(_romClass);
@@ -1021,7 +1021,7 @@ ClassFileWriter::writeAttributes()
 		writeAttributeHeader((J9UTF8 *) &NEST_HOST, 2);
 		writeU16(indexForClass(nestHost));
 	}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (NULL != enclosingObject) {
 		J9ROMNameAndSignature * nas = J9ENCLOSINGOBJECT_NAMEANDSIGNATURE(enclosingObject);

--- a/runtime/bcutil/ConstantPoolMap.hpp
+++ b/runtime/bcutil/ConstantPoolMap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -230,9 +230,9 @@ public:
 				&& (_context->alwaysSplitBytecodes()
 					|| isMarked(cfrCPIndex, INVOKE_INTERFACE)
 					|| isMarked(cfrCPIndex, INVOKE_SPECIAL)
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 					|| isMarked(cfrCPIndex, INVOKE_VIRTUAL)
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 				));
 	}
 
@@ -246,9 +246,9 @@ public:
 		return (isMarked(cfrCPIndex, INVOKE_SPECIAL)
 				&& (_context->alwaysSplitBytecodes()
 					|| isMarked(cfrCPIndex, INVOKE_INTERFACE)
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 					|| isMarked(cfrCPIndex, INVOKE_VIRTUAL)
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 				));
 	}
 

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -296,9 +296,9 @@ ROMClassWriter::ROMClassWriter(BufferManager *bufferManager, ClassFileOracle *cl
 	_fieldsSRPKey(srpKeyProducer->generateKey()),
 	_cpDescriptionShapeSRPKey(srpKeyProducer->generateKey()),
 	_innerClassesSRPKey(srpKeyProducer->generateKey()),
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	_nestMembersSRPKey(srpKeyProducer->generateKey()),
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	_optionalInfoSRPKey(srpKeyProducer->generateKey()),
 	_enclosingMethodSRPKey(srpKeyProducer->generateKey()),
 	_sourceDebugExtensionSRPKey(srpKeyProducer->generateKey()),
@@ -383,12 +383,12 @@ ROMClassWriter::writeROMClass(Cursor *cursor,
 		cursor->writeU32(_classFileOracle->getMemberAccessFlags(), Cursor::GENERIC);
 		cursor->writeU32(_classFileOracle->getInnerClassCount(), Cursor::GENERIC);
 		cursor->writeSRP(_innerClassesSRPKey, Cursor::SRP_TO_GENERIC);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 		cursor->writeSRP(_srpKeyProducer->mapCfrConstantPoolIndexToKey(_classFileOracle->getNestHostNameIndex()), Cursor::SRP_TO_UTF8);
 		cursor->writeU16(_classFileOracle->getNestMembersCount(), Cursor::GENERIC);
 		cursor->writeU16(0, Cursor::GENERIC); /* padding */
 		cursor->writeSRP(_nestMembersSRPKey, Cursor::SRP_TO_GENERIC);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 		cursor->writeU16(_classFileOracle->getMajorVersion(), Cursor::GENERIC);
 		cursor->writeU16(_classFileOracle->getMinorVersion(), Cursor::GENERIC);
 		cursor->writeU32(optionalFlags, Cursor::OPTIONAL_FLAGS);
@@ -418,9 +418,9 @@ ROMClassWriter::writeROMClass(Cursor *cursor,
 	writeFields(cursor, markAndCountOnly);
 	writeInterfaces(cursor, markAndCountOnly);
 	writeInnerClasses(cursor, markAndCountOnly);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	writeNestMembers(cursor, markAndCountOnly);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	writeNameAndSignatureBlock(cursor);
 	writeMethods(cursor, lineNumberCursor, variableInfoCursor, markAndCountOnly);
 	writeConstantPoolShapeDescriptions(cursor, markAndCountOnly);
@@ -722,14 +722,14 @@ public:
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	void writeNestMembers()
 	{
 		if (!_markAndCountOnly) {
 			_classFileOracle->nestMembersDo(this); /* visitConstantPoolIndex */
 		}
 	}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	void writeInterfaces()
 	{
@@ -1095,7 +1095,7 @@ ROMClassWriter::writeInnerClasses(Cursor *cursor, bool markAndCountOnly)
 	Helper(cursor, markAndCountOnly, _classFileOracle, _srpKeyProducer, _srpOffsetTable, _constantPoolMap, size).writeInnerClasses();
 }
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 void
 ROMClassWriter::writeNestMembers(Cursor *cursor, bool markAndCountOnly)
 {
@@ -1104,7 +1104,7 @@ ROMClassWriter::writeNestMembers(Cursor *cursor, bool markAndCountOnly)
 	CheckSize _(cursor,size);
 	Helper(cursor, markAndCountOnly, _classFileOracle, _srpKeyProducer, _srpOffsetTable, _constantPoolMap, size).writeNestMembers();
 }
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 void
 ROMClassWriter::writeNameAndSignatureBlock(Cursor *cursor)

--- a/runtime/bcutil/ROMClassWriter.hpp
+++ b/runtime/bcutil/ROMClassWriter.hpp
@@ -158,9 +158,9 @@ private:
 	UDATA _fieldsSRPKey;
 	UDATA _cpDescriptionShapeSRPKey;
 	UDATA _innerClassesSRPKey;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	UDATA _nestMembersSRPKey;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	UDATA _optionalInfoSRPKey;
 	UDATA _stackMapsSRPKey;
 	UDATA _enclosingMethodSRPKey;

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -145,10 +145,10 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 	J9CfrAttributeStackMap *stackMap;
 	J9CfrAttributeBootstrapMethods *bootstrapMethods;
 	J9CfrAttributeRecord *record;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9CfrAttributeNestHost *nestHost;
 	J9CfrAttributeNestMembers *nestMembers;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	U_32 name, length;
 	U_32 tag, errorCode, offset;
 	U_8 *end;
@@ -166,9 +166,9 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 	BOOLEAN visibleParameterAnnotationsRead  = FALSE;
 	BOOLEAN invisibleParameterAnnotationsRead  = FALSE;
 	BOOLEAN recordAttributeRead = FALSE;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	BOOLEAN nestAttributeRead = FALSE;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (NULL != syntheticFound) {
 		*syntheticFound = FALSE;
@@ -877,7 +877,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 				}
 			}
 			break;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 		case CFR_ATTRIBUTE_NestHost:
 			if (nestAttributeRead) {
 				errorCode = J9NLS_CFR_ERR_MULTIPLE_NEST_ATTRIBUTES__ID;
@@ -924,7 +924,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 			}
 			break;
 		}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 		case CFR_ATTRIBUTE_StrippedLineNumberTable:
 		case CFR_ATTRIBUTE_StrippedLocalVariableTable:
@@ -2283,7 +2283,7 @@ checkAttributes(J9CfrClassFile* classfile, J9CfrAttribute** attributes, U_32 att
 
 			break;
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 		case CFR_ATTRIBUTE_NestHost:
 			value = ((J9CfrAttributeNestHost*)attrib)->hostClassIndex;
 			if ((!value) || (value > cpCount)) {
@@ -2311,7 +2311,7 @@ checkAttributes(J9CfrClassFile* classfile, J9CfrAttribute** attributes, U_32 att
 			}
 			break;
 		}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 		case CFR_ATTRIBUTE_StackMap: /* CLDC StackMap attribute - not supported in J2SE */
 		case CFR_ATTRIBUTE_Synthetic:

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -531,10 +531,10 @@ static void dumpAttribute(J9CfrClassFile* classfile, J9CfrAttribute* attrib, U_3
 	U_16 index, index2;
 	J9CfrAttributeCode* code;
 	J9CfrAttributeInnerClasses* classes;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9CfrAttributeNestMembers* nestMembers;
 	U_16 nestMemberCount;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	J9CfrAttributeExceptions* exceptions;
 	U_32 i;
 	U_32 j;
@@ -667,7 +667,7 @@ static void dumpAttribute(J9CfrClassFile* classfile, J9CfrAttribute* attrib, U_3
 			}
 			break;
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 		case CFR_ATTRIBUTE_NestMembers: {
 			nestMembers = (J9CfrAttributeNestMembers*)attrib;
 			nestMemberCount = nestMembers->numberOfClasses;
@@ -686,7 +686,7 @@ static void dumpAttribute(J9CfrClassFile* classfile, J9CfrAttribute* attrib, U_3
 			j9tty_printf( PORTLIB, "%i -> %s\n", index, classfile->constantPool[classfile->constantPool[index].slot1].bytes);
 			break;
 		}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 		case CFR_ATTRIBUTE_LineNumberTable:
 			for(i = 0; i < ((J9CfrAttributeLineNumberTable*)attrib)->lineNumberTableLength; i++)

--- a/runtime/cmake/options.cmake
+++ b/runtime/cmake/options.cmake
@@ -82,28 +82,21 @@ option(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH "Atomic free uses FlushProcessWrit
 option(J9VM_INTERP_BYTECODE_PREVERIFICATION "Does this VM support 1st pass bytecode verification (able to dynamically generate pre-verify data)")
 option(J9VM_INTERP_BYTECODE_VERIFICATION "Does this VM support 2nd pass bytecode verification (pre-verify data in .jxe only)")
 
-
 option(J9VM_INTERP_DEBUG_SUPPORT "Controls if a debugging support is included in the VM.")
 option(J9VM_INTERP_ENABLE_JIT_ON_DESKTOP "TEMPORARY FLAG for arm test environment")
 
-
 option(J9VM_INTERP_FLOAT_SUPPORT "Determines if float and double data types are supported by the VM.")
-
 
 option(J9VM_INTERP_GP_HANDLER "Determines if protection faults are caught by the VM and handled cleanly.")
 option(J9VM_INTERP_GP_GROWABLE_STACKS "Enables dynamic java stack growing")
 
-
 option(J9VM_INTERP_JIT_ON_BY_DEFAULT "Turns JIT on by default")
 option(J9VM_INTERP_JNI_SUPPORT "Determines if JNI native support is available.")
-
-
 
 option(J9VM_INTERP_NATIVE_SUPPORT "Controls if the native translator is included in the VM.")
 option(J9VM_INTERP_NEW_HEADER_SHAPE "Temporary flag for experimentation with the object header shape.")
 option(J9VM_INTERP_PROFILING_BYTECODES "If enabled, profiling versions of branch and call bytecodes are available. These gather additional info for the JIT for optimal code generation")
 option(J9VM_INTERP_ROMABLE_AOT_SUPPORT "ROMable AOT Support for TJ Watson")
-
 
 option(J9VM_INTERP_TRACING "DEBUGGING FEATURE.  Determines if the interpreter produces debug information at every bytecode.")
 option(J9VM_INTERP_TWO_PASS_EXCLUSIVE "Exclusive VM access - Set halt bit in one pass, count responders in another pass")
@@ -119,24 +112,17 @@ option(J9VM_MODULE_AOTRT_COMMON "Enables compilation of the aotrt_common module.
 option(J9VM_MODULE_BCUTIL "Enables compilation of the bcutil module.")
 option(J9VM_MODULE_BCVERIFY "Enables compilation of the bcverify module.")
 
-
-
 option(J9VM_MODULE_CASSUME "Enables compilation of the cassume module.")
 option(J9VM_MODULE_CFDUMPER "Enables compilation of the cfdumper module.")
 
-
 option(J9VM_MODULE_DBGEXT "Enables compilation of the dbgext module.")
 
-
-
 option(J9VM_MODULE_EXELIB "Enables compilation of the exelib module.")
-
 
 option(J9VM_MODULE_VM "Enables compilation of the vm module.")
 option(J9VM_MODULE_WINDBG "Enables compilation of the windbg module.")
 option(J9VM_MODULE_ZIP "Enables compilation of the zip module.")
 option(J9VM_MODULE_ZLIB "Enables compilation of the zlib module.")
-
 
 j9vm_shadowed_option(J9VM_OPT_CUDA "Add support for CUDA")
 
@@ -144,18 +130,14 @@ option(J9VM_OPT_DYNAMIC_LOAD_SUPPORT "Determines if the dynamic loader is includ
 option(J9VM_OPT_FIPS "Add supports for FIPs")
 option(J9VM_OPT_FRAGMENT_RAM_CLASSES "Transitional flag for the the GC during the switch to fragmented RAM class allocation")
 
-
 option(J9VM_OPT_JVMTI "Support for the JVMTI interface")
 option(J9VM_OPT_JXE_LOAD_SUPPORT "Controls if main will allow -jxe: and relocate the disk image for you.")
-
 
 option(J9VM_OPT_METHOD_HANDLE "Turns on methodhandle support")
 option(J9VM_OPT_MODULE "Turns on module support")
 option(J9VM_OPT_MULTI_VM "Decides if multiple VMs can be created in the same address space")
 
-
 option(J9VM_OPT_PANAMA "Enables support for Project Panama features such as native method handles")
-option(J9VM_OPT_VALHALLA_NESTMATES "Enables support for Project Valhalla Nest Mates")
 option(J9VM_OPT_VALHALLA_VALUE_TYPES "Enables support for Project Valhalla Value Types")
 
 option(J9VM_OPT_ROM_IMAGE_SUPPORT "Controls if the VM includes basic support for linked rom images")
@@ -166,8 +148,6 @@ option(J9VM_OPT_ZLIB_COMPRESSION "Controls if the compression routines in zlib a
 option(J9VM_OPT_ZLIB_SUPPORT "Controls if the VM includes the zlib compression library.")
 
 option(J9VM_PORT_RUNTIME_INSTRUMENTATION "Controls whether runtime instrumentation support exists on this platform.")
-
-
 
 option(J9VM_RAS_DUMP_AGENTS "Support multiple dump agents, instead of just console dump.")
 option(J9VM_RAS_EYE_CATCHERS "Add eyecatcher blocks to key structures")

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2697,7 +2697,7 @@ illegalAccess:
 			/* Private methods are visible only within their declaring class
 			 * unless the two classes are in the same nest (JDK11 and beyond).
 			 */
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 			if (NULL == thisClass->nestHost) {
 				if (J9_VISIBILITY_ALLOWED != vmFuncs->loadAndVerifyNestHost(currentThread, thisClass, 0)) {
 					goto illegalAccess;
@@ -2709,7 +2709,7 @@ illegalAccess:
 				}
 			}
 			if (thisClass->nestHost != callerClass->nestHost)
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 			{
 				if (thisClass != callerClass) {
 					goto illegalAccess;

--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -60,10 +60,6 @@ extern "C" {
 </#if>
 </#list>
 
-#if JAVA_SPEC_VERSION >= 11
-#define J9VM_OPT_VALHALLA_NESTMATES
-#endif
-
 #if defined(J9VM_ENV_DATA64)
 #define J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
 #endif

--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -278,10 +278,6 @@ extern "C" {
 #cmakedefine J9VM_THR_PREEMPTIVE
 #cmakedefine J9VM_THR_SMART_DEFLATION
 
-#if JAVA_SPEC_VERSION >= 11
-#define J9VM_OPT_VALHALLA_NESTMATES
-#endif
-
 #if defined(J9VM_ENV_DATA64)
 #define J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
 #endif

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1507,12 +1507,14 @@ JVM_GetNestHost(JNIEnv *env, jclass clz)
 	assert(!"JVM_GetNestHost unimplemented");
 	return NULL;
 }
+
 JNIEXPORT jobjectArray JNICALL
 JVM_GetNestMembers(JNIEnv *env, jclass clz)
 {
 	assert(!"JVM_GetNestMembers unimplemented");
 	return NULL;
 }
+
 /**
  * Check if two classes belong to the same nest
  *
@@ -1525,7 +1527,6 @@ JVM_GetNestMembers(JNIEnv *env, jclass clz)
 JNIEXPORT jboolean JNICALL
 JVM_AreNestMates(JNIEnv *env, jclass jClassOne, jclass jClassTwo)
 {
-#ifdef J9VM_OPT_VALHALLA_NESTMATES
 	jboolean result = JNI_FALSE;
 
 	if ((NULL != jClassOne) && (NULL != jClassTwo)) {
@@ -1565,10 +1566,6 @@ done:
 	}
 
 	return result;
-#else
-	assert(!"JVM_GetNestMembers unimplemented");
-	return JNI_FALSE;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
 }
 #endif /* JAVA_SPEC_VERSION >= 11 */
 

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1796,7 +1796,7 @@ storePDobjectsHelper(J9VMThread* vmThread, J9Class* arrayClass, J9StackWalkState
 jobject JNICALL
 Java_java_lang_Class_getNestHostImpl(JNIEnv *env, jobject recv)
 {
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9VMThread *currentThread = (J9VMThread*)env;
 	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
@@ -1823,16 +1823,16 @@ Java_java_lang_Class_getNestHostImpl(JNIEnv *env, jobject recv)
 
 	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
-#else /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#else /* JAVA_SPEC_VERSION >= 11 */
 	Assert_JCL_unimplemented();
 	return NULL;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
 jobject JNICALL
 Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv)
 {
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9VMThread *currentThread = (J9VMThread*)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
@@ -1913,10 +1913,10 @@ Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv)
 _done:
 	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
-#else /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#else /* JAVA_SPEC_VERSION >= 11 */
 	Assert_JCL_unimplemented();
 	return NULL;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
 }

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1247,10 +1247,10 @@ redefineClassesCommon(jvmtiEnv* env,
 				/* Indicate that a redefine has occurred */
 				vm->hotSwapCount += 1;
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 				/* Update nests with redefined nest tops */
 				fixNestMembers(currentThread, classPairs);
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 				/* Notify the JIT about redefined classes */

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -27,7 +27,6 @@
 extern "C" {
 #endif
 
-
 #include "j9.h"
 #include "j9port.h"
 
@@ -486,7 +485,7 @@ typedef struct J9CfrAttributeSynthetic {
     UDATA romAddress;
 } J9CfrAttributeSynthetic;
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 typedef struct J9CfrAttributeNestHost {
 	U_8 tag;
 	U_16 nameIndex;
@@ -503,7 +502,7 @@ typedef struct J9CfrAttributeNestMembers {
 	U_16 numberOfClasses;
 	U_16* classes;
 } J9CfrAttributeNestMembers;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 typedef struct J9CfrAttributeUnknown {
     U_8 tag;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
- *
  * Copyright (c) 1991, 2020 IBM Corp. and others
+ *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
@@ -249,11 +249,11 @@
 #define J9_VISIBILITY_NON_MODULE_ACCESS_ERROR 0
 #define J9_VISIBILITY_MODULE_READ_ACCESS_ERROR -1
 #define J9_VISIBILITY_MODULE_PACKAGE_EXPORT_ERROR -2
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 #define J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR -3
 #define J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR -4
 #define J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR -5
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_4BYTES 0xFFFFFFFF
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_2BYTES 0xFFFF
@@ -3044,9 +3044,9 @@ typedef struct J9Class {
 	struct J9JITExceptionTable* jitMetaDataList;
 	struct J9Class* gcLink;
 	struct J9Class* hostClass;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	struct J9Class* nestHost;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	struct J9FlattenedClassCache* flattenedClassCache;
 } J9Class;
 
@@ -3117,9 +3117,9 @@ typedef struct J9ArrayClass {
 	struct J9JITExceptionTable* jitMetaDataList;
 	struct J9Class* gcLink;
 	struct J9Class* hostClass;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	struct J9Class* nestHost;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	/* Added temporarily for consistency */
 	UDATA flattenedElementSize;
 } J9ArrayClass;
@@ -3226,12 +3226,12 @@ typedef struct J9ROMClass {
 	U_32 memberAccessFlags;
 	U_32 innerClassCount;
 	J9SRP innerClasses;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9SRP nestHost;
 	U_16 nestMemberCount;
 	U_16 unused;
 	J9SRP nestMembers;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	U_16 majorVersion;
 	U_16 minorVersion;
 	U_32 optionalFlags;
@@ -3250,14 +3250,14 @@ typedef struct J9ROMClass {
 	J9SRP specialSplitMethodRefIndexes;
 	J9SRP varHandleMethodTypeLookupTable;
 #if defined(J9VM_ENV_DATA64)
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	U_32 padding;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #else /* J9VM_ENV_DATA64 */
-#if !defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION < 11
 	U_32 padding;
-#endif /* !J9VM_OPT_VALHALLA_NESTMATES */
-#endif /* J9VM_ENV_DATA64 && J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION < 11 */
+#endif /* J9VM_ENV_DATA64 */
 } J9ROMClass;
 
 #define J9ROMCLASS_CLASSNAME(base) NNSRP_GET((base)->className, struct J9UTF8*)
@@ -3269,10 +3269,10 @@ typedef struct J9ROMClass {
 #define J9ROMCLASS_CPSHAPEDESCRIPTION(base) NNSRP_GET((base)->cpShapeDescription, U_32*)
 #define J9ROMCLASS_OUTERCLASSNAME(base) SRP_GET((base)->outerClassName, struct J9UTF8*)
 #define J9ROMCLASS_INNERCLASSES(base) NNSRP_GET((base)->innerClasses, J9SRP*)
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 #define J9ROMCLASS_NESTHOSTNAME(base) SRP_GET((base)->nestHost, struct J9UTF8*)
 #define J9ROMCLASS_NESTMEMBERS(base) SRP_GET((base)->nestMembers, J9SRP*)
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #define J9ROMCLASS_OPTIONALINFO(base) SRP_GET((base)->optionalInfo, U_32*)
 #define J9ROMCLASS_CALLSITEDATA(base) SRP_GET((base)->callSiteData, U_8*)
 #define J9ROMCLASS_STATICSPLITMETHODREFINDEXES(base) SRP_GET((base)->staticSplitMethodRefIndexes, U_16*)
@@ -3303,12 +3303,12 @@ typedef struct J9ROMArrayClass {
 	U_32 memberAccessFlags;
 	U_32 innerClassCount;
 	J9SRP innerClasses;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9SRP nestHost;
 	U_16 nestMemberCount;
 	U_16 unused;
 	J9SRP nestMembers;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	U_16 majorVersion;
 	U_16 minorVersion;
 	U_32 optionalFlags;
@@ -3327,14 +3327,14 @@ typedef struct J9ROMArrayClass {
 	J9SRP specialSplitMethodRefIndexes;
 	J9SRP varHandleMethodTypeLookupTable;
 #if defined(J9VM_ENV_DATA64)
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	U_32 padding;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #else /* J9VM_ENV_DATA64 */
-#if !defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION < 11
 	U_32 padding;
-#endif /* !J9VM_OPT_VALHALLA_NESTMATES */
-#endif /* J9VM_ENV_DATA64 && J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION < 11 */
+#endif /* J9VM_ENV_DATA64 */
 } J9ROMArrayClass;
 
 #define J9ROMARRAYCLASS_CLASSNAME(base) NNSRP_GET((base)->className, struct J9UTF8*)
@@ -3375,12 +3375,12 @@ typedef struct J9ROMReflectClass {
 	U_32 memberAccessFlags;
 	U_32 innerClassCount;
 	J9SRP innerClasses;
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	J9SRP nestHost;
 	U_16 nestMemberCount;
 	U_16 unused;
 	J9SRP nestMembers;
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	U_16 majorVersion;
 	U_16 minorVersion;
 	U_32 optionalFlags;
@@ -3399,14 +3399,14 @@ typedef struct J9ROMReflectClass {
 	J9SRP specialSplitMethodRefIndexes;
 	J9SRP varHandleMethodTypeLookupTable;
 #if defined(J9VM_ENV_DATA64)
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	U_32 padding;
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #else /* J9VM_ENV_DATA64 */
-#if !defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION < 11
 	U_32 padding;
-#endif /* !J9VM_OPT_VALHALLA_NESTMATES */
-#endif /* J9VM_ENV_DATA64 && J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION < 11 */
+#endif /* J9VM_ENV_DATA64 */
 } J9ROMReflectClass;
 
 #define J9ROMREFLECTCLASS_CLASSNAME(base) NNSRP_GET((base)->className, struct J9UTF8*)
@@ -4525,10 +4525,10 @@ typedef struct J9InternalVMFunctions {
 	IDATA ( *registerOSHandler)(struct J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
 	void ( *throwNativeOOMError)(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
 	void ( *throwNewJavaIoIOException)(JNIEnv *env, const char *message);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	UDATA ( *loadAndVerifyNestHost)(struct J9VMThread *vmThread, struct J9Class *clazz, UDATA options);
 	void ( *setNestmatesError)(struct J9VMThread *vmThread, struct J9Class *nestMember, struct J9Class *nestHost, IDATA errorCode);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	BOOLEAN ( *areValueTypesEnabled)(struct J9JavaVM *vm);
 	J9Class* ( *peekClassHashTable)(struct J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* className, UDATA classNameLength);
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -895,10 +895,10 @@ jobject JNICALL Java_java_security_AccessController_getCallerPD(JNIEnv* env, jcl
 jobject JNICALL Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass);
 jobject JNICALL Java_java_lang_Class_getDeclaredFieldImpl(JNIEnv *env, jobject recv, jstring jname);
 jarray JNICALL Java_java_lang_Class_getDeclaredFieldsImpl(JNIEnv *env, jobject recv);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 jobject JNICALL Java_java_lang_Class_getNestHostImpl(JNIEnv *env, jobject recv);
 jobject JNICALL Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 /* sun_misc_Perf.c */
 void JNICALL Java_sun_misc_Perf_registerNatives(JNIEnv *env, jclass klass);

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2168,10 +2168,10 @@ jitClassRedefineEvent(J9VMThread * currentThread, J9JVMTIHCRJitEventData * jitEv
 void
 notifyGCOfClassReplacement(J9VMThread * currentThread, J9HashTable * classPairs, UDATA isFastHCR);
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 void
 fixNestMembers(J9VMThread * currentThread, J9HashTable * classPairs);
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 #endif /* J9VM_INTERP_HOT_CODE_REPLACEMENT */
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -29,7 +29,6 @@
 *
 * This file contains public function prototypes and
 * type definitions for the VM module.
-*
 */
 
 #include "j9.h"
@@ -3184,7 +3183,7 @@ trace(J9VMThread *vmStruct);
 #endif /* J9VM_INTERP_TRACING || INTERP_UPDATE_VMCTRACING */ /* End File Level Build Flags */
 
 /* ---------------- visible.c ---------------- */
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 /**
  * Loads the nest host and ensures that the nest host belongs
  * to the same runtime package as the class. This function requires
@@ -3214,7 +3213,7 @@ loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options);
  */
 void
 setNestmatesError(J9VMThread *vmThread, J9Class *nestMember, J9Class *nestHost, IDATA errorCode);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 /* ---------------- VMAccess.cpp ---------------- */
 
@@ -4369,4 +4368,3 @@ throwNewJavaIoIOException(JNIEnv *env, const char *message);
 #endif
 
 #endif /* vm_api_h */
-

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -7979,7 +7979,7 @@ checkROMClassUTF8SRPs(J9ROMClass *romClass)
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	Trc_SHR_Assert_True((UDATA)J9ROMCLASS_NESTHOSTNAME(romClass) < romClassEnd);
 
 	if (romClass->nestMemberCount > 0) {
@@ -7989,7 +7989,7 @@ checkROMClassUTF8SRPs(J9ROMClass *romClass)
 			nestMemberNames++;
 		}
 	}
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
 /**

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2319,8 +2319,7 @@ flushClassLoaderReflectCache(J9VMThread * currentThread, J9HashTable * classPair
 	}
 }
 
-
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 /**
  * \brief  Fix any resolved nest members
  * \ingroup
@@ -2334,7 +2333,6 @@ flushClassLoaderReflectCache(J9VMThread * currentThread, J9HashTable * classPair
  *	class within its next class. In order for these access checks to be accurate
  *	post nest host resolution, any classes that point to the original class def
  *	as their nest host must be updated to point do the replaced class def instead.
- *
  */
 void
 fixNestMembers(J9VMThread * currentThread, J9HashTable * classPairs)
@@ -2366,7 +2364,7 @@ fixNestMembers(J9VMThread * currentThread, J9HashTable * classPairs)
 		classPair = hashTableNextDo(&hashTableState);
 	}
 }
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 static void
 swapClassesForFastHCR(J9Class *originalClass, J9Class *obsoleteClass)
@@ -2381,7 +2379,6 @@ swapClassesForFastHCR(J9Class *originalClass, J9Class *obsoleteClass)
 
 	/* Preserved values. */
 	obsoleteClass->initializeStatus = originalClass->initializeStatus;
-
 
 	obsoleteClass->classObject = originalClass->classObject;
 	obsoleteClass->module = originalClass->module;
@@ -3171,7 +3168,7 @@ done:
 
 }
 
-#if (JAVA_SPEC_VERSION >= 15)
+#if JAVA_SPEC_VERSION >= 15
 static jvmtiError
 verifyRecordAttributesAreSame(J9ROMClass *originalROMClass, J9ROMClass *replacementROMClass)
 {
@@ -3216,7 +3213,7 @@ verifyRecordAttributesAreSame(J9ROMClass *originalROMClass, J9ROMClass *replacem
 done:
 	return rc;
 }
-#endif /* (JAVA_SPEC_VERSION >= 15) */
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
 jvmtiError
 verifyClassesAreCompatible(J9VMThread * currentThread, jint class_count, J9JVMTIClassPair * classPairs,
@@ -3320,15 +3317,15 @@ verifyClassesAreCompatible(J9VMThread * currentThread, jint class_count, J9JVMTI
 			return rc;
 		}
 
-#if (JAVA_SPEC_VERSION >= 15)
+#if JAVA_SPEC_VERSION >= 15
 		/* Verify that records attributes are the same */
 		rc = verifyRecordAttributesAreSame(originalROMClass, replacementROMClass);
 		if (rc != JVMTI_ERROR_NONE) {
 			return rc;
 		}
-#endif /* (JAVA_SPEC_VERSION >= 15) */
+#endif /* JAVA_SPEC_VERSION >= 15 */
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 		/* Verify that the nestmates attributes - nest host & nest members - are the same */
 		{
 			J9UTF8 *originalNestHostName = J9ROMCLASS_NESTHOSTNAME(originalROMClass);
@@ -3360,7 +3357,7 @@ verifyClassesAreCompatible(J9VMThread * currentThread, jint class_count, J9JVMTI
 				}
 			}
 		}
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 		if (0 != classUsesExtensions) {
 			classPairs[i].flags |= J9JVMTI_CLASS_PAIR_FLAG_USES_EXTENSIONS;
@@ -3931,7 +3928,6 @@ hshelpUTRegister(J9JavaVM *vm)
 	UT_J9HSHELP_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(vm));
 }
 
-
 /**
  * \brief	Notify the jit about redefined classes
  * \ingroup
@@ -3962,6 +3958,3 @@ jitClassRedefineEvent(J9VMThread * currentThread, J9JVMTIHCRJitEventData * jitEv
 }
 
 #endif /* J9VM_INTERP_HOT_CODE_REPLACEMENT */ /* End File Level Build Flags */
-
-
-

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,9 +75,9 @@ static I_32 dumpMethodDebugInfo (J9PortLibrary *portLib, J9ROMClass *romClass, J
 static I_32 dumpNative ( J9PortLibrary *portLib, J9ROMMethod * romMethod, U_32 flags);
 static I_32 dumpGenericSignature (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
 static I_32 dumpEnclosingMethod (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 static I_32 dumpNest (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 static I_32 dumpSimpleName (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
 static I_32 dumpUTF ( J9UTF8 *utfString, J9PortLibrary *portLib, U_32 flags);
 static I_32 dumpSourceDebugExtension (J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags);
@@ -180,10 +180,10 @@ IDATA j9bcutil_dumpRomClass( J9ROMClass *romClass, J9PortLibrary *portLib, J9Tra
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	/* dump the nest members or nest host, if defined */
 	dumpNest(portLib, romClass, flags);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	j9tty_printf( PORTLIB, "Fields (%i):\n", romClass->romFieldCount);
 	currentField = romFieldsStartDo(romClass, &state);
@@ -823,7 +823,7 @@ dumpEnclosingMethod(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 	return BCT_ERR_NO_ERROR;
 }
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 static I_32
 dumpNest(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 {
@@ -848,7 +848,7 @@ dumpNest(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 	}
 	return BCT_ERR_NO_ERROR;
 }
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 static I_32
 dumpSimpleName(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -136,12 +136,12 @@ void allSlotsInROMClassDo(J9ROMClass* romClass,
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, memberAccessFlags);
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, innerClassCount);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, innerClasses);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, nestHost);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, nestMemberCount);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, unused);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, nestMembers);
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, majorVersion);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, minorVersion);
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, optionalFlags);

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -365,10 +365,10 @@ J9InternalVMFunctions J9InternalFunctions = {
 	registerOSHandler,
 	throwNativeOOMError,
 	throwNewJavaIoIOException,
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	loadAndVerifyNestHost,
 	setNestmatesError,
-#endif
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	areValueTypesEnabled,
 	peekClassHashTable,
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1059,7 +1059,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 	Trc_VM_illegalAccessMessage_Entry(currentThread, J9UTF8_LENGTH(senderClassNameUTF), J9UTF8_DATA(senderClassNameUTF),
 			J9UTF8_LENGTH(targetClassNameUTF), J9UTF8_DATA(targetClassNameUTF), badMemberModifier);
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 	/* If an issue with the nest host loading and verification occurred, then
 	 * it will be one of:
 	 * 		J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR
@@ -1130,7 +1130,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 					J9UTF8_DATA(nestHostNameUTF));
 		}
 	} else
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	if (J9_VISIBILITY_NON_MODULE_ACCESS_ERROR != errorType) {
 		/* illegal module access */
 		j9object_t srcModuleObject = J9VMJAVALANGCLASS_MODULE(currentThread, senderClass->classObject);

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,7 +113,7 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 		} else if (modifiers & J9AccPrivate) {
 			/* Private */
 			if (sourceClass != destClass) {
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 				if (J9_ARE_NO_BITS_SET(lookupOptions, J9_LOOK_NO_NESTMATES)) {
 					/* loadAndVerifyNestHost returns an error code if setting the
 					 * nest host field fails.
@@ -144,7 +144,7 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 						result = J9_VISIBILITY_NON_MODULE_ACCESS_ERROR;
 					}
 				} else
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 				{
 					result = J9_VISIBILITY_NON_MODULE_ACCESS_ERROR;
 				}
@@ -172,9 +172,9 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 		}
 	}
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 _exit:
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	if (J9_VISIBILITY_NON_MODULE_ACCESS_ERROR == result) {
 		/* "checkVisibility from %p (%.*s) to %p (%.*s) modifiers=%zx failed" */
 		Trc_VM_checkVisibility_Failed(currentThread,
@@ -188,7 +188,7 @@ _exit:
 	return result;
 }
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+#if JAVA_SPEC_VERSION >= 11
 
 /**
  * Sets the nestmates error based on the errorCode
@@ -340,4 +340,4 @@ loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options)
 
 	return result;
 }
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#endif /* JAVA_SPEC_VERSION >= 11 */


### PR DESCRIPTION
Replace occurrences of `defined(J9VM_OPT_VALHALLA_NESTMATES)` with `JAVA_SPEC_VERSION >= 11`.

Fixes: #9618