### PR TITLE
 Replace cpu architecture checks with queries for inlining integer rotation

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -368,10 +368,10 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          return cg()->supportsInliningOfIsAssignableFrom();
       case TR::java_lang_Integer_rotateLeft:
       case TR::java_lang_Integer_rotateRight:
-         return comp()->target().cpu.isX86() || comp()->target().cpu.isZ() || comp()->target().cpu.isPower();
+         return comp()->target().cpu.getSupportsHardware32bitRotate();
       case TR::java_lang_Long_rotateLeft:
       case TR::java_lang_Long_rotateRight:
-         return comp()->target().cpu.isX86() || comp()->target().cpu.isZ() || (comp()->target().cpu.isPower() && comp()->target().is64Bit());
+         return comp()->target().cpu.getSupportsHardware64bitRotate();
       case TR::java_lang_Math_abs_I:
       case TR::java_lang_Math_abs_L:
       case TR::java_lang_Math_abs_F:


### PR DESCRIPTION
This commit replaces cpu architecture checks with queries to CPU class
when determining if `rotateRight`/`rotateLeft` methods of `Integer`/`Long`
class should be inlined.

As a result of this change, inlined versions of those methods are enabled for aarch64.

Related issue: https://github.com/eclipse/openj9/issues/7139

Depends on https://github.com/eclipse/omr/pull/5454

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>