### PR TITLE
Update Xcode version requirement

### DIFF
--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -540,12 +540,12 @@ The following instructions guide you through the process of building a macOS **O
 
 ### 1. Prepare your system
 :apple:
-You must install a number of software dependencies to create a suitable build environment on your system:
+You must install a number of software dependencies to create a suitable build environment on your system (the specified versions are minimums):
 
-- [Xcode >= 11.4](https://developer.apple.com/download/more/) (requires an Apple account to log in).
+- [Xcode 10.3](https://developer.apple.com/download/more/) (requires an Apple account to log in).
 - [macOS OpenJDK 8](https://api.adoptopenjdk.net/v3/binary/latest/8/ga/mac/x64/jdk/openj9/normal/adoptopenjdk), which is used as the boot JDK.
 
-The following dependencies can be installed by using [Homebrew](https://brew.sh/) (the specified versions are minimums):
+The following dependencies can be installed by using [Homebrew](https://brew.sh/):
 
 - [autoconf 2.6.9](https://formulae.brew.sh/formula/autoconf)
 - [bash 4.4.23](https://formulae.brew.sh/formula/bash)


### PR DESCRIPTION
Updated to based on the fact that adoptopenjdk.net is using Xcode 10.3 to build Java 8.