### PR TITLE
Disable jitdump at the server

### DIFF
--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -435,6 +435,21 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
       "<jitDump>\n"
       );
 
+#if defined(J9VM_OPT_JITSERVER)
+   if (context && context->javaVM && context->javaVM->jitConfig)
+      {
+      J9JITConfig *jitConfig = context->javaVM->jitConfig;
+      TR::CompilationInfo *compInfo = TR::CompilationInfo::get(context->javaVM->jitConfig);
+      if (compInfo &&
+          compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+         {
+         jitDumpFailedBecause(crashedThread, "Skipped jitdump at the JITServer");
+         trfprintf(logFile, "Skipped jitdump at the JITServer\n");
+         trfclose(logFile);
+         return OMR_ERROR_NONE;
+         }
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
    // if some thread holds exclusive VM access we cannot do much
    if (J9_XACCESS_NONE != jitConfig->javaVM->exclusiveAccessState)


### PR DESCRIPTION
During jitdump, the server could try to read and write messages to the client to retrieve information such as `TR_J9ServerVM::sampleSignature()` could be triggered as part of `printIRTrees()`. Since at the time the server has encountered a crash, any stream related exception won’t be handled at this point. Since at the moment there is no value with the jitdmp at the server, we could disable it for now.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>