### PR TITLE
Add function for aborting compilation with bad value type operations

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -238,6 +238,7 @@ private:
    void         handleSideEffect(TR::Node *);
    bool         valueMayBeModified(TR::Node *, TR::Node *);
    TR::Node *    genCompressedRefs(TR::Node *, bool genTT = true, int32_t isLoad = 1);
+   void         abortForUnresolvedValueTypeOp(const char* bytecodeName, const char* refType);
 
    // IlGenerator
    //


### PR DESCRIPTION
Currently, the IL generator will abort compilation when an operation with an unresolved CP reference that may need value type handling is encountered. To aid readability and maintainability, this commit
adds a new helper function that encapsulates the code that does the abort. All instances of similar code are replaced with a call to this new function.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>