### PR TITLE
Collect stats about sizes of different types of messages sent in JITServer

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -26,6 +26,9 @@
 #include "control/JITServerCompilationThread.hpp"
 #include "control/MethodToBeCompiled.hpp"
 #include "infra/CriticalSection.hpp"
+#include "infra/Statistics.hpp"
+#include "net/CommunicationStream.hpp"
+
 
 
 uint32_t     JITServerHelpers::serverMsgTypeCount[] = {};
@@ -123,12 +126,22 @@ JITServerHelpers::printJITServerMsgStats(J9JITConfig *jitConfig)
    int totalMsgCount = 0;	   
    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
    j9tty_printf(PORTLIB, "JITServer Message Type Statistics:\n");
-   j9tty_printf(PORTLIB, "Type# #called TypeName\n");
+   j9tty_printf(PORTLIB, "Type# #called");
+#ifdef MESSAGE_SIZE_STATS
+   j9tty_printf(PORTLIB, "\t\tMax\t\tMin\t\tMean\t\tStdDev\t\tSum");
+#endif
+   j9tty_printf(PORTLIB, "\t\tTypeName\n");
    for (int i = 0; i < JITServer::MessageType_ARRAYSIZE; ++i)
       {
       if (JITServerHelpers::serverMsgTypeCount[i] > 0)
          {
-         j9tty_printf(PORTLIB, "#%04d %7u %s\n", i, JITServerHelpers::serverMsgTypeCount[i], JITServer::messageNames[i]);
+         j9tty_printf(PORTLIB, "#%04d %7u", i, JITServerHelpers::serverMsgTypeCount[i]);
+#ifdef MESSAGE_SIZE_STATS            
+         j9tty_printf(PORTLIB, "\t%f\t%f\t%f\t%f\t%f", JITServer::CommunicationStream::collectMsgStat[i].maxVal(), 
+                     JITServer::CommunicationStream::collectMsgStat[i].minVal(), JITServer::CommunicationStream::collectMsgStat[i].mean(),
+                     JITServer::CommunicationStream::collectMsgStat[i].stddev(), JITServer::CommunicationStream::collectMsgStat[i].sum());
+#endif
+         j9tty_printf(PORTLIB, "\t\t%s\n", JITServer::messageNames[i]);
          totalMsgCount += JITServerHelpers::serverMsgTypeCount[i];
          }
       }

--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -29,6 +29,9 @@
 namespace JITServer
 {
 uint32_t CommunicationStream::CONFIGURATION_FLAGS = 0;
+#ifdef MESSAGE_SIZE_STATS
+TR_Stats JITServer::CommunicationStream::collectMsgStat[];
+#endif
 
 void
 CommunicationStream::initConfigurationFlags()
@@ -73,6 +76,11 @@ CommunicationStream::readMessage(Message &msg)
 
    // rebuild the message
    msg.deserialize();
+
+   // collect message size
+#ifdef MESSAGE_SIZE_STATS
+   collectMsgStat[int(msg.type())].update(messageSize);
+#endif
    }
 
 void

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -28,6 +28,7 @@
 #include <openssl/err.h>
 #include "net/LoadSSLLibs.hpp"
 #include "net/Message.hpp"
+#include "infra/Statistics.hpp"
 
 
 namespace JITServer
@@ -43,6 +44,10 @@ class CommunicationStream
 public:
    static bool useSSL();
    static void initSSL();
+   
+#ifdef MESSAGE_SIZE_STATS
+   static TR_Stats collectMsgStat[JITServer::MessageType_ARRAYSIZE];
+#endif
 
    static void initConfigurationFlags();
 


### PR DESCRIPTION
I'm keeping track of the size of different types of messages sent using msg.type()
and I'm using the class TR_Stats to store avg,min,max and stddev of every type of message.
issue: #9708

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>