### PR TITLE
Add JDK15 JVMTI Version

### DIFF
--- a/runtime/include/jvmti.h.m4
+++ b/runtime/include/jvmti.h.m4
@@ -45,16 +45,18 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM* vm, char *options, void *reserved)
 #define JVMTI_VERSION_1_1 0x30010100
 #define JVMTI_VERSION_1_2 0x30010200
 #define JVMTI_VERSION_1 (JVMTI_VERSION_1_0)
-#define JVMTI_VERSION_9  0x30090000
+ifelse(eval(JAVA_SPEC_VERSION > 8), 1, [#define JVMTI_VERSION_9  0x30090000
 #define JVMTI_VERSION_11 0x300b0000
-
-#define JVMTI_VERSION JVMTI_VERSION_11
+ifelse(eval(JAVA_SPEC_VERSION >= 15), 1, [#define JVMTI_VERSION_15 0x300f0000], [dnl])], [dnl])
 
 #define JVMTI_1_0_SPEC_VERSION           (JVMTI_VERSION_1_0 + 37)	/* Spec version is 1.0.37 */
 #define JVMTI_1_1_SPEC_VERSION           (JVMTI_VERSION_1_1 + 102)	/* Spec version is 1.1.102 */
 #define JVMTI_1_2_SPEC_VERSION           (JVMTI_VERSION_1_2 + 1)	/* Spec version is 1.2.1 */
 #define JVMTI_1_2_3_SPEC_VERSION         (JVMTI_VERSION_1_2 + 3)  /* Spec version is 1.2.3 */
 
+ifelse(eval(JAVA_SPEC_VERSION >= 15), 1, [#define JVMTI_VERSION JVMTI_VERSION_15], [
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [#define JVMTI_VERSION JVMTI_VERSION_11], [
+#define JVMTI_VERSION JVMTI_1_2_SPEC_VERSION])])
 
 #define JVMTI_CLASS_STATUS_VERIFIED		0x00000001
 #define JVMTI_CLASS_STATUS_PREPARED		0x00000002

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -177,19 +177,26 @@ jvmtiError JNICALL
 jvmtiGetVersionNumber(jvmtiEnv* env,
 	jint* version_ptr)
 {
+#if JAVA_SPEC_VERSION >= 11
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	jvmtiError rc;
+#endif /* JAVA_SPEC_VERSION >= 11 */
+	jvmtiError rc = JVMTI_ERROR_NONE;
 	jint rv_version = JVMTI_1_2_3_SPEC_VERSION;
 
 	Trc_JVMTI_jvmtiGetVersionNumber_Entry(env);
 
 	ENSURE_NON_NULL(version_ptr);
 
+#if JAVA_SPEC_VERSION >= 11
+#if JAVA_SPEC_VERSION >= 15
+	if (J2SE_VERSION(vm) >= J2SE_V15) {
+		rv_version = JVMTI_VERSION_15;
+	} else
+#endif /* JAVA_SPEC_VERSION >= 15 */
 	if (J2SE_VERSION(vm) >= J2SE_V11) {
 		rv_version = JVMTI_VERSION_11;
 	}
-
-	rc = JVMTI_ERROR_NONE;
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 done:
 	if (NULL != version_ptr) {

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1582,20 +1582,22 @@ jvmtiHookGetEnv(J9HookInterface** hook, UDATA eventNum, void* eventData, void* u
 	if (data->rc == JNI_EVERSION) {
 		jint version = data->version & ~JVMTI_VERSION_MASK_MICRO;
 
-		if ((version == JVMTI_VERSION_1_0) 
-			|| (version == JVMTI_VERSION_1_1) 
-			|| (version == JVMTI_VERSION_1_2) 
-			|| (version == JVMTI_VERSION_9)
-			|| (version == JVMTI_VERSION_11)
+		if ((JVMTI_VERSION_1_0 == version)
+			|| (JVMTI_VERSION_1_1 == version)
+			|| (JVMTI_VERSION_1_2 == version)
+#if JAVA_SPEC_VERSION > 8
+			|| (JVMTI_VERSION_9 == version)
+			|| (JVMTI_VERSION_11 == version)
+#if JAVA_SPEC_VERSION >= 15
+			|| (JVMTI_VERSION_15 == version)
+#endif /* JAVA_SPEC_VERSION >= 15 */
+#endif /* JAVA_SPEC_VERSION > 8 */
 		) {
-			/* Jazz 99339: obtain the pointer to J9JavaVM from J9InvocationJavaVM so as to store J9NativeLibrary in J9JVMTIEnv */
-			J9InvocationJavaVM * invocationJavaVM = (J9InvocationJavaVM *)data->jvm;
 			J9JVMTIData * jvmtiData = userData;
 
-			if (jvmtiData != NULL) {
-				if (jvmtiData->phase != JVMTI_PHASE_DEAD) {
-					data->rc = allocateEnvironment(invocationJavaVM, data->version, data->penv);
-				}
+			if ((NULL != jvmtiData) && (JVMTI_PHASE_DEAD != jvmtiData->phase)) {
+				/* Jazz 99339: obtain the pointer to J9JavaVM from J9InvocationJavaVM so as to store J9NativeLibrary in J9JVMTIEnv */
+				data->rc = allocateEnvironment((J9InvocationJavaVM *)data->jvm, data->version, data->penv);
 			}
 		}
 	}

--- a/runtime/tests/jvmtitests/agent/version.c
+++ b/runtime/tests/jvmtitests/agent/version.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@ const static char *versionNames[] =
 	"JVMTI 1.2",
 	"JVMTI 9.0",
 	"JVMTI 11",
+	"JVMTI 15",
 	"unknown"
 };
 
@@ -60,10 +61,16 @@ getVersionName(agentEnv * agent_env, jint version)
 			return versionNames[1];
 		case JVMTI_VERSION_1_2:
 			return versionNames[2];
+#if JAVA_SPEC_VERSION > 8
 		case JVMTI_VERSION_9:
 			return versionNames[3];
 		case JVMTI_VERSION_11:
 			return versionNames[4];
+#if JAVA_SPEC_VERSION >= 15
+		case JVMTI_VERSION_15:
+			return versionNames[5];
+#endif /* JAVA_SPEC_VERSION >= 15 */
+#endif /* JAVA_SPEC_VERSION > 8 */
 		default:
 			error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "Query for an unknown version");
 	}


### PR DESCRIPTION
* Defined `JVMTI_VERSION_15`;
* Updated `jvmtiGetVersionNumber()` & `jvmtiHookGetEnv()`;
* Minor refactoring.

This is based on https://github.com/eclipse/openj9/pull/9883 with additional changes to keep `#define JVMTI_VERSION JVMTI_VERSION_11` for pre-JDK15.
```
ifelse(eval(JAVA_SPEC_VERSION >= 15), 1, [#define JVMTI_VERSION JVMTI_VERSION_15], [#define JVMTI_VERSION JVMTI_VERSION_11])
```

fixes: https://github.com/eclipse/openj9/issues/9889

Signed-off-by: Jason Feng <fengj@ca.ibm.com>