### PR TITLE
DTFJ: Add API to query the byte order of an address space

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageAddressSpace.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageAddressSpace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.view.dtfj.image;
 
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -48,6 +49,11 @@ public class J9DDRImageAddressSpace implements ImageAddressSpace {
 	
 	public IAddressSpace getIAddressSpace() {
 		return as;
+	}
+
+	@Override
+	public ByteOrder getByteOrder() {
+		return as.getByteOrder();
 	}
 	
 	public J9DDRImageProcess getCurrentProcess() {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/addressspace/IAbstractAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/addressspace/IAbstractAddressSpace.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package com.ibm.dtfj.addressspace;
 
+import java.nio.ByteOrder;
 import java.util.Iterator;
 
 import com.ibm.dtfj.corereaders.MemoryAccessException;
@@ -89,6 +90,13 @@ public interface IAbstractAddressSpace
 	public short getShortAt(int asid, long address) throws MemoryAccessException;
 
 	/**
+	 * Return the byte order of this address space.
+	 *
+	 * @return the byte order of this address space
+	 */
+	public ByteOrder getByteOrder();
+
+	/**
 	 * @param asid an address space ID
 	 * @param address a byte-offset into the asid
 	 * @return the 8-bit byte stored at address in asid
@@ -96,8 +104,21 @@ public interface IAbstractAddressSpace
 	 */
 	public byte getByteAt(int asid, long address) throws MemoryAccessException;
 	
+	/**
+	 * @param asid an address space ID
+	 * @param address a byte-offset into the asid
+	 * @return the pointer stored at address in asid
+	 * @throws MemoryAccessException if the memory cannot be read
+	 */
 	public long getPointerAt(int asid, long address) throws MemoryAccessException;
 	
+	/**
+	 * @param asid an address space ID
+	 * @param address a byte-offset into the asid
+	 * @param buffer a byte array to receive the bytes
+	 * @return the number of bytes read into buffer
+	 * @throws MemoryAccessException if the memory cannot be read
+	 */
 	public int getBytesAt(int asid, long address, byte[] buffer) throws MemoryAccessException;
 	
 	/**
@@ -117,7 +138,6 @@ public interface IAbstractAddressSpace
 	 * @param alignment The alignment boundary where the pattern can be expected to start
 	 * @param startFrom The first memory address to start searching in
 	 * @return
-	 * 
 	 */
 	public long findPattern(byte[] whatBytes, int alignment, long startFrom);
 
@@ -128,7 +148,6 @@ public interface IAbstractAddressSpace
 	 * @param vaddr
 	 * @param size
 	 * @return
-	 * 
 	 */
 	public byte[] getMemoryBytes(long vaddr, int size);
 }

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/ImageAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/ImageAddressSpace.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package com.ibm.dtfj.image;
 
+import java.nio.ByteOrder;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -50,7 +51,14 @@ public interface ImageAddressSpace {
      * @see CorruptData
      */
     public Iterator getProcesses();
-    
+
+	/**
+	 * Return the byte order of this address space.
+	 *
+	 * @return the byte order of this address space
+	 */
+	public ByteOrder getByteOrder();
+
     /**
      * A factory method for creating pointers into this address space.
      * @param address the address to point to.

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImageAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImageAddressSpace.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package com.ibm.dtfj.image.j9;
 
+import java.nio.ByteOrder;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Vector;
@@ -48,6 +49,12 @@ public class ImageAddressSpace implements com.ibm.dtfj.image.ImageAddressSpace
 	{
 		_shadow = memory;
 		_asid = asid;
+	}
+
+	@Override
+	public ByteOrder getByteOrder()
+	{
+		return _shadow.getByteOrder();
 	}
 
 	/* (non-Javadoc)

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/javacore/JCImageAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/javacore/JCImageAddressSpace.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package com.ibm.dtfj.image.javacore;
 
+import java.nio.ByteOrder;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Vector;
@@ -50,6 +51,11 @@ public class JCImageAddressSpace implements ImageAddressSpace {
 		fProcesses = new Vector();
 		fImageSections = new Vector();
 		image.addAddressSpace(this);
+	}
+
+	@Override
+	public ByteOrder getByteOrder() {
+		return ByteOrder.BIG_ENDIAN; // FIXME
 	}
 
 	/**

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/javacore/JCImageAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/javacore/JCImageAddressSpace.java
@@ -55,7 +55,8 @@ public class JCImageAddressSpace implements ImageAddressSpace {
 
 	@Override
 	public ByteOrder getByteOrder() {
-		return ByteOrder.BIG_ENDIAN; // FIXME
+		// Return a default value since javacore image memory can't be accessed anyways.
+		return ByteOrder.BIG_ENDIAN;
 	}
 
 	/**

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDImageAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDImageAddressSpace.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@ package com.ibm.dtfj.phd;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -40,7 +41,6 @@ import com.ibm.dtfj.image.ImageProcess;
 import com.ibm.dtfj.image.ImageSection;
 import com.ibm.dtfj.java.JavaHeap;
 import com.ibm.dtfj.java.JavaRuntime;
-import com.ibm.dtfj.phd.parser.HeapdumpReader;
 import com.ibm.dtfj.runtime.ManagedRuntime;
 
 /** 
@@ -53,22 +53,33 @@ class PHDImageAddressSpace implements ImageAddressSpace {
 	
 	PHDImageAddressSpace(File file, PHDImage parentImage, ImageAddressSpace metaImageAddressSpace) throws IOException {
 		this.metaImageAddressSpace = metaImageAddressSpace;
-		processList = new ArrayList<ImageProcess>();
+		processList = new ArrayList<>();
 		ImageProcess metaProc = metaImageAddressSpace != null ? metaImageAddressSpace.getCurrentProcess() : null;
 		processList.add(new PHDImageProcess(file, parentImage,this, metaProc));
 	}
 	
 	PHDImageAddressSpace(ImageInputStream stream, PHDImage parentImage, ImageAddressSpace metaImageAddressSpace) throws IOException {
 		this.metaImageAddressSpace = metaImageAddressSpace;
-		processList = new ArrayList<ImageProcess>();
+		processList = new ArrayList<>();
 		ImageProcess metaProc = metaImageAddressSpace != null ? metaImageAddressSpace.getCurrentProcess() : null;
-		processList.add(new PHDImageProcess(stream, parentImage,this, metaProc));
+		processList.add(new PHDImageProcess(stream, parentImage, this, metaProc));
 	}
 
+	@Override
 	public ImageProcess getCurrentProcess() {
-		return (ImageProcess)processList.get(0);
+		return processList.get(0);
 	}
 
+	@Override
+	public ByteOrder getByteOrder() {
+		if (metaImageAddressSpace != null) {
+			return metaImageAddressSpace.getByteOrder();
+		}
+
+		return ByteOrder.BIG_ENDIAN; // FIXME
+	}
+
+	@Override
 	public Iterator<ImageSection> getImageSections() {
 		List<ImageSection> list = new ArrayList<ImageSection>();
 		for (Iterator<ImageProcess>ip = getProcesses(); ip.hasNext(); ) {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDImageAddressSpace.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDImageAddressSpace.java
@@ -72,11 +72,8 @@ class PHDImageAddressSpace implements ImageAddressSpace {
 
 	@Override
 	public ByteOrder getByteOrder() {
-		if (metaImageAddressSpace != null) {
-			return metaImageAddressSpace.getByteOrder();
-		}
-
-		return ByteOrder.BIG_ENDIAN; // FIXME
+		 // Return a default value since PHD image memory can't be accessed anyways.
+		return ByteOrder.BIG_ENDIAN;
 	}
 
 	@Override

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/FindPtrCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/FindPtrCommand.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,78 +23,94 @@
 package com.ibm.jvm.dtfjview.commands;
 
 import java.io.PrintStream;
+import java.nio.ByteOrder;
 
+import com.ibm.dtfj.image.ImageAddressSpace;
 import com.ibm.java.diagnostics.utils.IContext;
+import com.ibm.java.diagnostics.utils.IDTFJContext;
 import com.ibm.java.diagnostics.utils.commands.CommandException;
 import com.ibm.java.diagnostics.utils.plugins.DTFJPlugin;
 
-@DTFJPlugin(version="1.*", runtime=false)
-public class FindPtrCommand extends BaseJdmpviewCommand{
-	
+@DTFJPlugin(version = "1.*", runtime = false)
+public class FindPtrCommand extends BaseJdmpviewCommand {
+
 	String pattern;
-	
+
 	{
-		addCommand("findptr", "", "searches memory for the given pointer");	
+		addCommand("findptr", "", "searches memory for the given pointer");
 	}
-	
+
+	@Override
 	public void run(String command, String[] args, IContext context, PrintStream out) throws CommandException {
-		if(initCommand(command, args, context, out)) {
-			return;		//processing already handled by super class
+		if (initCommand(command, args, context, out)) {
+			return; // processing already handled by super class
 		}
-		if(args.length == 1) {
+		if (args.length == 1) {
 			String line = args[0];
-			if(line.endsWith(",")) {
-				//in order for the split to work there needs to always be a last parameter present. If it is missing we can default to only displaying the first match.
+			if (line.endsWith(",")) {
+				// In order for the split to work there needs to always be a last parameter present.
+				// If it is missing we can default to only displaying the first match.
 				line += "1";
 			}
 			String[] params = line.split(",");
-			if (!isParametersValid(params)) return;
-			if(isLittleEndian())
+			if (!isParametersValid(params)) {
+				return;
+			}
+			if (isLittleEndian(context)) {
 				pattern = reorderBytes();
-			String parameters = getparameters(params);
+			}
+			String parameters = getParameters(params);
 
 			out.println("issuing: find" + " " + parameters);
-			
+
 			ctx.execute("find" + " " + parameters, out);
 		} else {
 			out.println("\"find\" takes a set comma separated parameters with no spaces");
 		}
 	}
-		
-	private String getparameters(String[] params){
+
+	private String getParameters(String[] params) {
 		String temp = "0x" + pattern;
-		for(int i = 1; i < params.length; i++){
-			temp+=(","+params[i]);
+		for (int i = 1; i < params.length; i++) {
+			temp += ("," + params[i]);
 		}
 		return temp;
 	}
-	
-	private String reorderBytes(){
-		if (0 != pattern.length()%2)
+
+	private String reorderBytes() {
+		if (0 != pattern.length() % 2) {
 			pattern = "0" + pattern;
+		}
 		String temp = "";
-		for (int i = pattern.length()/2 - 1; i >= 0; i--){
-			temp+=pattern.substring(i*2,i*2+2);
+		for (int i = pattern.length() / 2 - 1; i >= 0; i--) {
+			temp += pattern.substring(i * 2, i * 2 + 2);
 		}
 		return temp;
 	}
-	
-	private boolean isLittleEndian(){
-		//TODO implement this method once the API is available
-		return true;
+
+	private static boolean isLittleEndian(IContext context) {
+		if (context instanceof IDTFJContext) {
+			ImageAddressSpace addressSpace = ((IDTFJContext) context).getAddressSpace();
+
+			if (ByteOrder.LITTLE_ENDIAN == addressSpace.getByteOrder()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
-	
-	private boolean isParametersValid(String[] params){
-		if (6 != params.length){
+
+	private boolean isParametersValid(String[] params) {
+		if (6 != params.length) {
 			out.println("insufficient number of parameters");
 			return false;
 		}
-		pattern = params[0]; 
+		pattern = params[0];
 		if (pattern.equals("")) {
 			out.println("missing pattern string");
 			return false;
 		}
-		
+
 		if (pattern.startsWith("0x")) {
 			pattern = pattern.substring(2);
 		}
@@ -103,10 +119,11 @@ public class FindPtrCommand extends BaseJdmpviewCommand{
 
 	@Override
 	public void printDetailedHelp(PrintStream out) {
-		out.println("searches memory for the given pointer\n\n" +
-				"parameters: see parameters for \"find\" command\n\n" +
-				"the findptr command searches for <pattern> as a pointer in the memory segment from <start_address> to <end_address> (both inclusive), " +
-				"and outputs the first <matches_to_display> matching addresses that start at the corresponding <memory_boundary>. " +
-				"It also display the next <bytes_to_print> bytes for the last match.");
+		out.println("searches memory for the given pointer\n\n"
+				+ "parameters: see parameters for \"find\" command\n\n"
+				+ "the findptr command searches for <pattern> as a pointer in the memory segment from <start_address> to <end_address> (both inclusive), "
+				+ "and outputs the first <matches_to_display> matching addresses that start at the corresponding <memory_boundary>. "
+				+ "It also display the next <bytes_to_print> bytes for the last match.");
 	}
+
 }


### PR DESCRIPTION
Adds an API to query byte order so `findptr` can use the correct byte order instead of defaulting to little endian.

Fixes https://github.com/eclipse/openj9/issues/8749

