### PR TITLE
CMake: Disable enhanced warnings part 2

### DIFF
--- a/runtime/j9vm/CMakeLists.txt
+++ b/runtime/j9vm/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 add_tracegen(j9scar.tdf)
 
 # Note we add all the actual sources to this interface library.

--- a/runtime/jextractnatives/CMakeLists.txt
+++ b/runtime/jextractnatives/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(j9jextract SHARED
 	jextractglue.c
 	jextractnatives.c

--- a/runtime/redirector/CMakeLists.txt
+++ b/runtime/redirector/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/generated.c" PROPERTIES GENERATED TRUE)
 
 ################################################################################

--- a/runtime/runtimetools/migration/CMakeLists.txt
+++ b/runtime/runtimetools/migration/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(migration SHARED
 	MigrationAgent.cpp
 )

--- a/runtime/runtimetools/softmxtest/CMakeLists.txt
+++ b/runtime/runtimetools/softmxtest/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(softmxtest SHARED
 	SoftMxTest.cpp
 )

--- a/runtime/tests/bcverify/CMakeLists.txt
+++ b/runtime/tests/bcverify/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 set_source_files_properties(${j9vm_BINARY_DIR}/bcverify/ut_j9bcverify.c PROPERTIES GENERATED TRUE)
 j9vm_add_library(bcuwhite SHARED
 	natives/bcvnatives.c

--- a/runtime/tests/gp/CMakeLists.txt
+++ b/runtime/tests/gp/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 add_tracegen(gptest.tdf)
 
 j9vm_add_library(gptest SHARED

--- a/runtime/tests/jni/CMakeLists.txt
+++ b/runtime/tests/jni/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(j9ben SHARED
 	critical.c
 	DeadlockNativeTest.c

--- a/runtime/tests/jniarg/CMakeLists.txt
+++ b/runtime/tests/jniarg/CMakeLists.txt
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
 j9vm_add_library(jniargtests SHARED
 	args_01.c
 	args_02.c

--- a/runtime/tests/jvmtitests/agent/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/agent/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(jvmti_test_agent STATIC
 	agent.c
 	args.c

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/addToBootstrapClassLoaderSearch/abcl001.c
 	com/ibm/jvmti/tests/addToBootstrapClassLoaderSearch/abcl002.c

--- a/runtime/tests/redirector/jep178/CMakeLists.txt
+++ b/runtime/tests/redirector/jep178/CMakeLists.txt
@@ -25,6 +25,8 @@ add_subdirectory(testjvmtiB)
 add_subdirectory(testlibA)
 add_subdirectory(testlibB)
 
+set(OMR_ENHANCED_WARNINGS OFF)
+set(OMR_WARNINGS_AS_ERRORS OFF)
 
 #TODO: this is how its done in the module.xml, but its probably a toolchain thing
 if(OMR_OS_LINUX)

--- a/runtime/tests/thread/CMakeLists.txt
+++ b/runtime/tests/thread/CMakeLists.txt
@@ -20,6 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+set(OMR_ENHANCED_WARNINGS OFF)
+
 j9vm_add_library(thread_cutest_harness STATIC
 	cuharness/CuTest.c
 	cuharness/parser.c


### PR DESCRIPTION
Disable enhanced warnings / warnings as errors on a number of targets.
The uma equivilent is the absence of
`<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>`
or
`<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>` respectively

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>