### PR TITLE
Remove some statics from z/codegen

### DIFF
--- a/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/DFPTreeEvaluator.cpp
@@ -49,7 +49,7 @@
 **/
 
 // used when querying VM for BigDecimal dfp field
-static int16_t dfpFieldOffset = -1; // initialize to an illegal val
+int16_t dfpFieldOffset = -1; // initialize to an illegal val
 
 // Rounding modes
 const uint8_t rmIEEEdefault = 0x0; // round to nearest ties to even

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -8505,34 +8505,16 @@ J9::Z::TreeEvaluator::VMnewEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    //   on if turned on as a runtime option)
    // 2.The JVM has to support the call - on z/OS, Modron GC is not enabled yet and so batch tlh clearing
    //   can not be enabled yet.
-   static bool needZeroReg = !fej9->tlhHasBeenCleared();
+   bool needZeroReg = !fej9->tlhHasBeenCleared();
 
    opCode = node->getOpCodeValue();
 
    // Since calls to canInlineAllocate could result in different results during the same compilation,
    // We must be conservative and only do inline allocation if the first call (in LocalOpts.cpp) has succeeded and we have the litPoolBaseChild added.
    // Refer to defects 161084 and 87089
-   bool doInline = cg->doInlineAllocate(node);
-
-   static int count = 0;
-   doInline = doInline &&
-   performTransformation(comp, "O^O <%3d> Inlining Allocation of %s [0x%p].\n", count++, node->getOpCode().getName(), node);
-
-   if (doInline)
+   if (cg->doInlineAllocate(node)
+            && performTransformation(comp, "O^O Inlining Allocation of %s [0x%p].\n", node->getOpCode().getName(), node))
       {
-
-      static char *maxNumOfOOLOptStr = feGetEnv("TR_MaxNumOfOOLOpt");
-      if (maxNumOfOOLOptStr)
-         {
-         int maxNumOfOOLOpt = atoi(maxNumOfOOLOptStr);
-         traceMsg(cg->comp(),"TR_MaxNumOfOOLOpt: count=%d, maxNumOfOOLOpt=%d %d\n", count, maxNumOfOOLOpt, __LINE__);
-         if(maxNumOfOOLOpt < count)
-            {
-            traceMsg(cg->comp(),"TR_MaxNumOfOOLOpt: maxNumOfOOLOpt < count, Setting TR_DisableHeapAllocOOL %d\n", __LINE__);
-            comp->setOption(TR_DisableHeapAllocOOL);
-            }
-         }
-
       objectSize = comp->canAllocateInline(node, classAddress);
       isVariableLen = (objectSize == 0);
       allocateSize = objectSize;

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -112,7 +112,7 @@ J9::Z::PrivateLinkage::PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390Linkage
       comp()->setOption(TR_DisableSIMD);
       }
 
-   static const bool enableVectorLinkage = codeGen->getSupportsVectorRegisters();
+   const bool enableVectorLinkage = codeGen->getSupportsVectorRegisters();
    if (enableVectorLinkage) setVectorReturnRegister(TR::RealRegister::VRF24);
 
    setStackPointerRegister  (TR::RealRegister::GPR5 );
@@ -248,14 +248,6 @@ void J9::Z::PrivateLinkage::alignLocalsOffset(uint32_t &stackIndex, uint32_t loc
 // J9::Z::PrivateLinkage::mapCompactedStack - maps variables onto the stack, sharing
 //     stack slots for automatic variables with non-interfering live ranges.
 ////////////////////////////////////////////////////////////////////////////////
-#ifdef DEBUG
-// track the total size of the stacks of all methods compiled had we not compacted them
-static uint32_t accumOrigSize = 0;
-
-// track the total size of the stacks of all methods compiled with stack compaction
-static uint32_t accumMappedSize = 0;
-#endif
-
 void
 J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    {
@@ -635,13 +627,6 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
                   (mappedSize),
                   origSize,
                   origSize - mappedSize,
-                  comp()->signature());
-
-      accumMappedSize += mappedSize;
-      accumOrigSize += origSize;
-
-      diagnostic("\n**** Accumulated totals: mapped size=%d, shared size=%d, original size=%d after %s\n",
-                  accumMappedSize, accumOrigSize-accumMappedSize, accumOrigSize,
                   comp()->signature());
       }
 #endif


### PR DESCRIPTION
JITServer cannot operate correctly if certain fields
are static. This is because the JITServer can talk to
multiple JVM clients such that the static field's value on
the JITServer side is no longer valid for all client JVMs.
This commit removes those problematic statics.

Some unused/dead code is also removed.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>