### PR TITLE
Fix class resolve for VT multianewarray

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -313,10 +313,12 @@ static const struct { \
 #define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsValueType)
 #define J9_IS_J9CLASS_FLATTENED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened)
 #define J9_VALUETYPE_FLATTENED_SIZE(clazz)((clazz)->totalInstanceSize - (clazz)->backfillOffset)
+#define IS_REF_OR_VAL_SIGNATURE(firstChar) ('L' == (firstChar) || 'Q' == (firstChar))
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
 #define J9_IS_J9CLASS_FLATTENED(clazz) FALSE
 #define J9_VALUETYPE_FLATTENED_SIZE(clazz)((UDATA) 0) /* It is not possible for this macro to be used since we always check J9_IS_J9CLASS_FLATTENED before ever using it. */
+#define IS_REF_OR_VAL_SIGNATURE(firstChar) ('L' == (firstChar))
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #if defined(OPENJ9_BUILD)

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -108,7 +108,7 @@ internalFindArrayClass(J9VMThread* vmThread, J9Module *j9module, UDATA arity, U_
 		/* the first level of arity is already present in the array class */
 		arity -= 1;
 
-	} else if (firstChar == 'L' && lastChar == ';') {
+	} else if (IS_REF_OR_VAL_SIGNATURE(firstChar) && lastChar == ';') {
 
 		name += arity + 1; /* 1 for 'L' */
 		length -= arity + 2; /* 2 for 'L and ';' */

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -119,6 +119,7 @@ public class ValueTypeGenerator extends ClassLoader {
 				makeGeneric(cw, className, "makeValueGeneric", "makeValue", makeValueSig, makeValueGenericSig, fields, makeMaxLocal, isRef);
 			}
 		}
+		test2DMultiANewArray(cw, className, isRef);
 		testCheckCastOnInvalidQtype(cw);
 		testCheckCastOnInvalidLtype(cw);
 		addStaticSynchronizedMethods(cw);
@@ -932,5 +933,16 @@ public class ValueTypeGenerator extends ClassLoader {
 	public static Class<?> generateRefClass(String name, String[] fields) throws Throwable {
 		byte[] bytes = generateClass(name, fields, false, true);
 		return generator.defineClass(name, bytes, 0, bytes.length);
+	}
+
+	public static void test2DMultiANewArray(ClassWriter cw, String className, boolean isRef) {
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "generate2DMultiANewArray", "(II)Ljava/lang/Object;", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ILOAD, 0);
+		mv.visitVarInsn(ILOAD, 1);
+		mv.visitMultiANewArrayInsn("[[" + getSigFromSimpleName(className, isRef), 2);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(2, 2);
+		mv.visitEnd();
 	}
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -2019,6 +2019,54 @@ public class ValueTypeTests {
 		}
 	}
 
+	/**
+	 * Create multi dimensional array with Point Class without initialization.
+	 * Set each array value to a default value and check field access method handler.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInPointInstanceMultiArray() throws Throwable {
+		Object pointArray = Array.newInstance(point2DClass, new int[]{genericArraySize, genericArraySize});
+		String[] fields = {"x:I", "y:I"};
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(point2DClass, fields);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object pointNew = createPoint2D(defaultPointPositions1);
+				Array.set(Array.get(pointArray,i),j, pointNew);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object pointObject = Array.get(Array.get(pointArray,i),j);
+				checkFieldAccessMHOfAssortedType(getterAndWither, pointObject, fields, true);
+			}
+		}
+	}
+
+	/**
+	 * Create multi dimensional array with Point Class using bytecode instruction
+	 * multianewarray.
+	 * Set each array value to a default value and check field access method handler.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInPointByteCodeMultiArray() throws Throwable {
+		MethodHandle makePointArray = lookup.findStatic(point2DClass, "generate2DMultiANewArray", MethodType.methodType(Object.class, int.class, int.class));
+		Object pointArray = makePointArray.invoke(genericArraySize, genericArraySize);
+		String[] fields = {"x:I", "y:I"};
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(point2DClass, fields);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object pointNew = createPoint2D(defaultPointPositions1);
+				Array.set(Array.get(pointArray,i),j, pointNew);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object pointObject = Array.get(Array.get(pointArray,i),j);
+				checkFieldAccessMHOfAssortedType(getterAndWither, pointObject, fields, true);
+			}
+		}
+	}
+
 	/*
 	 * Create Array Objects with Flattened Line without initialization
 	 * Check the fields of each element in arrays. No field should be NULL.
@@ -2031,6 +2079,54 @@ public class ValueTypeTests {
 			assertNotNull(lineObject);
 			assertNotNull(getFlatSt.invoke(lineObject));
 			assertNotNull(getFlatEn.invoke(lineObject));
+		}
+	}
+
+	/**
+	 * Create multi dimensional array with Line Class without initialization.
+	 * Set each array value to a default value and check field access method handler.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInLineInstanceMultiArray() throws Throwable {
+		Object flattenedLineArray = Array.newInstance(flattenedLine2DClass, new int[]{genericArraySize, genericArraySize});
+		String[] fields = {"st:QPoint;:value","en:QPoint;:value"};
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(flattenedLine2DClass, fields);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object lineNew = createFlattenedLine2D(defaultLinePositions1);
+				Array.set(Array.get(flattenedLineArray,i),j, lineNew);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object lineObject = Array.get(Array.get(flattenedLineArray,i),j);
+				checkFieldAccessMHOfAssortedType(getterAndWither, lineObject, fields, true);
+			}
+		}
+	}
+
+	/**
+	 * Create multi dimensional array with Line Class using bytecode instruction
+	 * multianewarray.
+	 * Set each array value to a default value and check field access method handler.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInLineByteCodeMultiArray() throws Throwable {
+		MethodHandle makeLineArray = lookup.findStatic(flattenedLine2DClass, "generate2DMultiANewArray", MethodType.methodType(Object.class, int.class, int.class));
+		Object flattenedLineArray = makeLineArray.invoke(genericArraySize, genericArraySize);
+		String[] fields = {"st:QPoint;:value","en:QPoint;:value"};
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(flattenedLine2DClass, fields);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object lineNew = createFlattenedLine2D(defaultLinePositions1);
+				Array.set(Array.get(flattenedLineArray,i),j, lineNew);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object lineObject = Array.get(Array.get(flattenedLineArray,i),j);
+				checkFieldAccessMHOfAssortedType(getterAndWither, lineObject, fields, true);
+			}
 		}
 	}
 
@@ -2050,6 +2146,54 @@ public class ValueTypeTests {
 		}
 	}
 
+	/**
+	 * Create multi dimensional array with Triangle Class without initialization.
+	 * Set each array value to a default value and check field access method handler.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInTriangleInstanceMultiArray() throws Throwable {
+		Object triangleArray = Array.newInstance(triangle2DClass, new int[]{genericArraySize, genericArraySize});
+		String[] fields = {"v1:QFlattenedLine2D;:value", "v2:QFlattenedLine2D;:value", "v3:QFlattenedLine2D;:value"};
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(triangle2DClass, fields);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object triNew = createTriangle2D(new int[][][] {defaultLinePositions1, defaultLinePositions1, defaultLinePositions1});
+				Array.set(Array.get(triangleArray,i),j, triNew);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object triangleObject = Array.get(Array.get(triangleArray,i),j);
+				checkFieldAccessMHOfAssortedType(getterAndWither, triangleObject, fields, true);
+			}
+		}
+	}
+
+	/**
+	 * Create multi dimensional array with Triangle Class using bytecode instruction
+	 * multianewarray.
+	 * Set each array value to a default value and check field access method handler.
+	 */
+	@Test(priority=4)
+	static public void testDefaultValueInTriangleByteCodeMultiArray() throws Throwable {
+		MethodHandle makeTriangleArray = lookup.findStatic(triangle2DClass, "generate2DMultiANewArray", MethodType.methodType(Object.class, int.class, int.class));
+		Object triangleArray = makeTriangleArray.invoke(genericArraySize, genericArraySize);
+		String[] fields = {"v1:QFlattenedLine2D;:value", "v2:QFlattenedLine2D;:value", "v3:QFlattenedLine2D;:value"};
+		MethodHandle[][] getterAndWither = generateGenericGetterAndWither(triangle2DClass, fields);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object triNew = createTriangle2D(new int[][][] {defaultLinePositions1, defaultLinePositions1, defaultLinePositions1});
+				Array.set(Array.get(triangleArray,i),j, triNew);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object triangleObject = Array.get(Array.get(triangleArray,i),j);
+				checkFieldAccessMHOfAssortedType(getterAndWither, triangleObject, fields, true);
+			}
+		}
+	}
+
 	/*
 	 * Create an Array Object with assortedValueWithLongAlignment class without initialization
 	 * Check the fields of each element in arrays. No field should be NULL.
@@ -2062,6 +2206,54 @@ public class ValueTypeTests {
 			assertNotNull(assortedValueWithLongAlignmentObject);
 			for (int j = 0; j < 7; j++) {
 				assertNotNull(assortedValueWithLongAlignmentGetterAndWither[j][0].invoke(assortedValueWithLongAlignmentObject));
+			}
+		}
+	}
+
+	/**
+	 * Create multi dimensional array with assortedValueWithLongAlignment without initialization.
+	 * Set each array value to a default value and check field access method handler.
+	 *
+	 * Fails tests with array flattening enabled
+	 */
+	@Test(enabled = false, priority=5)
+	static public void testDefaultValueInAssortedValueWithLongAlignmenInstanceMultiArray() throws Throwable {
+		Object assortedValueWithLongAlignmentArray = Array.newInstance(assortedValueWithLongAlignmentClass, new int[]{genericArraySize, genericArraySize});
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object assortedValueWithLongAlignment = createAssorted(makeAssortedValueWithLongAlignment, typeWithLongAlignmentFields);
+				Array.set(Array.get(assortedValueWithLongAlignmentArray,i),j, assortedValueWithLongAlignment);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object assortedValueWithLongAlignmentObject = Array.get(Array.get(assortedValueWithLongAlignmentArray,i),j);
+				checkFieldAccessMHOfAssortedType(assortedValueWithLongAlignmentGetterAndWither, assortedValueWithLongAlignmentObject, typeWithLongAlignmentFields, true);
+			}
+		}
+	}
+
+	/**
+	 * Create multi dimensional array with assortedValueWithLongAlignment using bytecode instruction
+	 * multianewarray.
+	 * Set each array value to a default value and check field access method handler.
+	 *
+	 * Fails tests with array flattening enabled
+	 */
+	@Test(enabled = false, priority=5)
+	static public void testDefaultValueInAssortedValueWithLongAlignmentByteCodeMultiArray() throws Throwable {
+		MethodHandle makeAssortedValueWithLongAlignmentArray = lookup.findStatic(assortedValueWithLongAlignmentClass, "generate2DMultiANewArray", MethodType.methodType(Object.class, int.class, int.class));
+		Object assortedValueWithLongAlignmentArray = makeAssortedValueWithLongAlignmentArray.invoke(genericArraySize, genericArraySize);
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object assortedValueWithLongAlignment = createAssorted(makeAssortedValueWithLongAlignment, typeWithLongAlignmentFields);
+				Array.set(Array.get(assortedValueWithLongAlignmentArray,i),j, assortedValueWithLongAlignment);
+			}
+		}
+		for (int i = 0; i < genericArraySize; i++) {
+			for (int j = 0; j < genericArraySize; j++) {
+				Object assortedValueWithLongAlignmentObject = Array.get(Array.get(assortedValueWithLongAlignmentArray,i),j);
+				checkFieldAccessMHOfAssortedType(assortedValueWithLongAlignmentGetterAndWither, assortedValueWithLongAlignmentObject, typeWithLongAlignmentFields, true);
 			}
 		}
 	}


### PR DESCRIPTION
Create ValueType test to check that multiarrays made using
MULTIANEWARRAY bytecode and Array.newInstance() correctly
store flattened types. Added multianewarray creation for
Valuetypes.

Testing two paths:
- Using Array.instance()
- Using opcode for MULTIANEWARRAY

Tested following types:
- Point2D
- FlattenedLine2D
- Triangle2D
- AssortedValueWithLongAlginment

Temporarily disabled ValueTypeTests 1 and 2 due to array flattening
bug causing failures

Added support for multianewarray bytecode operation on Q types by
modifying the interalFindArrayClass method in classsupport.c.

Related to: https://github.com/eclipse/openj9/issues/10077

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>