### PR TITLE
Use an extension of FileImageInputStream to avoid loading the awt shared library

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ClassGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ClassGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,9 @@ public final class ClassGenerator {
 	}
 
 	private static StructureReader readBlob(String fileName) throws IOException {
-		FileImageInputStream image = new FileImageInputStream(new RandomAccessFile(fileName, "r"));
+		FileImageInputStream image = new FileImageInputStream(new RandomAccessFile(fileName, "r")) {
+			// Extending FileImageInputStream avoids loading the awt shared library.
+		};
 
 		try {
 			return new StructureReader(image);


### PR DESCRIPTION
Fixes: #8841.
Fixes: #9425