### PR TITLE
Fix assert on checking obj location reference on KNOT

### DIFF
--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -233,10 +233,10 @@ void
 J9::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient)
    {
    TR_ASSERT_FATAL(self()->comp()->isOutOfProcessCompilation(), "updateKnownObjectTableAtServer should only be called at the server");
-   TR_ASSERT(objectReferenceLocationClient, "objectReferenceLocationClient should not be NULL");
-
    if (index == TR::KnownObjectTable::UNKNOWN)
       return;
+
+   TR_ASSERT(objectReferenceLocationClient || (index == 0), "objectReferenceLocationClient should not be NULL (index=%d)", index);
 
    uint32_t nextIndex = self()->getEndIndex();
 


### PR DESCRIPTION
The known object table index `0` stores the `NULL` object reference pointer. The assert on checking if it's not NULL should consider this special case.

Related to #9760

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>