### PR TITLE
Fix incorrect superclass processRelocations() call

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2875,7 +2875,7 @@ J9::CodeGenerator::processRelocations()
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->comp()->fe());
 
    //Project neutral non-AOT processRelocation
-   OMR::CodeGenerator::processRelocations();
+   OMR::CodeGeneratorConnector::processRelocations();
 
    int32_t missedSite = -1;
 


### PR DESCRIPTION
Currently, the J9::CodeGenerator class overrides the parent class's
processRelocations() method, adding extra AOT functionality while also
calling OMR::CodeGenerator::processRelocations. However, there are plans
to override processRelocations in OMR::Power::CodeGenerator. Under the
current implementation, this overridden version will never be called and
will be bypassed to call OMR::CodeGenerator's method instead.

Signed-off-by: Ben Thomas <ben@benthomas.ca>