### PR TITLE
CMake: Set libpath for constgen on AIX

### DIFF
--- a/runtime/jilgen/CMakeLists.txt
+++ b/runtime/jilgen/CMakeLists.txt
@@ -20,6 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+if(OMR_OS_AIX)
+	# We need to set the libpath on aix, so that when we run constgen it can find
+	# the thread library
+	set(CMAKE_INSTALL_RPATH .)
+endif()
 j9vm_add_executable(constgen
     jilconsts.c
 )


### PR DESCRIPTION
Ensure that "." is in the libpath of constgen so that the thread library
can be located when it is executed. Note that is this is not needed in
the uma builds as CMake uses `-bnolibpath` by default on all targets,
where as in uma we only use `-bnolibpath` when building shared libraries

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>