### PR TITLE
Add explicit type parameters for Java 8

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/BytecodeGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/BytecodeGenerator.java
@@ -85,7 +85,7 @@ public class BytecodeGenerator {
 	}
 
 	static Map<String, String> getFlagAliasesFor(String className) {
-		return addFlagAliasesFor(new HashMap<>(), className);
+		return addFlagAliasesFor(new HashMap<String, String>(), className);
 	}
 
 	public static Map<String, String> getConstantsAndAliases(StructureDescriptor structure) {


### PR DESCRIPTION
Fixes the build error for Java 8 seen in #9992.