### PR TITLE
Do not enter class segment mutex inside read mutex

### DIFF
--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -273,7 +273,7 @@ public:
 
 	bool isCacheCorruptReported(void);
 
-	IDATA runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCache, const char** subcstr, bool acquireClassSegmentMutex = false);
+	IDATA runEntryPointChecks(J9VMThread* currentThread, void* isAddressInCache, const char** subcstr);
 
 	void protectPartiallyFilledPages(J9VMThread *currentThread);
 

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -2404,6 +2404,8 @@ SH_CompositeCacheImpl::decReaderCount(J9VMThread* currentThread)
  * @param [in] caller  A string representing the caller of this method
  *
  * @return 0 if call succeeded and -1 for failure
+ * 
+ * THREADING: Do not acquire class segment mutex inside read mutex.
  */
 IDATA
 SH_CompositeCacheImpl::enterReadMutex(J9VMThread* currentThread, const char* caller)
@@ -2477,6 +2479,8 @@ SH_CompositeCacheImpl::enterReadMutex(J9VMThread* currentThread, const char* cal
  *
  * @param [in] currentThread  Pointer to J9VMThread structure for the current thread
  * @param [in] caller  A string representing the caller of this method
+ * 
+ * THREADING: Do not acquire class segment mutex inside read mutex.
  */
 void
 SH_CompositeCacheImpl::exitReadMutex(J9VMThread* currentThread, const char* caller)


### PR DESCRIPTION
We always update the romclass segment at the end of
SH_CacheMap:findROMClass() if a class is returned. There is no 
need to update romclass segment in other places in findROMClass().

Fixes #9893

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>