### PR TITLE
Explicitly check for PERSONAL_BUILD string true

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -718,7 +718,7 @@ def set_test_misc() {
 
 def set_slack_channel() {
     SLACK_CHANNEL = params.SLACK_CHANNEL
-    if (!SLACK_CHANNEL && (!params.PERSONAL_BUILD || params.PERSONAL_BUILD != 'true')) {
+    if (!SLACK_CHANNEL && !params.PERSONAL_BUILD.equalsIgnoreCase('true')) {
         SLACK_CHANNEL = VARIABLES.slack_channel
     }
 }
@@ -875,7 +875,7 @@ def set_build_identifier() {
         if (params.ghprbPullId && params.ghprbGhRepository) {
             // If Pull Request build
             BUILD_IDENTIFIER = params.ghprbGhRepository + '#' + params.ghprbPullId
-        } else if (PERSONAL_BUILD) {
+        } else if (PERSONAL_BUILD.equalsIgnoreCase('true')) {
             // If Personal build
             wrap([$class: 'BuildUser']) {
                 BUILD_IDENTIFIER = "${BUILD_USER_EMAIL}"

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -304,7 +304,7 @@ try {
 
                     SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 
-                    if (PERSONAL_BUILD) {
+                    if (PERSONAL_BUILD.equalsIgnoreCase('true')) {
                         // update build description
                         currentBuild.description += "<br/>${PLATFORMS}"
                     }


### PR DESCRIPTION
- All instances of PERSONAL_BUILD assume type string.
  These two cases have been working up until now
  based on the use cases that it is either not
  set or it is set to blank. We have a new use case
  where we set it to false (string) which doesn't
  satisfy this if condition. Explicitly checking
  if PERSONAL_BUILD is equal to string true will
  solve this.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>