### PR TITLE
DefineClass -Xjni:check should be fatal with NULL class name

### DIFF
--- a/runtime/jnichk/jnicwrappers.c
+++ b/runtime/jnichk/jnicwrappers.c
@@ -276,7 +276,7 @@ checkDefineClass(JNIEnv *env, const char *name, jobject loader, const jbyte *buf
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jclass actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_STRING, JNIC_JOBJECT, JNIC_POINTER, JNIC_JSIZE, 0 };
+	static const U_32 argDescriptor[] = { JNIC_CLASSNAME, JNIC_JOBJECT, JNIC_POINTER, JNIC_JSIZE, 0 };
 	static const char function[] = "DefineClass";
 	U_32 nameCRC, bufCRC;
 


### PR DESCRIPTION
Changed the argDescriptor from `JNIC_STRING` to `JNIC_CLASSNAME`.

Now `OpenJ9 -Xcheck:jni` throws following fatal error:
```
JVMJNCK031E JNI error in DefineClass: Argument #2 is NULL
JVMJNCK077E Error detected in HelloJNI.sayHello()I
``` 

closes #10318 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>