### PR TITLE
Selectively enforce lookup class package check

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -215,24 +215,40 @@ public class MethodHandles {
 			accessMode = lookupMode;
 		}
 		
-		Lookup(Class<?> lookupClass, Class<?> prevLookupClass, int lookupMode) {
-			this(lookupClass, prevLookupClass, lookupMode, true);
+		/* For Java 15, the default is not to check for the "java.lang.invoke" package.
+		 * For earlier releases, these lookups are illegal
+		  */
+		private static boolean lookupJLIPackageCheckDefault() {
+			/*[IF Java15]
+			return false;
+			/*[ELSE] Java15*/
+			return true;
+			/*[ENDIF] Java15*/
 		}
 		
-		Lookup(Class<?> lookupClass, int lookupMode, boolean doCheck) {
-			this(lookupClass, null, lookupMode, doCheck);
+		Lookup(Class<?> lookupClass, Class<?> prevLookupClass, int lookupMode) {
+			this(lookupClass, prevLookupClass, lookupMode, lookupJLIPackageCheckDefault());
 		}
 		
 		Lookup(Class<?> lookupClass, int lookupMode) {
-			this(lookupClass, lookupMode, true);
+			this(lookupClass, null, lookupMode, lookupJLIPackageCheckDefault());
 		}
 		
 		Lookup(Class<?> lookupClass) {
-			this(lookupClass, FULL_ACCESS_MASK, true);
+			this(lookupClass, null, FULL_ACCESS_MASK, lookupJLIPackageCheckDefault());
 		}
 		
+		/* Note:
+		 * The constructor Lookup(Class<?> lookupClass) above performs package check by default.
+		 * Following constructor is used when there is no need for such check,
+		 * i.e., incoming performSecurityCheck is expected to be false here.
+		 * JDK15+ expects only following three APIs invoking Lookup constructors to do such package check (matching RI behaviors):
+		 * 	MethodHandles.Lookup.in(Class<?> lookupClass)
+		 * 	MethodHandles.Lookup.dropLookupMode(Class<?> lookupClass)
+		 * 	MethodHandles.Lookup.privateLookupIn(Class<?> targetClass, MethodHandles.Lookup caller)
+		 */
 		Lookup(Class<?> lookupClass, boolean performSecurityCheck) {
-			this(lookupClass, FULL_ACCESS_MASK, performSecurityCheck);
+			this(lookupClass, null, FULL_ACCESS_MASK, performSecurityCheck);
 		}
 	
 		/**
@@ -1426,7 +1442,7 @@ public class MethodHandles {
 				newPrevAccessClass = null;
 			}
 			
-			return new Lookup(lookupClass, newPrevAccessClass, newAccessMode);
+			return new Lookup(lookupClass, newPrevAccessClass, newAccessMode, true);
 			/*[ELSE]*/
 			return new Lookup(lookupClass, newAccessMode);
 			/*[ENDIF] Java14*/
@@ -2214,7 +2230,7 @@ public class MethodHandles {
 				newPrevAccessClass = null;
 			}
 			
-			return new Lookup(accessClass, newPrevAccessClass, newAccessMode);
+			return new Lookup(accessClass, newPrevAccessClass, newAccessMode, true);
 			/*[ELSE]*/
 			return new Lookup(accessClass, newAccessMode);
 			/*[ENDIF] Java14*/
@@ -2483,9 +2499,9 @@ public class MethodHandles {
 		
 		/*[IF Java14]*/
 		if (Objects.equals(targetClassModule, accessClassModule)) {
-			return new Lookup(targetClass, null, callerLookupMode);
+			return new Lookup(targetClass, null, callerLookupMode, true);
 		} else {
-			return new Lookup(targetClass, callerLookup.lookupClass(), (callerLookupMode & ~Lookup.MODULE));
+			return new Lookup(targetClass, callerLookup.lookupClass(), (callerLookupMode & ~Lookup.MODULE), true);
 		}
 		/*[ELSE]*/
 		return new Lookup(targetClass);

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/invoke/Test_MethodHandleInfo.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/invoke/Test_MethodHandleInfo.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.invoke;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,9 +33,9 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.*;
 import java.security.AccessControlException;
 import org.openj9.test.java.lang.invoke.helpers.*;
+import org.openj9.test.util.VersionCheck;
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.*;
-
 
 public class Test_MethodHandleInfo {
 	@SuppressWarnings("unused")
@@ -686,6 +686,11 @@ public class Test_MethodHandleInfo {
 	 */
 	@Test(groups = { "level.sanity" })
 	public void test_RevealDirect_Security() throws Throwable {
+		if (VersionCheck.major() >= 15) {
+			/* This test doesn't apply to JDK15+ after removing package check for MethodHandles.Lookup() constructors exception three APIs */
+			return;
+		}
+
 		final String lookup = "org.openj9.test.java.lang.invoke.Helper_MethodHandleInfo";
 		final String methodHandle = "org.openj9.test.java.lang.invoke.helpers.Helper_MethodHandleInfoOtherPackagePublic";
 


### PR DESCRIPTION
Only following APIs are subject to lookup class package check (matching RI behaviours):
```
MethodHandles.Lookup.in​(Class<?> lookupClass)
MethodHandles.Lookup.dropLookupMode​(int modeToDrop)
MethodHandles.Lookup.privateLookupIn​(Class<?> targetClass, MethodHandles.Lookup caller)
```
The change only applies to `JDK15+`. The package check stays same for pre-JDK15 levels.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>