### PR TITLE
Weak root Read Barrier for VLHGC

### DIFF
--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -28,8 +28,7 @@
 #include "ModronAssertions.h"
 
 #include "EnvironmentBase.hpp"
-#include "GCExtensionsBase.hpp"
-#include "ScavengerForwardedHeader.hpp"
+#include "GCExtensions.hpp"
 #include "StringTable.hpp"
 #include "VMHelpers.hpp"
 

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
@@ -78,6 +78,9 @@ public:
 	virtual bool preBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
 	virtual void recentlyAllocatedObject(J9VMThread *vmThread, J9Object *object); 
 	virtual void postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass);
+	
+	virtual bool preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
+	virtual bool preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress);
 
 	virtual I_32 backwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
 	virtual I_32 forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);


### PR DESCRIPTION
While strictly speaking VLHGC does not require require Read Barrier
(Copy-Forward is fully STW operation), stringComparatorFn can be used
both by Mutators and GC threads (in a middle of STW operation).

During comparison,
- when fetching a string from StringTable that has already been
forwarded, a forwarded variant needs to be fetched. If
- when fetching a string that has NOT been forwarded (since ST in not a
hard root), we do not copy-forward but use original variant

So, this definitely acts as a RB, and even if invoked from GC threads
during STW operation. Since the comparator method can be invoked from
Mutator as well, common denominator is to use RB API.

This was already addressed by
#9330,
but it missed to preserve the functionality for VLHGC.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>