### PR TITLE
Sampling allocation bytes precisely without compromising the performance

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCObjectHeapIteratorAddressOrderedList_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCObjectHeapIteratorAddressOrderedList_V1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,9 +75,9 @@ class GCObjectHeapIteratorAddressOrderedList_V1 extends GCObjectHeapIterator
 						excludedRangeList.add(new U8Pointer[] {heapAlloc, heapTop});
 					} else {
 						/* Might be an instrumented VM */
-						U8Pointer realHeapAlloc = adjustedToRange(vmThread.allocateThreadLocalHeap().realHeapAlloc(), base, top);
-						if(realHeapAlloc.notNull() && isSomethingToAdd(realHeapAlloc, heapTop)) {
-							excludedRangeList.add(new U8Pointer[] {realHeapAlloc, heapTop});
+						U8Pointer realHeapTop = adjustedToRange(vmThread.allocateThreadLocalHeap().realHeapTop(), base, top);
+						if(realHeapTop.notNull() && isSomethingToAdd(heapAlloc, realHeapTop)) {
+							excludedRangeList.add(new U8Pointer[] {heapAlloc, realHeapTop});
 						}
 					}
 				}
@@ -91,9 +91,9 @@ class GCObjectHeapIteratorAddressOrderedList_V1 extends GCObjectHeapIterator
 							excludedRangeList.add(new U8Pointer[] {heapAlloc, heapTop});
 						} else {
 							/* Might be an instrumented VM */
-							U8Pointer realHeapAlloc = adjustedToRange(vmThread.nonZeroAllocateThreadLocalHeap().realHeapAlloc(), base, top);
-							if(realHeapAlloc.notNull() && isSomethingToAdd(realHeapAlloc, heapTop)) {
-								excludedRangeList.add(new U8Pointer[] {realHeapAlloc, heapTop});
+							U8Pointer realHeapTop = adjustedToRange(vmThread.nonZeroAllocateThreadLocalHeap().realHeapTop(), base, top);
+							if(realHeapTop.notNull() && isSomethingToAdd(heapAlloc, realHeapTop)) {
+								excludedRangeList.add(new U8Pointer[] {heapAlloc, realHeapTop});
 							}
 						}
 					}

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -866,9 +866,9 @@ j9gc_allocation_threshold_changed(J9VMThread *currentThread)
  *		j9gc_set_allocation_sampling_interval(vm, (UDATA)4096);
  *	To trigger an event for every object allocation:
  *		j9gc_set_allocation_sampling_interval(vm, (UDATA)0);
- * The initial MM_GCExtensions::oolObjectSamplingBytesGranularity value is 16M
- * or set by command line option "-Xgc:allocationSamplingGranularity".
- * By default, the sampling interval is going to be set to 512 KB.
+ *	To disable allocation sampling
+ *		j9gc_set_allocation_sampling_interval(vm, UDATA_MAX);
+ * The initial MM_GCExtensionsBase::objectSamplingBytesGranularity value is UDATA_MAX.
  * 
  * @parm[in] vm The J9JavaVM
  * @parm[in] samplingInterval The allocation sampling interval.
@@ -878,10 +878,15 @@ j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval)
 {
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(vm);
 	if (0 == samplingInterval) {
-		/* avoid (env->_oolTraceAllocationBytes) % 0 which could be undefined. */
+		/* avoid (env->_traceAllocationBytes) % 0 which could be undefined. */
 		samplingInterval = 1;
 	}
-	extensions->oolObjectSamplingBytesGranularity = samplingInterval;
+
+	if (samplingInterval != extensions->objectSamplingBytesGranularity) {
+		extensions->objectSamplingBytesGranularity = samplingInterval;
+		J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
+		j9gc_allocation_threshold_changed(currentThread);
+	}
 }
 
 /**

--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -161,20 +161,20 @@ public:
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	/**
-	 * Disable inline TLH allocates by hiding the real heap allocation address from
-	 * JIT/Interpreter in realHeapAlloc and setting heapALloc == HeapTop so TLH
+	 * Disable inline TLH allocates by hiding the real heap top address from
+	 * JIT/Interpreter in realHeapTop and setting HeapTop == heapALloc so TLH
 	 * looks full.
 	 *
 	 */
 	void disableInlineTLHAllocate();
 
 	/**
-	 * Re-enable inline TLH allocate by restoring heapAlloc from realHeapAlloc
+	 * Re-enable inline TLH allocate by restoring heapTop from realHeapTop
 	 */
 	void enableInlineTLHAllocate();
 
 	/**
-	 * Determine if inline TLH allocate is enabled; its enabled if realheapAlloc is NULL.
+	 * Determine if inline TLH allocate is enabled; its enabled if realheapTop is NULL.
 	 * @return TRUE if inline TLH allocates currently enabled for this thread; FALSE otherwise
 	 */
 	bool isInlineTLHAllocateEnabled();
@@ -187,18 +187,18 @@ public:
 	 *
 	 * @param size the number of bytes to next sampling point
 	 */
-	void setTLHSamplingTop(uintptr_t size) {}
+	void setTLHSamplingTop(uintptr_t size);
 
 	/**
 	 * Restore heapTop from realHeapTop if realHeapTop != NULL
 	 */
-	void resetTLHSamplingTop() {}
+	void resetTLHSamplingTop();
 
 	/**
 	 * Retrieve allocation size inside TLH Cache.
 	 * @return (heapAlloc - heapBase)
 	 */
-	uintptr_t getAllocatedSizeInsideTLH() { return 0; }
+	uintptr_t getAllocatedSizeInsideTLH();
 
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 

--- a/runtime/gc_modron_startup/mgcalloc.cpp
+++ b/runtime/gc_modron_startup/mgcalloc.cpp
@@ -61,7 +61,7 @@ static uintptr_t stackIterator(J9VMThread *currentThread, J9StackWalkState *walk
 static void dumpStackFrames(J9VMThread *currentThread);
 static void traceAllocateIndexableObject(J9VMThread *vmThread, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields);
 static J9Object * traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields=0);
-static bool traceObjectCheck(J9VMThread *vmThread);
+static bool traceObjectCheck(J9VMThread *vmThread, bool *shouldTriggerAllocationSampling = NULL);
 
 #define STACK_FRAMES_TO_DUMP	8
 
@@ -225,18 +225,45 @@ traceAllocateIndexableObject(J9VMThread *vmThread, J9Class* clazz, uintptr_t obj
 static J9Object *
 traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uintptr_t objSize, uintptr_t numberOfIndexedFields)
 {
-	if(traceObjectCheck(vmThread)){
-		PORT_ACCESS_FROM_VMC(vmThread);
+	bool shouldTrigggerObjectAllocationSampling = false;
+	uintptr_t byteGranularity = 0;
+
+	if (traceObjectCheck(vmThread, &shouldTrigggerObjectAllocationSampling)){
 		MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
 		MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-		uintptr_t byteGranularity = extensions->oolObjectSamplingBytesGranularity;
 		J9ROMClass *romClass = clazz->romClass;
+		byteGranularity = extensions->oolObjectSamplingBytesGranularity;
 	
 		if (J9ROMCLASS_IS_ARRAY(romClass)){
 			traceAllocateIndexableObject(vmThread, clazz, objSize, numberOfIndexedFields);
 		}else{
 			Trc_MM_J9AllocateObject_outOfLineObjectAllocation(
 				vmThread, clazz, J9UTF8_LENGTH(J9ROMCLASS_CLASSNAME(romClass)), J9UTF8_DATA(J9ROMCLASS_CLASSNAME(romClass)), objSize);
+		}
+
+		/* Keep the remainder, want this to happen so that we don't miss objects
+		 * after seeing large objects
+		 */
+		env->_oolTraceAllocationBytes = (env->_oolTraceAllocationBytes) % byteGranularity;
+	}
+
+	if (shouldTrigggerObjectAllocationSampling) {
+		PORT_ACCESS_FROM_VMC(vmThread);
+		MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+		MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+
+		byteGranularity = extensions->objectSamplingBytesGranularity;
+		/* Keep the remainder, want this to happen so that we don't miss objects
+		 * after seeing large objects
+		 */
+		uintptr_t allocSizeInsideTLH = env->getAllocatedSizeInsideTLH();
+		uintptr_t remainder = (env->_traceAllocationBytes + allocSizeInsideTLH) % byteGranularity;
+		env->_traceAllocationBytesCurrentTLH = allocSizeInsideTLH + (env->_traceAllocationBytes % byteGranularity) - remainder;
+		env->_traceAllocationBytes = (env->_traceAllocationBytes) % byteGranularity;
+
+		if (!extensions->needDisableInlineAllocation()) {
+
+			env->setTLHSamplingTop(byteGranularity - remainder);
 		}
 
 		TRIGGER_J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING(
@@ -247,11 +274,6 @@ traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uin
 			object,
 			clazz,
 			objSize);
-
-		/* Keep the remainder, want this to happen so that we don't miss objects
-		 * after seeing large objects
-		 */
-		env->_oolTraceAllocationBytes = (env->_oolTraceAllocationBytes) % byteGranularity;
 	}
 	return object;
 }
@@ -262,14 +284,19 @@ traceAllocateObject(J9VMThread *vmThread, J9Object * object, J9Class* clazz, uin
  * Returns true if we should trace the object
  *  */
 static bool
-traceObjectCheck(J9VMThread *vmThread)
+traceObjectCheck(J9VMThread *vmThread, bool *shouldTriggerAllocationSampling)
 {
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	uintptr_t byteGranularity = 0;
 
-	if(extensions->doOutOfLineAllocationTrace){
-		uintptr_t byteGranularity = extensions->oolObjectSamplingBytesGranularity;
-	
+	if (NULL != shouldTriggerAllocationSampling) {
+		byteGranularity = extensions->objectSamplingBytesGranularity;
+		*shouldTriggerAllocationSampling = (env->_traceAllocationBytes + env->getAllocatedSizeInsideTLH() - env->_traceAllocationBytesCurrentTLH) >= byteGranularity;
+	}
+
+	if (extensions->doOutOfLineAllocationTrace){
+		byteGranularity = extensions->oolObjectSamplingBytesGranularity;
 		if(env->_oolTraceAllocationBytes >= byteGranularity){
 			return true;
 		}
@@ -478,9 +505,9 @@ J9AllocateObject(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFlags)
 	}
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-	if (extensions->fvtest_disableInlineAllocation || extensions->instrumentableAllocateHookEnabled || extensions->disableInlineCacheForAllocationThreshold) {
+	if (extensions->needDisableInlineAllocation()) {
 		env->disableInlineTLHAllocate();
-	}	
+	}
 #endif /* J9VM_GC_THREAD_LOCAL_HEAP */	
 
 	return objectPtr;
@@ -617,9 +644,9 @@ J9AllocateIndexableObject(J9VMThread *vmThread, J9Class *clazz, uint32_t numberO
 	}
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-	if (extensions->fvtest_disableInlineAllocation || extensions->instrumentableAllocateHookEnabled || extensions->disableInlineCacheForAllocationThreshold ) {
+	if (extensions->needDisableInlineAllocation()) {
 		env->disableInlineTLHAllocate();
-	}	
+	}
 #endif /* J9VM_GC_THREAD_LOCAL_HEAP */	
 
 	return objectPtr;
@@ -662,25 +689,37 @@ memoryManagerTLHAsyncCallbackHandler(J9VMThread *vmThread, IDATA handlerKey, voi
 	
 	if (extensions->isStandardGC() || extensions->isVLHGC()) {
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
-		if (extensions->fvtest_disableInlineAllocation || extensions->instrumentableAllocateHookEnabled || extensions->disableInlineCacheForAllocationThreshold) {
+		if (extensions->needDisableInlineAllocation()) {
 			Trc_MM_memoryManagerTLHAsyncCallbackHandler_disableInlineTLHAllocates(vmThread,extensions->lowAllocationThreshold,extensions->highAllocationThreshold,extensions->tlhMinimumSize,extensions->tlhMaximumSize);
-			if (env->isInlineTLHAllocateEnabled()) {
+			if (allocationInterface->cachedAllocationsEnabled(env)) {
 				/* BEN TODO: Collapse the env->enable/disableInlineTLHAllocate with these enable/disableCachedAllocations */
 				env->disableInlineTLHAllocate();
 				allocationInterface->disableCachedAllocations(env);
 			}
 		} else {
 			Trc_MM_memoryManagerTLHAsyncCallbackHandler_enableInlineTLHAllocates(vmThread,extensions->lowAllocationThreshold,extensions->highAllocationThreshold,extensions->tlhMinimumSize,extensions->tlhMaximumSize);
-			if (!env->isInlineTLHAllocateEnabled()) {
+			if (!allocationInterface->cachedAllocationsEnabled(env)) {
 				/* BEN TODO: Collapse the env->enable/disableInlineTLHAllocate with these enable/disableCachedAllocations */
 				env->enableInlineTLHAllocate();
 				allocationInterface->enableCachedAllocations(env);
 			}
 		}
+
+		if (allocationInterface->cachedAllocationsEnabled(env)) {
+			uintptr_t samplingBytesGranularity = extensions->objectSamplingBytesGranularity;
+			if (UDATA_MAX != extensions->objectSamplingBytesGranularity) {
+				env->_traceAllocationBytes = 0;
+				env->_traceAllocationBytesCurrentTLH = 0;
+				env->setTLHSamplingTop(samplingBytesGranularity);
+			} else if (!env->isInlineTLHAllocateEnabled()) {
+				env->resetTLHSamplingTop();
+			}
+		}
+
 #endif /* defined(J9VM_GC_THREAD_LOCAL_HEAP) */
 	} else if (extensions->isSegregatedHeap()) {
 #if defined(J9VM_GC_SEGREGATED_HEAP)
-		if (extensions->fvtest_disableInlineAllocation || extensions->instrumentableAllocateHookEnabled || extensions->disableInlineCacheForAllocationThreshold) {
+		if (extensions->needDisableInlineAllocation()) {
 			Trc_MM_memoryManagerTLHAsyncCallbackHandler_disableAllocationCache(vmThread,extensions->lowAllocationThreshold,extensions->highAllocationThreshold);
 			if (allocationInterface->cachedAllocationsEnabled(env)) {
 				allocationInterface->disableCachedAllocations(env);

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -381,9 +381,8 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 				goto fail;
 			}
 
-			/* Initial sampling interval is MM_GCExtensions::oolObjectSamplingBytesGranularity which is 16M by default
-			 * or set by command line option -Xgc:allocationSamplingGranularity.
-			 * Set it to 512KB which is default sampling interval as per JEP 331 specification.
+			/* Initial sampling interval is MM_GCExtensions::objectSamplingBytesGranularity which is UDATA_MAX(SAMPLED_OBJECT_ALLOC is disabled) by default.
+			 * Set it to 512KB which is default sampling interval as per JEP 331 specification for enabling jvmti SAMPLED_OBJECT_ALLOC.
 			 */
 			vm->memoryManagerFunctions->j9gc_set_allocation_sampling_interval(vm, 512 * 1024);
 			jvmtiData->flags |= J9JVMTI_FLAG_SAMPLED_OBJECT_ALLOC_ENABLED;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2770,7 +2770,6 @@ typedef struct J9GCThreadInfo {
 
 typedef struct J9ModronThreadLocalHeap {
 	U_8* heapBase;
-	U_8* realHeapAlloc;
 	U_8* realHeapTop;
 	UDATA objectFlags;
 	UDATA refreshSize;


### PR DESCRIPTION
in order to sampling heap allocation bytes precisely without
compromising the performance, we have the below changes.

Handle instrumentableAllocateHook and
VM_OBJECT_ALLOCATE_WITHIN_THRESHOLD is still via disabling inline
allocation
Handle smapling for tracepoint is still during out of line allocation
Handle smapling for JEP331 is via setTLHSamplingTop(size)

Using fake Heap Top instead of fake Heap Alloc for disabling inline
allocation (realHeapAlloc-->realHeapTop,
set/getRealAlloc()-->set/getRealTop(), getRealSize(), getUsedSize())
Using fake Heap Top to force out of line allocation at sampling thresold
for sampling heap allocation (setTLHSamplingTop()/resetTLHSamplingTop())
setTLHSamplingTop(size) are only called in the below 3 cases
	1, sampling threshold has been changed via GC-VM api
j9gc_set_allocation_sampling_interval()
	2, TLH is refreshed
	3, after sampling is done

Counting trace allocation byte includes allocation bytes inside TLH
Cache before flushing(_stats.bytesAllocated(true),
stats->_tlhAllocatedUsed, )
Handle traceAllocationByte for Health
Center(_oolTraceAllocationBytesForTracepoint,
oolObjectSamplingBytesGranularityForTracepoint) and traceAllocationByte
for JEP331(_traceAllocationBytesForHook,
objectSamplingBytesGranularityForHook) independently

depend on https://github.com/eclipse/omr/pull/5260
fix: https://github.com/eclipse/openj9/issues/7740

Signed-off-by: Lin Hu <linhu@ca.ibm.com>