### PR TITLE
Use unchecked version of addExceptionEdge in monitor elimination

### DIFF
--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4526,7 +4526,7 @@ void TR::MonitorElimination::addCatchBlocks()
                }
 
             firstTime = false;
-            cfg->addExceptionEdge(block, catchBlock);
+            cfg->addExceptionEdgeUnchecked(block, catchBlock);
             if (trace())
                traceMsg(comp(), "Added edge from block_%d to catch block_%d\n", block->getNumber(), catchBlock->getNumber());
 


### PR DESCRIPTION
See: #9754

This commit fixes a bug in monitor elimination where a new exception edge was
not properly created, resulting in uncaught exceptions.

Monitor elimination attempted to use `OMR::CFG::addExceptionEdge` to create an
exception edge before removing an existing one. However, the method
`OMR::CFG::addExceptionEdge` silently fails to create a new edge when one
already exists. This commit changes monitor elimination to use
`addExceptionEdgeUnchecked` which does not check for an existing edge.

Signed-off-by: Ryan Shukla <ryans@ibm.com>