### PR TITLE
CMake: Reintroduce base warning flags

### DIFF
--- a/runtime/cmake/platform/toolcfg/gnu.cmake
+++ b/runtime/cmake/platform/toolcfg/gnu.cmake
@@ -21,6 +21,7 @@
 ################################################################################
 
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -O3 -g -fstack-protector)
+list(APPEND OMR_PLATFORM_C_COMPILE_OPTIONS -Wimplicit -Wreturn-type)
 list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -fno-threadsafe-statics)
 
 # OMR_PLATFORM_CXX_COMPILE_OPTIONS gets applied to the jit (which needs exceptions),

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -81,12 +81,7 @@ add_custom_target(j9jit_tracegen DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/env/ut_j9ji
 
 # J9VM_OPT_JITSERVER
 if(J9VM_OPT_JITSERVER)
-	message(STATUS "JITServer is supported")
-
-	if(OPENSSL_CFLAGS)
-		set(J9_CFLAGS "${J9_CFLAGS} ${OPENSSL_CFLAGS}")
-		set(J9_CXXFLAGS "${J9_CXXFLAGS} ${OPENSSL_CFLAGS}")
-	endif()
+	message(STATUS "JITServer is enabled")
 
 	if(OPENSSL_BUNDLE_LIB_PATH) # --enable-openssl-bundling
 		set(OPENSSL_ROOT_DIR ${OPENSSL_BUNDLE_LIB_PATH})
@@ -95,7 +90,6 @@ if(J9VM_OPT_JITSERVER)
 		set(OPENSSL_ROOT_DIR ${OPENSSL_DIR})
 	endif()
 
-	include(FindOpenSSL)
 	find_package(OpenSSL REQUIRED)
 	include_directories(${OPENSSL_INCLUDE_DIR})
 endif()
@@ -225,6 +219,8 @@ set(J9_INCLUDES
 # Makefiles
 set(J9_SHAREDFLAGS
 	${OMR_PLATFORM_COMPILE_OPTIONS}
+)
+set(J9_CFLAGS
 	${OMR_PLATFORM_C_COMPILE_OPTIONS}
 )
 set(J9_CXXFLAGS


### PR DESCRIPTION
Rehash of #9679 but introduces the flags via the platform compile options.
This ensures they don't get applied to NASM.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>