### PR TITLE
Add native type to jvmnativetest

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -66,6 +66,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<types>
+			<type>native</type>
+		</types>
 		<subsets>
 			<subset>11+</subset>
 		</subsets>


### PR DESCRIPTION
Test depends on test libs, which should be tagged as `native`

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>