### PR TITLE
Duplicate PassThrough nodes when creating acmp fastpaths

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -291,6 +291,15 @@ J9::CodeGenerator::fastpathAcmpHelper(TR::Node *node, TR::TreeTop *tt, const boo
             TR::Node* temp = expectedDeps->getChild(i);
             if (temp->getGlobalRegisterNumber() == depNode->getGlobalRegisterNumber())
                continue;
+            else if (temp->getOpCodeValue() == TR::PassThrough)
+               {
+               // PassThrough nodes cannot be commoned because doing so does not
+               // actually anchor the child, causing it's lifetime to not be extended
+               TR::Node* original = temp;
+               temp = TR::Node::create(original, TR::PassThrough, 1, original->getFirstChild());
+               temp->setLowGlobalRegisterNumber(original->getLowGlobalRegisterNumber());
+               temp->setHighGlobalRegisterNumber(original->getHighGlobalRegisterNumber());
+               }
             glRegDeps->addChildren(&temp, 1);
             }
          }


### PR DESCRIPTION
Previously, when inserting fastpaths for acmp in the JIT, PassThrough nodes under new GlRegDeps were commoned with nodes from existing GlRegDeps. This is incorrect because the commoned PassThrough does not anchor its child, which causes it's lifetime to not be extended up to that code point.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>