### PR TITLE
AArch64: Enhance VMnewEvaluator to support newarray with constant length

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -745,7 +745,7 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
       }
    else if (!isRealTimeGC && size == 0)
       {
-#if (defined(TR_HOST_S390) && defined(TR_TARGET_S390)) || (defined(TR_TARGET_X86) && defined(TR_HOST_X86)) || (defined(TR_TARGET_POWER) && defined(TR_HOST_POWER))
+#if (defined(TR_HOST_S390) && defined(TR_TARGET_S390)) || (defined(TR_TARGET_X86) && defined(TR_HOST_X86)) || (defined(TR_TARGET_POWER) && defined(TR_HOST_POWER)) || (defined(TR_TARGET_ARM64) && defined(TR_HOST_ARM64))
       size = TR::Compiler->om.discontiguousArrayHeaderSizeInBytes();
       if (self()->getOption(TR_TraceCG))
          traceMsg(self(), "inline array allocation @ node %p for size 0\n", node);


### PR DESCRIPTION
Enhance `VMnewEvaluator` in aarch64 code generator to support `TR::newarray`
with constant length.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>