### PR TITLE
Add missing break statement for case BCV_ERR_BYTECODE_ERROR

### DIFF
--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -942,6 +942,7 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 		break;
 	case BCV_ERR_BYTECODE_ERROR:
 		printMessage(&msgBuf, "Error exists in the bytecode.");
+		break;
 	default:
 		Assert_VRB_ShouldNeverHappen();
 		break;


### PR DESCRIPTION
`break` statement is missing from the `BCV_ERR_BYTECODE_ERROR` case in runtime/verbose/errormessageframeworkrtv.c.

This was missing from: https://github.com/eclipse/openj9/pull/9660