### PR TITLE
Set extraTestLabels per SDK_VERSION

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -680,7 +680,7 @@ def set_test_misc() {
     if (!params.TEST_NODE) {
         // Only add extra test labels if the user has not specified a specific TEST_NODE
         TESTS.each { id, target ->
-            target['extraTestLabels'] = buildspec.getVectorField("extra_test_labels", target).join('&&') ?: ''
+            target['extraTestLabels'] = buildspec.getVectorField("extra_test_labels", SDK_VERSION).join('&&') ?: ''
         }
     } else {
         TESTS.each { id, target ->


### PR DESCRIPTION
- Our use case to set by target is no longer needed
  but a new use case to set by version is.

[skip ci]
Related #10138 #9855

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>