### PR TITLE
Store OMRProcessorDesc in AOT Header

### DIFF
--- a/runtime/compiler/aarch64/env/J9CPU.cpp
+++ b/runtime/compiler/aarch64/env/J9CPU.cpp
@@ -23,25 +23,32 @@
 #include "env/CompilerEnv.hpp"
 #include "env/CPU.hpp"
 
-namespace J9
-{
-
-namespace ARM64
-{
-
-TR_ProcessorFeatureFlags
-CPU::getProcessorFeatureFlags()
-   {
-   TR_ProcessorFeatureFlags processorFeatureFlags = { {0} };
-   return processorFeatureFlags;
-   }
-
 bool
-CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+J9::ARM64::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   return self()->id() == processorSignature;
+   return self()->getProcessorDescription().processor == processorDescription.processor;
    }
 
-}
-
-}
+OMRProcessorDesc
+J9::ARM64::CPU::getProcessorDescription()
+   {
+   static bool initialized = false;
+   if (!initialized)
+      {
+      memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+      switch (self()->id())
+         {
+         case TR_DefaultARM64Processor:
+            _processorDescription.processor = OMR_PROCESSOR_ARM64_UNKNOWN;
+            break;
+         case TR_ARMv8_A:
+            _processorDescription.processor = OMR_PROCESSOR_ARM64_V8_A;
+            break;
+         default:
+            TR_ASSERT_FATAL(false, "Invalid ARM64 Processor ID");
+         }
+      _processorDescription.physicalProcessor = _processorDescription.processor;
+      initialized = true;
+      }
+   return _processorDescription;
+   }

--- a/runtime/compiler/aarch64/env/J9CPU.hpp
+++ b/runtime/compiler/aarch64/env/J9CPU.hpp
@@ -37,19 +37,6 @@ namespace J9 { typedef J9::ARM64::CPU CPUConnector; }
 #include "compiler/env/J9CPU.hpp"
 #include "env/ProcessorInfo.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -65,8 +52,8 @@ protected:
 
 public:
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+   OMRProcessorDesc getProcessorDescription();
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
 
    };
 

--- a/runtime/compiler/arm/env/J9CPU.cpp
+++ b/runtime/compiler/arm/env/J9CPU.cpp
@@ -23,25 +23,37 @@
 #include "env/CompilerEnv.hpp"
 #include "env/CPU.hpp"
 
-namespace J9
-{
-
-namespace ARM 
-{
-
-TR_ProcessorFeatureFlags
-CPU::getProcessorFeatureFlags()
-   {
-   TR_ProcessorFeatureFlags processorFeatureFlags = { {0} };
-   return processorFeatureFlags;
-   }
-
 bool
-CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+J9::ARM::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   return self()->id() == processorSignature;
+   return self()->getProcessorDescription().processor == processorDescription.processor;
    }
-   
-}
 
-}
+OMRProcessorDesc
+J9::ARM::CPU::getProcessorDescription()
+   {
+   static bool initialized = false;
+   if (!initialized)
+      {
+      memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+      switch (self()->id())
+         {
+         case TR_DefaultARMProcessor:
+            _processorDescription.processor = OMR_PROCESSOR_ARM_UNKNOWN;
+            break;
+         case TR_ARMv6:
+            _processorDescription.processor = OMR_PROCESSOR_ARM_V6;
+            break;
+         case TR_ARMv7:
+            _processorDescription.processor = OMR_PROCESSOR_ARM_V7;
+            break;
+         default:
+            TR_ASSERT_FATAL(false, "Invalid ARM64 Processor ID");
+         }
+      _processorDescription.physicalProcessor = _processorDescription.processor;
+      initialized = true;
+      }
+   return _processorDescription;
+   }
+
+

--- a/runtime/compiler/arm/env/J9CPU.hpp
+++ b/runtime/compiler/arm/env/J9CPU.hpp
@@ -37,19 +37,6 @@ namespace J9 { typedef J9::ARM::CPU CPUConnector; }
 #include "compiler/env/J9CPU.hpp"
 #include "env/ProcessorInfo.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -65,9 +52,8 @@ protected:
 
 public:
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
+   OMRProcessorDesc getProcessorDescription();
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
    };
 
 }

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -183,6 +183,14 @@ J9::Compilation::Compilation(int32_t id,
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)
    {
+
+#if defined(J9VM_OPT_JITSERVER)
+   // In JITServer, we would like to use JITClient's processor info for the compilation
+   // The following code effectively replaces the cpu with client's cpu through the getProcessorDescription() that has JITServer support
+   if (self()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      _target.cpu = TR::CPU(TR::Compiler->target.cpu.getProcessorDescription());
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
    _aotClassClassPointer = NULL;

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -505,7 +505,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._readBarrierType = TR::Compiler->om.readBarrierType();
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
-         vmInfo._processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
+         vmInfo._processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
          vmInfo._invokeWithArgumentsHelperMethod = J9VMJAVALANGINVOKEMETHODHANDLE_INVOKEWITHARGUMENTSHELPER_METHOD(fe->getJ9JITConfig()->javaVM);
          vmInfo._noTypeInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false)->getMethodAddress();
          vmInfo._int64InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false)->getMethodAddress();

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -51,6 +51,8 @@ public:
 
    const char *getProcessorVendorId() { TR_ASSERT(false, "Vendor ID not defined for this platform!"); return NULL; }
    uint32_t getProcessorSignature() { TR_ASSERT(false, "Processor Signature not defined for this platform!"); return 0; }
+
+   OMRProcessorArchitecture getProcessor() { return _processorDescription.processor; }
    };
 }
 

--- a/runtime/compiler/p/env/J9CPU.hpp
+++ b/runtime/compiler/p/env/J9CPU.hpp
@@ -39,19 +39,6 @@ namespace J9 { typedef J9::Power::CPU CPUConnector; }
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -74,9 +61,8 @@ public:
    bool hasPopulationCountInstruction();
    bool supportsDecimalFloatingPoint();
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
+   OMRProcessorDesc getProcessorDescription();
    };
 
 }

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -26,7 +26,6 @@
 #include "infra/Monitor.hpp"  // TR::Monitor
 #include "env/PersistentCollections.hpp" // for PersistentUnorderedMap
 #include "il/DataTypes.hpp" // for DataType
-#include "env/J9CPU.hpp" // for TR_ProcessorFeatureFlags
 #include "env/VMJ9.h" // for TR_StaticFinalData
 
 class J9ROMClass;
@@ -316,7 +315,7 @@ class ClientSessionData
       MM_GCReadBarrierType _readBarrierType;
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;
-      TR_ProcessorFeatureFlags _processorFeatureFlags;
+      OMRProcessorDesc _processorDescription;
       J9Method *_invokeWithArgumentsHelperMethod;
       void *_noTypeInvokeExactThunkHelper;
       void *_int64InvokeExactThunkHelper;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -949,7 +949,7 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(TR_AOTHeader *hdrInCache, i
    {
    bool defaultMessage = true;
 
-   if (!TR::Compiler->target.cpu.isCompatible((TR_Processor)hdrInCache->processorSignature, hdrInCache->processorFeatureFlags))
+   if (!TR::Compiler->target.cpu.isCompatible(hdrInCache->processorDescription))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_WRONG_HARDWARE, "AOT header validation failed: Processor incompatible.");
    if ((featureFlags & TR_FeatureFlag_sanityCheckBegin) != (hdrInCache->featureFlags & TR_FeatureFlag_sanityCheckBegin))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_START_SANITY_BIT_MANGLED, "AOT header validation failed: Processor feature sanity bit mangled.");
@@ -1045,7 +1045,7 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
          }
       else if
          (hdrInCache->featureFlags != featureFlags ||
-          !TR::Compiler->target.cpu.isCompatible((TR_Processor)hdrInCache->processorSignature, hdrInCache->processorFeatureFlags)
+          !TR::Compiler->target.cpu.isCompatible(hdrInCache->processorDescription)
          )
          {
          checkAOTHeaderFlags(hdrInCache, featureFlags);
@@ -1115,12 +1115,10 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
       strncpy(aotHeaderVersion->vmBuildVersion, EsBuildVersionString, sizeof(EsBuildVersionString));
       strncpy(aotHeaderVersion->jitBuildVersion, TR_BUILD_NAME, std::min(strlen(TR_BUILD_NAME), sizeof(aotHeaderVersion->jitBuildVersion)));
 
-      aotHeader->processorSignature = TR::Compiler->target.cpu.id();
       aotHeader->gcPolicyFlag = javaVM()->memoryManagerFunctions->j9gc_modron_getWriteBarrierType(javaVM());
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(javaVM());
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
-
-      aotHeader->processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
+      aotHeader->processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
 
       // Set up other feature flags
       aotHeader->featureFlags = generateFeatureFlags(fe);

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -95,14 +95,13 @@ typedef struct TR_AOTHeader {
     uintptr_t *relativeMethodMetaDataTable;
     uintptr_t architectureAndOs;
     uintptr_t endiannessAndWordSize;
-    uintptr_t processorSignature;
     uintptr_t featureFlags;
     uintptr_t vendorId;
     uintptr_t gcPolicyFlag;
     uintptr_t compressedPointerShift;
     uint32_t lockwordOptionHashValue;
     int32_t   arrayLetLeafSize;
-    TR_ProcessorFeatureFlags processorFeatureFlags;
+    OMRProcessorDesc processorDescription;
 } TR_AOTHeader;
 
 typedef struct TR_AOTRuntimeInfo {

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -36,14 +36,8 @@
 // Without this definition, we get an undefined symbol of JITConfig::instance() at runtime
 TR::JitConfig * TR::JitConfig::instance() { return NULL; }
 
-namespace J9
-{
-
-namespace X86
-{
-
 TR_X86CPUIDBuffer *
-CPU::queryX86TargetCPUID()
+J9::X86::CPU::queryX86TargetCPUID()
    {
    static TR_X86CPUIDBuffer buf = { {'U','n','k','n','o','w','n','B','r','a','n','d'} };
    jitGetCPUID(&buf);
@@ -51,19 +45,19 @@ CPU::queryX86TargetCPUID()
    }
 
 const char *
-CPU::getProcessorVendorId()
+J9::X86::CPU::getProcessorVendorId()
    {
    return self()->getX86ProcessorVendorId();
    }
 
 uint32_t
-CPU::getProcessorSignature()
+J9::X86::CPU::getProcessorSignature()
    {
    return self()->getX86ProcessorSignature();
    }
 
 bool
-CPU::hasPopulationCountInstruction()
+J9::X86::CPU::hasPopulationCountInstruction()
    {
    if ((self()->getX86ProcessorFeatureFlags2() & TR_POPCNT) != 0x00000000)
       return true;
@@ -71,70 +65,69 @@ CPU::hasPopulationCountInstruction()
       return false;
    }
 
-TR_ProcessorFeatureFlags
-CPU::getProcessorFeatureFlags()
-   {
-#if defined(J9VM_OPT_JITSERVER)
-   if (auto stream = TR::CompilationInfo::getStream())
-      {
-      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags;
-      }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-   TR_ProcessorFeatureFlags processorFeatureFlags = { {self()->getX86ProcessorFeatureFlags(), self()->getX86ProcessorFeatureFlags2(), self()->getX86ProcessorFeatureFlags8()} };
-   return processorFeatureFlags;
-   }
-
 bool
-CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+J9::X86::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   for (int i = 0; i < PROCESSOR_FEATURES_SIZE; i++)
+   for (int i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
       {
       // Check to see if the current processor contains all the features that code cache's processor has
-      if ((processorFeatureFlags.featureFlags[i] & self()->getProcessorFeatureFlags().featureFlags[i]) != processorFeatureFlags.featureFlags[i])
+      if ((processorDescription.features[i] & self()->getProcessorDescription().features[i]) != processorDescription.features[i])
          return false;
       }
    return true;
    }
 
-uint32_t
-CPU::getX86ProcessorFeatureFlags()
+OMRProcessorDesc
+J9::X86::CPU::getProcessorDescription()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags.featureFlags[0];
+      return vmInfo->_processorDescription;
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   return _processorDescription;
+   }
+
+uint32_t
+J9::X86::CPU::getX86ProcessorFeatureFlags()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_processorDescription.features[0];
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return self()->queryX86TargetCPUID()->_featureFlags;
    }
 
 uint32_t
-CPU::getX86ProcessorFeatureFlags2()
+J9::X86::CPU::getX86ProcessorFeatureFlags2()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags.featureFlags[1];
+      return vmInfo->_processorDescription.features[1];
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return self()->queryX86TargetCPUID()->_featureFlags2;
    }
 
 uint32_t
-CPU::getX86ProcessorFeatureFlags8()
+J9::X86::CPU::getX86ProcessorFeatureFlags8()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags.featureFlags[2];
+      return vmInfo->_processorDescription.features[3];
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return self()->queryX86TargetCPUID()->_featureFlags8;
    }
 
-}
-}
+
+

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -37,21 +37,6 @@ namespace J9 { typedef J9::X86::CPU CPUConnector; }
 #include "compiler/env/J9CPU.hpp"
 #include "env/ProcessorInfo.hpp"
 
-namespace TR { class Compilation; }
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 3
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -74,13 +59,11 @@ public:
    bool hasPopulationCountInstruction();
    bool testOSForSSESupport() { return true; }
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
+   OMRProcessorDesc getProcessorDescription();
    uint32_t getX86ProcessorFeatureFlags();
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
-
    };
 
 }

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -39,19 +39,6 @@ namespace J9 { typedef J9::Z::CPU CPUConnector; }
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -78,9 +65,8 @@ class OMR_EXTENSIBLE CPU : public J9::CPU
 
    void applyUserOptions();
    void initializeS390ProcessorFeatures();
-
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
+   OMRProcessorDesc getProcessorDescription();
    };
 
 }


### PR DESCRIPTION
Previously we have TR_Processor and TR_ProcessorFeatureFlags in
AOT header. We will no longer be using TR_Processor and
TR_ProcessorFeatureFlags soon.

depends on: https://github.com/eclipse/omr/pull/5197

Signed-off-by: Harry Yu <harryyu1994@gmail.com>