### PR TITLE
Make JVMTI test variables static

### DIFF
--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/traceSubscription/ts001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/traceSubscription/ts001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ static jvmtiExtensionFunction subscribe  = NULL;
 static jvmtiExtensionFunction unsubscribe  = NULL;
 static jvmtiExtensionFunction flush  = NULL;
 static jvmtiExtensionFunction metadata = NULL;
-void *subscriptionID;
+static void *subscriptionID;
 volatile static jint bufferCount = 0;
 volatile static jint bufferCountFinal = 0;
 volatile static int completed = 0;

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/verboseGC/vgc001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/verboseGC/vgc001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,15 +31,15 @@ static agentEnv * env;
 static jvmtiExtensionFunction subscribe  = NULL;
 static jvmtiExtensionFunction unsubscribe  = NULL;
 
-void *subscriptionID;
+static void *subscriptionID;
 volatile static jint bufferCount = 0;
 volatile static int alarmed = 0;
 
-void *subscriptionID2;
+static void *subscriptionID2;
 volatile static jint bufferCount2 = 0;
 volatile static int alarmed2 = 0;
 
-void *subscriptionID3;
+static void *subscriptionID3;
 volatile static jint bufferCount3 = 0;
 volatile static int alarmed3 = 0;
 


### PR DESCRIPTION
Two tests declare the same named global non-statically which breaks some
newer compilers.

Fixes: #10252

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>