### PR TITLE
Move lowering of ArrayStoreCHK to lowerTreesPreChildrenVisit

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -88,8 +88,6 @@ private:
 
    void lowerArrayStoreCHK(TR::Node *node, TR::TreeTop *tt);
 
-   void findArrayStoreCHKOperands(TR::Node *node, TR::Node *&destination, TR::Node *&source);
-
 public:
 
    bool collectSymRefs(TR::Node *node, TR_BitVector *symRefs, vcount_t secondVisitCount);


### PR DESCRIPTION
Lowering of `ArrayStoreCHK` depends on its source and destination operands.  However, compression/decompression of those child operands might be performed by lowering afterwards, leaving the lowered `ArrayStoreCHK` trees in an incomplete state.

Fixed this by moving the call to `lowerArrayStoreCHK` into `lowerTreesPreChildrenVisit`, to ensure compression sequences are generated afterwards.  This also eliminates the need for the `findArrayStoreCHKOperands` method, which was attempting to perform pattern matching of the ArrayStoreCHK tree after compression/decompression had been applied to its operands.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>