### PR TITLE
Add option to pax to retain extattr settings

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -289,7 +289,7 @@ def archive_sdk() {
 
         dir(OPENJDK_CLONE_DIR) {
             // The archiver receives pathnames on stdin and writes to stdout.
-            def archiveCmd = SPEC.contains('zos') ? 'pax -wvz' : 'tar -cvz -T -'
+            def archiveCmd = SPEC.contains('zos') ? 'pax -wvz -p x' : 'tar -cvz -T -'
             // Filter out unwanted files (most of which are available in the debug-image).
             def filterCmd = "sed -e '/\\.dbg\$/d' -e '/\\.debuginfo\$/d' -e '/\\.diz\$/d' -e '/\\.dSYM\\//d' -e '/\\.map\$/d' -e '/\\.pdb\$/d'"
             sh "( cd ${buildDir} && find ${JDK_FOLDER} -type f | ${filterCmd} | ${archiveCmd} ) > ${SDK_FILENAME}"

--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -617,7 +617,8 @@ def set_build_variables() {
 
 def set_sdk_variables() {
     DATESTAMP = get_date()
-    SDK_FILENAME = "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}.tar.gz"
+    SDK_FILE_EXT = SPEC.contains('zos') ? '.pax' : '.tar.gz'
+    SDK_FILENAME =  "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}${SDK_FILE_EXT}"
     TEST_FILENAME = "test-images.tar.gz"
     JAVADOC_FILENAME = "OpenJ9-JDK${SDK_VERSION}-Javadoc-${SPEC}-${DATESTAMP}.tar.gz"
     JAVADOC_OPENJ9_ONLY_FILENAME = "OpenJ9-JDK${SDK_VERSION}-Javadoc-openj9-${SPEC}-${DATESTAMP}.tar.gz"


### PR DESCRIPTION
* [skip ci]
* change extension to indicate its pax and not just a compressed tar
* impact is on z/OS SDK artifact only

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>