### PR TITLE
AArch64: Change GCC option for trclog.c

### DIFF
--- a/runtime/rastrace/module.xml
+++ b/runtime/rastrace/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-   Copyright (c) 2006, 2019 IBM Corp. and others
+   Copyright (c) 2006, 2020 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,7 @@
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="CFLAGS+=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1"/>
-			<makefilestub data="trclog.o: CFLAGS+=-U_FORTIFY_SOURCE">
+			<makefilestub data="trclog.o: CFLAGS+=-Wno-error">
 				<include-if condition="spec.linux_aarch64.*"/>
 			</makefilestub>
 		</makefilestubs>


### PR DESCRIPTION
This commit changes the GCC option for rastrace/trclog.c for AArch64
Linux.  It avoids the compilation error caused by strict check with
strncpy() in the file.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>