### PR TITLE
Move verifyQualifiedName to internalFindClassString

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -556,7 +556,8 @@ JVM_FindLoadedClass(JNIEnv* env, jobject classLoader, jobject className)
 			NULL,
 			J9_JNI_UNWRAP_REFERENCE(className),
 			vmClassLoader,
-			J9_FINDCLASS_FLAG_EXISTING_ONLY);
+			J9_FINDCLASS_FLAG_EXISTING_ONLY,
+			CLASSNAME_INVALID);
 done:
 	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5753,7 +5753,7 @@ JVM_DefineClassWithSource(JNIEnv *env, const char * className, jobject classLoad
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
-	if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(classNameString))) {
+	if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(classNameString), CLASSNAME_VALID)) {
 		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (UDATA *)*(j9object_t*)classNameString);
 		vmFuncs->internalExitVMToJNI(currentThread);
 		return NULL;

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -48,7 +48,7 @@ Java_java_lang_ClassLoader_defineClassImpl(JNIEnv *env, jobject receiver, jstrin
 	if (NULL != className) {
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 
-		if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(className))) {
+		if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(className), CLASSNAME_VALID)) {
 			/*
 			 * We don't yet know if the class being defined is exempt. Setting this option tells
 			 * defineClassCommon() to fail if it discovers that the class is not exempt. That failure

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -41,9 +41,11 @@
 #define J9VM_OBJECT_MONITOR_CACHE_SIZE  32
 #define J9VM_ASYNC_MAX_HANDLERS 32
 
+/* The bit fields used by verifyQualifiedName to verify a qualified class name */
 #define CLASSNAME_INVALID			0
-#define CLASSNAME_VALID_NON_ARRARY	1
-#define CLASSNAME_VALID_ARRARY		2
+#define CLASSNAME_VALID_NON_ARRARY	0x1
+#define CLASSNAME_VALID_ARRARY		0x2
+#define CLASSNAME_VALID				(CLASSNAME_VALID_NON_ARRARY | CLASSNAME_VALID_ARRARY)
 
 /* @ddr_namespace: map_to_type=J9JITDataCacheConstants */
 
@@ -4233,7 +4235,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *internalExceptionDescribe)(struct J9VMThread* vmStruct) ;
 	struct J9Class*  ( *internalFindClassUTF8)(struct J9VMThread *currentThread, U_8 *className, UDATA classNameLength, struct J9ClassLoader *classLoader, UDATA options) ;
 	struct J9Class*  ( *internalFindClassInModule)(struct J9VMThread *currentThread, struct J9Module *j9module, U_8 *className, UDATA classNameLength, struct J9ClassLoader *classLoader, UDATA options) ;
-	struct J9Class*  ( *internalFindClassString)(struct J9VMThread* currentThread, j9object_t moduleName, j9object_t className, struct J9ClassLoader* classLoader, UDATA options) ;
+	struct J9Class*  ( *internalFindClassString)(struct J9VMThread* currentThread, j9object_t moduleName, j9object_t className, struct J9ClassLoader* classLoader, UDATA options, UDATA allowedBitsForClassName) ;
 	struct J9Class*  ( *hashClassTableAt)(struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength) ;
 	UDATA  ( *hashClassTableAtPut)(struct J9VMThread *vmThread, struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength, struct J9Class *value) ;
 	UDATA  ( *hashClassTableDelete)(struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength) ;
@@ -4423,7 +4425,7 @@ typedef struct J9InternalVMFunctions {
 	UDATA  ( *compareStrings)(struct J9VMThread * vmThread, j9object_t string1, j9object_t string2) ;
 	UDATA  ( *compareStringToUTF8)(struct J9VMThread * vmThread, j9object_t stringObject, UDATA stringFlags, const U_8 * utfData, UDATA utfLength) ;
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
-	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
+	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string, UDATA allowedBitsForClassName) ;
 	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, UDATA stringOffset, UDATA stringLength, U_8 *utf8Data, UDATA utf8DataLength);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -356,12 +356,14 @@ internalCreateArrayClass(J9VMThread* vmThread, J9ROMArrayClass* romClass, J9Clas
  * @param className String object representing name of the class to load
  * @param classLoader J9ClassLoader to use
  * @param options load options such as J9_FINDCLASS_FLAG_EXISTING_ONLY
+ * @param allowedBitsForClassName the allowed bits for a valid class name,
+ *        including CLASSNAME_INVALID, CLASSNAME_VALID_NON_ARRARY, CLASSNAME_VALID_ARRARY, or CLASSNAME_VALID.
  * 
  * @return pointer to J9Class if success, NULL if fail
  *
  */
 J9Class*  
-internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9object_t className, J9ClassLoader* classLoader, UDATA options);
+internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9object_t className, J9ClassLoader* classLoader, UDATA options, UDATA allowedBitsForClassName);
 
 /**
  * Load the class with the specified name in the given module.
@@ -3115,10 +3117,13 @@ getStringUTF8Length(J9VMThread *vmThread,j9object_t string);
 *
 * @param[in] *vmThread current thread
 * @param[in] string the class name string
+* @param[in] allowedBitsForClassName the allowed bits for a valid class name,
+*            including CLASSNAME_VALID_NON_ARRARY, CLASSNAME_VALID_ARRARY, or CLASSNAME_VALID.
+*
 * @return a UDATA to indicate the nature of incoming class name string, see descriptions above.
 */
 UDATA
-verifyQualifiedName(J9VMThread *vmThread, j9object_t string);
+verifyQualifiedName(J9VMThread *vmThread, j9object_t string, UDATA allowedBitsForClassName);
 
 
 /* ---------------- swalk.c ---------------- */

--- a/runtime/vm/FastJNI_com_ibm_oti_vm_VM.cpp
+++ b/runtime/vm/FastJNI_com_ibm_oti_vm_VM.cpp
@@ -47,17 +47,18 @@ Fast_java_lang_VMAccess_findClassOrNull(J9VMThread *currentThread, j9object_t cl
 		} else {
 			loader = vm->systemClassLoader;
 		}
-		if (CLASSNAME_VALID_NON_ARRARY == verifyQualifiedName(currentThread, className)) {
-			j9Class = internalFindClassString(currentThread, NULL, className, loader, J9_FINDCLASS_FLAG_USE_LOADER_CP_ENTRIES);
-			if (VM_VMHelpers::exceptionPending(currentThread)) {
-				J9Class *exceptionClass = J9VMJAVALANGCLASSNOTFOUNDEXCEPTION(vm);
-				/* If the current exception is ClassNotFoundException, discard it. */
-				if (exceptionClass == J9OBJECT_CLAZZ(currentThread, currentThread->currentException)) {
-					VM_VMHelpers::clearException(currentThread);
-				}
-			} else {
-				classObject = J9VM_J9CLASS_TO_HEAPCLASS(j9Class);
+
+		j9Class = internalFindClassString(currentThread, NULL, className, loader,
+											J9_FINDCLASS_FLAG_USE_LOADER_CP_ENTRIES,
+											CLASSNAME_VALID_NON_ARRARY);
+		if (VM_VMHelpers::exceptionPending(currentThread)) {
+			J9Class *exceptionClass = J9VMJAVALANGCLASSNOTFOUNDEXCEPTION(vm);
+			/* If the current exception is ClassNotFoundException, discard it. */
+			if (exceptionClass == J9OBJECT_CLAZZ(currentThread, currentThread->currentException)) {
+				VM_VMHelpers::clearException(currentThread);
 			}
+		} else {
+			classObject = J9VM_J9CLASS_TO_HEAPCLASS(j9Class);
 		}
 	}
 	return classObject;

--- a/runtime/vm/FastJNI_java_lang_Class.cpp
+++ b/runtime/vm/FastJNI_java_lang_Class.cpp
@@ -87,20 +87,14 @@ Fast_java_lang_Class_forNameImpl(J9VMThread *currentThread, j9object_t className
 		}
 	}
 
-	/* Make sure the name is legal */
-	if (CLASSNAME_INVALID == verifyQualifiedName(currentThread, classNameObject)) {
-		goto throwCNFE;
-	}
-
 	/* Find the class */
 	PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, classNameObject);
-	foundClass = internalFindClassString(currentThread, NULL, classNameObject, classLoader, 0);
+	foundClass = internalFindClassString(currentThread, NULL, classNameObject, classLoader, 0, CLASSNAME_VALID);
 	classNameObject = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 
 	if (NULL == foundClass) {
 		/* Not found - if no exception is pending, throw ClassNotFoundException */
 		if (NULL == currentThread->currentException) {
-throwCNFE:
 			setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGCLASSNOTFOUNDEXCEPTION, (UDATA*)classNameObject);
 		}
 		goto done;

--- a/runtime/vm/FastJNI_java_lang_ClassLoader.cpp
+++ b/runtime/vm/FastJNI_java_lang_ClassLoader.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,11 +35,11 @@ Fast_java_lang_Classloader_findLoadedClassImpl(J9VMThread *currentThread, j9obje
 	if (NULL != className) {
 		J9ClassLoader *loader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, classloaderObject);
 		if (NULL != loader) {
-			if (CLASSNAME_INVALID != verifyQualifiedName(currentThread, className)) {
-				J9Class *j9Class = internalFindClassString(currentThread, NULL, className, loader, J9_FINDCLASS_FLAG_EXISTING_ONLY);
-				/* macro handles NULL */
-				resultObject = J9VM_J9CLASS_TO_HEAPCLASS(j9Class);
-			}
+			J9Class *j9Class = internalFindClassString(currentThread, NULL, className, loader,
+														J9_FINDCLASS_FLAG_EXISTING_ONLY,
+														CLASSNAME_VALID);
+			/* macro handles NULL */
+			resultObject = J9VM_J9CLASS_TO_HEAPCLASS(j9Class);
 		}
 	}
 	return resultObject;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -371,7 +371,7 @@ getStringUTF8Length(J9VMThread *vmThread, j9object_t string)
 }
 
 UDATA 
-verifyQualifiedName(J9VMThread *vmThread, j9object_t string)
+verifyQualifiedName(J9VMThread *vmThread, j9object_t string, UDATA allowedBitsForClassName)
 {
 	UDATA unicodeLength = J9VMJAVALANGSTRING_LENGTH(vmThread, string);
 	j9object_t unicodeBytes = J9VMJAVALANGSTRING_VALUE(vmThread, string);
@@ -382,6 +382,7 @@ verifyQualifiedName(J9VMThread *vmThread, j9object_t string)
 	U_8 currentChar = 0;
 	IDATA arity = 0;
 	UDATA i = 0;
+	UDATA result = CLASSNAME_INVALID;
 
 	/* strip leading ['s for array classes */
 	for (i = 0; i < unicodeLength; i++) {
@@ -450,11 +451,14 @@ verifyQualifiedName(J9VMThread *vmThread, j9object_t string)
 	 */
 	if (arity < 0) {
 		return CLASSNAME_INVALID;
-	} else if (0 == arity) {
-		return CLASSNAME_VALID_NON_ARRARY;
-	} else {
-		return CLASSNAME_VALID_ARRARY;
 	}
+
+	result = (0 == arity) ? CLASSNAME_VALID_NON_ARRARY : CLASSNAME_VALID_ARRARY;
+	if (J9_ARE_ANY_BITS_SET(result, allowedBitsForClassName)) {
+		return result;
+	}
+
+	return CLASSNAME_INVALID;
 }
 
 /**


### PR DESCRIPTION
The intention is to move verifyQualifiedName to internalFindClassString
so as to call hashClassTableAtString before verifyQualifiedName
to avoid verifying duplicate classes.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>