### PR TITLE
Disable vectorization of induction variable

### DIFF
--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -698,8 +698,9 @@ bool TR_SPMDKernelParallelizer::visitNodeToSIMDize(TR::Node *parent, int32_t chi
 
 	       if (trace && !platformSupport)
                   traceMsg(comp, "   Found use of induction variable at node [%p] - platform does not support this vectorization\n", node);
-
-               return platformSupport;
+               if (trace && platformSupport)
+                  traceMsg(comp, "   Found use of induction variable at node [%p] - vectorization disabled for now\n", node);
+               return false;  // see : eclipse/openj9/9446
                }
             }
          }


### PR DESCRIPTION
AutoSIMD was generating incorrect IL due to the side effect of node
commoning. Upon investigating further it was clear that to come up with
a general solution, it would require time. Moreover, it appears that even
for correct IL, AutoSIMD was failing in functionality tests.
This suggest that there may be bug in the codegen as well. Thus, it was
decided that for such cases, AutoSIMD will be disabled until a generalized
solution is ready.

This kind of optimization is currently available only in z Systems. and
does not affect amd64 / powerpc.

Fixes: #9446

Signed-off-by: Mohammad Nazmul Alam <mohammad.nazmul.alam@ibm.com>