### PR TITLE
Update macOS buildenv variables

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -545,17 +545,13 @@ x86-64_mac:
     8: 'macosx-x86_64-normal-server-release'
     11: 'macosx-x86_64-normal-server-release'
   extra_configure_options:
-    8: '--with-xcode-path=/Users/jenkins/Xcode4/Xcode.app --with-openj9-cc=/Users/jenkins/Xcode7/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang --with-openj9-cxx=/Users/jenkins/Xcode7/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ --with-openj9-developer-dir=/Users/jenkins/Xcode7/Xcode.app/Contents/Developer'
+    8: '--with-toolchain-type=clang'
   freemarker: '/Users/jenkins/freemarker.jar'
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:
-    build:
-      all: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
-      8: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_11'
+    build: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_14'
   build_env:
-    vars:
-      all: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
-      8: 'MACOSX_DEPLOYMENT_TARGET=10.9.0 SDKPATH=/Users/jenkins/Xcode4/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk'
+    vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
   excluded_tests:
     11:
       - special.system


### PR DESCRIPTION
For issue #9806

extra_configure_options:
    8: '--with-toolchain-type=clang'

SDKPATH removed

node_labels changed to sw.os.osx.10_14
  build_env var changed to MACOSX_DEPLOYMENT_TARGET=10.10.0

@jdekonin 