### PR TITLE
Add more wait when checking the thread terminate status

### DIFF
--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -128,7 +128,11 @@ public class JITServerTest {
 
 		p.destroy();
 
-		Thread.sleep(PROCESS_DESTROY_WAIT_TIME_MS);
+		int waitCount = 0;
+		while (p.isAlive() && (waitCount <= 3)) {
+			Thread.sleep(PROCESS_DESTROY_WAIT_TIME_MS);
+			waitCount++;
+		}
 
 		final int exitValue = p.exitValue();
 


### PR DESCRIPTION
When a thread is not termiated, `IllegalThreadStateException` is thrown by `exitValue()`. Add more wait time if the thread is still alive.

Related to #9792

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>