### PR TITLE
Move lookupswitch match order verification to second pass

### DIFF
--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -2017,6 +2017,8 @@ _illegalPrimitiveReturn:
 						bcIndex += 4;
 						if (!firstKey) {
 							if (nextKey <= currentKey) {
+								verboseErrorCode = BCV_ERR_BYTECODE_ERROR;
+								storeVerifyErrorData(verifyData, (I_16)verboseErrorCode, (U_32)errorStackIndex, (UDATA)-1, (UDATA)-1, start);
 								errorType = J9NLS_CFR_ERR_BC_SWITCH_NOT_SORTED__ID;
 								errorModule = J9NLS_CFR_ERR_BC_SWITCH_NOT_SORTED__MODULE;
 								goto _verifyError;

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 #include "bcvcfr.h"
 #include "j9bcvnls.h"
+#include "cfrerrnls.h"
 
 #include "cfreader.h"
 #include "bcnames.h"
@@ -2003,13 +2004,28 @@ _illegalPrimitiveReturn:
 						}
 					}
 				} else {
+					BOOLEAN firstKey = TRUE;
+					I_32 currentKey = 0;
+					I_32 nextKey = 0;
 					i2 = (I_32) PARAM_32(bcIndex, 1);
 					bcIndex += 4;
 
 					pc += (I_32)i2 * 8;
 					CHECK_END;
 					for (i1 = 0; (I_32)i1 < (I_32)i2; i1++) {
+						nextKey = (I_32) PARAM_32(bcIndex, 1);
 						bcIndex += 4;
+						if (!firstKey) {
+							if (nextKey <= currentKey) {
+								errorType = J9NLS_CFR_ERR_BC_SWITCH_NOT_SORTED__ID;
+								errorModule = J9NLS_CFR_ERR_BC_SWITCH_NOT_SORTED__MODULE;
+								goto _verifyError;
+							}
+						} else {
+							firstKey = FALSE;
+						}
+						currentKey = nextKey;
+
 						offset32 = (I_32) PARAM_32(bcIndex, 1);
 						bcIndex += 4;
 						target = offset32 + start;

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -745,17 +745,10 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			CHECK_END;
 			bcIndex -= (I_32) u1 * 8;
 
-			firstKey = TRUE;
 			for (i = 0; i < u1; i++) {
-				i1 = (IDATA) NEXT_U32(u2, bcIndex);
-				if (!firstKey) {
-					if ((I_32)i1 <= (I_32)i2) {
-						errorType = J9NLS_CFR_ERR_BC_SWITCH_NOT_SORTED__ID;
-						goto _verifyError;
-					}
-				}
-				firstKey = FALSE;
-				i2 = i1;
+				/* Skip over match/key part of match-offset pair. Match/key order is verified in the second verification pass */
+				NEXT_U32(u2, bcIndex);
+
 				target = start + (I_32) NEXT_U32(u2, bcIndex);
 				if ((UDATA) target >= length) {
 					errorType = J9NLS_CFR_ERR_BC_SWITCH_OFFSET__ID;

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -528,6 +528,7 @@ extern "C" {
 #define BCV_ERR_BAD_BYTECODE							-31
 #define BCV_ERR_UNEXPECTED_EOF							-32
 #define BCV_ERR_INACCESSIBLE_CLASS						-33
+#define BCV_ERR_BYTECODE_ERROR							-34
 
 #define J9_GC_OBJ_HEAP_HOLE 0x1
 #define J9_GC_MULTI_SLOT_HOLE 0x1

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -940,6 +940,8 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 	case BCV_ERR_UNEXPECTED_EOF:
 		printMessage(&msgBuf, "Unexpected EOF is detected in the class file.");
 		break;
+	case BCV_ERR_BYTECODE_ERROR:
+		printMessage(&msgBuf, "Error exists in the bytecode.");
 	default:
 		Assert_VRB_ShouldNeverHappen();
 		break;


### PR DESCRIPTION
Related: https://github.com/eclipse/openj9/issues/9323, https://github.com/eclipse/openj9/issues/9336, https://github.com/eclipse/openj9/issues/9357

Demonstrated in the related issues, it appears that the verification of `lookupswitch` bytecode order is being done too early. For example, in #9323, the test results in `java.lang.VerifyError: JVMCFRE072 entries not sorted in lookupswitch bytecode` instead of a `NoClassDefFoundError`, which the reference implementation throws. Moving the `lookupswitch` bytecode order check to the second verification pass should be more appropriate timing.

This PR moves the `lookupswitch` check to the second verification pass. I have tested these changes against the related issues listed above and the test output now matches the user's expected output/RI output.

---

Moving the `lookupswitch` check to the second pass verification appears to be working as expected (shown in the output below). However, there is less detail in the exception message. Do we want to maintain the same level of exception message detail?

Previous exception message:
```
Exception in thread "main" java.lang.VerifyError: JVMCFRE072 entries not sorted in lookupswitch bytecode; class=Example, method=sampleSwitch()V, pc=4
Exception Details:
  Location:
    Example.sampleSwitch()V @4: JBlookupswitch
  Reason:
    Error exists in the bytecode.
  Stackmap Table:
    append_frame(@32,integer)
	at java.base/java.lang.ClassLoader.defineClassImpl(Native Method)
	at java.base/java.lang.ClassLoader.defineClassInternal(ClassLoader.java:479)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:440)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:392)
	at CustomClassLoader.getClass(Main.java:32)
	at Main.main(Main.java:18)
```

Exception message after relocated `lookupswitch` order check:
```
Exception in thread "main" java.lang.VerifyError: JVMVRFY043 entries not sorted in lookupswitch bytecode; class=Example, method=sampleSwitch()V, pc=4
	at java.base/java.lang.J9VMInternals.prepareClassImpl(Native Method)
	at java.base/java.lang.J9VMInternals.prepare(J9VMInternals.java:342)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:803)
	at Main.main(Main.java:21)
```

@gacholio Please review. Should a new test be added to confirm these changes are working?