### PR TITLE
Move verifyQualifiedName to jvmDefineClassHelper & defineClassCommon

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2555,9 +2555,15 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
 	if (NULL != className) {
-		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		j9object_t classNameObject = J9_JNI_UNWRAP_REFERENCE(className);
+		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, classNameObject, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+			goto done;
+		}
+
+		if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, classNameObject, CLASSNAME_VALID_NON_ARRARY)) {
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (UDATA *)*(j9object_t*)className);
 			goto done;
 		}
 	}

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5747,17 +5747,9 @@ JVM_DefineClassWithSource(JNIEnv *env, const char * className, jobject classLoad
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9ClassLoader* vmLoader;
 	j9object_t loaderObject;
-	jstring classNameString;
-
-	classNameString = (*env)->NewStringUTF(env,className);
+	jstring classNameString = (*env)->NewStringUTF(env,className);
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
-
-	if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(classNameString), CLASSNAME_VALID)) {
-		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (UDATA *)*(j9object_t*)classNameString);
-		vmFuncs->internalExitVMToJNI(currentThread);
-		return NULL;
-	}
 
 	loaderObject = J9_JNI_UNWRAP_REFERENCE(classLoader);
 	vmLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, loaderObject);
@@ -5769,6 +5761,7 @@ JVM_DefineClassWithSource(JNIEnv *env, const char * className, jobject classLoad
 		}
 	}
 	vmFuncs->internalExitVMToJNI(currentThread);
+
 	return jvmDefineClassHelper(env, classLoader, classNameString, (jbyte*)classArray, 0, length, domain, 0);
 }
 

--- a/runtime/jcl/common/proxy.c
+++ b/runtime/jcl/common/proxy.c
@@ -88,7 +88,7 @@ static jclass proxyDefineClass(
 		defineClassOptions |= J9_FINDCLASS_FLAG_UNSAFE;
 	}
 #endif /* JAVA_SPEC_VERSION == 8 */
-	return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, defineClassOptions, NULL, NULL);
+	return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, &defineClassOptions, NULL, NULL, FALSE);
 }
 
 jclass JNICALL Java_java_lang_reflect_Proxy_defineClassImpl(JNIEnv * env, jclass recvClass, jobject classLoader, jstring className, jbyteArray classBytes)
@@ -119,7 +119,7 @@ Java_java_lang_reflect_Proxy_defineClass0__Ljava_lang_ClassLoader_2Ljava_lang_St
 			defineClassOptions |= J9_FINDCLASS_FLAG_UNSAFE;
 		}
 #endif /* JAVA_SPEC_VERSION == 8 */
-		return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, defineClassOptions, NULL, NULL);
+		return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, &defineClassOptions, NULL, NULL, FALSE);
 	}
 }
 

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -49,6 +49,7 @@ Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader
 	JNIEnv *env, jobject receiver, jstring className, jbyteArray classRep, jint offset, jint length, jobject classLoader, jobject protectionDomain)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
+	UDATA defineClassOptions = J9_FINDCLASS_FLAG_UNSAFE;
 
 	if (NULL == classLoader) {
 		J9JavaVM *vm = currentThread->javaVM;
@@ -62,7 +63,7 @@ Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader
 		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
-	return defineClassCommon(env, classLoader, className, classRep, offset, length, protectionDomain, J9_FINDCLASS_FLAG_UNSAFE, NULL, NULL);
+	return defineClassCommon(env, classLoader, className, classRep, offset, length, protectionDomain, &defineClassOptions, NULL, NULL, FALSE);
 }
 
 jclass JNICALL
@@ -71,6 +72,7 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	UDATA defineClassOptions = (J9_FINDCLASS_FLAG_UNSAFE | J9_FINDCLASS_FLAG_ANON);
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	if (NULL == bytecodes) {
@@ -122,7 +124,7 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 	jsize length = env->GetArrayLength(bytecodes);
 
 	/* acquires access internally */
-	jclass anonClass = defineClassCommon(env, hostClassLoaderLocalRef, NULL,bytecodes, 0, length, protectionDomainLocalRef, J9_FINDCLASS_FLAG_UNSAFE | J9_FINDCLASS_FLAG_ANON, hostClazz, &cpPatchMap);
+	jclass anonClass = defineClassCommon(env, hostClassLoaderLocalRef, NULL,bytecodes, 0, length, protectionDomainLocalRef, &defineClassOptions, hostClazz, &cpPatchMap, FALSE);
 	if (env->ExceptionCheck()) {
 		return NULL;
 	} else if (NULL == anonClass) {

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -711,7 +711,7 @@ UDATA initializeRequiredClasses(J9VMThread *vmThread, char* libName);
 /* J9SourceJclDefineClass*/
 extern J9_CFUNC jclass 
 defineClassCommon (JNIEnv *env, jobject classLoaderObject,
-	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA options, J9Class *hostClass, J9ClassPatchMap *patchMap);
+	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA *options, J9Class *hostClass, J9ClassPatchMap *patchMap, BOOLEAN validateName);
 
 /* BBjclNativesCommonAccessController*/
 jboolean JNICALL Java_java_security_AccessController_initializeInternal (JNIEnv *env, jclass thisClz);


### PR DESCRIPTION
The intention is to move verifyQualifiedName to jvmDefineClassHelper &
defineClassCommon in order to share the memory allocated by
copyStringToUTF8WithMemAlloc for the class name string later.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>