### PR TITLE
Add jni check to detect non-throwable object

### DIFF
--- a/runtime/jnichk/jnicwrappers.c
+++ b/runtime/jnichk/jnicwrappers.c
@@ -438,7 +438,7 @@ checkThrowNew(JNIEnv *env, jclass clazz, const char *msg)
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jint actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_JCLASS, JNIC_STRING, 0 };
+	static const U_32 argDescriptor[] = { JNIC_JTHROWABLE, JNIC_STRING, 0 };
 	static const char function[] = "ThrowNew";
 	U_32 msgCRC;
 


### PR DESCRIPTION
Specify the arg descriptor as JNIC_JTHROWABLE instead of JNIC_JCLASS.

Now the testcase in #10272 has following output:
```
JVMJNCK001I JNI check utility installed. Use -Xcheck:jni:help for usage
JVMJNCK042E JNI error in ThrowNew: Argument #2 is not a subclass of java/lang/Throwable
JVMJNCK077E Error detected in HelloJNI.sayHello()I

JVMJNCK024E JNI error detected. Aborting.
JVMJNCK025I Use -Xcheck:jni:nonfatal to continue running when errors are detected.

Fatal error: JNI error
```

closes: #10272 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>