### PR TITLE
AArch64: Remove the call to setAllowRecompilation(false)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2634,11 +2634,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       }
 
 #if defined(TR_HOST_ARM64)
-   // Recompilation support is not available in AArch64 yet.
-   // OpenJ9 issue #6607 tracks the work to enable.
-   //
-   self()->setAllowRecompilation(false);
-
    // Internal Pointers support is not available in AArch64 yet.
    // OpenJ9 issue #6367 tracks the work to enable.
    //


### PR DESCRIPTION
This commit removes the call to setAllowRecompilation(false) for
AArch64, to enable recompilation.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>