### PR TITLE
Fix compile warnings in openj9.dataaccess

### DIFF
--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/ByteArrayUnmarshaller.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/ByteArrayUnmarshaller.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF DAA]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package com.ibm.dataaccess;
 
 /**
@@ -45,6 +44,7 @@ public final class ByteArrayUnmarshaller {
 
     // private constructor, class contains only static methods.
     private ByteArrayUnmarshaller() {
+    	super();
     }
 
     /**
@@ -352,7 +352,7 @@ public final class ByteArrayUnmarshaller {
     
     private static long readLong_(byte[] byteArray, int offset, boolean bigEndian) {
         if (bigEndian) {
-            return (long) (((long) (byteArray[offset] & 0xFF)) << 56)
+            return (((long) (byteArray[offset] & 0xFF)) << 56)
                     | (((long) (byteArray[offset + 1] & 0xFF)) << 48)
                     | (((long) (byteArray[offset + 2] & 0xFF)) << 40)
                     | (((long) (byteArray[offset + 3] & 0xFF)) << 32)
@@ -361,7 +361,7 @@ public final class ByteArrayUnmarshaller {
                     | (((byteArray[offset + 6] & 0xFF)) << 8)
                     | (((byteArray[offset + 7] & 0xFF)));
         } else {
-            return (long) (((long) (byteArray[offset + 7] & 0xFF)) << 56)
+            return (((long) (byteArray[offset + 7] & 0xFF)) << 56)
                     | (((long) (byteArray[offset + 6] & 0xFF)) << 48)
                     | (((long) (byteArray[offset + 5] & 0xFF)) << 40)
                     | (((long) (byteArray[offset + 4] & 0xFF)) << 32)

--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/DecimalData.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF DAA]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package com.ibm.dataaccess;
 
 import java.math.BigDecimal;
@@ -315,18 +314,15 @@ public final class DecimalData
 
         // fill in high/low nibble pairs from next-to-last up to first
         for (i = last - 1; i > offset && value != 0; i--) {
-            packedDecimal[i] = CommonData
-                    .getBinaryToPackedValues((int) (value % 100));
+            packedDecimal[i] = CommonData.getBinaryToPackedValues(value % 100);
             value = value / 100;
         }
 
         if (i == offset && value != 0) {
             if (evenPrecision)
-                packedDecimal[i] = (byte) (CommonData
-                        .getBinaryToPackedValues((int) (value % 100)) & CommonData.LOWER_NIBBLE_MASK);
+                packedDecimal[i] = (byte) (CommonData.getBinaryToPackedValues(value % 100) & CommonData.LOWER_NIBBLE_MASK);
             else
-                packedDecimal[i] = CommonData
-                        .getBinaryToPackedValues((int) (value % 100));
+                packedDecimal[i] = CommonData.getBinaryToPackedValues(value % 100);
             value = value / 100;
             i--;
         }

--- a/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/PackedDecimal.java
+++ b/jcl/src/openj9.dataaccess/share/classes/com/ibm/dataaccess/PackedDecimal.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF DAA]*/
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corp. and others
+ * Copyright (c) 2013, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
 package com.ibm.dataaccess;
 
 import java.math.BigInteger;
@@ -40,6 +39,7 @@ public final class PackedDecimal {
      * Private constructor, class contains only static methods.
      */
     private PackedDecimal() {
+        super();
     }
 
     private static final ThreadLocal<PackedDecimalOperand> op1_threadLocal = new ThreadLocal<PackedDecimalOperand>() {
@@ -1451,7 +1451,7 @@ public final class PackedDecimal {
         
     	if ((byte) (packedDecimal[end] & CommonData.HIGHER_NIBBLE_MASK) == (byte) 0x00) 
         {        
-        	byte[] addTenArray = { (0x01), (byte) packedDecimal[end] };
+        	byte[] addTenArray = { 0x01, packedDecimal[end] };
             addPackedDecimal(packedDecimal, offset, precision,
                     packedDecimal, offset, precision, addTenArray, 0, 2,
                     checkOverflow);
@@ -1988,6 +1988,10 @@ public final class PackedDecimal {
     }
 
     private static class PackedDecimalOperand {
+
+    	PackedDecimalOperand() {
+            super();
+    	}
 
         private static final byte PACKED_ZERO = 0x00;
 


### PR DESCRIPTION
Remove redundant casts which will allow us to stop ignoring warnings in openj9.dataaccess (see [custom-spec.gmk](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/openj9/closed/autoconf/custom-spec.gmk.in#L53)).