### PR TITLE
Enable Record preview tests for both 14 and 15

### DIFF
--- a/test/functional/Java14andUp/build.xml
+++ b/test/functional/Java14andUp/build.xml
@@ -35,6 +35,7 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -51,6 +52,7 @@
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
+			<src path="${TestUtilities}" />
 			<compilerarg line='--enable-preview --release ${JDK_VERSION}' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
@@ -75,11 +77,19 @@
 	
 	<target name="build" >
 		<if>
-			<not>
-				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13)$$" />
-			</not>
+			<or>
+				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
+				<equals arg1="${JDK_IMPL}" arg2="openj9" />
+			</or>
 			<then>
-				<antcall target="clean" inheritall="true" />
+				<if>
+					<not>
+						<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13)$$" />
+					</not>
+					<then>
+						<antcall target="clean" inheritall="true" />
+					</then>
+				</if>
 			</then>
 		</if>
 	</target>

--- a/test/functional/Java14andUp/playlist.xml
+++ b/test/functional/Java14andUp/playlist.xml
@@ -41,10 +41,13 @@
         <groups>
             <group>functional</group>
         </groups>
-        <!-- Run for Java 14 only since this is a preview feature. -->
         <subsets>
-            <subset>14</subset>
+            <subset>14+</subset>
         </subsets>
+        <impls>
+            <impl>openj9</impl>
+            <impl>ibm</impl>
+        </impls>
     </test>
     <test>
         <testCaseName>ThreadInterruptImplTest</testCaseName>
@@ -68,5 +71,9 @@
         <subsets>
             <subset>14+</subset>
         </subsets>
+        <impls>
+            <impl>openj9</impl>
+            <impl>ibm</impl>
+        </impls>
     </test>
 </playlist>

--- a/test/functional/Java14andUp/src/org/openj9/test/utilities/RecordClassGenerator.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/utilities/RecordClassGenerator.java
@@ -23,13 +23,16 @@ package org.openj9.test.utilities;
  *******************************************************************************/
 
 import org.objectweb.asm.*;
+import org.openj9.test.util.VersionCheck;
 
  public class RecordClassGenerator implements Opcodes {
+
+    static final int classVersion = VersionCheck.classFile();
 
     /* Generata a valid record with optional attributes */
     public static byte[] generateRecordAttributes(String className, String rcName, String rcType, String rcSignature) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(V14 | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
+        cw.visit(classVersion | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
 
         /* add record component */
         RecordComponentVisitor rcv = cw.visitRecordComponentExperimental(
@@ -60,14 +63,14 @@ import org.objectweb.asm.*;
 
     private static byte[] generateRecordWithCustomOpcodes(String className, int access) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(V14 | V_PREVIEW, access, className, null, "java/lang/Record", null);
+        cw.visit(classVersion | V_PREVIEW, access, className, null, "java/lang/Record", null);
         cw.visitEnd();
         return cw.toByteArray();
     }
 
     public static byte[] generateRecordAttributesWithNoAccessor(String className, String rcName, String rcType) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(V14 | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
+        cw.visit(classVersion | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
 
         RecordComponentVisitor rcv = cw.visitRecordComponentExperimental(
                 ACC_DEPRECATED,
@@ -84,7 +87,7 @@ import org.objectweb.asm.*;
 
     public static byte[] generateRecordAttributesWithInvalidAccessor(String className, String rcName, String rcType, String invalidType) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(V14 | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
+        cw.visit(classVersion | V_PREVIEW, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Record", null);
 
         RecordComponentVisitor rcv = cw.visitRecordComponentExperimental(
                 ACC_DEPRECATED,

--- a/test/functional/TestUtilities/src/org/openj9/test/util/VersionCheck.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/VersionCheck.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,9 +51,9 @@ public class VersionCheck {
 	
 	
 	/**
-	 * Get the Major version for the running JVM - either 8, 9, ....
+	 * Get the Major version for the running JVM
 	 * 
-	 * @return The JDK major version
+	 * @return The JDK major version, defaults to 8 if not available
 	 */
 	public static int major() {
 		if (versionInstance != null) {
@@ -64,5 +64,13 @@ public class VersionCheck {
 			}
 		}
 		return 8;
+	}
+
+	/* Get the highest available class file version for this JDK.
+	 *
+	 * @return The highest available class file version
+	 */ 
+	public static int classFile() {
+		return major() + 44;
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/8590

- its necessary for asm to create class file with specific version because this is the only way previews are accessible
- this test has been excluded from hotspot because the TestUtilities libraries is IBM/OpenJ9 specific

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>