### PR TITLE
Compiler Flags changes for Java11 on z/OS

### DIFF
--- a/runtime/compiler/build/toolcfg/zos-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/zos-xlc/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2019 IBM Corp. and others
+# Copyright (c) 2000, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,11 +32,15 @@ SOSUFF=.so
 EXESUFF=
 LIBPREFIX=lib
 DEPSUFF=.depend.mk
+ifeq ($(VERSION_MAJOR),8)
+	ARCHLEVEL=7
+	TGTLEVEL=zOSV1R13
+else
+	ARCHLEVEL=10
+	TGTLEVEL=zOSV2R3
+endif
 
-ARCHLEVEL?=7
 TUNELEVEL?=10
-TGTLEVEL?=zOSV1R13
-
 #
 # Paths for default programs on the platform
 # Most rules will use these default programs, but they can be overwritten individually if,


### PR DESCRIPTION
Java 11 for z/OS supports V2R3 and later on zEC12/zBC12. This commit contains appropriate change for this in compiler build file.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>