### PR TITLE
JITHelpers for flattenable fields

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4539,6 +4539,11 @@ typedef struct J9InternalVMFunctions {
 	IDATA ( *createJoinableThreadWithCategory)(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend, omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category) ;
 	BOOLEAN ( *valueTypeCapableAcmp)(struct J9VMThread *currentThread, j9object_t lhs, j9object_t rhs) ;
 	BOOLEAN ( *isClassRefQtype)(struct J9Class *cpContextClass, U_16 cpIndex) ;
+	UDATA ( *getFlattenableFieldOffset)(struct J9Class *fieldOwner, J9ROMFieldShape *field);
+	BOOLEAN ( *isFlattenableFieldFlattened)(J9Class *fieldOwner, J9ROMFieldShape *field);
+	struct J9Class* ( *getFlattenableFieldType)(J9Class *fieldOwner, J9ROMFieldShape *field);
+	UDATA ( *getFlattenableFieldSize)(struct J9VMThread* currentThread, J9Class *fieldOwner, J9ROMFieldShape *field);
+	UDATA ( *arrayElementSize)(J9ArrayClass* arrayClass);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2343,6 +2343,64 @@ UDATA
 findIndexInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, J9ROMNameAndSignature *nameAndSignature);
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
+/**
+ * Returns the offset of a qtype field.
+ *
+ * @param[in] fieldOwner the J9class that defines the field
+ * @param[in] field romfieldshape of the field
+ *
+ * @return field offset
+ */
+UDATA
+getFlattenableFieldOffset(J9Class *fieldOwner, J9ROMFieldShape *field);
+
+/**
+ * Returns if a field is flattened. `J9_IS_J9CLASS_FLATTENED` will be deprecated.
+ * This helper assumes field is a qtype.
+ *
+ * @param[in] fieldOwner the J9class that defines the field
+ * @param[in] field romfieldshape of the field
+ *
+ * @return TRUE if field is flattened, false otherwise
+ */
+BOOLEAN
+isFlattenableFieldFlattened(J9Class *fieldOwner, J9ROMFieldShape *field);
+
+/**
+ * Returns the type of an instance field. `J9_IS_J9CLASS_FLATTENED` will be deprecated.
+ * This helper assumes field is a qtype.
+ *
+ * @param[in] fieldOwner the J9class that defines the field
+ * @param[in] field romfieldshape of the field
+ *
+ * @return TRUE if field is flattened, false otherwise
+ */
+J9Class *
+getFlattenableFieldType(J9Class *fieldOwner, J9ROMFieldShape *field);
+
+/**
+ * Returns the size of an instance field. `J9_VALUETYPE_FLATTENED_SIZE` will be deprecated.
+ * This helper assumes field is a qtype.
+ *
+ * @param[in] currentThread thread token
+ * @param[in] fieldOwner the J9class that defines the field
+ * @param[in] fieldref cp ref of the field
+ *
+ * @return TRUE if field is flattened, false otherwise
+ */
+UDATA
+getFlattenableFieldSize(J9VMThread *currentThread, J9Class *fieldOwner, J9ROMFieldShape *field);
+
+/**
+ * Returns the size of an array element field. `J9_VALUETYPE_FLATTENED_SIZE`
+ * will be deprecated.
+ *
+ * @param[in] arrayClass containing elements
+ *
+ * @return size of the array element
+ */
+UDATA
+arrayElementSize(J9ArrayClass* arrayClass);
 
 /**
 * @brief

--- a/runtime/tests/vm/CMakeLists.txt
+++ b/runtime/tests/vm/CMakeLists.txt
@@ -39,6 +39,7 @@ j9vm_add_executable(vmtest
 	${j9vm_SOURCE_DIR}/vm/visible.c
 	${j9vm_SOURCE_DIR}/vm/vmthinit.c
 	${j9vm_SOURCE_DIR}/vm/stringhelpers.cpp
+	${j9vm_SOURCE_DIR}/vm/ValueTypeHelpers.cpp
 	${j9vm_BINARY_DIR}/vm/ut_j9vm.c
 )
 add_dependencies(vmtest trc_j9vm)

--- a/runtime/tests/vm/module.xml
+++ b/runtime/tests/vm/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2019 IBM Corp. and others
+  Copyright (c) 2001, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,7 @@
 			<vpath path="j9vm" pattern="visible.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="vmthinit.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="stringhelpers.cpp" augmentObjects="true"/>
+			<vpath path="j9vm" pattern="ValueTypeHelpers.cpp" augmentObjects="true"/>
 		</vpaths>
 		<objects>
 			<object name="resolvefield_tests"/>

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -39,6 +39,7 @@
 
 #include "ObjectAccessBarrierAPI.hpp"
 #include "VMHelpers.hpp"
+#include "vm_api.h"
 
 class VM_ValueTypeHelpers {
 	/*

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -377,4 +377,9 @@ J9InternalVMFunctions J9InternalFunctions = {
 	createJoinableThreadWithCategory,
 	valueTypeCapableAcmp,
 	isClassRefQtype,
+	getFlattenableFieldOffset,
+	isFlattenableFieldFlattened,
+	getFlattenableFieldType,
+	getFlattenableFieldSize,
+	arrayElementSize,
 };

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -578,47 +578,6 @@ addHiddenInstanceField(J9JavaVM *vm, const char *className, const char *fieldNam
 	return 0;
 }
 
-#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
-J9Class *
-findJ9ClassInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, U_8 *className, UDATA classNameLength)
-{
-	/* first field indicates the number of classes in the cache */
-	UDATA length = flattenedClassCache->numberOfEntries;
-	J9Class *clazz = NULL;
-
-	for (UDATA i = 0; i < length; i++) {
-		J9UTF8* currentClassName = J9ROMCLASS_CLASSNAME(J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->clazz->romClass);
-		if (J9UTF8_DATA_EQUALS(J9UTF8_DATA(currentClassName), J9UTF8_LENGTH(currentClassName), className, classNameLength)) {
-			clazz = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->clazz;
-			break;
-		}
-	}
-
-	Assert_VM_notNull(clazz);
-	return clazz;
-}
-
-UDATA
-findIndexInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, J9ROMNameAndSignature *nameAndSignature)
-{
-	/* first field indicates the number of classes in the cache */
-	UDATA index = UDATA_MAX;
-	UDATA length = flattenedClassCache->numberOfEntries;
-	J9ROMFieldShape *fccEntryField = NULL;
-
-	for (UDATA i = 0; i < length; i++) {
-		fccEntryField = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, i)->field;
-		if (J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_NAME(nameAndSignature), J9ROMFIELDSHAPE_NAME(fccEntryField))
-			&& J9UTF8_EQUALS(J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSignature), J9ROMFIELDSHAPE_SIGNATURE(fccEntryField))
-		) {
-			index = i;
-			break;
-		}
-	}
-	return index;
-}
-#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
-
 J9ROMFieldOffsetWalkResult *
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
 fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9ROMFieldOffsetWalkState *state, U_32 flags, J9FlattenedClassCache *flattenedClassCache)

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -33,6 +33,7 @@
 #include "stackwalk.h"
 #include "j9modifiers_api.h"
 #include "VMHelpers.hpp"
+#include "vm_api.h"
 
 #define MAX_STACK_SLOTS 255
 


### PR DESCRIPTION
Added JITHelpers for flattenable fields, modified existing vm
test files, and moved existing c functions.

The following are the added helper functions:
- getFlattenableFieldOffset: Returns offset of a qtype field
- isFlattenableFieldFlattened: Returns if a field is flattened
- getFlattenableFieldType: Returnss the type of an instance field
- getFlattenableFieldSize: Returns the size of an instance field
- arrayElementSize: Returns the flattenedElementSize of an arrayClass

Moved following C functions from resolveField to ValueTypeHelpers
- findJ9ClassInFlattenedClassCache
- findIndexInFlattenedClassCache

Modified vm test cmake and module files
 
Related to: https://github.com/eclipse/openj9/issues/9627

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>