### PR TITLE
Override canUseRelativeLongInstructions in Z codegen

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3675,6 +3675,15 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
    return cursor;
    }
 
+bool J9::Z::CodeGenerator::canUseRelativeLongInstructions(int64_t value)
+   {
+   if (self()->comp()->isOutOfProcessCompilation())
+      {
+      return false;
+      }
+   return OMR::CodeGeneratorConnector::canUseRelativeLongInstructions(value);
+   }
+
 TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperPrePrologue(TR::Instruction* cursor)
    {
    TR::Compilation* comp = self()->comp();

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -76,6 +76,7 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    bool alwaysGeneratesAKnownCleanSign(TR::Node *node);
    bool alwaysGeneratesAKnownPositiveCleanSign(TR::Node *node);
+   bool canUseRelativeLongInstructions(int64_t value);
    TR_RawBCDSignCode alwaysGeneratedSign(TR::Node *node);
 
    uint32_t getPDMulEncodedSize(TR::Node *pdmul, TR_PseudoRegister *multiplicand, TR_PseudoRegister *multiplier);


### PR DESCRIPTION
This commit overrides OMR's canUseRelativeLongInstructions
in the Z codegen in order to extend the functionality for
remote compiles.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>