### PR TITLE
Remove obsolete 'tenant' references. Cache VMFunctionTable.

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
While reviewing code I ran across some old tenant references in
the code and while cleaning them up, also decided to cache the
vmfunction table in a local to save repeated pointer chasing.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>