### PR TITLE
Add warning about using lastOptSubIndex in monitor elimination

### DIFF
--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -351,7 +351,11 @@ int32_t TR::MonitorElimination::perform()
 
    if (trace())
       {
-      traceMsg(comp(), "Starting Monitor Elimination for %s\n", comp()->signature());
+      traceMsg(
+         comp(),
+         "Starting Monitor Elimination for %s\n"
+         "Warning: limiting lastOptSubIndex in Monitor Elimination may leave monitors in an unbalanced state.\n",
+         comp()->signature());
       comp()->dumpMethodTrees("Trees before Monitor Elimination");
       }
 


### PR DESCRIPTION
While debugging another issue with monitor elimination, I was using the jit option `lastOptSubIndex` to try to narrow down the failing transformation. In doing so, I ran into `IllegalMonitorStateException`s which I spent some time trying to debug before I realized that they were actually bogus. In this commit I have added a warning message to the jit log so that other developers are aware of potential issues that may arise when debugging monitor elimination.

I will also note that there doesn't seem to be an easy way of fixing this behaviour without coarsening the places where `performTransformation` is called in monitor elimination.

Since monitor elimination removes one monitor at a time, limiting the number of
transformations it does may lead to an unbalanced state where some monenter
nodes have been eliminated while the corresponding monexit nodes remain.
This can cause an IllegalMonitorStateException.

This commit adds a warning message in the jit log.

Signed-off-by: Ryan Shukla <ryans@ibm.com>