### PR TITLE
(0.21.0) AArch64: Fix VMnewEvaluator to patch correct instruction under AOT

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1299,7 +1299,6 @@ J9::ARM64::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    if (!performTransformation(comp, "O^O <%3d> Inlining Allocation of %s [0x%p].\n", count++, node->getOpCode().getName(), node))
       return NULL;
 
-   TR::Instruction *firstInstruction = cg->getAppendInstruction();
 
    // 1. Evaluate children
    int32_t headerSize;
@@ -1332,6 +1331,7 @@ J9::ARM64::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       classReg = cg->gprClobberEvaluate(secondChild);
       }
 
+   TR::Instruction *firstInstructionAfterClassAndLengthRegsAreReady = cg->getAppendInstruction();
    // 2. Calculate allocation size
    int32_t allocateSize = isVariableLength ? headerSize : (objectSize + TR::Compiler->om.objectAlignmentInBytes() - 1) & (-TR::Compiler->om.objectAlignmentInBytes());
 
@@ -1382,7 +1382,7 @@ J9::ARM64::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    // 9. Setup AOT relocation
    if (cg->comp()->compileRelocatableCode() && (opCode == TR::New || opCode == TR::anewarray))
       {
-      firstInstruction = firstInstruction->getNext();
+      TR::Instruction *firstInstruction = firstInstructionAfterClassAndLengthRegsAreReady->getNext();
       TR_OpaqueClassBlock *classToValidate = clazz;
 
       TR_RelocationRecordInformation *recordInfo = (TR_RelocationRecordInformation *) comp->trMemory()->allocateMemory(sizeof(TR_RelocationRecordInformation), heapAlloc);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8635,7 +8635,8 @@ TR_J9SharedCacheVM::supportAllocationInlining(TR::Compilation *comp, TR::Node *n
 
    if ((comp->target().cpu.isX86() ||
         comp->target().cpu.isPower() ||
-        comp->target().cpu.isZ()) &&
+        comp->target().cpu.isZ() ||
+        comp->target().cpu.isARM64()) &&
        !comp->getOption(TR_DisableAllocationInlining))
       return true;
 


### PR DESCRIPTION
This commit fixes `VMnewEvaluator` to patch the correct instruction
under AOT compilation and re-enable allocation inlining under AOT.

Master PR: https://github.com/eclipse/openj9/pull/9830

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>