### PR TITLE
Fix crash printing to verbose log

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2285,6 +2285,9 @@ TR_ResolvedRelocatableJ9Method::allocateException(uint32_t numBytes, TR::Compila
    eTbl->ramMethod = NULL;
    eTbl->constantPool = NULL;
 
+   // This exception table doesn't get initialized until relocation
+   eTbl->flags |= JIT_METADATA_NOT_INITIALIZED;
+
    return (U_8 *) eTbl;
    }
 

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -377,8 +377,23 @@ J9::CodeCache::addFreeBlock(void  *voidMetaData)
       {
       if (config.verboseReclamation())
          {
-         TR_J9VMBase *fe = _manager->fej9();
-         TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"CC=%p unloading j9method=%p metaData=%p warmBlock=%p size=%d: %.*s.%.*s%.*s", this, metaData->ramMethod,metaData, warmBlock, (int)warmBlock->_size, J9UTF8_LENGTH(metaData->className), J9UTF8_DATA(metaData->className), J9UTF8_LENGTH(metaData->methodName), J9UTF8_DATA(metaData->methodName), J9UTF8_LENGTH(metaData->methodSignature), J9UTF8_DATA(metaData->methodSignature));
+         if (metaData->ramMethod)
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"CC=%p unloading j9method=%p metaData=%p warmBlock=%p size=%d: %.*s.%.*s%.*s",
+                                           this, metaData->ramMethod,metaData, warmBlock, (int)warmBlock->_size,
+                                           J9UTF8_LENGTH(metaData->className), J9UTF8_DATA(metaData->className),
+                                           J9UTF8_LENGTH(metaData->methodName), J9UTF8_DATA(metaData->methodName),
+                                           J9UTF8_LENGTH(metaData->methodSignature), J9UTF8_DATA(metaData->methodSignature));
+            }
+         else
+            {
+            TR_ASSERT_FATAL(metaData->flags & JIT_METADATA_NOT_INITIALIZED,
+                            "metaData->ramMethod is NULL but metaData (%p) does not have the JIT_METADATA_NOT_INITIALIZED flag set",
+                            metaData);
+
+            TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"CC=%p unloading metaData=%p warmBlock=%p size=%d",
+                                           this, metaData, warmBlock, (int)warmBlock->_size);
+            }
          }
 
       // When entire method is removed we can remove the jittedBodyInfo as well

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1495,7 +1495,6 @@ createMethodMetaData(
    data->endWarmPC = data->endPC;
    data->codeCacheAlloc = (UDATA)comp->cg()->getBinaryBufferStart();
 
-   data->flags = 0;
    if (fourByteOffsets)
       data->flags |= JIT_METADATA_GC_MAP_32_BIT_OFFSETS;
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -733,16 +733,8 @@ TR_RelocationRuntime::relocateMethodMetaData(UDATA codeRelocationAmount, UDATA d
       _exceptionTable->osrInfo = (void *) (((U_8 *)_exceptionTable->osrInfo) + dataRelocationAmount);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
-   #if 0
-      fprintf(stdout, "-> %p", _exceptionTable->ramMethod);
-      if (classReloAmount())
-         {
-         name = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(((J9ROMMethod *)_exceptionTable->ramMethod)));
-         fprintf(stdout, " (%.*s)", name->length, name->data);
-         }
-      fprintf(stdout, "\n");
-      fflush(stdout);
-   #endif
+   // Reset the uninitialized bit
+   _exceptionTable->flags &= ~JIT_METADATA_NOT_INITIALIZED;
    }
 
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -387,8 +387,11 @@ void TR_RelocationRuntime::relocationFailureCleanup()
       {
       case (RelocationFailure):
          {
-         //remove our code cache entry
-         _codeCache->addFreeBlock(_exceptionTable);
+         /* The compiled copy of the exception table is freed
+          * in CompilationThread.cpp
+          */
+         if (!useCompiledCopy())
+            _codeCache->addFreeBlock(_exceptionTable);
          }
       case RelocationCodeCreateError:
          {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -538,9 +538,10 @@ typedef struct J9JITExceptionTable {
 	void* riData;
 } J9JITExceptionTable;
 
-#define JIT_METADATA_FLAGS_USED_FOR_SIZE 1
-#define JIT_METADATA_GC_MAP_32_BIT_OFFSETS 2
-#define JIT_METADATA_IS_STUB 4
+#define JIT_METADATA_FLAGS_USED_FOR_SIZE 0x1
+#define JIT_METADATA_GC_MAP_32_BIT_OFFSETS 0x2
+#define JIT_METADATA_IS_STUB 0x4
+#define JIT_METADATA_NOT_INITIALIZED 0x8
 
 typedef struct J9JIT16BitExceptionTableEntry {
 	U_16 startPC;


### PR DESCRIPTION
After an AOT Compilation, the compiler either delays the relocation of
the body, or the relocation can fail. When this occurs, the
J9JITExceptionTable that was allocated has to freed. As part of this
freeing process, information is printed out to the verbose log if the
code cache verbose options are set. Part of the information that is
printed out is the name of the method. This information is retrieved
from the J9JITExceptionTable. However, this information can be NULL
because it gets populated when the table is relocated.

This PR adds a NULL check, as well as some sanity checks to ensure
that those fields are only NULL in the expected scenarios.