### PR TITLE
Validate Class Chain of class of method being compiled

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7153,7 +7153,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
                   // If we can not inflate the method data, JIT compile the method.
                   canRelocateMethod = false;
                   *aotCachedMethod = NULL;
-                  entry->_doNotUseAotCodeFromSharedCache = false;
+                  entry->_doNotUseAotCodeFromSharedCache = true;
                   }
                else
                   {


### PR DESCRIPTION
Currently, the JIT assumes that if there is a method that can be loaded, which was acquired using the J9ROMMethod of the J9Method that the  VM requested a compilation of, then the J9Class of the method being compiled (henceforward referred to as the Root Class) must have the same layout as in the compile run. However, it is possible for the J9ROMClass of some super class of the Root Class to be modified on disk, such that the JVM has to load the new jar file, mark the old J9ROMClass of the super class in the SCC as stale, and add the new J9ROMClass (if there's space). If this happens, the J9ROMClass of the Root Class won't change, but the object whose type is the Root Class could now have its layout changed, in which case, the AOT code is no longer valid.

This PR addresses this problem by requiring the successful store of the class chain of the Root Class as a condition for eligibility for AOT compilation, and successful validation of the class chain as a condition to load the AOT method.

For posterity, one of the ways this issue manifests is the JIT'd code will be off by a few bytes when loading from the field of an object. The way to check if this problem is the cause of the bad load is

1. The object from which the field is being loaded should an instance of the class of the JIT'd method - if `A.foo()` is incorrectly loading a field from some object `obj`, `obj` must be of type `A`.
2. In `jdmpview`, use `!shrc findclass <class name>` on each class in the hierarchy to see if any class has been marked stale in a way that resulted in a new J9ROMClass being created - a J9ROMClass in the SCC could be marked stale if the class path changes, but a new J9ROMClass won't be created unless the layout also changes.

Fixes https://github.com/eclipse/openj9/issues/9710