### PR TITLE
Modified printJITServerMsgStats to print at shutdown on server

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4164,8 +4164,8 @@ void JitShutdown(J9JITConfig * jitConfig)
 
 #if defined(J9VM_OPT_JITSERVER)
    static char * isPrintJITServerMsgStats = feGetEnv("TR_PrintJITServerMsgStats");
-   if (isPrintJITServerMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-      JITServerHelpers::printJITServerMsgStats(jitConfig);
+   if (isPrintJITServerMsgStats)
+      JITServerHelpers::printJITServerMsgStats(jitConfig, compInfo);
    static char * isPrintJITServerCHTableStats = feGetEnv("TR_PrintJITServerCHTableStats");
    if (isPrintJITServerCHTableStats)
       JITServerHelpers::printJITServerCHTableStats(jitConfig, compInfo);

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -93,7 +93,7 @@ class JITServerHelpers
    static void postStreamConnectionSuccess();
    static bool isServerAvailable() { return _serverAvailable; }
 
-   static void printJITServerMsgStats(J9JITConfig *);
+   static void printJITServerMsgStats(J9JITConfig *, TR::CompilationInfo *);
    static void printJITServerCHTableStats(J9JITConfig *, TR::CompilationInfo *);
    static void printJITServerCacheStats(J9JITConfig *, TR::CompilationInfo *);
 

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -356,8 +356,8 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
       if (compInfo)
          {
          static char * isPrintJITServerMsgStats = feGetEnv("TR_PrintJITServerMsgStats");
-         if (isPrintJITServerMsgStats && compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-            JITServerHelpers::printJITServerMsgStats(jitConfig);
+         if (isPrintJITServerMsgStats)
+            JITServerHelpers::printJITServerMsgStats(jitConfig, compInfo);
          if (feGetEnv("TR_PrintJITServerCHTableStats"))
             JITServerHelpers::printJITServerCHTableStats(jitConfig, compInfo);
          if (feGetEnv("TR_PrintJITServerIPMsgStats"))


### PR DESCRIPTION
To trigger the jitDump use the option `-Xdump:jit:events=user` from the server side
and then run the Java client and then  `kill -3 (pidof jitserver)`. This will print
the message stats received by the server at shutdown.
issue: #9708

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>