### PR TITLE
Use _NSGetEnviron() on OSX to retrieve environ

### DIFF
--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -38,6 +38,10 @@
 #include <WinBase.h>
 #endif /* defined(WIN32) || defined(WIN64) */
 
+#if defined(OSX)
+#include <crt_externs.h>
+#endif /* defined(OSX) */
+
 #define PRIMORDIAL_DUMP_ATTACHED_THREAD 0x01
 
 #define RAS_NETWORK_WARNING_TIME 60000
@@ -289,7 +293,12 @@ configureRasDump(J9JavaVM *vm)
 void
 J9RASInitialize(J9JavaVM* javaVM)
 {
+#if defined(OSX)
+	char **environ = *_NSGetEnviron();
+#else /* defined(OSX) */
 	extern char **environ;
+#endif /* defined(OSX) */
+
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 	const char *osarch = j9sysinfo_get_CPU_architecture();
 	const char *osname = j9sysinfo_get_OS_type();


### PR DESCRIPTION
As per: https://github.com/eclipse/openj9/issues/7247

Direct access to `environ` on OSX should use `_NSGetEnviron`, as `environ` is only directly accessible via that environment
subroutine from shared libraries and bundles since Mac OS X 10.5 (Leopard).

---

`environ` is a list of strings that is made available when a process begins. Each string has the convention "name=value" which is set in the user environment.

`environ` can be directly accessed, except from shared libraries and bundles, since it is only available to the loader `ld` when a complete program is being linked. The environment routines `getenv`, `setenv` and `putenv` can be used to access `environ` whether referenced by the loader or in shared libraries and bundles. If direct access to `environ` is needed in shared libraries or bundles for OSX, `_NSGetEnviron` (defined in `crt_externs.h`) can be used to retrieve `environ` at runtime.

Source: https://opensource.apple.com/source/Libc/Libc-1353.41.1/man/FreeBSD/environ.7.auto.html
Some other info: https://www.gnu.org/software/gnulib/manual/gnulib.html#environ
`crt_externs.h`: https://opensource.apple.com/source/Libc/Libc-1353.41.1/sys/crt_externs.c.auto.html