### PR TITLE
Add uma to list of suffixes not applicable to test

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -773,7 +773,7 @@ def move_spec_suffix_to_id(spec, id) {
     def spec_id = [:]
     spec_id['spec'] = spec
     spec_id['id'] = id
-    for (suffix in ['cm', 'jit', 'valhalla']) {
+    for (suffix in ['cm', 'jit', 'valhalla', 'uma']) {
         if (spec.contains("_${suffix}")) {
             spec_id['spec'] = spec - "_${suffix}"
             spec_id['id'] = "${suffix}_" + id


### PR DESCRIPTION
- New specs were temporarily added for uma.
  This is meaningless to the test job. Adding
  the uma suffix to the list. This will strip
  the uma suffix from the PLATFORM and move
  it into the build identfier suffix.

Related #9713
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>