### PR TITLE
AArch64: Remove length parameter from MemoryReference (step 4)

### DIFF
--- a/runtime/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/MemoryReference.hpp
@@ -56,21 +56,6 @@ class OMR_EXTENSIBLE MemoryReference : public J9::MemoryReferenceConnector
          TR::CodeGenerator *cg)
       : J9::MemoryReferenceConnector(br, disp, cg) {}
 
-   // To be obsoleted
-   MemoryReference(
-         TR::Node *node,
-         uint32_t len,
-         TR::CodeGenerator *cg)
-      : J9::MemoryReferenceConnector(node, cg) {}
-
-   // To be obsoleted
-   MemoryReference(
-         TR::Node *node,
-         TR::SymbolReference *symRef,
-         uint32_t len,
-         TR::CodeGenerator *cg)
-      : J9::MemoryReferenceConnector(node, symRef, cg) {}
-
    MemoryReference(
          TR::Node *node,
          TR::CodeGenerator *cg)


### PR DESCRIPTION
This commit removes the old MemoryReference constructors with the
length parameter.
It depends on eclipse/omr#5349.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>