### PR TITLE
AArch64: Change instruction class to use new method for bookkeeping register use count

### DIFF
--- a/runtime/compiler/aarch64/codegen/Instruction.hpp
+++ b/runtime/compiler/aarch64/codegen/Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,7 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
       {
       self()->setDependencyConditions(cond);
       if (cond)
-         cond->incRegisterTotalUseCounts(cg);
+         cond->bookKeepingRegisterUses(self(), cg);
       }
 
    /**
@@ -88,7 +88,7 @@ class OMR_EXTENSIBLE Instruction : public J9::InstructionConnector
       {
       self()->setDependencyConditions(cond);
       if (cond)
-         cond->incRegisterTotalUseCounts(cg);
+         cond->bookKeepingRegisterUses(self(), cg);
       }
 
    };


### PR DESCRIPTION
This commit changes instruction class to use `bookKeeptingRegisterUses`
method of register dependency class instead of `incRegisterTotalUseCount`.

Depends on https://github.com/eclipse/omr/pull/5385

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>