### PR TITLE
AArch64: Change a call to decReferenceCount()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -2229,7 +2229,7 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
          if (firstChild->getOpCode().isStoreIndirect()
                && firstChild->getReferenceCount() > 1)
             {
-            firstChild->decReferenceCount();
+            cg->decReferenceCount(firstChild);
             fixRefCount = true;
             }
          cg->evaluate(firstChild);


### PR DESCRIPTION
This commit changes `node->decReferenceCount()` in AArch64 code to
`cg->decReferenceCount(node)`.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>