### PR TITLE
Remove OpenJ9 restriction on jps, jstack, etc. tests

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -294,7 +294,6 @@ public class TestJcmd extends AttachApiTest {
 
 	@BeforeSuite
 	protected void setupSuite() {
-		assertTrue(PlatformInfo.isOpenJ9(), "This test is valid only on OpenJ9");
 		userDir = new File(System.getProperty("user.dir"));
 		getJdkUtilityPath(JCMD_COMMAND);
 		commandExpectedOutputs = new HashMap<>();

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJmap.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJmap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,8 +103,6 @@ public class TestJmap extends AttachApiTest {
 
 	@BeforeSuite
 	protected void setupSuite() {
-		assertTrue("This test is valid only on OpenJ9", //$NON-NLS-1$
-				System.getProperty("java.vm.vendor").contains("OpenJ9")); //$NON-NLS-1$//$NON-NLS-2$
 		getJdkUtilityPath(JMAP_COMMAND);
 		myId = TargetManager.getVmId();
 		assertNotNull(myId, "Attach ID missing"); //$NON-NLS-1$

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,7 +132,6 @@ public class TestJps extends AttachApiTest {
 	 */
 	@BeforeSuite
 	void setupSuite() {
-		assertTrue("This test is valid only on OpenJ9",PlatformInfo.isOpenJ9()); //$NON-NLS-1$
 		getJdkUtilityPath(JPS_COMMAND);
 		assertTrue("Attach API failed to launch", TargetManager.waitForAttachApiInitialization()); //$NON-NLS-1$
 		vmId = TargetManager.getVmId();

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstack.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstack.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,6 @@ public class TestJstack extends AttachApiTest {
 
 	@BeforeSuite
 	protected void setupSuite() {
-		assertTrue(PlatformInfo.isOpenJ9(), "This test is valid only on OpenJ9"); //$NON-NLS-1$
 		getJdkUtilityPath(JSTACK_COMMAND);
 	}
 

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstat.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJstat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,6 @@ public class TestJstat extends AttachApiTest {
 
 	@BeforeSuite
 	protected void setupSuite() {
-		AssertJUnit.assertTrue("This test is valid only on OpenJ9", PlatformInfo.isOpenJ9()); //$NON-NLS-1$
 		getJdkUtilityPath(JSTAT_COMMAND);
 		AssertJUnit.assertTrue("Attach API failed to launch", TargetManager.waitForAttachApiInitialization()); //$NON-NLS-1$
 		vmId = TargetManager.getVmId();


### PR DESCRIPTION
Remove the test asserts that occur when running on z/OS Java 11+.