### PR TITLE
Trap when DF flag is incorrectly set

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -51,6 +51,7 @@
 #include "x/codegen/CheckFailureSnippet.hpp"
 #include "x/codegen/HelperCallSnippet.hpp"
 #include "x/codegen/X86Instruction.hpp"
+#include "x/codegen/J9LinkageUtils.hpp"
 
 TR::Register *J9::X86::AMD64::JNILinkage::processJNIReferenceArg(TR::Node *child)
    {
@@ -469,30 +470,6 @@ J9::X86::AMD64::JNILinkage::buildVolatileAndReturnDependencies(
    }
 
 
-void J9::X86::AMD64::JNILinkage::switchToMachineCStack(TR::Node *callNode)
-   {
-   TR::RealRegister *espReal     = machine()->getRealRegister(TR::RealRegister::esp);
-   TR::Register        *vmThreadReg = cg()->getVMThreadRegister();
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-
-   // Squirrel Java SP away into VM thread.
-   //
-   generateMemRegInstruction(SMemReg(),
-                             callNode,
-                             generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg()),
-                             espReal,
-                             cg());
-
-   // Load machine SP from VM thread.
-   //
-   generateRegMemInstruction(LRegMem(),
-                             callNode,
-                             espReal,
-                             generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg()),
-                             cg());
-   }
-
-
 void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(
       TR::Node *callNode,
       TR::LabelSymbol *returnAddrLabel)
@@ -828,23 +805,6 @@ J9::X86::AMD64::JNILinkage::generateMethodDispatch(
       }
 
    return instr;
-   }
-
-
-void J9::X86::AMD64::JNILinkage::switchToJavaStack(TR::Node *callNode)
-   {
-   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
-   TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-
-   //    2) Load up the java sp so we have the callout frame on top of the java stack.
-   //
-   generateRegMemInstruction(
-      LRegMem(),
-      callNode,
-      espReal,
-      generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg()),
-      cg());
    }
 
 
@@ -1393,7 +1353,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
       }
 
    // Switch from the Java stack to the C stack:
-   switchToMachineCStack(callNode);
+   TR::J9LinkageUtils::switchToMachineCStack(callNode, cg());
 
    // Preserve the VMThread pointer on the C stack.
    // Adjust the argSize to include the just pushed VMThread pointer.
@@ -1505,7 +1465,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
       espReal,
       cg());
 
-   switchToJavaStack(callNode);
+   TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
 
    if (createJNIFrame)
       {

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.hpp
@@ -58,8 +58,6 @@ class JNILinkage : public PrivateLinkage
    int32_t computeMemoryArgSize(TR::Node *callNode, int32_t first, int32_t last, bool passThread = true);
    int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool passThread = true, bool passReceiver = true);
    TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps, bool omitDedicatedFrameRegister);
-   void switchToMachineCStack(TR::Node *callNode);
-   void switchToJavaStack(TR::Node *callNode);
    void cleanupReturnValue(TR::Node *callNode, TR::Register *linkageReturnReg, TR::Register *targetReg);
 
    TR::Register *buildDirectDispatch(TR::Node *callNode, bool spillFPRegs);

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -397,6 +397,13 @@ J9::X86::CodeGenerator::supportsInliningOfIsAssignableFrom()
    return !disableInliningOfIsAssignableFrom;
    }
 
+bool
+J9::X86::CodeGenerator::canEmitBreakOnDFSet()
+   {
+   static const bool enableBreakOnDFSet = feGetEnv("TR_enableBreakOnDFSet") != NULL;
+   return enableBreakOnDFSet;
+   }
+
 void
 J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
    {

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -86,6 +86,10 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     * \brief Determines whether the code generator supports stack allocations
     */
    bool supportsStackAllocations() { return true; }
+   /** \brief
+    *     Determines whether to insert instructions to check DF flag and break on DF set
+    */
+   bool canEmitBreakOnDFSet();
    };
 
 }

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -133,6 +133,10 @@ void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg
       espReal,
       generateX86MemoryReference(vmThreadReg, cg->fej9()->thisThreadGetJavaSPOffset(), cg),
       cg);
+
+   // Add DF check on return of JNI/System call
+   if (cg->canEmitBreakOnDFSet())
+      generateBreakOnDFSet(cg);
    }
 
 }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1253,6 +1253,12 @@ TR::Register *J9::X86::TreeEvaluator::newEvaluator(TR::Node *node, TR::CodeGener
       bool spillFPRegs = (comp->canAllocateInlineOnStack(node, classInfo) <= 0);
       targetRegister = TR::TreeEvaluator::performHelperCall(node, NULL, TR::acall, spillFPRegs, cg);
       }
+   else if (cg->canEmitBreakOnDFSet())
+      {
+      // Check DF flag after inline new
+      generateBreakOnDFSet(cg);
+      }
+
    return targetRegister;
    }
 
@@ -1523,6 +1529,9 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
 
 TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   if (cg->canEmitBreakOnDFSet())
+      generateBreakOnDFSet(cg);
+
    TR::Compilation *comp = cg->comp();
 
    if (!node->isReferenceArrayCopy())
@@ -11500,7 +11509,6 @@ J9::X86::TreeEvaluator::tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-
    static bool useJapaneseCompression = (feGetEnv("TR_JapaneseComp") != NULL);
    TR::Compilation *comp = cg->comp();
    TR::SymbolReference *symRef = node->getSymbolReference();

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -319,5 +319,9 @@ TR::Register* J9::X86::HelperCallSite::BuildCall()
       {
       generateRegRegInstruction(MOVRegReg(), _Node, ret, EAX, cg());
       }
+
+   if (cg()->canEmitBreakOnDFSet())
+      generateBreakOnDFSet(cg());
+
    return ret;
 }

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -781,6 +781,9 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
          generateLabelInstruction(JMP4, cursor->getNode(), endLabel, cg());
          }
 
+      if (cg()->canEmitBreakOnDFSet())
+         cursor = generateBreakOnDFSet(cg(), cursor);
+
       if (atlas)
          {
          uint32_t  numberOfParmSlots = atlas->getNumberOfParmSlotsMapped();
@@ -1019,6 +1022,9 @@ TR::Instruction *J9::X86::PrivateLinkage::deallocateFrameIfNeeded(TR::Instructio
 
 void J9::X86::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
+   if (cg()->canEmitBreakOnDFSet())
+      cursor = generateBreakOnDFSet(cg(), cursor);
+
    TR::RealRegister* espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    cursor = cg()->generateDebugCounter(cursor, "cg.epilogues", 1, TR::DebugCounter::Expensive);


### PR DESCRIPTION
Check DF flag at method entry, before object/array new and before
arraycopy. Trap if it is incorrectly set.

The check is off by default, it can be turned on by setting
environment variable `TR_doDFCheck`.

Incorrect DF flag is the cause of a memory corruption defect in which a
rep stosb instruction is executed in the wrong direction. This defect
is intermittent and hasn't been reproduced. This change will provide a
way to catch such case in our builds.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>