### PR TITLE
Hold VM access during getStringCritical for CS

### DIFF
--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -492,6 +492,10 @@ MM_StandardAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str
 			isCompressed = true;
 			shouldCopy = true;
 		}
+	} else if (_extensions->isConcurrentScavengerEnabled()) {
+		/* reading value field from String object may trigger object movement */
+		VM_VMAccess::inlineEnterVMFromJNI(vmThread);
+		hasVMAccess = true;
 	}
 
 	if (shouldCopy) {


### PR DESCRIPTION
If Concurrent Scavenger is in progress, while entering Critical Section
for jniGetStringCritical, we may copy the char array so that JNI code
deals with survived variant.

That's all good and safe, but we missed to acquire VM access during this
object movement.

The fix is to acquire VM access when CS is enabled. We cannot be more
specific, like if CS is in progress or if the array is in Evacuate,
since those more specific checks would also need VM access anyway.

We don't need similar fix for getPrimitiveArrayCritical, since the array
in hand is already copied (at the moment whereever the reference was
obtained prior to entering these APIs)

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>