### PR TITLE
[Test] Adjust the setting of GC specific tests on RISC-V

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/nogc/TestGCPolicyNogc.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/nogc/TestGCPolicyNogc.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,7 +118,7 @@ public class TestGCPolicyNogc {
 		while (allocator.isAlive()) {
 			try {
 				count++;
-				if (count > 5) {
+				if (count > 200) {
 					Allocator.bQuit = true;
 				}
 				Thread.sleep(2*1000);

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2001, 2019 IBM Corp. and others
+  Copyright (c) 2001, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -224,6 +224,13 @@
  	<echo value="CMVC 148977:  Excessive GC throws OOM may fail if there is other activity on the machine - at least 5 GCs are required, in the 20 second test" />
  	<!-- does the test fail to run (thus implying that we encountered excessive GC)? -->
  	<command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -Xdump:none -Xms8m -Xmx8m -Xgc:fvtest=forceExcessiveAllocFailureAfter=5 -verbose:gc -Xverbosegclog:foo.log $CP$ com.ibm.tests.garbagecollector.SpinAllocate 20</command>
+ 	<output regex="no" type="failure">Test ran to completion</output>
+ 	<output regex="no" type="success">java.lang.OutOfMemoryError</output>
+ </test>
+ <test id="Excessive GC throws OOM on RISC-V">
+ 	<echo value="CMVC 148977:  Excessive GC throws OOM may fail if there is other activity on the machine - at least 5 GCs are required, in the 20 second test" />
+ 	<!-- does the test fail to run (thus implying that we encountered excessive GC)? -->
+ 	<command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -Xdump:none -Xms2m -Xmx2m -Xgc:fvtest=forceExcessiveAllocFailureAfter=5 -verbose:gc -Xverbosegclog:foo.log $CP$ com.ibm.tests.garbagecollector.SpinAllocate 20</command>
  	<output regex="no" type="failure">Test ran to completion</output>
  	<output regex="no" type="success">java.lang.OutOfMemoryError</output>
  </test>

--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests_excludes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2001, 2018 IBM Corp. and others
+  Copyright (c) 2001, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,5 +43,8 @@
 <exclude id="Excessive GC throws OOM" platform="Mode301" shouldFix="true"><reason>Metronome and Staccato do not use excessive GC</reason></exclude>
 <exclude id="Excessive GC appears in verbose log" platform="Mode301" shouldFix="true"><reason>Metronome and Staccato do not use excessive GC</reason></exclude>
 
+<!-- only Gencon GC is supported on RISC-V -->
+<exclude id="Excessive GC throws OOM" platform="linux_riscv.*" shouldFix="false"><reason>The initial memory setting does not work on RISC-V</reason></exclude>
+<include id="Excessive GC throws OOM on RISC-V" platform="linux_riscv.*" shouldFix="false"><reason>The initial memory setting is only used to trigger the OOM on RISC-V</reason></include>
 </suite>
 

--- a/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,26 @@
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_GCRegressionTests_RISCV</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)gcRegressionTests.jar$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)gcRegressionTests.xml$(Q) \
+		-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)gcRegressionTests_excludes.xml$(Q) -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>arch.riscv</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
 		</impls>
 	</test>
 	<test>


### PR DESCRIPTION
The test change is to update the initial memory setting &
the threshold values in GC specific tests to ensure the
JVM works appropriately as expected in tests due to the
lack of JIT on RISC-V.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>