### PR TITLE
Sampling allocation bytes precisely - step1

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -178,6 +178,28 @@ public:
 	 * @return TRUE if inline TLH allocates currently enabled for this thread; FALSE otherwise
 	 */
 	bool isInlineTLHAllocateEnabled();
+
+	/**
+	 * Set TLH Sampling Top by hiding the real heap top address from
+	 * JIT/Interpreter in realHeapTop and setting HeapTop = (HeapAlloc + size) if size < (HeapTop - HeapAlloc)
+	 * so out of line allocate would happen at TLH Sampling Top.
+	 * If size >= (HeapTop - HeapAlloc) resetTLHSamplingTop()
+	 *
+	 * @param size the number of bytes to next sampling point
+	 */
+	void setTLHSamplingTop(uintptr_t size) {}
+
+	/**
+	 * Restore heapTop from realHeapTop if realHeapTop != NULL
+	 */
+	void resetTLHSamplingTop() {}
+
+	/**
+	 * Retrieve allocation size inside TLH Cache.
+	 * @return (heapAlloc - heapBase)
+	 */
+	uintptr_t getAllocatedSizeInsideTLH() { return 0; }
+
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 
 	MM_EnvironmentDelegate()

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2771,6 +2771,7 @@ typedef struct J9GCThreadInfo {
 typedef struct J9ModronThreadLocalHeap {
 	U_8* heapBase;
 	U_8* realHeapAlloc;
+	U_8* realHeapTop;
 	UDATA objectFlags;
 	UDATA refreshSize;
 	void* memorySubSpace;


### PR DESCRIPTION
Introduce APIs and fields needed by OMR's for allocation sampling.

related: https://github.com/eclipse/openj9/issues/7740

Signed-off-by: Lin Hu <linhu@ca.ibm.com>