### PR TITLE
Fix Class Chain Validation Caching

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -435,6 +435,14 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableGuardedCountingRecompilations);
                }
 
+            if (isAOT
+                && TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching)
+                && (!TR::Options::getCmdLineOptions()->allowRecompilation()
+                    || TR::Options::getCmdLineOptions()->getOption(TR_DisableCHOpts)))
+               {
+               TR::Options::getAOTCmdLineOptions()->setOption(TR_EnableClassChainValidationCaching, false);
+               }
+
             if (rv == -1)
                {
                // cannot free JIT config because shutdown stage expects it to exist

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2371,6 +2371,12 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
       methodCount = classPair->methodCount;
       methodList = classPair->methodList;
 
+      // Do this before modifying the CHTable
+      if (table && TR::Options::sharedClassCache() && TR::Options::getCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching))
+         {
+         table->resetCachedCCVResult(fe, oldClass);
+         }
+
       // Step 3  patch modified classes
       if (rat)
          {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1914,10 +1914,6 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
             }
          }
 
-      if (TR::Options::sharedClassCache() && TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableClassChainValidationCaching))
-         if (!TR_J9SharedCache::initCCVCaching())
-            return -1;
-
       if (TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT))
          {
          javaVM->sharedClassConfig->runtimeFlags &= ~J9SHR_RUNTIMEFLAG_ENABLE_AOT;

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,12 @@ public:
    friend bool operator !=(const PersistentAllocator &left, const PersistentAllocator &right)
       {
       return !operator ==(left, right);
+      }
+
+   // Enable automatic conversion into a form compatible with C++ standard library containers
+   template<typename T> operator TR::typed_allocator<T, PersistentAllocator& >()
+      {
+      return TR::typed_allocator<T, PersistentAllocator& >(*this);
       }
 
 private:

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -738,3 +738,20 @@ TR_PersistentCHTable::collectAllSubClassesLocked(TR_PersistentClassInfo *clazz, 
          }
       }
    }
+
+void
+TR_PersistentCHTable::resetCachedCCVResult(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz)
+   {
+   TR::ClassTableCriticalSection collectSubClasses(fej9);
+
+   ClassList classList(TR::Compiler->persistentAllocator());
+   TR_PersistentClassInfo *classInfo = findClassInfo(clazz);
+
+   classList.push_front(classInfo);
+   collectAllSubClasses(classInfo, classList, fej9, true);
+
+   for (auto iter = classList.begin(); iter != classList.end(); iter++)
+      {
+      (*iter)->setCCVResult(CCVResult::notYetValidated);
+      }
+   }

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -713,3 +713,28 @@ TR_PersistentCHTable::classGotLoaded(
       }
    return clazz;
    }
+
+void
+TR_PersistentCHTable::collectAllSubClasses(TR_PersistentClassInfo *clazz, ClassList &classList, TR_J9VMBase *fej9, bool locked)
+   {
+   TR::ClassTableCriticalSection collectSubClasses(fej9, locked);
+
+   VisitTracker<> marked(TR::Compiler->persistentAllocator());
+
+   collectAllSubClassesLocked(clazz, classList, marked);
+   }
+
+void
+TR_PersistentCHTable::collectAllSubClassesLocked(TR_PersistentClassInfo *clazz, ClassList &classList, VisitTracker<> &marked)
+   {
+   for (auto subClass = clazz->getFirstSubclass(); subClass; subClass = subClass->getNext())
+      {
+      if (!subClass->getClassInfo()->hasBeenVisited())
+         {
+         TR_PersistentClassInfo *sc = subClass->getClassInfo();
+         classList.push_front(sc);
+         marked.visit(sc);
+         collectAllSubClassesLocked(sc, classList, marked);
+         }
+      }
+   }

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -122,6 +122,15 @@ class TR_PersistentCHTable
     */
    void collectAllSubClasses(TR_PersistentClassInfo *clazz, ClassList &classList, TR_J9VMBase *fej9, bool locked = false);
 
+   /**
+    * @brief Resets the Cached CCV Result for class passed in as well as all
+    *        subclasses
+    *
+    * @param fej9 TR_J9VMBase object
+    * @param clazz The class whose cached CCV Result (as well as those of its subclasses) is to be reset.
+    */
+   void resetCachedCCVResult(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz);
+
 #ifdef DEBUG
    void dumpStats(TR_FrontEnd *);
 #endif

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -45,6 +45,16 @@ class TR_PreXRecompile;
 class TR_RedefinedClassPicSite;
 class TR_UnloadedClassPicSite;
 
+/**
+ * @brief Enum to describe the result of a Class Chain Validation (CCV).
+ */
+enum CCVResult : uint8_t
+   {
+   notYetValidated,
+   success,
+   failure
+   };
+
 class TR_SubClass : public TR_Link0<TR_SubClass>
    {
 public:
@@ -60,7 +70,10 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    {
    public:
    TR_PERSISTENT_ALLOC(TR_Memory::PersistentInfo);
-   TR_PersistentClassInfo(TR_OpaqueClassBlock *id) : _classId(id), _fieldInfo(0), _prexAssumptions(0), _timeStamp(0), _nameLength(-1)
+   TR_PersistentClassInfo(TR_OpaqueClassBlock *id) :
+      _classId(id), _fieldInfo(0),
+      _prexAssumptions(0), _timeStamp(0),
+      _nameLength(-1), _ccvResult(notYetValidated)
     {
     uintptr_t classPointerValue = (uintptr_t) id;
 
@@ -147,6 +160,9 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    int32_t getNameLength()                       { return _nameLength; }
    virtual void setNameLength(int32_t length)            { _nameLength = length; }
 
+   void setCCVResult(CCVResult result) { _ccvResult = result; }
+   CCVResult getCCVResult() const { return _ccvResult; }
+
    private:
 
    enum // flag bits
@@ -180,6 +196,7 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    int32_t                             _nameLength;
    flags8_t                            _flags;
    flags8_t                            _shouldNotBeNewlyExtended; // one bit for each possible compilation thread
+   CCVResult                           _ccvResult;
    };
 
 class TR_AddressRange


### PR DESCRIPTION
Prior to this PR, if Class Chain Validation Caching was enabled, the result was cached using the offset of the ROM Class of the RAM Class to be validated. However, this is not functionally correct as outlined in [1]. It is possible for two J9Classes to have completely different class hierarchies and yet have the same ROM Class; that is, even though two J9Classes have the same J9ROMClass, one or more of their super classes may not have the same J9ROMClass as the other. Thus, the class chains of these two classes would be completely different. If the result of the class chain validation is cached using the J9ROMClass, the validation may incorrectly succeed.

Additionally, if a class gets redefined for any reason, the cached CCV result for it AND all of its subclasses must be reset.

For these two reasons, the CCV Result is cached in the Persistent CH Table. This allows the result to be keyed against the J9Class, and also provides the means to reset the cached value should the hierarchy change. The consequence of doing so, however, is that CCV Caching is now dependant on the CHTable not being disabled.

[1] https://github.com/eclipse/openj9/pull/9403#issuecomment-639726358