### PR TITLE
Improve group caching of resolved methods

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,7 +60,7 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
 
-   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, const TR_ResolvedJ9JITServerMethodInfo &methodInfo);
+   void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, int32_t ttlForUnresolved = 2);
    bool getCachedResolvedMethod(TR_ResolvedMethodKey key, TR_ResolvedJ9JITServerMethod *owningMethod, TR_ResolvedMethod **resolvedMethod, bool *unresolvedInCP = NULL);
    TR_ResolvedMethodKey getResolvedMethodKey(TR_ResolvedMethodType type, TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_OpaqueClassBlock *classObject = NULL);
 

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -118,6 +118,7 @@ TR_ResolvedMethodCacheEntry
    TR_PersistentJittedBodyInfo *persistentBodyInfo;
    TR_PersistentMethodInfo *persistentMethodInfo;
    TR_ContiguousIPMethodHashTableEntry *IPMethodInfo;
+   int32_t ttlForUnresolved;
    };
 
 using TR_ResolvedMethodInfoCache = UnorderedMap<TR_ResolvedMethodKey, TR_ResolvedMethodCacheEntry>;
@@ -216,7 +217,7 @@ public:
    static void createResolvedMethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    static void createResolvedMethodFromJ9MethodMirror(TR_ResolvedJ9JITServerMethodInfo &methodInfo, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, TR_ResolvedMethod *owningMethod, TR_FrontEnd *fe, TR_Memory *trMemory);
    bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method);
-   void cacheResolvedMethodsCallees();
+   void cacheResolvedMethodsCallees(int32_t ttlForUnresolved = 2);
 
 protected:
    JITServer::ServerStream *_stream;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -443,8 +443,15 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
       // JITServer optimization:
       // request this resolved method to create all of its callee resolved methods
       // in a single query.
+      //
+      // If the method is unresolved, return NULL for 2 requests without asking the client,
+      // since they are called almost immediately after this request and are unlikely to
+      // become resolved.
+      //
+      // NOTE: first request occurs in the for loop over bytecodes, immediately after this request,
+      // second request occurs in InterpreterEmulator::findAndCreateCallsitesFromBytecodes
       auto calleeMethod = static_cast<TR_ResolvedJ9JITServerMethod *>(calltarget->_calleeMethod);
-      calleeMethod->cacheResolvedMethodsCallees();
+      calleeMethod->cacheResolvedMethodsCallees(2);
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 


### PR DESCRIPTION
We already perform caching of method's callees during inlining
in one message. This commit builds on that strategy in the following
ways:
- Group cache all callees of the method being compiled during ILGen
- Since callees are cached right before they are used, we could
cache even unresolved methods, not having to worry about them becoming
resolved in-between calls. Thus, every cached unresolved method entry
now has a `time-to-live`, which is set at the moment of caching.
When `ttl` expires, the entry is deleted from cache.