### PR TITLE
(0.21.0) Fix Power ArrayCopyBNDCHK handling of negative constants

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -2488,7 +2488,7 @@ TR::Register *J9::Power::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node,
       {
       gcPoint = generateLabelInstruction(cg, TR::InstOpCode::bl, node, snippetLabel);
       }
-   else if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() <= UPPER_IMMED && firstChild->getRegister() == NULL)
+   else if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() >= LOWER_IMMED && firstChild->getInt() <= UPPER_IMMED && firstChild->getRegister() == NULL)
       {
       TR::Register *copyIndexReg = cg->evaluate(secondChild);
       if (noTrap)
@@ -2507,7 +2507,7 @@ TR::Register *J9::Power::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node,
    else
       {
       TR::Register *boundReg = cg->evaluate(firstChild);
-      if (secondChild->getOpCode().isLoadConst() && secondChild->getInt() <= UPPER_IMMED)
+      if (secondChild->getOpCode().isLoadConst() && secondChild->getInt() >= LOWER_IMMED && secondChild->getInt() <= UPPER_IMMED)
          {
          if (noTrap)
             {


### PR DESCRIPTION
Previously, the Power codegen's evaluator for ArrayCopyBNDCHK implicitly
assumed that neither of its children was a negative constant by failing
to check them against LOWER_IMMED when generating cmpi/twi instructions.
This could result in incorrect behaviour if exactly one of the children
is a constant which happens to be less than LOWER_IMMED. Prior to the
binary encoder refactor, this would result in the immediate being
silently truncated to 16 bits. This can cause the check to behave
incorrectly and can cause the bound check to pass when it shouldn't.

This has now been corrected by adding the necessary checks of constant
values against LOWER_IMMED.

Signed-off-by: Ben Thomas <ben@benthomas.ca>

Cherry pick of #10162 for the 0.21.0 release.