### PR TITLE
Support JEP383 (Part 2) and CDS natives

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -420,6 +420,9 @@ K0679=Module '{0}' no access to: package '{1}' because module '{0}' can't read m
 K0680=Class '{0}' no access to: class '{1}'
 K0681=Failed to build collector
 K0682=The requested lookup class must not be null
+K0683=Target class '{0}' cannot be an array class
+K0684=Target class '{0}' cannot be a primitive class
+K0685=Target class '{0}' cannot be accessed from Lookup class '{1}'
 
 #java.lang.StackWalker
 K0639="Stack walker not configured with RETAIN_CLASS_REFERENCE"

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -29,6 +29,8 @@ package java.lang.invoke;
  */
 
 class DirectMethodHandle extends MethodHandle {
+	MemberName member;
+	
 	DirectMethodHandle(MethodType mt, LambdaForm lf) {
 		super(mt, lf);
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,3 +21,47 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+/*[IF Java15]*/
+package java.lang.invoke;
+
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Member;
+
+class InfoFromMemberName implements MethodHandleInfo {
+	InfoFromMemberName(Lookup lookup, MemberName member, byte kind) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public Class<?> getDeclaringClass() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public String getName() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public MethodType getMethodType() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+
+	}
+
+	@Override
+	public int getModifiers() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public int getReferenceKind() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public <T extends Member> T reflectAs(Class<T> expected, Lookup lookup) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+}
+/*[ENDIF] Java15 */
+

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -86,18 +86,19 @@ final class MemberName {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
-	/*[IF Java10]*/
+	/*[IF Java11]*/
 	public MethodType getMethodType() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	
+
 	String getMethodDescriptor() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+
 	public Class<?> getDeclaringClass() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[IF Java11]*/
+
 	public boolean isFinal() {
 		if (mh instanceof FieldHandle) {
 			return ((FieldHandle)mh).isFinal();
@@ -105,6 +106,11 @@ final class MemberName {
 		/*[MSG "K0675", "Unexpected MethodHandle instance: {0} with {1}"]*/
 		throw new InternalError(com.ibm.oti.util.Msg.getString("K0675", mh, mh.getClass())); //$NON-NLS-1$
 	}
-	/*[ENDIF]*/
-	/*[ENDIF]*/
+	/*[ENDIF] Java11 */
+	
+	/*[IF Java15]*/
+	public byte getReferenceKind() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	/*[ENDIF] Java15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1609,7 +1609,7 @@ public abstract class MethodHandle
 	}
 	
 	MethodHandle viewAsType(MethodType mt, boolean flag) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		return this.cloneWithNewType(mt);
 	}
 	
 	MemberName internalMemberName() {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -22,11 +22,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 /*[IF Java11]*/
-
 package java.lang.invoke;
 
 class MethodHandleNatives {
-
 	static LinkageError mapLookupExceptionToError(ReflectiveOperationException roe) {
 		String exMsg = roe.getMessage();
 		LinkageError linkageErr;
@@ -44,7 +42,7 @@ class MethodHandleNatives {
 		return linkageErr;
 	}
 
-/*[IF Java14]*/
+	/*[IF Java14]*/
 	static long objectFieldOffset(MemberName memberName) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -56,7 +54,20 @@ class MethodHandleNatives {
 	static Object staticFieldBase(MemberName memberName) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF] Java14 */
+	/*[ENDIF] Java14 */
+	
+	/*[IF Java15]*/
+	static boolean refKindIsMethod(byte kind) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	
+	static boolean refKindIsField(byte kind) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	
+	static boolean refKindIsConstructor(byte kind) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	/*[ENDIF] Java15 */
 }
-
 /*[ENDIF] Java11 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -74,6 +74,10 @@ import java.lang.reflect.Module;
 import sun.reflect.CallerSensitive;
 /*[ENDIF] Sidecar19-SE*/
 
+/*[IF Java15]*/
+import jdk.internal.misc.Unsafe;
+/*[ENDIF] Java15 */
+
 /**
  * Factory class for creating and adapting MethodHandles.
  * 
@@ -2312,6 +2316,22 @@ public class MethodHandles {
 		ClassDefiner makeHiddenClassDefiner(String name, byte[] template) {
 			ClassDefiner definer = new ClassDefiner(name, template, this);
 			return definer;
+		}
+		
+		public Class<?> ensureInitialized(Class<?> cls) throws IllegalArgumentException, IllegalAccessException {
+			if (cls.isArray()) {
+				/*[MSG "K0683", "Target class '{0}' cannot be an array class"]*/
+				throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0683", cls));
+			} else if (cls.isPrimitive()) {
+				/*[MSG "K0684", "Target class '{0}' cannot be a primitive class"]*/
+				throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0684", cls));
+			} else if (!isClassAccessible(cls)) {
+				/*[MSG "K0685", "Target class '{0}' cannot be accessed from Lookup class '{1}'"]*/
+				throw new IllegalAccessException(com.ibm.oti.util.Msg.getString("K0685", cls, this));
+			} else {
+				Unsafe.getUnsafe().ensureClassInitialized(cls);
+			}
+			return cls;
 		}
 		/*[ENDIF] Java15 */		
 	}
@@ -5393,15 +5413,19 @@ public class MethodHandles {
 		}
 	}
 
-/*[IF Java15]*/
+	/*[IF Java15]*/
 	static boolean permuteArgumentChecks(int[] arr, MethodType mt1, MethodType mt2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF] Java15 */
+	
+	static MethodHandle collectReturnValue(MethodHandle mh1, MethodHandle mh2) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	/*[ENDIF] Java15 */
 
-/*[IF Sidecar18-SE-OpenJ9]*/	
+	/*[IF Sidecar18-SE-OpenJ9]*/	
 	static MethodHandle basicInvoker(MethodType mt) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF]*/	
+	/*[ENDIF]*/	
 }

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -355,6 +355,10 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 	jvm_add_exports(jvm
 		# Additions for Java 15 (General)
 		JVM_GetRandomSeedForCDSDump
+		JVM_RegisterLambdaProxyClassForArchiving
+		JVM_LookupLambdaProxyClassFromArchive
+		JVM_IsCDSDumpingEnabled
+		JVM_IsCDSSharingEnabled
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -347,6 +347,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<exports group="jdk15">
 		<!-- Additions for Java 15 (General) -->
 		<export name="JVM_GetRandomSeedForCDSDump"/>
+		<export name="JVM_RegisterLambdaProxyClassForArchiving"/>
+		<export name="JVM_LookupLambdaProxyClassFromArchive"/>
+		<export name="JVM_IsCDSDumpingEnabled"/>
+		<export name="JVM_IsCDSSharingEnabled"/>
 	</exports>
 
 </exportlists>

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1744,4 +1744,31 @@ JVM_GetRandomSeedForCDSDump()
 	/* OpenJ9 does not support -Xshare:dump, so we return zero unconditionally. */
 	return 0;
 }
+
+JNIEXPORT void JNICALL
+JVM_RegisterLambdaProxyClassForArchiving(JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jclass arg7)
+{
+	assert(!"JVM_RegisterLambdaProxyClassForArchiving unimplemented");
+}
+
+JNIEXPORT jclass JNICALL
+JVM_LookupLambdaProxyClassFromArchive(JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jboolean arg7)
+{
+	assert(!"JVM_LookupLambdaProxyClassFromArchive unimplemented");
+	return NULL;
+}
+
+JNIEXPORT jboolean JNICALL
+JVM_IsCDSDumpingEnabled(JNIEnv *env)
+{
+	/* OpenJ9 does not support -Xshare:dump, so we return false unconditionally. */
+	return JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+JVM_IsCDSSharingEnabled(JNIEnv *env)
+{
+	/* OpenJ9 does not support -Xshare:dump, so we return false unconditionally. */
+	return JNI_FALSE;
+}
 #endif /* JAVA_SPEC_VERSION >= 15 */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -324,3 +324,11 @@ _IF([JAVA_SPEC_VERSION >= 14],
 	[_X(JVM_GetExtendedNPEMessage, JNICALL, false, jstring, JNIEnv *env, jthrowable throwableObj)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_GetRandomSeedForCDSDump, JNICALL, false, jlong)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_RegisterLambdaProxyClassForArchiving, JNICALL, false, void, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jclass arg7)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_LookupLambdaProxyClassFromArchive, JNICALL, false, jclass, JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jboolean arg7)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
+_IF([JAVA_SPEC_VERSION >= 15],
+	[_X(JVM_IsCDSSharingEnabled, JNICALL, false, jboolean, JNIEnv *env)])


### PR DESCRIPTION
Refer to the individual commits for more details.

CDS: Class Data Sharing.

Fixes https://github.com/eclipse/openj9/issues/9849, and unreported JDK15 compilation issues.

The following are implemented since they are invoked during the build process:
- `JVM_IsCDSDumpingEnabled`
- `JVM_IsCDSSharingEnabled`
- `Lookup.ensureInitialized`
- `MethodHandle.viewAsType`

The remaining dependencies are introduced as stubs.

Related: https://github.com/eclipse/openj9/issues/9625

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>
