### PR TITLE
AArch64: Enable inlineDirectCall()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -2244,17 +2244,24 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
 
 TR::Register *J9::ARM64::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::SymbolReference *symRef = node->getSymbolReference();
-   TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
-   TR::Linkage *linkage;
+   TR::Register *returnRegister;
 
-   if (callee->isJNI() && (node->isPreparedForDirectJNI() || callee->getResolvedMethodSymbol()->canDirectNativeCall()))
+   if (!cg->inlineDirectCall(node, returnRegister))
       {
-      linkage = cg->getLinkage(TR_J9JNILinkage);
+      TR::SymbolReference *symRef = node->getSymbolReference();
+      TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
+      TR::Linkage *linkage;
+
+      if (callee->isJNI() && (node->isPreparedForDirectJNI() || callee->getResolvedMethodSymbol()->canDirectNativeCall()))
+         {
+         linkage = cg->getLinkage(TR_J9JNILinkage);
+         }
+      else
+         {
+         linkage = cg->getLinkage(callee->getLinkageConvention());
+         }
+      returnRegister = linkage->buildDirectDispatch(node);
       }
-   else
-      {
-      linkage = cg->getLinkage(callee->getLinkageConvention());
-      }
-   return linkage->buildDirectDispatch(node);
+
+   return returnRegister;
    }


### PR DESCRIPTION
This commit adds a call to inlineDirectCall() in directCallEvaluator()
for AArch64.

Issue: #10089

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>