### PR TITLE
AArch64: Remove length parameter from MemoryReference (step 2)

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/aarch64/codegen/J9MemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,9 +28,8 @@
 
 J9::ARM64::MemoryReference::MemoryReference(
       TR::Node *node,
-      uint32_t len,
       TR::CodeGenerator *cg)
-   : OMR::MemoryReferenceConnector(node, len, cg)
+   : OMR::MemoryReferenceConnector(node, cg)
    {
    if (self()->getUnresolvedSnippet())
       self()->adjustForResolution(cg);
@@ -39,9 +38,8 @@ J9::ARM64::MemoryReference::MemoryReference(
 J9::ARM64::MemoryReference::MemoryReference(
       TR::Node *node,
       TR::SymbolReference *symRef,
-      uint32_t len,
       TR::CodeGenerator *cg)
-   : OMR::MemoryReferenceConnector(node, symRef, len, cg)
+   : OMR::MemoryReferenceConnector(node, symRef, cg)
    {
    if (self()->getUnresolvedSnippet())
       self()->adjustForResolution(cg);

--- a/runtime/compiler/aarch64/codegen/J9MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/J9MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,19 +96,17 @@ public:
    /**
     * @brief Constructor
     * @param[in] node : load or store node
-    * @param[in] len : length
     * @param[in] cg : CodeGenerator object
     */
-   MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg);
+   MemoryReference(TR::Node *node, TR::CodeGenerator *cg);
 
    /**
     * @brief Constructor
     * @param[in] node : node
     * @param[in] symRef : symbol reference
-    * @param[in] len : length
     * @param[in] cg : CodeGenerator object
     */
-   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg);
+   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg);
 
    /**
     * @brief Adjustment for resolution

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -153,7 +153,7 @@ generateSoftwareReadBarrier(TR::Node *node, TR::CodeGenerator *cg, bool isArdbar
 
    node->setRegister(tempReg);
 
-   tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, isArdbari ? 8 : 4, cg);
+   tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
    if (tempMR->getUnresolvedSnippet() != NULL)
       {
       generateTrg1MemInstruction(cg, TR::InstOpCode::addx, node, locationReg, tempMR);
@@ -417,7 +417,7 @@ J9::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg
    else
       sourceRegister = valueReg;
 
-   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, TR::Compiler->om.sizeofReferenceAddress(), cg);
+   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
 
    if (needSync)
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xE);
@@ -514,9 +514,8 @@ J9::ARM64::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *c
 
    TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::strimmw : TR::InstOpCode::strimmx;
    TR::Register *translatedSrcReg = usingCompressedPointers ? cg->evaluate(node->getSecondChild()) : sourceRegister;
-   int32_t sizeofMR = usingCompressedPointers ? TR::Compiler->om.sizeofReferenceField() : TR::Compiler->om.sizeofReferenceAddress();
 
-   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, sizeofMR, cg);
+   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
 
    if (needSync)
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xE);
@@ -1822,9 +1821,8 @@ J9::ARM64::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR::CodeGenerat
       }
    TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::strimmw : TR::InstOpCode::strimmx;
    TR::Register *translatedSrcReg = usingCompressedPointers ? cg->evaluate(firstChild->getSecondChild()) : srcReg;
-   int32_t sizeofMR = usingCompressedPointers ? TR::Compiler->om.sizeofReferenceField() : TR::Compiler->om.sizeofReferenceAddress();
 
-   TR::MemoryReference *storeMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, sizeofMR, cg);
+   TR::MemoryReference *storeMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, cg);
    generateMemSrc1Instruction(cg, storeOp, node, storeMR, translatedSrcReg);
 
    if (!sourceChild->isNull())
@@ -1992,7 +1990,7 @@ J9::ARM64::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::CodeGenerator *c
    TR::Register *resultReg;
    TR::Symbol *sym = node->getSymbol();
    TR::Compilation *comp = cg->comp();
-   TR::MemoryReference *mref = new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSymbolReference(), 0, cg);
+   TR::MemoryReference *mref = new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSymbolReference(), cg);
 
    if (mref->getUnresolvedSnippet() != NULL)
       {

--- a/runtime/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,18 +56,31 @@ class OMR_EXTENSIBLE MemoryReference : public J9::MemoryReferenceConnector
          TR::CodeGenerator *cg)
       : J9::MemoryReferenceConnector(br, disp, cg) {}
 
+   // To be obsoleted
    MemoryReference(
          TR::Node *node,
          uint32_t len,
          TR::CodeGenerator *cg)
-      : J9::MemoryReferenceConnector(node, len, cg) {}
+      : J9::MemoryReferenceConnector(node, cg) {}
 
+   // To be obsoleted
    MemoryReference(
          TR::Node *node,
          TR::SymbolReference *symRef,
          uint32_t len,
          TR::CodeGenerator *cg)
-      : J9::MemoryReferenceConnector(node, symRef, len, cg) {}
+      : J9::MemoryReferenceConnector(node, symRef, cg) {}
+
+   MemoryReference(
+         TR::Node *node,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(node, cg) {}
+
+   MemoryReference(
+         TR::Node *node,
+         TR::SymbolReference *symRef,
+         TR::CodeGenerator *cg)
+      : J9::MemoryReferenceConnector(node, symRef, cg) {}
    };
 
 } // TR


### PR DESCRIPTION
This commit removes the unused length parameter from MemoryReference
constructors.
It depends on eclipse/omr#5348.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>