### PR TITLE
Enable using Level 1 data cache on RISC-V specific hardware

### DIFF
--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -1719,6 +1719,17 @@ j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, const J9CacheInfoQue
 	case J9PORT_CACHEINFO_QUERY_LINESIZE:
 	case J9PORT_CACHEINFO_QUERY_CACHESIZE:
 		result =  getCacheSize(portLibrary, query->cpu, query->level, query->cacheType, query->cmd);
+
+#if defined(RISCV64)
+	/* The L1 data cache at "cache/index1" is set up from "/sys/devices/system/cpu/cpu1" on some Linux distro
+	 * (e.g. Debian_riscv) rather than "/sys/devices/system/cpu/cpu0" in which "cache/index1" doesn't exist.
+	 * Note: this is a temporary solution specific to Debian_riscv which won't be used or simply
+	 * removed once we confirm "cpu0/cache/index1" does exist on the latest version of Debian_riscv.
+	 */
+	if (result < 0) {
+		result =  getCacheSize(portLibrary, query->cpu + 1, query->level, query->cacheType, query->cmd);
+	}
+#endif /* defined(RISCV64) */
 		break;
 	case J9PORT_CACHEINFO_QUERY_TYPES:
 		result =  getCacheTypes(portLibrary, query->cpu, query->level);

--- a/runtime/tests/port/si.c
+++ b/runtime/tests/port/si.c
@@ -2183,9 +2183,17 @@ j9sysinfo_test_get_l1dcache_line_size(struct J9PortLibrary *portLibrary)
 	cQuery.level = 1;
 	cQuery.cacheType = J9PORT_CACHEINFO_DCACHE;
 	rc = j9sysinfo_get_cache_info(&cQuery);
-#if !(defined(J9ARM) || defined(RISCV64))
+#if !defined(J9ARM)
 	if (rc < 0) {
+#if defined(RISCV64)
+		outputComment(PORTLIB, "j9sysinfo_get_cache_info is not supported on this platform\n");
+		if (J9PORT_ERROR_SYSINFO_NOT_SUPPORTED != rc) {
+			outputErrorMessage(PORTTEST_ERROR_ARGS, "j9sysinfo_get_cache_info should have returned %d but returned %d\n", 
+				J9PORT_ERROR_SYSINFO_NOT_SUPPORTED, rc);
+		}
+#else /* defined(RISCV64) */
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9sysinfo_get_cache_info returned %d\n", rc);
+#endif /* defined(RISCV64) */
 	} else {
 		l1DcacheSize = rc;
 		outputComment(PORTLIB, "DCache line size = %d\n",l1DcacheSize);
@@ -2199,13 +2207,13 @@ j9sysinfo_test_get_l1dcache_line_size(struct J9PortLibrary *portLibrary)
 					l1DcacheSize, rc);
 		}
 	}
-#else /* !(defined(J9ARM) || defined(RISCV64)) */
+#else /* !defined(J9ARM) */
 	outputComment(PORTLIB, "j9sysinfo_get_cache_info is not supported on this platform\n");
 	if (J9PORT_ERROR_SYSINFO_NOT_SUPPORTED != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9sysinfo_get_cache_info should have returned %d but returned %d\n", 
 			J9PORT_ERROR_SYSINFO_NOT_SUPPORTED, rc);
 	}
-#endif /* !(defined(J9ARM) || defined(RISCV64)) */
+#endif /* !defined(J9ARM) */
 
 	return reportTestExit(portLibrary, testName);
 }


### PR DESCRIPTION
The change is to enable the L1 data cache (no support
on the emulator) on the hardware to ensure it works
appropriately after setup.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>