### PR TITLE
Add jit helper stubs for flattenable fields

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -284,6 +284,13 @@ SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportInstanceFieldWrite,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldRead,1)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldWrite,2)
 FAST_PATH_ONLY_HELPER(jitAcmpHelper,2)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitWithFlattenableField,3)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableField,3)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
+OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/armnathelp.m4
+++ b/runtime/codert_vm/armnathelp.m4
@@ -289,6 +289,13 @@ SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportInstanceFieldWrite,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldRead,1)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldWrite,2)
 FAST_PATH_ONLY_HELPER(jitAcmpHelper,2)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitWithFlattenableField,3)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableField,3)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
+OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -679,6 +679,90 @@ old_fast_jitNewObjectNoZeroInit(J9VMThread *currentThread)
 	return slowPath;
 }
 
+void* J9FASTCALL
+old_slow_jitGetFlattenableField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitGetFlattenableField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_slow_jitWithFlattenableField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitWithFlattenableField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_slow_jitPutFlattenableField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitPutFlattenableField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_slow_jitGetFlattenableStaticField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitGetFlattenableStaticField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_slow_jitPutFlattenableStaticField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitPutFlattenableStaticField(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_slow_jitLoadFlattenableArrayElement(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitLoadFlattenableArrayElement(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_slow_jitStoreFlattenableArrayElement(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
+void* J9FASTCALL
+old_fast_jitStoreFlattenableArrayElement(J9VMThread *currentThread)
+{
+	return NULL;
+}
+
 static VMINLINE bool
 fast_jitANewArrayImpl(J9VMThread *currentThread, J9Class *elementClass, I_32 size, bool nonZeroTLH)
 {
@@ -3479,6 +3563,13 @@ initPureCFunctionTable(J9JavaVM *vm)
 	jitConfig->old_slow_jitNewInstanceImplAccessCheck = (void*)old_slow_jitNewInstanceImplAccessCheck;
 	jitConfig->old_slow_jitTranslateNewInstanceMethod = (void*)old_slow_jitTranslateNewInstanceMethod;
 	jitConfig->old_slow_jitReportFinalFieldModified = (void*)old_slow_jitReportFinalFieldModified;
+	jitConfig->old_fast_jitGetFlattenableField = (void*) old_fast_jitGetFlattenableField;
+	jitConfig->old_fast_jitWithFlattenableField = (void*) old_fast_jitWithFlattenableField;
+	jitConfig->old_fast_jitPutFlattenableField = (void*) old_fast_jitPutFlattenableField;
+	jitConfig->old_fast_jitGetFlattenableStaticField = (void*) old_fast_jitGetFlattenableStaticField;
+	jitConfig->old_fast_jitPutFlattenableStaticField = (void*) old_fast_jitPutFlattenableStaticField;
+	jitConfig->old_fast_jitLoadFlattenableArrayElement = (void*) old_fast_jitLoadFlattenableArrayElement;
+	jitConfig->old_fast_jitStoreFlattenableArrayElement = (void*) old_fast_jitStoreFlattenableArrayElement;
 	jitConfig->old_fast_jitAcmpHelper = (void*)old_fast_jitAcmpHelper;
 	jitConfig->fast_jitNewValue = (void*)fast_jitNewValue;
 	jitConfig->fast_jitNewValueNoZeroInit = (void*)fast_jitNewValueNoZeroInit;

--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -334,6 +334,13 @@ SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportInstanceFieldWrite,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldRead,1)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldWrite,2)
 FAST_PATH_ONLY_HELPER(jitAcmpHelper,2)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitWithFlattenableField,3)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableField,3)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
+OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -388,6 +388,13 @@ SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportInstanceFieldWrite,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldRead,1)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldWrite,2)
 FAST_PATH_ONLY_HELPER(jitAcmpHelper,2)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitWithFlattenableField,3)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableField,3)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
+OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 
 dnl Trap handlers
 

--- a/runtime/codert_vm/znathelp.m4
+++ b/runtime/codert_vm/znathelp.m4
@@ -334,6 +334,13 @@ SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportInstanceFieldWrite,3)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldRead,1)
 SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE(jitReportStaticFieldWrite,2)
 FAST_PATH_ONLY_HELPER(jitAcmpHelper,2)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitWithFlattenableField,3)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableField,3)
+OLD_DUAL_MODE_HELPER(jitGetFlattenableStaticField,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitPutFlattenableStaticField,3)
+OLD_DUAL_MODE_HELPER(jitLoadFlattenableArrayElement,2)
+OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE(jitStoreFlattenableArrayElement,3)
 
 dnl Trap handlers
 

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1016,6 +1016,14 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_newValueNoZeroInit,        (void *)jitNewValueNoZeroInit, TR_CHelper);
    SET(TR_newArrayNoZeroInit,         (void *)jitNewArrayNoZeroInit,  TR_CHelper);
    SET(TR_aNewArrayNoZeroInit,        (void *)jitANewArrayNoZeroInit, TR_CHelper);
+
+   SET(TR_getFlattenableField,        (void *)jitGetFlattenableField, TR_CHelper);
+   SET(TR_withFlattenableField,        (void *)jitWithFlattenableField, TR_CHelper);
+   SET(TR_putFlattenableField,        (void *)jitPutFlattenableField, TR_CHelper);
+   SET(TR_getFlattenableStaticField,        (void *)jitGetFlattenableStaticField, TR_CHelper);
+   SET(TR_putFlattenableStaticField,        (void *)jitPutFlattenableStaticField, TR_CHelper);
+   SET(TR_ldFlattenableArrayElement,        (void *)jitLoadFlattenableArrayElement, TR_CHelper);
+   SET(TR_strFlattenableArrayElement,        (void *)jitStoreFlattenableArrayElement, TR_CHelper);
 #else
    SET(TR_newObject,                  (void *)jitNewObject,              TR_Helper);
    SET(TR_newValue,                  (void *)jitNewValue,              TR_Helper);
@@ -1026,6 +1034,14 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_newValueNoZeroInit,        (void *)jitNewValueNoZeroInit, TR_Helper);
    SET(TR_newArrayNoZeroInit,         (void *)jitNewArrayNoZeroInit,  TR_Helper);
    SET(TR_aNewArrayNoZeroInit,        (void *)jitANewArrayNoZeroInit, TR_Helper);
+
+   SET(TR_getFlattenableField,        (void *)jitGetFlattenableField, TR_Helper);
+   SET(TR_withFlattenableField,        (void *)jitWithFlattenableField, TR_Helper);
+   SET(TR_putFlattenableField,        (void *)jitPutFlattenableField, TR_Helper);
+   SET(TR_getFlattenableStaticField,        (void *)jitGetFlattenableStaticField, TR_Helper);
+   SET(TR_putFlattenableStaticField,        (void *)jitPutFlattenableStaticField, TR_Helper);
+   SET(TR_ldFlattenableArrayElement,        (void *)jitLoadFlattenableArrayElement, TR_Helper);
+   SET(TR_strFlattenableArrayElement,        (void *)jitStoreFlattenableArrayElement, TR_Helper);
 #endif
 
    SET(TR_acmpHelper,                  (void *)jitAcmpHelper, TR_Helper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -86,6 +86,13 @@ JIT_HELPER(jitMonitorExit);  // asm calling-convention helper
 JIT_HELPER(jitNewArray);  // asm calling-convention helper
 JIT_HELPER(jitNewInstanceImplAccessCheck);  // asm calling-convention helper
 JIT_HELPER(jitNewObject);  // asm calling-convention helper
+JIT_HELPER(jitGetFlattenableField);  // asm calling-convention helper
+JIT_HELPER(jitWithFlattenableField);  // asm calling-convention helper
+JIT_HELPER(jitPutFlattenableField);  // asm calling-convention helper
+JIT_HELPER(jitGetFlattenableStaticField);  // asm calling-convention helper
+JIT_HELPER(jitPutFlattenableStaticField);  // asm calling-convention helper
+JIT_HELPER(jitLoadFlattenableArrayElement);  // asm calling-convention helper
+JIT_HELPER(jitStoreFlattenableArrayElement);  // asm calling-convention helper
 JIT_HELPER(jitAcmpHelper);  // asm calling-convention helper
 JIT_HELPER(jitNewValue);  // asm calling-convention helper
 JIT_HELPER(jitObjectHashCode);  // asm calling-convention helper

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -633,6 +633,13 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitReportStaticFieldRead", offsetof(J9JITConfig, old_slow_jitReportStaticFieldRead)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitReportStaticFieldWrite", offsetof(J9JITConfig, old_slow_jitReportStaticFieldWrite)) |
 
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitGetFlattenableField", offsetof(J9JITConfig, old_fast_jitGetFlattenableField)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitWithFlattenableField", offsetof(J9JITConfig, old_fast_jitWithFlattenableField)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitPutFlattenableField", offsetof(J9JITConfig, old_fast_jitPutFlattenableField)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitGetFlattenableStaticField", offsetof(J9JITConfig, old_fast_jitGetFlattenableStaticField)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitPutFlattenableStaticField", offsetof(J9JITConfig, old_fast_jitPutFlattenableStaticField)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitLoadFlattenableArrayElement", offsetof(J9JITConfig, old_fast_jitLoadFlattenableArrayElement)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitStoreFlattenableArrayElement", offsetof(J9JITConfig, old_fast_jitStoreFlattenableArrayElement)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitAcmpHelper", offsetof(J9JITConfig, old_fast_jitAcmpHelper)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_fast_jitNewValue", offsetof(J9JITConfig, fast_jitNewValue)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_fast_jitNewValueNoZeroInit", offsetof(J9JITConfig, fast_jitNewValueNoZeroInit)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3594,6 +3594,13 @@ typedef struct J9JITConfig {
 	void *old_slow_jitNewInstanceImplAccessCheck;
 	void *old_slow_jitTranslateNewInstanceMethod;
 	void *old_slow_jitReportFinalFieldModified;
+	void *old_fast_jitGetFlattenableField;
+	void *old_fast_jitWithFlattenableField;
+	void *old_fast_jitPutFlattenableField;
+	void *old_fast_jitGetFlattenableStaticField;
+	void *old_fast_jitPutFlattenableStaticField;
+	void *old_fast_jitLoadFlattenableArrayElement;
+	void *old_fast_jitStoreFlattenableArrayElement;
 	void *old_fast_jitAcmpHelper;
 	void *fast_jitNewValue;
 	void *fast_jitNewValueNoZeroInit;


### PR DESCRIPTION
Add jit helper stubs for flattenable fields

Added:
- jitGetFlattenableField
- jitWithFlattenableField
- jitPutFlattenableField
- jitGetFlattenableStaticField
- jitPutFlattenableStaticField
- jitLoadFlattenableArrayElement
- jitStoreFlattenableArrayElement

Details are in https://github.com/eclipse/openj9/issues/9627

Depends on: https://github.com/eclipse/omr/pull/5278

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>