### PR TITLE
Rework trampolines for POWER10

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1310,6 +1310,8 @@ onLoadInternal(
    // Now that the options have been processed we can initialize the RuntimeAssumptionTables
    // If we cannot allocate various runtime assumption hash tables, fail the JVM
 
+   fe->initializeSystemProperties();
+
    // Allocate trampolines for z/OS 64-bit
 #if defined(J9ZOS390)
    if (TR::Options::getCmdLineOptions()->getOption(TR_EnableRMODE64) && !isQuickstart)
@@ -1466,8 +1468,6 @@ onLoadInternal(
       }
 
    jitConfig->thunkLookUpNameAndSig = &j9ThunkLookupNameAndSig;
-
-   fe->initializeSystemProperties();
 
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get();
 

--- a/runtime/compiler/p/codegen/Trampoline.cpp
+++ b/runtime/compiler/p/codegen/Trampoline.cpp
@@ -52,7 +52,8 @@ void * ppcPicTrampInit(TR_FrontEnd *vm, TR::PersistentInfo * persistentInfo)
 
 #ifdef TR_TARGET_64BIT
    TR_J9VMBase *fej9 = (TR_J9VMBase *)vm;
-   if (!fej9->isAOT_DEPRECATED_DO_NOT_USE()) // don't init TOC if it is jar2jxe AOT compile
+   if (!fej9->isAOT_DEPRECATED_DO_NOT_USE() &&  // don't init TOC if it is jar2jxe AOT compile
+       !TR::Options::getCmdLineOptions()->getOption(TR_DisableTOC))
       {
       retVal = TR_PPCTableOfConstants::initTOC(fej9, persistentInfo, 0);
       }

--- a/runtime/compiler/p/codegen/Trampoline.cpp
+++ b/runtime/compiler/p/codegen/Trampoline.cpp
@@ -34,23 +34,10 @@
 
 namespace TR { class PersistentInfo; }
 
-#if defined(TR_TARGET_64BIT)
-#define TRAMPOLINE_SIZE       28
-#define OFFSET_IPIC_TO_CALL   36
-#else
-#define TRAMPOLINE_SIZE       16
-#define OFFSET_IPIC_TO_CALL   32
-#endif
-
 extern "C"
    {
    extern   int __j9_smp_flag;
-   int32_t  ppcTrampolineInitByCodeCache(TR_FrontEnd *, uint8_t *, uintptr_t);
    };
-
-#ifdef TR_HOST_POWER
-extern void     ppcCodeSync(uint8_t *, uint32_t);
-#endif
 
 void * ppcPicTrampInit(TR_FrontEnd *vm, TR::PersistentInfo * persistentInfo)
    {


### PR DESCRIPTION
This PR adds newly revamped trampolines when POWER10 support is enabled that use PC-relative prefixed load instructions rather than pTOC loads or address materialization sequences.