### PR TITLE
JEP371 ClassData Support and JEP383 Support (Part 3)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -400,9 +400,7 @@ final class Access implements JavaLangAccess {
 /*[IF Java15]*/
 	public Class<?> defineClass(ClassLoader classLoader, Class<?> clazz, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object classData) {
 		ClassLoader targetClassLoader = (null == classLoader) ? ClassLoader.bootstrapClassLoader : classLoader;
-		Class <?> ret = targetClassLoader.defineClassInternal(clazz, className, classRep, protectionDomain, init, flags, classData);
-		ret.setClassData(classData);
-		return ret;
+		return targetClassLoader.defineClassInternal(clazz, className, classRep, protectionDomain, init, flags, classData);
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -398,17 +398,26 @@ final class Access implements JavaLangAccess {
 /*[ENDIF] Java14 */
 
 /*[IF Java15]*/
-	public Class<?> defineClass(ClassLoader classLoader, Class<?> clazz, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object obj) {
+	public Class<?> defineClass(ClassLoader classLoader, Class<?> clazz, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object classData) {
 		ClassLoader targetClassLoader = (null == classLoader) ? ClassLoader.bootstrapClassLoader : classLoader;
-		return targetClassLoader.defineClassInternal(clazz, className, classRep, protectionDomain, init, flags, obj);
+		Class <?> ret = targetClassLoader.defineClassInternal(clazz, className, classRep, protectionDomain, init, flags, classData);
+		ret.setClassData(classData);
+		return ret;
+	}
+
+	/**
+	 * Returns the classData stored in the class.
+	 * 
+	 * @param the class from where to retrieve the classData.
+	 * 
+	 * @return the classData (Object).
+	 */
+	public Object classData(Class<?> clazz) {
+		return clazz.getClassData();
 	}
 
 	public ProtectionDomain protectionDomain(Class<?> clazz) {
 		return clazz.getProtectionDomain();
-	}
-
-	public Object classData(Class<?> clazz) {
-		return null;
 	}
 
 	public MethodHandle stringConcatHelper(String arg0, MethodType type) {

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -266,6 +266,10 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	private Class<?> nestHost;
 /*[ENDIF] Java11*/
 	
+/*[IF Java15]*/
+	private transient Object classData;
+/*[ENDIF] Java15*/
+	
 /**
  * Prevents this class from being instantiated. Instances
  * created by the virtual machine only.
@@ -4777,6 +4781,26 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 	 */
 	public boolean isHidden() {
 		return isHiddenImpl(); 
+	}
+
+	/**
+	 * Returns the classData stored in the class.
+	 * 
+	 * @return the classData (Object).
+	 */
+	Object getClassData() {
+		return classData;
+	}
+
+	/**
+	 * Stores the classData in the class.
+	 * 
+	 * @param the classData (Object) to be stored.
+	 * 
+	 * @return void.
+	 */
+	void setClassData(Object classData) {
+		this.classData = classData;
 	}
 /*[ENDIF] Java15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4791,16 +4791,5 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 	Object getClassData() {
 		return classData;
 	}
-
-	/**
-	 * Stores the classData in the class.
-	 * 
-	 * @param the classData (Object) to be stored.
-	 * 
-	 * @return void.
-	 */
-	void setClassData(Object classData) {
-		this.classData = classData;
-	}
 /*[ENDIF] Java15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -601,7 +601,7 @@ final Class<?> defineClassInternal(
 
 /*[IF Java15]*/
 
-private final native Class<?> defineClassImpl1(Class<?> hostClass, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object obj);
+private final native Class<?> defineClassImpl1(Class<?> hostClass, String className, byte[] classRep, ProtectionDomain protectionDomain, boolean init, int flags, Object classData);
 final Class<?> defineClassInternal(
 		Class<?> hostClass, 
 		String className, 
@@ -609,10 +609,10 @@ final Class<?> defineClassInternal(
 		ProtectionDomain protectionDomain, 
 		boolean init, 
 		int flags, 
-		Object obj)
+		Object classData)
 		throws java.lang.ClassFormatError 
 {
-	Class<?> answer = defineClassImpl1(hostClass, className, classRep, protectionDomain, init, flags, obj);
+	Class<?> answer = defineClassImpl1(hostClass, className, classRep, protectionDomain, init, flags, classData);
 	return answer;
 }
 /*[ENDIF] Java15 */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -24,6 +24,11 @@
 /*[IF Java11]*/
 package java.lang.invoke;
 
+/*[IF Java15]*/
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+/*[ENDIF] Java15 */
+
 class MethodHandleNatives {
 	static LinkageError mapLookupExceptionToError(ReflectiveOperationException roe) {
 		String exMsg = roe.getMessage();
@@ -67,6 +72,19 @@ class MethodHandleNatives {
 	
 	static boolean refKindIsConstructor(byte kind) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	
+	private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
+	/**
+	 * Returns the classData stored in the class.
+	 * 
+	 * @param the class from where to retrieve the classData.
+	 * 
+	 * @return the classData (Object).
+	 */
+	static Object classData(Class<?> c) {
+		return JLA.classData(c);
 	}
 	/*[ENDIF] Java15 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2298,16 +2298,7 @@ public class MethodHandles {
 			}
 
 			Class<?> defineClass(boolean initOption) {
-				Class<?> ret = AccessController.doPrivileged(new PrivilegedAction<Class<?>>() {
-					@Override
-					public Class<?> run() {
-						JavaLangAccess jlAccess = SharedSecrets.getJavaLangAccess();
-						Class<?> lookupClass = lookup.lookupClass();
-						return jlAccess.defineClass(lookupClass.getClassLoader(), lookupClass, className, classBytes,
-								jlAccess.protectionDomain(lookupClass), initOption, ClassOptFlags, null);
-					}
-				});
-				return ret;
+				return defineClass(initOption, null);
 			}
 
 			Class<?> defineClass(boolean initOption, Object classData) {
@@ -2325,9 +2316,9 @@ public class MethodHandles {
 		}
 
 		/**
-		 * Constructs a new hidden class from an array of class data bytes.
+		 * Constructs a new hidden class from an array of class file bytes.
 		 * 
-		 * @param bytes the class data bytes of the hidden class to be defined.
+		 * @param bytes the class file bytes of the hidden class to be defined.
 		 * @param initOption whether to initialize the hidden class.
 		 * @param classOptions the {@link ClassOption} to define the hidden class.
 		 * 
@@ -2340,9 +2331,10 @@ public class MethodHandles {
 		}
 		
 		/**
-		 * Constructs a new hidden class from an array of class data bytes.
+		 * Constructs a new hidden class from an array of class file bytes.
+		 * Equivalent to defineHiddenClass(bytes, true, classOptions).
 		 * 
-		 * @param bytes the class data bytes of the hidden class to be defined.
+		 * @param bytes the class file bytes of the hidden class to be defined.
 		 * @param classData the classData to be stored in the hidden class.
 		 * @param classOptions the {@link ClassOption} to define the hidden class.
 		 * 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2282,45 +2282,83 @@ public class MethodHandles {
 			private final String className;
 			private final Lookup lookup;
 			private final int ClassOptFlags;
+
 			ClassDefiner(String name, byte[] template, Lookup lookupObj, int flags) {
 				className = name;
 				classBytes = template;
 				lookup = lookupObj;
 				ClassOptFlags = flags;
 			}
+
 			ClassDefiner(String name, byte[] template, Lookup lookupObj) {
 				className = name;
 				classBytes = template;
 				lookup = lookupObj;
 				ClassOptFlags = 0;
 			}
+
 			Class<?> defineClass(boolean initOption) {
 				Class<?> ret = AccessController.doPrivileged(new PrivilegedAction<Class<?>>() {
 					@Override
 					public Class<?> run() {
 						JavaLangAccess jlAccess = SharedSecrets.getJavaLangAccess();
 						Class<?> lookupClass = lookup.lookupClass();
-						return jlAccess.defineClass(lookupClass.getClassLoader(), lookupClass, className, classBytes, jlAccess.protectionDomain(lookupClass), initOption, ClassOptFlags, null);
+						return jlAccess.defineClass(lookupClass.getClassLoader(), lookupClass, className, classBytes,
+								jlAccess.protectionDomain(lookupClass), initOption, ClassOptFlags, null);
+					}
+				});
+				return ret;
+			}
+
+			Class<?> defineClass(boolean initOption, Object classData) {
+				Class<?> ret = AccessController.doPrivileged(new PrivilegedAction<Class<?>>() {
+					@Override
+					public Class<?> run() {
+						JavaLangAccess jlAccess = SharedSecrets.getJavaLangAccess();
+						Class<?> lookupClass = lookup.lookupClass();
+						return jlAccess.defineClass(lookupClass.getClassLoader(), lookupClass, className, classBytes,
+								jlAccess.protectionDomain(lookupClass), initOption, ClassOptFlags, classData);
 					}
 				});
 				return ret;
 			}
 		}
+
 		/**
 		 * Constructs a new hidden class from an array of class data bytes.
 		 * 
-		 * @param bytes the class data bytes of the hidden class to be defined.  
+		 * @param bytes the class data bytes of the hidden class to be defined.
 		 * @param initOption whether to initialize the hidden class.
 		 * @param classOptions the {@link ClassOption} to define the hidden class.
+		 * 
 		 * @return A Lookup object of the newly created hidden class.
 		 * @throws IllegalAccessException if this Lookup does not have full privilege access.
 		 */
-
 		public Lookup defineHiddenClass(byte[] bytes, boolean initOption, ClassOption... classOptions) throws IllegalAccessException {
+			ClassDefiner definer = classDefiner(bytes, classOptions);
+			return new Lookup(definer.defineClass(initOption));
+		}
+		
+		/**
+		 * Constructs a new hidden class from an array of class data bytes.
+		 * 
+		 * @param bytes the class data bytes of the hidden class to be defined.
+		 * @param classData the classData to be stored in the hidden class.
+		 * @param classOptions the {@link ClassOption} to define the hidden class.
+		 * 
+		 * @return A Lookup object of the newly created hidden class.
+		 * @throws IllegalAccessException if this Lookup does not have full privilege access.
+		 */
+		Lookup defineHiddenClassWithClassData(byte[] bytes, Object classData, ClassOption... classOptions) throws IllegalAccessException {
+			ClassDefiner definer = classDefiner(bytes, classOptions);
+			return new Lookup(definer.defineClass(true, classData));
+		}
+
+		private ClassDefiner classDefiner(byte[] bytes, ClassOption... classOptions) throws IllegalAccessException {
 			if (!hasFullPrivilegeAccess()) {
 				throw new IllegalAccessException();
 			}
-			
+
 			ClassReader cr;
 			try {
 				cr = new ClassReader(bytes);
@@ -2334,12 +2372,8 @@ public class MethodHandles {
 			for (ClassOption opt : classOptions) {
 				flags |= opt.toFlag();
 			}
-			ClassDefiner definer = makeHiddenClassDefiner(targetClassName, bytes, flags);
-			return new Lookup(definer.defineClass(initOption));
-		}
 
-		Lookup defineHiddenClassWithClassData(byte[] bytes, Object data, ClassOption... classOptions) {
-			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+			return makeHiddenClassDefiner(targetClassName, bytes, flags);
 		}
 
 		ClassDefiner makeHiddenClassDefiner(String name, byte[] template) {
@@ -5466,12 +5500,96 @@ public class MethodHandles {
 	}
 
 	/*[IF Java15]*/
-	static boolean permuteArgumentChecks(int[] arr, MethodType mt1, MethodType mt2) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	/**
+	 * Validates that the permute[] specifies a valid permutation from permuteType to handleType.
+	 * This method throws IllegalArgumentException on failure and returns true on success. This
+	 * disjointness allows it to be used in asserts.
+	 * 
+	 * @param permute array specifies the conversion from permuteType to handleType.
+	 * @param permuteType source method type.
+	 * @param handleType target method type.
+	 * 
+	 * @return true on success.
+	 * @throws IllegalArgumentException on failure.
+	 */
+	static boolean permuteArgumentChecks(int[] permute, MethodType permuteType, MethodType handleType) {
+		return validatePermutationArray(permuteType, handleType, permute);
 	}
 	
-	static MethodHandle collectReturnValue(MethodHandle mh1, MethodHandle mh2) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	/**
+	 * Return the classData stored in the accessClass of the Lookup object.
+	 * 
+	 * @param caller Lookup object used to verify privileged access and retrieve classData.
+	 * @param unused.
+	 * @param type used to cast the classData of the accessClass.
+	 * 
+	 * @return the classData casted to the appropriate type.
+	 * @throws IllegalAccessException in the absence of full privilege access.
+	 */
+	static <T> T classData(Lookup caller, String unused, Class<T> type) throws IllegalAccessException {
+		if (caller.hasFullPrivilegeAccess()) {
+			Object classData = MethodHandleNatives.classData(caller.accessClass);
+			return type.cast(classData);
+		}
+		throw new IllegalAccessException("No full privilege access found for " + caller);
+	}
+
+	/**
+	 * Helper class used by collectReturnValue.
+	 */
+	private static final class CollectReturnHelper implements ArgumentHelper {
+		private final MethodHandle target;
+		private final MethodHandle filter;
+
+		CollectReturnHelper(MethodHandle target, MethodHandle filter) {
+			this.target = target;
+			this.filter = filter;
+		}
+
+		public Object helper(Object[] arguments) throws Throwable {
+			// Invoke target
+			int targetArity = target.type.parameterCount();
+			Object targetReturn = target.invokeWithArguments(Arrays.copyOfRange(arguments, 0, targetArity));
+
+			// Construct filter arguments
+			int filterArity = filter.type.parameterCount();
+			Object[] newArguments = new Object[filterArity];
+			System.arraycopy(arguments, targetArity, newArguments, 0, filterArity - 1);
+			newArguments[filterArity - 1] = targetReturn;
+
+			// Invoke filter
+			return filter.invokeWithArguments(newArguments);
+		}
+	}
+	
+	/**
+	 * Creates an adapter MethodHandle (MH) which invokes the target MH and then
+	 * invokes the filter MH while passing the output from the target MH as an
+	 * input to the filter MH.
+	 * 
+	 * targetMH:  O target(P...)
+	 * filterMH:  Q filter(R..., O)
+	 * adapterMH: Q adapter(P... p, R... r) {
+	 *                O o = target(p);
+	 *                return filter(r, o);  
+	 *            }
+	 *
+	 * @param target represents the above targetMH.
+	 * @param filter represent the above filterMH.
+	 * 
+	 * @return a MH similar to the above adapterMH.
+	 */
+	static MethodHandle collectReturnValue(MethodHandle target, MethodHandle filter) {
+		MethodType targetType = target.type();
+		MethodType filterType = filter.type();
+		MethodType resultType = targetType.changeReturnType(filterType.returnType());
+		int filterParamCount = filterType.parameterCount();
+		if (filterParamCount > 1) {
+			for (int i = 0; i < filterParamCount - 1; i++) {
+				resultType = resultType.appendParameterTypes(filterType.parameterType(i));
+			}
+		}
+		return buildTransformHandle(new CollectReturnHelper(target, filter), resultType);
 	}
 	/*[ENDIF] Java15 */
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1538,28 +1538,52 @@ public abstract class VarHandle extends VarHandleInternal
 /*[ENDIF] Java12 */ 
 
 /*[IF Java15]*/
+	/**
+	 * Return the target VarHandle. For a direct VarHandle, the target
+	 * VarHandle is null. An indirect VarHandle will override this method to
+	 * return a non-null target VarHandle.
+	 * 
+	 * @return null for the target VarHandle.
+	 */
 	VarHandle target() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		return null;
 	}
 
+	/**
+	 * Return the direct-target VarHandle. For a direct VarHandle, the
+	 * direct-target is itself. An indirect VarHandle will override this method 
+	 * to return a direct-target, which should be a direct VarHandle.
+	 * 
+	 * @return "this" for a direct VarHandle.
+	 */
 	VarHandle asDirect() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		return this;
 	}
 
-	MethodHandle getMethodHandle(int i) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
-	}
-
+	/**
+	 * Return true for a direct VarHandle and false for an indirect VarHandle.
+	 * An indirect VarHandle will override this method to return false. By
+	 * default, all VarHandles are direct VarHandles.
+	 * 
+	 * @return true for a direct VarHandle and false for an indirect VarHandle.
+	 */
 	boolean isDirect() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		return true;
 	}
 /*[ENDIF] Java15 */
 
-	abstract MethodType accessModeTypeUncached(AccessMode accessMode);
-
-/*[IF OPENJDK_METHODHANDLES]*/
-	final MethodHandle getMethodHandle(int i) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+/*[IF Java15 | OPENJDK_METHODHANDLES]*/
+	/**
+	 * Return the MethodHandle corresponding to the integer-value of the AccessMode.
+	 * 
+	 * @param i integer value of the AccessMode.
+	 * 
+	 * @return the MethodHandle corresponding to the integer-value of the AccessMode.
+	 */
+	MethodHandle getMethodHandle(int i) {
+		return handleTable[i];
 	}
-/*[ENDIF] OPENJDK_METHODHANDLES */
+/*[ENDIF] Java15 | OPENJDK_METHODHANDLES */
+
+	abstract MethodType accessModeTypeUncached(AccessMode accessMode);
 }

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -95,7 +95,7 @@ Java_java_lang_ClassLoader_defineClassImpl(JNIEnv *env, jobject receiver, jstrin
 
 #if JAVA_SPEC_VERSION >= 15
 jclass JNICALL
-Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclass hostClass, jstring className, jbyteArray classRep, jobject protectionDomain, jboolean init, jint flags, jobject obj)
+Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclass hostClass, jstring className, jbyteArray classRep, jobject protectionDomain, jboolean init, jint flags, jobject classData)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
@@ -135,6 +135,12 @@ Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclas
 	} else if (NULL == result) {
 		throwNewInternalError(env, NULL);
 		return NULL;
+	}
+
+	if (NULL != classData) {
+		j9object_t classDataObject = J9_JNI_UNWRAP_REFERENCE(classData);
+		j9object_t resultClassObject = J9_JNI_UNWRAP_REFERENCE(result);
+		J9VMJAVALANGCLASS_SET_CLASSDATA(currentThread, resultClassObject, classDataObject);
 	}
 
 	if (init) {

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -363,7 +363,7 @@ Java_com_ibm_lang_management_internal_ExtendedGarbageCollectorMXBeanImpl_getLast
 jboolean JNICALL Java_java_lang_ClassLoader_isVerboseImpl (JNIEnv *env, jclass clazz);
 jclass JNICALL Java_java_lang_ClassLoader_defineClassImpl (JNIEnv *env, jobject receiver, jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain);
 #if JAVA_SPEC_VERSION >= 15
-jclass JNICALL Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclass hostClass, jstring className, jbyteArray classRep, jobject protectionDomain, jboolean init, jint flags, jobject obj);
+jclass JNICALL Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclass hostClass, jstring className, jbyteArray classRep, jobject protectionDomain, jboolean init, jint flags, jobject classData);
 #endif /* JAVA_SPEC_VERSION >= 15 */
 jboolean JNICALL Java_java_lang_ClassLoader_foundJavaAssertOption (JNIEnv *env, jclass ignored);
 jint JNICALL Java_com_ibm_oti_vm_BootstrapClassLoader_addJar(JNIEnv *env, jobject receiver, jbyteArray jarPath);

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -147,6 +147,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<fieldref class="java/lang/Class" name="annotationCache" signature="Ljava/lang/Class$AnnotationCache;"/>
 	<fieldref class="java/lang/Class" name="module" signature="Ljava/lang/Module;" flags="opt_module" versions="9-"/>
 	<fieldref class="java/lang/Class" name="methodHandleCache" signature="Ljava/lang/Object;" flags="opt_methodHandle"/>
+	<fieldref class="java/lang/Class" name="classData" signature="Ljava/lang/Object;" versions="15-"/>
 
 	<staticfieldref class="java/lang/String" name="compressionFlag" signature="Ljava/lang/String$StringCompressionFlag;"/>
 	<fieldref class="java/lang/String" name="value" signature="[B" versions="9-">


### PR DESCRIPTION
**JEP371 ClassData Support:**
1. Implement `Class.setClassData(...) and Class.getClassData()`
2. Store `classData` before init in `ClassLoader_defineClassImpl1`
3. Implement `Access.classData(...)`
4. Implement `MethodHandleNatives.classData(...)`
5. Implement `ClassDefiner.defineClass(initOption, classData)`
6. Implement `Lookup.defineHiddenClassWithClassData(...)`
7. Implement `MethodHandles.classData(...)`

**JEP383 Support (Part 3):**
1. Implement `MethodHandles.permuteArgumentChecks(...)`
2. Implement `MethodHandles.collectReturnValue(...)`
3. Implement `VarHandle.target()`
4. Implement `VarHandle.asDirect()`
5. Implement `VarHandle.isDirect()`
6. Implement `VarHandle.getMethodHandle(...)`

Related: https://github.com/eclipse/openj9/issues/9625

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>