### PR TITLE
Revert "CMake: Enable base warnings for gnu toolchains"

### DIFF
--- a/runtime/cmake/platform/toolcfg/gnu.cmake
+++ b/runtime/cmake/platform/toolcfg/gnu.cmake
@@ -23,12 +23,6 @@
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3 -g -fstack-protector)
 list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -fno-threadsafe-statics)
 
-list(APPEND OMR_BASE_WARNING_FLAGS
-	# -Wimplicit is only valid for C. Newer compilers error if given for c++ compile
-	$<$<COMPILE_LANGUAGE:C>:-Wimplicit>
-	-Wreturn-type
-)
-
 # OMR_PLATFORM_CXX_COMPILE_OPTIONS gets applied to the jit (which needs exceptions),
 # so we put these in the CMAKE_CXX_FLAGS instead
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")


### PR DESCRIPTION
This reverts commit 02d62796ffcd2c5e6d53dedaa5e5fd0f928aa2c6.

See failed builds in #9688 and #9689.