### PR TITLE
AArch64: Enable allocation inlining on AOT

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -734,13 +734,42 @@ static void
 genInitObjectHeader(TR::Node *node, TR::CodeGenerator *cg, TR_OpaqueClassBlock *clazz, TR::Register *objectReg, TR::Register *classReg, TR::Register *tempReg1)
    {
    TR_ASSERT(clazz, "Cannot have a null OpaqueClassBlock\n");
+   TR_J9VM *fej9 = reinterpret_cast<TR_J9VM *>(cg->fe());
+   TR::Compilation *comp = cg->comp();
    TR::Register * clzReg = classReg;
+   TR::Register *metaReg = cg->getMethodMetaDataRegister();
 
    // For newarray/anewarray, classReg holds the class pointer of array elements
    // Prepare valid class pointer for arrays
    if (node->getOpCodeValue() != TR::New)
       {
-      loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(clazz), tempReg1, NULL, true, TR_ClassPointer);
+      if (cg->needClassAndMethodPointerRelocations())
+         {
+         if (comp->getOption(TR_UseSymbolValidationManager))
+            {
+            loadAddressConstantInSnippet(cg, node, reinterpret_cast<intptr_t>(clazz), tempReg1, TR_ClassPointer);
+            }
+         else
+            {
+            if (node->getOpCodeValue() == TR::newarray)
+               {
+               generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, tempReg1,
+                  new (cg->trHeapMemory()) TR::MemoryReference(metaReg, offsetof(J9VMThread, javaVM), cg));
+               generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, tempReg1,
+                  new (cg->trHeapMemory()) TR::MemoryReference(tempReg1,
+                     fej9->getPrimitiveArrayOffsetInJavaVM(node->getSecondChild()->getInt()), cg));
+               }
+            else
+               {
+               generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, tempReg1,
+                  new (cg->trHeapMemory()) TR::MemoryReference(classReg, offsetof(J9Class, arrayClass), cg));
+               }
+            }
+         }
+      else
+         {
+         loadAddressConstant(cg, node, reinterpret_cast<intptr_t>(clazz), tempReg1);
+         }
       clzReg = tempReg1;
       }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8635,7 +8635,8 @@ TR_J9SharedCacheVM::supportAllocationInlining(TR::Compilation *comp, TR::Node *n
 
    if ((comp->target().cpu.isX86() ||
         comp->target().cpu.isPower() ||
-        comp->target().cpu.isZ()) &&
+        comp->target().cpu.isZ() ||
+        comp->target().cpu.isARM64()) &&
        !comp->getOption(TR_DisableAllocationInlining))
       return true;
 


### PR DESCRIPTION
This commit enables allocation inlining under AOT compilation for aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>