### PR TITLE
Fix client UUID printing in verbose log

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2130,8 +2130,8 @@ J9::Options::setupJITServerOptions()
          TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "JITServer Client Mode. Server address: %s port: %d. Connection Timeout %ums",
                persistentInfo->getJITServerAddress().c_str(), persistentInfo->getJITServerPort(),
                persistentInfo->getSocketTimeout());
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Identifier for current client JVM: %" OMR_PRIu64 "\n",
-               compInfo->getPersistentInfo()->getClientUID());
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Identifier for current client JVM: %llu\n",
+               (unsigned long long) compInfo->getPersistentInfo()->getClientUID());
          }
       }
 


### PR DESCRIPTION
On the client-side, the uuid appeared truncated
to 32 bits, as described in #9962.
This is due to custom OMR print function and `PRI`
format specifiers not interacting correctly.
Fix it by using `%llu` specifier instead of `%OMR_PRIu64`.