### PR TITLE
Revert "Enable CFG simplifier"

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -34,6 +34,10 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
+   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
+   if (enableCFGSimplification == NULL)
+      return false;
+
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
           || simplifyResolvedRequireNonNull(needToDuplicateTree)
           || simplifyUnresolvedRequireNonNull(needToDuplicateTree)


### PR DESCRIPTION
There seem to be other issues with CFG simplification which were missed when it
was enabled. This disables CFG simplification while we investigate further.

This reverts commit ae567a49a58811e45abd2e25b0709fba5fd76ec9.

See: #9754

Signed-off-by: Ryan Shukla <ryans@ibm.com>