### PR TITLE
Added jitHelpers for store and load

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1704,6 +1704,24 @@ exit:
 		}
 		return method;
 	}
+	static VMINLINE bool
+	objectArrayStoreAllowed(j9object_t array, j9object_t storeValue)
+	{
+		bool rc = true;
+		if (NULL != storeValue) {
+			J9Class *valueClass = J9OBJECT_CLAZZ(_currentThread, storeValue);
+			J9Class *componentType = ((J9ArrayClass*)J9OBJECT_CLAZZ(_currentThread, array))->componentType;
+			/* quick check -- is this a store of a C into a C[]? */
+			if (valueClass != componentType) {
+				/* quick check -- is this a store of a C into a java.lang.Object[]? */
+				if (0 != J9CLASS_DEPTH(componentType)) {
+					rc = inlineCheckCast(valueClass, componentType);
+				}
+			}
+		}
+		return rc;
+	}
+
 };
 
 #endif /* VMHELPERS_HPP_ */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4592,6 +4592,8 @@ typedef struct J9InternalVMFunctions {
 #if JAVA_SPEC_VERSION >= 15
 	I_32 (*checkClassBytes) (struct J9VMThread *currentThread, U_8* classBytes, UDATA classBytesLength, U_8* segment, U_32 segmentLength);
 #endif /* JAVA_SPEC_VERSION >= 15 */
+	void ( *storeFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, j9object_t paramObject);
+	j9object_t ( *loadFlattenableArrayElement)(struct J9VMThread *currentThread, j9object_t receiverObject, U_32 index, BOOLEAN fast);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2362,6 +2362,39 @@ isNameOrSignatureQtype(J9UTF8 *utfWrapper);
 BOOLEAN
 isClassRefQtype(J9Class *cpContextClass, U_16 cpIndex);
 
+/**
+ * Performs an aaload operation on an object. Handles flattened and non-flattened cases.
+ *
+ * Assumes recieverObject is not null.
+ * All AIOB exceptions must be thrown before calling.
+ *
+ * Returns null if newObjectRef retrieval fails.
+ *
+ * If fast == false, special stack frame must be built and receiverObject must be pushed onto it.
+ *
+ * @param[in] currentThread thread token
+ * @param[in] receiverObject arrayObject
+ * @param[in] index array index
+ * @param[in] fast bool for fast or slow path
+ *
+ * @return array element
+ */
+j9object_t
+loadFlattenableArrayElement(J9VMThread *currentThread, j9object_t receiverObject, U_32 index, BOOLEAN fast);
+
+/**
+ * Performs an aastore operation on an object. Handles flattened and non-flattened cases.
+ *
+ * Assumes recieverObject and paramObject are not null.
+ * All AIOB exceptions must be thrown before calling.
+ *
+ * @param[in] currentThread thread token
+ * @param[in] receiverObject arrayObject
+ * @param[in] index array index
+ * @param[in] paramObject obj arg
+ */
+void
+storeFlattenableArrayElement(J9VMThread *currentThread, j9object_t receiverObject, U_32 index, j9object_t paramObject);
 
 /**
 * @brief Iterate over fields of the specified class in JVMTI order.

--- a/runtime/vm/ValueTypeHelpers.cpp
+++ b/runtime/vm/ValueTypeHelpers.cpp
@@ -220,4 +220,19 @@ arrayElementSize(J9ArrayClass* arrayClass)
         return arrayClass->flattenedElementSize;
 }
 
+void
+storeFlattenableArrayElement(J9VMThread *currentThread, j9object_t receiverObject, U_32 index, j9object_t paramObject)
+{
+        MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
+        VM_ValueTypeHelpers::storeFlattenableArrayElement(currentThread, objectAccessBarrier, receiverObject, index, paramObject);
+}
+
+j9object_t
+loadFlattenableArrayElement(J9VMThread *currentThread, j9object_t receiverObject, U_32 index, BOOLEAN fast)
+{
+        MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
+        MM_ObjectAllocationAPI objectAllocate(currentThread);
+        return VM_ValueTypeHelpers::loadFlattenableArrayElement(currentThread, objectAccessBarrier, objectAllocate, receiverObject, index, fast != false);
+}
+
 } /* extern "C" */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -389,4 +389,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if JAVA_SPEC_VERSION >= 15
 	checkClassBytes,
 #endif /* JAVA_SPEC_VERSION >= 15 */
+	storeFlattenableArrayElement,
+	loadFlattenableArrayElement,
 };


### PR DESCRIPTION
Added jitHelpers for loading and storing flattenable array
element with a slow and fast variant.
-old_fast-jitLoadFlattenableArrayElement: Attempts to use fast
path to load array element. If it fails calls the slow variant.
-old_slow_jitLoadFlattenableArrayElement: Proceeds thorugh slow
path for loading, throwing appropriate exceptions when needed.
-old_fast_jitStoreFlattenableArrayElement: Attempts to use fast
path to store value into array. If it fails, calls the slow\
variant.
-old_slow_jitStoreFlattenableArrayElement: Proceeds through
sllow path for storing, throws appropriate exceptions when
needed.

Added runtime helper to check if storing object in an array
is allowed.
-jitObjectArrayStoreAllowed

Added ValueTypeHelpers loadFlattenableArrayElement and
storeFlattenableArrayElement which perform aaload and
aastore functions respectively. Both handle flattened and
unflattened cases. Both contain an option for either a fast
or a slow variant.
-loadFlattenableArrayElement: Loads flattenable array element
-storeFlattenableArrayElement: Stores flattenable array element
-loadFlattenableArrayElement: c function that initializes
required objects and calls loadFlattenableArrayElement
-storeFlattenableArrayElement: c function that initializes
required objects and calls storeFlattenableArrayElement

Replaced existing code in aaload and aastore functions in
ByteCodeInterpreter.hpp with calls to loadFlattenableArrayElement
and storeFlattenableArrayElement. Functionality remains the same.

Related to: https://github.com/eclipse/openj9/issues/9627

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>