### PR TITLE
Ensure that J9SH_DESTROY_TOP_LAYER_ONLY is properly defined

### DIFF
--- a/runtime/shared_common/CacheLifecycleManager.hpp
+++ b/runtime/shared_common/CacheLifecycleManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@
 
 /* @ddr_namespace: default */
 #include <j9port.h>
+#include "shchelp.h" /* J9SH_LAYER_NUM_MAX_VALUE */
 #include "ibmjvmti.h"
 
 /*


### PR DESCRIPTION
Include schhelp.h to introduce the definition of J9SH_LAYER_NUM_MAX_VALUE,
which is needed for J9SH_DESTROY_TOP_LAYER_ONLY

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>