### PR TITLE
Support JDK15 new field java.lang.reflect.Field.trustedFinal

### DIFF
--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -829,6 +829,11 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 	J9VMJAVALANGREFLECTFIELD_SET_DECLARINGCLASS(vmThread, fieldObject, J9VM_J9CLASS_TO_HEAPCLASS(j9FieldID->declaringClass));
 #if defined(USE_SUN_REFLECT)
 	J9VMJAVALANGREFLECTFIELD_SET_MODIFIERS(vmThread, fieldObject, j9FieldID->field->modifiers & CFR_FIELD_ACCESS_MASK);
+#if JAVA_SPEC_VERSION >= 15
+	if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccFinal | J9AccStatic)) {
+		J9VMJAVALANGREFLECTFIELD_SET_TRUSTEDFINAL(vmThread, fieldObject, JNI_TRUE);
+	}
+#endif /* JAVA_SPEC_VERSION >= 15 */
 #endif
 
 	return fieldObject;

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -208,6 +208,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/reflect/Field" name="type" signature="Ljava/lang/Class;"/>
 	<fieldref class="java/lang/reflect/Field" name="signature" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/reflect/Field" name="modifiers" signature="I"/>
+	<fieldref class="java/lang/reflect/Field" name="trustedFinal" signature="Z" versions="15-"/>
 	<fieldref class="java/lang/reflect/Field" name="annotations" signature="[B"/>
 	<fieldref class="java/lang/reflect/Field" name="intFieldID" signature="I">
 		<fieldalias name="slot"/>


### PR DESCRIPTION
Set it to `TRUE` if the field is `static` & `final`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>