### PR TITLE
Rename S390JNICallDataSnippet2 to S390JNICallDataSnippet

### DIFF
--- a/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
@@ -70,7 +70,7 @@ J9::Z::zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode,
 	TR::LabelSymbol * returnFromJNICallLabel,
 	TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
-   TR::S390JNICallDataSnippet2 * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet2 *>(callDataSnippet);
+   TR::S390JNICallDataSnippet * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet *>(callDataSnippet);
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
    J9::Z::PrivateLinkage * privateLinkage = static_cast<J9::Z::PrivateLinkage *>(cg()->getLinkage(TR_Private));

--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -68,7 +68,7 @@ J9::Z::zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
-   TR::S390JNICallDataSnippet2 * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet2 *>(callDataSnippet);
+   TR::S390JNICallDataSnippet * jniCallDataSnippet = static_cast<TR::S390JNICallDataSnippet *>(callDataSnippet);
    TR::CodeGenerator * codeGen = cg();
    TR::Compilation *comp = codeGen->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -1276,73 +1276,73 @@ TR::J9S390InterfaceCallDataSnippet::getLength(int32_t)
 
 
 uint32_t
-TR::S390JNICallDataSnippet2::getJNICallOutFrameFlagsOffset()
+TR::S390JNICallDataSnippet::getJNICallOutFrameFlagsOffset()
    {
    return TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getReturnFromJNICallOffset()
+TR::S390JNICallDataSnippet::getReturnFromJNICallOffset()
    {
    return 2 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getSavedPCOffset()
+TR::S390JNICallDataSnippet::getSavedPCOffset()
    {
    return 3 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getTagBitsOffset()
+TR::S390JNICallDataSnippet::getTagBitsOffset()
    {
    return 4 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getPCOffset()
+TR::S390JNICallDataSnippet::getPCOffset()
    {
    return 5 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getLiteralsOffset()
+TR::S390JNICallDataSnippet::getLiteralsOffset()
    {
    return 6 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getJitStackFrameFlagsOffset()
+TR::S390JNICallDataSnippet::getJitStackFrameFlagsOffset()
    {
    return 7 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getConstReleaseVMAccessMaskOffset()
+TR::S390JNICallDataSnippet::getConstReleaseVMAccessMaskOffset()
    {
    return 8 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getConstReleaseVMAccessOutOfLineMaskOffset()
+TR::S390JNICallDataSnippet::getConstReleaseVMAccessOutOfLineMaskOffset()
    {
    return 9 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getTargetAddressOffset()
+TR::S390JNICallDataSnippet::getTargetAddressOffset()
    {
    return 10 * TR::Compiler->om.sizeofReferenceAddress();
    }
 
 uint32_t
-TR::S390JNICallDataSnippet2::getLength(int32_t estimatedSnippetStart)
+TR::S390JNICallDataSnippet::getLength(int32_t estimatedSnippetStart)
    {
    return 12 * TR::Compiler->om.sizeofReferenceAddress(); /*one ptr more for possible padding */
    }
 
 
-TR::S390JNICallDataSnippet2::S390JNICallDataSnippet2(TR::CodeGenerator * cg,
+TR::S390JNICallDataSnippet::S390JNICallDataSnippet(TR::CodeGenerator * cg,
                                TR::Node * node)
 : TR::S390ConstantDataSnippet(cg, node, generateLabelSymbol(cg),0),
  _baseRegister(0),
@@ -1362,11 +1362,11 @@ TR::S390JNICallDataSnippet2::S390JNICallDataSnippet2(TR::CodeGenerator * cg,
    }
 
 uint8_t *
-TR::S390JNICallDataSnippet2::emitSnippetBody()
+TR::S390JNICallDataSnippet::emitSnippetBody()
    {
    uint8_t * cursor = cg()->getBinaryBufferCursor();
 
-   /* TR::S390JNICallDataSnippet2 Layout: all fields are pointer sized
+   /* TR::S390JNICallDataSnippet Layout: all fields are pointer sized
        ramMethod
        JNICallOutFrameFlags
        returnFromJNICall
@@ -1381,7 +1381,7 @@ TR::S390JNICallDataSnippet2::emitSnippetBody()
    */
       TR::Compilation *comp = cg()->comp();
 
-      AOTcgDiag1(comp, "TR::S390JNICallDataSnippet2::emitSnippetBody cursor=%x\n", cursor);
+      AOTcgDiag1(comp, "TR::S390JNICallDataSnippet::emitSnippetBody cursor=%x\n", cursor);
       // Ensure pointer sized alignment
       int32_t alignSize = TR::Compiler->om.sizeofReferenceAddress();
       int32_t padBytes = ((intptr_t)cursor + alignSize -1) / alignSize * alignSize - (intptr_t)cursor;
@@ -1488,7 +1488,7 @@ TR::S390JNICallDataSnippet2::emitSnippetBody()
    }
 
 void
-TR::S390JNICallDataSnippet2::print(TR::FILE *pOutFile, TR_Debug *debug)
+TR::S390JNICallDataSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    {
 /*
        ramMethod

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
@@ -171,7 +171,7 @@ class J9S390InterfaceCallDataSnippet : public TR::S390ConstantDataSnippet
    virtual uint32_t getLastSlotOffset();
    };
 
-class S390JNICallDataSnippet2 : public TR::S390ConstantDataSnippet
+class S390JNICallDataSnippet : public TR::S390ConstantDataSnippet
    {
    /** Base register for this snippet */
    TR::Register *  _baseRegister;
@@ -198,7 +198,7 @@ class S390JNICallDataSnippet2 : public TR::S390ConstantDataSnippet
 
    public:
 
-  S390JNICallDataSnippet2(TR::CodeGenerator *,
+  S390JNICallDataSnippet(TR::CodeGenerator *,
                                   TR::Node *);
 
    virtual Kind getKind() { return IsJNICallData; }

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -2521,7 +2521,7 @@ J9::Z::PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
    TR::RealRegister * javaStackPointerRealRegister,
    TR::Register * methodMetaDataVirtualRegister,
    TR::LabelSymbol * returnFromJNICallLabel,
-   TR::S390JNICallDataSnippet2 *jniCallDataSnippet)
+   TR::S390JNICallDataSnippet *jniCallDataSnippet)
    {
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
@@ -2598,7 +2598,7 @@ J9::Z::PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
  */
 void J9::Z::JNILinkage::releaseVMAccessMask(TR::Node * callNode,
    TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg,
-   TR::S390JNICallDataSnippet2 * jniCallDataSnippet, TR::RegisterDependencyConditions * deps)
+   TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps)
    {
    TR::LabelSymbol * loopHead = generateLabelSymbol(self()->cg());
    TR::LabelSymbol * longReleaseLabel = generateLabelSymbol(self()->cg());
@@ -2946,7 +2946,7 @@ TR::Register * J9::Z::JNILinkage::buildDirectDispatch(TR::Node * callNode)
    deps = generateRegisterDependencyConditions(numDeps, numDeps, cg());
    int64_t killMask = -1;
    TR::Register *vftReg = NULL;
-   TR::S390JNICallDataSnippet2 * jniCallDataSnippet = NULL;
+   TR::S390JNICallDataSnippet * jniCallDataSnippet = NULL;
    TR::RealRegister * javaStackPointerRealRegister = getStackPointerRealRegister();
    TR::RealRegister * methodMetaDataRealRegister = getMethodMetaDataRealRegister();
    TR::RealRegister * javaLitPoolRealRegister = getLitPoolRealRegister();
@@ -3032,7 +3032,7 @@ TR::Register * J9::Z::JNILinkage::buildDirectDispatch(TR::Node * callNode)
      {
      TR::Register * JNISnippetBaseReg = NULL;
      killMask = killAndAssignRegister(killMask, deps, &JNISnippetBaseReg, TR::RealRegister::GPR12, codeGen, true);
-     jniCallDataSnippet = new (trHeapMemory()) TR::S390JNICallDataSnippet2(cg(), callNode);
+     jniCallDataSnippet = new (trHeapMemory()) TR::S390JNICallDataSnippet(cg(), callNode);
      cg()->addSnippet(jniCallDataSnippet);
      jniCallDataSnippet->setBaseRegister(JNISnippetBaseReg);
      new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, callNode,

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.hpp
@@ -25,7 +25,7 @@
 
 #include "codegen/PrivateLinkage.hpp"
 
-namespace TR { class S390JNICallDataSnippet2; }
+namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
 namespace TR { class RegisterDependencyConditions; }
@@ -123,7 +123,7 @@ protected:
       TR::RealRegister * javaStackPointerRealRegister,
       TR::Register * methodMetaDataVirtualRegister,
       TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet2 *jniCallDataSnippet);
+      TR::S390JNICallDataSnippet *jniCallDataSnippet);
 
    };
 
@@ -172,7 +172,7 @@ public:
 
    void checkException(TR::Node * callNode, TR::Register *methodMetaDataVirtualRegister, TR::Register * tempReg);
    void releaseVMAccessMask(TR::Node * callNode, TR::Register * methodMetaDataVirtualRegister,
-         TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::S390JNICallDataSnippet2 * jniCallDataSnippet, TR::RegisterDependencyConditions * deps);
+         TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::S390JNICallDataSnippet * jniCallDataSnippet, TR::RegisterDependencyConditions * deps);
    void acquireVMAccessMask(TR::Node * callNode, TR::Register * javaLitPoolVirtualRegister,
       TR::Register * methodMetaDataVirtualRegister, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg);
 


### PR DESCRIPTION
This commit restores the original name of the class now that
the dependency has been removed from OMR and it is safe to do so.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>