### PR TITLE
Add ResolveCHK for value types before NULLCHK

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2364,6 +2364,8 @@ TR_J9ByteCodeIlGenerator::genCheckCast()
  *
  * If the class specified in the bytecode is unresolved, this leaves out the
  * ResolveCHK since it has to be conditional on a non-null object.
+ * If the class specified in the bytecode is a value type, it has to be resolved
+ * unconditionally, regardless of whether the value is null.
  *
  * @param cpIndex The constant pool entry of the class given in the bytecode
  *
@@ -2376,12 +2378,16 @@ TR_J9ByteCodeIlGenerator::genCheckCast(int32_t cpIndex)
    if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->cls.isClassRefValueType(comp(), method()->classOfMethod(), cpIndex))
       {
       TR::Node * objNode = _stack->top();
+
+      loadClassObject(cpIndex);
+
       TR::Node *passThruNode = TR::Node::create(TR::PassThrough, 1, objNode);
       genTreeTop(genNullCheck(passThruNode));
-      loadClassObject(cpIndex);
       }
    else
+      {
       loadClassObjectForTypeTest(cpIndex, TR_DisableAOTCheckCastInlining);
+      }
    genCheckCast();
    }
 


### PR DESCRIPTION
Add `ResolveCHK` for value types before `NULLCHK`.

Fixes #10056

Co-authored-by: Yi Zhang <yizhang@ca.ibm.com>

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>