### PR TITLE
Revert unnecessary changes to VM shutdown

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -492,7 +492,6 @@ void OMRNORETURN exitJavaVM(J9VMThread * vmThread, IDATA rc)
 
 	if (vm != NULL) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
-		omrthread_monitor_t mutex = vm->runtimeFlagsMutex;
 
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 		/* exitJavaVM is always called from a JNI context */
@@ -502,17 +501,13 @@ void OMRNORETURN exitJavaVM(J9VMThread * vmThread, IDATA rc)
 
 		/* we only let the shutdown code run once */
 
-		if (NULL != mutex) {
-			omrthread_monitor_enter(mutex);
+		if(vm->runtimeFlagsMutex != NULL) {
+			omrthread_monitor_enter(vm->runtimeFlagsMutex);
 		}
 
-		/* CLEANUP indicates that the VM is running the exit hooks/finalizers on exit - exit
-		 * must be allowed in this case. CLEANUP will only ever be set once EXIT_STARTED has
-		 * been set, so setting the flag again below is harmless.
-		 */
-		if (J9_RUNTIME_EXIT_STARTED == (vm->runtimeFlags & (J9_RUNTIME_EXIT_STARTED | J9_RUNTIME_CLEANUP))) {
-			if (NULL != mutex) {
-				omrthread_monitor_exit(mutex);
+		if(vm->runtimeFlags & J9_RUNTIME_EXIT_STARTED) {
+			if (vm->runtimeFlagsMutex != NULL) {
+				omrthread_monitor_exit(vm->runtimeFlagsMutex);
 			}
 
 			if (vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) {
@@ -526,8 +521,8 @@ void OMRNORETURN exitJavaVM(J9VMThread * vmThread, IDATA rc)
 		}
 
 		vm->runtimeFlags |= J9_RUNTIME_EXIT_STARTED;
-		if (NULL != mutex) {
-			omrthread_monitor_exit(mutex);
+		if(vm->runtimeFlagsMutex != NULL) {
+			omrthread_monitor_exit(vm->runtimeFlagsMutex);
 		}
 
 #ifdef J9VM_OPT_SIDECAR


### PR DESCRIPTION
Now that https://github.com/eclipse/openj9/pull/10273 is merged, these two changes are no longer needed and do nothing but add complexity.