### PR TITLE
JEP 371 implementation part 3

### DIFF
--- a/runtime/bcutil/ClassFileWriter.hpp
+++ b/runtime/bcutil/ClassFileWriter.hpp
@@ -338,7 +338,7 @@ public:
 		, _originalClassName(NULL)
 	{
 		/* anonClasses have the following name format: '[originalName]/[ROMSegmentAddress]' */
-		if (J9_ARE_ALL_BITS_SET(_romClass->extraModifiers, J9AccClassAnonClass)) {
+		if (J9_ARE_ANY_BITS_SET(_romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden)) {
 			PORT_ACCESS_FROM_JAVAVM(_javaVM);
 			_isAnon = true;
 			_anonClassName = J9ROMCLASS_CLASSNAME(_romClass);

--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -176,7 +176,7 @@ j9bcutil_buildRomClass(J9LoadROMClassData *loadData, U_8 * intermediateData, UDA
 	UDATA bcuFlags = javaVM->dynamicLoadBuffers->flags;
 	UDATA findClassFlags = loadData->options;
 
-	ROMClassSegmentAllocationStrategy romClassSegmentAllocationStrategy(javaVM, loadData->classLoader, J9_ARE_ANY_BITS_SET(findClassFlags, J9_FINDCLASS_FLAG_HIDDEN));
+	ROMClassSegmentAllocationStrategy romClassSegmentAllocationStrategy(javaVM, loadData->classLoader);
 	ROMClassBuilder *romClassBuilder = ROMClassBuilder::getROMClassBuilder(PORTLIB, javaVM);
 	if (NULL == romClassBuilder) {
 		return BCT_ERR_OUT_OF_MEMORY;
@@ -429,7 +429,7 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 	Trc_BCU_Assert_False(context->isRetransforming() && !context->isRetransformAllowed());
 
 	bool isLambda = false;
-	if (context->isClassAnon()) {
+	if (context->isClassAnon() || context->isClassHidden()) {
 		BuildResult res = handleAnonClassName(classFileParser->getParsedClassFile(), &isLambda);
 		if (OK != res) {
 			return res;
@@ -719,7 +719,7 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 	 * Use an if statement here and call finishPrepareAndLaydown() in both cases to allow the scope of SCStringTransaction() to survive the life of the call to
 	 * finishPrepareAndLaydown(). Otherwise, the scope of SCStringTransaction() would end early and it would not be safe to us interned strings.
 	 */
-	if (J9_ARE_ALL_BITS_SET(context->findClassFlags(), J9_FINDCLASS_FLAG_ANON)) {
+	if (J9_ARE_ANY_BITS_SET(context->findClassFlags(), J9_FINDCLASS_FLAG_ANON | J9_FINDCLASS_FLAG_HIDDEN)) {
 		U_16 classNameIndex = classFileOracle.getClassNameIndex();
 		U_8* classNameBytes = classFileOracle.getUTF8Data(classNameIndex);
 		U_16 classNameFullLength = classFileOracle.getUTF8Length(classNameIndex);

--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -234,7 +234,9 @@ public:
 	bool isClassUnmodifiable() const {
 		bool unmodifiable = false;
 		if (NULL != _javaVM) {
-			if ((J2SE_VERSION(_javaVM) >= J2SE_V11) && isClassAnon()) {
+			if ((J2SE_VERSION(_javaVM) >= J2SE_V11) 
+				&& (isClassAnon() || isClassHidden())
+			) {
 				unmodifiable = true;
 			} else if (NULL == J9VMJAVALANGOBJECT_OR_NULL(_javaVM)) {
 				/* Object is currently only allowed to be redefined in fast HCR */

--- a/runtime/bcutil/ROMClassSegmentAllocationStrategy.cpp
+++ b/runtime/bcutil/ROMClassSegmentAllocationStrategy.cpp
@@ -35,7 +35,7 @@ ROMClassSegmentAllocationStrategy::allocate(UDATA bytesRequired)
 
 	J9MemorySegment* segment = NULL;
 	/* always make a new segment if its an anonClass */
-	bool allocNewSegment = ((_allocNewSeg) || (_classLoader == _javaVM->anonClassLoader));
+	bool allocNewSegment = (_classLoader == _javaVM->anonClassLoader);
 	
 	if (!allocNewSegment) {
 		J9MemorySegmentList* classSegments = _javaVM->classMemorySegments;

--- a/runtime/bcutil/ROMClassSegmentAllocationStrategy.hpp
+++ b/runtime/bcutil/ROMClassSegmentAllocationStrategy.hpp
@@ -36,10 +36,9 @@
 class ROMClassSegmentAllocationStrategy : public AllocationStrategy
 {
 public:
-	ROMClassSegmentAllocationStrategy(J9JavaVM* javaVM, J9ClassLoader* classLoader, bool allocNewSeg) :
+	ROMClassSegmentAllocationStrategy(J9JavaVM* javaVM, J9ClassLoader* classLoader) :
 		_javaVM(javaVM),
 		_classLoader(classLoader),
-		_allocNewSeg(allocNewSeg),
 		_segment(NULL),
 		_bytesRequested(0)
 	{
@@ -52,7 +51,6 @@ public:
 private:
 	J9JavaVM* _javaVM;
 	J9ClassLoader* _classLoader;
-	bool _allocNewSeg;
 	J9MemorySegment* _segment;
 	UDATA _bytesRequested;
 };

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2725,7 +2725,7 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 	VERBOSE_START(ParseClassFileConstantPool);
 	/* Space for the constant pool */
 
-	if (J9_ARE_ANY_BITS_SET(findClassFlags, J9_FINDCLASS_FLAG_ANON)) {
+	if (J9_ARE_ANY_BITS_SET(findClassFlags, J9_FINDCLASS_FLAG_ANON | J9_FINDCLASS_FLAG_HIDDEN)) {
 		/* Preemptively add new entry to the end of the constantPool for the modified anonClassName.
 		 * If it turns out we dont need it, simply reduce the constantPoolCount by 1, which is
 		 * cheaper than allocating twice.

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -420,7 +420,7 @@ MM_ConcurrentMarkingDelegate::concurrentClassMark(MM_EnvironmentBase *env, bool 
 				 * so, if this pointer happened to be NULL at this point let it crash here
 				 */
 				Assert_MM_true(NULL != classLoader->classHashTable);
-				clazz = _javaVM->internalVMFunctions->hashClassTableStartDo(classLoader, &walkState);
+				clazz = _javaVM->internalVMFunctions->hashClassTableStartDo(classLoader, &walkState, 0);
 				while (NULL != clazz) {
 					sizeTraced += sizeof(uintptr_t);
 					_markingScheme->markObject(env, (j9object_t)clazz->classObject);

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -314,7 +314,7 @@ MM_MarkingDelegate::completeMarking(MM_EnvironmentBase *env)
 								 * so, if this pointer happened to be NULL at this point let it crash here
 								 */
 								Assert_MM_true(NULL != classLoader->classHashTable);
-								clazz = javaVM->internalVMFunctions->hashClassTableStartDo(classLoader, &walkState);
+								clazz = javaVM->internalVMFunctions->hashClassTableStartDo(classLoader, &walkState, 0);
 								while (NULL != clazz) {
 									_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )clazz->classObject);
 									_anotherClassMarkPass = true;

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -966,7 +966,7 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 					 * while GC was in the middle of iterating the hash table.
 					 */
 					hashTableSetFlag(classLoader->classHashTable, J9HASH_TABLE_DO_NOT_REHASH);
-					clazz = _javaVM->internalVMFunctions->hashClassTableStartDo(classLoader, &walkState);
+					clazz = _javaVM->internalVMFunctions->hashClassTableStartDo(classLoader, &walkState, 0);
 					while (NULL != clazz) {
 						didWork |= markClass(env, clazz);
 						clazz = _javaVM->internalVMFunctions->hashClassTableNextDo(&walkState);

--- a/runtime/gc_structs/ClassLoaderClassesIterator.cpp
+++ b/runtime/gc_structs/ClassLoaderClassesIterator.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ GC_ClassLoaderClassesIterator::firstClass()
 	if (ANONYMOUS_CLASSES == _mode) {
 		result = nextAnonymousClass();
 	} else {
-		result = _javaVM->internalVMFunctions->hashClassTableStartDo(_classLoader, &_walkState);
+		result = _javaVM->internalVMFunctions->hashClassTableStartDo(_classLoader, &_walkState, 0);
 		if ( (NULL == result) && switchToSystemMode() ) {
 			result = nextSystemClass();
 		}

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -102,12 +102,14 @@ Java_java_lang_ClassLoader_defineClassImpl1(JNIEnv *env, jobject receiver, jclas
 
 	vmFuncs->internalExitVMToJNI(currentThread);
 
-	options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE | J9_FINDCLASS_FLAG_ANON);
+	options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE);
 	if (J9_ARE_ALL_BITS_SET(flags, CLASSOPTION_FLAG_NESTMATE)) {
 		options |= J9_FINDCLASS_FLAG_CLASS_OPTION_NESTMATE;
 	}
 	if (J9_ARE_ALL_BITS_SET(flags, CLASSOPTION_FLAG_STRONG)) {
 		options |= J9_FINDCLASS_FLAG_CLASS_OPTION_STRONG;
+	} else {
+		options |= J9_FINDCLASS_FLAG_ANON;
 	}
 	
 	jsize length = env->GetArrayLength(classRep);

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -340,7 +340,7 @@ Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass
 	if (NULL != utfData) {
 		UDATA flags = J9_STR_INTERN | J9_STR_XLAT;
 
-		if (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)) {
+		if (J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden)) {
 			flags |= J9_STR_ANON_CLASS_NAME;
 		}
 		j9object_t classNameObject = vm->memoryManagerFunctions->j9gc_createJavaLangString(currentThread, utfData, utfLength, flags);

--- a/runtime/jcl/common/java_lang_StackWalker.cpp
+++ b/runtime/jcl/common/java_lang_StackWalker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -202,7 +202,7 @@ Java_java_lang_StackWalker_getImpl(JNIEnv *env, jobject clazz, jlong walkStateP)
 			stringObject = J9VMJAVALANGCLASS_CLASSNAMESTRING(vmThread, J9VM_J9CLASS_TO_HEAPCLASS(ramClass));
 			if (stringObject == NULL) {
 				UDATA flags = J9_STR_XLAT;
-				if (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)) {
+				if (J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden)) {
 					flags |= J9_STR_ANON_CLASS_NAME;
 				}
 				J9UTF8 *nameUTF = J9ROMCLASS_CLASSNAME(romClass);

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -164,8 +164,8 @@ retry:
 	 */
 	dynFuncs->findLocallyDefinedClassFunction(currentThread, NULL, utf8Name, (U_32) utf8Length, classLoader, classLoader->classPathEntries, classLoader->classPathEntryCount, (UDATA) FALSE, &localBuffer);
 
-	/* skip if we are anonClass */
-	if (J9_ARE_NO_BITS_SET(*options, J9_FINDCLASS_FLAG_ANON)) {
+	/* skip if we are anonClass or hidden classes */
+	if (J9_ARE_NO_BITS_SET(*options, J9_FINDCLASS_FLAG_ANON | J9_FINDCLASS_FLAG_HIDDEN)) {
 		/* Check for romClass cookie, it indicates that we are  defining a class out of a JXE not from class bytes */
 
 		loadedClass = vmFuncs->romClassLoadFromCookie(currentThread, utf8Name, utf8Length, classBytes, (UDATA) length);

--- a/runtime/jcl/common/jclexception.c
+++ b/runtime/jcl/common/jclexception.c
@@ -195,7 +195,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 				}
 				if (NULL == string) {
 					UDATA flags = J9_STR_XLAT | J9_STR_TENURE | J9_STR_INTERN;
-					if (J9_ARE_ALL_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass)) {
+					if (J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden)) {
 						flags |= J9_STR_ANON_CLASS_NAME;
 					}
 					string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utfClassName), (U_32) J9UTF8_LENGTH(utfClassName), flags);

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -241,9 +241,8 @@ jvmtiGetClassLoaderClasses(jvmtiEnv* env,
 
 		stats.vm = vm;
 		stats.currentThread = currentThread;
-
 		/* Search for classes who have this class loader as the initiating loader (wind up count) */
-		clazz = vmFuncs->hashClassTableStartDo(loader, &hashWalkState);
+		clazz = vmFuncs->hashClassTableStartDo(loader, &hashWalkState, J9_HASH_TABLE_STATE_FLAG_SKIP_HIDDEN);
 		while (clazz != NULL) {
 			countInitiatedClass(clazz, &stats);
 			clazz = vmFuncs->hashClassTableNextDo(&hashWalkState);
@@ -265,7 +264,7 @@ jvmtiGetClassLoaderClasses(jvmtiEnv* env,
 			rv_classes = stats.classRefs;
 
 			/* Record classes who have this class loader as the initiating loader (wind down count) */
-			clazz = vmFuncs->hashClassTableStartDo(loader, &hashWalkState);
+			clazz = vmFuncs->hashClassTableStartDo(loader, &hashWalkState, J9_HASH_TABLE_STATE_FLAG_SKIP_HIDDEN);
 			while (clazz != NULL) {
 				copyInitiatedClass(clazz, &stats);
 				clazz = vmFuncs->hashClassTableNextDo(&hashWalkState);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4435,7 +4435,7 @@ typedef struct J9InternalVMFunctions {
 	IDATA  ( *J9SignalAsyncEvent)(struct J9JavaVM * vm, struct J9VMThread * targetThread, IDATA handlerKey) ;
 	IDATA  ( *J9SignalAsyncEventWithoutInterrupt)(struct J9JavaVM * vm, struct J9VMThread * targetThread, IDATA handlerKey) ;
 	IDATA  ( *J9CancelAsyncEvent)(struct J9JavaVM * vm, struct J9VMThread * targetThread, IDATA handlerKey) ;
-	struct J9Class*  ( *hashClassTableStartDo)(struct J9ClassLoader *classLoader, struct J9HashTableState* walkState) ;
+	struct J9Class*  ( *hashClassTableStartDo)(struct J9ClassLoader *classLoader, struct J9HashTableState* walkState, UDATA flags) ;
 	struct J9Class*  ( *hashClassTableNextDo)(struct J9HashTableState* walkState) ;
 	struct J9PackageIDTableEntry* (*hashPkgTableAt)(J9ClassLoader* classLoader, J9ROMClass* romClass);
 	struct J9PackageIDTableEntry*  ( *hashPkgTableStartDo)(struct J9ClassLoader *classLoader, struct J9HashTableState* walkState) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1738,6 +1738,11 @@ setExceptionForErroredRomClass( J9ROMClass *romClass, J9VMThread *vmThread );
 
 /* ---------------- KeyHashTable.c ---------------- */
 
+/* Flag(s) used by hashClassTableStartDo()/hashClassTableNextDo() and set to J9HashTableState.flags
+ * to control whether to skip special classes, like hidden classes, in the hash table iteration. 
+ */
+#define J9_HASH_TABLE_STATE_FLAG_SKIP_HIDDEN 1
+
 /**
 * Searches classLoader for any loaded classes in a specific package
 *
@@ -1824,12 +1829,13 @@ hashClassTableReplace(J9VMThread* vmThread, J9ClassLoader *classLoader, J9Class 
 
 /**
 * @brief Iterate over the classes defined by or cached in the specified class loader
-* @param *classLoader
-* @param *walkState
+* @param *classLoader The class loader to use.
+* @param *walkState The J9HashTableState. 
+* @param flags Flags to control whether to skip special classes, like hidden classes, in the iteration.
 * @return J9Class*
 */
 J9Class*
-hashClassTableStartDo(J9ClassLoader *classLoader, J9HashTableState* walkState);
+hashClassTableStartDo(J9ClassLoader *classLoader, J9HashTableState* walkState, UDATA flags);
 
 /**
 * @brief Iterate over the classes defined by or cached in the specified class loader

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2470,12 +2470,14 @@ recreateRAMClasses(J9VMThread * currentThread, J9HashTable * classHashTable, J9H
 			options |= J9_FINDCLASS_FLAG_FAST_HCR;
 		}
 		if (J9ROMCLASS_IS_HIDDEN(originalRAMClass->romClass)) {
-			options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE | J9_FINDCLASS_FLAG_ANON);
+			options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE);
 			if (J9ROMCLASS_IS_OPTIONNESTMATE_SET(originalRAMClass->romClass)) {
 				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_NESTMATE;
 			}
 			if (J9ROMCLASS_IS_OPTIONSTRONG_SET(originalRAMClass->romClass)) {
 				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_STRONG ;
+			} else {
+				options |= J9_FINDCLASS_FLAG_ANON;
 			}
 		} else if (J9_ARE_ALL_BITS_SET(originalRAMClass->classFlags, J9ClassIsAnonymous)) {
 			options |= J9_FINDCLASS_FLAG_ANON;
@@ -3503,14 +3505,16 @@ reloadROMClasses(J9VMThread * currentThread, jint class_count, const jvmtiClassD
 		}
 		loadData.classLoader = originalRAMClass->classLoader;
 		if (J9ROMCLASS_IS_HIDDEN(originalRAMClass->romClass)) {
-			options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE | J9_FINDCLASS_FLAG_ANON);
+			options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE);
 			if (J9ROMCLASS_IS_OPTIONNESTMATE_SET(originalRAMClass->romClass)) {
 				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_NESTMATE;
 			}
 			if (J9ROMCLASS_IS_OPTIONSTRONG_SET(originalRAMClass->romClass)) {
 				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_STRONG ;
+			} else {
+				options |= J9_FINDCLASS_FLAG_ANON;
+				loadData.classLoader = vm->anonClassLoader;
 			}
-			loadData.classLoader = vm->anonClassLoader;
 		} else if (J9_ARE_ALL_BITS_SET(originalRAMClass->classFlags, J9ClassIsAnonymous)) {
 			options = options | J9_FINDCLASS_FLAG_ANON;
 			loadData.classLoader = vm->anonClassLoader;

--- a/runtime/util/pkgname.c
+++ b/runtime/util/pkgname.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,15 +28,15 @@ UDATA
 packageNameLength(J9ROMClass* romClass)
 {
 	const J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
-	const BOOLEAN isAnonClass = J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass);
+	const BOOLEAN isAnonOrHidden = J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden);
 	BOOLEAN foundFirstSlash = FALSE;
 	UDATA result = 0;
 	IDATA i = J9UTF8_LENGTH(className) - 1;
 
 	for (; i >= 0; i--) {
 		if (J9UTF8_DATA(className)[i] == '/') {
-			/* Lambda names contain a '/'. If romClass is an anonymous class, find the second last '/'. */
-			if (!isAnonClass || foundFirstSlash) {
+			/* Lambda names contain a '/'. If romClass is an anonymous or hidden class, find the second last '/'. */
+			if (!isAnonOrHidden || foundFirstSlash) {
 				result = (UDATA)i;
 				break;
 			}

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -224,12 +224,14 @@ internalCreateArrayClass(J9VMThread* vmThread, J9ROMArrayClass* romClass, J9Clas
 
 	if (elementInitSuccess) {
 		if (J9ROMCLASS_IS_HIDDEN(elementClass->romClass)) {
-			options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE | J9_FINDCLASS_FLAG_ANON);
+			options |= (J9_FINDCLASS_FLAG_HIDDEN | J9_FINDCLASS_FLAG_UNSAFE);
 			if (J9ROMCLASS_IS_OPTIONNESTMATE_SET(elementClass->romClass)) {
 				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_NESTMATE;
 			}
 			if (J9ROMCLASS_IS_OPTIONSTRONG_SET(elementClass->romClass)) {
-				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_STRONG ;
+				options |= J9_FINDCLASS_FLAG_CLASS_OPTION_STRONG;
+			} else {
+				options |= J9_FINDCLASS_FLAG_ANON;
 			}
 		} else if (J9_ARE_ANY_BITS_SET(elementClass->classFlags, J9ClassIsAnonymous)) {
 			options = J9_FINDCLASS_FLAG_ANON;
@@ -365,7 +367,7 @@ internalRunPreInitInstructions(J9Class * ramClass, J9VMThread * vmThread)
 		U_32 description = 0;
 		UDATA i;
 		
-		BOOLEAN isAnonClass = J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass);
+		BOOLEAN isAnonClass = J9_ARE_ANY_BITS_SET(romClass->extraModifiers, J9AccClassAnonClass | J9AccClassHidden);
 
 		for (i = 0; i < ramConstantPoolCount; ++i) {
 			if (descriptionCount == 0) {

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3059,11 +3059,8 @@ internalCreateRAMClassFromROMClass(J9VMThread *vmThread, J9ClassLoader *classLoa
 	PORT_ACCESS_FROM_VMC(vmThread);
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
-	/* if this is an anon class classLoader should be anonClassLoader */
 	if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_ANON)) {
-		if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_HIDDEN)) {
-			classLoader = javaVM->anonClassLoader;
-		}
+		classLoader = javaVM->anonClassLoader;
 	}
 
 	memset(&state, 0, sizeof(state));
@@ -3132,7 +3129,7 @@ retry:
 				 * Therefore for classes loaded by bootloader from boot classpath,
 				 * J9Class.module should be set to J9JavaVM.unamedModuleForSystemLoader.
 				 */
-				if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_ANON)) {
+				if (J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_ANON | J9_FINDCLASS_FLAG_HIDDEN)) {
 					module = hostClass->module;
 				} else {
 					bool findModule = false;
@@ -3223,7 +3220,7 @@ retry:
 			const U_32 inheritedFlags = J9ClassHasWatchedFields | J9ClassIsExemptFromValidation;
 			classFlags |= (superclass->classFlags & inheritedFlags);
 		}
-		if (0 != (J9_FINDCLASS_FLAG_ANON & options)) {
+		if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_ANON)) {
 			/* if anonClass replace classLoader with hostClassLoader, no one can know about anonClassLoader */
 			result->classLoader = hostClassLoader;
 			if (NULL != result->classObject) {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1565,7 +1565,7 @@ dumpClassLoader(J9JavaVM *vm, J9ClassLoader *loader, IDATA fd){
 	J9HashTableState walkState = {0};
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	J9Class* clazz = vmFuncs->hashClassTableStartDo(loader, &walkState);
+	J9Class* clazz = vmFuncs->hashClassTableStartDo(loader, &walkState, 0);
 	while (NULL != clazz) {
 		J9ROMClass* romClass = clazz->romClass;
 		J9UTF8* utf = J9ROMCLASS_CLASSNAME(romClass);


### PR DESCRIPTION
This change adds code to handle ClassOption.STRONG
1) For hidden class defined without ClassOption.STRONG, 
set its classLoader to anon classLoader. J9_FINDCLASS_FLAG_ANON is 
set for such classes. 
2) For hidden class defined with ClassOption.STRONG, set its 
classLoader to its hostclass's classLoader. J9_FINDCLASS_FLAG_ANON is 
not set for such classes. 
3) With 1) and 2) the field that I added in my previous change
ROMClassSegmentAllocationStrategy::__allocNewSeg is not necessary
anymore. Remove this field.
4) Add hidden class in 2) to the classTable of its hostclass's 
ClassLoader. In this way, the current balanced GC code is able to 
find such class when iterating through the classTable. 

Adding hidden classes to the classTable makes it not sharable via 
shared classes cache, as its name won't be unique across JVMs. The 
change in 4) is temporary if we finally decide to change balance 
GC to scan the ram segment like other collectors. 

Issue #9328
Fixes #10249
Depends on eclipse/omr#5453

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>