### PR TITLE
Fix warnings building on osx

### DIFF
--- a/runtime/compiler/codegen/CodeGenGC.cpp
+++ b/runtime/compiler/codegen/CodeGenGC.cpp
@@ -300,7 +300,7 @@ J9::CodeGenerator::createStackAtlas()
             // the same GC index.
             //
             TR_IGNode * igNode;
-            if (igNode = self()->getLocalsIG()->getIGNodeForEntity(localCursor))
+            if ((igNode = self()->getLocalsIG()->getIGNodeForEntity(localCursor)) != NULL)
                {
                IGNodeColour colour = igNode->getColour();
 
@@ -350,7 +350,7 @@ J9::CodeGenerator::createStackAtlas()
             // the same GC index.
             //
             TR_IGNode * igNode;
-            if (igNode = self()->getLocalsIG()->getIGNodeForEntity(localCursor))
+            if ((igNode = self()->getLocalsIG()->getIGNodeForEntity(localCursor)) != NULL)
                {
                IGNodeColour colour = igNode->getColour();
 

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1428,7 +1428,7 @@ J9::SymbolReferenceTable::findJavaLangReferenceReferentShadowSymbol(TR_ResolvedM
    TR::SymbolReference * symRef;
    TR_SymRefIterator i(type == TR::Address ? aliasBuilder.addressShadowSymRefs() :
                                             (type == TR::Int32 ? aliasBuilder.intShadowSymRefs() : aliasBuilder.nonIntPrimitiveShadowSymRefs()), self());
-   while (symRef = i.getNext())
+   while ((symRef = i.getNext()) != NULL)
       if (symRef->getSymbol()->getDataType() == type &&
           symRef->getOffset() == offset &&
           symRef->getOwningMethod(comp()) == owningMethod)
@@ -2295,7 +2295,7 @@ J9::SymbolReferenceTable::findShadowSymbol(TR_ResolvedMethod * owningMethod, int
    TR::SymbolReference * symRef;
    TR_SymRefIterator i(type == TR::Address ? aliasBuilder.addressShadowSymRefs() :
                                             (type == TR::Int32 ? aliasBuilder.intShadowSymRefs() : aliasBuilder.nonIntPrimitiveShadowSymRefs()), self());
-   while (symRef = i.getNext())
+   while ((symRef = i.getNext()) != NULL)
       {
       if ((recognizedField &&
           *recognizedField != TR::Symbol::UnknownField &&

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4336,10 +4336,14 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
           // after 10 minutes or STEADY_STATE switch to DEEPSTEADY_STATE
           // The 10 minutes may be shorter when multiple threads are running full speed
           // or longer when there isn't much work to be done
-          oldState == STEADY_STATE && (persistentInfo->getJitTotalSampleCount() - persistentInfo->getJitSampleCountWhenActiveStateEntered() > 60000))
+          ((oldState == STEADY_STATE) && ((persistentInfo->getJitTotalSampleCount() - persistentInfo->getJitSampleCountWhenActiveStateEntered()) > 60000)))
+         {
          newState = DEEPSTEADY_STATE;
+         }
       else
+         {
          newState = STEADY_STATE;
+         }
       }
    // A surge in compilations can make the transition back to STARTUP
    //t= 98186 oldState=3 newState=2 cSamples=125 iSamples= 11 comp=239 recomp=  4, Q_SZ=114


### PR DESCRIPTION
* Use explicit boolean conditions and additional brackets
when assigning to a local in an conditional

* Add brackets to clarify intended order of operations
when using both && and || in the same conditional

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>