### PR TITLE
Fix static field cycle value tests

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -78,13 +78,16 @@ public class ValueTypeGenerator extends ClassLoader {
 			}
 			fv = cw.visitField(fieldModifiers, nameAndSigValue[0], nameAndSigValue[1], null, null);
 			fv.visitEnd();
-			makeValueSig += nameAndSigValue[1];
-			makeValueGenericSig += "Ljava/lang/Object;";
-			if (nameAndSigValue[1].equals("J") || nameAndSigValue[1].equals("D")) {
-				makeMaxLocal += 2;
-			} else {
-				makeMaxLocal += 1;
+			if ((nameAndSigValue.length <= 2) || !nameAndSigValue[2].equals("static")) {
+				makeValueSig += nameAndSigValue[1];
+				makeValueGenericSig += "Ljava/lang/Object;";
+				if (nameAndSigValue[1].equals("J") || nameAndSigValue[1].equals("D")) {
+					makeMaxLocal += 2;
+				} else {
+					makeMaxLocal += 1;
+				}
 			}
+
 			generateFieldMethods(cw, nameAndSigValue, className, isVerifiable, isRef);
 		}
 		
@@ -389,49 +392,51 @@ public class ValueTypeGenerator extends ClassLoader {
 		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, methodName, "(" + makeValueGenericSig + ")Ljava/lang/Object;", null, new String[] {"java/lang/Exception"});
 		mv.visitCode();
 		for (int i = 0; i <  fields.length; i++) {
-			mv.visitVarInsn(ALOAD, i);
 			String nameAndSigValue[] = fields[i].split(":");
-			switch (nameAndSigValue[1]) {
-			case "D":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Double");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()D", false);
-				break;
-			case "I":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Integer");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Integer", "intValue", "()I", false);
-				break;
-			case "Z":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Boolean");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z", false);
-				break;
-			case "B":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Byte");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Byte", "byteValue", "()B", false);
-				break;
-			case "C":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Character");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Character", "charValue", "()C", false);
-				break;
-			case "S":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Short");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Short", "shortValue", "()S", false);
-				break;
-			case "F":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Float");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Float", "floatValue", "()F", false);
-				break;
-			case "J":
-				mv.visitTypeInsn(CHECKCAST, "java/lang/Long");
-				mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Long", "longValue", "()J", false);
-				break;
-			default:
-				String signature = nameAndSigValue[1];
-				
-				if ('L' == signature.charAt(0)) {
-					signature = signature.substring(1, signature.length() - 1);
+			if ((nameAndSigValue.length < 3) ||  !(nameAndSigValue[2].equals("static"))) {
+				mv.visitVarInsn(ALOAD, i);
+				switch (nameAndSigValue[1]) {
+				case "D":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Double");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()D", false);
+					break;
+				case "I":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Integer");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Integer", "intValue", "()I", false);
+					break;
+				case "Z":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Boolean");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z", false);
+					break;
+				case "B":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Byte");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Byte", "byteValue", "()B", false);
+					break;
+				case "C":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Character");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Character", "charValue", "()C", false);
+					break;
+				case "S":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Short");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Short", "shortValue", "()S", false);
+					break;
+				case "F":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Float");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Float", "floatValue", "()F", false);
+					break;
+				case "J":
+					mv.visitTypeInsn(CHECKCAST, "java/lang/Long");
+					mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Long", "longValue", "()J", false);
+					break;
+				default:
+					String signature = nameAndSigValue[1];
+					
+					if ('L' == signature.charAt(0)) {
+						signature = signature.substring(1, signature.length() - 1);
+					}
+					mv.visitTypeInsn(CHECKCAST, signature);
+					break;
 				}
-				mv.visitTypeInsn(CHECKCAST, signature);
-				break;
 			}
 		}
 		mv.visitMethodInsn(INVOKESTATIC, className, specificMethodName, "(" + makeValueSig + ")" + getSigFromSimpleName(className, isRef), false);

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -1871,8 +1871,11 @@ public class ValueTypeTests {
 		Class cycleA1Class = ValueTypeGenerator.generateValueClass("CycleA1", cycleA1);
 		Class cycleB1Class = ValueTypeGenerator.generateValueClass("CycleB1", cycleB1);
 		
-		cycleA1Class.newInstance();
-		cycleB1Class.newInstance();
+		MethodHandle makeCycleA1 = lookup.findStatic(cycleA1Class, "makeValueGeneric", MethodType.methodType(Object.class));
+		MethodHandle makeCycleB1 = lookup.findStatic(cycleB1Class, "makeValueGeneric", MethodType.methodType(Object.class));
+		
+		makeCycleA1.invoke();
+		makeCycleB1.invoke();
 	}
 	
 	@Test(priority=1)
@@ -1885,9 +1888,13 @@ public class ValueTypeTests {
 		Class cycleB2Class = ValueTypeGenerator.generateValueClass("CycleB2", cycleB2);
 		Class cycleC2Class = ValueTypeGenerator.generateValueClass("CycleC2", cycleC2);
 		
-		cycleA2Class.newInstance();
-		cycleB2Class.newInstance();
-		cycleC2Class.newInstance();
+		MethodHandle makeCycleA2 = lookup.findStatic(cycleA2Class, "makeValueGeneric", MethodType.methodType(Object.class));
+		MethodHandle makeCycleB2 = lookup.findStatic(cycleB2Class, "makeValueGeneric", MethodType.methodType(Object.class));
+		MethodHandle makeCycleC2 = lookup.findStatic(cycleB2Class, "makeValueGeneric", MethodType.methodType(Object.class));
+		
+		makeCycleA2.invoke();
+		makeCycleB2.invoke();
+		makeCycleC2.invoke();
 	}
 	
 	@Test(priority=1)
@@ -1896,7 +1903,9 @@ public class ValueTypeTests {
 		
 		Class cycleA3Class = ValueTypeGenerator.generateValueClass("CycleA3", cycleA3);
 		
-		cycleA3Class.newInstance();
+		MethodHandle makeCycleA3 = lookup.findStatic(cycleA3Class, "makeValueGeneric", MethodType.methodType(Object.class));
+		
+		makeCycleA3.invoke();
 	}
 
 	@Test(priority=4)


### PR DESCRIPTION
Fix static field cycle value tests

There are persistent failures for
testCyclicalStaticFieldDefaultValues{1|2|3} running with -Xjit:count=0.
These were traced back to the calls to Class.newInstance in those tests.
When a particular optimization is enabled, the JIT will end up calling
jitTranslateNewInstanceMethod.  But it looks like the implementation
doesn’t currently handle value types, and we end up with an
InstantiationError being thrown.

The current solution is to avoid calling Class.newInstance in the tests
until the behaviour of that call is updated.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>