### PR TITLE
Minor javadoc improvements

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/TraceBuffer.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/TraceBuffer.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,28 +23,29 @@
 package com.ibm.dtfj.java.j9;
 
 /**
- * @author jmdisher
- * A container for the information that is described by the &lt;trace&gt; data in the XML index
- * 
+ * A container for the information that is described by the &lt;trace&gt; data in the XML index.
+ *
  * Data looks like this:
- * <trace>
- 	<header address="0x10a63008" size="1484"/>
- 	<buffers address="0x10a5ef00" size="8192" offset="40" link="24" terminator="0x0"/>
- * </trace>
- * 
- * We will have to know more about what is desired from this component before implementing it
+ * &lt;trace&gt;
+ *  &lt;header address="0x10a63008" size="1484"/&gt;
+ *  &lt;buffers address="0x10a5ef00" size="8192" offset="40" link="24" terminator="0x0"/&gt;
+ * &lt;/trace&gt;
+ *
+ * We will have to know more about what is desired from this component before implementing it.
+ *
+ * @author jmdisher
  */
 public class TraceBuffer
 {
 	public void setHeader(long address, long size)
 	{
-		//we will need the capability to turn these addresses into ImagePointer instances but there is no 
+		//we will need the capability to turn these addresses into ImagePointer instances but there is no
 		// API to read this type, yet
 	}
-	
+
 	public void setBuffer(long address, long size, int offset, int link, int terminator)
 	{
-		//we will need the capability to turn these addresses into ImagePointer instances but there is no 
+		//we will need the capability to turn these addresses into ImagePointer instances but there is no
 		// API to read this type, yet
 	}
 }

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/indexsupport/NodeGPF.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/indexsupport/NodeGPF.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,20 +27,20 @@ import org.xml.sax.Attributes;
 import com.ibm.dtfj.image.j9.ImageProcess;
 
 /**
- * @author jmdisher
- * 
  * Example:
- * <gpf failingThread="0x806a600" nativeFailingThread="0xb7e286c0">
-J9Generic_Signal_Number=00000004 Signal_Number=0000000b Error_Value=00000000 Signal_Code=00000001
-Handler1=B7DADB8F Handler2=B7D7B0C6 InaccessibleAddress=FFFFFFFB
-EDI=083639B0 ESI=09010101 EAX=96C5879E EBX=082EACDC
-ECX=00000000 EDX=00000000
-EIP=96C587A1 ES=C010007B DS=C010007B ESP=BFAB3634
-EFlags=00210246 CS=00000073 SS=0000007B EBP=BFAB3634
-Module=/tmp/rtj_jextract/jre/bin/libgptest.so
-Module_base_address=96C58000 Symbol=Java_VMBench_GPTests_GPTest_gpWrite
-Symbol_address=96C5879E
-</gpf>
+ * &lt;gpf failingThread="0x806a600" nativeFailingThread="0xb7e286c0"&gt;
+ * J9Generic_Signal_Number=00000004 Signal_Number=0000000b Error_Value=00000000 Signal_Code=00000001
+ * Handler1=B7DADB8F Handler2=B7D7B0C6 InaccessibleAddress=FFFFFFFB
+ * EDI=083639B0 ESI=09010101 EAX=96C5879E EBX=082EACDC
+ * ECX=00000000 EDX=00000000
+ * EIP=96C587A1 ES=C010007B DS=C010007B ESP=BFAB3634
+ * EFlags=00210246 CS=00000073 SS=0000007B EBP=BFAB3634
+ * Module=/tmp/rtj_jextract/jre/bin/libgptest.so
+ * Module_base_address=96C58000 Symbol=Java_VMBench_GPTests_GPTest_gpWrite
+ * Symbol_address=96C5879E
+ * &lt;/gpf&gt;
+ * 
+ * @author jmdisher
  */
 public class NodeGPF extends NodeAbstract
 {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/indexsupport/NodeJ9Dump.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/indexsupport/NodeJ9Dump.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,10 +29,10 @@ import com.ibm.dtfj.image.j9.ImageAddressSpace;
 import com.ibm.dtfj.image.j9.ImageProcess;
 
 /**
- * @author jmdisher
- * 
  * Example:
- * <j9dump endian="little" size="32" version="2.3" stamp="20060714_07189_lHdSMR" uuid="16994021750723430015" format="1.1" arch="x86" cpus="2" memory="1593016320" osname="Linux" osversion="2.6.15-1-686-smp" environ="0x80569c0">
+ * &lt;j9dump endian="little" size="32" version="2.3" stamp="20060714_07189_lHdSMR" uuid="16994021750723430015" format="1.1" arch="x86" cpus="2" memory="1593016320" osname="Linux" osversion="2.6.15-1-686-smp" environ="0x80569c0"&gt;
+ *
+ * @author jmdisher
  */
 public class NodeJ9Dump extends NodeAbstract
 {
@@ -41,13 +41,13 @@ public class NodeJ9Dump extends NodeAbstract
 	private String _vmVersion;
 	private ImageProcess _process;
 	private Image _image;
-	
+
 	public NodeJ9Dump(XMLIndexReader reader, Attributes attributes)
 	{
-		//<j9dump endian="little" size="32" version="2.3" stamp="20050823_02904_lHdSMR" 
-		//uuid="16827002721828718167" format="1.1" arch="x86" cpus="1" memory="536330240" 
+		//<j9dump endian="little" size="32" version="2.3" stamp="20050823_02904_lHdSMR"
+		//uuid="16827002721828718167" format="1.1" arch="x86" cpus="1" memory="536330240"
 		//osname="Windows XP" osversion="5.1 build 2600 Service Pack 1" environ="0x7c38c8f4">
-		
+
 		String osType = attributes.getValue("osname");
 		String osSubType = attributes.getValue("osversion");
 		String cpuType = attributes.getValue("arch");
@@ -75,12 +75,12 @@ public class NodeJ9Dump extends NodeAbstract
 	public IParserNode nodeToPushAfterStarting(String uri, String localName, String qName, Attributes attributes)
 	{
 		IParserNode child = null;
-		
+
 		if (qName.equals("gpf")) {
 			child = new NodeGPF(_process, attributes);
-		} else if (qName.equals("net")){
+		} else if (qName.equals("net")) {
 			child = new NodeNet(_image, attributes);
-		} else if (qName.equals("javavm")){
+		} else if (qName.equals("javavm")) {
 			child = new NodeJavaVM(_parent, _process, _addressSpace, _vmVersion, attributes);
 		} else {
 			child = super.nodeToPushAfterStarting(uri, localName, qName, attributes);

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/indexsupport/NodeJavaVM.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/indexsupport/NodeJavaVM.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,27 +30,27 @@ import com.ibm.dtfj.image.CorruptDataException;
 import com.ibm.dtfj.image.ImagePointer;
 import com.ibm.dtfj.image.j9.ImageAddressSpace;
 import com.ibm.dtfj.image.j9.ImageProcess;
+import com.ibm.dtfj.java.JavaClass;
 import com.ibm.dtfj.java.JavaClassLoader;
 import com.ibm.dtfj.java.JavaMonitor;
-import com.ibm.dtfj.java.j9.JavaObject;
 import com.ibm.dtfj.java.JavaThread;
-import com.ibm.dtfj.java.JavaClass;
+import com.ibm.dtfj.java.j9.JavaObject;
 import com.ibm.dtfj.java.j9.JavaRuntime;
 
 /**
- * @author jmdisher
- * 
  * Example:
- * <javavm id="0x805fd90">
+ * &lt;javavm id="0x805fd90"&gt;
+ *
+ * @author jmdisher
  */
 public class NodeJavaVM extends NodeAbstract
 {
 	private JavaRuntime _runtime;
-	
+
 	public NodeJavaVM(XMLIndexReader parent, ImageProcess process, ImageAddressSpace addressSpace, String vmVersion, Attributes attributes)
 	{
 		long id = _longFromString(attributes.getValue("id"));
-		
+
 		ImagePointer vmPointer = addressSpace.getPointer(id);
 		_runtime = new JavaRuntime(process, vmPointer, vmVersion);
 		if (process != null) {
@@ -64,7 +64,7 @@ public class NodeJavaVM extends NodeAbstract
 	public IParserNode nodeToPushAfterStarting(String uri, String localName, String qName, Attributes attributes)
 	{
 		IParserNode child = null;
-		
+
 		if (qName.equals("systemProperties")) {
 			child = new NodeSystemProperties(_runtime, attributes);
 		} else if (qName.equals("class")) {
@@ -92,7 +92,7 @@ public class NodeJavaVM extends NodeAbstract
 		}
 		return child;
 	}
-	
+
 	public void didFinishParsing()
 	{
 		Iterator classLoaders = _runtime.getJavaClassLoaders();
@@ -100,7 +100,7 @@ public class NodeJavaVM extends NodeAbstract
 			Object potentialClassLoader = classLoaders.next();
 			if (potentialClassLoader instanceof JavaClassLoader) {
 				JavaClassLoader loader = (JavaClassLoader) potentialClassLoader;
-				
+
 				//sets the associated object
 				try {
 					Object potentialLoaderObject = loader.getObject();
@@ -113,11 +113,11 @@ public class NodeJavaVM extends NodeAbstract
 							Object potentialClass = classes.next();
 							if (potentialClass instanceof JavaClass) {
 								JavaClass theClass = (JavaClass)potentialClass;
-								
+
 								try {
 									Object potentialClassObject = theClass.getObject();
 									if (null != potentialClassObject && potentialClassObject instanceof com.ibm.dtfj.java.j9.JavaObject) {
-										JavaObject classObject = (com.ibm.dtfj.java.j9.JavaObject)potentialClassObject; 
+										JavaObject classObject = (com.ibm.dtfj.java.j9.JavaObject)potentialClassObject;
 										classObject.setAssociatedClass(theClass);
 										_runtime.addSpecialObject(classObject);
 									}
@@ -140,11 +140,11 @@ public class NodeJavaVM extends NodeAbstract
 			Object potentialMonitor = monitors.next();
 			if (potentialMonitor instanceof JavaMonitor) {
 				JavaMonitor monitor = (JavaMonitor) potentialMonitor;
-				
+
 				//sets the associated object
 				Object potentialMonitorObject = monitor.getObject();
 				if (null != potentialMonitorObject && potentialMonitorObject instanceof com.ibm.dtfj.java.j9.JavaObject) {
-					JavaObject monitorObject = (com.ibm.dtfj.java.j9.JavaObject)potentialMonitorObject; 
+					JavaObject monitorObject = (com.ibm.dtfj.java.j9.JavaObject)potentialMonitorObject;
 					monitorObject.setAssociatedMonitor(monitor);
 					_runtime.addSpecialObject(monitorObject);
 				}

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelper.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelper.java
@@ -1,8 +1,6 @@
 /*[INCLUDE-IF SharedClasses]*/
-package com.ibm.oti.shared;
-
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,34 +20,36 @@ package com.ibm.oti.shared;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.oti.shared;
 
 /**
- * The SharedClassHelper superinterface defines functions that are common to all class helpers. 
- * <p>
+ * The SharedClassHelper superinterface defines functions that are common
+ * to all class helpers.
+ *
  * @see SharedHelper
  * @see SharedClassHelperFactory
- */ 
-public interface SharedClassHelper extends SharedHelper { 
-    /* Some functions have been moved to generic SharedHelper interface */
+ */
+public interface SharedClassHelper extends SharedHelper {
+	/* Some functions have been moved to generic SharedHelper interface */
 
 	/**
-	 * Applies the sharing filter to the SharedClassHelper.<p>
+	 * Applies the sharing filter to the SharedClassHelper.
 	 *
-	 * If a SecurityManager is installed, this method can only be called 
-     * by an object whose caller ClassLoader has shared 
-     * class "read,write" permissions.<br>
+	 * If a SecurityManager is installed, this method can only be called
+	 * by an object whose caller ClassLoader has shared
+	 * class "read,write" permissions.<br>
 	 * If a SharedClassFilter is already set, it is replaced by the new filter.<br>
 	 * Passing null as the argument removes the sharing filter.
-	 * 
+	 *
 	 * @param filter The SharedClassFilter instance or null.
 	 */
 	public void setSharingFilter(SharedClassFilter filter);
-	
+
 	/**
 	 * Returns the sharing filter associated with this helper.
 	 * <p>
-	 * @return The filter instance, or null if non is associated
+	 * @return The filter instance, or null if none is associated.
 	 */
 	public SharedClassFilter getSharingFilter();
-	
+
 }

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactory.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassHelperFactory.java
@@ -1,8 +1,6 @@
 /*[INCLUDE-IF SharedClasses]*/
-package com.ibm.oti.shared;
-
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +20,7 @@ package com.ibm.oti.shared;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package com.ibm.oti.shared;
 
 import java.net.URL;
 /*[IF Sidecar19-SE]*/
@@ -278,9 +277,10 @@ public interface SharedClassHelperFactory {
 	 * @param 		loader ClassLoader.
 	 * 					ClassLoader which may or may not have a SharedClassHelper
 	 *  
-	 * @return		Set<SharedClassHelper>.
+	 * @return		Set&lt;SharedClassHelper&gt;.
 	 * 					A set of helpers exist for this ClassLoader.
 	 */
 	public Set<SharedClassHelper> findHelpersForClassLoader(ClassLoader loader);
 	/*[ENDIF]*/
+
 }


### PR DESCRIPTION
Avoid `<` and `>` in javadoc; use `&lt;` and `&gt;` instead.

Without these changes, building openj9 javadocs for jdknext (via ibmruntimes/openj9-openjdk-jdk#210) fails:
```
javadoc: error - An internal exception has occurred. 
	(java.lang.NullPointerException)
Please file a bug against the javadoc tool via the Java bug reporting page
(http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com)
for duplicates. Include error messages and the following diagnostic in your report. Thank you.
java.lang.NullPointerException
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.isSelfClosingAllowed(Checker.java:424)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.visitStartElement(Checker.java:382)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.visitStartElement(Checker.java:106)
	at jdk.compiler.interim/com.sun.tools.javac.tree.DCTree$DCStartElement.accept(DCTree.java:850)
	at jdk.compiler.interim/com.sun.source.util.DocTreePathScanner.scan(DocTreePathScanner.java:71)
	at jdk.compiler.interim/com.sun.source.util.DocTreeScanner.scanAndReduce(DocTreeScanner.java:83)
	at jdk.compiler.interim/com.sun.source.util.DocTreeScanner.scan(DocTreeScanner.java:98)
	at jdk.compiler.interim/com.sun.source.util.DocTreeScanner.visitAuthor(DocTreeScanner.java:147)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.visitAuthor(Checker.java:815)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.visitAuthor(Checker.java:106)
	at jdk.compiler.interim/com.sun.tools.javac.tree.DCTree$DCAuthor.accept(DCTree.java:238)
	at jdk.compiler.interim/com.sun.source.util.DocTreePathScanner.scan(DocTreePathScanner.java:71)
	at jdk.compiler.interim/com.sun.source.util.DocTreeScanner.scan(DocTreeScanner.java:98)
	at jdk.compiler.interim/com.sun.source.util.DocTreeScanner.scanAndReduce(DocTreeScanner.java:106)
	at jdk.compiler.interim/com.sun.source.util.DocTreeScanner.visitDocComment(DocTreeScanner.java:185)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.visitDocComment(Checker.java:269)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.visitDocComment(Checker.java:106)
	at jdk.compiler.interim/com.sun.tools.javac.tree.DCTree$DCDocComment.accept(DCTree.java:138)
	at jdk.compiler.interim/com.sun.source.util.DocTreePathScanner.scan(DocTreePathScanner.java:50)
	at jdk.compiler.interim/com.sun.tools.doclint.Checker.scan(Checker.java:231)
	at jdk.compiler.interim/com.sun.tools.doclint.DocLint.scan(DocLint.java:351)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.WorkArounds.runDocLint(WorkArounds.java:111)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.Utils.getDocCommentTree0(Utils.java:2725)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.Utils.getDocCommentTree(Utils.java:2768)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.Utils$CommentHelperCache.computeIfAbsent(Utils.java:2914)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.Utils.getCommentHelper(Utils.java:2588)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.Utils.hasBlockTag(Utils.java:2632)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.Utils.hasHiddenTag(Utils.java:1556)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.ClassTree.buildTree(ClassTree.java:175)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.util.ClassTree.<init>(ClassTree.java:119)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.startGeneration(AbstractDoclet.java:204)
	at jdk.javadoc.interim/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.run(AbstractDoclet.java:113)
	at jdk.javadoc.interim/jdk.javadoc.doclet.StandardDoclet.run(StandardDoclet.java:103)
	at jdk.javadoc.interim/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:555)
	at jdk.javadoc.interim/jdk.javadoc.internal.tool.Start.begin(Start.java:399)
	at jdk.javadoc.interim/jdk.javadoc.internal.tool.Start.begin(Start.java:348)
	at jdk.javadoc.interim/jdk.javadoc.internal.tool.Main.execute(Main.java:63)
	at jdk.javadoc.interim/jdk.javadoc.internal.tool.Main.main(Main.java:52)
```