### PR TITLE
Clear non-zAAP eligible bit for JCL natives

### DIFF
--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 #include "j9consts.h"
 #include "jni.h"
 #include "j9protos.h"
+#include "jcl_internal.h"
 #include "jclprots.h"
 #include "ut_j9jcl.h"
 #include "VM_MethodHandleKinds.h"
@@ -55,9 +56,6 @@ static void JNICALL vmInvalidate(JNIEnv *env, jclass mutableCallSiteClass, jlong
 static BOOLEAN accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object_t methodType, J9UTF8 *lookupSig);
 static BOOLEAN accessCheckFieldSignature(J9VMThread *currentThread, J9Class* lookupClass, UDATA romField, j9object_t methodType, J9UTF8 *lookupSig);
 static char * expandNLSTemplate(J9VMThread *vmThread, const char *nlsTemplate, ...);
-#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
-static void clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *nativeMethods, jint nativeMethodCount);
-#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 
 /**
  * Lookup static method name of type signature on lookupClass class.
@@ -1025,7 +1023,7 @@ setClassLoadingConstraintLinkageError(J9VMThread *vmThread, J9Class *methodOrFie
  * @param[in] nativeMethods       The JNI native method pointer
  * @param[in] nativeMethodCount  The count of native methods
  */
-static void
+void
 clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *nativeMethods, jint nativeMethodCount)
 {
 	J9VMThread *vmThread = (J9VMThread *) env;

--- a/runtime/jcl/common/sun_misc_Perf.c
+++ b/runtime/jcl/common/sun_misc_Perf.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2016 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "jcl.h"
+#include "jcl_internal.h"
 
 /*
  * This is the minimum implementation of sun.misc.Perf natives to
@@ -125,7 +126,11 @@ registerJdkInternalPerfPerfNatives(JNIEnv *env, jclass clazz) {
 			(void *)&Java_sun_misc_Perf_highResFrequency
 		},
 	};
-	(*env)->RegisterNatives(env, clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
+	jint numNatives = sizeof(natives)/sizeof(JNINativeMethod);
+	(*env)->RegisterNatives(env, clazz, natives, numNatives);
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
 
 void JNICALL

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -1051,7 +1051,11 @@ registerJdkInternalMiscUnsafeNativesCommon(JNIEnv *env, jclass clazz) {
 			(void*)&Java_sun_misc_Unsafe_getUncompressedObject
 		},
 	};
-	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
+	jint numNatives = sizeof(natives)/sizeof(JNINativeMethod);
+	env->RegisterNatives(clazz, natives, numNatives);
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
 
 /* register jdk.internal.misc.Unsafe natives for Java 10 */
@@ -1065,7 +1069,11 @@ registerJdkInternalMiscUnsafeNativesJava10(JNIEnv *env, jclass clazz) {
 			(void*)&Java_jdk_internal_misc_Unsafe_objectFieldOffset1
 		}
 	};
-	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
+	jint numNatives = sizeof(natives)/sizeof(JNINativeMethod);
+	env->RegisterNatives(clazz, natives, numNatives);
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
 
 /* register jdk.internal.misc.Unsafe natives for Java 14 */
@@ -1084,7 +1092,11 @@ registerJdkInternalMiscUnsafeNativesJava14(JNIEnv *env, jclass clazz) {
 			(void*)&Java_jdk_internal_misc_Unsafe_isWritebackEnabled
 		}
 	};
-	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
+	jint numNatives = sizeof(natives)/sizeof(JNINativeMethod);
+	env->RegisterNatives(clazz, natives, numNatives);
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+	clearNonZAAPEligibleBit(env, clazz, natives, numNatives);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 }
 
 /* class jdk.internal.misc.Unsafe only presents in Java 9 and beyond */

--- a/runtime/jcl/common/sun_reflect_ConstantPool.c
+++ b/runtime/jcl/common/sun_reflect_ConstantPool.c
@@ -24,6 +24,7 @@
 #include "jcl.h"
 #include "jclprots.h"
 #include "jclglob.h"
+#include "jcl_internal.h"
 #include "jniidcacheinit.h"
 #include "j9.h"
 
@@ -907,6 +908,7 @@ registerJdkInternalReflectConstantPoolNatives(JNIEnv *env) {
 			(void *)&Java_sun_reflect_ConstantPool_getUTF8At0,
 		},
 	};
+	jint numNatives = sizeof(natives)/sizeof(JNINativeMethod);
 
 	/* jdk.internal.reflect.ConstantPool is currently cached in CLS_sun_reflect_ConstantPool */
 	jclass jdk_internal_reflect_ConstantPool = JCL_CACHE_GET(env, CLS_sun_reflect_ConstantPool);
@@ -922,7 +924,10 @@ registerJdkInternalReflectConstantPoolNatives(JNIEnv *env) {
 		Assert_JCL_true(NULL != jdk_internal_reflect_ConstantPool);
 	}
 
-	result = (*env)->RegisterNatives(env, jdk_internal_reflect_ConstantPool, natives, sizeof(natives)/sizeof(JNINativeMethod));
+	result = (*env)->RegisterNatives(env, jdk_internal_reflect_ConstantPool, natives, numNatives);
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+	clearNonZAAPEligibleBit(env, jdk_internal_reflect_ConstantPool, natives, numNatives);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 
 _end:
 	return result;

--- a/runtime/jcl/jcl_internal.h
+++ b/runtime/jcl/jcl_internal.h
@@ -167,6 +167,10 @@ initializeUnsafeMemoryTracking(J9JavaVM* vm);
 void
 freeUnsafeMemory(J9JavaVM* vm);
 
+/* ---------------- java_dyn_methodhandle.c ---------------- */
+#if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
+void clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *nativeMethods, jint nativeMethodCount);
+#endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Invoke `clearNonZAAPEligibleBit()` for JCL natives:
```
Java_sun_misc_Perf
Java_sun_misc_Unsafe
Java_sun_reflect_ConstantPool
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>