### PR TITLE
GetObjectRefType -Xcheck:jni uses argDescriptor JNIC_JOBJECT

### DIFF
--- a/runtime/jnichk/jnicwrappers.c
+++ b/runtime/jnichk/jnicwrappers.c
@@ -4269,7 +4269,7 @@ checkGetObjectRefType(JNIEnv *env, jobject obj)
 	J9JavaVM* j9vm = ((J9VMThread*)env)->javaVM;
 	jobjectRefType actualResult;
 	J9JniCheckLocalRefState refTracking;
-	static const U_32 argDescriptor[] = { JNIC_POINTER, 0 };
+	static const U_32 argDescriptor[] = { JNIC_JOBJECT, 0 };
 	static const char function[] = "GetObjectRefType";
 
 	jniCheckArgs(function, 0, CRITICAL_WARN, &refTracking, argDescriptor, env, obj);


### PR DESCRIPTION
`jniCheckRef()` is invoked for `JNIC_JOBJECT` check hence find a bad object reference.

The testcase output w/ this PR is as following:
```
JVMJNCK038E JNI error in GetObjectRefType: Argument #2 (0x000000000DA49940) is not a valid object reference. It's type is: freed local reference
JVMJNCK077E Error detected in HelloJNI.sayHello()I
```
Note: RI `-Xcheck:jni` doesn't throw error for a `NULL` reference, hence this PR uses `JNIC_JOBJECT` instead of `JNIC_NONNULLOBJECT`.

closes: #10310 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>