### PR TITLE
Fix ilgen not clearing node flag when auto slot 0 is overwritten

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -71,9 +71,22 @@ TR_J9ByteCodeIterator::isThisChanged()
       {
       switch (bc)
          {
+         case J9BCistore0:
+         case J9BClstore0:
+         case J9BCfstore0:
+         case J9BCdstore0:
          case J9BCastore0:
             return true;
+         case J9BCistore:
+         case J9BClstore:
+         case J9BCfstore:
+         case J9BCdstore:
          case J9BCastore:
+         case J9BCistorew:
+         case J9BClstorew:
+         case J9BCfstorew:
+         case J9BCdstorew:
+         case J9BCastorew:
             if (nextByte() == 0)
                return true;
          default:


### PR DESCRIPTION
TR_J9ByteCodeIterator::isThisChanged is supposed to check for a store to auto
slot 0. This allows TR_J9ByteCodeIlGenerator::loadAuto to clear the
nodeIsNonNull flag if the value in auto slot 0 has changed.

However, isThisChanged only handles astore bytecodes and not other types of
stores such as istore and lstore. This is causing issue #9381 where there is an
istore to auto slot 0 but the nodeIsNonNull flag is not cleared.

- Add cases in TR_J9ByteCodeIterator::isThisChanged to handle other types of
  stores such as istore and lstore.

Fixes: #9381

Signed-off-by: Ryan Shukla <ryans@ibm.com>