### PR TITLE
(0.21.0) Disable cpu assert tests for JITServer and store OMRProcessorDesc in SCC

### DIFF
--- a/runtime/compiler/aarch64/env/J9CPU.cpp
+++ b/runtime/compiler/aarch64/env/J9CPU.cpp
@@ -23,25 +23,32 @@
 #include "env/CompilerEnv.hpp"
 #include "env/CPU.hpp"
 
-namespace J9
-{
-
-namespace ARM64
-{
-
-TR_ProcessorFeatureFlags
-CPU::getProcessorFeatureFlags()
-   {
-   TR_ProcessorFeatureFlags processorFeatureFlags = { {0} };
-   return processorFeatureFlags;
-   }
-
 bool
-CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+J9::ARM64::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   return self()->id() == processorSignature;
+   return self()->getProcessorDescription().processor == processorDescription.processor;
    }
 
-}
-
-}
+OMRProcessorDesc
+J9::ARM64::CPU::getProcessorDescription()
+   {
+   static bool initialized = false;
+   if (!initialized)
+      {
+      memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+      switch (self()->id())
+         {
+         case TR_DefaultARM64Processor:
+            _processorDescription.processor = OMR_PROCESSOR_ARM64_UNKNOWN;
+            break;
+         case TR_ARMv8_A:
+            _processorDescription.processor = OMR_PROCESSOR_ARM64_V8_A;
+            break;
+         default:
+            TR_ASSERT_FATAL(false, "Invalid ARM64 Processor ID");
+         }
+      _processorDescription.physicalProcessor = _processorDescription.processor;
+      initialized = true;
+      }
+   return _processorDescription;
+   }

--- a/runtime/compiler/aarch64/env/J9CPU.hpp
+++ b/runtime/compiler/aarch64/env/J9CPU.hpp
@@ -37,19 +37,6 @@ namespace J9 { typedef J9::ARM64::CPU CPUConnector; }
 #include "compiler/env/J9CPU.hpp"
 #include "env/ProcessorInfo.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -65,8 +52,8 @@ protected:
 
 public:
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+   OMRProcessorDesc getProcessorDescription();
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
 
    };
 

--- a/runtime/compiler/arm/env/J9CPU.cpp
+++ b/runtime/compiler/arm/env/J9CPU.cpp
@@ -23,25 +23,37 @@
 #include "env/CompilerEnv.hpp"
 #include "env/CPU.hpp"
 
-namespace J9
-{
-
-namespace ARM 
-{
-
-TR_ProcessorFeatureFlags
-CPU::getProcessorFeatureFlags()
-   {
-   TR_ProcessorFeatureFlags processorFeatureFlags = { {0} };
-   return processorFeatureFlags;
-   }
-
 bool
-CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+J9::ARM::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   return self()->id() == processorSignature;
+   return self()->getProcessorDescription().processor == processorDescription.processor;
    }
-   
-}
 
-}
+OMRProcessorDesc
+J9::ARM::CPU::getProcessorDescription()
+   {
+   static bool initialized = false;
+   if (!initialized)
+      {
+      memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+      switch (self()->id())
+         {
+         case TR_DefaultARMProcessor:
+            _processorDescription.processor = OMR_PROCESSOR_ARM_UNKNOWN;
+            break;
+         case TR_ARMv6:
+            _processorDescription.processor = OMR_PROCESSOR_ARM_V6;
+            break;
+         case TR_ARMv7:
+            _processorDescription.processor = OMR_PROCESSOR_ARM_V7;
+            break;
+         default:
+            TR_ASSERT_FATAL(false, "Invalid ARM64 Processor ID");
+         }
+      _processorDescription.physicalProcessor = _processorDescription.processor;
+      initialized = true;
+      }
+   return _processorDescription;
+   }
+
+

--- a/runtime/compiler/arm/env/J9CPU.hpp
+++ b/runtime/compiler/arm/env/J9CPU.hpp
@@ -37,19 +37,6 @@ namespace J9 { typedef J9::ARM::CPU CPUConnector; }
 #include "compiler/env/J9CPU.hpp"
 #include "env/ProcessorInfo.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -65,9 +52,8 @@ protected:
 
 public:
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
+   OMRProcessorDesc getProcessorDescription();
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
    };
 
 }

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -183,6 +183,14 @@ J9::Compilation::Compilation(int32_t id,
 #endif /* defined(J9VM_OPT_JITSERVER) */
    _osrProhibitedOverRangeOfTrees(false)
    {
+
+#if defined(J9VM_OPT_JITSERVER)
+   // In JITServer, we would like to use JITClient's processor info for the compilation
+   // The following code effectively replaces the cpu with client's cpu through the getProcessorDescription() that has JITServer support
+   if (self()->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      _target.cpu = TR::CPU(TR::Compiler->target.cpu.getProcessorDescription());
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
    _aotClassClassPointer = NULL;

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -505,7 +505,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._readBarrierType = TR::Compiler->om.readBarrierType();
          vmInfo._writeBarrierType = TR::Compiler->om.writeBarrierType();
          vmInfo._compressObjectReferences = TR::Compiler->om.compressObjectReferences();
-         vmInfo._processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
+         vmInfo._processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
          vmInfo._invokeWithArgumentsHelperMethod = J9VMJAVALANGINVOKEMETHODHANDLE_INVOKEWITHARGUMENTSHELPER_METHOD(fe->getJ9JITConfig()->javaVM);
          vmInfo._noTypeInvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExact0, false, false, false)->getMethodAddress();
          vmInfo._int64InvokeExactThunkHelper = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_icallVMprJavaSendInvokeExactJ, false, false, false)->getMethodAddress();

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -51,6 +51,8 @@ public:
 
    const char *getProcessorVendorId() { TR_ASSERT(false, "Vendor ID not defined for this platform!"); return NULL; }
    uint32_t getProcessorSignature() { TR_ASSERT(false, "Processor Signature not defined for this platform!"); return 0; }
+
+   OMRProcessorArchitecture getProcessor() { return _processorDescription.processor; }
    };
 }
 

--- a/runtime/compiler/p/env/J9CPU.hpp
+++ b/runtime/compiler/p/env/J9CPU.hpp
@@ -39,19 +39,6 @@ namespace J9 { typedef J9::Power::CPU CPUConnector; }
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -74,9 +61,8 @@ public:
    bool hasPopulationCountInstruction();
    bool supportsDecimalFloatingPoint();
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
+   OMRProcessorDesc getProcessorDescription();
    };
 
 }

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -26,7 +26,6 @@
 #include "infra/Monitor.hpp"  // TR::Monitor
 #include "env/PersistentCollections.hpp" // for PersistentUnorderedMap
 #include "il/DataTypes.hpp" // for DataType
-#include "env/J9CPU.hpp" // for TR_ProcessorFeatureFlags
 #include "env/VMJ9.h" // for TR_StaticFinalData
 
 class J9ROMClass;
@@ -316,7 +315,7 @@ class ClientSessionData
       MM_GCReadBarrierType _readBarrierType;
       MM_GCWriteBarrierType _writeBarrierType;
       bool _compressObjectReferences;
-      TR_ProcessorFeatureFlags _processorFeatureFlags;
+      OMRProcessorDesc _processorDescription;
       J9Method *_invokeWithArgumentsHelperMethod;
       void *_noTypeInvokeExactThunkHelper;
       void *_int64InvokeExactThunkHelper;

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -949,7 +949,7 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(TR_AOTHeader *hdrInCache, i
    {
    bool defaultMessage = true;
 
-   if (!TR::Compiler->target.cpu.isCompatible((TR_Processor)hdrInCache->processorSignature, hdrInCache->processorFeatureFlags))
+   if (!TR::Compiler->target.cpu.isCompatible(hdrInCache->processorDescription))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_WRONG_HARDWARE, "AOT header validation failed: Processor incompatible.");
    if ((featureFlags & TR_FeatureFlag_sanityCheckBegin) != (hdrInCache->featureFlags & TR_FeatureFlag_sanityCheckBegin))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_START_SANITY_BIT_MANGLED, "AOT header validation failed: Processor feature sanity bit mangled.");
@@ -1045,7 +1045,7 @@ TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThread *
          }
       else if
          (hdrInCache->featureFlags != featureFlags ||
-          !TR::Compiler->target.cpu.isCompatible((TR_Processor)hdrInCache->processorSignature, hdrInCache->processorFeatureFlags)
+          !TR::Compiler->target.cpu.isCompatible(hdrInCache->processorDescription)
          )
          {
          checkAOTHeaderFlags(hdrInCache, featureFlags);
@@ -1115,12 +1115,10 @@ TR_SharedCacheRelocationRuntime::createAOTHeader(TR_FrontEnd *fe)
       strncpy(aotHeaderVersion->vmBuildVersion, EsBuildVersionString, sizeof(EsBuildVersionString));
       strncpy(aotHeaderVersion->jitBuildVersion, TR_BUILD_NAME, std::min(strlen(TR_BUILD_NAME), sizeof(aotHeaderVersion->jitBuildVersion)));
 
-      aotHeader->processorSignature = TR::Compiler->target.cpu.id();
       aotHeader->gcPolicyFlag = javaVM()->memoryManagerFunctions->j9gc_modron_getWriteBarrierType(javaVM());
       aotHeader->lockwordOptionHashValue = getCurrentLockwordOptionHashValue(javaVM());
       aotHeader->compressedPointerShift = javaVM()->memoryManagerFunctions->j9gc_objaccess_compressedPointersShift(javaVM()->internalVMFunctions->currentVMThread(javaVM()));
-
-      aotHeader->processorFeatureFlags = TR::Compiler->target.cpu.getProcessorFeatureFlags();
+      aotHeader->processorDescription = TR::Compiler->target.cpu.getProcessorDescription();
 
       // Set up other feature flags
       aotHeader->featureFlags = generateFeatureFlags(fe);

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -95,14 +95,13 @@ typedef struct TR_AOTHeader {
     uintptr_t *relativeMethodMetaDataTable;
     uintptr_t architectureAndOs;
     uintptr_t endiannessAndWordSize;
-    uintptr_t processorSignature;
     uintptr_t featureFlags;
     uintptr_t vendorId;
     uintptr_t gcPolicyFlag;
     uintptr_t compressedPointerShift;
     uint32_t lockwordOptionHashValue;
     int32_t   arrayLetLeafSize;
-    TR_ProcessorFeatureFlags processorFeatureFlags;
+    OMRProcessorDesc processorDescription;
 } TR_AOTHeader;
 
 typedef struct TR_AOTRuntimeInfo {

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -232,7 +232,7 @@ uint8_t* TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t* prefetchSnippetBuf
    //
    for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset)
       {
-      TR_ASSERT_FATAL(TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
+      TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H), "OMR_PROCESSOR_X86_AMDFAMILY15H\n");
       prefetchSnippetBuffer[0] = 0x0F;
       if (comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H))
          prefetchSnippetBuffer[1] = 0x0D;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -86,8 +86,8 @@ J9::X86::CodeGenerator::CodeGenerator() :
    cg->setSupportsInliningOfTypeCoersionMethods();
    cg->setSupportsNewInstanceImplOpt();
    
-   TR_ASSERT_FATAL(comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
-   TR_ASSERT_FATAL(comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
+   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) == cg->getX86ProcessorInfo().supportsSSE4_1(), "supportsSSE4_1() failed\n");
+   TR_ASSERT_FATAL(comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed\n");
    
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&
        !comp->getOption(TR_DisableSIMDStringCaseConv) &&
@@ -379,7 +379,7 @@ J9::X86::CodeGenerator::nopsAlsoProcessedByRelocations()
 bool
 J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    {
-   TR_ASSERT_FATAL(self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
+   TR_ASSERT_FATAL(self()->comp()->isOutOfProcessCompilation() || self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) == TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI(), "supportsAESNI() failed\n");
    if (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AESNI) && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
       return true;
    else

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -573,7 +573,7 @@ static TR::Instruction *generatePrefetchAfterHeaderAccess(TR::Node              
    TR::Instruction *instr = NULL;
 
    static const char *prefetch = feGetEnv("TR_EnableSoftwarePrefetch");
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
+   TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2() failed\n");
    if (prefetch && cg->comp()->getMethodHotness()>=scorching && cg->comp()->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2))
       {
       int32_t fieldOffset = 0;
@@ -4700,14 +4700,14 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    if (cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord())
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG8MemReg : CMPXCHG8MemReg;
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG8MemReg : XACMPXCHG8MemReg;
       }
    else
       {
       op = cg->comp()->target().isSMP() ? LCMPXCHG4MemReg : CMPXCHG4MemReg;
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          op = cg->comp()->target().isSMP() ? XALCMPXCHG4MemReg : XACMPXCHG4MemReg;
       }
@@ -5534,7 +5534,7 @@ TR::Register
 
    if (!node->isReadMonitor() && !reservingLock)
       {
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) == cg->getX86ProcessorInfo().supportsHLE(), "supportsHLE() failed!\n");
       if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_HLE) && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
@@ -9100,7 +9100,7 @@ static TR::Register* inlineStringHashCode(TR::Node* node, bool isCompressed, TR:
       generateRegMemInstruction(LEARegMem(), node, tmp, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
       auto mr = generateX86MemoryReference(tmp, index, shift, 0, cg);
-      TR_ASSERT_FATAL(cg->getX86ProcessorInfo().supportsAVX() == cg->comp()->target().cpu.supportsAVX(), "supportsAVX() failed\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->getX86ProcessorInfo().supportsAVX() == cg->comp()->target().cpu.supportsAVX(), "supportsAVX() failed\n");
       if (cg->comp()->target().cpu.supportsAVX())
          {
          generateRegMemInstruction(PANDRegMem, node, hashXMM, mr, cg);
@@ -9510,7 +9510,7 @@ inlineCompareAndSwapNative(
       }
    else
       {
-      TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
+      TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8) == cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "supportsCMPXCHG8BInstruction() failed\n");
       if (!cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8))
          return false;
 
@@ -9932,7 +9932,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderAccesses:
             {
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(), "supportsMFence() failed\n");
             if (cg->comp()->target().cpu.supportsMFence())
                {
                TR_X86OpCode fenceOp;
@@ -9946,8 +9946,8 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderReads:
             {
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(), "supportsLFence() failed\n");
 
             if (cg->comp()->target().cpu.requiresLFence() &&
                 cg->comp()->target().cpu.supportsLFence())
@@ -9963,7 +9963,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
 
          case TR::java_util_concurrent_atomic_Fences_orderWrites:
             {
-            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
+            TR_ASSERT_FATAL(cg->comp()->isOutOfProcessCompilation() || cg->comp()->target().cpu.supportsSFence() == cg->getX86ProcessorInfo().supportsSFence(), "supportsSFence() failed\n");
             
             if (cg->comp()->target().cpu.supportsSFence())
                {

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -26,6 +26,7 @@
 #include "env/VMJ9.h"
 #include "x/runtime/X86Runtime.hpp"
 #include "env/JitConfig.hpp"
+#include "codegen/CodeGenerator.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -129,5 +129,145 @@ J9::X86::CPU::getX86ProcessorFeatureFlags8()
    return self()->queryX86TargetCPUID()->_featureFlags8;
    }
 
+bool
+J9::X86::CPU::is_test(OMRProcessorArchitecture p)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
+   switch(p)
+      {
+      case OMR_PROCESSOR_X86_INTELWESTMERE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelWestmere() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELNEHALEM:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelNehalem() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELPENTIUM:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELP6:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelP6() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELPENTIUM4:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium4() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELCORE2:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelCore2() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELTULSA:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelTulsa() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELSANDYBRIDGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSandyBridge() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELIVYBRIDGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelIvyBridge() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELHASWELL:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelHaswell() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELBROADWELL:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelBroadwell() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELSKYLAKE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSkylake() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDATHLONDURON:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMDAthlonDuron() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDOPTERON:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMDOpteron() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDFAMILY15H:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == (_processorDescription.processor == p);
+      default:
+         return false;
+      }
+   return false;
+   }
 
+bool
+J9::X86::CPU::supports_feature_test(uint32_t feature)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
+
+   switch(feature)
+      {
+      case OMR_FEATURE_X86_OSXSAVE:
+         return TR::CodeGenerator::getX86ProcessorInfo().enabledXSAVE() == ans;
+      case OMR_FEATURE_X86_FPU:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasBuiltInFPU() == ans;
+      case OMR_FEATURE_X86_VME:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsVirtualModeExtension() == ans;
+      case OMR_FEATURE_X86_DE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsDebuggingExtension() == ans;
+      case OMR_FEATURE_X86_PSE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPageSizeExtension() == ans;
+      case OMR_FEATURE_X86_TSC:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsRDTSCInstruction() == ans;
+      case OMR_FEATURE_X86_MSR:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasModelSpecificRegisters() == ans;
+      case OMR_FEATURE_X86_PAE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPhysicalAddressExtension() == ans;
+      case OMR_FEATURE_X86_MCE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsMachineCheckException() == ans;
+      case OMR_FEATURE_X86_CX8:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG8BInstruction() == ans;
+      case OMR_FEATURE_X86_CMPXCHG16B:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG16BInstruction() == ans;
+      case OMR_FEATURE_X86_APIC:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasAPICHardware() == ans;
+      case OMR_FEATURE_X86_MTRR:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasMemoryTypeRangeRegisters() == ans;
+      case OMR_FEATURE_X86_PGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPageGlobalFlag() == ans;
+      case OMR_FEATURE_X86_MCA:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasMachineCheckArchitecture() == ans;
+      case OMR_FEATURE_X86_CMOV:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMOVInstructions() == ans;
+      case OMR_FEATURE_X86_PAT:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasPageAttributeTable() == ans;
+      case OMR_FEATURE_X86_PSE_36:
+         return TR::CodeGenerator::getX86ProcessorInfo().has36BitPageSizeExtension() == ans;
+      case OMR_FEATURE_X86_PSN:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasProcessorSerialNumber() == ans;
+      case OMR_FEATURE_X86_CLFSH:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLFLUSHInstruction() == ans;
+      case OMR_FEATURE_X86_DS:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsDebugTraceStore() == ans;
+      case OMR_FEATURE_X86_ACPI:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasACPIRegisters() == ans;
+      case OMR_FEATURE_X86_MMX:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsMMXInstructions() == ans;
+      case OMR_FEATURE_X86_FXSR:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsFastFPSavesRestores() == ans;
+      case OMR_FEATURE_X86_SSE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE() == ans;
+      case OMR_FEATURE_X86_SSE2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE2() == ans;
+      case OMR_FEATURE_X86_SSE3:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE3() == ans;
+      case OMR_FEATURE_X86_SSSE3:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSSE3() == ans;
+      case OMR_FEATURE_X86_SSE4_1:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() == ans;
+      case OMR_FEATURE_X86_SSE4_2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_2() == ans;
+      case OMR_FEATURE_X86_PCLMULQDQ:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLMUL() == ans;
+      case OMR_FEATURE_X86_AESNI:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() == ans;
+      case OMR_FEATURE_X86_POPCNT:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPOPCNT() == ans;
+      case OMR_FEATURE_X86_SS:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSelfSnoop() == ans;
+      case OMR_FEATURE_X86_RTM:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsTM() == ans;
+      case OMR_FEATURE_X86_HTT:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsHyperThreading() == ans;
+      case OMR_FEATURE_X86_HLE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsHLE() == ans;
+      case OMR_FEATURE_X86_TM:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasThermalMonitor() == ans;
+      case OMR_FEATURE_X86_AVX:
+         return true;
+      default:
+         return false;
+      }
+   return false;
+   }

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -36,14 +36,8 @@
 // Without this definition, we get an undefined symbol of JITConfig::instance() at runtime
 TR::JitConfig * TR::JitConfig::instance() { return NULL; }
 
-namespace J9
-{
-
-namespace X86
-{
-
 TR_X86CPUIDBuffer *
-CPU::queryX86TargetCPUID()
+J9::X86::CPU::queryX86TargetCPUID()
    {
    static TR_X86CPUIDBuffer buf = { {'U','n','k','n','o','w','n','B','r','a','n','d'} };
    jitGetCPUID(&buf);
@@ -51,19 +45,19 @@ CPU::queryX86TargetCPUID()
    }
 
 const char *
-CPU::getProcessorVendorId()
+J9::X86::CPU::getProcessorVendorId()
    {
    return self()->getX86ProcessorVendorId();
    }
 
 uint32_t
-CPU::getProcessorSignature()
+J9::X86::CPU::getProcessorSignature()
    {
    return self()->getX86ProcessorSignature();
    }
 
 bool
-CPU::hasPopulationCountInstruction()
+J9::X86::CPU::hasPopulationCountInstruction()
    {
    if ((self()->getX86ProcessorFeatureFlags2() & TR_POPCNT) != 0x00000000)
       return true;
@@ -71,70 +65,69 @@ CPU::hasPopulationCountInstruction()
       return false;
    }
 
-TR_ProcessorFeatureFlags
-CPU::getProcessorFeatureFlags()
-   {
-#if defined(J9VM_OPT_JITSERVER)
-   if (auto stream = TR::CompilationInfo::getStream())
-      {
-      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags;
-      }
-#endif /* defined(J9VM_OPT_JITSERVER) */
-   TR_ProcessorFeatureFlags processorFeatureFlags = { {self()->getX86ProcessorFeatureFlags(), self()->getX86ProcessorFeatureFlags2(), self()->getX86ProcessorFeatureFlags8()} };
-   return processorFeatureFlags;
-   }
-
 bool
-CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+J9::X86::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
-   for (int i = 0; i < PROCESSOR_FEATURES_SIZE; i++)
+   for (int i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
       {
       // Check to see if the current processor contains all the features that code cache's processor has
-      if ((processorFeatureFlags.featureFlags[i] & self()->getProcessorFeatureFlags().featureFlags[i]) != processorFeatureFlags.featureFlags[i])
+      if ((processorDescription.features[i] & self()->getProcessorDescription().features[i]) != processorDescription.features[i])
          return false;
       }
    return true;
    }
 
-uint32_t
-CPU::getX86ProcessorFeatureFlags()
+OMRProcessorDesc
+J9::X86::CPU::getProcessorDescription()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags.featureFlags[0];
+      return vmInfo->_processorDescription;
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   return _processorDescription;
+   }
+
+uint32_t
+J9::X86::CPU::getX86ProcessorFeatureFlags()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_processorDescription.features[0];
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return self()->queryX86TargetCPUID()->_featureFlags;
    }
 
 uint32_t
-CPU::getX86ProcessorFeatureFlags2()
+J9::X86::CPU::getX86ProcessorFeatureFlags2()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags.featureFlags[1];
+      return vmInfo->_processorDescription.features[1];
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return self()->queryX86TargetCPUID()->_featureFlags2;
    }
 
 uint32_t
-CPU::getX86ProcessorFeatureFlags8()
+J9::X86::CPU::getX86ProcessorFeatureFlags8()
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (auto stream = TR::CompilationInfo::getStream())
       {
       auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-      return vmInfo->_processorFeatureFlags.featureFlags[2];
+      return vmInfo->_processorDescription.features[3];
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
    return self()->queryX86TargetCPUID()->_featureFlags8;
    }
 
-}
-}
+
+

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -64,6 +64,9 @@ public:
    uint32_t getX86ProcessorFeatureFlags();
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
+
+   bool is_test(OMRProcessorArchitecture p);
+   bool supports_feature_test(uint32_t feature);
    };
 
 }

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -37,21 +37,6 @@ namespace J9 { typedef J9::X86::CPU CPUConnector; }
 #include "compiler/env/J9CPU.hpp"
 #include "env/ProcessorInfo.hpp"
 
-namespace TR { class Compilation; }
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 3
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -74,13 +59,11 @@ public:
    bool hasPopulationCountInstruction();
    bool testOSForSSESupport() { return true; }
 
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
+   OMRProcessorDesc getProcessorDescription();
    uint32_t getX86ProcessorFeatureFlags();
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
-
    };
 
 }

--- a/runtime/compiler/z/env/J9CPU.cpp
+++ b/runtime/compiler/z/env/J9CPU.cpp
@@ -385,6 +385,81 @@ J9::Z::CPU::initializeS390ProcessorFeatures()
    }
 
 bool
+J9::Z::CPU::is_at_least_test(OMRProcessorArchitecture p)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   switch(p)
+      {
+      case OMR_PROCESSOR_S390_Z10:
+         return (self()->getSupportsArch(TR::CPU::z10) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z196:
+         return (self()->getSupportsArch(TR::CPU::z196) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_ZEC12:
+         return (self()->getSupportsArch(TR::CPU::zEC12) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z13:
+         return (self()->getSupportsArch(TR::CPU::z13) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z14:
+         return (self()->getSupportsArch(TR::CPU::z14) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_Z15:
+         return (self()->getSupportsArch(TR::CPU::z15) == (_processorDescription.processor >= p));
+      case OMR_PROCESSOR_S390_ZNEXT:
+         return (self()->getSupportsArch(TR::CPU::zNext) == (_processorDescription.processor >= p));
+      default:
+         return false;
+      }
+   return false;
+   }
+
+bool
+J9::Z::CPU::supports_feature_test(uint32_t feature)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (TR::CompilationInfo::getStream())
+      return true;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
+
+   switch(feature)
+      {
+      case OMR_FEATURE_S390_HIGH_WORD:
+         return (self()->getSupportsHighWordFacility() == ans);
+      case OMR_FEATURE_S390_DFP:
+         return (self()->getSupportsDecimalFloatingPointFacility() == ans);
+      case OMR_FEATURE_S390_FPE:
+         return (self()->getSupportsFloatingPointExtensionFacility() == ans);
+      case OMR_FEATURE_S390_TE:
+         return (self()->getSupportsTransactionalMemoryFacility() == ans);
+      case OMR_FEATURE_S390_RI:
+         return (self()->getSupportsRuntimeInstrumentationFacility() == ans);
+      case OMR_FEATURE_S390_VECTOR_FACILITY:
+         return (self()->getSupportsVectorFacility() == ans);
+      case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL:
+         return (self()->getSupportsVectorPackedDecimalFacility() == ans);
+      case OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3:
+         return (self()->getSupportsMiscellaneousInstructionExtensions3Facility() == ans);
+      case OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_2:
+         return (self()->getSupportsVectorFacilityEnhancement2() == ans);
+      case OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY:
+         return (self()->getSupportsVectorPackedDecimalEnhancementFacility() == ans);
+      case OMR_FEATURE_S390_GUARDED_STORAGE:
+         return (self()->getSupportsGuardedStorageFacility() == ans);
+      case OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_2:
+         return (self()->getSupportsMiscellaneousInstructionExtensions2Facility() == ans);
+      case OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_1:
+         return (self()->getSupportsVectorFacilityEnhancement1() == ans);
+      default:
+         return false;
+      }
+   return false;
+   }
+
+bool
 J9::Z::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
    if (!self()->isAtLeast(processorDescription.processor))

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -39,19 +39,6 @@ namespace J9 { typedef J9::Z::CPU CPUConnector; }
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define PROCESSOR_FEATURES_SIZE 1
-typedef struct TR_ProcessorFeatureFlags {
-  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
-} TR_ProcessorFeatureFlags;
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace J9
 {
 
@@ -78,9 +65,8 @@ class OMR_EXTENSIBLE CPU : public J9::CPU
 
    void applyUserOptions();
    void initializeS390ProcessorFeatures();
-
-   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
-   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+   bool isCompatible(const OMRProcessorDesc& processorDescription);
+   OMRProcessorDesc getProcessorDescription();
    };
 
 }

--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -67,6 +67,9 @@ class OMR_EXTENSIBLE CPU : public J9::CPU
    void initializeS390ProcessorFeatures();
    bool isCompatible(const OMRProcessorDesc& processorDescription);
    OMRProcessorDesc getProcessorDescription();
+
+   bool is_at_least_test(OMRProcessorArchitecture p);
+   bool supports_feature_test(uint32_t feature);
    };
 
 }


### PR DESCRIPTION
This change fixes issue https://github.com/eclipse/openj9/issues/9833 as well as a defect in JITServer where it doesn't use client's processor information properly.

depends on: https://github.com/eclipse/openj9-omr/pull/65
original PR: https://github.com/eclipse/openj9/pull/9826 and https://github.com/eclipse/openj9/pull/9837
closes: https://github.com/eclipse/openj9/issues/9833