### PR TITLE
Stop requiring GDK_HOME

### DIFF
--- a/runtime/compiler/build/toolcfg/common.mk
+++ b/runtime/compiler/build/toolcfg/common.mk
@@ -60,10 +60,6 @@ ifdef ENABLE_GPU
         $(error You must set CUDA_HOME if ENABLE_GPU is set)
     endif
 
-    ifeq (,$(GDK_HOME))
-        $(error You must set GDK_HOME if ENABLE_GPU is set)
-    endif
-
     PRODUCT_INCLUDES+=$(CUDA_HOME)/include $(CUDA_HOME)/nvvm/include $(GDK_HOME)
     PRODUCT_DEFINES+=ENABLE_GPU
 endif


### PR DESCRIPTION
Since CUDA 8.0 nvml.h is part of the CUDA toolkit rather than a separate package.