### PR TITLE
Remove obsolete comments

### DIFF
--- a/jcl/src/ibm.jzos/share/classes/module-info.java
+++ b/jcl/src/ibm.jzos/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Provides access to z/OS datasets.
  */

--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /*[IF PLATFORM-mz31 | PLATFORM-mz64 | PLATFORM-xz64]*/
 exports com.ibm.jit.crypto to ibm.crypto.hdwrcca;
 /*[ENDIF]*/

--- a/jcl/src/java.management/share/classes/module-info.java.extra
+++ b/jcl/src/java.management/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
 exports com.ibm.java.lang.management.internal to jdk.jcmd, jdk.management;
 uses com.ibm.sharedclasses.spi.SharedClassProvider;

--- a/jcl/src/jdk.attach/share/classes/module-info.java.extra
+++ b/jcl/src/jdk.attach/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
 provides com.sun.tools.attach.spi.AttachProvider with com.ibm.tools.attach.attacher.OpenJ9AttachProvider;
 exports com.ibm.tools.attach.attacher to jdk.jcmd;

--- a/jcl/src/jdk.jcmd/share/classes/module-info.java
+++ b/jcl/src/jdk.jcmd/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
 /**
  * Defines the jcmd tool, used for obtaining information about a running JVM, or requesting a

--- a/jcl/src/jdk.management/share/classes/module-info.java.extra
+++ b/jcl/src/jdk.management/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
 
 exports com.ibm.lang.management;
 exports openj9.lang.management;

--- a/jcl/src/openj9.cuda/share/classes/module-info.java
+++ b/jcl/src/openj9.cuda/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Provides access to CUDA-capable devices from Java.
  * <p>

--- a/jcl/src/openj9.dataaccess/share/classes/module-info.java
+++ b/jcl/src/openj9.dataaccess/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Packed decimal and decimal data access accelerator API. Arithmetic, copying and shifting operations
  * for packed decimal data. Convert between decimal data types stored in byte arrays and Java binary types.

--- a/jcl/src/openj9.dtfj/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfj/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Diagnostic Tool Framework for Java&trade; (DTFJ)
  *

--- a/jcl/src/openj9.dtfjview/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfjview/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /** 
  * Defines the jdmpview tool for reading system core and java core diagnostic files.
  */

--- a/jcl/src/openj9.gpu/share/classes/module-info.java
+++ b/jcl/src/openj9.gpu/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Defines API to perform certain operations using any connected CUDA capable GPU,
  * such as sorting arrays of natives types.

--- a/jcl/src/openj9.jvm/share/classes/module-info.java
+++ b/jcl/src/openj9.jvm/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Defines API for creating diagnostic dump files, querying and controlling OS logging,
  * querying Java heap and OS memory stats, and controlling and logging trace file output. 

--- a/jcl/src/openj9.sharedclasses/share/classes/module-info.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Defines the shared class cache API. Used to add shared class caching to a ClassLoader implementation.
  * Obtain information about the current shared class cache, available shared class caches, or destroy caches.

--- a/jcl/src/openj9.traceformat/share/classes/module-info.java
+++ b/jcl/src/openj9.traceformat/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  *  Provides the traceformat utility for formatting binary trace files.
  */

--- a/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
+++ b/jcl/src/openj9.zosconditionhandling/share/classes/module-info.java
@@ -21,8 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*[REM] This file must not use tabs because the dependency recognition code in openjdk does not support them. */
-
 /**
  * Provides the ConditionException class for z/OS Language Environment condition handling.
  */


### PR DESCRIPTION
`module-info.java.extra` files are now processed by [GenModuleInfoSource.java](https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9/make/jdk/src/classes/build/tools/module/GenModuleInfoSource.java) which uses `String.trim()` to handle whitespace.