### PR TITLE
Add AARCH64 as a target processor for JDK 8 in libargs.c

### DIFF
--- a/runtime/exelib/common/libargs.c
+++ b/runtime/exelib/common/libargs.c
@@ -320,6 +320,8 @@ vmOptionsTableAddOptionWithCopy(void **vmOptionsTable, char *optionString, void 
 	#define JVM_ARCH_DIR "amd64"
   #elif defined(J9ARM)
 	#define JVM_ARCH_DIR "arm"
+  #elif defined(J9AARCH64)
+	#define JVM_ARCH_DIR "aarch64"
   #elif defined(J9X86)
 	#define JVM_ARCH_DIR "i386"
   #elif defined(S39064) || defined(J9ZOS39064)


### PR DESCRIPTION
This commit adds AARCH64 as a target processor for JDK 8 in libargs.c.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>