### PR TITLE
JIT support for re-sizable SCC

### DIFF
--- a/doc/features/SharedClassesCache.md
+++ b/doc/features/SharedClassesCache.md
@@ -1,0 +1,57 @@
+<!--
+Copyright (c) 2019, 2020 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+The Shared Classes Cache (SCC) is a feature of OpenJ9 that enables sharing 
+data between JVMs. For more information see [1].
+
+## JIT
+
+The JIT Compiler uses the SCC to store both AOT code as well as data either
+necessary for AOT 
+(e.g. [Class Chains](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/ClassChains.md)),
+or for performace (e.g. IProfiler data). The JIT interfaces with the SCC via
+the `TR_J9SharedCache` class.
+
+### Offsets
+
+When data that is stored into the SCC needs to refer to other data, it is
+referred to by using offsets. Traditionally, the offset would always be
+relative to the start of the SCC. However, if the SCC is resized, only 
+offsets of data in the ROM Class section of the SCC will be invariant. 
+Therefore, offsets of all data, which must be in the metadata section,
+are calculated relative to the start of the metadata section. Another 
+point of clarification is that offsets of data within the ROMClass section 
+is calculated using the start of the ROMClass section as no ROM Structure 
+pointer should point before the start of the section. The offsets that
+are generated and stored as part of relocation information are first
+left shifted 1 bit; the low bit is used to determine whether the offset
+is relative to the start of the ROM Class section or the start of the
+metadata section.
+
+The APIs in in `TR_J9SharedCache` provide an abstraction layer so that
+other parts of the compiler do not need to worry about the details. 
+However, it is important that one does not use the offsets directly, but
+only via the `TR_J9SharedCache` class.
+
+<hr/>
+
+[1] https://www.eclipse.org/openj9/docs/shrc/ 

--- a/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/aarch64/codegen/J9AheadOfTimeCompile.cpp
@@ -75,8 +75,8 @@ void J9::ARM64::AheadOfTimeCompile::processRelocations()
          TR::SymbolValidationManager *svm =
             self()->comp()->getSymbolValidationManager();
          void *offsets = const_cast<void*>(svm->wellKnownClassChainOffsets());
-         *(uintptr_t *)relocationDataCursor = reinterpret_cast<uintptr_t>(
-            fej9->sharedCache()->offsetInSharedCacheFromPointer(offsets));
+         *(uintptr_t *)relocationDataCursor =
+            self()->offsetInSharedCacheFromPointer(fej9->sharedCache(), offsets);
          relocationDataCursor += SIZEPOINTER;
          }
 
@@ -681,7 +681,7 @@ uint8_t *J9::ARM64::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
          J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
-         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
+         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromROMMethod(sharedCache, romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
          binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -64,7 +64,31 @@ J9::AheadOfTimeCompile::offsetInSharedCacheFromPointer(TR_SharedCache *sharedCac
    if (sharedCache->isPointerInSharedCache(ptr, &offset))
       return offset;
    else
-      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find pointer in SCC");
+      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find pointer %p in SCC", ptr);
+
+   return offset;
+   }
+
+uintptr_t
+J9::AheadOfTimeCompile::offsetInSharedCacheFromROMClass(TR_SharedCache *sharedCache, J9ROMClass *romClass)
+   {
+   uintptr_t offset = 0;
+   if (sharedCache->isROMClassInSharedCache(romClass, &offset))
+      return offset;
+   else
+      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find romClass %p in SCC", romClass);
+
+   return offset;
+   }
+
+uintptr_t
+J9::AheadOfTimeCompile::offsetInSharedCacheFromROMMethod(TR_SharedCache *sharedCache, J9ROMMethod *romMethod)
+   {
+   uintptr_t offset = 0;
+   if (sharedCache->isROMMethodInSharedCache(romMethod, &offset))
+      return offset;
+   else
+      self()->comp()->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find romMethod %p in SCC", romMethod);
 
    return offset;
    }

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -406,8 +406,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
             }
 
          TR_OpaqueClassBlock *inlinedMethodClass = resolvedMethod->containingClass();
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(inlinedMethodClass));
-         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romClass);
+         J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedMethodClass));
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
 
          imRecord->setReloFlags(reloTarget, flags);
          imRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
@@ -429,8 +429,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uintptr_t inlinedSiteIndex = reinterpret_cast<uintptr_t>(relocation->getTargetAddress());
          TR::AOTClassInfo *aotCI = reinterpret_cast<TR::AOTClassInfo*>(relocation->getTargetAddress2());
 
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(aotCI->_clazz));
-         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romClass);
+         J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(aotCI->_clazz));
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
 
          vsfRecord->setInlinedSiteIndex(reloTarget, inlinedSiteIndex);
          vsfRecord->setConstantPool(reloTarget, reinterpret_cast<uintptr_t>(aotCI->_constantPool));
@@ -472,8 +472,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          TR_ResolvedMethod *inlinedMethod = ((TR_AOTMethodInfo *)ics._methodInfo)->resolvedMethod;
          TR_OpaqueClassBlock *inlinedCodeClass = reinterpret_cast<TR_OpaqueClassBlock *>(inlinedMethod->classOfMethod());
 
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass));
-         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romClass);
+         J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(inlinedCodeClass));
+         uintptr_t romClassOffsetInSharedCache = self()->offsetInSharedCacheFromROMClass(sharedCache, romClass);
          traceMsg(comp, "class is %p, romclass is %p, offset is %llu\n", inlinedCodeClass, romClass, romClassOffsetInSharedCache);
 
          uintptr_t classChainIdentifyingLoaderOffsetInSharedCache = sharedCache->getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(inlinedCodeClass);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -112,7 +112,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
     *
     * @param sharedCache pointer to the TR_SharedCache object
     * @param ptr pointer whose offset in the SCC is required
-    * @return he offset into the SCC of ptr
+    * @return The offset into the SCC of ptr
     */
    uintptr_t offsetInSharedCacheFromPointer(TR_SharedCache *sharedCache, void *ptr);
    };

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -68,10 +68,9 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
    static bool classAddressUsesReloRecordInfo() { return false; }
 
    protected:
+
    /**
-    * @brief Wrapper around TR_J9SharedCache::isPointerInSharedCache
-    *
-    * TR_J9SharedCache::offsetInSharedCacheFromPointer asserts if the pointer
+    * @brief TR_J9SharedCache::offsetInSharedCacheFrom* asserts if the pointer
     * passed in does not exist in the SCC. Under HCR, when an agent redefines
     * a class, it causes the J9Class pointer to stay the same, but the
     * J9ROMClass pointer changes. This means that if the compiler has a
@@ -85,7 +84,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
     *
     * Calling TR_J9SharedCache::offsetInSharedCacheFromPointer after such a
     * redefinition could result in an assert. Therefore, this method exists as
-    * a wrapper around TR_J9SharedCache::isPointerInSharedCache which doesn't
+    * a wrapper around TR_J9SharedCache::isROMClassInSharedCache which doesn't
     * assert and conveniently, updates the location referred to by the cacheOffset
     * pointer passed in as a parameter.
     *
@@ -93,8 +92,27 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
     * compilation. If the ptr is in the SCC, then the cacheOffset will be updated.
     *
     * @param sharedCache pointer to the TR_SharedCache object
+    * @param romClass J9ROMClass * whose offset in the SCC is required
+    * @return The offset into the SCC of romClass
+    */
+   uintptr_t offsetInSharedCacheFromROMClass(TR_SharedCache *sharedCache, J9ROMClass *romClass);
+
+   /**
+    * @brief Same circumstance as offsetInSharedCacheFromROMClass above
+    *
+    * @param sharedCache pointer to the TR_SharedCache object
+    * @param romMethod J9ROMMethod * whose offset in the SCC is required
+    * @return The offset into the SCC of romMethod
+    */
+   uintptr_t offsetInSharedCacheFromROMMethod(TR_SharedCache *sharedCache, J9ROMMethod *romMethod);
+
+   /**
+    * @brief Wrapper around TR_J9SharedCache::offsetInSharedCacheFromPointer for
+    *        consistency with the above APIs
+    *
+    * @param sharedCache pointer to the TR_SharedCache object
     * @param ptr pointer whose offset in the SCC is required
-    * @return The offset into the SCC of ptr
+    * @return he offset into the SCC of ptr
     */
    uintptr_t offsetInSharedCacheFromPointer(TR_SharedCache *sharedCache, void *ptr);
    };

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7242,7 +7242,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
             !TR::CompilationInfo::isCompiled(method) &&
             !entry->isDLTCompile() &&
             !entry->_doNotUseAotCodeFromSharedCache &&
-            fe->sharedCache()->isPointerInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) &&
+            fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) &&
             !isMethodIneligibleForAot(method) &&
             (!TR::Options::getAOTCmdLineOptions()->getOption(TR_AOTCompileOnlyFromBootstrap) ||
                fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)method), true) &&

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -460,7 +460,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
          // been created before options were processed.
          TR_J9SharedCache *sc = TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache();
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT) && defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-         if (TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isPointerInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass))
+         if (TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass))
             {
             PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
             I_64 sharedQueryTime = 0;
@@ -623,7 +623,7 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       int32_t sigLen = sprintf(buf, "%.*s.%.*s%.*s", className->length, utf8Data(className), name->length, utf8Data(name), signature->length, utf8Data(signature));
       printf("Initial: Signature %s Count %d isLoopy %d isAOT %lu is in SCC %d SCCContainsProfilingInfo %d \n",buf,TR::CompilationInfo::getInvocationCount(method),J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod),
             TR::Options::sharedClassCache() ? jitConfig->javaVM->sharedClassConfig->existsCachedCodeForROMMethod(vmThread, romMethod) : 0,
-            TR::Options::sharedClassCache() ? TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isPointerInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) : 0,containsInfo) ; fflush(stdout);
+            TR::Options::sharedClassCache() ? TR_J9VMBase::get(jitConfig, vmThread, TR_J9VMBase::AOT_VM)->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(method)->romClass) : 0,containsInfo) ; fflush(stdout);
       }
    }
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1864,7 +1864,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          // Collect AOT stats
          TR_ResolvedJ9Method *resolvedMethod = std::get<0>(methodInfo).remoteMirror;
 
-         isRomClassForMethodInSC = fe->sharedCache()->isPointerInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass);
+         isRomClassForMethodInSC = fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass);
 
          J9Class *j9clazz = (J9Class *) J9_CLASS_FROM_CP(((J9RAMConstantPoolItem *) J9_CP_FROM_METHOD(((J9Method *)j9method))));
          TR_OpaqueClassBlock *clazzOfInlinedMethod = fe->convertClassPtrToClassOffset(j9clazz);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1196,7 +1196,7 @@ TR_J9SharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR
    if (comp)
       {
       /*
-       * TR_J9SharedCache::offsetInSharedCacheFromPointer asserts if the pointer
+       * TR_J9SharedCache::offsetInSharedCacheFrom* asserts if the pointer
        * passed in does not exist in the SCC. Under HCR, when an agent redefines
        * a class, it causes the J9Class pointer to stay the same, but the
        * J9ROMClass pointer changes. This means that if the compiler has a
@@ -1218,7 +1218,7 @@ TR_J9SharedCache::getClassChainOffsetOfIdentifyingLoaderForClazzInSharedCache(TR
        * compilation. If the ptr is in the SCC, then the cacheOffset will be updated.
        */
       if (!isPointerInSharedCache(classChainIdentifyingLoaderForClazz, &classChainOffsetInSharedCache))
-         comp->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find pointer in SCC");
+         comp->failCompilation<J9::ClassChainPersistenceFailure>("Failed to find pointer %p in SCC", classChainIdentifyingLoaderForClazz);
       }
    else
       {

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -748,8 +748,7 @@ TR_J9SharedCache::startingROMClassOfClassChain(UDATA *classChain)
    TR_ASSERT_FATAL(lengthInBytes >= 2 * sizeof (UDATA), "class chain is too short!");
 
    UDATA romClassOffset = classChain[1];
-   void *romClass = pointerFromOffsetInSharedCache(romClassOffset);
-   return static_cast<J9ROMClass*>(romClass);
+   return romClassFromOffsetInSharedCache(romClassOffset);
    }
 
 // convert an offset into a string of 8 characters
@@ -1171,7 +1170,7 @@ TR_OpaqueClassBlock *
 TR_J9SharedCache::lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader)
    {
    UDATA *ptrToRomClassOffset = chainData+1;
-   J9ROMClass *romClass = (J9ROMClass *)pointerFromOffsetInSharedCache(*ptrToRomClassOffset);
+   J9ROMClass *romClass = romClassFromOffsetInSharedCache(*ptrToRomClassOffset);
    J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
    J9VMThread *vmThread = fej9->getCurrentVMThread();

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -783,7 +783,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    LOG(1, "rememberClass class %p romClass %p %.*s\n", clazz, romClass, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 
    uintptr_t classOffsetInCache;
-   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
+   if (!isROMClassInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(1,"\trom class not in shared cache, returning\n");
       return NULL;
@@ -913,7 +913,7 @@ bool
 TR_J9SharedCache::writeClassToChain(J9ROMClass *romClass, UDATA * & chainPtr)
    {
    uintptr_t classOffsetInCache;
-   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
+   if (!isROMClassInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(3, "\t\tromclass %p not in shared cache, writeClassToChain returning false\n", romClass);
       return false;
@@ -987,7 +987,7 @@ TR_J9SharedCache::romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & c
    {
    J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
    UDATA romClassOffset;
-   if (!isPointerInSharedCache(romClass, &romClassOffset))
+   if (!isROMClassInSharedCache(romClass, &romClassOffset))
       return false;
    LOG(3, "\t\tExamining romclass %p (%.*s) offset %d, comparing to %d\n", romClass, J9UTF8_LENGTH(className), J9UTF8_DATA(className), romClassOffset, *chainPtr);
    if ((chainPtr > chainEnd) || (romClassOffset != *chainPtr++))
@@ -1093,7 +1093,7 @@ TR_J9SharedCache::classMatchesCachedVersion(J9Class *clazz, UDATA *chainData)
    /* If the pointer isn't the SCC, then return false immmediately
     * as the map holds offsets into the SCC of romclasses
     */
-   if (!isPointerInSharedCache(romClass, &classOffsetInCache))
+   if (!isROMClassInSharedCache(romClass, &classOffsetInCache))
       {
       LOG(1, "\tclass not in shared cache, returning false\n");
       return false;

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -75,7 +75,7 @@ public:
    virtual bool isMostlyFull();
 
    /**
-    * \brief Converts a shared cache offset into a pointer.
+    * \brief Converts a shared cache offset into the metadata section of the SCC into a pointer.
     *
     * \param[in] offset The offset to convert.
     * \return A pointer. Raises a fatal assertion before returning NULL if the offset is invalid.
@@ -83,12 +83,61 @@ public:
    virtual void *pointerFromOffsetInSharedCache(uintptr_t offset);
 
    /**
-    * \brief Converts a pointer into the shared cache into an offset.
+    * \brief Converts a pointer into the metadata section of the SCC into an offset.
     *
     * \param[in] ptr The pointer to convert.
     * \return An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
     */
    virtual uintptr_t offsetInSharedCacheFromPointer(void *ptr);
+
+   /**
+    * \brief Converts an offset into the ROMClass section into a J9ROMClass *.
+    *
+    * \param[in] offset The offset to convert.
+    * \return A J9ROMClass *. Raises a fatal assertion before returning NULL if the offset is invalid.
+    */
+   virtual J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset);
+
+   /**
+    * \brief Converts a J9ROMClass * pointer into the SCC into an offset.
+    *
+    * \param[in] romClass The J9ROMClass * to convert
+    * \return An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
+    */
+   virtual uintptr_t offsetInSharedCacheFromROMClass(J9ROMClass *romClass);
+
+   /**
+    * \brief Converts an offset into the ROMClass section into a J9ROMMethod *.
+    *
+    * \param[in] offset The offset to convert
+    * \return A J9ROMMethod *. Raises a fatal assertion before returning NULL if the offset is invalid.
+    */
+   virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset);
+
+   /**
+    * \brief Converts a J9ROMMethod * pointer into the SCC into an offset.
+    *
+    * \param[in] romMethod The J9ROMMethod * to convert
+    * \return An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
+    */
+   virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod);
+
+   /**
+    * \brief Converts an offset into the ROMClass section into a pointer.
+    *
+    * \param[in] offset The offset to convert
+    * \return A pointer. Raises a fatal assertion before returning NULL if the offset is invalid.
+    */
+   virtual void *ptrToROMClassesSectionFromOffsetInSharedCache(uintptr_t offset);
+
+   /**
+    * \brief Converts a pointer into the ROM Classes section of the SCC into an offset.
+    *
+    * \param[in] ptr The pointer to convert
+    * \return  An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
+    */
+   virtual uintptr_t offsetInSharedCacheFromPtrToROMClassesSection(void *ptr);
+
 
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp);
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp);
@@ -117,22 +166,101 @@ public:
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader);
 
    /**
-    * \brief Checks whether the specified pointer points into the shared cache.
+    * \brief Checks whether the specified pointer points into the metadata section
+    *        of the shared cache.
     *
     * \param[in] ptr The pointer to check.
-    * \param[out] cacheOffset If ptr points into the shared cache and this parameter is not NULL the result of converting ptr into an offset will be returned here. If ptr does not point into the shared cache this parameter is ignored.
+    * \param[out] cacheOffset If ptr points into the shared cache and this parameter
+    *             is not NULL the result of converting ptr into an offset will be
+    *             returned here. If ptr does not point into the shared cache this
+    *             parameter is ignored.
     * \return True if the pointer points into the shared cache, false otherwise.
     */
    virtual bool isPointerInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL);
 
    /**
-    * \brief Checks whether the specified offset is within the shared cache.
+    * \brief Checks whether the specified offset is within the metadata section
+    *        of the shared cache.
     *
     * \param[in] offset The offset to check.
-    * \param[out] ptr If offset is within the shared cache and this parameter is not NULL the result of converting offset into a pointer will be returned here. If offset is not within the shared cache this parameter is ignored.
+    * \param[out] ptr If offset is within the shared cache and this parameter is not
+    *             NULL the result of converting offset into a pointer will be returned
+    *             here. If offset is not within the shared cache this parameter is ignored.
     * \return True if the offset is within the shared cache, false otherwise.
     */
    virtual bool isOffsetInSharedCache(uintptr_t offset, void *ptr = NULL);
+
+   /**
+    * \brief Checks whether the specified J9ROMClass exists in the SCC
+    *
+    * \param[in] romClass The J9ROMClass * to check
+    * \param[out] cacheOffset If the J9ROMClass is in the SCC and this parameter
+    *             is not NULL the result of converting romClass into an offset will
+    *             be returned here. If romClass does not point into the SCC, this
+    *             parameter is ignored.
+    * \return True if romClass points into the SCC, false otherwise.
+    */
+   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL);
+
+   /**
+    * \brief Checks whether the specified offset is within the ROMClass section
+    *        of the shared cache.
+    *
+    * \param[in] offset The offset to check
+    * \param[out] romClass If offset is within the shared cache and this parameter is not
+    *             NULL the result of converting offset into a J9ROMClass * will be returned
+    *             here. If offset is not within the shared cache this parameter is ignored.
+    * \return True if the offset is within the shared cache, false otherwise.
+    */
+   virtual bool isROMClassOffsetInSharedCache(uintptr_t offset, J9ROMClass **romClassPtr = NULL);
+
+   /**
+    * \brief Checks whether the specified J9ROMMethod exists in the SCC
+    *
+    * \param[in] romMethod The J9ROMMethod * to check
+    * \param[out] cacheOffset If the J9ROMMethod is in the SCC and this parameter
+    *             is not NULL the result of converting romMethod into an offset will
+    *             be returned here. If romMethod does not point into the SCC, this
+    *             parameter is ignored.
+    * \return True if romMethod points into the SCC, false otherwise.
+    */
+   virtual bool isROMMethodInSharedCache(J9ROMMethod *romMethod, uintptr_t *cacheOffset = NULL);
+
+   /**
+    * \brief Checks whether the specified offset is within the ROMClass section
+    *        of the shared cache.
+    * \param[in] offset The offset to check
+    * \param[out] romMethodPtr If offset is within the shared cache and this parameter is not
+    *             NULL the result of converting offset into a J9ROMMethod * will be returned
+    *             here. If offset is not within the shared cache this parameter is ignored.
+    * \return True if the offset is within the shared cache, false otherwise.
+    */
+   virtual bool isROMMethodOffsetInSharedCache(uintptr_t offset, J9ROMMethod **romMethodPtr = NULL);
+
+   /**
+    * \brief Checks whether the specified pointer points into the ROMClass section
+    *        of the shared cache.
+    *
+    * \param[in] ptr The pointer to check
+    * \param[out] cacheOffset If ptr points into the shared cache and this parameter
+    *             is not NULL the result of converting ptr into an offset will be
+    *             returned here. If ptr does not point into the shared cache this
+    *             parameter is ignored.
+    * \return True if the pointer points into the shared cache, false otherwise.
+    */
+   virtual bool isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL);
+
+   /**
+    * \brief Checks whether the specified offset is within the ROMClass section
+    *        of the shared cache.
+    *
+    * \param[in] offset The offset to check.
+    * \param[out] ptr If offset is within the shared cache and this parameter is not
+    *             NULL the result of converting offset into a pointer will be returned
+    *             here. If offset is not within the shared cache this parameter is ignored.
+    * \return True if the offset is within the shared cache, false otherwise.
+    */
+   virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL);
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
 
@@ -207,6 +335,47 @@ private:
 
    bool romclassMatchesCachedVersion(J9ROMClass *romClass, UDATA * & chainPtr, UDATA *chainEnd);
    UDATA *findChainForClass(J9Class *clazz, const char *key, uint32_t keyLength);
+
+   /**
+    * \brief Helper Method; Converts an offset into the ROMClass section into a pointer.
+    *
+    * \param offset The offset to convert
+    * \return A pointer. Raises a fatal assertion before returning NULL if the offset is invalid.
+    */
+   void *romStructureFromOffsetInSharedCache(uintptr_t offset);
+
+   /**
+    * \brief Converts a pointer into the ROMClass section of the SCC into an offset.
+    *
+    * \param[in] romStructure The pointer to convert.
+    * \return An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
+    */
+   uintptr_t offsetInSharedcacheFromROMStructure(void *romStructure);
+
+   /**
+    * \brief Checks whether the specified pointer points into the ROMClass section
+    *        of the shared cache.
+    *
+    * \param[in] romStructure The pointer to check
+    * \param[out] cacheOffset If romStructure points into the shared cache and this parameter
+    *             is not NULL the result of converting romStructure into an offset will be
+    *             returned here. If romStructure does not point into the shared cache this
+    *             parameter is ignored.
+    * \return True if the pointer points into the shared cache, false otherwise.
+    */
+   bool isROMStructureInSharedCache(void *romStructure, uintptr_t *cacheOffset = NULL);
+
+   /**
+    * \brief Checks whether the specified offset is within the ROMClass section
+    *        of the shared cache.
+    *
+    * \param[in] offset The offset to check.
+    * \param[out] romStructurePtr If offset is within the shared cache and this parameter is not
+    *             NULL the result of converting offset into a pointer will be returned
+    *             here. If offset is not within the shared cache this parameter is ignored.
+    * \return True if the offset is within the shared cache, false otherwise.
+    */
+   bool isROMStructureOffsetInSharedCache(uintptr_t offset, void **romStructurePtr = NULL);
 
    /**
     * @brief Validates the provided class chain. This method modifies the chainPtr arg.

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -23,6 +23,7 @@
 #ifndef SHARED_CACHE_HPP
 #define SHARED_CACHE_HPP
 
+#include "j9.h"
 #include "env/jittypes.h"
 
 class TR_PersistentClassLoaderTable;
@@ -43,8 +44,23 @@ public:
 
    virtual void *pointerFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
    virtual uintptr_t offsetInSharedCacheFromPointer(void *ptr) { return 0; }
-
    virtual bool isPointerInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) { return false; }
+   virtual bool isOffsetInSharedCache(uintptr_t offset, void *ptr = NULL) { return false; }
+
+   virtual J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
+   virtual uintptr_t offsetInSharedCacheFromROMClass(J9ROMClass *romClass) { return 0; }
+   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL) { return false; }
+   virtual bool isROMClassOffsetInSharedCache(uintptr_t offset, J9ROMClass **romClassPtr = NULL) { return false; }
+
+   virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
+   virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod) { return 0; }
+   virtual bool isROMMethodInSharedCache(J9ROMMethod *romMethod, uintptr_t *cacheOffset = NULL) { return false; }
+   virtual bool isROMMethodOffsetInSharedCache(uintptr_t offset, J9ROMMethod **romMethodPtr = NULL) { return false; }
+
+   virtual void *ptrToROMClassesSectionFromOffsetInSharedCache(uintptr_t offset) { return NULL; }
+   virtual uintptr_t offsetInSharedCacheFromPtrToROMClassesSection(void *ptr) { return 0; }
+   virtual bool isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) { return false; }
+   virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL) { return false; }
 
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *cinaData, void *loader) { return NULL; }
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1130,7 +1130,7 @@ static intptr_t getInitialCountForMethod(TR_ResolvedMethod *rm, TR::Compilation 
       J9ROMClass *romClass = m->romClassPtr();
       J9ROMMethod *romMethod = m->romMethod();
 
-      if (!comp->fej9()->sharedCache()->isPointerInSharedCache(romClass))
+      if (!comp->fej9()->sharedCache()->isROMClassInSharedCache(romClass))
          {
 #if defined(J9ZOS390)
           // Do not change the counts on zos at the moment since the shared cache capacity is higher on this platform
@@ -2215,7 +2215,7 @@ TR_ResolvedRelocatableJ9Method::createResolvedMethodFromJ9Method(TR::Compilation
          isSystemClassLoader = ((void*)_fe->vmThread()->javaVM->systemClassLoader->classLoaderObject ==  (void*)_fe->getClassLoader(clazzOfInlinedMethod));
          }
 
-      bool methodInSCC = _fe->sharedCache()->isPointerInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass);
+      bool methodInSCC = _fe->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass);
       if (methodInSCC)
          {
          bool sameLoaders = false;

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1612,7 +1612,7 @@ TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(TR_Resolved
             isSystemClassLoader = ((void*)fej9->vmThread()->javaVM->systemClassLoader->classLoaderObject ==  (void*)fej9->getClassLoader(clazzOfInlinedMethod));
             }
 
-         if (fej9->sharedCache()->isPointerInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass))
+         if (fej9->sharedCache()->isROMClassInSharedCache(J9_CLASS_FROM_METHOD(j9method)->romClass))
             {
             bool sameLoaders = false;
             TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -852,7 +852,7 @@ uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
          J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
-         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
+         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromROMMethod(sharedCache, romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
          binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3146,10 +3146,10 @@ TR_IPBCDataCallGraph::loadFromPersistentCopy(TR_IPBCDataStorageHeader * storage,
       if (store->_csInfo.getClazz(i))
          {
          J9Class *ramClass = NULL;
-         uintptr_t romClass = 0;
+         J9ROMClass *romClass = 0;
 
          uintptr_t csInfoClazzOffset = store->_csInfo.getClazz(i);
-         if (comp->fej9()->sharedCache()->isOffsetInSharedCache(csInfoClazzOffset, &romClass))
+         if (comp->fej9()->sharedCache()->isROMClassOffsetInSharedCache(csInfoClazzOffset, &romClass))
             ramClass = ((TR_J9VM *)comp->fej9())->matchRAMclassFromROMclass((J9ROMClass *)romClass, comp);
 
          if (ramClass)

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -398,9 +398,9 @@ TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol
       int32_t currentCount = resolvedMethod->getInvocationCount();
 
       // can only persist profile info if the method is in the shared cache
-      if (comp->fej9()->sharedCache()->isPointerInSharedCache(romMethod))
+      if (comp->fej9()->sharedCache()->isROMMethodInSharedCache(romMethod))
         {
-         TR_ASSERT(comp->fej9()->sharedCache()->isPointerInSharedCache((void *)methodStart), "bytecodes not in shared cache");
+         TR_ASSERT(comp->fej9()->sharedCache()->isPtrToROMClassesSectionInSharedCache((void *)methodStart), "bytecodes not in shared cache");
          // check if there is already an entry
          unsigned char storeBuffer[1000];
          uint32_t bufferLength = 1000;
@@ -1259,7 +1259,7 @@ TR_IProfiler::persistentProfilingSample(TR_OpaqueMethodBlock *method, uint32_t b
       void *methodStart = (void *)TR::Compiler->mtd.bytecodeStart(method);
 
       // can only persist profile info if the method is in the shared cache
-      if (!comp->fej9()->sharedCache()->isPointerInSharedCache(methodStart))
+      if (!comp->fej9()->sharedCache()->isPtrToROMClassesSectionInSharedCache(methodStart))
          return NULL;
 
       // check the shared cache
@@ -1332,7 +1332,7 @@ TR_IProfiler::persistentProfilingSample(TR_OpaqueMethodBlock *method, uint32_t b
       void *methodStart = (void *) TR::Compiler->mtd.bytecodeStart(method);
 
       // can only persist profile info if the method is in the shared cache
-      if (!comp->fej9()->sharedCache()->isPointerInSharedCache(methodStart))
+      if (!comp->fej9()->sharedCache()->isPtrToROMClassesSectionInSharedCache(methodStart))
          return NULL;
 
       *methodProfileExistsInSCC = true;
@@ -3062,7 +3062,7 @@ TR_IPBCDataCallGraph::canBePersisted(TR_J9SharedCache *sharedCache, TR::Persiste
             return IPBC_ENTRY_PERSIST_UNLOADED;
             }
 
-         if (!sharedCache->isPointerInSharedCache(clazz->romClass))
+         if (!sharedCache->isROMClassInSharedCache(clazz->romClass))
             {
             releaseEntry(); // release the lock on the entry
             return IPBC_ENTRY_PERSIST_NOTINSCC;
@@ -3111,7 +3111,7 @@ TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPB
              * performance, in order to prevent an issue in loadFromPersistentCopy, check again whether
              * the romClass is within the SCC.
              */
-            if (sharedCache->isPointerInSharedCache(clazz->romClass))
+            if (sharedCache->isROMClassInSharedCache(clazz->romClass))
                {
                store->_csInfo.setClazz(i, (uintptr_t)sharedCache->offsetInSharedCacheFromROMClass(clazz->romClass));
                TR_ASSERT(_csInfo.getClazz(i), "Race condition detected: cached value=%p, pc=%p", clazz, _pc);

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -1281,7 +1281,7 @@ TR_IProfiler::persistentProfilingSample(TR_OpaqueMethodBlock *method, uint32_t b
       *methodProfileExistsInSCC = true;
       // Compute the pc we are interested in
       uintptr_t pc = getSearchPC(method, byteCodeIndex, comp);
-      store = searchForPersistentSample(store, (uintptr_t)comp->fej9()->sharedCache()->offsetInSharedCacheFromPointer((void *)pc));
+      store = searchForPersistentSample(store, (uintptr_t)comp->fej9()->sharedCache()->offsetInSharedCacheFromPtrToROMClassesSection((void *)pc));
 
       if (TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableIprofilerChanges) || TR::Options::getJITCmdLineOptions()->getOption(TR_EnableIprofilerChanges))
          {
@@ -1337,7 +1337,7 @@ TR_IProfiler::persistentProfilingSample(TR_OpaqueMethodBlock *method, uint32_t b
 
       *methodProfileExistsInSCC = true;
       void *pc = (void *)getSearchPC(method, byteCodeIndex, comp);
-      store = searchForPersistentSample(store, (uintptr_t)comp->fej9()->sharedCache()->offsetInSharedCacheFromPointer(pc));
+      store = searchForPersistentSample(store, (uintptr_t)comp->fej9()->sharedCache()->offsetInSharedCacheFromPtrToROMClassesSection(pc));
       return store;
       }
    return NULL;
@@ -2627,7 +2627,7 @@ void
 TR_IPBCDataFourBytes::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info)
    {
    TR_IPBCDataFourBytesStorage * store = (TR_IPBCDataFourBytesStorage *) storage;
-   uintptr_t offset = (uintptr_t)sharedCache->offsetInSharedCacheFromPointer((void *)_pc);
+   uintptr_t offset = (uintptr_t)sharedCache->offsetInSharedCacheFromPtrToROMClassesSection((void *)_pc);
    TR_ASSERT_FATAL(offset <= UINT_MAX, "Offset too large for TR_IPBCDataFourBytes");
    storage->pc = (uint32_t)offset;
    storage->left = 0;
@@ -2676,7 +2676,7 @@ void
 TR_IPBCDataEightWords::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info)
    {
    TR_IPBCDataEightWordsStorage * store = (TR_IPBCDataEightWordsStorage *) storage;
-   uintptr_t offset = (uintptr_t)sharedCache->offsetInSharedCacheFromPointer((void *)_pc);
+   uintptr_t offset = (uintptr_t)sharedCache->offsetInSharedCacheFromPtrToROMClassesSection((void *)_pc);
    TR_ASSERT_FATAL(offset <= UINT_MAX, "Offset too large for TR_IPBCDataEightWords");
    storage->pc = (uint32_t)offset;
    storage->ID = TR_IPBCD_EIGHT_WORDS;
@@ -3077,7 +3077,7 @@ void
 TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info)
    {
    TR_IPBCDataCallGraphStorage * store = (TR_IPBCDataCallGraphStorage *) storage;
-   uintptr_t offset = (uintptr_t)sharedCache->offsetInSharedCacheFromPointer((void *)_pc);
+   uintptr_t offset = (uintptr_t)sharedCache->offsetInSharedCacheFromPtrToROMClassesSection((void *)_pc);
    TR_ASSERT_FATAL(offset <= UINT_MAX, "Offset too large for TR_IPBCDataCallGraph");
    storage->pc = (uint32_t)offset;
    storage->ID = TR_IPBCD_CALL_GRAPH;
@@ -3113,7 +3113,7 @@ TR_IPBCDataCallGraph::createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPB
              */
             if (sharedCache->isPointerInSharedCache(clazz->romClass))
                {
-               store->_csInfo.setClazz(i, (uintptr_t)sharedCache->offsetInSharedCacheFromPointer(clazz->romClass));
+               store->_csInfo.setClazz(i, (uintptr_t)sharedCache->offsetInSharedCacheFromROMClass(clazz->romClass));
                TR_ASSERT(_csInfo.getClazz(i), "Race condition detected: cached value=%p, pc=%p", clazz, _pc);
                }
             else

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2183,7 +2183,7 @@ TR_RelocationRecordInlinedMethod::print(TR_RelocationRuntime *reloRuntime)
    TR_RelocationTarget *reloTarget = reloRuntime->reloTarget();
    TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
    TR_RelocationRecordConstantPoolWithIndex::print(reloRuntime);
-   J9ROMClass *inlinedCodeRomClass = (J9ROMClass *)reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
+   J9ROMClass *inlinedCodeRomClass = reloRuntime->fej9()->sharedCache()->romClassFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
    J9UTF8 *inlinedCodeClassName = J9ROMCLASS_CLASSNAME(inlinedCodeRomClass);
    reloLogger->printf("\tromClassOffsetInSharedCache %x %.*s\n", romClassOffsetInSharedCache(reloTarget), inlinedCodeClassName->length, inlinedCodeClassName->data );
    //reloLogger->printf("\tromClassOffsetInSharedCache %x %.*s\n", romClassOffsetInSharedCache(reloTarget), J9UTF8_LENGTH(inlinedCodeClassname), J9UTF8_DATA(inlinedCodeClassName));
@@ -2345,8 +2345,8 @@ TR_RelocationRecordInlinedMethod::inlinedSiteValid(TR_RelocationRuntime *reloRun
       if (inlinedSiteIsValid)
          {
          /* Calculate the runtime rom class value from the code cache */
-         void *compileRomClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
-         void *currentRomClass = (void *)J9_CLASS_FROM_METHOD(currentMethod)->romClass;
+         J9ROMClass *compileRomClass = reloRuntime->fej9()->sharedCache()->romClassFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
+         J9ROMClass *currentRomClass = J9_CLASS_FROM_METHOD(currentMethod)->romClass;
 
          RELO_LOG(reloRuntime->reloLogger(), 6, "\tinlinedSiteValid: compileRomClass %p currentRomClass %p\n", compileRomClass, currentRomClass);
          if (compileRomClass == currentRomClass)
@@ -2804,7 +2804,7 @@ TR_RelocationRecordProfiledInlinedMethod::preparePrivateData(TR_RelocationRuntim
       }
    else
       {
-      J9ROMClass *inlinedCodeRomClass = (J9ROMClass *) reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
+      J9ROMClass *inlinedCodeRomClass = reloRuntime->fej9()->sharedCache()->romClassFromOffsetInSharedCache(romClassOffsetInSharedCache(reloTarget));
       J9UTF8 *inlinedCodeClassName = J9ROMCLASS_CLASSNAME(inlinedCodeRomClass);
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: inlinedCodeRomClass %p %.*s\n", inlinedCodeRomClass, inlinedCodeClassName->length, inlinedCodeClassName->data);
 
@@ -3787,7 +3787,7 @@ TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationR
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_beholderID);
 
    uintptr_t romMethodOffset = reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_romMethodOffsetInSCC);
-   void *romMethod = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romMethodOffset);
+   J9ROMMethod *romMethod = reloRuntime->fej9()->sharedCache()->romMethodFromOffsetInSharedCache(romMethodOffset);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
@@ -3799,7 +3799,7 @@ TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationR
       reloRuntime->reloLogger()->printf("\tapplyRelocation: romMethod %p\n", romMethod);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassAndSignatureRecord(methodID, definingClassID, lookupClassID, beholderID, static_cast<J9ROMMethod *>(romMethod)))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassAndSignatureRecord(methodID, definingClassID, lookupClassID, beholderID, romMethod))
       return 0;
    else
       return compilationAotClassReloFailure;

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3130,8 +3130,13 @@ TR_RelocationRecordValidateClass::applyRelocation(TR_RelocationRuntime *reloRunt
    bool verified = false;
    if (definingClass)
       {
-      void *classChain = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffsetInSharedCache(reloTarget));
-      verified = validateClass(reloRuntime, definingClass, classChain);
+      void *classChainOrROMClass;
+      if (isStaticFieldValidation())
+         classChainOrROMClass = reloRuntime->fej9()->sharedCache()->romClassFromOffsetInSharedCache(classChainOffsetInSharedCache(reloTarget));
+      else
+         classChainOrROMClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffsetInSharedCache(reloTarget));
+
+      verified = validateClass(reloRuntime, definingClass, classChainOrROMClass);
       }
 
    if (!verified)

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1348,6 +1348,8 @@ class TR_RelocationRecordValidateClass : public TR_RelocationRecordConstantPoolW
 
       virtual int32_t bytesInHeaderAndPayload();
 
+      virtual bool isStaticFieldValidation() { return false ; }
+
       void setClassChainOffsetInSharedCache(TR_RelocationTarget *reloTarget, uintptr_t classChainOffsetInSharedCache);
       uintptr_t classChainOffsetInSharedCache(TR_RelocationTarget *reloTarget);
 
@@ -1365,7 +1367,7 @@ class TR_RelocationRecordValidateInstanceField : public TR_RelocationRecordValid
    public:
       TR_RelocationRecordValidateInstanceField() {}
       TR_RelocationRecordValidateInstanceField(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordValidateClass(reloRuntime, record) {}
-      virtual char *name();
+      virtual char *name();      
 
    protected:
       virtual TR_OpaqueClassBlock *getClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, void *void_cp);
@@ -1381,6 +1383,8 @@ class TR_RelocationRecordValidateStaticField : public TR_RelocationRecordValidat
       virtual void print(TR_RelocationRuntime *reloRuntime);
 
       virtual int32_t bytesInHeaderAndPayload();
+
+      virtual bool isStaticFieldValidation() { return true; }
 
       void setRomClassOffsetInSharedCache(TR_RelocationTarget *reloTarget, uintptr_t romClassOffsetInSharedCache);
       uintptr_t romClassOffsetInSharedCache(TR_RelocationTarget *reloTarget);

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1021,12 +1021,45 @@ TR_SharedCacheRelocationRuntime::getProcessorDescriptionFromSCC(TR_FrontEnd *fe,
    return hdrInCache->processorDescription;
    }
 
+static void setAOTHeaderInvalid(TR_JitPrivateConfig *privateConfig)
+   {
+   TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
+   TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
+   privateConfig->aotValidHeader = TR_no;
+   TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_HEADER_INVALID);
+   }
+
 // This function currently does not rely on the object beyond the v-table override (compiled as static without any problems).
 // If this changes, we will need to look further into whether its users risk concurrent access.
 bool
 TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *curThread)
    {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+   bool cacheTooBig;
+   J9SharedClassCacheDescriptor *curCache = javaVM()->sharedClassConfig->cacheDescriptorList;
+#if defined(TR_TARGET_64BIT)
+   cacheTooBig = (curCache->cacheSizeBytes > 0x7FFFFFFFFFFFFFFF);
+#else
+   cacheTooBig = (curCache->cacheSizeBytes > 0x7FFFFFFF);
+#endif
+
+   /* We don't have to check all caches (in the multi-SCC case)
+    * as this check would have had to pass for all layers.
+    *
+    * That said, it is technically possible for there to be
+    * multiple layers such that it won't be possible for the JIT
+    * to encode the offsets, for example two layers if at least one
+    * of them was of size 0x7FFFFFFFFFFFFFFF. However, given that
+    * currently the max size of a SCC is 0x7FFFFFF8, it would
+    * require over 0x100000000 layers, which can safely be assumed
+    * to never be occur.
+    */
+   if (cacheTooBig)
+      {
+      incompatibleCache(J9NLS_RELOCATABLE_CODE_CACHE_TOO_BIG,
+                        "SCC is too big for the JIT to correctly encode offsets into it");
+      setAOTHeaderInvalid(static_cast<TR_JitPrivateConfig *>(jitConfig()->privateConfig));
+      return false;
+      }
 
    /* Look for an AOT header in the cache and see if this JVM is compatible */
 
@@ -1097,10 +1130,7 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
          }
 
       // not compatible, so stop looking and don't compile anything for cache
-      TR::Options::getAOTCmdLineOptions()->setOption(TR_NoStoreAOT);
-      TR::Options::getAOTCmdLineOptions()->setOption(TR_NoLoadAOT);
-      static_cast<TR_JitPrivateConfig *>(jitConfig()->privateConfig)->aotValidHeader = TR_no;
-      TR_J9SharedCache::setSharedCacheDisabledReason(TR_J9SharedCache::AOT_HEADER_INVALID);
+      setAOTHeaderInvalid(static_cast<TR_JitPrivateConfig *>(jitConfig()->privateConfig));
 
       // Generate a trace point
       Trc_JIT_IncompatibleAOTHeader(curThread);

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -679,7 +679,7 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
          J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
-         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
+         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromROMMethod(sharedCache, romMethod);
 
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
          binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -555,7 +555,7 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          // Store rom method to get name of method
          J9Method *methodToValidate = reinterpret_cast<J9Method *>(record->_method);
          J9ROMMethod *romMethod = static_cast<TR_J9VM *>(fej9)->getROMMethodFromRAMMethod(methodToValidate);
-         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromPointer(sharedCache, romMethod);
+         uintptr_t romMethodOffsetInSharedCache = self()->offsetInSharedCacheFromROMMethod(sharedCache, romMethod);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
          binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_lookupClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_lookupClass));

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -232,6 +232,14 @@ J9NLS_RELOCATABLE_CODE_CMPRS_REF_SHIFT_MISMATCH.user_response=Destroy and recrea
 J9NLS_RELOCATABLE_CODE_CMPRS_REF_SHIFT_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
 # END NON-TRANSLATABLE
 
+J9NLS_RELOCATABLE_CODE_CACHE_TOO_BIG=The SCC is too big for the JIT to correctly encode offsets. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_CACHE_TOO_BIG.explanation=The SCC is too big for the JIT to correctly encode offsets.
+J9NLS_RELOCATABLE_CODE_CACHE_TOO_BIG.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_CACHE_TOO_BIG.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_CACHE_TOO_BIG.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE
+
 
 J9NLS_RELOCATABLE_CODE_UNKNOWN_PROBLEM=Unknown Problem. Ignoring AOT code in shared class cache.
 # START NON-TRANSLATABLE


### PR DESCRIPTION
Once https://github.com/eclipse/openj9/issues/7494 is implemented, the metadata section of the SCC will be moved if the SCC is resized. This means that any pointers into that section that the JIT converted into offsets from the start of the SCC will be invalid. This affects IProfiler data as well as Class Chains (which are fundamental to AOT).

In this PR, the logic used to convert between pointers and offsets is updated to handle the fact that for pointers into the ROMClass section of the SCC, the offset should be calculated using the start of the SCC, whereas for pointers into the metadata section of the SCC, the offset should be calculated using the end of the SCC.

In order to simplify which version of the API should be called, this PR introduces several APIs specific for the context, namely APIs for J9ROMClasses, J9ROMmethods, Pointers into the ROM Class section, and Pointers into the metadata. Asserts are also added to minimize the risk of calling the wrong APIs.

~Leaving this as a draft for now; things look OK from some of the tests I've done, but I need to do more comprehensive tests before I'll feel comfortable enough to undo the draft status.~

fyi @mstoodle @mpirvu 