### PR TITLE
verbose:module/nomodule option implementation

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -887,6 +887,8 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 							TRIGGER_J9HOOK_JAVA_BASE_LOADED(vm->hookInterface, currentThread);
 							Trc_MODULE_defineModule(currentThread, "java.base", j9mod);
 						}
+
+						TRIGGER_J9HOOK_VM_MODULE_LOAD(vm->hookInterface, currentThread, j9mod);
 					} else {
 						throwExceptionHelper(currentThread, rc);
 					}

--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2019 IBM Corp. and others
+Copyright (c) 2006, 2021 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1298,5 +1298,25 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<struct>J9VMRuntimeStateChanged</struct>
 		<data type="struct J9VMThread*" name="vmThread" description="current thread" />
 		<data type="U_32" name="state" description="the VM runtime state" />
+	</event>
+
+	<event>
+		<name>J9HOOK_VM_MODULE_LOAD</name>
+		<description>
+			Triggered when Java module has been loaded
+		</description>
+		<struct>J9VMModuleLoadEvent</struct>
+		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
+		<data type="struct J9Module*" name="module" description="module" />
+	</event>
+
+	<event>
+		<name>J9HOOK_VM_MODULE_UNLOAD</name>
+		<description>
+			Triggered when Java module is being unloaded
+		</description>
+		<struct>J9VMModuleUnloadEvent</struct>
+		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
+		<data type="struct J9Module*" name="module" description="module" />
 	</event>
 </interface>

--- a/runtime/oti/verbose_api.h
+++ b/runtime/oti/verbose_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,6 +105,9 @@ typedef struct J9VerboseSettings {
 	U_8 shutdown;
 	U_8 verification;
 	U_8 verifyErrorDetails;
+#if (JAVA_SPEC_VERSION >= 11)
+	U_8 module;
+#endif /* (JAVA_SPEC_VERSION >= 11) */
 } J9VerboseSettings;
 
 /**

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -305,6 +305,8 @@ freeJ9Module(J9JavaVM *javaVM, J9Module *j9module) {
 	if (TrcEnabled_Trc_MODULE_freeJ9ModuleV2_entry) {
 		trcModulesFreeJ9ModuleEntry(javaVM, j9module);
 	}
+
+	TRIGGER_J9HOOK_VM_MODULE_UNLOAD(javaVM->hookInterface, javaVM->mainThread, j9module);
 
 	if (NULL != j9module->removeAccessHashTable) {
 		J9Module **modulePtr = (J9Module**)hashTableStartDo(j9module->removeAccessHashTable, &walkState);

--- a/test/functional/cmdLineTests/verbosetest/playlist.xml
+++ b/test/functional/cmdLineTests/verbosetest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,30 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_verbosetest_11</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DTESTNG=$(Q)$(TESTNG)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) -DJDK_VERSION=$(Q)$(JDK_VERSION)$(Q) -DREPORTDIR=$(REPORTDIR) -DTEST_GROUP=$(Q)$(TEST_GROUP)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)verbosetests_11.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<!-- https://github.com/eclipse/openj9/issues/1608, exclude test on Win temporarily -->
+		<platformRequirements>^arch.arm,^os.win</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>

--- a/test/functional/cmdLineTests/verbosetest/verbosetests.xml
+++ b/test/functional/cmdLineTests/verbosetest/verbosetests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2010, 2018 IBM Corp. and others
+  Copyright (c) 2010, 2021 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@
 	<variable name="VGC" value="<verbosegc" />
 	<variable name="VCLASS" value="class load: java/lang/Object" />
 	<variable name="VJNI" value="<JNI FindClass: java/lang/Class>" />
-	<variable name="OLDOUPUT" value="$EXP_OP$" />
 	<variable name="EXP_OP" value="100000 x ObjectAllocation.allocArrays" />
 
  <echo value="Test options alone" />

--- a/test/functional/cmdLineTests/verbosetest/verbosetests_11.xml
+++ b/test/functional/cmdLineTests/verbosetest/verbosetests_11.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2020, 2021 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="Test -verbose parsing" timeout="900">
+	<variable name="PROGRAM" value="-cp $Q$$RESOURCES_DIR$$CPDL$$TESTNG$$CPDL$$JVM_TEST_ROOT$/functional/JIT_Test/jitt.jar$Q$ org.testng.TestNG -d $Q$$REPORTDIR$$Q$ $Q$$JVM_TEST_ROOT$/functional/JIT_Test/testng.xml$Q$ -testnames AllocationTest -groups $TEST_GROUP$" />
+    <variable name="VGC" value="<verbosegc" />
+	<variable name="VCLASS" value="class load: java/lang/Object" />
+	<variable name="VJNI" value="<JNI FindClass: java/lang/Class>" />
+    <variable name="VMODULE" value="module load: java.base from: jrt:/java.base" />
+	<variable name="EXP_OP" value="100000 x ObjectAllocation.allocArrays" />
+
+    <!-- test with isolated options -->
+    <test id="-verbose:module">
+        <command>$EXE$ -verbose:module $PROGRAM$</command>
+        <output regex="no" type="failure">$VGC$</output>
+        <output regex="no" type="failure">$VCLASS$</output>
+        <output regex="no" type="failure">$VJNI$</output>
+        <output regex="no" type="required">$VMODULE$</output>
+        <output regex="no" type="success">$EXP_OP$</output>
+    </test>
+
+    <test id="-verbose:nomodule">
+        <command>$EXE$ -verbose:nomodule $PROGRAM$</command>
+        <output regex="no" type="failure">$VGC$</output>
+        <output regex="no" type="failure">$VCLASS$</output>
+        <output regex="no" type="failure">$VJNI$</output>
+        <output regex="no" type="failure">$VMODULE$</output>
+        <output regex="no" type="success">$EXP_OP$</output>
+    </test>
+
+    <!-- test with option combinations-->
+    <test id="-verbose:module -verbose:class">
+        <command>$EXE$ -verbose:module -verbose:class $PROGRAM$</command>
+        <output regex="no" type="failure">$VGC$</output>
+        <output regex="no" type="success">$VCLASS$</output>
+        <output regex="no" type="failure">$VJNI$</output>
+        <output regex="no" type="success">$VMODULE$</output>
+        <output regex="no" type="success">$EXP_OP$</output>
+    </test>
+
+    <test id="-verbose:module,class">
+        <command>$EXE$ -verbose:module,class $PROGRAM$</command>
+        <output regex="no" type="failure">$VGC$</output>
+        <output regex="no" type="success">$VCLASS$</output>
+        <output regex="no" type="failure">$VJNI$</output>
+        <output regex="no" type="success">$VMODULE$</output>
+        <output regex="no" type="success">$EXP_OP$</output>
+    </test>
+    
+    <test id="-verbose:module -verbose:nomodule">
+        <command>$EXE$ -verbose:module -verbose:nomodule $PROGRAM$</command>
+        <output regex="no" type="failure">$VGC$</output>
+        <output regex="no" type="failure">$VCLASS$</output>
+        <output regex="no" type="failure">$VJNI$</output>
+        <output regex="no" type="failure">$VMODULE$</output>
+        <output regex="no" type="success">$EXP_OP$</output>
+    </test>
+
+    <test id="-verbose:nomodule -verbose:module">
+        <command>$EXE$ -verbose:nomodule -verbose:module $PROGRAM$</command>
+        <output regex="no" type="failure">$VGC$</output>
+        <output regex="no" type="failure">$VCLASS$</output>
+        <output regex="no" type="failure">$VJNI$</output>
+        <output regex="no" type="success">$VMODULE$</output>
+        <output regex="no" type="success">$EXP_OP$</output>
+    </test>
+ </suite>


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/9248
Docs issue: https://github.com/eclipse/openj9-docs/issues/593

Hotspot -verbose:module output format:
```
[0.034s][info][module,load] java.base location: jrt:/java.base
[0.035s][info][module,load] jdk.jlink location: jrt:/jdk.jlink
[0.035s][info][module,load] java.net.http location: jrt:/java.net.http
[0.035s][info][module,load] java.security.jgss location: jrt:/java.security.jgss
[0.035s][info][module,load] java.transaction.xa location: jrt:/java.transaction.xa
[0.036s][info][module,load] jdk.internal.jvmstat location: jrt:/jdk.internal.jvmstat
```

OpenJ9 output format (similar to OpenJ9 verbose:class):
```
module load: java.base from: jrt:/java.base
module load: jdk.dynalink from: jrt:/jdk.dynalink
module load: jdk.httpserver from: jrt:/jdk.httpserver
module load: jdk.unsupported from: jrt:/jdk.unsupported
module load: openj9.dtfj from: jrt:/openj9.dtfj
module load: jdk.jdwp.agent from: jrt:/jdk.jdwp.agent
module load: jdk.localedata from: jrt:/jdk.localedata
module load: jdk.zipfs from: jrt:/jdk.zipfs
```

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>