### PR TITLE
(0.21.0) AArch64: Add code in getJitRecompilationResolvePushes()

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -1060,6 +1060,22 @@ public class MethodMetaData
 				XX:	<linkage area>						<== unwindSP should point here
 				*/
 				return 3;
+			} else if (J9ConfigFlags.arch_aarch64) {
+				/* AArch64 recompilation resolve shape
+				0:	x7 (arg register)
+				1:	x6 (arg register)
+				2:	x5 (arg register)
+				3:	x4 (arg register)
+				4:	x3 (arg register)
+				5:	x2 (arg register)
+				6:	x1 (arg register)
+				7:	x0 (arg register)
+				8:	x8 return PC		<== unwindSP points here
+				9:	x9
+				10:	old startPC
+				XX:	<linkage area>		<== unwindSP should point here
+				*/
+				return 3;
 			} else {
 				return 0;
 			}

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -1545,6 +1545,18 @@ void J9::ARM64::PrivateLinkage::performPostBinaryEncoding()
    linkageInfoWordInstruction->setSourceImmediate(linkageInfoWord);
 
    *(uint32_t *)(linkageInfoWordInstruction->getBinaryEncoding()) = linkageInfoWord;
+
+   // Set recompilation info
+   //
+   TR::Recompilation *recomp = comp()->getRecompilationInfo();
+   if (recomp != NULL && recomp->couldBeCompiledAgain())
+      {
+      J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(cg()->getCodeStart());
+      if (recomp->useSampling())
+         lkInfo->setSamplingMethodBody();
+      else
+         lkInfo->setCountingMethodBody();
+      }
    }
 
 int32_t J9::ARM64::HelperLinkage::buildArgs(TR::Node *callNode,

--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
@@ -52,7 +52,7 @@ TR_PersistentMethodInfo *TR_ARM64Recompilation::getExistingMethodInfo(TR_Resolve
 
 TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
    {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_compilation->fe());
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
 
    // If in Full Speed Debug, allow to go through
    if (!couldBeCompiledAgain() && !_compilation->getOption(TR_FullSpeedDebug))
@@ -65,7 +65,7 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
    TR::Register *x8 = machine->getRealRegister(TR::RealRegister::x8);
    TR::Register *lr = machine->getRealRegister(TR::RealRegister::lr); // Link Register
    TR::Register *xzr = machine->getRealRegister(TR::RealRegister::xzr); // zero register
-   TR::Node *firstNode = _compilation->getStartTree()->getNode();
+   TR::Node *firstNode = comp()->getStartTree()->getNode();
    TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64samplingRecompileMethod, false, false, false);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
 
@@ -85,7 +85,7 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
                                          new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg()->trMemory()),
                                          recompileMethodSymRef, NULL, cursor);
       cursor = generateRelocatableImmInstruction(cg(), TR::InstOpCode::dd, firstNode, (uintptr_t)info, TR_BodyInfoAddress, cursor);
-      cursor->setNeedsAOTRelocation();
+
       // space for preserving original jitEntry instruction
       cursor = generateImmInstruction(cg(), TR::InstOpCode::dd, firstNode, 0, cursor);
       }
@@ -95,6 +95,11 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
 
 TR::Instruction *TR_ARM64Recompilation::generatePrologue(TR::Instruction *cursor)
    {
-   TR_UNIMPLEMENTED();
+   TR::Recompilation *recomp = comp()->getRecompilationInfo();
+   if (!recomp->useSampling())
+      {
+      // counting recompilation
+      TR_UNIMPLEMENTED();
+      }
    return cursor;
    }

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -2239,6 +2239,22 @@ UDATA getJitRecompilationResolvePushes()
       XX: (linkage area)                                 <== unwindSP should point here
    */
    return 2;
+#elif defined(TR_HOST_ARM64)
+   /* AArch64 recompilation resolve shape
+      0:  x7 (arg register)
+      1:  x6 (arg register)
+      2:  x5 (arg register)
+      3:  x4 (arg register)
+      4:  x3 (arg register)
+      5:  x2 (arg register)
+      6:  x1 (arg register)
+      7:  x0 (arg register)
+      8:  x8 return PC (caller of recompiled method)     <== unwindSP points here
+      9:  x9
+      10: old startPC
+      XX: (linkage area)                                 <== unwindSP should point here
+   */
+   return 3;
 #else
    return 0;
 #endif


### PR DESCRIPTION
This commit adds code for AArch64 in getJitRecompilationResolvePushes()
and in the corresponding DDR method.
It also adds code for recompilation in performPostBinaryEncoding() and
in generatePrologue().

Original PRs for master: #9847, #9882, #9923

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>