### PR TITLE
jilgen: wrap declaration of writeMacros in an ifdef

### DIFF
--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -32,8 +32,11 @@ static int values = 0;
 
 static UDATA writeConstant(OMRPortLibrary *OMRPORTLIB, IDATA fd, char const *name, UDATA value);
 static jint writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd);
-static jint writeMacros(OMRPortLibrary *OMRPORTLIB, IDATA fd);
 static IDATA createConstant(OMRPortLibrary *OMRPORTLIB, char const *name, UDATA value);
+
+#if defined(J9VM_ARCH_X86)
+static jint writeMacros(OMRPortLibrary *OMRPORTLIB, IDATA fd);
+#endif
 
 static jint
 writeHeader(OMRPortLibrary *OMRPORTLIB, IDATA fd)


### PR DESCRIPTION
Otherwise compiler errors that we have declared a static function with
no definition.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>