### PR TITLE
Remove explicit cast

### DIFF
--- a/runtime/gc_trace/TgcParallel.cpp
+++ b/runtime/gc_trace/TgcParallel.cpp
@@ -305,7 +305,7 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 	uint64_t prevReadObjectBarrierUpdate = 0;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	while (historyRecord < endRecord) {
-		totalRecordUpdates += (uintptr_t) historyRecord->updates;
+		totalRecordUpdates += historyRecord->updates;
 		uint64_t elapsedMicros = extensions->copyScanRatio.getSpannedMicros(env, historyRecord);
 		double majorUpdates = (double)historyRecord->majorUpdates;
 		double lists = (double)historyRecord->lists / majorUpdates;


### PR DESCRIPTION
https://github.com/eclipse/openj9/pull/8626/files
Remove explicit type cast of historyRecord->updates.

Depends on: https://github.com/eclipse/omr/pull/5216

Signed-off-by: Enson <enson.guo@ibm.com>