### PR TITLE
Add S390JNICallDataSnippet class

### DIFF
--- a/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
@@ -48,6 +48,7 @@
 #include "z/codegen/S390Evaluator.hpp"
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390HelperCallSnippet.hpp"
+#include "z/codegen/S390J9CallSnippet.hpp"
 #include "z/codegen/S390StackCheckFailureSnippet.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +70,7 @@ J9::Z::zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode,
 	TR::LabelSymbol * returnFromJNICallLabel,
 	TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
-   TR::S390JNICallDataSnippet * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet *>(callDataSnippet);
+   TR::S390JNICallDataSnippet2 * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet2 *>(callDataSnippet);
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
    J9::Z::PrivateLinkage * privateLinkage = static_cast<J9::Z::PrivateLinkage *>(cg()->getLinkage(TR_Private));

--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -48,6 +48,7 @@
 #include "z/codegen/S390Evaluator.hpp"
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390HelperCallSnippet.hpp"
+#include "z/codegen/S390J9CallSnippet.hpp"
 #include "z/codegen/S390StackCheckFailureSnippet.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +68,7 @@ J9::Z::zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
-   TR::S390JNICallDataSnippet * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet *>(callDataSnippet);
+   TR::S390JNICallDataSnippet2 * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet2 *>(callDataSnippet);
    TR::CodeGenerator * codeGen = cg();
    TR::Compilation *comp = codeGen->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,6 +169,75 @@ class J9S390InterfaceCallDataSnippet : public TR::S390ConstantDataSnippet
    virtual uint32_t getLastSlotFieldOffset();
    virtual uint32_t getFirstSlotOffset();
    virtual uint32_t getLastSlotOffset();
+   };
+
+class S390JNICallDataSnippet2 : public TR::S390ConstantDataSnippet
+   {
+   /** Base register for this snippet */
+   TR::Register *  _baseRegister;
+
+   //for JNI Callout frame
+   uintptr_t _ramMethod;
+   uintptr_t _JNICallOutFrameFlags;
+   TR::LabelSymbol * _returnFromJNICallLabel;  //for savedCP slot
+   uintptr_t _savedPC; // This is unused, and hence zero
+   uintptr_t _tagBits;
+
+   // VMThread setup
+   uintptr_t _pc;
+   uintptr_t _literals;
+   uintptr_t _jitStackFrameFlags;
+
+   //for releaseVMaccess
+   uintptr_t _constReleaseVMAccessMask;
+   uintptr_t _constReleaseVMAccessOutOfLineMask;
+
+   /** For CallNativeFunction */
+   uintptr_t _targetAddress;
+
+
+   public:
+
+  S390JNICallDataSnippet2(TR::CodeGenerator *,
+                                  TR::Node *);
+
+   virtual Kind getKind() { return IsJNICallData; }
+   virtual uint8_t *emitSnippetBody();
+   virtual void print(TR::FILE *, TR_Debug*);
+   void setBaseRegister(TR::Register * aValue){ _baseRegister = aValue; }
+   TR::Register * getBaseRegister() { return _baseRegister; }
+
+   void setRAMMethod(uintptr_t aValue){ _ramMethod = aValue; }
+   void setJNICallOutFrameFlags(uintptr_t aValue){ _JNICallOutFrameFlags = aValue; }
+   void setReturnFromJNICall( TR::LabelSymbol * aValue){ _returnFromJNICallLabel = aValue; }
+   void setSavedPC(uintptr_t aValue){ _savedPC = aValue; }
+   void setTagBits(uintptr_t aValue){ _tagBits = aValue; }
+
+   void setPC(uintptr_t aValue){ _pc = aValue; }
+   void setLiterals(uintptr_t aValue){ _literals = aValue; }
+   void setJitStackFrameFlags(uintptr_t aValue){ _jitStackFrameFlags = aValue; }
+
+   void setConstReleaseVMAccessMask(uintptr_t aValue){ _constReleaseVMAccessMask = aValue; }
+   void setConstReleaseVMAccessOutOfLineMask(uintptr_t aValue){ _constReleaseVMAccessOutOfLineMask = aValue; }
+   void setTargetAddress(uintptr_t aValue){ _targetAddress = aValue; }
+
+   uint32_t getJNICallOutFrameDataOffset(){ return 0; }
+   uint32_t getRAMMethodOffset(){ return 0; }
+   uint32_t getJNICallOutFrameFlagsOffset();
+   uint32_t getReturnFromJNICallOffset();
+   uint32_t getSavedPCOffset();
+   uint32_t getTagBitsOffset();
+
+   uint32_t getPCOffset();
+   uint32_t getLiteralsOffset();
+   uint32_t getJitStackFrameFlagsOffset();
+
+   uint32_t getConstReleaseVMAccessMaskOffset();
+   uint32_t getConstReleaseVMAccessOutOfLineMaskOffset();
+
+   uint32_t getTargetAddressOffset();
+
+   uint32_t getLength(int32_t estimatedSnippetStart);
    };
 
 

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -2521,7 +2521,7 @@ J9::Z::PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
    TR::RealRegister * javaStackPointerRealRegister,
    TR::Register * methodMetaDataVirtualRegister,
    TR::LabelSymbol * returnFromJNICallLabel,
-   TR::S390JNICallDataSnippet *jniCallDataSnippet)
+   TR::S390JNICallDataSnippet2 *jniCallDataSnippet)
    {
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
@@ -2598,7 +2598,7 @@ J9::Z::PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
  */
 void J9::Z::JNILinkage::releaseVMAccessMask(TR::Node * callNode,
    TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg,
-   TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps)
+   TR::S390JNICallDataSnippet2 * jniCallDataSnippet, TR::RegisterDependencyConditions * deps)
    {
    TR::LabelSymbol * loopHead = generateLabelSymbol(self()->cg());
    TR::LabelSymbol * longReleaseLabel = generateLabelSymbol(self()->cg());
@@ -2946,7 +2946,7 @@ TR::Register * J9::Z::JNILinkage::buildDirectDispatch(TR::Node * callNode)
    deps = generateRegisterDependencyConditions(numDeps, numDeps, cg());
    int64_t killMask = -1;
    TR::Register *vftReg = NULL;
-   TR::S390JNICallDataSnippet * jniCallDataSnippet = NULL;
+   TR::S390JNICallDataSnippet2 * jniCallDataSnippet = NULL;
    TR::RealRegister * javaStackPointerRealRegister = getStackPointerRealRegister();
    TR::RealRegister * methodMetaDataRealRegister = getMethodMetaDataRealRegister();
    TR::RealRegister * javaLitPoolRealRegister = getLitPoolRealRegister();
@@ -3032,7 +3032,7 @@ TR::Register * J9::Z::JNILinkage::buildDirectDispatch(TR::Node * callNode)
      {
      TR::Register * JNISnippetBaseReg = NULL;
      killMask = killAndAssignRegister(killMask, deps, &JNISnippetBaseReg, TR::RealRegister::GPR12, codeGen, true);
-     jniCallDataSnippet = new (trHeapMemory()) TR::S390JNICallDataSnippet(cg(), callNode);
+     jniCallDataSnippet = new (trHeapMemory()) TR::S390JNICallDataSnippet2(cg(), callNode);
      cg()->addSnippet(jniCallDataSnippet);
      jniCallDataSnippet->setBaseRegister(JNISnippetBaseReg);
      new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, callNode,

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
@@ -25,7 +25,7 @@
 
 #include "codegen/PrivateLinkage.hpp"
 
-namespace TR { class S390JNICallDataSnippet; }
+namespace TR { class S390JNICallDataSnippet2; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
 namespace TR { class RegisterDependencyConditions; }
@@ -125,7 +125,7 @@ protected:
       TR::RealRegister * javaStackPointerRealRegister,
       TR::Register * methodMetaDataVirtualRegister,
       TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet *jniCallDataSnippet);
+      TR::S390JNICallDataSnippet2 *jniCallDataSnippet);
 
    };
 
@@ -174,7 +174,7 @@ public:
 
    void checkException(TR::Node * callNode, TR::Register *methodMetaDataVirtualRegister, TR::Register * tempReg);
    void releaseVMAccessMask(TR::Node * callNode, TR::Register * methodMetaDataVirtualRegister,
-         TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps);
+         TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::S390JNICallDataSnippet2 * jniCallDataSnippet, TR::RegisterDependencyConditions * deps);
    void acquireVMAccessMask(TR::Node * callNode, TR::Register * javaLitPoolVirtualRegister,
       TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg);
 


### PR DESCRIPTION
Adding this class will remove the dependency on the OMR version of this class, allowing a future PR to remove the OMR code in the future.

Once the OMR code is removed, the name will be reverted back to `S390JNICallDataSnippet` in OpenJ9.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>