### PR TITLE
Read message in buffer capacity first

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1264,7 +1264,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
             if (auto stream = TR::CompilationInfo::getStream())
                {
                stream->write(JITServer::MessageType::CHTable_clearReservable, classPointer);
-               // No response necessary - we can continue concurrently
+               stream->read<JITServer::Void>();
                }
 #endif /* defined(J9VM_OPT_JITSERVER) */
             }

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2581,6 +2581,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
       case MessageType::CHTable_clearReservable:
          {
          auto clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock*>());
+         client->write(response, JITServer::Void());
          auto table = (JITClientPersistentCHTable*)comp->getPersistentInfo()->getPersistentCHTable();
          auto info = table->findClassInfoAfterLocking(clazz, comp);
          info->setReservable(false);

--- a/runtime/compiler/net/Message.hpp
+++ b/runtime/compiler/net/Message.hpp
@@ -326,9 +326,30 @@ public:
    */
    void setSerializedSize(uint32_t serializedSize)
       {
-      _buffer.expandIfNeeded(serializedSize);
       _buffer.writeValue(serializedSize);
       }
+
+   /**
+      @brief Expand the internal buffer when requiredSize is greater than the capacity
+
+      If expansion occurred, this method copies the number of bytes from the beginning
+      of the buffer to _curPtr from the old buffer to the new buffer.
+   */
+   void expandBufferIfNeeded(uint32_t requiredSize)
+      {
+      _buffer.expandIfNeeded(requiredSize);
+      }
+
+   /**
+      @brief Expand the internal buffer to requiredSize and copy numBytesToCopy
+      from the old buffer into the new one
+   */
+   void expandBuffer(uint32_t requiredSize, uint32_t numBytesToCopy)
+      {
+      _buffer.expand(requiredSize, numBytesToCopy);
+      }
+
+   uint32_t getBufferCapacity() const { return _buffer.getCapacity(); }
 
    /**
       @brief Get the pointer to the start of the buffer.

--- a/runtime/compiler/net/MessageBuffer.cpp
+++ b/runtime/compiler/net/MessageBuffer.cpp
@@ -41,7 +41,6 @@ MessageBuffer::expandIfNeeded(uint32_t requiredSize)
    // expand the storage
    if (requiredSize > _capacity)
       {
-      char *oldPtr = _curPtr;
       _capacity = requiredSize * 2;
       char *newStorage = static_cast<char *>(TR_Memory::jitPersistentAlloc(_capacity));
       if (!newStorage)
@@ -52,6 +51,26 @@ MessageBuffer::expandIfNeeded(uint32_t requiredSize)
       _storage = newStorage;
       _curPtr = _storage + curSize;
       }
+   }
+
+void
+MessageBuffer::expand(uint32_t requiredSize, uint32_t numBytesToCopy)
+   {
+   TR_ASSERT_FATAL((requiredSize > _capacity), "requiredSize %u has to be greater than _capacity %u", requiredSize, _capacity);
+   TR_ASSERT_FATAL((numBytesToCopy <= _capacity), "numBytesToCopy %u has to be less than _capacity %u", numBytesToCopy, _capacity);
+
+   _capacity = requiredSize;
+   uint32_t curSize = size();
+
+   char *newStorage = static_cast<char *>(TR_Memory::jitPersistentAlloc(_capacity));
+   if (!newStorage)
+      throw std::bad_alloc();
+
+   memcpy(newStorage, _storage, numBytesToCopy);
+
+   TR_Memory::jitPersistentFree(_storage);
+   _storage = newStorage;
+   _curPtr = _storage + curSize;
    }
 
 uint32_t

--- a/runtime/compiler/net/MessageBuffer.hpp
+++ b/runtime/compiler/net/MessageBuffer.hpp
@@ -184,14 +184,24 @@ public:
 
       If requiredSize is greater than _capacity, allocates a new buffer of size
       requiredSize * 2 (to prevent frequent reallocations),
-      copies all existing data there, and frees the old buffer.
+      copies all existing data based on _curPtr location to the new buffer,
+      and frees the old buffer.
 
       @param requiredSize the number of bytes the buffer needs to fit.
    */
    void expandIfNeeded(uint32_t requiredSize);
 
+   /**
+      @brief Expand the underlying buffer to requiredSize and copy numBytesToCopy
+      from the old buffer to the new buffer when requiredSize is greater than
+      the capacity, and free the old buffer.
+   */
+   void expand(uint32_t requiredSize, uint32_t numBytesToCopy);
+
+   uint32_t getCapacity() const { return _capacity; }
+
 private:
-   static const size_t INITIAL_BUFFER_SIZE = 10000;
+   static const size_t INITIAL_BUFFER_SIZE = 18000;
    uint32_t offset(char *addr) const { return addr - _storage; }
 
    uint32_t _capacity;


### PR DESCRIPTION
The original message read involves at least two reads:
The first one is to read the message size. The second one is to read the rest of the message based on the message size that’s read in the first read. This change optimizes the incoming message read to attempt to read the full buffer capacity in the first read. It then decides whether or not subsequent reads are required based on `bytesRead` from the first read.

Also increase `INITIAL_BUFFER_SIZE` to `18000` from `10000` based on the average message size observed in #9708.

Implements #9711

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>