### PR TITLE
Part 2: JEP 360 Sealed Classes

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1980,3 +1980,21 @@ J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.explanation=The two command line opt
 J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.system_action=The JVM will terminate while processing the command line options.
 J9NLS_VM_INCOMPATIBLE_CMDLINE_OPTIONS_ERROR.user_response=Remove one of the incompatible command line options in order to resolve the issue.
 # END NON-TRANSLATABLE
+
+# Message to use when class is not permitted in PermittedSubclasses attribute of sealed super class
+# argument 1 is the class name
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDCLASS=class %2$.*1$s is not permitted to inherit from its sealed super class.
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDCLASS.explanation=The specified class is not permitted to extend its sealed super class.
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDCLASS.system_action=The JVM will throw an IncompatibleClassChangeError.
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDCLASS.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Message to use when class is not permitted in PermittedSubclasses attribute of sealed super interface
+# argument 1 is the class name,
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDINTERFACE=class %2$.*1$s is not permitted to inherit from its sealed super interface.
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDINTERFACE.explanation=The specified class is not permitted to extend its sealed super interface.
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDINTERFACE.system_action=The JVM will throw an IncompatibleClassChangeError.
+J9NLS_VM_CLASS_LOADING_ERROR_CLASS_NOT_PERMITTED_BY_SEALEDINTERFACE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -795,3 +795,6 @@ TraceEvent=Trc_VM_GetCompleteNPEMessage_MissedBytecode Overhead=1 Level=1 Templa
 TraceExit=Trc_VM_GetCompleteNPEMessage_Exit Overhead=1 Level=3 Template="GetCompleteNPEMessage - npeMsg (%s)"
 
 TraceException=Trc_VM_CreateRAMClassFromROMClass_circularity2 noEnv Overhead=1 Level=1 Template="Class loading circularity detected"
+
+TraceException=Trc_VM_CreateRAMClassFromROMClass_classIsNotPermittedBySealedSuperclass Overhead=1 Level=1 Template="Superclass (RAM class=%p) does not include %.*s in PermittedSubclasses list"
+TraceException=Trc_VM_CreateRAMClassFromROMClass_classIsNotPermittedBySealedSuperinterface Overhead=1 Level=1 Template="Superinterface (RAM class=%p) does not include %.*s in PermittedSubclasses list"

--- a/test/functional/Java15andUp/build.xml
+++ b/test/functional/Java15andUp/build.xml
@@ -55,6 +55,7 @@
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>
+				<pathelement location="${LIB_DIR}/asm.jar" />
 				<pathelement location="${build}" />
 			</classpath>
 		</javac>

--- a/test/functional/Java15andUp/playlist.xml
+++ b/test/functional/Java15andUp/playlist.xml
@@ -29,7 +29,7 @@
             <variation>--enable-preview</variation>
         </variations>
         <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-            -cp $(Q)$(LIB_DIR)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+            -cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
             org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Jep360Tests \
             -groups $(TEST_GROUP) \
             -excludegroups $(DEFAULT_EXCLUDE); \

--- a/test/functional/Java15andUp/src/org/openj9/test/sealedclasses/SealedClassesTests.java
+++ b/test/functional/Java15andUp/src/org/openj9/test/sealedclasses/SealedClassesTests.java
@@ -1,0 +1,68 @@
+package org.openj9.test.sealedclasses;
+
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.Test;
+
+import org.openj9.test.utilities.CustomClassLoader;
+import org.openj9.test.utilities.SealedClassGenerator;
+
+/* JEP 360 sealed classes VM tests */
+
+@Test(groups = { "level.sanity" })
+public class SealedClassesTests {
+    private String name = "TestIllegalSealedClass";
+
+    /* sealed classes cannot be final */
+    @Test(expectedExceptions = java.lang.ClassFormatError.class)
+    public void test_sealedClassesCannotBeFinal() {
+        CustomClassLoader classloader = new CustomClassLoader();
+        byte[] bytes = SealedClassGenerator.generateFinalSealedClass(name);
+        Class<?> clazz = classloader.getClass(name, bytes);
+    }
+
+    /* Class declarations for classloading tests */
+    sealed class TestClassSealed permits TestSubclass {}
+    non-sealed class TestSubclass extends TestClassSealed {}
+
+    /* ClassLoading: a class cannot extend a sealed superclass if it is
+     * not named in the superclasses PermittedSubclasses list. */
+    @Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class)
+    public void test_loadIllegalSubclassOfSealedClass() {
+        CustomClassLoader classloader = new CustomClassLoader();
+        byte[] bytes = SealedClassGenerator.generateSubclassIllegallyExtendingSealedSuperclass(name, TestClassSealed.class);
+        Class<?> clazz = classloader.getClass(name, bytes);
+    }
+
+    sealed interface TestInterfaceSealed permits TestSubinterface {}
+    non-sealed interface TestSubinterface extends TestInterfaceSealed {}
+
+    /* ClassLoading: an interface cannot extend a sealed superinterface if it is
+     * not named in the superinterfaces PermittedSubclasses list. */
+    @Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class)
+    public void test_loadIllegalSubinterfaceOfSealedInterface() {
+        CustomClassLoader classloader = new CustomClassLoader();
+        byte[] bytes = SealedClassGenerator.generateSubinterfaceIllegallyExtendingSealedSuperinterface(name, TestInterfaceSealed.class);
+        Class<?> clazz = classloader.getClass(name, bytes);
+    }
+}

--- a/test/functional/Java15andUp/src/org/openj9/test/utilities/CustomClassLoader.java
+++ b/test/functional/Java15andUp/src/org/openj9/test/utilities/CustomClassLoader.java
@@ -1,0 +1,29 @@
+package org.openj9.test.utilities;
+
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public class CustomClassLoader extends ClassLoader {
+	public Class<?> getClass(String name, byte[] bytes){
+		return defineClass(name, bytes, 0, bytes.length);
+	}
+}

--- a/test/functional/Java15andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
+++ b/test/functional/Java15andUp/src/org/openj9/test/utilities/SealedClassGenerator.java
@@ -1,0 +1,58 @@
+package org.openj9.test.utilities;
+
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+ import org.objectweb.asm.*;
+
+ public class SealedClassGenerator implements Opcodes {
+    private static String dummySubclassName = "TestSubclass";
+
+    public static byte[] generateFinalSealedClass(String className) {
+        int accessFlags = ACC_FINAL | ACC_SUPER;
+
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        cw.visit(V15 | V_PREVIEW, accessFlags, className, null, "java/lang/Object", null);
+
+        /* Sealed class must have a PermittedSubclasses attribute */
+        cw.visitPermittedSubclass(dummySubclassName);
+
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    public static byte[] generateSubclassIllegallyExtendingSealedSuperclass(String className, Class<?> superClass) {
+        String superName = superClass.getName().replace('.', '/');
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        cw.visit(V15 | V_PREVIEW, ACC_SUPER, className, null, superName, null);
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    public static byte[] generateSubinterfaceIllegallyExtendingSealedSuperinterface(String className, Class<?> superInterface) {
+        String[] interfaces = { superInterface.getName().replace('.', '/') };
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        cw.visit(V15 | V_PREVIEW, ACC_SUPER, className, null, "java/lang/Object", interfaces);
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+ }

--- a/test/functional/Java15andUp/testng.xml
+++ b/test/functional/Java15andUp/testng.xml
@@ -27,6 +27,7 @@
     <test name="Jep360Tests">
         <classes>
             <class name="org.openj9.test.java.lang.Test_Class"/>
+            <class name="org.openj9.test.sealedclasses.SealedClassesTests"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
related to: #9626

Class loading restrictions and tests for JEP 360. JVM should throw an IncompatibleClassChangeError if a class that inherits from a sealed superclass/interface is not listed in its PermittedSubclasses attribute.

Signed-off-by: Theresa Mammarella Theresa.T.Mammarella@ibm.com