### PR TITLE
Disable cpu asserts for JITServer

### DIFF
--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -232,7 +232,7 @@ uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuf
    //
    for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset)
       {
-      TR_ASSERT_FATAL(TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
+      TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
       prefetchSnippetBuffer[0] = 0x0F;
       if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H))
          prefetchSnippetBuffer[1] = 0x0D;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -86,8 +86,8 @@ J9::X86::CodeGenerator::CodeGenerator() :
    cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsNewInstanceImplOpt();
    
-   TR_ASSERT_FATAL(comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
-   TR_ASSERT_FATAL(comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
+   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
+   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
    
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringCaseConv) &&
@@ -379,7 +379,7 @@ J9::X86::CodeGenerator::nopsAlsoProcessedByRelocations()
 bool
 J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    {
-   TR_ASSERT_FATAL(self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
+   TR_ASSERT_FATAL(self()->comp()->isOutOfProcessCompilation() || self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
    if (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
       return true;
    else

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -573,7 +573,7 @@ static TR::Instruction *generatePrefetchAfterHeaderAccess(TR::Node              
    TR::Instruction *instr = NULL;
 
    static const char *prefetch = feGetEnv("TR_EnableSoftwarePrefetch");
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
+   TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
    if (prefetch && cg->comp()->getMethodHotness()>=scorching && cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2))
       {
       int32_t fieldOffset = 0;
@@ -4700,14 +4700,14 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    if (cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord())
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG8MemReg : CMPXCHG8MemReg;
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG8MemReg : XACMPXCHG8MemReg;
       }
    else
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG4MemReg : CMPXCHG4MemReg;
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG4MemReg : XACMPXCHG4MemReg;
       }
@@ -5534,7 +5534,7 @@ TR::Register
 
    if (!node->isReadMonitor() && !reservingLock)
       {
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
@@ -9100,7 +9100,7 @@ static TR::Register* inlineStringHashCode(TR::Node* node, bool isCompressed, TR:
       generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
       auto mr = generateX86MemoryReference(tmp, index, shift, 0, cg);
-      TR_ASSERT_FATAL(cg->getX86ProcessorInfo().supportsAVX() == cg->comp()->target().cpu.supportsAVX(), "supportsAVX() failed\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->getX86ProcessorInfo().supportsAVX() == cg->comp()->target().cpu.supportsAVX(), "supportsAVX() failed\n");
       if (cg->comp()->target().cpu.supportsAVX())
          {
          generateRegMemInstruction(PANDRegMem, node, hashXMM, mr, cg);
@@ -9510,7 +9510,7 @@ inlineCompareAndSwapNative(
       }
    else
       {
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
       if (!cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8))
          return false;
 
@@ -9932,7 +9932,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderAccesses:
             {
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
             if (cg->comp()->target().cpu.supportsMFence())
                {
                TR_X86OpCode fenceOp;
@@ -9946,8 +9946,8 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderReads:
             {
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
 
             if (cg->comp()->target().cpu.requiresLFence() &&
                 cg->comp()->target().cpu.supportsLFence())
@@ -9963,7 +9963,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderWrites:
             {
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
             
             if (cg->comp()->target().cpu.supportsSFence())
                {

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -26,6 +26,7 @@
 #include "env/VMJ9.h"
 #include "x/runtime/X86Runtime.hpp"
 #include "env/JitConfig.hpp"
+#include "codegen/CodeGenerator.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -130,5 +130,145 @@ J9::X86::CPU::getX86ProcessorFeatureFlags8()
    return self()->queryX86TargetCPUID()->_featureFlags8;
    }
 
+bool
+J9::X86::CPU::is_test(OMRProcessorArchitecture p)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
+   switch(p)
+      {
+      case OMR_PROCESSOR_X86_INTELWESTMERE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelWestmere() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELNEHALEM:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelNehalem() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELPENTIUM:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELP6:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelP6() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELPENTIUM4:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium4() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELCORE2:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelCore2() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELTULSA:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelTulsa() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELSANDYBRIDGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSandyBridge() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELIVYBRIDGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelIvyBridge() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELHASWELL:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelHaswell() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELBROADWELL:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelBroadwell() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELSKYLAKE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSkylake() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDATHLONDURON:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMDAthlonDuron() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDOPTERON:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMDOpteron() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDFAMILY15H:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == (_processorDescription.processor == p);
+      default:
+         return false;
+      }
+   return false;
+   }
 
+bool
+J9::X86::CPU::supports_feature_test(uint32_t feature)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
+
+   switch(feature)
+      {
+      case OMR_FEATURE_X86_OSXSAVE:
+         return TR::CodeGenerator::getX86ProcessorInfo().enabledXSAVE() == ans;
+      case OMR_FEATURE_X86_FPU:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasBuiltInFPU() == ans;
+      case OMR_FEATURE_X86_VME:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsVirtualModeExtension() == ans;
+      case OMR_FEATURE_X86_DE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsDebuggingExtension() == ans;
+      case OMR_FEATURE_X86_PSE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPageSizeExtension() == ans;
+      case OMR_FEATURE_X86_TSC:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsRDTSCInstruction() == ans;
+      case OMR_FEATURE_X86_MSR:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasModelSpecificRegisters() == ans;
+      case OMR_FEATURE_X86_PAE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPhysicalAddressExtension() == ans;
+      case OMR_FEATURE_X86_MCE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsMachineCheckException() == ans;
+      case OMR_FEATURE_X86_CX8:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG8BInstruction() == ans;
+      case OMR_FEATURE_X86_CMPXCHG16B:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG16BInstruction() == ans;
+      case OMR_FEATURE_X86_APIC:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasAPICHardware() == ans;
+      case OMR_FEATURE_X86_MTRR:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasMemoryTypeRangeRegisters() == ans;
+      case OMR_FEATURE_X86_PGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPageGlobalFlag() == ans;
+      case OMR_FEATURE_X86_MCA:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasMachineCheckArchitecture() == ans;
+      case OMR_FEATURE_X86_CMOV:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMOVInstructions() == ans;
+      case OMR_FEATURE_X86_PAT:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasPageAttributeTable() == ans;
+      case OMR_FEATURE_X86_PSE_36:
+         return TR::CodeGenerator::getX86ProcessorInfo().has36BitPageSizeExtension() == ans;
+      case OMR_FEATURE_X86_PSN:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasProcessorSerialNumber() == ans;
+      case OMR_FEATURE_X86_CLFSH:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLFLUSHInstruction() == ans;
+      case OMR_FEATURE_X86_DS:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsDebugTraceStore() == ans;
+      case OMR_FEATURE_X86_ACPI:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasACPIRegisters() == ans;
+      case OMR_FEATURE_X86_MMX:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsMMXInstructions() == ans;
+      case OMR_FEATURE_X86_FXSR:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsFastFPSavesRestores() == ans;
+      case OMR_FEATURE_X86_SSE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE() == ans;
+      case OMR_FEATURE_X86_SSE2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE2() == ans;
+      case OMR_FEATURE_X86_SSE3:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE3() == ans;
+      case OMR_FEATURE_X86_SSSE3:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSSE3() == ans;
+      case OMR_FEATURE_X86_SSE4_1:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() == ans;
+      case OMR_FEATURE_X86_SSE4_2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_2() == ans;
+      case OMR_FEATURE_X86_PCLMULQDQ:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLMUL() == ans;
+      case OMR_FEATURE_X86_AESNI:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() == ans;
+      case OMR_FEATURE_X86_POPCNT:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPOPCNT() == ans;
+      case OMR_FEATURE_X86_SS:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSelfSnoop() == ans;
+      case OMR_FEATURE_X86_RTM:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsTM() == ans;
+      case OMR_FEATURE_X86_HTT:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsHyperThreading() == ans;
+      case OMR_FEATURE_X86_HLE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsHLE() == ans;
+      case OMR_FEATURE_X86_TM:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasThermalMonitor() == ans;
+      case OMR_FEATURE_X86_AVX:
+         return true;
+      default:
+         return false;
+      }
+   return false;
+   }

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -64,6 +64,9 @@ public:
    uint32_t getX86ProcessorFeatureFlags();
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
+
+   bool is_test(OMRProcessorArchitecture p);
+   bool supports_feature_test(uint32_t feature);
    };
 
 }

--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -385,6 +385,81 @@ J9::Z::CPU::initializeS390ProcessorFeatures()
    }
 
 bool
+J9::Z::CPU::is_at_least_test(OMRProcessorArchitecture p)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   switch(p)
+      {
+      case OMR_PROCESSOR_S390_Z10:
+         return (self()->getSupportsArch(TR::CPU::z10) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z196:
+         return (self()->getSupportsArch(TR::CPU::z196) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_ZEC12:
+         return (self()->getSupportsArch(TR::CPU::zEC12) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z13:
+         return (self()->getSupportsArch(TR::CPU::z13) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z14:
+         return (self()->getSupportsArch(TR::CPU::z14) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z15:
+         return (self()->getSupportsArch(TR::CPU::z15) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_ZNEXT:
+         return (self()->getSupportsArch(TR::CPU::zNext) == (_processorDescription.processor >= p));
+      default:
+         return false;
+      }
+   return false;
+   }
+
+bool
+J9::Z::CPU::supports_feature_test(uint32_t feature)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
+
+   switch(feature)
+      {
+      case OMR_FEATURE_S390_HIGH_WORD:
+         return (self()->getSupportsHighWordFacility() == ans);
+      case OMR_FEATURE_S390_DFP:
+         return (self()->getSupportsDecimalFloatingPointFacility() == ans);
+      case OMR_FEATURE_S390_FPE:
+         return (self()->getSupportsFloatingPointExtensionFacility() == ans);
+      case OMR_FEATURE_S390_TE:
+         return (self()->getSupportsTransactionalMemoryFacility() == ans);
+      case OMR_FEATURE_S390_RI:
+         return (self()->getSupportsRuntimeInstrumentationFacility() == ans);
+      case OMR_FEATURE_S390_VECTOR_FACILITY:
+         return (self()->getSupportsVectorFacility() == ans);
+      case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL:
+         return (self()->getSupportsVectorPackedDecimalFacility() == ans);
+      case OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3:
+         return (self()->getSupportsMiscellaneousInstructionExtensions3Facility() == ans);
+      case OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_2:
+         return (self()->getSupportsVectorFacilityEnhancement2() == ans);
+      case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY:
+         return (self()->getSupportsVectorPackedDecimalEnhancementFacility() == ans);
+      case OMR_FEATURE_S390_GUARDED_STORAGE:
+         return (self()->getSupportsGuardedStorageFacility() == ans);
+      case OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_2:
+         return (self()->getSupportsMiscellaneousInstructionExtensions2Facility() == ans);
+      case OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1:
+         return (self()->getSupportsVectorFacilityEnhancement1() == ans);
+      default:
+         return false;
+      }
+   return false;
+   }
+
+bool
 J9::Z::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
    if (!self()->isAtLeast(processorDescription.processor))

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -67,6 +67,9 @@ class OMR_EXTENSIBLE CPU : public J9::CPU
    void initializeS390ProcessorFeatures();
    bool isCompatible(const OMRProcessorDesc& processorDescription);
    OMRProcessorDesc getProcessorDescription();
+
+   bool is_at_least_test(OMRProcessorArchitecture p);
+   bool supports_feature_test(uint32_t feature);
    };
 
 }


### PR DESCRIPTION
Disabled the cpu related asserts for JITServer.
These asserts are meant to only test the correctness of new APIs
against old APIs for a single host processor and they fall apart
when we introduce remote target processors into the picture.

Issue: https://github.com/eclipse/openj9/issues/9833

Signed-off-by: Harry Yu <harryyu1994@gmail.com>