### PR TITLE
LoadInstance support for sym ref generation for flattened fields

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -164,6 +164,7 @@ private:
    //
    void         loadInstance(int32_t);
    void         loadInstance(TR::SymbolReference *);
+   void         loadFlattenableInstance(int32_t);
    void         loadFlattenableInstanceWithHelper(int32_t cpIndex);
    void         loadStatic(int32_t);
    void         loadAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);


### PR DESCRIPTION
Support flattened fields in loadinstance.

Dependencies
- [x] 1. https://github.com/eclipse/openj9/pull/10115 Add TypeLayoutEntry build for flattened fields 
- [x] 2. https://github.com/eclipse/openj9/pull/10352 Create JIT helper functions on checking flattened fields 
- [x] 3. https://github.com/eclipse/omr/pull/5493 Create JIT option to select between runtime helpers or SymRef generation for flattened field support 
- [x] 4. https://github.com/eclipse/openj9/pull/10462 Runtime flattened fields helper

This change was originally authored by Yi Zhang who is listed as a co-author below.
    
Co-authored-by: Yi Zhang yizhang@ca.ibm.com

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>