### PR TITLE
Change where J9Method_HT, and DLT_Record Tables are cleaned

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -297,7 +297,7 @@ class J9Method_HT
       J9Method_HT(TR::PersistentInfo *persistentInfo);
       size_t getNumEntries() const { return _numEntries; }
       // method used by various hooks that perform class unloading
-      void onClassUnloading(J9ClassLoader *unloadedClass);
+      void onClassUnloading();
 
    protected:
       TR::PersistentInfo *getPersistentInfo() const { return _persistentInfo; }
@@ -710,7 +710,7 @@ public:
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
    void *searchForDLTRecord(J9Method *method, int32_t bcIndex);
    void  insertDLTRecord(J9Method *method, int32_t bcIndex, void *dltEntry);
-   void  cleanDLTRecordOnUnload(J9ClassLoader *classloader);
+   void  cleanDLTRecordOnUnload();
    DLTTracking *getDLT_HT() const { return _dltHT; }
    void setDLT_HT(DLTTracking *dltHT) { _dltHT = dltHT; }
 #else

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -41,6 +41,7 @@
 #include <time.h>
 #include "j9.h"
 #include "j9cfg.h"
+#include "j9modron.h"
 #include "j9protos.h"
 #include "vmaccess.h"
 #include "objhelp.h"
@@ -2993,15 +2994,20 @@ void TR::CompilationInfo::insertDLTRecord(J9Method *method, int32_t bcIndex, voi
    }
    }
 
-void TR::CompilationInfo::cleanDLTRecordOnUnload(J9ClassLoader *classloader)
+void TR::CompilationInfo::cleanDLTRecordOnUnload()
    {
    for (int32_t i=0; i<DLT_HASHSIZE; i++)
       {
       struct DLT_record *prev=NULL, *curr=_dltHash[i], *next;
       while (curr != NULL)
          {
+         J9Class *clazz = J9_CLASS_FROM_METHOD(curr->_method);
          next = curr->_next;
-         if (J9_CLASS_FROM_METHOD(curr->_method)->classLoader == classloader)
+
+         // Non-Anon classes will be unloaded with their classloaders, hence the class's classloader will be marked as dead.
+         // Anon Classes can be independently unloaded without their classloaders, however their classes are marked as dying.
+         if ( J9_ARE_ALL_BITS_SET(clazz->classLoader->gcFlags, J9_GC_CLASS_LOADER_DEAD)
+            || (J9CLASS_FLAGS(clazz) & J9AccClassDying) )
             {
             if (prev == NULL)
                _dltHash[i] = next;
@@ -12649,10 +12655,9 @@ J9Method_HT::HT_Entry * J9Method_HT::find(J9Method *j9method) const
    return entry;
    }
 
-
 // onClassUnloading is executed when all threads are stopped
 // so there are no synchronization issues
-void J9Method_HT::onClassUnloading(J9ClassLoader *j9classLoader)
+void J9Method_HT::onClassUnloading()
    {
    // Scan the entire DLT_HT and delete entries matching the given classloader
    // Also free invalid entries that have j9method==NULL
@@ -12662,8 +12667,12 @@ void J9Method_HT::onClassUnloading(J9ClassLoader *j9classLoader)
       HT_Entry *prev = NULL;
       while (entry)
          {
-         if (NULL == entry->_j9method
-            || J9_CLASS_FROM_METHOD(entry->_j9method)->classLoader == j9classLoader)
+         J9Class *clazz = J9_CLASS_FROM_METHOD(entry->_j9method);
+
+         // Non-Anon classes will be unloaded with their classloaders, hence the class's classloader will be marked as dead.
+         // Anon Classes can be independently unloaded without their classloaders, however their classes are marked as dying.
+         if ( J9_ARE_ALL_BITS_SET(clazz->classLoader->gcFlags, J9_GC_CLASS_LOADER_DEAD)
+            || (J9CLASS_FLAGS(clazz) & J9AccClassDying) )
             {
             HT_Entry *removed = NULL;
             if (prev)
@@ -12709,10 +12718,6 @@ bool J9Method_HT::addNewEntry(J9Method *j9method, uint64_t timestamp)
          (unsigned)getPersistentInfo()->getElapsedTime(), j9method, alreadyCompiled, added, _numEntries);
    return added;
    }
-
-
-
-
 
 bool DLTTracking::shouldIssueDLTCompilation(J9Method *j9method, int32_t numHitsInDLTBuffer)
    {

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1985,9 +1985,9 @@ static void jitHookAnonClassesUnload(J9HookInterface * * hookInterface, UDATA ev
    J9JITConfig *jitConfig = vmThread->javaVM->jitConfig;
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
-   compInfo->cleanDLTRecordOnUnload(&dummyClassLoader);
+   compInfo->cleanDLTRecordOnUnload();
    if (compInfo->getDLT_HT())
-      compInfo->getDLT_HT()->onClassUnloading(&dummyClassLoader);
+      compInfo->getDLT_HT()->onClassUnloading();
 #endif
 
    compInfo->getLowPriorityCompQueue().purgeEntriesOnClassLoaderUnloading(&dummyClassLoader);
@@ -2152,11 +2152,6 @@ static void jitHookClassLoaderUnload(J9HookInterface * * hookInterface, UDATA ev
    // CodeGen-specific actions on class unloading
    cgOnClassUnloading(classLoader);
 
-#if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
-   compInfo->cleanDLTRecordOnUnload(classLoader);
-   if (compInfo->getDLT_HT())
-      compInfo->getDLT_HT()->onClassUnloading(classLoader);
-#endif
    compInfo->getLowPriorityCompQueue().purgeEntriesOnClassLoaderUnloading(classLoader);
 
 #if defined(J9VM_INTERP_PROFILING_BYTECODES)
@@ -2179,6 +2174,19 @@ static void jitHookClassLoaderUnload(J9HookInterface * * hookInterface, UDATA ev
    }
 
 #endif /* defined (J9VM_GC_DYNAMIC_CLASS_UNLOADING)*/
+
+#if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) && defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
+static void jitHookClassLoadersUnload(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData)
+   {
+   J9VMClassUnloadEvent * unloadedEvent = (J9VMClassUnloadEvent *)eventData;
+   J9VMThread * vmThread = unloadedEvent->currentThread;
+   J9JITConfig * jitConfig = vmThread->javaVM->jitConfig;
+   TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
+   compInfo->cleanDLTRecordOnUnload();
+   if (compInfo->getDLT_HT())
+      compInfo->getDLT_HT()->onClassUnloading();
+   }
+#endif /* defined (J9VM_GC_DYNAMIC_CLASS_UNLOADING) and defined (J9VM_JIT_DYNAMIC_LOOP_TRANSFER) */
 
 void jitDiscardPendingCompilationsOfNatives(J9VMThread *vmThread, J9Class *clazz)
    {
@@ -6539,6 +6547,9 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
            (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, jitHookClassesUnload, OMR_GET_CALLSITE(), NULL) ||
            (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASS_LOADER_UNLOAD, jitHookClassLoaderUnload, OMR_GET_CALLSITE(), NULL) ||
            (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_ANON_CLASSES_UNLOAD, jitHookAnonClassesUnload, OMR_GET_CALLSITE(), NULL) ||
+#if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
+           (*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASS_LOADERS_UNLOAD, jitHookClassLoadersUnload, OMR_GET_CALLSITE(), NULL) ||
+#endif
            (*gcHooks)->J9HookRegisterWithCallSite(gcHooks, J9HOOK_MM_INTERRUPT_COMPILATION, jitHookInterruptCompilation, OMR_GET_CALLSITE(), NULL) ||
            (*gcHooks)->J9HookRegisterWithCallSite(gcHooks, J9HOOK_MM_CLASS_UNLOADING_END, jitHookClassesUnloadEnd, OMR_GET_CALLSITE(), NULL))
          {


### PR DESCRIPTION
For Non-Anon Clases, rather than cleaning up the J9Method_HT, and DLT_Record Tables during the `jitHookClassLoaderUnload` it should be cleaned up during the `jitHookClassLoadersUnload` hook.

Also, since dying classes and class-loaders are marked by the GC during class unloading we can also remove the `j9classloader` argument. 

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>