### PR TITLE
Fix missing libraries for VS2019 linker

### DIFF
--- a/runtime/compiler/build/toolcfg/win-msvc/common.mk
+++ b/runtime/compiler/build/toolcfg/win-msvc/common.mk
@@ -217,7 +217,7 @@ ifeq ($(origin MSVC_VERSION), undefined)
         SOLINK_SLINK+=ucrt vcruntime
     endif
 else
-    ifneq (,$(filter 2015 2017, $(MSVC_VERSION)))
+    ifneq (,$(filter 2015 2017 2019, $(MSVC_VERSION)))
         SOLINK_SLINK+=ucrt vcruntime
     endif
 endif


### PR DESCRIPTION
In recent versions of Visual Studio, some of the contents of msvcrt.lib have
been moved into ucrt.lib and vcruntime.lib. The makefiles were already set up
to add these 2 additional libraries to the linker command when building using
VS 2015 or 2017. This commit ensures these libraries are also included when
using VS2019.

Fixes: #9978

Signed-off-by: Ryan Shukla <ryans@ibm.com>