### PR TITLE
Use TR_ExternalRelocationTargetKind enum for relocation kinds

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -70,6 +70,7 @@
 #include "p/codegen/PPCInstruction.hpp"
 #include "p/codegen/PPCTableOfConstants.hpp"
 #include "runtime/CodeCache.hpp"
+#include "runtime/Runtime.hpp"
 #include "env/VMJ9.h"
 
 #define MAX_PPC_ARRAYCOPY_INLINE 256
@@ -9416,7 +9417,7 @@ static TR::Register *inlineFPTrg1Src3(TR::Node *node, TR::InstOpCode::Mnemonic o
       targetRegister = cg->allocateSinglePrecisionRegister();
    else
       targetRegister = cg->allocateRegister(TR_FPR);
-   
+
    generateTrg1Src3Instruction(cg, op, node, targetRegister, src1Register, src2Register, src3Register);
 
    node->setRegister(targetRegister);
@@ -9424,7 +9425,7 @@ static TR::Register *inlineFPTrg1Src3(TR::Node *node, TR::InstOpCode::Mnemonic o
    cg->decReferenceCount(secondChild);
    cg->decReferenceCount(thirdChild);
    return targetRegister;
-   } 
+   }
 
 static TR::Register *inlineDoublePrecisionFP(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
    {
@@ -12807,7 +12808,7 @@ TR::Instruction *loadAddressRAM32(TR::CodeGenerator *cg, TR::Node * node, int32_
 
    if (value != 0x0)
       {
-      uint32_t reloType;
+      TR_ExternalRelocationTargetKind reloType;
       if (node->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
          reloType = TR_SpecialRamMethodConst;
       else if (node->getSymbol()->castToResolvedMethodSymbol()->isStatic())
@@ -12822,7 +12823,7 @@ TR::Instruction *loadAddressRAM32(TR::CodeGenerator *cg, TR::Node * node, int32_
       if(isAOT)
          cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                  (TR_ExternalRelocationTargetKind) reloType, cg),
+                  reloType, cg),
                   __FILE__, __LINE__, node);
       }
 
@@ -12849,7 +12850,7 @@ TR::Instruction *loadAddressRAM(TR::CodeGenerator *cg, TR::Node * node, intptr_t
    cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, trgReg, isAOT? 0: (value>>48) , cursor);
    if (value != 0x0)
       {
-      uint32_t reloType;
+      TR_ExternalRelocationTargetKind reloType;
       if (node->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
          reloType = TR_SpecialRamMethodConst;
       else if (node->getSymbol()->castToResolvedMethodSymbol()->isStatic())
@@ -12864,7 +12865,7 @@ TR::Instruction *loadAddressRAM(TR::CodeGenerator *cg, TR::Node * node, intptr_t
       if(isAOT)
          cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                  (TR_ExternalRelocationTargetKind) reloType, cg),
+                  reloType, cg),
                   __FILE__,__LINE__, node);
       }
    // ori trgReg, trgReg, next 16-bits
@@ -12895,7 +12896,7 @@ TR::Instruction *loadAddressJNI32(TR::CodeGenerator *cg, TR::Node * node, int32_
 
    if (value != 0x0)
       {
-      uint32_t reloType;
+      TR_ExternalRelocationTargetKind reloType;
       if (node->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
          reloType = TR_JNISpecialTargetAddress;
       else if (node->getSymbol()->castToResolvedMethodSymbol()->isStatic())
@@ -12910,7 +12911,7 @@ TR::Instruction *loadAddressJNI32(TR::CodeGenerator *cg, TR::Node * node, int32_
       if(isAOT)
          cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                  (TR_ExternalRelocationTargetKind) reloType, cg),
+                  reloType, cg),
                   __FILE__, __LINE__, node);
       }
 
@@ -12937,7 +12938,7 @@ TR::Instruction *loadAddressJNI(TR::CodeGenerator *cg, TR::Node * node, intptr_t
    cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, trgReg, isAOT? 0: (value>>48) , cursor);
    if (value != 0x0)
       {
-      uint32_t reloType;
+      TR_ExternalRelocationTargetKind reloType;
       if (node->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
          reloType = TR_JNISpecialTargetAddress;
       else if (node->getSymbol()->castToResolvedMethodSymbol()->isStatic())
@@ -12952,7 +12953,7 @@ TR::Instruction *loadAddressJNI(TR::CodeGenerator *cg, TR::Node * node, intptr_t
       if(isAOT)
          cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                  (TR_ExternalRelocationTargetKind) reloType, cg),
+                  reloType, cg),
                   __FILE__,__LINE__, node);
       }
    // ori trgReg, trgReg, next 16-bits

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -47,6 +47,7 @@
 #include "il/SymbolReference.hpp"
 #include "infra/Assert.hpp"
 #include "env/VMJ9.h"
+#include "runtime/Runtime.hpp"
 #include "x/codegen/CheckFailureSnippet.hpp"
 #include "x/codegen/HelperCallSnippet.hpp"
 #include "x/codegen/X86Instruction.hpp"
@@ -576,9 +577,9 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(
       if (!scratchReg)
          scratchReg = cg()->allocateRegister();
 
-      static const int reloTypes[] = { TR_VirtualRamMethodConst, 0 /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst };
+      static const TR_ExternalRelocationTargetKind reloTypes[] = { TR_VirtualRamMethodConst, TR_NoRelocation /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst };
       int reloType = callSymbol->getMethodKind() - 1; //method kinds are 1-based!!
-      TR_ASSERT(reloTypes[reloType], "There shouldn't be direct JNI interface calls!");
+      TR_ASSERT(reloTypes[reloType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
       generateRegImm64Instruction(MOV8RegImm64, callNode, scratchReg, methodAddr, cg(), reloTypes[reloType]);
       generateRegInstruction(PUSHReg, callNode, scratchReg, cg());
       }
@@ -779,10 +780,10 @@ J9::X86::AMD64::JNILinkage::generateMethodDispatch(
    //
 
 
-   static const int reloTypes[] = {TR_JNIVirtualTargetAddress, 0 /*Interfaces*/, TR_JNIStaticTargetAddress, TR_JNISpecialTargetAddress};
+   static const TR_ExternalRelocationTargetKind reloTypes[] = {TR_JNIVirtualTargetAddress, TR_NoRelocation /*Interfaces*/, TR_JNIStaticTargetAddress, TR_JNISpecialTargetAddress};
    int reloType = callSymbol->getMethodKind()-1;  //method kinds are 1-based!!
 
-   TR_ASSERT(reloTypes[reloType], "There shouldn't be direct JNI interface calls!");
+   TR_ASSERT(reloTypes[reloType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
 
    TR::X86RegInstruction *patchedInstr=
    generateRegImm64Instruction(

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -45,6 +45,7 @@
 #include "il/Symbol.hpp"
 #include "il/SymbolReference.hpp"
 #include "env/VMJ9.h"
+#include "runtime/Runtime.hpp"
 #include "x/codegen/CheckFailureSnippet.hpp"
 #include "x/codegen/IA32LinkageUtils.hpp"
 #include "x/codegen/X86Instruction.hpp"
@@ -169,9 +170,9 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
       // Push the RAM method for the native.
       //
-      static const int reloTypes[] = {TR_VirtualRamMethodConst, 0 /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst};
+      static const TR_ExternalRelocationTargetKind reloTypes[] = {TR_VirtualRamMethodConst, TR_NoRelocation /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst};
       int rType = resolvedMethodSymbol->getMethodKind()-1; //method kinds are 1-based
-      TR_ASSERT(reloTypes[rType], "There shouldn't be direct JNI interface calls!");
+      TR_ASSERT(reloTypes[rType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
       generateImmInstruction(PUSHImm4, callNode, (uintptr_t) resolvedMethod->resolvedMethodAddress(), cg(), reloTypes[rType]);
 
       // Store out pc and literals values indicating the callout frame.

--- a/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkageLinux.cpp
@@ -42,6 +42,7 @@
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/StaticSymbol.hpp"
 #include "il/Symbol.hpp"
+#include "runtime/Runtime.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "z/codegen/CallSnippet.hpp"
 #include "z/codegen/OpMemToMem.hpp"
@@ -126,7 +127,7 @@ J9::Z::zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode,
    else if (codeGen->needClassAndMethodPointerRelocations()
     		  && callNode->isPreparedForDirectJNI())
       {
-      uint32_t reloType;
+      TR_ExternalRelocationTargetKind reloType;
       if (callNode->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
          reloType = TR_JNISpecialTargetAddress;
       else if (callNode->getSymbol()->castToResolvedMethodSymbol()->isStatic())

--- a/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
+++ b/runtime/compiler/z/codegen/J9SystemLinkagezOS.cpp
@@ -42,6 +42,7 @@
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/StaticSymbol.hpp"
 #include "il/Symbol.hpp"
+#include "runtime/Runtime.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "z/codegen/CallSnippet.hpp"
 #include "z/codegen/OpMemToMem.hpp"
@@ -120,7 +121,7 @@ J9::Z::zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Re
       {
       if (codeGen->needClassAndMethodPointerRelocations() && callNode->isPreparedForDirectJNI())
          {
-         uint32_t reloType;
+         TR_ExternalRelocationTargetKind reloType;
          if (callNode->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
             reloType = TR_JNISpecialTargetAddress;
          else if (callNode->getSymbol()->castToResolvedMethodSymbol()->isStatic())

--- a/runtime/compiler/z/codegen/S390AOTRelocation.hpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include "codegen/Relocation.hpp"
 
 #include "codegen/Instruction.hpp"
+#include "runtime/Runtime.hpp"
 
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -84,14 +85,14 @@ class S390EncodingRelocation
    {
    public:
    TR_ALLOC(TR_Memory::S390EncodingRelocation)
-   S390EncodingRelocation(uint32_t             rt,
+   S390EncodingRelocation(TR_ExternalRelocationTargetKind rt,
                           TR::SymbolReference  *sr,
                           uintptr_t inlinedSiteIndex = -1)
       : _reloType(rt),
         _symbolReference(sr),
         _inlinedSiteIndex(inlinedSiteIndex) {}
 
-   uint32_t                      _reloType;
+   TR_ExternalRelocationTargetKind _reloType;
    TR::SymbolReference*           _symbolReference;
    uintptr_t                     _inlinedSiteIndex;
 
@@ -101,8 +102,8 @@ class S390EncodingRelocation
       return _symbolReference = sr;
       }
 
-   uint32_t            getReloType() { return _reloType;}
-   uint32_t            setReloType(uint32_t rt)
+   TR_ExternalRelocationTargetKind getReloType() { return _reloType;}
+   TR_ExternalRelocationTargetKind setReloType(TR_ExternalRelocationTargetKind rt)
       {
       return _reloType = rt;
       }

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -34,6 +34,7 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "runtime/CodeCacheManager.hpp"
+#include "runtime/Runtime.hpp"
 
 uint8_t *
 TR::S390J9CallSnippet::generateVIThunk(TR::Node * callNode, int32_t argSize, TR::CodeGenerator * cg)
@@ -1396,7 +1397,7 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
       // _ramMethod
       *(intptr_t *) cursor = (intptr_t) _ramMethod;
 
-      uint32_t reloType;
+      TR_ExternalRelocationTargetKind reloType;
       if (getNode()->getSymbol()->castToResolvedMethodSymbol()->isSpecial())
          reloType = TR_SpecialRamMethodConst;
       else if (getNode()->getSymbol()->castToResolvedMethodSymbol()->isStatic())
@@ -1414,7 +1415,7 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
          {
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
                callNode  ? (uint8_t *)(intptr_t)callNode->getInlinedSiteIndex() : (uint8_t *)-1,
-                     (TR_ExternalRelocationTargetKind) reloType, cg()),
+                     reloType, cg()),
                      __FILE__, __LINE__, callNode);
          }
 
@@ -1478,7 +1479,7 @@ TR::S390JNICallDataSnippet::emitSnippetBody()
          {
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(),
                callNode  ? (uint8_t *)(intptr_t)callNode->getInlinedSiteIndex() : (uint8_t *)-1,
-                     (TR_ExternalRelocationTargetKind) reloType, cg()),
+                     reloType, cg()),
                      __FILE__, __LINE__, callNode);
          }
 


### PR DESCRIPTION
Use the proper enum type rather than an integral type.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>