### PR TITLE
Fix a couple minor issues with 16-bit immediates on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -5539,7 +5539,7 @@ reservationLockEnter(TR::Node *node, int32_t lwOffset, TR::CodeGenerator *cg, TR
    generateLabelInstruction(cg, TR::InstOpCode::label, node, resLabel);
    generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, cndReg, monitorReg, 0);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, reserved_checkLabel, cndReg);
-   generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, lwOffset & 0x0000FFFF);
+   generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, tempReg, lwOffset);
    if (!isPrimitive)
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, valReg, metaReg, LOCK_RESERVATION_BIT | LOCK_INC_DEC_VALUE);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -6426,7 +6426,15 @@ static void genHeapAlloc(TR::Node *node, TR::Instruction *&iCursor, TR_OpaqueCla
                   int32_t arrayletLeafSize = TR::Compiler->om.arrayletLeafSize();
                   int32_t maxContiguousArrayletLeafSizeInBytes = arrayletLeafSize - TR::Compiler->om.sizeofReferenceAddress(); //need to add definition
                   int32_t maxArrayletSizeInElements = maxContiguousArrayletLeafSizeInBytes / elementSize;
-                  iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, condReg, enumReg, maxArrayletSizeInElements, iCursor);
+                  if (maxArrayletSizeInElements <= UPPER_IMMED)
+                     {
+                     iCursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, condReg, enumReg, maxArrayletSizeInElements, iCursor);
+                     }
+                  else
+                     {
+                     iCursor = loadConstant(cg, node, maxArrayletSizeInElements, temp1Reg, iCursor);
+                     iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, condReg, enumReg, temp1Reg, iCursor);
+                     }
                   static const char *p = feGetEnv("TR_TarokPreLeafSizeCheckVarBreak");
                   if (p)
                      generateInstruction(cg, TR::InstOpCode::bad, node);


### PR DESCRIPTION
This PR corrects a couple of minor issues with the range of 16-bit immediates being used in the Power codegen in the `J9TreeEvaluator.cpp` file.