### PR TITLE
Acquire Thread.lock while calling jvmti suspendThread

### DIFF
--- a/runtime/jvmti/suspendhelper.cpp
+++ b/runtime/jvmti/suspendhelper.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,7 +45,17 @@ suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, UDATA 
 				if (currentThread == targetThread) {
 					*currentThreadSuspended = TRUE;
 				} else {
-					currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
+					J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+					/* Match Thread.suspend() synchronization by acquiring the target thread's Thread.lock before suspending.
+					 * This will prevent deadlocks in the JCL library that could occur if a thread is suspended while
+					 * holding Thread.lock.
+					 * For example if thread1 is suspended while in the middle of running Thread.isAlive which is synchronized, 
+					 * thread2 calling thread1.interrupt will hang forever since the lock belonging to thread1 will never be released.
+					 */
+					vmFuncs->objectMonitorEnter(currentThread, J9VMJAVALANGTHREAD_LOCK(currentThread, targetThread->threadObject));
+
+					vmFuncs->internalExitVMToJNI(currentThread);
+
 					omrthread_monitor_enter(targetThread->publicFlagsMutex);
 					VM_VMAccess::setHaltFlagForVMAccessRelease(targetThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 					if (VM_VMAccess::mustWaitForVMAccessRelease(targetThread)) {
@@ -54,7 +64,11 @@ suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, UDATA 
 						}
 					}
 					omrthread_monitor_exit(targetThread->publicFlagsMutex);
-					currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
+
+					vmFuncs->internalEnterVMFromJNI(currentThread);
+
+					/* Release java.lang.Thread.lock */
+					vmFuncs->objectMonitorExit(currentThread, J9VMJAVALANGTHREAD_LOCK(currentThread, targetThread->threadObject));
 				}
 				Trc_JVMTI_threadSuspended(targetThread);
 			}


### PR DESCRIPTION
Match Thread.suspend() synchronization by acquiring the target thread's Thread.lock before suspending. This will prevent deadlocks in the JCL library that could occur if a thread is suspended while holding Thread.lock.

For example if thread1 is suspended while in the middle of running Thread.isAlive which is synchronized, thread2 calling thread1.interrupt will hang forever since the lock belonging to thread1 will never be released.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>