### PR TITLE
Convert monitor enter tests to equality checks

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5281,6 +5281,11 @@ typedef struct J9JavaVM {
  */
 #define J9_OBJECT_MONITOR_BLOCKING 3
 
+#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
+#define J9_OBJECT_MONITOR_ENTER_FAILED(rc) ((rc) < J9_OBJECT_MONITOR_BLOCKING)
+#else
+#define J9_OBJECT_MONITOR_ENTER_FAILED(rc) ((rc) == J9_OBJECT_MONITOR_OOM)
+#endif
 #define J9JAVAVM_REFERENCE_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(U_32) : sizeof(UDATA))
 #define J9JAVAVM_OBJECT_HEADER_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))
 #define J9JAVAVM_CONTIGUOUS_HEADER_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(J9IndexableObjectContiguousCompressed) : sizeof(J9IndexableObjectContiguousFull))

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1565,7 +1565,7 @@ obj:
 					rc = GOTO_ASYNC_CHECK;
 					goto done;
 				}
-				if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
+				if (J9_OBJECT_MONITOR_ENTER_FAILED(monitorRC)) {
 					/* Monitor was not entered - hide the frame to prevent exception throw from processing it */
 					if (j2i) {
 						((UDATA*)(((J9SFJ2IFrame*)_sp) + 1))[-1] |= J9SF_A0_INVISIBLE_TAG;
@@ -1638,7 +1638,7 @@ done:
 			goto done;
 		}
 
-		if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
+		if (J9_OBJECT_MONITOR_ENTER_FAILED(monitorRC)) {
 			*bp |= J9SF_A0_INVISIBLE_TAG;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 			if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
@@ -1763,7 +1763,7 @@ throwStackOverflow:
 					rc = GOTO_ASYNC_CHECK;
 					goto done;
 				}
-				if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
+				if (J9_OBJECT_MONITOR_ENTER_FAILED(monitorRC)) {
 					/* Monitor was not entered - hide the frame to prevent exception throw from processing it */
 					*(_arg0EA + relativeBP) |= J9SF_A0_INVISIBLE_TAG;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
@@ -2129,7 +2129,7 @@ done:
 			UDATA monitorRC = enterObjectMonitor(REGISTER_ARGS, receiver);
 			// No immediate async possible due to the current frame being for a native method.
 			bp = _arg0EA - relativeBP;
-			if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
+			if (J9_OBJECT_MONITOR_ENTER_FAILED(monitorRC)) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
 					_currentThread->tempSlot = (UDATA) receiver;
@@ -7724,7 +7724,7 @@ done:
 			 * release VM access, so the immediate async and failed enter cases are
 			 * mutually exclusive.
 			 */
-			if (monitorRC < J9_OBJECT_MONITOR_BLOCKING) {
+			if (J9_OBJECT_MONITOR_ENTER_FAILED(monitorRC)) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monitorRC) {
 					_currentThread->tempSlot = (UDATA) obj;

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -1860,7 +1860,7 @@ monitorEnter(JNIEnv* env, jobject obj)
 	j9object_t object = *(j9object_t*)obj;
 	UDATA monstatus = objectMonitorEnter(vmThread, object);
 
-	if (monstatus < J9_OBJECT_MONITOR_BLOCKING) {
+	if (J9_OBJECT_MONITOR_ENTER_FAILED(monstatus)) {
 fail:
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		if (J9_OBJECT_MONITOR_VALUE_TYPE_IMSE == monstatus) {


### PR DESCRIPTION
Convert monitor enter tests to equality checks

The https://github.com/eclipse/openj9/pull/8889 changes caused a
performance degradation in -Xint runs. This was caused by equality tests
being converted to < tests. These tests are only needed for valuetype
code. A new macro is introduced such that the old equality will continue
to be used for non-valuetype code.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>