### PR TITLE
Mac: set compatibility and current version of dylib's to 1.0.0

### DIFF
--- a/runtime/cmake/platform/os/osx.cmake
+++ b/runtime/cmake/platform/os/osx.cmake
@@ -1,0 +1,24 @@
+################################################################################
+# Copyright (c) 2020, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
+
+# set OpenJ9 dylib versions
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-compatibility_version,1.0.0,-current_version,1.0.0" )

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -454,6 +454,11 @@ ifeq ($(HOST_ARCH),x)
             SOLINK_FLAGS+=-static-libgcc -static-libstdc++
         endif
     endif
+
+    ifeq ($(OS),osx)
+        SOLINK_FLAGS+=-install_name @rpath/lib$(PRODUCT_NAME).dylib
+        SOLINK_FLAGS+=-compatibility_version 1.0.0 -current_version 1.0.0
+    endif
 endif
 
 ifeq ($(HOST_ARCH),p)

--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -128,6 +128,7 @@ endif
 
 # https://stackoverflow.com/questions/21907504/how-to-compile-shared-lib-with-clang-on-osx
 UMA_DLL_LINK_FLAGS += -shared -undefined dynamic_lookup -install_name @rpath/lib$(UMA_LIB_NAME).dylib
+UMA_DLL_LINK_FLAGS += -compatibility_version 1.0.0 -current_version 1.0.0
 UMA_DLL_LINK_FLAGS += -Xlinker -rpath -Xlinker @loader_path -Xlinker -rpath -Xlinker @loader_path/..
 
 UMA_DLL_LINK_POSTFLAGS += $(UMA_LINK_STATIC_LIBRARIES)

--- a/runtime/thread/threadshared.mk.ftl
+++ b/runtime/thread/threadshared.mk.ftl
@@ -1,7 +1,7 @@
 # This makefile is generated using an UMA template.
 
 #
-# Copyright (c) 2015, 2019 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,10 +92,6 @@ MODULE_SHARED_LIBS += rt
 # weak symbols.
 MODULE_SHARED_LIBS += pthread
 endif # Linux
-
-ifeq (osx,$(OMR_HOST_OS))
-GLOBAL_LDFLAGS += -install_name lib$(MODULE_NAME).dylib
-endif # OSX
 
 include $(top_srcdir)/omrmakefiles/rules.mk
 


### PR DESCRIPTION
For compatibility with OpenJDK.
Removed obsolete -install_name setting for j9thr29.dylib since this is
set by OMR.
https://github.com/eclipse/omr/blob/master/omrmakefiles/rules.osx.mk#L125

Fixes #9676