### PR TITLE
Move ibm.jzos

### DIFF
--- a/jcl/.classpath
+++ b/jcl/.classpath
@@ -30,7 +30,6 @@
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/jdk.attach/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/jdk.jcmd/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/jdk.management/share/classes"/>
-	<classpathentry excluding="**/module-info.java" kind="src" path="src/ibm.jzos/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/openj9.cuda/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/openj9.dataaccess/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/openj9.dtfj/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -82,7 +82,6 @@
 		  dependencies="SIDECAR18-SE"
 		  jdkcompliance="1.8">
 		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun180.jar"/>
-		<source path="src/ibm.jzos/share/classes"/>
 		<source path="src/java.base/share/classes"/>
 		<source path="src/java.desktop/share/classes"/>
 		<source path="src/java.logging/share/classes"/>

--- a/jcl/stubs/ibm.jzos/share/classes/com/ibm/jzos/ZFile.java
+++ b/jcl/stubs/ibm.jzos/share/classes/com/ibm/jzos/ZFile.java
@@ -1,6 +1,5 @@
-/*[INCLUDE-IF Sidecar19-SE&(PLATFORM-mz31|PLATFORM-mz64)]*/
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,11 +19,55 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.jzos;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
- * Provides access to z/OS datasets.
+ * This class is a stub that allows DDR to be compiled on platforms other than z/OS.
  */
-module ibm.jzos {
-  requires java.base;
-  exports com.ibm.jzos;
+public class ZFile {
+
+	public static boolean exists(String name) {
+		return false;
+	}
+
+	public ZFile(String name, String options) throws IOException {
+		super();
+		throw new FileNotFoundException();
+	}
+
+	public void close() throws IOException {
+		return;
+	}
+
+	public int getLrecl() throws IOException {
+		return 0;
+	}
+
+	public byte[] getPos() throws IOException {
+		return new byte[] { 0 };
+	}
+
+	public long getRecordCount() throws IOException {
+		return 0;
+	}
+
+	public int read(byte[] buffer) throws IOException {
+		return 0;
+	}
+
+	public int read(byte[] buf, int offset, int len) throws IOException {
+		return 0;
+	}
+
+	public void seek(long offset, int origin) throws IOException {
+		return;
+	}
+
+	public void setPos(byte[] position) throws IOException {
+		return;
+	}
+
 }

--- a/jcl/stubs/ibm.jzos/share/classes/module-info.java
+++ b/jcl/stubs/ibm.jzos/share/classes/module-info.java
@@ -1,6 +1,5 @@
-/*[INCLUDE-IF PLATFORM-mz31|PLATFORM-mz64]*/
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,55 +19,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-package com.ibm.jzos;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
 
 /**
- * This class is a stub that allows DDR to be compiled on platforms other than z/OS.
+ * Provides access to z/OS datasets.
  */
-public class ZFile {
-
-	public static boolean exists(String name) {
-		return false;
-	}
-
-	public ZFile(String name, String options) throws IOException {
-		super();
-		throw new FileNotFoundException();
-	}
-
-	public void close() throws IOException {
-		return;
-	}
-
-	public int getLrecl() throws IOException {
-		return 0;
-	}
-
-	public byte[] getPos() throws IOException {
-		return new byte[] { 0 };
-	}
-
-	public long getRecordCount() throws IOException {
-		return 0;
-	}
-
-	public int read(byte[] buffer) throws IOException {
-		return 0;
-	}
-
-	public int read(byte[] buf, int offset, int len) throws IOException {
-		return 0;
-	}
-
-	public void seek(long offset, int origin) throws IOException {
-		return;
-	}
-
-	public void setPos(byte[] position) throws IOException {
-		return;
-	}
-
+module ibm.jzos {
+  requires java.base;
+  exports com.ibm.jzos;
 }


### PR DESCRIPTION
Move jcl/src/ibm.jzos to jcl/stubs/. The package is required to compile
DDR on non z/OS platforms. For z/OS the ibm.jzos module is available as
add-on to the build via z/OS components.
Clean up ibm.jzos references.

[skip ci]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>