### PR TITLE
Add ability to filter AOT Compilations

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7020,7 +7020,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
                   // If we can not inflate the method data, JIT compile the method.
                   canRelocateMethod = false;
                   *aotCachedMethod = NULL;
-                  entry->_doNotUseAotCodeFromSharedCache = false;
+                  entry->_doNotUseAotCodeFromSharedCache = true;
                   }
                else
                   {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -585,7 +585,7 @@ Options::loadLimitOption(char * option, void * base, TR::OptionTable *entry)
       J9JITConfig * jitConfig = (J9JITConfig*)base;
       PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
       // otherwise, we're processing JIT options
-      j9tty_printf(PORTLIB, "<JIT: loadLimit option should be specified on -Xaot --> '%s'>\n", option);
+      j9tty_printf(PORTLIB, "<JIT: loadLimit/reloCompileLimit option should be specified on -Xaot --> '%s'>\n", option);
       return option;
       //return J9::Options::getDebug()->limitOption(option, base, entry, getJITCmdLineOptions(), true);
       }
@@ -616,7 +616,7 @@ Options::loadLimitfileOption(char * option, void * base, TR::OptionTable *entry)
       J9JITConfig * jitConfig = (J9JITConfig*)base;
       PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
       // otherwise, we're processing JIT options
-      j9tty_printf(PORTLIB, "<JIT: loadLimitfile option should be specified on -Xaot --> '%s'>\n", option);
+      j9tty_printf(PORTLIB, "<JIT: loadLimitfile/reloCompileLimitfile option should be specified on -Xaot --> '%s'>\n", option);
       return option;
       }
    }
@@ -915,6 +915,9 @@ TR::OptionTable OMR::Options::_feOptions[] = {
    {"regmap",             0, SET_JITCONFIG_RUNTIME_FLAG(J9JIT_CG_REGISTER_MAPS) },
    {"relaxedCompilationLimitsSampleThreshold=", "R<nnn>\tGlobal samples below this threshold means we can use higher compilation limits",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_relaxedCompilationLimitsSampleThreshold, 0, " %d", NOT_IN_SUBSET },
+   {"reloCompileExclude=",           "D\talias of loadExclude", TR::Options::loadLimitOption, 1, 0, "P%s"},
+   {"reloCompileLimit=",             "D\talias of loadLimit", TR::Options::loadLimitOption, 0, 0, "P%s"},
+   {"reloCompileLimitFile=",         "D\talias of loadLimitFile", TR::Options::loadLimitfileOption, 0, 0, "P%s"},
    {"resetCountThreshold=", "R<nnn>\tThe number of global samples which if exceed during a method's sampling interval will cause the method's sampling counter to be incremented by the number of samples in a sampling interval",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_resetCountThreshold, 0, " %d", NOT_IN_SUBSET},
    {"rtlog=",             "L<filename>\twrite verbose run-time output to filename",


### PR DESCRIPTION
Motivated by https://github.com/eclipse/openj9/issues/9600#issuecomment-631497856

This PR has two main components:
1. If a method is filtered via loadExclude, loadLimit, or loadLimitFile, the AOT compilation will also be filtered; instead a JIT compilation will be performed.
2. reloCompileExclude, reloCompileLimit, and reloCompileLimitFile are added as aliases of the three filters in the previous point to lower the cognitive overhead of reconciling the fact that "load*" also applies to relocatable compilations.

Now, there's a different way we can approach this. Currently, if you specify a `limit`, `exclude`, or `limitFile` filter on the `-Xaot` cmd line, it also limits JIT compilation (and vice versa). 

Conceptually, it would make most sense if we had something like:

1. `-Xjit:exclude=`, `-Xjit:limit=`, `-Xjit:limitFile=` to filter JIT compilations
2. `-Xaot:exclude=`, `-Xaot:limit=`, `-Xaot:limitFile=` to filter AOT compilations
3. `-Xaot:loadExclude=`, `-Xaot:loadLimit=`, `-Xaot:loadLimitFile=` to filter AOT loads.

I initially went about it this way. However, there were a couple of concerns I had. 

1. Will this cause any sort of backward compatibility problems for users who are currently using these options for workarounds
2. Unlike the current behaviour where the filter affects both Xjit and Xaot, should a filter on the -Xjit option apply for AOT compilations but not vice versa - the reasoning here is that a relocatable compilation is, after all, a JIT compilation with relocation records, whereas a JIT compilation is **not** an AOT compilation.

To keep things simple, I opened the PR as is, but I'm open to discussion regarding a better way of doing things.
