### PR TITLE
Break JITServer connection for interrupted compilations

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3308,10 +3308,6 @@ remoteCompile(
 
       compiler->failCompilation<JITServer::StreamMessageTypeMismatch>(e.what());
       }
-   catch (const TR::CompilationInterrupted &e)
-      {
-      throw; // rethrow the exception
-      }
    catch (...)
       {
       // For any other type of exception disconnect the socket 


### PR DESCRIPTION
PR #9859 introduced a performance optimization where, most of the time
we read a message sent over the network with just one system call instead
of two. This is achieved by reading as much as possible with a first
"read" system call followed by others if not the entire message was delivered.
However, when a compilation is interrupted at the client, the client will
inform the server and proceed with the next compilation request over the same
connection. This means that two messages are sent by the client back to back
and in some cases the server will read both (or at least part of the second)
with just one system call. As a consequence the compilation request will
be aborted and in the end the server will need to clear its caches as explained
in issue #10081.

The solution adopted in the PR is to break the client-server connection when
a compilation is interrupted.

Fixes: #10081

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>