### PR TITLE
CMake: ensure J9VM_OPT_USE_OMR_DDR is defined

### DIFF
--- a/runtime/include/j9cfg.h.in
+++ b/runtime/include/j9cfg.h.in
@@ -278,6 +278,9 @@ extern "C" {
 #cmakedefine J9VM_THR_PREEMPTIVE
 #cmakedefine J9VM_THR_SMART_DEFLATION
 
+/* CMake build only supports OMR DDR */
+#define J9VM_OPT_USE_OMR_DDR
+
 #if defined(J9VM_ENV_DATA64)
 #define J9VM_OPT_MULTI_LAYER_SHARED_CLASS_CACHE
 #endif


### PR DESCRIPTION
This causes ddr to select the appropriate alias file.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>