### PR TITLE
Support for JEP 383 (Java 15): Part 1

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,6 +61,16 @@ abstract class BoundMethodHandle extends MethodHandle {
 	LambdaForm.NamedFunction getterFunction(int num) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+
+/*[IF Java15]*/
+	final int fieldCount() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	final Object arg(int i) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] Java15 */
 
 	class SpeciesData {
 		MethodHandle constructor() {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,3 +21,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+/*[IF Java15]*/
+package java.lang.invoke;
+
+/*
+ * Stub class to compile RI j.l.i.MethodHandleImpl
+ */
+
+class DirectMethodHandle extends MethodHandle {
+	DirectMethodHandle(MethodType mt, LambdaForm lf) {
+		super(mt, lf);
+		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+}
+/*[ENDIF] Java15 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2305,6 +2305,10 @@ public class MethodHandles {
 			return new Lookup(definer.defineClass(initOption), false);
 		}
 
+		Lookup defineHiddenClassWithClassData(byte[] bytes, Object data, ClassOption... classOptions) {
+			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		}
+
 		ClassDefiner makeHiddenClassDefiner(String name, byte[] template) {
 			ClassDefiner definer = new ClassDefiner(name, template, this);
 			return definer;
@@ -5388,6 +5392,12 @@ public class MethodHandles {
 			return target.invokeWithArguments(newArguments);
 		}
 	}
+
+/*[IF Java15]*/
+	static boolean permuteArgumentChecks(int[] arr, MethodType mt1, MethodType mt2) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] Java15 */
 
 /*[IF Sidecar18-SE-OpenJ9]*/	
 	static MethodHandle basicInvoker(MethodType mt) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -523,7 +523,11 @@ public abstract class VarHandle extends VarHandleInternal
 	 * 
 	 * @return The field type
 	 */
+	/*[IF Java15]*/
+	public Class<?> varType() {
+	/*[ELSE]*/
 	public final Class<?> varType() {
+	/*[ENDIF] Java15 */
 		return this.fieldType;
 	}
 	
@@ -535,7 +539,11 @@ public abstract class VarHandle extends VarHandleInternal
 	 * 
 	 * @return The parameters required to access the field.
 	 */
+	/*[IF Java15]*/
+	public List<Class<?>> coordinateTypes() {
+	/*[ELSE]*/
 	public final List<Class<?>> coordinateTypes() {
+	/*[ENDIF] Java15 */
 		return Collections.unmodifiableList(Arrays.<Class<?>>asList(coordinateTypes));
 	}
 
@@ -730,7 +738,11 @@ public abstract class VarHandle extends VarHandleInternal
 	 * @return A {@link MethodHandle} for the specified {@link AccessMode}, bound to
 	 * 			this {@link VarHandle} instance.
 	 */
+	/*[IF Java15]*/
+	public MethodHandle toMethodHandle(AccessMode accessMode) {
+	/*[ELSE]*/
 	public final MethodHandle toMethodHandle(AccessMode accessMode) {
+	/*[ENDIF] Java15 */
 		MethodHandle mh = handleTable[accessMode.ordinal()];
 
 		if (mh != null) {
@@ -1506,6 +1518,24 @@ public abstract class VarHandle extends VarHandleInternal
 		}		
 	}
 /*[ENDIF] Java12 */ 
+
+/*[IF Java15]*/
+	VarHandle target() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	VarHandle asDirect() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	MethodHandle getMethodHandle(int i) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	boolean isDirect() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF] Java15 */
 
 	abstract MethodType accessModeTypeUncached(AccessMode accessMode);
 }


### PR DESCRIPTION
1. Includes stubs for the following new methods:
    - class BoundMethodHandle: fieldCount and arg
    - class Lookup: defineHiddenClassWithClassData
    - class MethodHandles: permuteArgumentChecks
    - class VarHandle: target, asDirect, getMethodHandle and isDirect
2. Includes a stub implementation for class DirectMethodHandle.
3. The following VarHandle methods are no longer final:
    - varType, coordinateTypes and toMethodHandle

Fixes: https://github.com/eclipse/openj9/issues/9684
Related: https://github.com/eclipse/openj9/issues/9625

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>