### PR TITLE
Enable the static verification for unsafe classes

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -272,8 +272,10 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda)
 	/* Find if there are any Constant_String or CFR_CONSTANT_NameAndType references to the className.
 	 * If there are none we don't need to make a new cpEntry, we can overwrite the existing
 	 * one since the only reference to it is the classRef
+	 * Note: The check only applies to the existing cpEntries of the constant pool rather than
+	 * the last cpEntry (not yet initialized) for the anonClassName.
 	 */
-	for (i = 0; i < classfile->constantPoolCount; i++) {
+	for (i = 0; i < newUtfCPEntry; i++) {
 		if ((CFR_CONSTANT_String == constantPool[i].tag)
 			|| (CFR_CONSTANT_NameAndType == constantPool[i].tag)
 		) {

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -511,8 +511,7 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 		translationFlags |= stripFlags;
 	}
 
-	if ((0 == (loadData->options & J9_FINDCLASS_FLAG_UNSAFE)) &&
-		(0 != (vm->runtimeFlags & J9_RUNTIME_VERIFY))) {
+	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_VERIFY)) {
 		translationFlags |= BCT_StaticVerification;
 	}
 

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -857,9 +857,9 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			}
 			info = &(classfile->constantPool[index]);
 			if (info->tag != CFR_CONSTANT_Methodref) {
-				if (((flags & BCT_MajorClassFileVersionMask) >= BCT_Java8MajorVersionShifted)
-				&& (bc != CFR_BC_invokevirtual) && (info->tag == CFR_CONSTANT_InterfaceMethodref)
-				) {
+				BOOLEAN isJava8orLater = ((flags & BCT_MajorClassFileVersionMask) >= BCT_Java8MajorVersionShifted) || J9_ARE_ANY_BITS_SET(flags, BCT_Unsafe);
+
+				if (isJava8orLater && (bc != CFR_BC_invokevirtual) && (info->tag == CFR_CONSTANT_InterfaceMethodref)) {
 					/* JVMS 4.9.1 Static Constraints:
 					 * The indexbyte operands of each invokespecial and invokestatic instruction must represent
 					 * a valid index into the constant_pool table. The constant pool entry referenced by that

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1965,6 +1965,7 @@ typedef struct J9BCTranslationData {
 #define BCT_RetainRuntimeInvisibleAttributes  0x80000
 #define BCT_AnyPreviewVersion  0x100000
 #define BCT_EnablePreview 0x200000
+#define BCT_Unsafe  0x400000
 #define BCT_DumpMaps  0x40000000
 
 #define BCT_J9DescriptionCpTypeScalar  0


### PR DESCRIPTION
The change is to enable the static verification for
unsafe classes (including anoClasses) so as to support
the implementation of valueTypes.

Fixes: #9880

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>