### PR TITLE
Create cross codegen extensible peephole phase

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -84,6 +84,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/OMRLinkage.cpp \
     omr/compiler/codegen/OMRMachine.cpp \
     omr/compiler/codegen/OMRMemoryReference.cpp \
+    omr/compiler/codegen/OMRPeephole.cpp \
     omr/compiler/codegen/OMRRealRegister.cpp \
     omr/compiler/codegen/OMRRegister.cpp \
     omr/compiler/codegen/OMRRegisterPair.cpp \

--- a/runtime/compiler/build/files/target/p.mk
+++ b/runtime/compiler/build/files/target/p.mk
@@ -30,6 +30,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/p/codegen/OMRLinkage.cpp \
     omr/compiler/p/codegen/OMRMachine.cpp \
     omr/compiler/p/codegen/OMRMemoryReference.cpp \
+    omr/compiler/p/codegen/OMRPeephole.cpp \
     omr/compiler/p/codegen/OMRRealRegister.cpp \
     omr/compiler/p/codegen/OMRRegisterDependency.cpp \
     omr/compiler/p/codegen/OMRSnippet.cpp \

--- a/runtime/compiler/build/files/target/p.mk
+++ b/runtime/compiler/build/files/target/p.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -68,6 +68,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/z/codegen/J9Instruction.cpp \
     compiler/z/codegen/J9Linkage.cpp \
     compiler/z/codegen/J9MemoryReference.cpp \
+    compiler/z/codegen/J9Peephole.cpp \
     compiler/z/codegen/J9S390Snippet.cpp \
     compiler/z/codegen/J9SystemLinkageLinux.cpp \
     compiler/z/codegen/J9SystemLinkagezOS.cpp \

--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -34,6 +34,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/OMRLinkage.cpp \
     omr/compiler/z/codegen/OMRMachine.cpp \
     omr/compiler/z/codegen/OMRMemoryReference.cpp \
+    omr/compiler/z/codegen/OMRPeephole.cpp \
     omr/compiler/z/codegen/OMRRealRegister.cpp \
     omr/compiler/z/codegen/OMRRegister.cpp \
     omr/compiler/z/codegen/OMRRegisterDependency.cpp \

--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -47,7 +47,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/S390HelperCallSnippet.cpp \
     omr/compiler/z/codegen/S390Instruction.cpp \
     omr/compiler/z/codegen/S390OutOfLineCodeSection.cpp \
-    omr/compiler/z/codegen/S390Peephole.cpp \
     omr/compiler/z/codegen/S390Snippets.cpp \
     omr/compiler/z/codegen/SystemLinkage.cpp \
     omr/compiler/z/codegen/SystemLinkageLinux.cpp \

--- a/runtime/compiler/z/codegen/CMakeLists.txt
+++ b/runtime/compiler/z/codegen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/codegen/CMakeLists.txt
+++ b/runtime/compiler/z/codegen/CMakeLists.txt
@@ -30,6 +30,7 @@ j9jit_files(
 	z/codegen/J9Instruction.cpp
 	z/codegen/J9Linkage.cpp
 	z/codegen/J9MemoryReference.cpp
+	z/codegen/J9Peephole.cpp
 	z/codegen/J9S390Snippet.cpp
 	z/codegen/J9SystemLinkageLinux.cpp
 	z/codegen/J9SystemLinkagezOS.cpp

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -30,6 +30,7 @@
     ReserveCodeCachePhase,
     FixUpProfiledInterfaceGuardTest,
 
+
     InliningReportPhase,
     LateSequentialConstantStoreSimplificationPhase,
 
@@ -55,7 +56,7 @@
     InstructionSelectionPhase,
     CreateStackAtlasPhase,
 
-    PreRAPeepholePhase,
+    PeepholePhase,
     RegisterAssigningPhase,
     MapStackPhase,
     PeepholePhase,

--- a/runtime/compiler/z/codegen/J9Peephole.cpp
+++ b/runtime/compiler/z/codegen/J9Peephole.cpp
@@ -40,11 +40,11 @@ J9::Z::Peephole::performOnInstruction(TR::Instruction* cursor)
    {
    bool performed = false;
 
-   if (cg()->afterRA())
+   if (self()->cg()->afterRA())
       {
       if (cursor->getNode() != NULL && cursor->getNode()->getOpCodeValue() == TR::BBStart)
          {
-         comp()->setCurrentBlock(cursor->getNode()->getBlock());
+         self()->comp()->setCurrentBlock(cursor->getNode()->getBlock());
 
          TR::Block* block = cursor->getNode()->getBlock();
          if (block->isCatchBlock() && (block->getFirstInstruction() == cursor))
@@ -64,17 +64,17 @@ J9::Z::Peephole::reloadLiteralPoolRegisterForCatchBlock(TR::Instruction* cursor)
    // This causes a failure when we come back to a catch block because the register context will not be preserved.
    // Hence, we can not assume that R6 will still contain the lit pool register and hence need to reload it.
 
-   bool isZ10 = comp()->target().cpu.getSupportsArch(TR::CPU::z10);
+   bool isZ10 = self()->comp()->target().cpu.getSupportsArch(TR::CPU::z10);
 
    // we only need to reload literal pool for Java on older z architecture on zos when on demand literal pool is off
-   if ( comp()->target().isZOS() && !isZ10 && !cg()->isLiteralPoolOnDemandOn())
+   if ( self()->comp()->target().isZOS() && !isZ10 && !self()->cg()->isLiteralPoolOnDemandOn())
       {
       // check to make sure that we actually need to use the literal pool register
-      TR::Snippet * firstSnippet = cg()->getFirstSnippet();
-      if ((cg()->getLinkage())->setupLiteralPoolRegister(firstSnippet) > 0)
+      TR::Snippet * firstSnippet = self()->cg()->getFirstSnippet();
+      if ((self()->cg()->getLinkage())->setupLiteralPoolRegister(firstSnippet) > 0)
          {
          // the imm. operand will be patched when the actual address of the literal pool is known at binary encoding phase
-         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(cg(), TR::InstOpCode::LARL, cursor->getNode(), cg()->getLitPoolRealRegister(), reinterpret_cast<void*>(0xBABE), cursor);
+         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(self()->cg(), TR::InstOpCode::LARL, cursor->getNode(), self()->cg()->getLitPoolRealRegister(), reinterpret_cast<void*>(0xBABE), cursor);
          inst->setIsLiteralPoolAddress();
          }
       }

--- a/runtime/compiler/z/codegen/J9Peephole.cpp
+++ b/runtime/compiler/z/codegen/J9Peephole.cpp
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#pragma csect(CODE,"TRJ9PeepholeBase#C")
+#pragma csect(STATIC,"TRJ9PeepholeBase#S")
+#pragma csect(TEST,"TRJ9PeepholeBase#T")
+
+#include "codegen/Peephole.hpp"
+
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/S390GenerateInstructions.hpp"
+#include "codegen/S390Instruction.hpp"
+
+J9::Z::Peephole::Peephole(TR::Compilation* comp) :
+   OMR::PeepholeConnector(comp)
+   {}
+
+bool
+J9::Z::Peephole::performOnInstruction(TR::Instruction* cursor)
+   {
+   bool performed = false;
+
+   if (cg()->afterRA())
+      {
+      if (cursor->getNode() != NULL && cursor->getNode()->getOpCodeValue() == TR::BBStart)
+         {
+         comp()->setCurrentBlock(cursor->getNode()->getBlock());
+
+         TR::Block* block = cursor->getNode()->getBlock();
+         if (block->isCatchBlock() && (block->getFirstInstruction() == cursor))
+            reloadLiteralPoolRegisterForCatchBlock(cursor);
+         }
+      }
+
+   performed |= OMR::PeepholeConnector::performOnInstruction(cursor);
+
+   return performed;
+   }
+
+void
+J9::Z::Peephole::reloadLiteralPoolRegisterForCatchBlock(TR::Instruction* cursor)
+   {
+   // When dynamic lit pool reg is disabled, we lock R6 as dedicated lit pool reg.
+   // This causes a failure when we come back to a catch block because the register context will not be preserved.
+   // Hence, we can not assume that R6 will still contain the lit pool register and hence need to reload it.
+
+   bool isZ10 = comp()->target().cpu.getSupportsArch(TR::CPU::z10);
+
+   // we only need to reload literal pool for Java on older z architecture on zos when on demand literal pool is off
+   if ( comp()->target().isZOS() && !isZ10 && !cg()->isLiteralPoolOnDemandOn())
+      {
+      // check to make sure that we actually need to use the literal pool register
+      TR::Snippet * firstSnippet = cg()->getFirstSnippet();
+      if ((cg()->getLinkage())->setupLiteralPoolRegister(firstSnippet) > 0)
+         {
+         // the imm. operand will be patched when the actual address of the literal pool is known at binary encoding phase
+         TR::S390RILInstruction * inst = (TR::S390RILInstruction *) generateRILInstruction(cg(), TR::InstOpCode::LARL, cursor->getNode(), cg()->getLitPoolRealRegister(), reinterpret_cast<void*>(0xBABE), cursor);
+         inst->setIsLiteralPoolAddress();
+         }
+      }
+   }

--- a/runtime/compiler/z/codegen/J9Peephole.hpp
+++ b/runtime/compiler/z/codegen/J9Peephole.hpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef J9_Z_PEEPHOLE_INCL
+#define J9_Z_PEEPHOLE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef J9_PEEPHOLE_CONNECTOR
+#define J9_PEEPHOLE_CONNECTOR
+   namespace J9 { namespace Z { class Peephole; } }
+   namespace J9 {typedef J9::Z::Peephole PeepholeConnector; }
+#else
+   #error J9::Z::Peephole expected to be a primary connector, but a J9 connector is already defined
+#endif
+
+#include "codegen/OMRPeephole.hpp"
+
+namespace J9
+{
+
+namespace Z
+{
+
+class OMR_EXTENSIBLE Peephole : public OMR::PeepholeConnector
+   {
+   public:
+
+   Peephole(TR::Compilation* comp);
+
+   virtual bool performOnInstruction(TR::Instruction* cursor);
+
+   private:
+      
+   /** \brief
+    *     Reloads the literal pool register in the catch block when literal pool on demand is turned off. This is
+    *     required because the signal handler will take control of the execution and we are not guaranteed that
+    *     the literal pool register will remaind valid once control is transferred back to the catch block.
+    *
+    *  \param cursor
+    *     The instruction cursor currently being processed.
+    */
+   void reloadLiteralPoolRegisterForCatchBlock(TR::Instruction* cursor);
+   };
+}
+
+}
+
+#endif

--- a/runtime/compiler/z/codegen/Peephole.hpp
+++ b/runtime/compiler/z/codegen/Peephole.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_PEEPHOLE_INCL
+#define TR_PEEPHOLE_INCL
+
+#include "codegen/J9Peephole.hpp"
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE Peephole : public J9::PeepholeConnector
+   {
+   public:
+
+   Peephole(TR::Compilation* comp) :
+      J9::PeepholeConnector(comp) {}
+   };
+
+}
+
+#endif


### PR DESCRIPTION
This is the OpenJ9 piece of eclipse/omr#5235. See the OMR PR for full details of what was performed. The changes here are code migration to OpenJ9 specific peepholes on Z.