### PR TITLE
AArch64: Do bookkeeping use count in J9::ARM64::MemoryReference::assignRegisters

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/aarch64/codegen/J9MemoryReference.cpp
@@ -23,6 +23,7 @@
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/MemoryReference.hpp"
+#include "codegen/Machine.hpp"
 #include "codegen/Relocation.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"
 
@@ -184,35 +185,20 @@ J9::ARM64::MemoryReference::assignRegisters(TR::Instruction *currentInstruction,
 
    if (baseRegister != NULL)
       {
-      if (baseRegister->decFutureUseCount() == 0)
-         {
-         baseRegister->setAssignedRegister(NULL);
-         assignedBaseRegister->setState(TR::RealRegister::Unlatched);
-         }
+      machine->decFutureUseCountAndUnlatch(currentInstruction, baseRegister);
       self()->setBaseRegister(assignedBaseRegister);
       }
 
    if (indexRegister != NULL)
       {
-      if (indexRegister->decFutureUseCount() == 0)
-         {
-         indexRegister->setAssignedRegister(NULL);
-         assignedIndexRegister->setState(TR::RealRegister::Unlatched);
-         }
+      machine->decFutureUseCountAndUnlatch(currentInstruction, indexRegister);
       self()->setIndexRegister(assignedIndexRegister);
       }
 
    if (extraRegister != NULL)
       {
-      if (extraRegister->decFutureUseCount() == 0)
-         {
-         extraRegister->setAssignedRegister(NULL);
-         assignedExtraRegister->setState(TR::RealRegister::Unlatched);
-         }
-      else
-         {
-         TR_ASSERT(false, "Unexpected future use count for extraReg");
-         }
+      machine->decFutureUseCountAndUnlatch(currentInstruction, extraRegister);
+      TR_ASSERT(extraRegister->getFutureUseCount() == 0, "Unexpected future use count for extraReg");
       self()->setExtraRegister(assignedExtraRegister);
       }
 


### PR DESCRIPTION
This commit changes `J9::ARM64::MemoryReference::assignRegisters` to
call `machine->decFutureUseCountAndUnlatch` which takes care of
use count of the register for OOL cases.

Depends on https://github.com/eclipse/omr/pull/5392

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>