### PR TITLE
Relax condition to require no exclusive VM access when generating jitdump

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7462,6 +7462,14 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
          }
       }
 
+   if (_compiler)
+      {
+      // The KOT needs to survive at least until we're done committing virtual guards and we must not be holding the
+      // comp monitor prior to freeing the KOT because it requires VM access.
+      if (_compiler->getKnownObjectTable())
+         _compiler->freeKnownObjectTable();
+      }
+
    // Re-acquire the compilation monitor so that we can update the J9Method.
    //
    _compInfo.debugPrint(vmThread, "\tacquiring compilation monitor\n");
@@ -7656,11 +7664,6 @@ TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread * vmThread,
 
    if (_compiler)
       {
-      // The KOT needs to survive at least until we're done committing virtual guards
-      //
-      if (_compiler->getKnownObjectTable())
-         _compiler->freeKnownObjectTable();
-
       _compiler->~Compilation();
       }
 
@@ -7862,6 +7865,8 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
 #endif /* defined(J9VM_OPT_JITSERVER) */
       if (getCompilation())
          {
+         // The KOT needs to survive at least until we're done committing virtual guards and we must not be holding the
+         // comp monitor prior to freeing the KOT because it requires VM access.
          if (getCompilation()->getKnownObjectTable())
             getCompilation()->freeKnownObjectTable();
 
@@ -8654,6 +8659,8 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
 
       if (compiler)
          {
+         // The KOT needs to survive at least until we're done committing virtual guards and we must not be holding the
+         // comp monitor prior to freeing the KOT because it requires VM access.
          if (compiler->getKnownObjectTable())
             compiler->freeKnownObjectTable();
 

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -451,17 +451,7 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
          }
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
-
-   // if some thread holds exclusive VM access we cannot do much
-   if (J9_XACCESS_NONE != jitConfig->javaVM->exclusiveAccessState)
-      {
-      jitDumpFailedBecause(crashedThread, "some thread is holding exclusive VM access");
-      trfprintf(logFile, "Some thread is holding exclusive VM access. No log created.\n");
-      trfclose(logFile);
-      return OMR_ERROR_NONE;
-      }
-
-
+   
    // to avoid deadlock, release compilation monitor until we are no longer holding it
    while (compInfo->getCompilationMonitor()->owned_by_self())
       compInfo->releaseCompMonitor(crashedThread);

--- a/runtime/compiler/control/JitDump.cpp
+++ b/runtime/compiler/control/JitDump.cpp
@@ -28,6 +28,7 @@
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
 #include "env/ut_j9jit.h"
+#include "env/VMAccessCriticalSection.hpp"
 #include "ilgen/J9ByteCodeIlGenerator.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/JITServerHelpers.hpp"
@@ -656,6 +657,13 @@ runJitdump(char *label, J9RASdumpContext *context, J9RASdumpAgent *agent)
                void *oldStartPC = 0;
                if (currentMethodBeingCompiled)
                   oldStartPC = currentMethodBeingCompiled->_oldStartPC;
+
+               // The current thread is a compilation thread which may or may not currently hold VM access. The request
+               // for recompilation to generate the jitdump will be performed synchronously for which the code path we
+               // will take will be the same as if we were an application thread. We will take the synchronous request
+               // path in `compileOnSeparateThread` which ends up releasing VM access prior to waiting on the diagnostic
+               // thread to finish the queued compile. To avoid deadlocks we must acquire VM access here.
+               TR::VMAccessCriticalSection requestSynchronousCompilation(TR_J9VMBase::get(jitConfig, crashedThread));
 
                // request the compilation
                TR_CompilationErrorCode compErrCode;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -338,6 +338,9 @@ bool acquireVMaccessIfNeeded(J9VMThread *vmThread, TR_YesNoMaybe isCompThread)
                     heldMonitor, TR_J9VMBase::get(jitConfig, NULL)->getJ9MonitorName((J9ThreadMonitor*)heldMonitor->getVMMonitor()));
 #endif // #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 
+            TR_ASSERT_FATAL(!compInfo->getCompilationMonitor()->owned_by_self(),
+               "Current VM thread [%p] holds the comp monitor [%p] while attempting to acquire VM access", vmThread, compInfo->getCompilationMonitor());
+
             TR::Compilation *comp = compInfoPT->getCompilation();
             if ((comp && comp->getOptions()->realTimeGC()) ||
                  TR::Options::getCmdLineOptions()->realTimeGC())


### PR DESCRIPTION
This PR is a series of commits which addresses three different deadlocks described in #9136 following which we remove the restriction that jitdumps need to ensure no other thread is holding exclusive access. Each commit within this PR describes within the commit message the scenario which can be observed when we are in the deadlock state. These scenarios are further elaborated with code references in #9136.

Fixes: #9136