### PR TITLE
Ensure enough space is allocated for the unique cache id

### DIFF
--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -8184,13 +8184,12 @@ SH_CacheMap::storeCacheUniqueID(J9VMThread* currentThread, const char* cacheDir,
 	}
 
 	Trc_SHR_CM_storeCacheUniqueID_generateCacheUniqueID_before(currentThread, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
-	SH_OSCache::generateCacheUniqueID(currentThread, cacheDir, _cacheName, layer - 1, getCacheTypeFromRuntimeFlags(*_runtimeFlags), key, sizeof(key), createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
-	UDATA keylen = strlen(key);
+	UDATA keylen = SH_OSCache::generateCacheUniqueID(currentThread, cacheDir, _cacheName, layer - 1, getCacheTypeFromRuntimeFlags(*_runtimeFlags), key, sizeof(key), createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
 	Trc_SHR_CM_storeCacheUniqueID_generateCacheUniqueID_after(currentThread, keylen, key);
 
 	J9UTF8* utfKeyStruct = (J9UTF8*)utfKeyPtr;
 	J9UTF8_SET_LENGTH(utfKeyStruct, (U_16)keylen);
-	memcpy((char*)J9UTF8_DATA(utfKeyStruct), (char*)key, keylen);
+	memcpy((char*)J9UTF8_DATA(utfKeyStruct), key, keylen);
 
 	tokenKey = addScopeToCache(currentThread, utfKeyStruct, TYPE_PREREQ_CACHE);
 	if (NULL == tokenKey) {

--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -39,7 +39,18 @@
 #define CM_CACHE_CORRUPT -2
 #define CM_CACHE_STORE_PREREQ_ID_FAILED -3
 
-#define J9SHR_UNIQUE_CACHE_ID_BUFSIZE  (J9SH_MAXPATH + 35)
+/*
+ * The maximum width of the hexadecimal representation of a value of type 'T'.
+ */
+#define J9HEX_WIDTH(T) (2 * sizeof(T))
+
+/*
+ * A unique cache id is a path followed by six hexadecimal values,
+ * the first two of which express 64-bits values and the remaining
+ * four express UDATA values. Additionally, there are six separator
+ * characters and a terminating NUL character.
+ */
+#define J9SHR_UNIQUE_CACHE_ID_BUFSIZE (J9SH_MAXPATH + (2 * J9HEX_WIDTH(U_64)) + (4 * J9HEX_WIDTH(UDATA)) + 6 + 1)
 
 typedef struct MethodSpecTable {
 	char* className;

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -1711,7 +1711,8 @@ releaseLockCheck:
 	}
 	if (rc == CC_STARTUP_OK) {
 		_started = true;
-		if (NULL == cacheMemory) {
+		/* We don't need to compute the cache id for the top layer. */
+		if ((NULL == cacheMemory) && (NULL != _previous)) {
 			Trc_SHR_CC_startup_getCacheUniqueID_before(currentThread, getCreateTime(), getMetadataBytes(), getClassesBytes(), getLineNumberTableBytes(), getLocalVariableTableBytes());
 			const char* uniqueId = getCacheUniqueID(currentThread);
 			Trc_SHR_CC_startup_getCacheUniqueID_after(currentThread, uniqueId);


### PR DESCRIPTION
Don't compute the cache unique id for layer 0
* fix `J9SHR_UNIQUE_CACHE_ID_BUFSIZE` - it was too small
* use a format with fixed field widths so the length of the unique id does not depend on things like the length of the lower layer cache file
* use return value of `generateCacheUniqueID()` instead of using `strlen()`

Fixes #9838.