### PR TITLE
AArch64: Call stopUsingRegister() in monent/monexitEvaluator()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -628,6 +628,10 @@ J9::ARM64::TreeEvaluator::monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg
    cg->addSnippet(snippet);
    doneLabel->setEndInternalControlFlow();
 
+   cg->stopUsingRegister(dataReg);
+   cg->stopUsingRegister(addrReg);
+   cg->stopUsingRegister(tempReg);
+
    cg->decReferenceCount(objNode);
    cg->machine()->setLinkRegisterKilled(true);
    return NULL;
@@ -1570,6 +1574,10 @@ J9::ARM64::TreeEvaluator::monentEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Snippet *snippet = new (cg->trHeapMemory()) TR::ARM64MonitorEnterSnippet(cg, node, incLabel, callLabel, doneLabel);
    cg->addSnippet(snippet);
    doneLabel->setEndInternalControlFlow();
+
+   cg->stopUsingRegister(dataReg);
+   cg->stopUsingRegister(addrReg);
+   cg->stopUsingRegister(tempReg);
 
    cg->decReferenceCount(objNode);
    cg->machine()->setLinkRegisterKilled(true);


### PR DESCRIPTION
This commit adds calls to stopUsingRegister() in
monent/monexitEvaluator() for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>