### PR TITLE
Prevent double free for client options

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -703,7 +703,10 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
    if (abortCompilation)
       {
       if (clientOptions)
+         {
          TR_Memory::jitPersistentFree(clientOptions);
+         entry._clientOptions = NULL;
+         }
       if (optPlan)
          TR_OptimizationPlan::freeOptimizationPlan(optPlan);
       if (_recompilationMethodInfo)


### PR DESCRIPTION
JITServer receives from the client the JIT command line options that
need to be applied for each compilation, allocates some memory for them
and attaches them to the compilation entry. If the compilation
needs to be aborted the allocated options are freed, but we also
need to set `entry._clientOptions` to NULL, otherwise the server
may try to free them again in `TR::CompilationInfo::recycleCompilationEntry`
which calls `entry->freeJITServerAllocations();`

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>