### PR TITLE
AIX JDK11 System.mapLibraryName() returns libraries with .a suffix

### DIFF
--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -241,7 +241,7 @@ void mapLibraryToPlatformName(const char *inPath, char *outPath) {
 #else
 	strcpy(outPath, "lib");
 	strcat(outPath,inPath);
-#if defined(AIXPPC) && (JAVA_SPEC_VERSION == 8)
+#if defined(AIXPPC) && (JAVA_SPEC_VERSION <= 14)
 	strcat(outPath, ".a");
 #else /* defined(AIXPPC) && (JAVA_SPEC_VERSION == 8) */
 	strcat(outPath, J9PORT_LIBRARY_SUFFIX);


### PR DESCRIPTION
**AIX JDK11 System.mapLibraryName() returns libraries with .a suffix**

`AIX` `JDK11` returns same native library suffix `.a` as `JDK8` while `JDK14+` match `hotspot` output `.so`.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>