### PR TITLE
Fix searching with a method signature

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/MethodForNameCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/MethodForNameCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,8 @@ package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
 
 import java.io.PrintStream;
 import java.util.Iterator;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.tools.ddrinteractive.Command;
@@ -43,18 +44,17 @@ import com.ibm.j9ddr.vm29.pointer.helper.J9MethodHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 
-public class MethodForNameCommand extends Command 
+public class MethodForNameCommand extends Command
 {
 	public MethodForNameCommand()
 	{
-		addCommand("methodforname", "<name>", "find the method corresponding to name (with wildcards)");		
+		addCommand("methodforname", "<name>", "find the method corresponding to name (with wildcards)");
 	}
-	
 
-	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException
 	{
 		try {
-			if(args.length == 1) {
+			if (args.length == 1) {
 				String name = args[0];
 				CommandUtils.dbgPrint(out, String.format("Searching for methods named '%s' in VM=%s...\n", name, J9RASHelper.getVM(DataType.getJ9RASPointer()).getHexAddress()));
 				int count = dbgGetMethodsForName(out, name);
@@ -68,85 +68,74 @@ public class MethodForNameCommand extends Command
 	}
 
 	int dbgGetMethodsForName(PrintStream out, String pattern) throws CorruptDataException {
-		int matchCount = 0;
-		// J9ClassWalkState walkState;
-		String classNeedle, methodNeedle, sigNeedle;
-		long classMatchFlags, methodMatchFlags, sigMatchFlags;
-		String classStart, nameStart, sigStart;
+		int dot = pattern.indexOf('.');
+		String classStart = (dot == -1) ? "*" : pattern.substring(0, dot);
+		int paren = pattern.indexOf('(', dot + 1);
+		String nameStart = (paren == -1) ? pattern.substring(dot + 1) : pattern.substring(dot + 1, paren);
+		String sigStart = (paren == -1) ? "*" : pattern.substring(paren);
+		StringBuffer needleBuffer;
 
-		if (pattern.indexOf('.') != -1) {
-			nameStart = pattern.substring(pattern.indexOf('.') + 1); // skip the .
-			classStart = pattern.substring(0, pattern.indexOf('.'));
-		} else {
-			classStart = "*";
-			nameStart = pattern;
-		}
-
-		if (pattern.indexOf('(') != -1) {
-			sigStart = pattern.substring(pattern.indexOf('('));
-		} else {
-			sigStart = "*";
-		}
-
-		StringBuffer needleBuffer = new StringBuffer();
-		classMatchFlags = WildCard.parseWildcard(classStart, needleBuffer);
-		classNeedle = needleBuffer.toString();
+		needleBuffer = new StringBuffer();
+		int classMatchFlags = WildCard.parseWildcard(classStart, needleBuffer);
+		String classNeedle = needleBuffer.toString();
 		if (classMatchFlags == -1) {
 			CommandUtils.dbgError(out, "Invalid wildcards in class name\n");
 			return 0;
 		}
 
 		needleBuffer = new StringBuffer();
-		methodMatchFlags = WildCard.parseWildcard(nameStart, needleBuffer);
-		methodNeedle = needleBuffer.toString();
+		int methodMatchFlags = WildCard.parseWildcard(nameStart, needleBuffer);
+		String methodNeedle = needleBuffer.toString();
 		if (methodMatchFlags == -1) {
 			CommandUtils.dbgError(out, "Invalid wildcards in method name\n");
 			return 0;
 		}
 
 		needleBuffer = new StringBuffer();
-		sigMatchFlags = WildCard.parseWildcard(sigStart, needleBuffer);
-		sigNeedle = needleBuffer.toString();
+		int sigMatchFlags = WildCard.parseWildcard(sigStart, needleBuffer);
+		String sigNeedle = needleBuffer.toString();
 		if (methodMatchFlags == -1) {
 			CommandUtils.dbgError(out, "Invalid wildcards in method name\n");
 			return 0;
 		}
-		
-		Hashtable<String,J9ClassPointer> loadedClasses = new Hashtable<String,J9ClassPointer>(); 
-		
-		GCClassLoaderIterator classLoaderIterator = GCClassLoaderIterator.from();		
+
+		int matchCount = 0;
+		Map<String, J9ClassPointer> loadedClasses = new HashMap<>();
+
+		GCClassLoaderIterator classLoaderIterator = GCClassLoaderIterator.from();
 		while (classLoaderIterator.hasNext()) {
 			J9ClassLoaderPointer loader = classLoaderIterator.next();
-			Iterator<J9ClassPointer> classItterator = ClassIterator.fromJ9Classloader(loader);
+			Iterator<J9ClassPointer> classIterator = ClassIterator.fromJ9Classloader(loader);
 
-			while (classItterator.hasNext()) {
-				J9ClassPointer clazz = classItterator.next();
+			while (classIterator.hasNext()) {
+				J9ClassPointer clazz = classIterator.next();
 				J9ROMClassPointer romClazz = clazz.romClass();
 				String className = J9UTF8Helper.stringValue(romClazz.className());
-				
+
 				if (loadedClasses.containsValue(clazz)) {
 					continue;
-				} else {
-					loadedClasses.put(clazz.toString(), clazz);
 				}
-				
+
+				loadedClasses.put(clazz.toString(), clazz);
+
 				if (WildCard.wildcardMatch(classMatchFlags, classNeedle, className)) {
 					J9MethodPointer methodCursor = clazz.ramMethods();
-					for (long count = romClazz.romMethodCount().longValue(); count > 0; count--, methodCursor = methodCursor.add(1)) {
+					for (long count = romClazz.romMethodCount().longValue(); count > 0; count -= 1, methodCursor = methodCursor.add(1)) {
 						J9ROMMethodPointer romMethod = J9MethodHelper.romMethod(methodCursor);
 						J9ROMNameAndSignaturePointer nameAndSignature = romMethod.nameAndSignature();
 						String nameUTF = J9UTF8Helper.stringValue(nameAndSignature.name());
 						if (WildCard.wildcardMatch(methodMatchFlags, methodNeedle, nameUTF)) {
 							String sigUTF = J9UTF8Helper.stringValue(nameAndSignature.signature());
 							if (WildCard.wildcardMatch(sigMatchFlags, sigNeedle, sigUTF)) {
-								matchCount++;
-								CommandUtils.dbgPrint(out, String.format("!j9method %s --> %s.%s%s\n", methodCursor.getHexAddress(), className,	nameUTF,sigUTF));
+								matchCount += 1;
+								CommandUtils.dbgPrint(out, String.format("!j9method %s --> %s.%s%s\n", methodCursor.getHexAddress(), className, nameUTF, sigUTF));
 							}
 						}
 					}
 				}
 			}
 		}
+
 		return matchCount;
 	}
 }


### PR DESCRIPTION
When decomposing a method search pattern, the 'name' portion should not include the 'signature' portion, if any.

Fixes #10080.