### PR TITLE
multianewarray creates an extra array class

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -981,21 +981,11 @@ old_slow_jitAMultiNewArray(J9VMThread *currentThread)
 	DECLARE_JIT_CLASS_PARM(elementClass, 1);
 	DECLARE_JIT_INT_PARM(dimensions, 2);
 	DECLARE_JIT_PARM(I_32*, dimensionsArray, 3);
-	J9Class *arrayClass = elementClass->arrayClass;
 	j9object_t obj = NULL;
 	void *oldPC = currentThread->jitReturnAddress;
 	void *addr = NULL;
-	if (NULL == arrayClass) {
-		buildJITResolveFrameForRuntimeHelper(currentThread, parmCount);
-		J9JavaVM *vm = currentThread->javaVM;
-		arrayClass = vm->internalVMFunctions->internalCreateArrayClass(currentThread, (J9ROMArrayClass*)J9ROMIMAGEHEADER_FIRSTCLASS(vm->arrayROMClasses), elementClass);
-		addr = restoreJITResolveFrame(currentThread, oldPC);
-		if (NULL != addr) {
-			goto done;
-		}
-	}
 	buildJITResolveFrameWithPC(currentThread, J9_STACK_FLAGS_JIT_ALLOCATION_RESOLVE | J9_SSF_JIT_RESOLVE, parmCount, true, 0, oldPC);
-	obj = currentThread->javaVM->internalVMFunctions->helperMultiANewArray(currentThread, (J9ArrayClass*)arrayClass, (UDATA)dimensions, dimensionsArray, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);
+	obj = currentThread->javaVM->internalVMFunctions->helperMultiANewArray(currentThread, (J9ArrayClass*)elementClass, (UDATA)dimensions, dimensionsArray, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);
 	currentThread->floatTemp1 = (void*)obj; // in case of decompile
 	addr = restoreJITResolveFrame(currentThread, oldPC);
 	if (NULL != addr) {

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1768,9 +1768,9 @@ JVM_NewMultiArray(JNIEnv *env, jclass eltClass, jintArray dim)
 	
 			if (NULL != componentTypeClassObject) {
 				J9Class *componentTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, componentTypeClassObject);
-				
-				/* create an array class with one greater arity than desired */
-				UDATA count = dimensions + 1;
+
+				/* create an array class with the desired arity */
+				UDATA count = dimensions;
 				J9Class *componentArrayClass = componentTypeClass;
 				BOOLEAN exceptionIsPending = FALSE;
 	

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -1200,8 +1200,8 @@ Java_java_lang_reflect_Array_multiNewArrayImpl(JNIEnv *env, jclass unusedClass, 
 	if (NULL != componentTypeClassObject) {
 		J9Class *componentTypeClass = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, componentTypeClassObject);
 
-		/* create an array class with one greater arity than desired */
-		UDATA count = dimensions + 1;
+		/* create an array class with the desired arity */
+		UDATA count = dimensions;
 		BOOLEAN exceptionIsPending = FALSE;
 
 		if (J9ROMCLASS_IS_ARRAY(componentTypeClass->romClass) && ((((J9ArrayClass *)componentTypeClass)->arity + dimensions) > J9_ARRAY_DIMENSION_LIMIT)) {

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7788,20 +7788,8 @@ retry:
 		J9RAMClassRef *ramCPEntry = ((J9RAMClassRef*)ramConstantPool) + index;
 		J9Class* volatile resolvedClass = ramCPEntry->value;
 		if (NULL != resolvedClass) {
-			J9Class *arrayClass = resolvedClass->arrayClass;
 			j9object_t instance = NULL;
 			I_32 *dimensionsArray = NULL;
-			if (NULL == arrayClass) {
-				buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
-				updateVMStruct(REGISTER_ARGS);
-				arrayClass = internalCreateArrayClass(_currentThread, (J9ROMArrayClass*)J9ROMIMAGEHEADER_FIRSTCLASS(_vm->arrayROMClasses), resolvedClass);
-				VMStructHasBeenUpdated(REGISTER_ARGS);
-				restoreGenericSpecialStackFrame(REGISTER_ARGS);
-				if (VM_VMHelpers::exceptionPending(_currentThread) ) {
-					rc = GOTO_THROW_CURRENT_EXCEPTION;
-					goto done;
-				}
-			}
 #if defined(J9VM_ENV_DATA64)
 			for (UDATA i = 1; i <= dimensions; ++i) {
 				((I_32*)_sp)[i] = ((I_32*)_sp)[i*2];
@@ -7810,7 +7798,7 @@ retry:
 			dimensionsArray = (I_32*)_sp;
 			buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 			updateVMStruct(REGISTER_ARGS);
-			instance = helperMultiANewArray(_currentThread, (J9ArrayClass*)arrayClass, dimensions, dimensionsArray, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);
+			instance = helperMultiANewArray(_currentThread, (J9ArrayClass*)resolvedClass, dimensions, dimensionsArray, J9_GC_ALLOCATE_OBJECT_INSTRUMENTABLE);
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			restoreGenericSpecialStackFrame(REGISTER_ARGS);
 			if (VM_VMHelpers::exceptionPending(_currentThread)) {

--- a/runtime/vm/bchelper.c
+++ b/runtime/vm/bchelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,7 +85,7 @@ helperMultiANewArray(J9VMThread *vmStruct, J9ArrayClass *classPtr, UDATA dimensi
 
 	/* call the recursive routine to fill in the elements */
 	PUSH_OBJECT_IN_SPECIAL_FRAME(vmStruct, saveTable);
-	result = allocate_dimension(vmStruct, (J9ArrayClass*)(classPtr->componentType), dimensions, dimensions - 1, (U_32 *)dimensionArray, allocationType);
+	result = allocate_dimension(vmStruct, classPtr, dimensions, dimensions - 1, (U_32 *)dimensionArray, allocationType);
 	DROP_OBJECT_IN_SPECIAL_FRAME(vmStruct);
 
 	/* The resulting object may have been tenured (and possibly remembered)


### PR DESCRIPTION
helperMultiANewArray takes an array class as a parameter, then
immediately fetches the componentType field from it. This means all of
the callers have to create an array class of one greater arity than the
allocation requires.

Change helperMultiANewArray and callers to avoid creating the extra
class.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>