### PR TITLE
Disable JEP 360 preview tests for Java 16+

### DIFF
--- a/test/functional/Java15andUp/playlist.xml
+++ b/test/functional/Java15andUp/playlist.xml
@@ -42,7 +42,8 @@
             <group>functional</group>
         </groups>
         <subsets>
-            <subset>15+</subset>
+            <!-- run for Java 15 only since this is a preview feature. -->
+            <subset>15</subset>
         </subsets>
     </test>
 </playlist>


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/10241

See #10243 for re-enabling.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>