### PR TITLE
Allow SDK Implementation to be passed

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -462,7 +462,7 @@ def get_test_job_name(targetName, spec, version, identifier) {
     if (spec ==~ /.*_valhalla/) {
         version = 'valhalla'
     }
-    return "Test_openjdk${version}_j9_${targetName}_${spec}_${id}"
+    return "Test_openjdk${version}_${SDK_IMPL_SHORT}_${targetName}_${spec}_${id}"
 }
 
 def convert_build_identifier(val) {
@@ -593,7 +593,7 @@ def generate_test_jobs(TESTS, SPEC, ARTIFACTORY_SERVER, ARTIFACTORY_REPO) {
             string(name: 'JDK_VERSIONS', value: sdk_version),
             string(name: 'SUFFIX', value: "_${spec_id['id']}"),
             string(name: 'ARCH_OS_LIST', value: spec_id['spec']),
-            string(name: 'JDK_IMPL', value: 'openj9'),
+            string(name: 'JDK_IMPL', value: SDK_IMPL),
             string(name: 'ARTIFACTORY_SERVER', value: ARTIFACTORY_SERVER),
             string(name: 'ARTIFACTORY_REPO', value: ARTIFACTORY_REPO),
             string(name: 'BUILDS_TO_KEEP', value: DISCARDER_NUM_BUILDS),

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -663,6 +663,12 @@ def set_test_targets() {
         }
     }
     echo "TESTS:'${TESTS}'"
+
+    // Set SDK Implementation, default to OpenJ9
+    SDK_IMPL = buildspec.getScalarField("sdk_impl", 'all') ?: 'openj9'
+    SDK_IMPL_SHORT = buildspec.getScalarField("sdk_impl_short", 'all') ?: 'j9'
+    echo "SDK_IMPL:'${SDK_IMPL}'"
+    echo "SDK_IMPL_SHORT:'${SDK_IMPL_SHORT}'"
 }
 
 /*


### PR DESCRIPTION
- Can be defined in the variable file as
  sdk_impl and sdk_impl_short.
- Short is used for the job name.
- Default values are openj9 and j9.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>