### PR TITLE
AArch64: Disable inlining of allocation under AOT

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8635,8 +8635,7 @@ TR_J9SharedCacheVM::supportAllocationInlining(TR::Compilation *comp, TR::Node *n
 
    if ((comp->target().cpu.isX86() ||
         comp->target().cpu.isPower() ||
-        comp->target().cpu.isZ() ||
-        comp->target().cpu.isARM64()) &&
+        comp->target().cpu.isZ()) &&
        !comp->getOption(TR_DisableAllocationInlining))
       return true;
 


### PR DESCRIPTION
This commit disables inlining of allocation under AOT.

This PR reverts the part of changes in https://github.com/eclipse/openj9/pull/9740.
There seems to be intermittent build failures after https://github.com/eclipse/openj9/pull/9740 is merged. We temporarily disable inlining of allocation under AOT until we fix the failure.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>