### PR TITLE
AArch64: Move call to setNeedsAOTRelocation() to constructor in OMR

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
@@ -85,7 +85,7 @@ TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
                                          new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg()->trMemory()),
                                          recompileMethodSymRef, NULL, cursor);
       cursor = generateRelocatableImmInstruction(cg(), TR::InstOpCode::dd, firstNode, (uintptr_t)info, TR_BodyInfoAddress, cursor);
-      cursor->setNeedsAOTRelocation();
+
       // space for preserving original jitEntry instruction
       cursor = generateImmInstruction(cg(), TR::InstOpCode::dd, firstNode, 0, cursor);
       }


### PR DESCRIPTION
eclipse/omr#5319 adds calls to setNeedsAOTRelocation() in constructors
of ARM64RelocatableInstruction.  This commit removes the call to the
function in ARM64Recompilation.cpp, because it is no longer needed.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>