### PR TITLE
testDDRExt allow jdk.internal classes to support JDK11+

### DIFF
--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -273,7 +273,7 @@ public class Constants {
 
 	public static final String SHRC_JITHFOR = "jithfor";
 	public static final String SHRC_JITHFOR_METHODNAME = "<init>";
-	public static final String SHRC_JITHFOR_SUCCESS_KEY = "<init>\\(.*\\),JITHINT data !j9x,(java|sun)/.*";
+	public static final String SHRC_JITHFOR_SUCCESS_KEY = "<init>\\(.*\\),JITHINT data !j9x,(java|sun|internal)/.*";
 	public static final String SHRC_JITHFOR_FAILURE_KEY = "No entry found in the cache";
 
 	public static final String SHRC_RTFLAGS = "rtflags";


### PR DESCRIPTION
Fixes #9809