### PR TITLE
WIP: AArch64: Improve asynccheckEvaluator()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -453,9 +453,8 @@ J9::ARM64::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::CodeGenerator 
    TR::Node *firstChild = testNode->getFirstChild();
    TR::Register *src1Reg = cg->evaluate(firstChild);
    TR::Node *secondChild = testNode->getSecondChild();
-   TR::Register *src2Reg = cg->evaluate(secondChild);
 
-   TR_ASSERT(testNode->getOpCodeValue() == TR::lcmpeq, "asynccheck bad format");
+   TR_ASSERT(testNode->getOpCodeValue() == TR::lcmpeq && secondChild->getLongInt() == -1L, "asynccheck bad format");
 
    TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
@@ -463,9 +462,7 @@ J9::ARM64::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::CodeGenerator 
    TR::Snippet *snippet = new (cg->trHeapMemory()) TR::ARM64HelperCallSnippet(cg, node, snippetLabel, asynccheckHelper, doneLabel);
    cg->addSnippet(snippet);
 
-   // ToDo:
-   // Optimize this using "cmp (immediate)" instead of "cmp (register)" when possible
-   generateCompareInstruction(cg, node, src1Reg, src2Reg, true); // 64-bit compare
+   generateCompareImmInstruction(cg, node, src1Reg, secondChild->getLongInt(), true); // 64-bit compare
 
    TR::Instruction *gcPoint = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, snippetLabel, TR::CC_EQ);
    gcPoint->ARM64NeedsGCMap(cg, 0xFFFFFFFF);


### PR DESCRIPTION
This commit removes one instruction from the code generated by
asynccheckEvaluator() for AArch64.
(mov regY, #-1 + cmp regX, regY -> cmn regX, #1)

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>