### PR TITLE
Created helper for inline array allocation

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1040,24 +1040,6 @@ obj:
 		return instance;
 	}
 
-	/* Allocate an array instance
-	 * 
-	 * @returns the allocated array instance
-	 */
-	VMINLINE j9object_t
-	inlineArrayAllocation(J9Class *arrayClass, U_32 size, bool initializeSlots = true, bool memoryBarrier = true, bool sizeCheck = true)
-	{
-		j9object_t instance = NULL;
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (J9_IS_J9CLASS_FLATTENED(arrayClass)) {
-			instance = _objectAllocate.inlineAllocateIndexableValueTypeObject(_currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
-		} else
-#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
-		{
-			instance = _objectAllocate.inlineAllocateIndexableObject(_currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
-		}
-		return instance;
-	}
 
 	/**
 	 * Perform a non-instrumentable allocation of an indexable class.
@@ -1080,7 +1062,7 @@ obj:
 		if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables)) 
 #endif
 		{
-			instance = inlineArrayAllocation(arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
+			instance = VM_VMHelpers::inlineAllocateIndexableObject(_currentThread, &_objectAllocate, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
 		}
 
 		if (NULL == instance) {
@@ -3173,7 +3155,7 @@ done:
 		if (flags & J9AccClassArray) {
 			U_32 size = J9INDEXABLEOBJECT_SIZE(_currentThread, original);
 
-			copy = inlineArrayAllocation(objectClass, size, false, false, false);
+			copy = VM_VMHelpers::inlineAllocateIndexableObject(_currentThread, &_objectAllocate, objectClass, size, false, false, false);
 
 			if (NULL == copy) {
 				pushObjectInSpecialFrame(REGISTER_ARGS, original);
@@ -7578,7 +7560,7 @@ retry:
 				if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables)) 
 #endif
 				{
-					instance = inlineArrayAllocation(arrayClass, (U_32) size);
+					instance = VM_VMHelpers::inlineAllocateIndexableObject(_currentThread, &_objectAllocate, arrayClass, (U_32) size);
 				}
 
 				if (NULL == instance) {

--- a/runtime/vm/FastJNI_java_lang_J9VMInternals.cpp
+++ b/runtime/vm/FastJNI_java_lang_J9VMInternals.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,14 +69,8 @@ Fast_java_lang_J9VMInternals_primitiveClone(J9VMThread *currentThread, j9object_
 	}
 	if (flags & J9AccClassArray) {
 		U_32 size = J9INDEXABLEOBJECT_SIZE(currentThread, original);
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
-			copy = objectAllocate.inlineAllocateIndexableValueTypeObject(currentThread, objectClass, size, false, false, false);
-		} else
-#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
-		{
-			copy = objectAllocate.inlineAllocateIndexableObject(currentThread, objectClass, size, false, false, false);
-		}
+		
+		copy = VM_VMHelpers::inlineAllocateIndexableObject(currentThread, &objectAllocate, objectClass, size, false, false, false);
 
 		if (NULL == copy) {
 			VM_VMHelpers::pushObjectInSpecialFrame(currentThread, original);

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -1234,8 +1234,7 @@ VM_MHInterpreter::collectForAsCollector(j9object_t methodHandle, BOOLEAN * found
 	J9Class *posArgumentClass = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, posArgumentType);
 	J9Class *arrayComponentClass = ((J9ArrayClass *)posArgumentClass)->componentType;
 
-	j9object_t collectedArgsArrayRef =
-			_objectAllocate->inlineAllocateIndexableObject(_currentThread, posArgumentClass, collectArraySize);
+	j9object_t collectedArgsArrayRef = VM_VMHelpers::inlineAllocateIndexableObject(_currentThread, _objectAllocate, posArgumentClass, collectArraySize);
 	if (NULL == collectedArgsArrayRef) {
 		UDATA *spPriorToFrameBuild = _currentThread->sp;
 		J9SFMethodTypeFrame * frame = buildMethodTypeFrame(_currentThread, currentType);


### PR DESCRIPTION
Created inlineAllocateIndexableObject helper function to handle 
allocation of indexable flattened or unflattened classes by calling one
of:
- inlineAllocateIndexableValueTypeObject for flattened array classes
- inlineAllocateIndexableObject for unflattened array classes with no 
  unflattened flattenables

Replaced explicit usages of the inlineAllocateIndexableValueTypeObject 
method with the new inlineAllocateIndexableObject helper.

Related to: https://github.com/eclipse/openj9/issues/9200

Signed-off-by:Oussama Saoudi <oussama.saoudi@ibm.com>