### PR TITLE
Inlining POWER10 arrayCopy

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -429,8 +429,8 @@ JIT_HELPER(__encodeUTF16Little);
 JIT_HELPER(__quadWordArrayCopy_vsx);
 JIT_HELPER(__forwardQuadWordArrayCopy_vsx);
 
-JIT_HELPER(__leArrayCopy);
-JIT_HELPER(__forwardLEArrayCopy);
+JIT_HELPER(__postP10ForwardCopy);
+JIT_HELPER(__postP10GenericCopy);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
 JIT_HELPER(ECP256MUL_PPC);
@@ -1338,8 +1338,8 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_PPCquadWordArrayCopy_vsx,        (void *) __quadWordArrayCopy_vsx,        TR_Helper);
    SET(TR_PPCforwardQuadWordArrayCopy_vsx, (void *) __forwardQuadWordArrayCopy_vsx, TR_Helper);
 
-   SET(TR_PPCLEArrayCopy,                  (void *) __leArrayCopy,                  TR_Helper);
-   SET(TR_PPCforwardLEArrayCopy,           (void *) __forwardLEArrayCopy,           TR_Helper);
+   SET(TR_PPCpostP10ForwardCopy,           (void *) __postP10ForwardCopy,           TR_Helper);
+   SET(TR_PPCpostP10GenericCopy,           (void *) __postP10GenericCopy,           TR_Helper);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    SET(TR_PPCP256Multiply,                 (void *) ECP256MUL_PPC);


### PR DESCRIPTION
Deleting inlineVSXArrayCopy: this was a piece of work with experimental characteristics
it bloated the codegen to such an extent that it hurt general workload performance 5-10%
range. It was disabled many years ago. I took this opportunity to delete it completely.

Adding the POWER10 inlining of arraycopy: this version is only applicable to Concurrent
Scavenge. We are limited somewhat in using registers.

Adding the capability to call the POWER10 arraycopy helpers too.

Deleting LEArrayCopy related stuffs.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>