### PR TITLE
Add -Xcheck:jni check for expected non-negative capacity numbers

### DIFF
--- a/runtime/jnichk/jnicwrappers.c
+++ b/runtime/jnichk/jnicwrappers.c
@@ -522,7 +522,7 @@ checkPushLocalFrame(JNIEnv *env, jint capacity)
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jint actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_JINT, 0 };
+	static const U_32 argDescriptor[] = { JNIC_JSIZE, 0 };
 	static const char function[] = "PushLocalFrame";
 
 	jniCheckArgs(function, 0, CRITICAL_WARN, &refTracking, argDescriptor, env, capacity);
@@ -675,7 +675,7 @@ checkEnsureLocalCapacity(JNIEnv *env, jint capacity)
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jint actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_JINT, 0 };
+	static const U_32 argDescriptor[] = { JNIC_JSIZE, 0 };
 	static const char function[] = "EnsureLocalCapacity";
 
 	jniCheckArgs(function, 0, CRITICAL_WARN, &refTracking, argDescriptor, env, capacity);


### PR DESCRIPTION
Added the non-negative numbers check for following methods:
```
checkPushLocalFrame(JNIEnv *env, jint capacity)
checkEnsureLocalCapacity(JNIEnv *env, jint capacity)
```

Note: these two methods take `jint capacity` which technically can be a negative number. To match `RI` behaviours, changed the check for `JNIC_JINT` to `JNIC_JSIZE`, and now the testcase has following output:
```
JVMJNCK040E JNI error in PushLocalFrame: Argument #2 is out of range for a jsize (0xffffffff < 0x0)
```
or 
```
JVMJNCK040E JNI error in EnsureLocalCapacity: Argument #2 is out of range for a jsize (0xfffffffb < 0x0)
```

closes #10231 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>