### PR TITLE
Exclude cmdLineTester_libpathTestRtf on zos

### DIFF
--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2019 IBM Corp. and others
+  Copyright (c) 2016, 2020 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3787 -->
-		<platformRequirements>bits.64,vm.cmprssptrs,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,vm.cmprssptrs,^os.osx,^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
The test fails due to unavailability of a X11 server.

`Can't connect to X11 window server using ':0.0' as the value of the
DISPLAY variable`

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>