### PR TITLE
Prefetch resolved implementor methods for CHTable

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1845,6 +1845,52 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, objLocation, obj);
          }
          break;
+      case MessageType::ResolvedMethod_getResolvedImplementorMethods:
+         {
+         auto recv = client->getRecvData<TR_ResolvedJ9Method *, std::vector<TR_OpaqueClassBlock *>, int32_t, bool>();
+         auto owningMethod = std::get<0>(recv);
+         auto &subClasses = std::get<1>(recv);
+         int32_t cpIndexOrOffset = std::get<2>(recv);
+         bool isInterface = std::get<3>(recv);
+
+         int32_t numMethods = subClasses.size();
+         std::vector<J9Method *> ramMethods;
+         std::vector<TR_ResolvedJ9JITServerMethodInfo> methodInfos;
+         ramMethods.reserve(numMethods);
+         methodInfos.reserve(numMethods);
+
+         for (int32_t i = 0; i < numMethods; ++i)
+            {
+            J9Method *ramMethod;
+            TR_ResolvedJ9JITServerMethodInfo methodInfo;
+            if (isInterface)
+               {
+               ramMethod = (J9Method *) fe->getResolvedInterfaceMethod(owningMethod->getPersistentIdentifier(), subClasses[i], cpIndexOrOffset);
+               bool resolved = ramMethod && J9_BYTECODE_START_FROM_RAM_METHOD(ramMethod);
+
+               if (resolved)
+                  TR_ResolvedJ9JITServerMethod::createResolvedMethodFromJ9MethodMirror(methodInfo, (TR_OpaqueMethodBlock *) ramMethod, 0, owningMethod, fe, trMemory);
+               }
+            else
+               {
+               TR_OpaqueMethodBlock *method = fe->getResolvedVirtualMethod(subClasses[i], cpIndexOrOffset);
+               ramMethod = reinterpret_cast<J9Method *>(method);
+               TR_ResolvedJ9JITServerMethodInfo methodInfo;
+               if (ramMethod)
+                  TR_ResolvedJ9JITServerMethod::createResolvedMethodMirror(methodInfo, method, 0, owningMethod, fe, trMemory);
+               }
+            ramMethods.push_back(ramMethod);
+            methodInfos.push_back(methodInfo);
+
+            // First unresolved method found, stop the walk.
+            // We will still cache this unresolved method,
+            // so that server doesn't need to make an extra remote call.
+            if (!std::get<0>(methodInfo).remoteMirror)
+               break;
+            }
+         client->write(response, ramMethods, methodInfos);
+         break;
+         }
       case MessageType::ResolvedRelocatableMethod_createResolvedRelocatableJ9Method:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, J9Method *, int32_t, uint32_t>();

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -32,6 +32,10 @@
 struct
 TR_ResolvedJ9JITServerMethodInfoStruct
    {
+   TR_ResolvedJ9JITServerMethodInfoStruct() :
+      remoteMirror(NULL)
+      {}
+
    TR_ResolvedJ9Method *remoteMirror;
    J9RAMConstantPoolItem *literals;
    J9Class *ramClass;
@@ -219,6 +223,7 @@ public:
    bool addValidationRecordForCachedResolvedMethod(const TR_ResolvedMethodKey &key, TR_OpaqueMethodBlock *method);
    void cacheResolvedMethodsCallees(int32_t ttlForUnresolved = 2);
    void cacheFields();
+   void cacheImplementorMethods(std::vector<TR_OpaqueClassBlock *> &subClasses, int32_t cpIndexOrOffset, bool isInterface, int32_t ttlForUnresolved = 2);
 
 protected:
    JITServer::ServerStream *_stream;

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -95,14 +95,15 @@ enum MessageType : uint16_t
    ResolvedMethod_isUnresolvedConstantDynamic,
    ResolvedMethod_dynamicConstant,
    ResolvedMethod_definingClassFromCPFieldRef,
+   ResolvedMethod_getResolvedImplementorMethods,
 
-   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, // 65
+   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method, // 66
    ResolvedRelocatableMethod_fieldAttributes,
    ResolvedRelocatableMethod_staticAttributes,
    ResolvedRelocatableMethod_getFieldType,
 
    // For TR_J9ServerVM methods
-   VM_isClassLibraryClass, // 69
+   VM_isClassLibraryClass, // 70
    VM_isClassLibraryMethod,
    VM_getSuperClass,
    VM_isInstanceOf,
@@ -205,7 +206,7 @@ enum MessageType : uint16_t
    VM_getFields,
 
    // For static TR::CompilationInfo methods
-   CompInfo_isCompiled, // 170
+   CompInfo_isCompiled, // 171
    CompInfo_getInvocationCount,
    CompInfo_setInvocationCount,
    CompInfo_getJ9MethodExtra,
@@ -218,7 +219,7 @@ enum MessageType : uint16_t
    CompInfo_getJ9MethodStartPC,
 
    // For J9::ClassEnv Methods
-   ClassEnv_classFlagsValue, // 181
+   ClassEnv_classFlagsValue, // 182
    ClassEnv_classDepthOf,
    ClassEnv_classInstanceSize,
    ClassEnv_superClassesOf,
@@ -231,13 +232,13 @@ enum MessageType : uint16_t
    ClassEnv_getROMClassRefName,
 
    // For TR_J9SharedCache
-   SharedCache_getClassChainOffsetInSharedCache, // 192
+   SharedCache_getClassChainOffsetInSharedCache, // 193
    SharedCache_rememberClass,
    SharedCache_addHint,
    SharedCache_storeSharedData,
 
    // For runFEMacro
-   runFEMacro_invokeCollectHandleNumArgsToCollect, // 196
+   runFEMacro_invokeCollectHandleNumArgsToCollect, // 197
    runFEMacro_invokeExplicitCastHandleConvertArgs,
    runFEMacro_targetTypeL,
    runFEMacro_invokeILGenMacrosInvokeExactAndFixup,
@@ -263,24 +264,24 @@ enum MessageType : uint16_t
    runFEMacro_invokeCollectHandleAllocateArray,
 
    // for JITServerPersistentCHTable
-   CHTable_getAllClassInfo, // 220
+   CHTable_getAllClassInfo, // 221
    CHTable_getClassInfoUpdates,
    CHTable_commit,
    CHTable_clearReservable,
 
    // for JITServerIProfiler
-   IProfiler_profilingSample, // 224
+   IProfiler_profilingSample, // 225
    IProfiler_searchForMethodSample,
    IProfiler_getMaxCallCount,
    IProfiler_setCallCount,
 
-   Recompilation_getExistingMethodInfo, // 228
+   Recompilation_getExistingMethodInfo, // 229
    Recompilation_getJittedBodyInfoFromPC,
 
    ClassInfo_getRemoteROMString,
 
    // for KnownObjectTable
-   KnownObjectTable_getOrCreateIndex, // 231
+   KnownObjectTable_getOrCreateIndex, // 232
    KnownObjectTable_getOrCreateIndexAt,
    KnownObjectTable_getPointer,
    KnownObjectTable_getExistingIndexAt,
@@ -294,7 +295,7 @@ enum MessageType : uint16_t
    KnownObjectTable_invokeDirectHandleDirectCall,
    KnownObjectTable_getKnownObjectTableDumpInfo,
 
-   ClassEnv_isClassRefValueType, // 243
+   ClassEnv_isClassRefValueType, // 244
    MessageType_MAXTYPE
    };
 
@@ -367,11 +368,12 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ResolvedMethod_isUnresolvedConstantDynamic",
    "ResolvedMethod_dynamicConstant",
    "ResolvedMethod_definingClassFromCPFieldRef",
-   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 65
+   "ResolvedMethod_getResolvedImplementorMethods",
+   "ResolvedRelocatableMethod_createResolvedRelocatableJ9Method", // 66
    "ResolvedRelocatableMethod_fieldAttributes",
    "ResolvedRelocatableMethod_staticAttributes",
    "ResolvedRelocatableMethod_getFieldType",
-   "VM_isClassLibraryClass", // 69
+   "VM_isClassLibraryClass", // 70
    "VM_isClassLibraryMethod",
    "VM_getSuperClass",
    "VM_isInstanceOf",
@@ -472,7 +474,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "VM_getObjectSizeClass",
    "VM_stackWalkerMaySkipFramesSVM",
    "VM_getFields",
-   "CompInfo_isCompiled", // 170
+   "CompInfo_isCompiled", // 171
    "CompInfo_getInvocationCount",
    "CompInfo_setInvocationCount",
    "CompInfo_getJ9MethodExtra",
@@ -483,7 +485,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "CompInfo_setInvocationCountAtomic",
    "CompInfo_isClassSpecial",
    "CompInfo_getJ9MethodStartPC",
-   "ClassEnv_classFlagsValue", // 181
+   "ClassEnv_classFlagsValue", // 182
    "ClassEnv_classDepthOf",
    "ClassEnv_classInstanceSize",
    "ClassEnv_superClassesOf",
@@ -494,11 +496,11 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "ClassEnv_getITable",
    "ClassEnv_classHasIllegalStaticFinalFieldModification",
    "ClassEnv_getROMClassRefName",
-   "SharedCache_getClassChainOffsetInSharedCache", // 192
+   "SharedCache_getClassChainOffsetInSharedCache", // 193
    "SharedCache_rememberClass",
    "SharedCache_addHint",
    "SharedCache_storeSharedData",
-   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 196
+   "runFEMacro_invokeCollectHandleNumArgsToCollect", // 197
    "runFEMacro_invokeExplicitCastHandleConvertArgs",
    "runFEMacro_targetTypeL",
    "runFEMacro_invokeILGenMacrosInvokeExactAndFixup",
@@ -522,18 +524,18 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleFilterPosition",
    "runFEMacro_invokeFilterArgumentsWithCombinerHandleArgumentIndices",
    "runFEMacro_invokeCollectHandleAllocateArray",
-   "CHTable_getAllClassInfo", // 220
+   "CHTable_getAllClassInfo", // 221
    "CHTable_getClassInfoUpdates",
    "CHTable_commit",
    "CHTable_clearReservable",
-   "IProfiler_profilingSample", // 224
+   "IProfiler_profilingSample", // 225
    "IProfiler_searchForMethodSample",
    "IProfiler_getMaxCallCount",
    "IProfiler_setCallCount",
-   "Recompilation_getExistingMethodInfo", // 228
+   "Recompilation_getExistingMethodInfo", // 229
    "Recompilation_getJittedBodyInfoFromPC",
    "ClassInfo_getRemoteROMString",
-   "KnownObjectTable_getOrCreateIndex", // 231
+   "KnownObjectTable_getOrCreateIndex", // 232
    "KnownObjectTable_getOrCreateIndexAt",
    "KnownObjectTable_getPointer",
    "KnownObjectTable_getExistingIndexAt",
@@ -545,7 +547,7 @@ static const char *messageNames[MessageType_ARRAYSIZE] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_invokeDirectHandleDirectCall",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "ClassEnv_isClassRefValueType", // 243
+   "ClassEnv_isClassRefValueType", // 244
    };
    }; // namespace JITServer
 #endif // MESSAGE_TYPES_HPP


### PR DESCRIPTION
`CollectImplementors` is used by CHTable to find
the number of implementors of a given method.
It works by recursively walking the class tree
and creating a resolved method for each implementor.
This results in many remote queries in JITServer.

This commit adds a new helper class - `CollectResolvedImplementors`.
Its purpose is to walk the class tree and pre-emptively cache
all resolved methods that might be created by `CollectImplementors`
in one message.
