### PR TITLE
Disable testJITServer for XL builds

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -523,7 +523,7 @@
 		echo $(Q)$(TEST_JDK_BIN)$(D)jitserver doesn't exist; assuming this JDK does not support JITServer and trivially passing the test.$(Q); \
 	fi; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<platformRequirements>os.linux,arch.x86,bits.64,vm.cmprssptrs</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Disable testJITServer for XL builds.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>