### PR TITLE
Jenkins: adjust test excludes for cmake builds

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -116,8 +116,6 @@ cmake:
   excluded_tests:
     8:
       - special.system
-    11:
-      - special.system
 #========================================#
 # Build with uma
 #========================================#
@@ -300,10 +298,11 @@ x86-64_linux:
 #========================================#
 x86-64_linux_cm:
   extends: ['x86-64_linux', 'cmake']
-  excluded_tests:
-      - extended.functional
-      - sanity.system
-      - extended.system
+    excluded_tests:
+      8:
+        - extended.functional
+        - sanity.system
+        - extended.system
 #========================================#
 # Linux x86 64bits Large Heap /w CMake
 #========================================#


### PR DESCRIPTION
- Remove test excludes on the "cmake" build spec. Exculdes can be added
on a per-spec basis
- Remove test expludes on xlinux cmake build

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>