### PR TITLE
Minimize contention between "finders" using SCC JCL helper

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassURLClasspathHelperImpl.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassURLClasspathHelperImpl.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.shared;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,8 +24,10 @@ package com.ibm.oti.shared;
  *******************************************************************************/
 
 import java.net.URL;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.ibm.oti.util.Msg;
+
 
 /**
  * <p>Implementation of SharedClassURLClasspathHelper.</p>
@@ -39,6 +41,7 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 	private boolean[] validated;
 	private int urlCount, confirmedCount;
 	private boolean invalidURLExists;
+	private ReentrantReadWriteLock urlcpReadWriteLock;
 	
 	private static native void init();
 	
@@ -54,13 +57,13 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 		this.validated = new boolean[classpath.length];
 		this.confirmedCount = 0;
 		this.invalidURLExists = false;
+		urlcpReadWriteLock = new ReentrantReadWriteLock();
 		initialize(loader, id, canFind, canStore);
 		initializeShareableClassloader(loader);
 		initializeURLs();
 		if (!invalidURLExists) {
 			notifyClasspathChange3(id, loader, this.urls, 0, this.urlCount, true);
 		}
-		
 	}
 
 	private void initializeURLs() {
@@ -93,7 +96,7 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 	}
 	
 	@Override
-	public synchronized byte[] findSharedClass(String partition, String className, IndexHolder indexFoundAtHolder) {
+	public byte[] findSharedClass(String partition, String className, IndexHolder indexFoundAtHolder) {
 		ClassLoader loader = getClassLoader();
 		if (loader == null) {
 			/*[MSG "K059f", "ClassLoader has been garbage collected. Returning null."]*/
@@ -108,40 +111,48 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 			printVerboseError(Msg.getString("K05a1")); //$NON-NLS-1$
 			return null;
 		}
-		if (invalidURLExists) {
-			/* Any URL which has its protocol other than 'jar:' or 'file:' is not supported by
-			 * shared class cache and is considered invalid.
-			 * invalidURLExists = true indicates classpath contains an invalid URL,
-			 * As such there is no point in calling native method findSharedClassImpl2() 
-			 * since it is bound to fail when creating classpath entries.
-			 */
-			/*[MSG "K05a4", "Classpath contains an invalid URL. Returning null."]*/
-			printVerboseInfo(Msg.getString("K05a4")); //$NON-NLS-1$
-			return null;
-		}
-		/* Important not to call findSharedClassImpl if confirmedCount==0 as 0 means "confirmedCount not set" */
-		if (confirmedCount==0) {
-			/*[MSG "K05a5", "There are no confirmed elements in the classpath. Returning null."]*/
-			printVerboseInfo(Msg.getString("K05a5")); //$NON-NLS-1$
-			return null;
-		}
 		SharedClassFilter theFilter = getSharingFilter();
 		boolean doFind, doStore;
 		if (theFilter!=null) {
-			doFind = theFilter.acceptFind(className);
-			/* Don't invoke the store filter if the cache is full */
-			if (nativeFlags[CACHE_FULL_FLAG] == 0) {
-				doStore = theFilter.acceptStore(className);
-			} else {
-				doStore = true;
+			synchronized(this) {
+				doFind = theFilter.acceptFind(className);
+				/* Don't invoke the store filter if the cache is full */
+				if (nativeFlags[CACHE_FULL_FLAG] == 0) {
+					doStore = theFilter.acceptStore(className);
+				} else {
+					doStore = true;
+				}
 			}
 		} else {
 			doFind = true;
 			doStore = true;
 		}
 		byte[] romClassCookie = new byte[ROMCLASS_COOKIE_SIZE];
-		int indexFoundAt = findSharedClassImpl2(this.id, partition, className, loader, this.urls, doFind, doStore, this.urlCount, this.confirmedCount, romClassCookie);
-		/* indexFoundAt will be -1 if class is not found */
+		int indexFoundAt = -1;
+		urlcpReadWriteLock.readLock().lock();
+		try {
+			if (invalidURLExists) {
+				/* Any URL which has its protocol other than 'jar:' or 'file:' is not supported by
+				 * shared class cache and is considered invalid.
+				 * invalidURLExists = true indicates classpath contains an invalid URL,
+				 * As such there is no point in calling native method findSharedClassImpl2() 
+				 * since it is bound to fail when creating classpath entries.
+				 */
+				/*[MSG "K05a4", "Classpath contains an invalid URL. Returning null."]*/
+				printVerboseInfo(Msg.getString("K05a4")); //$NON-NLS-1$
+				return null;
+			}
+			/* Important not to call findSharedClassImpl if confirmedCount==0 as 0 means "confirmedCount not set" */
+			if (confirmedCount==0) {
+				/*[MSG "K05a5", "There are no confirmed elements in the classpath. Returning null."]*/
+				printVerboseInfo(Msg.getString("K05a5")); //$NON-NLS-1$
+				return null;
+			}
+			indexFoundAt = findSharedClassImpl2(this.id, partition, className, loader, this.urls, doFind, doStore, this.urlCount, this.confirmedCount, romClassCookie);
+			/* indexFoundAt will be -1 if class is not found */
+		} finally {
+			urlcpReadWriteLock.readLock().unlock();
+		}
 		if (indexFoundAt < 0) {
 			return null;
 		}
@@ -157,7 +168,7 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 	}
 
 	@Override
-	public synchronized boolean storeSharedClass(String partition, Class<?> clazz, int foundAtIndex) {
+	public boolean storeSharedClass(String partition, Class<?> clazz, int foundAtIndex) {
 		if (!canStore) {
 			return false;
 		}
@@ -166,53 +177,66 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 			printVerboseError(Msg.getString("K05a3")); //$NON-NLS-1$
 			return false;
 		}
-		if (urlCount==0) {
-			/*[MSG "K05a6", "Classpath has zero elements. Cannot call storeSharedClass without classpath. Returning false."]*/
-			printVerboseError(Msg.getString("K05a6")); //$NON-NLS-1$
-			return false;
-		}
+		
 		if (foundAtIndex<0) {
 			/*[MSG "K05a7", "foundAtIndex cannot be <0 for storeSharedClass. Returning false."]*/
 			printVerboseError(Msg.getString("K05a7")); //$NON-NLS-1$
 			return false;
-		}
-		if (foundAtIndex>=urlCount) {
-			/*[MSG "K05a8", "foundAtIndex cannot be >= urls in classpath for storeSharedClass. Returning false."]*/
-			printVerboseError(Msg.getString("K05a8")); //$NON-NLS-1$
-			return false;
-		}
-		if (invalidURLExists) {
-			/* Any URL which has its protocol other than 'jar:' or 'file:' is not supported by
-			 * shared class cache and is considered invalid.
-			 * invalidURLExists = true indicates classpath contains an invalid URL,
-			 * As such there is no point in calling native method storeSharedClassImpl2() 
-			 * since it is bound to fail when creating classpath entries.
-			 */			
-			/*[MSG "K05a9", "Classpath contains an invalid URL. Returning false."]*/
-			printVerboseInfo(Msg.getString("K05a9")); //$NON-NLS-1$
-			return false;
-		}
-		if (!validated[foundAtIndex]) {
-			/* Because we only check each element once, we can afford to also check whether the URL exists */
-			if (!validateURL(urls[foundAtIndex], true)) {
-				return false;
-			}
-			validated[foundAtIndex]=true;
 		}
 		ClassLoader actualLoader = getClassLoader();
 		if (!validateClassLoader(actualLoader, clazz)) {
 			/* Attempt to call storeSharedClass with class defined by a different classloader */
 			return false;
 		}
-		if (confirmedCount <= foundAtIndex) {
-			confirmedCount = foundAtIndex+1;
-			/*[MSG "K05aa", "Number of confirmed entries is now {0}"]*/
-			printVerboseInfo(Msg.getString("K05aa", confirmedCount)); //$NON-NLS-1$
+		boolean storeRet = false;
+		boolean incConfirmedCount = false;
+		urlcpReadWriteLock.readLock().lock();
+		try {
+			if (urlCount==0) {
+				/*[MSG "K05a6", "Classpath has zero elements. Cannot call storeSharedClass without classpath. Returning false."]*/
+				printVerboseError(Msg.getString("K05a6")); //$NON-NLS-1$
+				return false;
+			}
+			if (foundAtIndex>=urlCount) {
+				/*[MSG "K05a8", "foundAtIndex cannot be >= urls in classpath for storeSharedClass. Returning false."]*/
+				printVerboseError(Msg.getString("K05a8")); //$NON-NLS-1$
+				return false;
+			}
+			if (invalidURLExists) {
+				/* Any URL which has its protocol other than 'jar:' or 'file:' is not supported by
+				 * shared class cache and is considered invalid.
+				 * invalidURLExists = true indicates classpath contains an invalid URL,
+				 * As such there is no point in calling native method storeSharedClassImpl2() 
+				 * since it is bound to fail when creating classpath entries.
+				 */			
+				/*[MSG "K05a9", "Classpath contains an invalid URL. Returning false."]*/
+				printVerboseInfo(Msg.getString("K05a9")); //$NON-NLS-1$
+				return false;
+			}
+			if (!validated[foundAtIndex]) {
+				/* Because we only check each element once, we can afford to also check whether the URL exists */
+				if (!validateURL(urls[foundAtIndex], true)) {
+					return false;
+				}
+				validated[foundAtIndex]=true;
+			}
+			if (confirmedCount <= foundAtIndex) {
+				incConfirmedCount = true;
+			}
+			storeRet = storeSharedClassImpl2(this.id, partition, actualLoader, this.urls, this.urlCount, foundAtIndex, clazz, nativeFlags);
+		} finally {
+			urlcpReadWriteLock.readLock().unlock();
 		}
-		return storeSharedClassImpl2(this.id, partition, actualLoader, this.urls, this.urlCount, foundAtIndex, clazz, nativeFlags);
+		if (incConfirmedCount) {
+			increaseConfirmedCount(foundAtIndex + 1);
+		}
+		return storeRet;
 	}
 
-	private synchronized void growURLs(int toMinSize) {
+	private void growURLs(int toMinSize) {
+		if (!urlcpReadWriteLock.writeLock().isHeldByCurrentThread()) {
+			throw new InternalError();
+		}
 		/*[MSG "K05ab", "Growing URL array to {0}"]*/
 		printVerboseInfo(Msg.getString("K05ab", toMinSize)); //$NON-NLS-1$
 		int newSize = ((toMinSize+1)*2);		/* toMinSize could be zero! */
@@ -228,7 +252,7 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 	}
 
 	@Override
-	public synchronized void addClasspathEntry(URL cpe) {
+	public void addClasspathEntry(URL cpe) {
 		ClassLoader loader = getClassLoader();
 		if (loader != null) {
 			if (cpe==null) {
@@ -236,129 +260,165 @@ final class SharedClassURLClasspathHelperImpl extends SharedClassAbstractHelper 
 				printVerboseError(Msg.getString("K05ac")); //$NON-NLS-1$
 				return;
 			}
-			/* If array is not big enough, grow it */
-			if (urls.length < (urlCount+1)) {
-				growURLs(urlCount+1);
+			URL convertedurl = convertJarURL(cpe);
+			boolean invalidUrl = false;
+			if (!validateURL(convertedurl, false)) {
+				invalidUrl = true;
 			}
-			origurls[urlCount] = cpe;
-			urls[urlCount] = convertJarURL(cpe);
-			if (!validateURL(urls[urlCount], false)) {
-				invalidURLExists = true;
+			urlcpReadWriteLock.writeLock().lock();
+			try {
+				/* If array is not big enough, grow it */
+				if (urls.length < (urlCount+1)) {
+					growURLs(urlCount+1);
+				}
+				origurls[urlCount] = cpe;
+				urls[urlCount] = convertedurl;
+				invalidURLExists = invalidUrl;
+				notifyClasspathChange2(loader);
+				if (!invalidURLExists) {
+					notifyClasspathChange3(id, loader, urls, urlCount, (urlCount + 1), true);
+				}
+				++urlCount;
+			} finally {
+				urlcpReadWriteLock.writeLock().unlock();
 			}
-			notifyClasspathChange2(loader);
-			if (!invalidURLExists) {
-				notifyClasspathChange3(id, loader, urls, urlCount, (urlCount + 1), true);
-			}
-			++urlCount;
 		}
 	}
 
 	/* Function required by the factory */
-	synchronized URL[] getClasspath() {
+	URL[] getClasspath() {
 		URL[] correctLengthArray = new URL[urlCount];
-		System.arraycopy(origurls, 0, correctLengthArray, 0, urlCount);
+		urlcpReadWriteLock.readLock().lock();
+		try {
+			System.arraycopy(origurls, 0, correctLengthArray, 0, urlCount);
+		} finally {
+			urlcpReadWriteLock.readLock().unlock();
+		}
 		return correctLengthArray;
 	}
-
-	@Override
-	public synchronized void confirmAllEntries() {
-		confirmedCount = urlCount;
+	
+	private void increaseConfirmedCount(int newCount) {
+		urlcpReadWriteLock.writeLock().lock();
+		try {
+			if (newCount > confirmedCount) {
+				confirmedCount = newCount;
+				/*[MSG "K05aa", "Number of confirmed entries is now {0}"]*/
+				printVerboseInfo(Msg.getString("K05aa", confirmedCount)); //$NON-NLS-1$
+			}
+		} finally {
+			urlcpReadWriteLock.writeLock().unlock();
+		}
 	}
 
 	@Override
-	public synchronized void setClasspath(URL[] newClasspath) throws CannotSetClasspathException {
+	public void confirmAllEntries() {
+		urlcpReadWriteLock.writeLock().lock();
+		try {
+			confirmedCount = urlCount;
+		} finally {
+			urlcpReadWriteLock.writeLock().unlock();
+		}
+	}
+
+	@Override
+	public void setClasspath(URL[] newClasspath) throws CannotSetClasspathException {
 		boolean changeMade = false;
 		boolean invalidURLFound = false;
-		int commonURLsLength = (origurls.length < newClasspath.length) ? origurls.length : newClasspath.length;
-		
+
 		ClassLoader loader = getClassLoader();
 		if (loader == null) {
 			/*[MSG "K059a", "ClassLoader has been garbage collected. Cannot set sharing filter."]*/
 			throw new CannotSetClasspathException(Msg.getString("K059a")); //$NON-NLS-1$
 		}
-
-		if (newClasspath.length < confirmedCount) {
-			/*[MSG "K05ad", "New classpath cannot be shorter than confirmed elements of original"]*/
-			throw new CannotSetClasspathException(Msg.getString("K05ad")); //$NON-NLS-1$
-		}
-		for (int i=0; i<confirmedCount; i++) {
-			if (!newClasspath[i].equals(origurls[i])) {
-				/*[MSG "K05ae", "Index {0} of newClasspath does not match confirmed original"]*/
-				throw new CannotSetClasspathException(Msg.getString("K05ae", i)); //$NON-NLS-1$
+		
+		urlcpReadWriteLock.writeLock().lock();
+		try {
+			int commonURLsLength = (origurls.length < newClasspath.length) ? origurls.length : newClasspath.length;
+			if (newClasspath.length < confirmedCount) {
+				/*[MSG "K05ad", "New classpath cannot be shorter than confirmed elements of original"]*/
+				throw new CannotSetClasspathException(Msg.getString("K05ad")); //$NON-NLS-1$
 			}
-		}
-		
-		/* Grow urls if necessary */
-		if (newClasspath.length > origurls.length) {
-			growURLs(newClasspath.length);
-		}
-		
-		/* Having ensured that confirmed URLs are the same, validate the others if required, and copy them if they have been modified */
-		for (int i = confirmedCount; i < commonURLsLength; i++) {
-			boolean urlUpdated = !newClasspath[i].equals(origurls[i]);
-
-			/* If the original classpath had any invalid URL then unconfirmed URLs in original classpath 
-			 * should be validated again in case invalid URL has been corrected now.
-			 */
-			if (invalidURLExists || urlUpdated) {
-				URL temp = null;
-				if (urlUpdated) {
-					temp = convertJarURL(newClasspath[i]);
-				} else {
-					temp = urls[i];
-				}
-				/* if an invalid URL is found, no need to validate any more URLs */
-				if (!invalidURLFound && !validateURL(temp, false)) {
-					invalidURLFound = true;
-					/*[MSG "K05af", "setClasspath() found an invalid URL {0} at index {1}"]*/
-					printVerboseInfo(Msg.getString("K05af", newClasspath[i], Integer.valueOf(i))); //$NON-NLS-1$
-				}
-				if (urlUpdated) {
-					origurls[i] = newClasspath[i];
-					urls[i] = temp;
-					changeMade = true;
+			for (int i=0; i<confirmedCount; i++) {
+				if (!newClasspath[i].equals(origurls[i])) {
+					/*[MSG "K05ae", "Index {0} of newClasspath does not match confirmed original"]*/
+					throw new CannotSetClasspathException(Msg.getString("K05ae", i)); //$NON-NLS-1$
 				}
 			}
-			/* validated[i] will already be false as it would be confirmed otherwise, so no need to set */
-		}
-		if (invalidURLFound) {
-			invalidURLExists = true;
-		} else {
-			invalidURLExists = false;
-		}
-
-		for (int i = commonURLsLength; i < newClasspath.length; i++) {
-			origurls[i] = newClasspath[i];
-			urls[i] = convertJarURL(newClasspath[i]);
 			
-			/* if 'invalidURLExists' is already set to true, no need to validate any more URLs */
-			if (!invalidURLExists && !validateURL(urls[i], false)) {
-				/*[MSG "K05b0", "setClasspath() added new invalid URL {0} at index {1}"]*/
-				printVerboseInfo(Msg.getString("K05b0", newClasspath[i], Integer.valueOf(i))); //$NON-NLS-1$
-				
+			/* Grow urls if necessary */
+			if (newClasspath.length > origurls.length) {
+				growURLs(newClasspath.length);
+			}
+			
+			/* Having ensured that confirmed URLs are the same, validate the others if required, and copy them if they have been modified */
+			for (int i = confirmedCount; i < commonURLsLength; i++) {
+				boolean urlUpdated = !newClasspath[i].equals(origurls[i]);
+	
+				/* If the original classpath had any invalid URL then unconfirmed URLs in original classpath 
+				 * should be validated again in case invalid URL has been corrected now.
+				 */
+				if (invalidURLExists || urlUpdated) {
+					URL temp = null;
+					if (urlUpdated) {
+						temp = convertJarURL(newClasspath[i]);
+					} else {
+						temp = urls[i];
+					}
+					/* if an invalid URL is found, no need to validate any more URLs */
+					if (!invalidURLFound && !validateURL(temp, false)) {
+						invalidURLFound = true;
+						/*[MSG "K05af", "setClasspath() found an invalid URL {0} at index {1}"]*/
+						printVerboseInfo(Msg.getString("K05af", newClasspath[i], Integer.valueOf(i))); //$NON-NLS-1$
+					}
+					if (urlUpdated) {
+						origurls[i] = newClasspath[i];
+						urls[i] = temp;
+						changeMade = true;
+					}
+				}
+				/* validated[i] will already be false as it would be confirmed otherwise, so no need to set */
+			}
+			if (invalidURLFound) {
 				invalidURLExists = true;
+			} else {
+				invalidURLExists = false;
 			}
-			changeMade = true;
-		}
-		
-		/* If new classpath is shorter, remaining entries will be ignored as they are > urlCount */
-		if (urlCount != newClasspath.length) {
-			urlCount = newClasspath.length;
-			changeMade = true;
-		}
-		if (!invalidURLExists) {
-			/*[MSG "K05b1", "setClasspath() updated classpath. No invalid URLs found"]*/
-			printVerboseInfo(Msg.getString("K05b1")); //$NON-NLS-1$
-		}
-		/* Only call notifyClasspathChange if a genuine change has been made, otherwise internal data caches
-		 * will be cleared unnecessarily */
-		if (changeMade) {
-			/*[MSG "K05b2", "setClasspath() updated classpath. Now urlCount={0}"]*/
-			printVerboseInfo(Msg.getString("K05b2", urlCount)); //$NON-NLS-1$
-			notifyClasspathChange2(loader);
+	
+			for (int i = commonURLsLength; i < newClasspath.length; i++) {
+				origurls[i] = newClasspath[i];
+				urls[i] = convertJarURL(newClasspath[i]);
+				
+				/* if 'invalidURLExists' is already set to true, no need to validate any more URLs */
+				if (!invalidURLExists && !validateURL(urls[i], false)) {
+					/*[MSG "K05b0", "setClasspath() added new invalid URL {0} at index {1}"]*/
+					printVerboseInfo(Msg.getString("K05b0", newClasspath[i], Integer.valueOf(i))); //$NON-NLS-1$
+					
+					invalidURLExists = true;
+				}
+				changeMade = true;
+			}
+			
+			/* If new classpath is shorter, remaining entries will be ignored as they are > urlCount */
+			if (urlCount != newClasspath.length) {
+				urlCount = newClasspath.length;
+				changeMade = true;
+			}
 			if (!invalidURLExists) {
-				notifyClasspathChange3(id, loader, urls, 0, urlCount, true);
+				/*[MSG "K05b1", "setClasspath() updated classpath. No invalid URLs found"]*/
+				printVerboseInfo(Msg.getString("K05b1")); //$NON-NLS-1$
 			}
+			/* Only call notifyClasspathChange if a genuine change has been made, otherwise internal data caches
+			 * will be cleared unnecessarily */
+			if (changeMade) {
+				/*[MSG "K05b2", "setClasspath() updated classpath. Now urlCount={0}"]*/
+				printVerboseInfo(Msg.getString("K05b2", urlCount)); //$NON-NLS-1$
+				notifyClasspathChange2(loader);
+				if (!invalidURLExists) {
+					notifyClasspathChange3(id, loader, urls, 0, urlCount, true);
+				}
+			}
+		} finally {
+			urlcpReadWriteLock.writeLock().unlock();
 		}
 	}
 

--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1082,13 +1082,9 @@ Java_com_ibm_oti_shared_SharedClassTokenHelperImpl_findSharedClassImpl2(JNIEnv* 
 	}
 
 	omrthread_monitor_exit(jclCacheMutex);
-	
-	omrthread_monitor_enter(vm->classTableMutex);
-	omrthread_monitor_enter(vm->classMemorySegments->segmentMutex);
 	ALWAYS_TRIGGER_J9HOOK_VM_FIND_LOCALLY_DEFINED_CLASS(vm->hookInterface, (J9VMThread*)env, classloader, NULL,
 			(const char*)nameChars, (UDATA)nameLen, token, 1, -1, NULL, !doFind, !doStore, NULL, romClass);
-	omrthread_monitor_exit(vm->classMemorySegments->segmentMutex);
-	omrthread_monitor_exit(vm->classTableMutex);
+
 
 	releaseStringPair(env, classNameObj, nameChars, tokenObj, tokenChars);
 
@@ -1290,12 +1286,8 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_findSharedClassImpl3(JNIEnv* en
 		config->updateClasspathOpenState(vm, urlEntry, 0, 1, TRUE);
 	}
 
-	omrthread_monitor_enter(vm->classTableMutex);
-	omrthread_monitor_enter(vm->classMemorySegments->segmentMutex);
 	ALWAYS_TRIGGER_J9HOOK_VM_FIND_LOCALLY_DEFINED_CLASS(vm->hookInterface, (J9VMThread*)env, classloader, NULL,
 			(const char*)nameChars, (UDATA)nameLen, urlEntry, 1, -1, partition, !doFind, !doStore, NULL, romClass);
-	omrthread_monitor_exit(vm->classMemorySegments->segmentMutex);
-	omrthread_monitor_exit(vm->classTableMutex);
 
 	releaseStringPair(env, urlElements.pathObj, urlElements.pathChars, urlElements.protocolObj, urlElements.protocolChars);
 	releaseStringPair(env, classNameObj, nameChars, partitionObj, partitionChars);
@@ -1698,12 +1690,8 @@ Java_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_findSharedClassImpl2(J
 
 	omrthread_monitor_exit(jclCacheMutex);
 
-	omrthread_monitor_enter(vm->classTableMutex);
-	omrthread_monitor_enter(vm->classMemorySegments->segmentMutex);
 	ALWAYS_TRIGGER_J9HOOK_VM_FIND_LOCALLY_DEFINED_CLASS(vm->hookInterface, (J9VMThread*)env, classloader, NULL,
 			(const char*)nameChars, (UDATA)nameLen, cpEntries, entryCount, confirmedCount, partition, !doFind, !doStore, &indexFoundAt, romClass);
-	omrthread_monitor_exit(vm->classMemorySegments->segmentMutex);
-	omrthread_monitor_exit(vm->classTableMutex);
 
 	if (NULL != urlArrayElements) {
 		for (i = 0; i < urlCount; i++) {

--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -262,7 +262,7 @@ public:
 
 	bool isCacheCorruptReported(void);
 
-	IDATA runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCache, const char** subcstr);
+	IDATA runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCache, const char** subcstr, bool acquireClassSegmentMutex = false);
 
 	void protectPartiallyFilledPages(J9VMThread *currentThread);
 

--- a/runtime/shared_common/hookhelpers.cpp
+++ b/runtime/shared_common/hookhelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,7 @@ ClasspathItem*
 getBootstrapClasspathItem(J9VMThread* currentThread, J9ClassPathEntry* bootstrapCPE, UDATA entryCount)
 {
 	J9JavaVM* vm = currentThread->javaVM;
+	Trc_SHR_Assert_ShouldHaveLocalMutex(vm->classMemorySegments->segmentMutex);
 
 	if (bootstrapCPE == vm->sharedClassConfig->lastBootstrapCPE) {
 		ClasspathItem* cpi = (ClasspathItem*) vm->sharedClassConfig->bootstrapCPI;
@@ -223,6 +224,7 @@ createClasspath(J9VMThread* currentThread, J9ClassPathEntry* classPathEntries, U
 {
 	ClasspathItem *classpath;
 	PORT_ACCESS_FROM_VMC(currentThread);
+	Trc_SHR_Assert_ShouldHaveLocalMutex(currentThread->javaVM->classMemorySegments->segmentMutex);
 
 	I_16 supportedEntries = (I_16)entryCount;
 	

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2987,3 +2987,6 @@ TraceEvent=Trc_SHR_CC_startup_getCacheUniqueID_after Overhead=1 Level=7 Template
 
 TraceEvent=Trc_SHR_API_j9shr_classStoreTransaction_start_cacheFull_Event Overhead=1 Level=3 Template="API j9shr_classStoreTransaction_start : J9SHR_RUNTIMEFLAG_BLOCK_SPACE_FULL is set. The shared cache is full"
 TraceEvent=Trc_SHR_API_j9shr_classStoreTransaction_start_cacheSoftFull_Event Overhead=1 Level=3 Template="API j9shr_classStoreTransaction_start : J9SHR_RUNTIMEFLAG_AVAILABLE_SPACE_FULL is set. The shared cache is soft full"
+
+TraceExit-Exception=Trc_SHR_CMI_Update_Exit5 Overhead=1 Level=2 Template="CMI Update: StoreIdentified failed to acquire _identifiedMutex. Returning -1."
+TraceExit-Exception=Trc_SHR_CMI_validate_Exit_IdentifiedMutex_Failed Overhead=1 Level=2 Template="CMI validate: Failed to acquire _identifiedMutex. Returning -1."

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -782,16 +782,16 @@ CorruptCacheTest::findDummyROMClass(J9JavaVM *vm, const char *romClassName)
 	cpEntry.pathLength = 1;
 	cpEntry.type = CPE_TYPE_DIRECTORY;
 
+	cacheMap = (SH_CacheMap *)vm->sharedClassConfig->sharedClassCache;
+	cacheMap->enterLocalMutex(vm->mainThread, vm->classMemorySegments->segmentMutex, "class segment mutex", "findDummyROMClass");
 	cpi = createClasspath(vm->mainThread, &cpEntry, 1, 0, CP_TYPE_CLASSPATH, 0);
+	cacheMap->exitLocalMutex(vm->mainThread, vm->classMemorySegments->segmentMutex, "class segment mutex", "findDummyROMClass");
 	if (NULL == cpi) {
 		j9tty_printf(PORTLIB, "testCorruptCache: failed to create dummy classpath\n");
 		return FAIL;
 	}
 
-	cacheMap = (SH_CacheMap *)vm->sharedClassConfig->sharedClassCache;
-	cacheMap->enterLocalMutex(vm->mainThread, vm->classMemorySegments->segmentMutex, "class segment mutex", "findDummyROMClass");
-	cacheMap->findROMClass(vm->mainThread, romClassName, cpi, NULL, NULL, -1, NULL);
-	cacheMap->exitLocalMutex(vm->mainThread, vm->classMemorySegments->segmentMutex, "class segment mutex", "findDummyROMClass");
+	cacheMap->findROMClass(vm->mainThread, romClassName, cpi, NULL, NULL, -1, NULL);	
 
 	return rc;
 }

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -525,21 +525,16 @@ callFindLocallyDefinedClass(J9VMThread* vmThread, J9Module *j9module, U_8* class
 	/* localBuffer should not be NULL */
 	Assert_VM_true(NULL != localBuffer);
 
-	omrthread_monitor_enter(vmThread->javaVM->classMemorySegments->segmentMutex);
 	if (NULL != dynamicLoadBuffers) {
 		 J9ClassPathEntry* classPathEntries = NULL;
 		 if (classLoader == vmThread->javaVM->systemClassLoader) {
 			 classPathEntries = classLoader->classPathEntries;
 		 }
-
-
 		 TRIGGER_J9HOOK_VM_FIND_LOCALLY_DEFINED_CLASS(vmThread->javaVM->hookInterface, vmThread, classLoader, j9module, (char*)className, classNameLength,
 						classPathEntries, classLoader->classPathEntryCount, -1, NULL, 0, 0,
 						(IDATA *) &localBuffer->entryIndex, returnVal);
 
 		findResult = (IDATA) returnVal;
-
- 		omrthread_monitor_exit(vmThread->javaVM->classMemorySegments->segmentMutex);
 		if (0 == findResult) {
 			TRIGGER_J9HOOK_VM_FIND_LOCALLY_DEFINED_CLASS_FROM_FILESYSTEM(vmThread->javaVM->hookInterface, 
 																		 vmThread, 
@@ -570,8 +565,6 @@ callFindLocallyDefinedClass(J9VMThread* vmThread, J9Module *j9module, U_8* class
 				localBuffer->loadLocationType = LOAD_LOCATION_CLASSPATH;
 			}
 		}
-	} else {
- 		omrthread_monitor_exit(vmThread->javaVM->classMemorySegments->segmentMutex);
 	}
 	return findResult;
 }


### PR DESCRIPTION
There are 2 issues with findSharedClass() in SCC Helpers being
synchronized:

A. For classLoader with isParallelCapable = true, the parallel 
class loading capability is lost.
B. In the case that there are multiple custom Classloaders setting 
the app ClassLoader as the parent, they all delegate to the app
ClassLoader first when finding classes. So all of them need to go 
through the synchronized method appClassloader.findSharedClass() 
one by one, which becomes a bottleneck.

The changes here are:
1. Change findSharedClass() as well as storeSharedClass() to be
non-synchronized.

2. Use a readWriteLock in SharedClassURLClasspathHelperImpl 
instead.

3. Do not enter classTableMutex and class segmentMutex in the 
native implementation of findSharedClass() in shared.c, as
entering these mutexes is essentially making findSharedClass()
synchronized in the native level.

4. Enter class segmentMutex only when necessary in 
hookFindSharedClass() and cacheMap::findROMClass().

5. Do not need to wrap callFindLocallyDefinedClass() inside class
segment mutex.

6. Change SharedClassURLHelperImpl.jarFileNameCache from a regular 
Set to a concurrent Set.

7. _identifiedClasspaths should be used inside _identifiedMutex.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>