### PR TITLE
[Test] Disable the timeout setting on RISC-V

### DIFF
--- a/test/functional/cmdline_options_tester/src/Test.java
+++ b/test/functional/cmdline_options_tester/src/Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,6 +70,9 @@ class Test {
 	 * The default is one minute.
 	 */
 	static final long CORE_SPACING_MILLIS = Long.getLong("cmdline.coreintervalms", 60 * 1000).longValue();
+	
+	static String archName = System.getProperty("os.arch");
+	static boolean isRiscv = archName.toLowerCase().contains("riscv");
 
 	/**
 	 * Create a new test case with the given id.
@@ -409,7 +412,7 @@ class Test {
 
 	public static int getUnixPID(Process process) throws Exception {
 		Class<?> cl = process.getClass();
-		if (!cl.getName().equals("java.lang.UNIXProcess")) {
+		if (!cl.getName().equals("java.lang.UNIXProcess") || isRiscv) {
 			return 0;
 		}
 		Field field = cl.getDeclaredField("pid");
@@ -578,7 +581,7 @@ class Test {
 				// Make sure we are on linux, otherwise there is no gdb.
 				int pid = getUnixPID(_proc);
 
-				if (0 == pid) {
+				if ((0 == pid) && !isRiscv) {
 					System.out.print("INFO: getUnixPID() has failed indicating this is not a UNIX System.");
 					System.out.println("'Debug on timeout' is currently only supported on Linux.");
 					return;

--- a/test/functional/cmdline_options_tester/src/TestConfigParser.java
+++ b/test/functional/cmdline_options_tester/src/TestConfigParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,9 @@ class TestConfigParser {
 	private int _outputLimit;
 	private boolean _debugCmdOnTimeout = false;
 	private String _modeHints;
+	
+	static String archName = System.getProperty("os.arch");
+	static boolean isRiscv = archName.toLowerCase().contains("riscv");
 	
 	/**
 	 * If true, the test suite will print out the full output for each test case, regardless of whether
@@ -156,6 +159,10 @@ class TestConfigParser {
 					String modeHints = (String)attributes.get("modeHints");
 					if (hasAllowedHints(modeHints)) {
 						String timeout = (String)attributes.get("timeout");
+						
+						/* Set 16 hours (57600 secs) for timeout on RISC-V due to the lack of JIT */
+						timeout = (isRiscv) ? "57600" : timeout;
+						
 						_currentTest = new Test( id, timeout, _debugCmdOnTimeout );
 					} else {
 						if ((_modeHints == null) || (_modeHints.matches("\\s*"))) {


### PR DESCRIPTION
The code change is to disable the timeout setting due to the lack
of JIT on RISC-V.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>