### PR TITLE
Mark VM as exitting earlier

### DIFF
--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -323,6 +323,26 @@ protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 	Trc_JNIinv_protectedDestroyJavaVM_FinishedThreadWait();
 
+	/* Prevents daemon threads from exiting */
+	if (vm->runtimeFlagsMutex != NULL) {
+		omrthread_monitor_enter(vm->runtimeFlagsMutex);
+	}
+
+	if (vm->runtimeFlags & J9_RUNTIME_EXIT_STARTED) {
+		if (vm->runtimeFlagsMutex != NULL) {
+			omrthread_monitor_exit(vm->runtimeFlagsMutex);
+		}
+		/* Do not acquire exclusive here as it may cause deadlocks with
+		 * the other thread shutting down.
+		 */
+		return JNI_ERR;
+	}
+
+	vm->runtimeFlags |= J9_RUNTIME_EXIT_STARTED;
+	if (vm->runtimeFlagsMutex != NULL) {
+		omrthread_monitor_exit(vm->runtimeFlagsMutex);
+	}
+
 	/* run exit hooks */
 	sidecarShutdown(vmThread);
 
@@ -368,26 +388,6 @@ protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 	if (terminateRemainingThreads(vmThread)) {
 		Trc_JNIinv_protectedDestroyJavaVM_terminateRemainingThreadsFailed();
-
-		/* Prevents daemon threads from exiting */
-		if (vm->runtimeFlagsMutex != NULL) {
-			omrthread_monitor_enter(vm->runtimeFlagsMutex);
-		}
-
-		if (vm->runtimeFlags & J9_RUNTIME_EXIT_STARTED) {
-			if (vm->runtimeFlagsMutex != NULL) {
-				omrthread_monitor_exit(vm->runtimeFlagsMutex);
-			}
-			/* Do not acquire exclusive here as it may cause deadlocks with
-			 * the other thread shutting down.
-			 */
-			return JNI_ERR;
-		}
-
-		vm->runtimeFlags |= J9_RUNTIME_EXIT_STARTED;
-		if (vm->runtimeFlagsMutex != NULL) {
-			omrthread_monitor_exit(vm->runtimeFlagsMutex);
-		}
 
 		/* If we cannot shut down, at least run exit code in loaded modules */
 		runExitStages(vm, vmThread);
@@ -551,16 +551,21 @@ jint JNICALL DetachCurrentThread(JavaVM * javaVM)
 	UDATA result = 0;
 	PORT_ACCESS_FROM_PORT(vm->portLibrary);
 
-	/* we should return here to avoid the detaching operations after the destroy call to avoid
-	 * the unexpected hang caused by the checking of exclusive VM access in deallocateVMThread()
-	 */
-	if (J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED)) {
-		return JNI_OK;
-	}
-
 	/* Verify that the current thread is allowed to detach from the VM */
 
-	if ((result = (UDATA) verifyCurrentThreadAttached(vm, &vmThread)) == JNI_OK) {
+	result = (UDATA) verifyCurrentThreadAttached(vm, &vmThread);
+	if (JNI_OK == result) {
+		/* If exit has started, do not perform the detach operation to avoid
+		 * the unexpected hang caused by the checking of exclusive VM access in deallocateVMThread()
+		 *
+		 * Allow system threads (those forked internally by the VM) to detach if exit has
+		 * started (VM shutdown itself will detach system threads).
+		 */
+		if (J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED)) {
+			if (J9_ARE_NO_BITS_SET(vmThread->privateFlags, J9_PRIVATE_FLAGS_SYSTEM_THREAD)) {
+				goto done;	
+			}
+		}
 
 		Trc_JNIinv_DetachCurrentThread(vmThread);
 
@@ -581,6 +586,7 @@ jint JNICALL DetachCurrentThread(JavaVM * javaVM)
 		}
 	}
 
+done:
 	return (jint) result;
 }
 


### PR DESCRIPTION
Move the multiple exit prevention code in DestroyJavaVM to earlier in the function.

Also allow system threads to detach during shutdown (required now that shutdown is marked earlier). Attach finalizer slave threads as system threads so they can detach properly during shutdown.

Fixes: #9558

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>