### PR TITLE
CMake: Disable enhanced warnings part 1

### DIFF
--- a/runtime/bcutil/CMakeLists.txt
+++ b/runtime/bcutil/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 omr_add_tracegen(j9bcu.tdf)
 
 # We define an interface library containing all the sources here

--- a/runtime/bcutil/test/recompiled/CMakeLists.txt
+++ b/runtime/bcutil/test/recompiled/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
 set_source_files_properties(${j9vm_BINARY_DIR}/bcutil/ut_j9bcu.c PROPERTIES GENERATED TRUE)
 j9vm_add_library(j9dyn_generic_test STATIC

--- a/runtime/bcverify/CMakeLists.txt
+++ b/runtime/bcverify/CMakeLists.txt
@@ -22,6 +22,7 @@
 
 #TODO specify -O3 for zos
 
+set(OMR_ENHANCED_WARNINGS OFF)
 add_tracegen(j9bcverify.tdf)
 
 j9vm_add_library(j9bcv STATIC

--- a/runtime/cassume/CMakeLists.txt
+++ b/runtime/cassume/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_executable(ctest
 	basesize.c
 	ctest.c

--- a/runtime/cfdumper/CMakeLists.txt
+++ b/runtime/cfdumper/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
 j9vm_add_executable(cfdump
 	main.c

--- a/runtime/codert_vm/CMakeLists.txt
+++ b/runtime/codert_vm/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(j9codertvm.tdf)
 j9vm_add_library(j9codert_vm STATIC
 	cache.c

--- a/runtime/dbgext/CMakeLists.txt
+++ b/runtime/dbgext/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(j9dbgext STATIC
 	dbgpool.c
 	j9dbgext.c

--- a/runtime/ddr/CMakeLists.txt
+++ b/runtime/ddr/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(j9ddr_misc SHARED
 	algorithm_versions.c
 	gcddr.cpp

--- a/runtime/exelib/CMakeLists.txt
+++ b/runtime/exelib/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(j9exelib STATIC
 	common/libargs.c
 	common/libhlp.c

--- a/runtime/jit_vm/CMakeLists.txt
+++ b/runtime/jit_vm/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(j9jit_vm STATIC
 	artifact.c
 	cthelpers.cpp

--- a/runtime/jnichk/CMakeLists.txt
+++ b/runtime/jnichk/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(j9jni.tdf)
 
 j9vm_add_library(j9jnichk SHARED

--- a/runtime/jniinv/CMakeLists.txt
+++ b/runtime/jniinv/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_executable(invtest
 	main.c
 )

--- a/runtime/libffi/CMakeLists.txt
+++ b/runtime/libffi/CMakeLists.txt
@@ -20,6 +20,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+set(OMR_WARNINGS_AS_ERRORS OFF)
+
 j9vm_add_library(ffi STATIC
 	closures.c
 	debug.c

--- a/runtime/port/CMakeLists.txt
+++ b/runtime/port/CMakeLists.txt
@@ -29,6 +29,8 @@
 # The final step is where the differences are. While vpaths under make handle everything automatically,
 # we have to actually resolve the full paths to the source files (via omr_find_files and output in resolvedPaths)
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(common/j9prt.tdf)
 j9vm_add_library(j9prt SHARED
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9prt.c
@@ -193,6 +195,15 @@ target_include_directories(j9prt
 		${CMAKE_CURRENT_BINARY_DIR}
 		${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+if(OMR_OS_LINUX)
+	if((OMR_ARCH_RISCV) OR (OMR_ARCH_X86 AND OMR_ENV_DATA64))
+		set_source_files_properties(unix/j9process.c
+			COMPILE_FLAGS
+			-Wno-unused-result
+		)
+	endif()
+endif()
 
 omr_add_exports(j9prt
 	j9port_allocate_library

--- a/runtime/runtimetools/agentbase/CMakeLists.txt
+++ b/runtime/runtimetools/agentbase/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(tools_agentbase STATIC
 	RuntimeToolsAgentBase.cpp
 	RuntimeToolsIntervalAgent.cpp

--- a/runtime/runtimetools/balloon/CMakeLists.txt
+++ b/runtime/runtimetools/balloon/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(balloon SHARED
 	BalloonAgent.cpp
 )

--- a/runtime/runtimetools/javacoregen/CMakeLists.txt
+++ b/runtime/runtimetools/javacoregen/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(jcoregen SHARED
 	JavacoreGenAgent.cpp
 )

--- a/runtime/runtimetools/jlm/CMakeLists.txt
+++ b/runtime/runtimetools/jlm/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(jlmagent SHARED
 	JLMAgent.cpp
 )

--- a/runtime/runtimetools/memorywatcher/CMakeLists.txt
+++ b/runtime/runtimetools/memorywatcher/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(memorywatcher SHARED
 	MemoryWatcherAgent.cpp
 )

--- a/runtime/runtimetools/osmemory/CMakeLists.txt
+++ b/runtime/runtimetools/osmemory/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(osmemory SHARED
 	OSMemoryAgent.cpp
 )

--- a/runtime/runtimetools/vmruntimestateagent/CMakeLists.txt
+++ b/runtime/runtimetools/vmruntimestateagent/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(vmruntimestateagent SHARED
 	VMRuntimeStateAgent.cpp
 )

--- a/runtime/stackmap/CMakeLists.txt
+++ b/runtime/stackmap/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(map.tdf)
 
 j9vm_add_library(j9stackmap STATIC

--- a/runtime/sunvmi/CMakeLists.txt
+++ b/runtime/sunvmi/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(sunvmi.tdf)
 
 j9vm_add_library(sunvmi STATIC

--- a/runtime/tests/algorithm/CMakeLists.txt
+++ b/runtime/tests/algorithm/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_executable(algotest
 	algotest.c
 	argscantest.c

--- a/runtime/tests/port/CMakeLists.txt
+++ b/runtime/tests/port/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_executable(pltest
 	j9cudaTest.c
 	j9dumpTest.c

--- a/runtime/tests/vm/CMakeLists.txt
+++ b/runtime/tests/vm/CMakeLists.txt
@@ -19,6 +19,9 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
+
+set(OMR_ENHANCED_WARNINGS OFF)
+
 set_source_files_properties(${j9vm_BINARY_DIR}/vm/ut_j9vm.c PROPERTIES GENERATED TRUE)
 j9vm_add_executable(vmtest
 	resolvefield_tests.c

--- a/runtime/tests/vm_lifecycle/CMakeLists.txt
+++ b/runtime/tests/vm_lifecycle/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_executable(vmLifecycleTests
 	main.c
 )

--- a/runtime/util/CMakeLists.txt
+++ b/runtime/util/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 add_tracegen(hshelp.tdf j9hshelp)
 add_tracegen(util.tdf j9util)
 add_tracegen(vmutil.tdf j9vmutil)

--- a/runtime/verbose/CMakeLists.txt
+++ b/runtime/verbose/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 add_tracegen(j9vrb.tdf)
 
 j9vm_add_library(j9vrb SHARED

--- a/runtime/verutil/CMakeLists.txt
+++ b/runtime/verutil/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(j9verutil STATIC
 	cfrerr.c
 	chverify.c

--- a/runtime/vmchk/CMakeLists.txt
+++ b/runtime/vmchk/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 add_tracegen(j9vmchk.tdf)
 
 j9vm_add_library(j9vmchk SHARED

--- a/runtime/zip/CMakeLists.txt
+++ b/runtime/zip/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(j9zip STATIC
 	zcpool.c
 	zipalloc.c


### PR DESCRIPTION
Disable enhanced warnings / warnings as errors on a number of targets.
The uma equivilent is the absence of
`<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>`
or
`<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>` respectively

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>