### PR TITLE
Retrieve info from the client in isClassRefValueType

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2098,6 +2098,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, std::string((char *) classRefName, classRefLen));
          }
          break;
+      case MessageType::ClassEnv_isClassRefValueType:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *, int32_t>();
+         auto clazz = std::get<0>(recv);
+         auto cpIndex = std::get<1>(recv);
+         client->write(response, TR::Compiler->cls.isClassRefValueType(comp, clazz, cpIndex));
+         }
+         break;
       case MessageType::SharedCache_getClassChainOffsetInSharedCache:
          {
          auto j9class = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -735,7 +735,17 @@ J9::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_Pers
 bool
 J9::ClassEnv::isClassRefValueType(TR::Compilation *comp, TR_OpaqueClassBlock *cpContextClass, int32_t cpIndex)
    {
-   J9Class * j9class = reinterpret_cast<J9Class *>(cpContextClass);
-   J9JavaVM *vm = getJ9JitConfigFromFE(comp->fej9())->javaVM;
-   return vm->internalVMFunctions->isClassRefQtype(j9class, cpIndex);
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      stream->write(JITServer::MessageType::ClassEnv_isClassRefValueType, cpContextClass, cpIndex);
+      return std::get<0>(stream->read<bool>());
+      }
+   else // non-jitserver
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      J9Class * j9class = reinterpret_cast<J9Class *>(cpContextClass);
+      J9JavaVM *vm = comp->fej9()->getJ9JITConfig()->javaVM;
+      return vm->internalVMFunctions->isClassRefQtype(j9class, cpIndex);
+      }
    }

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -565,8 +565,9 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
       if (currNode->getOpCodeValue() == TR::checkcast
           && currNode->getSecondChild()->getOpCodeValue() == TR::loadaddr
           && currNode->getSecondChild()->getSymbolReference()->isUnresolved()
-          // check whether the checkcast class is valuetype. Expansion is only needed for checkcast to reference type.
-          && !TR::Compiler->cls.isClassRefValueType(comp(), method()->classOfMethod(), currNode->getSecondChild()->getSymbolReference()->getCPIndex()))
+          && // check whether the checkcast class is valuetype. Expansion is only needed for checkcast to reference type.
+            (!TR::Compiler->om.areValueTypesEnabled()
+            || !TR::Compiler->cls.isClassRefValueType(comp(), method()->classOfMethod(), currNode->getSecondChild()->getSymbolReference()->getCPIndex())))
           {
           unresolvedCheckcastTopsNeedingNullGuard.add(currTree);
           }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -97,7 +97,7 @@ protected:
    ClientMessage _cMsg;
 
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 5;
+   static const uint16_t MINOR_NUMBER = 6;
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -293,6 +293,8 @@ enum MessageType : uint16_t
    KnownObjectTable_getReferenceField,
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
+
+   ClassEnv_isClassRefValueType, // 243
    MessageType_MAXTYPE
    };
 
@@ -542,7 +544,8 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_createSymRefWithKnownObject", // 239
    "KnownObjectTable_getReferenceField", // 240
    "KnownObjectTable_invokeDirectHandleDirectCall", // 241
-   "KnownObjectTable_getKnownObjectTableDumpInfo" // 242
+   "KnownObjectTable_getKnownObjectTableDumpInfo", // 242
+   "ClassEnv_isClassRefValueType" // 243
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP


### PR DESCRIPTION
The query of `isClassRefValueType` should be done at the client instead of the server. Sending a message to the client to check if a class reference entry in the constant pool represents a value type class.

Fixes #9892

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>