### PR TITLE
AArch64: Enable Escape Analysis to allocate objects on stack

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -93,6 +93,11 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
 
    bool supportsDirectJNICallsForAOT() { return true; }
+
+   /**
+    * \brief Determines whether the code generator supports stack allocations
+    */
+   bool supportsStackAllocations() { return true; }
    };
 
 }

--- a/runtime/compiler/codegen/CodeGenGC.cpp
+++ b/runtime/compiler/codegen/CodeGenGC.cpp
@@ -378,7 +378,7 @@ J9::CodeGenerator::createStackAtlas()
             localObjectsFound = true;
             int32_t localObjectAlignment = comp->fej9()->getLocalObjectAlignmentInBytes();
             if (localObjectAlignment > stackSlotSize &&
-                (comp->target().cpu.isX86() || comp->target().cpu.isPower() || comp->target().cpu.isZ()))
+                self()->supportsStackAllocations())
                {
                // We only get here in compressedrefs mode
                int32_t gcMapIndexAlignment = localObjectAlignment / stackSlotSize;

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -571,6 +571,12 @@ public:
     */
    bool supportVMInternalNatives();
 
+
+   /**
+    * \brief Determines whether the code generator supports stack allocations
+    */
+   bool supportsStackAllocations() { return false; }
+
 private:
 
    enum // Flags

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -133,7 +133,7 @@ TR_EscapeAnalysis::TR_EscapeAnalysis(TR::OptimizationManager *manager)
    _dememoizationSymRef = NULL;
 
    _createStackAllocations   = true;
-   _createLocalObjects       = comp()->target().cpu.isX86() || comp()->target().cpu.isPower() || comp()->target().cpu.isZ();
+   _createLocalObjects       = cg()->supportsStackAllocations();
    _desynchronizeCalls       = true;
 #if CHECK_MONITORS
    /* monitors */
@@ -4466,7 +4466,7 @@ void TR_EscapeAnalysis::checkEscapeViaNonCall(TR::Node *node, TR::NodeChecklist&
                if ((!_nonColdLocalObjectsValueNumbers ||
                     !_notOptimizableLocalObjectsValueNumbers ||
                     !resolvedBaseObject ||
-                    (comp()->useCompressedPointers() && (TR::Compiler->om.compressedReferenceShift() > 3) && !comp()->target().cpu.isX86() && !comp()->target().cpu.isPower() && !comp()->target().cpu.isZ()) ||
+                    (comp()->useCompressedPointers() && (TR::Compiler->om.compressedReferenceShift() > 3) && !cg()->supportsStackAllocations()) ||
                     !resolvedBaseObject->getOpCode().hasSymbolReference() ||
                     !_nonColdLocalObjectsValueNumbers->get(_valueNumberInfo->getValueNumber(resolvedBaseObject)) ||
                     (((node->getSymbolReference()->getSymbol()->getRecognizedField() != TR::Symbol::Java_lang_String_value) ||

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -101,6 +101,11 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    bool suppressInliningOfCryptoMethod(TR::RecognizedMethod method);
    bool inlineCryptoMethod(TR::Node *node, TR::Register *&resultReg);
 #endif
+
+   /**
+    * \brief Determines whether the code generator supports stack allocations
+    */
+   bool supportsStackAllocations() { return true; }
    };
 
 }

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -82,6 +82,10 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     */
    void reserveNTrampolines(int32_t numTrampolines);
 
+   /**
+    * \brief Determines whether the code generator supports stack allocations
+    */
+   bool supportsStackAllocations() { return true; }
    };
 
 }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -329,6 +329,11 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    // LL: move to .cpp
    bool arithmeticNeedsLiteralFromPool(TR::Node *node);
 
+   /**
+    * \brief Determines whether the code generator supports stack allocations
+    */
+   bool supportsStackAllocations() { return true; }
+
    private:
 
    /** \brief


### PR DESCRIPTION
These commits enable Escape Analysis to allocate objects on stack for aarch64.

As in below conversation, we add `supportsStackAllocation` API to code generators. All code generators except ARM override it to return true. Architecture checks for supporting stack allocations in Escape Analysis are replaced with it.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>