### PR TITLE
Compile the SupportJVM_GetNanoTimeAdjustment test for Java >= 11 only

### DIFF
--- a/runtime/tests/j9vm/jvmjni.c
+++ b/runtime/tests/j9vm/jvmjni.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corp. and others
+ * Copyright (c) 2002, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -360,7 +360,7 @@ Java_com_ibm_oti_jvmtests_SupportJVM_ArrayCopy(JNIEnv * env, jclass unused, jobj
 	JVM_ArrayCopy(env, unused, src, src_pos, dst, dst_pos, length);
 }
 
-#if JAVA_SPEC_VERSION >= 9
+#if JAVA_SPEC_VERSION >= 11
 jlong JNICALL
 Java_com_ibm_oti_jvmtests_SupportJVM_GetNanoTimeAdjustment(JNIEnv *env, jclass clazz, jlong offset_seconds)
 {


### PR DESCRIPTION
The 'Java_com_ibm_oti_jvmtests_SupportJVM_GetNanoTimeAdjustment' test
depends on the 'jlong JNICALL JVM_GetNanoTimeAdjustment(JNIEnv *env, jclass clazz, jlong offsetSeconds)'
method provided by the 'openj9\runtime\j9vm\java11vmi.c' file. This
method is exported for JAVA_SPEC_VERSION >= 11 only, see
'openj9\runtime\j9vm\exports.cmake'. If OpenJ9 is being built with
JAVA_SPEC_VERSION less than 11, a linker error occurs at least on Windows
since the 'JVM_GetNanoTimeAdjustment' dependency is not exported by j9vm.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>