### PR TITLE
Add JPP flag for inline types

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -37,7 +37,7 @@
 	<!-- START SET DEFINITIONS -->
 	<set
 		label="newflags"
-		flags="OPENJDK_METHODHANDLES"/>
+		flags="INLINE-TYPES,OPENJDK_METHODHANDLES"/>
 
 	<set
 		label="oldflags"


### PR DESCRIPTION
Add JPP flag for inline types

Merging adds a new JPP flag for inline types.

Related to: https://github.com/eclipse/openj9/issues/10078

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>