### PR TITLE
(0.21.0) Map symrefs in OSR liveness to those in current trees in creating calls to eaEscapeHelper

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysisTools.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysisTools.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,12 +75,16 @@ class TR_EscapeAnalysisTools
     *
     * \param[in] rms The method whose live autos and pending pushes are to be
     *                processed
+    * \param[in] induceDefiningMap \ref DefiningMap mapping from live symbol
+    *                references captured during the OSR def liveness analysis
+    *                to symbol references defining those symbols in the current
+    *                trees
     * \param[in] methodData \ref TR_OSRMethodData at this point in the
     *                relevant method
     * \param[in] byteCodeIndex The bytecode index at this point inside the
     *                relevant method
     */
-   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
+   void processAutosAndPendingPushes(TR::ResolvedMethodSymbol *rms, DefiningMap *induceDefiningMap, TR_OSRMethodData *methodData, int32_t byteCodeIndex);
 
    /**
     * Create \c aload references to each live symbol reference among those
@@ -90,11 +94,15 @@ class TR_EscapeAnalysisTools
     *
     * \param[in] symbolReferences \ref TR_Array<> of symbol references for
     *               autos or pending pushes
+    * \param[in] induceDefiningMap \ref DefiningMap mapping from live symbol
+    *               references captured during the OSR def liveness analysis
+    *               to symbol references defining those symbols in the current
+    *               trees
     * \param[in] deadSymRefs Liveness info for \c symbolReferences - a
     *               \ref TR_BitVector of symbols that are not live at the
     *               relevant point
     */
-   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, TR_BitVector *deadSymRefs);
+   void processSymbolReferences(TR_Array<List<TR::SymbolReference>> *symbolReferences, DefiningMap *induceDefiningMap, TR_BitVector *deadSymRefs);
    };
 
 #endif

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
@@ -42,11 +42,11 @@ int32_t TR_PreEscapeAnalysis::perform()
       return 0;
       }
 
-   if (comp()->getOSRMode() != TR::voluntaryOSR)
+   if (comp()->getOSRMode() != TR::voluntaryOSR || comp()->getOption(TR_DisableOSRLiveRangeAnalysis))
       {
       if (comp()->trace(OMR::escapeAnalysis))
          {
-         traceMsg(comp(), "Special handling of OSR points is not possible outside of voluntary OSR - nothing to do\n");
+         traceMsg(comp(), "Special handling of OSR points is not possible outside of voluntary OSR or if OSR Liveness is not available - nothing to do\n");
          }
       return 0;
       }
@@ -57,6 +57,16 @@ int32_t TR_PreEscapeAnalysis::perform()
          traceMsg(comp(), "EA has self-enabled, setup not required on subsequent passes - skipping preEscapeAnalysis\n");
          }
       return 0;
+      }
+
+   // Gather map of sym refs that were known during OSR Liveness analysis to
+   // the sym refs that occur in the current trees
+   //
+   static char *disableEADefiningMap = feGetEnv("TR_DisableEAEscapeHelperDefiningMap");
+
+   if (!disableEADefiningMap && comp()->getOSRCompilationData())
+      {
+      comp()->getOSRCompilationData()->buildDefiningMap();
       }
 
    TR_EscapeAnalysisTools tools(comp());

--- a/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/PreEscapeAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,9 +64,11 @@ int32_t TR_PreEscapeAnalysis::perform()
    //
    static char *disableEADefiningMap = feGetEnv("TR_DisableEAEscapeHelperDefiningMap");
 
+   TR::StackMemoryRegion stackMemoryRegion(*comp()->trMemory());
+
    if (!disableEADefiningMap && comp()->getOSRCompilationData())
       {
-      comp()->getOSRCompilationData()->buildDefiningMap();
+      comp()->getOSRCompilationData()->buildDefiningMap(comp()->trMemory()->currentStackRegion());
       }
 
    TR_EscapeAnalysisTools tools(comp());
@@ -94,6 +96,12 @@ int32_t TR_PreEscapeAnalysis::perform()
             break;
             }
          }
+      }
+
+   if (!disableEADefiningMap && comp()->getOSRCompilationData())
+      {
+      // Must discard references to the DefiningMaps when finished with them
+      comp()->getOSRCompilationData()->clearDefiningMap();
       }
 
    if (comp()->trace(OMR::escapeAnalysis))


### PR DESCRIPTION
`EscapeAnalysisTools` relied upon OSR liveness data to supply arguments to calls to `eaEscapeHelper` in OSR induce blocks.  This enables more stack allocation of objects under OSR.  However, after various transformations have been applied to the trees, the liveness data cannot be relied upon directly.

Instead, Pre-EscapeAnalysis must request a `DefiningMap` from the `OSRCompilationData`, which provides a map from the symbol references that existed at the point of OSR liveness analysis to the definitions that exist in the trees at the current point in the compilation.

For each of the relevant auto and pending push symrefs from the liveness data at the induce block, `EscapeAnalysisTools::processSymbolReferences` will add the defining symrefs mapped to by the original symref to the call to `eaEscapeHelper` that it inserts.

The use of the `DefiningMap` can be disabled by setting the environment variable `TR_DisableEAEscapeHelperDefiningMap`.

This pull request corresponds to pull request #9802 against the master branch, and depends on [openj9-omr pull request #67](https://github.com/eclipse/openj9-omr/pull/67)