### PR TITLE
Break connection to JITServer on exceptions (0.21.0)

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3271,6 +3271,10 @@ remoteCompile(
       }
    catch (const JITServer::StreamMessageTypeMismatch &e)
       {
+      client->~ClientStream();
+      TR_Memory::jitPersistentFree(client);
+      compInfoPT->setClientStream(NULL);
+
       if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))
          TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
             "JITServer::StreamMessageTypeMismatch: %s for %s @ %s", e.what(), compiler->signature(), compiler->getHotnessName());
@@ -3279,6 +3283,18 @@ remoteCompile(
                compiler->signature(), compiler->getHotnessName(), e.what());
 
       compiler->failCompilation<JITServer::StreamMessageTypeMismatch>(e.what());
+      }
+   catch (const TR::CompilationInterrupted &e)
+      {
+      throw; // rethrow the exception
+      }
+   catch (...)
+      {
+      // For any other type of exception disconnect the socket 
+      client->~ClientStream();
+      TR_Memory::jitPersistentFree(client);
+      compInfoPT->setClientStream(NULL);
+      throw; // rethrow the exception
       }
 
    TR_MethodMetaData *metaData = NULL;


### PR DESCRIPTION
The client connects to JITServer and then re-uses the same connection
for many compilation requests (as long as there is something in the
compilation queue). While this saves latency and CPU, it can cause
the following bad scenario:
1) During compilation, client throws an exception, but the server is
not aware about it.
2) Client starts a new compilation request re-using the same connection.
3) JITServer sends a query to client, but receives the compilation
request, so it throws an exception and sends an error message to client
4) Client sees the error message and aborts the compilation that just
started.
As a result, the seqNo sent by the client is forever lost and JITServer
is going to needlessly wait for it, increasing latencies and in the end
being forced to start over after clearing all the caches.

The solution implemented in this commit is to break the socket connection
when the client experiences an exception that the server does not know
about. Note that for `compilationInterrupted` the client notifies the
server, so it can keep the connection open.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>