### PR TITLE
Add JDK 8 build pipeline for AArch64 Linux

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All.groovy
@@ -42,8 +42,8 @@
  *              zos_390-64_cmprssptrs (Java 11 support only),
  *              osx_x86-64 (Java 8 and Java 11 support only),
  *              osx_x86-64_cmprssptrs (Java 8 and Java 11 support only),
- *              aarch64_linux (Java 11 support only),
- *              aarch64_linux_xl (Java 11 support only)
+ *              aarch64_linux (Java 8 and Java 11 support only),
+ *              aarch64_linux_xl (Java 8 and Java 11 support only)
  *   OPENJ9_REPO: String - the OpenJ9 git repository URL: e.g. https://github.com/eclipse/openj9.git (default)
  *   OPENJ9_BRANCH: String - the OpenJ9 branch to clone from: e.g. master (default)
  *   OPENJ9_SHA: String - the last commit SHA of the OpenJ9 repository
@@ -117,9 +117,9 @@ SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
          'x86-32_windows' : ['8'],
          'x86-64_windows' : CURRENT_RELEASES,
          'x86-64_windows_xl' : CURRENT_RELEASES,
-         'aarch64_linux' : ['11'],
+         'aarch64_linux' : ['8', '11'],
          'aarch64_linux_cm': ['11'],
-         'aarch64_linux_xl' : ['11'],
+         'aarch64_linux_xl' : ['8', '11'],
          'aarch64_linux_xl_cm': ['11']]
 
 // SHORT_NAMES is used for PullRequest triggers

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -403,12 +403,13 @@ x86-64_linux_valhalla:
 aarch64_linux:
   extends: ['debuginfo', 'freemarker', 'openjdk_reference_repo', 'openssl']
   boot_jdk:
+    8: '/usr/lib/jvm/java-1.8.0'
     11: '/usr/lib/jvm/adoptojdk-java-11'
   release:
+    8: 'linux-aarch64-normal-server-release'
     11: 'linux-aarch64-normal-server-release'
   node_labels:
-    build:
-      11: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
+    build: 'ci.role.build && hw.arch.aarch64 && sw.os.cent.7'
   build_env:
     vars: 'PATH+TOOLS=/usr/local/gcc-7.5.0/bin'
 #========================================#


### PR DESCRIPTION
This commit adds JDK 8 build pipeline for AArch64 Linux.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>