### PR TITLE
Avoid gpProtect path when -Xrs is set

### DIFF
--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -284,7 +284,8 @@ static UDATA gpProtectedToReflected(void *entryArg)
 
 static jclass JNICALL gpCheckFindClass(JNIEnv * env, const char *name)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		return findClass(env, name);
 	} else {
 		J9RedirectedFindClassArgs args;
@@ -299,7 +300,8 @@ static jclass JNICALL gpCheckFindClass(JNIEnv * env, const char *name)
 #if  !defined(J9VM_INTERP_MINIMAL_JNI)
 static jobject JNICALL gpCheckToReflectedField(JNIEnv * env, jclass clazz, jfieldID fieldID, jboolean isStatic)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		return (jobject) toReflectedField(env, clazz, fieldID, isStatic);
 	} else {
 		J9RedirectedToReflectedArgs args;
@@ -318,7 +320,8 @@ static jobject JNICALL gpCheckToReflectedField(JNIEnv * env, jclass clazz, jfiel
 #if  !defined(J9VM_INTERP_MINIMAL_JNI)
 static jobject JNICALL gpCheckToReflectedMethod(JNIEnv * env, jclass clazz, jmethodID methodID, jboolean isStatic)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		return (jobject) toReflectedMethod(env, clazz, methodID, isStatic);
 	} else {
 		J9RedirectedToReflectedArgs args;
@@ -411,9 +414,10 @@ static UDATA gpProtectedInitialize(void * entryArg)
 
 
 
-void JNICALL    gpCheckInitialize(J9VMThread* env, J9Class* clazz)
+void JNICALL gpCheckInitialize(J9VMThread* env, J9Class* clazz)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		initializeClass(env, clazz);
 	} else {
 		J9RedirectedInitializeArgs args;
@@ -436,7 +440,8 @@ gpCheckCallin(JNIEnv *env, jobject receiver, jclass cls, jmethodID methodID, voi
 	handlerArgs.methodID = methodID;
 	handlerArgs.args = args;
 
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		gpProtectedRunCallInMethod(&handlerArgs);
 	} else {
 		gpProtectAndRun(gpProtectedRunCallInMethod, env, &handlerArgs);
@@ -444,7 +449,7 @@ gpCheckCallin(JNIEnv *env, jobject receiver, jclass cls, jmethodID methodID, voi
 }
 
 
-UDATA JNICALL   pushArguments(J9VMThread *vmThread, J9Method* method, void *args) {
+UDATA JNICALL pushArguments(J9VMThread *vmThread, J9Method* method, void *args) {
 	jvalue* jvalues;
 	U_8 *sigChar;
 	jobject objArg;
@@ -532,9 +537,10 @@ UDATA JNICALL   pushArguments(J9VMThread *vmThread, J9Method* method, void *args
 
 
 
-void JNICALL    gpCheckSetCurrentException(J9VMThread* env, UDATA exceptionNumber, UDATA* detailMessage)
+void JNICALL gpCheckSetCurrentException(J9VMThread* env, UDATA exceptionNumber, UDATA* detailMessage)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		setCurrentException(env, exceptionNumber, detailMessage);
 	} else {
 		J9RedirectedSetCurrentExceptionArgs args;
@@ -1108,9 +1114,10 @@ exceptionOccurred(JNIEnv *env)
 }
 
 
-void JNICALL    gpCheckSetCurrentExceptionNLS(J9VMThread* env, UDATA exceptionNumber, U_32 moduleName, U_32 messageNumber)
+void JNICALL gpCheckSetCurrentExceptionNLS(J9VMThread* env, UDATA exceptionNumber, U_32 moduleName, U_32 messageNumber)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		setCurrentExceptionNLS(env, exceptionNumber, moduleName, messageNumber);
 	} else {
 		J9RedirectedSetCurrentExceptionNLSArgs args;
@@ -1141,9 +1148,10 @@ gpProtectedSetNativeOutOfMemoryError(void * entryArg)
 	return 0;
 }
 
-void JNICALL    gpCheckSetNativeOutOfMemoryError(J9VMThread* env, U_32 moduleName, U_32 messageNumber)
+void JNICALL gpCheckSetNativeOutOfMemoryError(J9VMThread* env, U_32 moduleName, U_32 messageNumber)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		setNativeOutOfMemoryError(env, moduleName, messageNumber);
 	} else {
 		J9RedirectedSetCurrentExceptionNLSArgs args;
@@ -1163,9 +1171,10 @@ gpProtectedSetHeapOutOfMemoryError(void * entryArg)
 	return 0;
 }
 
-void JNICALL    gpCheckSetHeapOutOfMemoryError(J9VMThread* env)
+void JNICALL gpCheckSetHeapOutOfMemoryError(J9VMThread* env)
 {
-	if (((J9VMThread *) env)->gpProtected) {
+	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
+	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
 		setHeapOutOfMemoryError(env);
 	} else {
 		J9RedirectedSetCurrentExceptionNLSArgs args;

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -285,7 +285,7 @@ static UDATA gpProtectedToReflected(void *entryArg)
 static jclass JNICALL gpCheckFindClass(JNIEnv * env, const char *name)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		return findClass(env, name);
 	} else {
 		J9RedirectedFindClassArgs args;
@@ -301,7 +301,7 @@ static jclass JNICALL gpCheckFindClass(JNIEnv * env, const char *name)
 static jobject JNICALL gpCheckToReflectedField(JNIEnv * env, jclass clazz, jfieldID fieldID, jboolean isStatic)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		return (jobject) toReflectedField(env, clazz, fieldID, isStatic);
 	} else {
 		J9RedirectedToReflectedArgs args;
@@ -321,7 +321,7 @@ static jobject JNICALL gpCheckToReflectedField(JNIEnv * env, jclass clazz, jfiel
 static jobject JNICALL gpCheckToReflectedMethod(JNIEnv * env, jclass clazz, jmethodID methodID, jboolean isStatic)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		return (jobject) toReflectedMethod(env, clazz, methodID, isStatic);
 	} else {
 		J9RedirectedToReflectedArgs args;
@@ -417,7 +417,7 @@ static UDATA gpProtectedInitialize(void * entryArg)
 void JNICALL gpCheckInitialize(J9VMThread* env, J9Class* clazz)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		initializeClass(env, clazz);
 	} else {
 		J9RedirectedInitializeArgs args;
@@ -441,7 +441,7 @@ gpCheckCallin(JNIEnv *env, jobject receiver, jclass cls, jmethodID methodID, voi
 	handlerArgs.args = args;
 
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		gpProtectedRunCallInMethod(&handlerArgs);
 	} else {
 		gpProtectAndRun(gpProtectedRunCallInMethod, env, &handlerArgs);
@@ -540,7 +540,7 @@ UDATA JNICALL pushArguments(J9VMThread *vmThread, J9Method* method, void *args) 
 void JNICALL gpCheckSetCurrentException(J9VMThread* env, UDATA exceptionNumber, UDATA* detailMessage)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		setCurrentException(env, exceptionNumber, detailMessage);
 	} else {
 		J9RedirectedSetCurrentExceptionArgs args;
@@ -1117,7 +1117,7 @@ exceptionOccurred(JNIEnv *env)
 void JNICALL gpCheckSetCurrentExceptionNLS(J9VMThread* env, UDATA exceptionNumber, U_32 moduleName, U_32 messageNumber)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		setCurrentExceptionNLS(env, exceptionNumber, moduleName, messageNumber);
 	} else {
 		J9RedirectedSetCurrentExceptionNLSArgs args;
@@ -1151,7 +1151,7 @@ gpProtectedSetNativeOutOfMemoryError(void * entryArg)
 void JNICALL gpCheckSetNativeOutOfMemoryError(J9VMThread* env, U_32 moduleName, U_32 messageNumber)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		setNativeOutOfMemoryError(env, moduleName, messageNumber);
 	} else {
 		J9RedirectedSetCurrentExceptionNLSArgs args;
@@ -1174,7 +1174,7 @@ gpProtectedSetHeapOutOfMemoryError(void * entryArg)
 void JNICALL gpCheckSetHeapOutOfMemoryError(J9VMThread* env)
 {
 	/* Check if already protected or -Xrs is set and short-circuit the path through gpProtectAndRun */
-	if ((((J9VMThread *) env)->gpProtected) || (J9_SIG_XRS_SYNC == (((J9VMThread *) env)->javaVM->sigFlags & J9_SIG_XRS_SYNC))) {
+	if ((((J9VMThread *) env)->gpProtected) || (J9_ARE_ALL_BITS_SET(((J9VMThread *) env)->javaVM->sigFlags, J9_SIG_XRS_SYNC))) {
 		setHeapOutOfMemoryError(env);
 	} else {
 		J9RedirectedSetCurrentExceptionNLSArgs args;


### PR DESCRIPTION
Threads are signal protected when created by the JVM or on
the first call-in to the VM.  Subsequent call-ins can see
that the thread is already gpProtected and avoid adding the
gpProtection again.

In the case that the user is running -Xrs, and the thread is
not yet gpProtected, we end up doing a couple of c calls
before we realize signal protection isn't required and then
call through the passed in function pointer.

We can check for -Xrs early and avoid a couple of c calls on
the first call-in.  This should be zero cost on the common
case where the thread is already gpProtected and minimal cost
on the uncommon case where a thread isn't gpProtected yet.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>