### PR TITLE
AArch64: Move J9-specific recompilation code from OMR

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1545,6 +1545,18 @@ void J9::ARM64::PrivateLinkage::performPostBinaryEncoding()
    linkageInfoWordInstruction->setSourceImmediate(linkageInfoWord);
 
    *(uint32_t *)(linkageInfoWordInstruction->getBinaryEncoding()) = linkageInfoWord;
+
+   // Set recompilation info
+   //
+   TR::Recompilation *recomp = comp()->getRecompilationInfo();
+   if (recomp != NULL && recomp->couldBeCompiledAgain())
+      {
+      J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(cg()->getCodeStart());
+      if (recomp->useSampling())
+         lkInfo->setSamplingMethodBody();
+      else
+         lkInfo->setCountingMethodBody();
+      }
    }
 
 int32_t J9::ARM64::HelperLinkage::buildArgs(TR::Node *callNode,

--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
@@ -52,7 +52,7 @@ TR_PersistentMethodInfo *TR_ARM64Recompilation::getExistingMethodInfo(TR_Resolve
 
 TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
    {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_compilation->fe());
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
 
    // If in Full Speed Debug, allow to go through
    if (!couldBeCompiledAgain() && !_compilation->getOption(TR_FullSpeedDebug))
@@ -65,7 +65,7 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
    TR::Register *x8 = machine->getRealRegister(TR::RealRegister::x8);
    TR::Register *lr = machine->getRealRegister(TR::RealRegister::lr); // Link Register
    TR::Register *xzr = machine->getRealRegister(TR::RealRegister::xzr); // zero register
-   TR::Node *firstNode = _compilation->getStartTree()->getNode();
+   TR::Node *firstNode = comp()->getStartTree()->getNode();
    TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64samplingRecompileMethod, false, false, false);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
 
@@ -95,6 +95,11 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
 
 TR::Instruction *TR_ARM64Recompilation::generatePrologue(TR::Instruction *cursor)
    {
-   TR_UNIMPLEMENTED();
+   TR::Recompilation *recomp = comp()->getRecompilationInfo();
+   if (!recomp->useSampling())
+      {
+      // counting recompilation
+      TR_UNIMPLEMENTED();
+      }
    return cursor;
    }


### PR DESCRIPTION
This commit moves J9-specific recompilation code from OMR to OpenJ9.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>