### PR TITLE
Avoid stringop-overflow errors

### DIFF
--- a/runtime/rastrace/module.xml
+++ b/runtime/rastrace/module.xml
@@ -1,29 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2006, 2019 IBM Corp. and others
+Copyright (c) 2006, 2020 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module>
-        
 	<exports group="all">
 		<export name="JVM_OnUnload"/>
 		<export name="JVM_OnLoad"/>
@@ -49,16 +46,13 @@
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="CFLAGS+=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1"/>
-			<makefilestub data="trclog.o: CFLAGS+=-U_FORTIFY_SOURCE">
-				<include-if condition="spec.linux_aarch64.*"/>
-			</makefilestub>
 		</makefilestubs>
 		<libraries>
 			<library name="j9util"/>
 			<library name="j9utilcore"/>
 			<library name="j9avl" type="external"/>
-			<library name="j9hashtable" type="external"/>		
-			<library name="j9pool" type="external"/>				
+			<library name="j9hashtable" type="external"/>
+			<library name="j9pool" type="external"/>
 			<library name="j9thr"/>
 			<library name="j9hookable"/>
 			<library name="j9stackmap"/>


### PR DESCRIPTION
Rework code that sets thread name in trace buffer to avoid compiler errors, e.g.:
```
error: '__builtin_strncpy' writing 512 bytes into a region of size 1 overflows the destination
```