### PR TITLE
CMake: enable -fstack-protector on gnu toolchains

### DIFF
--- a/runtime/cmake/platform/toolcfg/gnu.cmake
+++ b/runtime/cmake/platform/toolcfg/gnu.cmake
@@ -20,10 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3 -g)
-
-# Add these
-list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS  -fno-threadsafe-statics)
+list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3 -g -fstack-protector)
+list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -fno-threadsafe-statics)
 
 # OMR_PLATFORM_CXX_COMPILE_OPTIONS gets applied to the jit (which needs exceptions),
 # so we put these in the CMAKE_CXX_FLAGS instead


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>