### PR TITLE
Add portable AOT support on x86

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -183,13 +183,22 @@ J9::Compilation::Compilation(int32_t id,
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)
    {
-
 #if defined(J9VM_OPT_JITSERVER)
    // In JITServer, we would like to use JITClient's processor info for the compilation
    // The following code effectively replaces the cpu with client's cpu through the getProcessorDescription() that has JITServer support
    if (self()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-      _target.cpu = TR::CPU(TR::Compiler->target.cpu.getProcessorDescription());
+      {
+      OMRProcessorDesc JITClientProcessorDesc = TR::Compiler->target.cpu.getProcessorDescription();
+      _target.cpu = TR::CPU(JITClientProcessorDesc);
+      }
+   else
 #endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      if (((TR_J9VMBase *)fe)->isAOT_DEPRECATED_DO_NOT_USE() && TR::Compiler->target.cpu.isX86())
+         {
+         _target = TR::Compiler->relocatableTarget;
+         }
+      }
 
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1183,10 +1183,7 @@ J9::Options::fePreProcess(void * base)
    uint32_t numProc = compInfo->getNumTargetCPUs();
    TR::Compiler->host.setNumberOfProcessors(numProc);
    TR::Compiler->target.setNumberOfProcessors(numProc);
-
-   // Safe decision to assume always SMP
-   TR::Compiler->host.setSMP(true);
-   TR::Compiler->target.setSMP(true);
+   TR::Compiler->relocatableTarget.setNumberOfProcessors(numProc);
 
    J9MemoryManagerFunctions * mmf = vm->memoryManagerFunctions;
 #if defined(J9VM_GC_HEAP_CARD_TABLE)

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1914,7 +1914,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
          else
             {
-            TR::Compiler->relocatableTarget.cpu = TR::CPU(compInfo->reloRuntime()->getProcessorDescription(fe, curThread));
+            TR::Compiler->relocatableTarget.cpu = TR::CPU(compInfo->reloRuntime()->getProcessorDescriptionFromSCC(fe, curThread));
             }
          }
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1912,6 +1912,10 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
                TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_DISABLED);
                }
             }
+         else
+            {
+            TR::Compiler->relocatableTarget.cpu = TR::CPU(compInfo->reloRuntime()->getProcessorDescription(fe, curThread));
+            }
          }
 
       if (TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT))

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1139,9 +1139,7 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(javaVM());
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
       
-      OMRPORT_ACCESS_FROM_J9PORT(javaVM()->portLibrary);
-      BOOLEAN inContainer = omrsysinfo_is_running_in_container(); 
-      if (TRUE == inContainer || TRUE == javaVM()->sharedCacheAPI->sharedCachePortable)
+      if (TRUE == javaVM()->sharedCacheAPI->sharedCachePortable)
          {
          TR::Compiler->relocatableTarget.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
          aotHeader->processorDescription = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1002,7 +1002,7 @@ TR_SharedCacheRelocationRuntime::getCurrentLockwordOptionHashValue(J9JavaVM *vm)
    }
 
 OMRProcessorDesc
-TR_SharedCacheRelocationRuntime::getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread)
+TR_SharedCacheRelocationRuntime::getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
    J9SharedDataDescriptor firstDescriptor;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1001,6 +1001,26 @@ TR_SharedCacheRelocationRuntime::getCurrentLockwordOptionHashValue(J9JavaVM *vm)
    return currentLockwordOptionHashValue;
    }
 
+OMRProcessorDesc
+TR_SharedCacheRelocationRuntime::getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread)
+   {
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+   J9SharedDataDescriptor firstDescriptor;
+   firstDescriptor.address = NULL;
+   javaVM()->sharedClassConfig->findSharedData(curThread,
+                                             aotHeaderKey,
+                                             aotHeaderKeyLength,
+                                             J9SHR_DATA_TYPE_AOTHEADER,
+                                             FALSE,
+                                             &firstDescriptor,
+                                             NULL);
+
+   const void* result = firstDescriptor.address;
+   TR_ASSERT_FATAL(result, "No Shared Class Cache available for Processor Description\n");
+   TR_AOTHeader * hdrInCache = (TR_AOTHeader * )result;
+   return hdrInCache->processorDescription;
+   }
+
 // This function currently does not rely on the object beyond the v-table override (compiled as static without any problems).
 // If this changes, we will need to look further into whether its users risk concurrent access.
 bool
@@ -1118,7 +1138,18 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
       aotHeader->gcPolicyFlag = javaVM()->memoryManagerFunctions->j9gc_modron_getWriteBarrierType(javaVM());
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(javaVM());
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
-      aotHeader->processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
+      
+      OMRPORT_ACCESS_FROM_J9PORT(javaVM()->portLibrary);
+      BOOLEAN inContainer = omrsysinfo_is_running_in_container(); 
+      if (TRUE == inContainer || TRUE == javaVM()->sharedCacheAPI->sharedCachePortable)
+         {
+         TR::Compiler->relocatableTarget.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
+         aotHeader->processorDescription = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
+         }
+      else
+         {
+         aotHeader->processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
+         }
 
       // Set up other feature flags
       aotHeader->featureFlags = generateFeatureFlags(fe);

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -179,6 +179,7 @@ class TR_RelocationRuntime {
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
+      virtual OMRProcessorDesc getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread) { TR_ASSERT_FATAL(0, "Error: getProcessorDescription not supported in this relocation runtime"); return OMRProcessorDesc();}
 
       static uintptr_t    getGlobalValue(uint32_t g)
          {
@@ -346,6 +347,7 @@ public:
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
+      virtual OMRProcessorDesc getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread);
 
 private:
       uint32_t getCurrentLockwordOptionHashValue(J9JavaVM *vm) const;
@@ -378,6 +380,7 @@ public:
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
+      virtual OMRProcessorDesc getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread) override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return OMRProcessorDesc(); }
 
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -179,7 +179,7 @@ class TR_RelocationRuntime {
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-      virtual OMRProcessorDesc getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread) { TR_ASSERT_FATAL(0, "Error: getProcessorDescription not supported in this relocation runtime"); return OMRProcessorDesc();}
+      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread) { TR_ASSERT_FATAL(0, "Error: getProcessorDescriptionFromSCC not supported in this relocation runtime"); return OMRProcessorDesc();}
 
       static uintptr_t    getGlobalValue(uint32_t g)
          {
@@ -347,7 +347,7 @@ public:
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe);
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread);
-      virtual OMRProcessorDesc getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread);
+      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread);
 
 private:
       uint32_t getCurrentLockwordOptionHashValue(J9JavaVM *vm) const;
@@ -380,7 +380,7 @@ public:
       virtual bool storeAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
       virtual TR_AOTHeader *createAOTHeader(TR_FrontEnd *fe)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
       virtual bool validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)  override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return 0;}
-      virtual OMRProcessorDesc getProcessorDescription(TR_FrontEnd *fe, J9VMThread *curThread) override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return OMRProcessorDesc(); }
+      virtual OMRProcessorDesc getProcessorDescriptionFromSCC(TR_FrontEnd *fe, J9VMThread *curThread) override { TR_ASSERT_FATAL(0, "Should not be called in this RelocationRuntime!"); return OMRProcessorDesc(); }
 
       static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
 

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -232,7 +232,7 @@ uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuf
    //
    for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset)
       {
-      TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
+      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
       prefetchSnippetBuffer[0] = 0x0F;
       if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H))
          prefetchSnippetBuffer[1] = 0x0D;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -86,8 +86,8 @@ J9::X86::CodeGenerator::CodeGenerator() :
    cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsNewInstanceImplOpt();
    
-   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
-   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
    
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringCaseConv) &&
@@ -371,7 +371,7 @@ J9::X86::CodeGenerator::nopsAlsoProcessedByRelocations()
 bool
 J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    {
-   TR_ASSERT_FATAL(self()->comp()->isOutOfProcessCompilation() || self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
+   TR_ASSERT_FATAL(self()->comp()->compileRelocatableCode() || self()->comp()->isOutOfProcessCompilation() || self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
    if (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
       return true;
    else

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -574,7 +574,7 @@ static TR::Instruction *generatePrefetchAfterHeaderAccess(TR::Node              
    TR::Instruction *instr = NULL;
 
    static const char *prefetch = feGetEnv("TR_EnableSoftwarePrefetch");
-   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
    if (prefetch && comp->getMethodHotness()>=scorching && comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2))
       {
       int32_t fieldOffset = 0;
@@ -4653,7 +4653,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
          }
       }
 
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed\n");
+   TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed\n");
    if (cg->comp()->target().is64Bit() && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
       {
       TR::LabelSymbol *JITMonitorEntrySnippetLabel = generateLabelSymbol(cg);
@@ -4709,14 +4709,14 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    if (cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord())
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG8MemReg : CMPXCHG8MemReg;
-      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG8MemReg : XACMPXCHG8MemReg;
       }
    else
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG4MemReg : CMPXCHG4MemReg;
-      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG4MemReg : XACMPXCHG4MemReg;
       }
@@ -5543,7 +5543,7 @@ TR::Register
 
    if (!node->isReadMonitor() && !reservingLock)
       {
-      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
@@ -9113,7 +9113,7 @@ static TR::Register* inlineStringHashCode(TR::Node* node, bool isCompressed, TR:
       generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
       auto mr = generateX86MemoryReference(tmp, index, shift, 0, cg);
-      TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || cg->getX86ProcessorInfo().supportsAVX() == comp->target().cpu.supportsAVX(), "supportsAVX() failed\n");
+      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || cg->getX86ProcessorInfo().supportsAVX() == comp->target().cpu.supportsAVX(), "supportsAVX() failed\n");
       if (comp->target().cpu.supportsAVX())
          {
          generateRegMemInstruction(PANDRegMem, node, hashXMM, mr, cg);
@@ -9525,7 +9525,7 @@ inlineCompareAndSwapNative(
       }
    else
       {
-      TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
+      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
       if (!comp->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8))
          return false;
 
@@ -9947,7 +9947,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderAccesses:
             {
-            TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
+            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
             if (comp->target().cpu.supportsMFence())
                {
                TR_X86OpCode fenceOp;
@@ -9961,8 +9961,8 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderReads:
             {
-            TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
-            TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
+            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
+            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
 
             if (comp->target().cpu.requiresLFence() &&
                 comp->target().cpu.supportsLFence())
@@ -9978,7 +9978,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderWrites:
             {
-            TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
+            TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
 
             if (comp->target().cpu.supportsSFence())
                {

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -37,6 +37,43 @@
 // Without this definition, we get an undefined symbol of JITConfig::instance() at runtime
 TR::JitConfig * TR::JitConfig::instance() { return NULL; }
 
+TR::CPU
+J9::X86::CPU::detectRelocatable(OMRPortLibrary * const omrPortLib)
+   {
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
+   // Sandybridge Architecture is selected to be our default portable processor description
+   uint32_t enabledFeatures [] = {OMR_FEATURE_X86_FPU, OMR_FEATURE_X86_CX8, OMR_FEATURE_X86_CMOV,
+                                  OMR_FEATURE_X86_MMX, OMR_FEATURE_X86_SSE, OMR_FEATURE_X86_SSE2,
+                                  OMR_FEATURE_X86_SSSE3, OMR_FEATURE_X86_SSE4_1, OMR_FEATURE_X86_POPCNT,
+                                  OMR_FEATURE_X86_AESNI, OMR_FEATURE_X86_AVX};
+
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc customProcessorDescription;
+   memset(customProcessorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   for (size_t i = 0; i < sizeof(enabledFeatures)/sizeof(uint32_t); i++)
+      {
+      omrsysinfo_processor_set_feature(&customProcessorDescription, enabledFeatures[i], TRUE);
+      }
+
+   // Pick the older processor between our hand-picked processor and host processor to be the actual portable processor
+   TR::CPU host = TR::CPU::detect(omrPortLib);
+   OMRProcessorDesc hostProcessorDescription = host.getProcessorDescription();
+
+   OMRProcessorDesc portableProcessorDescription;
+   portableProcessorDescription.processor = OMR_PROCESSOR_X86_FIRST;
+   portableProcessorDescription.physicalProcessor = portableProcessorDescription.processor;
+   memset(portableProcessorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+
+   for (size_t i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
+      {
+      portableProcessorDescription.features[i] = hostProcessorDescription.features[i] & customProcessorDescription.features[i];
+      }
+
+   return TR::CPU(portableProcessorDescription);
+   }
+
 TR_X86CPUIDBuffer *
 J9::X86::CPU::queryX86TargetCPUID()
    {
@@ -137,6 +174,8 @@ J9::X86::CPU::is_test(OMRProcessorArchitecture p)
    if (TR::CompilationInfo::getStream())
       return true;
 #endif /* defined(J9VM_OPT_JITSERVER) */
+   if (TR::comp()->compileRelocatableCode())
+      return true;
 
    switch(p)
       {
@@ -183,6 +222,8 @@ J9::X86::CPU::supports_feature_test(uint32_t feature)
    if (TR::CompilationInfo::getStream())
       return true;
 #endif /* defined(J9VM_OPT_JITSERVER) */
+   if (TR::comp()->compileRelocatableCode())
+      return true;
 
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
    bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
@@ -272,3 +313,4 @@ J9::X86::CPU::supports_feature_test(uint32_t feature)
       }
    return false;
    }
+

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -51,13 +51,19 @@ protected:
    CPU(const OMRProcessorDesc& processorDescription) : J9::CPU(processorDescription) {}
 
 public:
+   /** 
+    * @brief Returns the processor type and features that will be used by portable AOT compilations
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
 
    TR_X86CPUIDBuffer *queryX86TargetCPUID();
    const char * getProcessorVendorId();
    uint32_t getProcessorSignature();
 
+   bool testOSForSSESupport() { return true; } // VM guarantees SSE/SSE2 are available
    bool hasPopulationCountInstruction();
-   bool testOSForSSESupport() { return true; }
 
    bool isCompatible(const OMRProcessorDesc& processorDescription);
    OMRProcessorDesc getProcessorDescription();

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1209,6 +1209,7 @@ typedef struct J9SharedCacheAPI {
 	U_8 sharedCacheEnabled;
 	U_8 inContainer; /* It is TRUE only when xShareClassesPresent is FALSE and J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) is TRUE and the JVM is running in container */
 	I_8 layer;
+	U_8 sharedCachePortable;
 } J9SharedCacheAPI;
 
 typedef struct J9SharedClassConfig {


### PR DESCRIPTION
`TR::Compiler->target` contains the host environment while `TR::Compiler->relocatableTarget` contains 
the target environment that AOT compilations will use. `TR::Compiler->relocatableTarget` is set according
to the presence of SCC, portable options and Docker containers. Then at the beginning of every compilation
(in the constructor) we set the target to be `TR::Compiler->target` if JIT compilation and
`TR::Compiler->relocatableTarget` if AOT compilation.
The following scenarios were considered:
- When there is no existing SCC and no portable option specified 
(-Xshareclasses:portable, -XX:+PortableShareClasses), we use the host processor for AOT
- When there is no existing SCC and has portable option specified, we use the hand-picked
portable processor for AOT
- When there is no existing SCC and in container, we use the hand-picked portable processor
for AOT
- When there is existing SCC and it passes processor compatibility check, we use the processor
stored in the SCC (ignoring portable options and whether we are in container or not)
- JITServer is not affected. Meaning JITServer will still use JITClient's processor information for
all of its compilations regardless of the portable/inContainer/SCC options

depends on: https://github.com/eclipse/omr/pull/4861
Issue: #7966 

Signed-off-by: Harry Yu <harryyu1994@gmail.com>