### PR TITLE
Remove unnecessary monitor enter during VM exit

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -575,7 +575,6 @@ void OMRNORETURN exitJavaVM(J9VMThread * vmThread, IDATA rc)
 
 #if defined(WIN32)
 		/* Do not attempt to exit while a JNI shared library open is in progress */
-		omrthread_monitor_enter(vm->nativeLibraryMonitor);
 		omrthread_monitor_enter(vm->classLoaderBlocksMutex);
 #endif
 


### PR DESCRIPTION
The nativeLibraryMonitor may be owned by a thread which is blocked by
exclusive VM access (acquired during VM exit), which results in a
deadlock on exit.

It is not necessary to enter the monitor in order to block native
library loading during exit - the classLoaderBlocksMutex is sufficient
to ensure that.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>