### PR TITLE
(0.21.0) Clone the StackTraceElement[] before validating it

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -231,8 +231,9 @@ public void setStackTrace(StackTraceElement[] trace) {
 	if (trace == null) {
 		throw new NullPointerException();
 	}
-	for (int i=0; i<trace.length; i++)	{
-		if (trace[i] == null) {
+	StackTraceElement[] localCopy = trace.clone();
+	for (int i=0; i<localCopy.length; i++)	{
+		if (localCopy[i] == null) {
 			throw new NullPointerException();
 		}
 	}
@@ -241,7 +242,7 @@ public void setStackTrace(StackTraceElement[] trace) {
 		return;
 	}
 	
-	stackTrace = (StackTraceElement[])trace.clone();
+	stackTrace = localCopy;
 }
 
 /**


### PR DESCRIPTION
The STE[] needs to be clone()'d before we iterate over it
looking for NULL array elements as otherwise there is a
timing hole where the caller may mutate the array and
insert a NULL after we've validated it but before it's
been cloned.

Port https://github.com/eclipse/openj9/pull/9917 to v0.21.0

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>