### PR TITLE
Assign getStackTrace result to a local variable to avoid refetching

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
  * Copyright (c) 1998, 2020 IBM Corp. and others
  *
@@ -283,16 +283,19 @@ private static int countDuplicates(StackTraceElement[] currentStack, StackTraceE
  * @return an array of StackTraceElement representing the stack
  */
 StackTraceElement[] getInternalStackTrace() {
-
 	if (disableWritableStackTrace) {
 		return	ZeroStackTraceElementArray;
 	}
 
-	if (stackTrace == null) {
-		stackTrace = J9VMInternals.getStackTrace(this, true);
+	StackTraceElement[] localStackTrace = stackTrace;
+	if (localStackTrace == null) {
+		// Assign the result to a local variable to avoid refetching
+		// the instance variable and any memory ordering issues
+		localStackTrace = J9VMInternals.getStackTrace(this, true);
+		stackTrace = localStackTrace;
 	} 
 	
-	return stackTrace;
+	return localStackTrace;
 }
 
 /**


### PR DESCRIPTION
Assigned `J9VMInternals.getStackTrace(this, true)` result to a local variable to avoid refetching the instance variable and any memory ordering issues.

A few notes:
The `NPE` reported in #9663 usually can be reproduced in 1 or 2 runs with JIT on, with this PR, 50 runs succeeded.

As per investigation https://github.com/eclipse/openj9/issues/9663#issuecomment-644699741, the native `J9VMInternals.getStackTrace(this, true)` returned non-null value when the `NPE` was thrown.

Submitting this PR since it is good thing to do. Will continue the investigation how a `null` value was returned from `getInternalStackTrace()`.

related #9663 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>