### PR TITLE
Add NULL check for JNIC_JMETHODID & JNIC_JFIELDID

### DIFF
--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -587,12 +587,18 @@ jniCheckArgs(const char *function, int exceptionSafe, int criticalSafe, J9JniChe
 
 		case JNIC_JMETHODID:
 			aJmethodID = va_arg(va, jmethodID);
+			if (NULL == aJmethodID) {
+				jniCheckFatalErrorNLS(env, J9NLS_JNICHK_NULL_ARGUMENT, function, argNum);
+			}
 			if (trace) {
 				jniTraceMethodID(env, aJmethodID);
 			}
 			break;
 		case JNIC_JFIELDID:
 			aJfieldID = va_arg(va, jfieldID);
+			if (NULL == aJfieldID) {
+				jniCheckFatalErrorNLS(env, J9NLS_JNICHK_NULL_ARGUMENT, function, argNum);
+			}
 			if (trace) {
 				jniTraceFieldID(env, aJfieldID);
 			}


### PR DESCRIPTION
Added `NULL` check for `JNIC_JMETHODID` & `JNIC_JFIELDID`.

With this PR, now the testcase from #10183 has following output:
```
JVMJNCK031E JNI error in CallBooleanMethod/CallBooleanMethodV: Argument #3 is NULL
JVMJNCK077E Error detected in HelloJNI.sayHello()I

JVMJNCK024E JNI error detected. Aborting.
JVMJNCK025I Use -Xcheck:jni:nonfatal to continue running when errors are detected.

Fatal error: JNI error
```

fixes: #10183 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>