### PR TITLE
Share the memory allocated by copyStringToUTF8WithMemAlloc

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2556,13 +2556,13 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 
 	if (NULL != className) {
 		j9object_t classNameObject = J9_JNI_UNWRAP_REFERENCE(className);
-		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, classNameObject, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, classNameObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
 		}
 
-		if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, classNameObject, CLASSNAME_VALID_NON_ARRARY)) {
+		if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, utf8Name, utf8Length, CLASSNAME_VALID_NON_ARRARY)) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (UDATA *)*(j9object_t*)className);
 			goto done;
 		}

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,15 +126,6 @@ j9bcv_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved);
 */
 I_32
 bcvCheckClassName (J9CfrConstantPoolInfo * info);
-
-/**
-* Check the validity of a class name during class loading.
-*
-* @param info A pointer to J9CfrConstantPoolInfo
-* @returns The arity of the class if valid, -1 otherwise
-*/
-I_32
-bcvCheckClassNameInLoading (J9CfrConstantPoolInfo * info);
 
 /**
 * @brief

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4427,7 +4427,7 @@ typedef struct J9InternalVMFunctions {
 	UDATA  ( *compareStrings)(struct J9VMThread * vmThread, j9object_t string1, j9object_t string2) ;
 	UDATA  ( *compareStringToUTF8)(struct J9VMThread * vmThread, j9object_t stringObject, UDATA stringFlags, const U_8 * utfData, UDATA utfLength) ;
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
-	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string, UDATA allowedBitsForClassName) ;
+	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, U_8 *className, UDATA classNameLength, UDATA allowedBitsForClassName) ;
 	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, UDATA stringOffset, UDATA stringLength, U_8 *utf8Data, UDATA utf8DataLength);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3116,14 +3116,15 @@ getStringUTF8Length(J9VMThread *vmThread,j9object_t string);
 * 	CLASSNAME_VALID_ARRARY - if it is valid and there is a '[' at beginning of class name string.
 *
 * @param[in] *vmThread current thread
-* @param[in] string the class name string
+* @param[in] className the class name string
+* @param[in] classNameLength the length of the class name string
 * @param[in] allowedBitsForClassName the allowed bits for a valid class name,
 *            including CLASSNAME_VALID_NON_ARRARY, CLASSNAME_VALID_ARRARY, or CLASSNAME_VALID.
 *
 * @return a UDATA to indicate the nature of incoming class name string, see descriptions above.
 */
 UDATA
-verifyQualifiedName(J9VMThread *vmThread, j9object_t string, UDATA allowedBitsForClassName);
+verifyQualifiedName(J9VMThread *vmThread, U_8 *className, UDATA classNameLength, UDATA allowedBitsForClassName);
 
 
 /* ---------------- swalk.c ---------------- */

--- a/runtime/verutil/chverify.c
+++ b/runtime/verutil/chverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -171,19 +171,6 @@ bcvCheckClassName (J9CfrConstantPoolInfo * info)
 {
 	/* Class checks, not method checks */
 	return checkNameImpl(info, TRUE, FALSE, FALSE);
-}
-
-/**
-* Determine if this a valid name for Classes during class loading.
-*
-* @param info A pointer to J9CfrConstantPoolInfo
-* @returns The arity of the class if valid, -1 otherwise
-*/
-I_32
-bcvCheckClassNameInLoading (J9CfrConstantPoolInfo * info)
-{
-	/* Class checks, not method checks */
-	return checkNameImpl(info, TRUE, FALSE, TRUE);
 }
 
 /**


### PR DESCRIPTION
The intention is to share the memory allocated by
copyStringToUTF8WithMemAlloc for the class name string between
verifyQualifiedName and its caller.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>