### PR TITLE
Fix port/shmem test

### DIFF
--- a/runtime/tests/port/shmem.c
+++ b/runtime/tests/port/shmem.c
@@ -1628,12 +1628,12 @@ j9shmem_test15(J9PortLibrary *portLibrary, char* argv0)
 			}
 			case 4: {
 				outputComment(PORTLIB, "\tSub Test %d: test a uid change\n", i+1);
-				newfileinfo.uid = 0;
+				newfileinfo.uid += 1;
 				break;
 			}
 			case 5: {
 				outputComment(PORTLIB, "\tSub Test %d:test a gid change\n", i+1);
-				newfileinfo.gid = 0;
+				newfileinfo.gid += 1;
 				break;
 			}
 			case 6: {


### PR DESCRIPTION
Handle the case where the current uid or gid is zero. Any change is
sufficient for testing.

Fixes the test on some z/OS machines where the gid is zero.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>