### PR TITLE
JEP 378: Text Blocks graduates in JDK 15

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -8454,8 +8454,9 @@ written authorization of the copyright holder.
 	 * @return the formatted result
 	 *
 	 * @see #format(String, Object...)
+	 * 
+	 * @since 15
 	 */
-	@Deprecated(forRemoval=true, since="13")
 	public String formatted(Object... args) {
 		return String.format(this, args);
 	}
@@ -8465,8 +8466,9 @@ written authorization of the copyright holder.
 	 * removes the trailing spaces in every line from the string
 	 *
 	 * @return this string with incidental whitespaces removed from every line
+	 * 
+	 * @since 15 
 	 */
-	@Deprecated(forRemoval=true, since="13")
 	public String stripIndent() {
 		if (isEmpty()) {
 			return this;
@@ -8533,8 +8535,9 @@ written authorization of the copyright holder.
 	 *
 	 * @throws IllegalArgumentException
 	 *          If invalid escape sequence is detected
+	 * 
+	 * @since 15
 	 */
-	@Deprecated(forRemoval=true, since="13")
 	public String translateEscapes() {
 		StringBuilder builder = new StringBuilder();
 		char[] charArray = toCharArray();


### PR DESCRIPTION
The Text Blocks feature has left preview so the new functions
added by it are no long deprecated.

I've left the inclusion of the functions in JDK 13+ preprocessor
tags so as not to break any JDK 13+ testing as after the next
feature release - 0.22.0 in Sept - neither 13 or 14 will be in
support.

It doesn't seem worthwhile to add !15 specific preprocessor tags
around the @deprecated annotations.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>