### PR TITLE
Replace the checks for inlining Math.abs() methods

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -374,9 +374,10 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          return comp()->target().cpu.getSupportsHardware64bitRotate();
       case TR::java_lang_Math_abs_I:
       case TR::java_lang_Math_abs_L:
+         return cg()->supportsIntAbs();
       case TR::java_lang_Math_abs_F:
       case TR::java_lang_Math_abs_D:
-         return comp()->target().cpu.isX86() || comp()->target().cpu.isZ() || comp()->target().cpu.isPower();
+         return cg()->supportsFPAbs();
       case TR::java_lang_Math_max_I:
       case TR::java_lang_Math_min_I:
       case TR::java_lang_Math_max_L:


### PR DESCRIPTION
Use CodeGenerator->supportsIntAbs()/supportFPAbs() in checks for
inlining Math.abs() methods.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>