### PR TITLE
AArch64: Add instructions for enabling CUDA support

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -710,6 +710,8 @@ bash configure --openjdk-target=${OPENJ9_CC_PREFIX} \
 
 :pencil: **DDR support:** You can build DDR support only on AArch64 Linux.  If you are building in a cross-compilation environment, you need the `--disable-ddr` option.
 
+:pencil: **CUDA support:** You can enable CUDA support if you are building on NVIDIA Jetson Developer Kit series.  Add `--enable-cuda --with-cuda=/usr/local/cuda` when you run `configure`.  The path `/usr/local/cuda` may be different depending on the version of JetPack.
+
 :pencil: You may need to add `--disable-warnings-as-errors-openj9` depending on the toolchain version.
 
 ### 6. Build


### PR DESCRIPTION
This commit adds description on how to build AArch64 Linux OpenJ9 with
CUDA enabled.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>