### PR TITLE
Export JVM_IsUseContainerSupport for Java 11+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -341,6 +341,7 @@ else()
 		JVM_AreNestMates
 		JVM_InitClassName
 		JVM_InitializeFromArchive
+		JVM_IsUseContainerSupport
 	)
 endif()
 
@@ -359,13 +360,6 @@ if(NOT JAVA_SPEC_VERSION LESS 15)
 		JVM_LookupLambdaProxyClassFromArchive
 		JVM_IsCDSDumpingEnabled
 		JVM_IsCDSSharingEnabled
-	)
-endif()
-
-if(NOT JAVA_SPEC_VERSION LESS 16)
-	jvm_add_exports(jvm
-		# Additions for Java 16 (General)
-		JVM_IsUseContainerSupport
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -337,6 +337,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_AreNestMates"/>
 		<export name="JVM_InitClassName"/>
 		<export name="JVM_InitializeFromArchive"/>
+		<export name="JVM_IsUseContainerSupport"/>
 	</exports>
 
 	<exports group="jdk14">
@@ -351,11 +352,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="JVM_LookupLambdaProxyClassFromArchive"/>
 		<export name="JVM_IsCDSDumpingEnabled"/>
 		<export name="JVM_IsCDSSharingEnabled"/>
-	</exports>
-
-	<exports group="jdk16">
-		<!-- Additions for Java 16 (General) -->
-		<export name="JVM_IsUseContainerSupport"/>
 	</exports>
 
 </exportlists>

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1785,7 +1785,7 @@ JVM_IsCDSSharingEnabled(JNIEnv *env)
 }
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
-#if JAVA_SPEC_VERSION >= 16
+#if JAVA_SPEC_VERSION >= 11
 JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(JNIEnv *env)
 {
@@ -1795,4 +1795,4 @@ JVM_IsUseContainerSupport(JNIEnv *env)
 
 	return inContainer ? JNI_TRUE : JNI_FALSE;
 }
-#endif /* JAVA_SPEC_VERSION >= 16 */
+#endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -64,9 +64,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk15">
 				<include-if condition="spec.java15"/>
 			</group>
-			<group name="jdk16">
-				<include-if condition="spec.java16"/>
-			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -332,5 +332,5 @@ _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSDumpingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
 _IF([JAVA_SPEC_VERSION >= 15],
 	[_X(JVM_IsCDSSharingEnabled, JNICALL, false, jboolean, JNIEnv *env)])
-_IF([JAVA_SPEC_VERSION >= 16],
+_IF([JAVA_SPEC_VERSION >= 11],
 	[_X(JVM_IsUseContainerSupport, JNICALL, false, jboolean, JNIEnv *env)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -65,9 +65,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<group name="jdk15">
 				<include-if condition="spec.java15"/>
 			</group>
-			<group name="jdk16">
-				<include-if condition="spec.java16"/>
-			</group>
 		</exports>
 		<includes>
 			<include path="j9include"/>


### PR DESCRIPTION
The dependency on `JVM_IsUseContainerSupport` was back-ported to Java 11.

See [OpenJDK11-Acceptance failure](https://ci.eclipse.org/openj9/view/Build_OpenJDK/job/Build_JDK11_ppc64le_linux_OpenJDK11/69/) and #10292.