### PR TITLE
Port: silence warning about ignored return value

### DIFF
--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-   Copyright (c) 2006, 2019 IBM Corp. and others
+   Copyright (c) 2006, 2020 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,14 +220,7 @@
 		</includes>
 
 		<makefilestubs>
-			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1">
-				<exclude-if condition="spec.linux_ppc.*"/>
-
-				<!--  Provisionally ignore the warning until RTC #132065 is resolved. -->
-				<exclude-if condition="spec.linux_390.*" />
-				<exclude-if condition="spec.linux_390-64.*" />
-			</makefilestub>
-
+			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="OMRPORT_SRCDIR=$(OMR_DIR)/port/" />
 
 			<makefilestub data="ifdef I5_VERSION">

--- a/runtime/port/unix/j9process.c
+++ b/runtime/port/unix/j9process.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -383,7 +383,7 @@ j9process_create(struct J9PortLibrary *portLibrary, const char *command[], uintp
 		}
 
 		/* if we get here ==> tell the parent that the execv failed ! Send the error number. */
-		write(forkedChildProcess[1], &errno, sizeof(errno));
+		J9_IGNORE_RETURNVAL(write(forkedChildProcess[1], &errno, sizeof(errno)));
 		close(forkedChildProcess[0]);
 		close(forkedChildProcess[1]);
 		/* If the exec failed, we must exit or there will be two VM processes running. */
@@ -461,7 +461,7 @@ j9process_create(struct J9PortLibrary *portLibrary, const char *command[], uintp
 
 		/* let the forked child start. */
 		close(forkedChildProcess[1]);
-		read(forkedChildProcess[0], &dummy, 1);
+		J9_IGNORE_RETURNVAL(read(forkedChildProcess[0], &dummy, 1));
 
 		/* [PR CMVC 143339] OTTBLD: jclmaxtest_jit_G1 Test_Runtime failure
 		 * Instead of using timeout to determine if child process has been created successfully,


### PR DESCRIPTION
Here the read/writes are used as a synchronization method, and there
really isn't much we can do if they fail

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>