### PR TITLE
JDK15 : skip fillInStackTrace frames

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -581,6 +581,7 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 			J9VMCONSTANTPOOL_JAVALANGCLASSNOTFOUNDEXCEPTION,
 			J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR,
 			J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR,
+			J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION,
 	};
 
 	/* Determine java/lang/String.value signature before any required class is initialized */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2986,7 +2986,14 @@ done:
 					walkState->restartException = receiver;
 				}
 				walkState->flags = walkFlags;
-				walkState->skipCount = 1;	// skip the INL frame
+#if JAVA_SPEC_VERSION >= 15
+				J9Class *receiverClass = J9OBJECT_CLAZZ(_currentThread, receiver);
+				if (J9VMJAVALANGNULLPOINTEREXCEPTION_OR_NULL(_vm) == receiverClass) {
+					walkState->skipCount = 2;	/* skip the INL & NullPointerException.fillInStackTrace() frames */
+				}
+#else /* JAVA_SPEC_VERSION >= 15 */
+				walkState->skipCount = 1;	/* skip the INL frame */
+#endif /* JAVA_SPEC_VERSION >= 15 */
 				walkState->walkThread = _currentThread;
 				updateVMStruct(REGISTER_ARGS);
 				UDATA walkRC = _vm->walkStackFrames(_currentThread, walkState);

--- a/runtime/vm/FastJNI_java_lang_Throwable.cpp
+++ b/runtime/vm/FastJNI_java_lang_Throwable.cpp
@@ -58,7 +58,14 @@ Fast_java_lang_Throwable_fillInStackTrace(J9VMThread *currentThread, j9object_t 
 				walkState->restartException = receiver;
 			}
 			walkState->flags = walkFlags;
-			walkState->skipCount = 1;	// skip the INL frame
+#if JAVA_SPEC_VERSION >= 15
+			J9Class *receiverClass = J9OBJECT_CLAZZ(currentThread, receiver);
+			if (J9VMJAVALANGNULLPOINTEREXCEPTION_OR_NULL(vm) == receiverClass) {
+				walkState->skipCount = 2;	/* skip the INL & NullPointerException.fillInStackTrace() frames */
+			}
+#else /* JAVA_SPEC_VERSION >= 15 */
+			walkState->skipCount = 1;	/* skip the INL frame */
+#endif /* JAVA_SPEC_VERSION >= 15 */
 			walkState->walkThread = currentThread;
 			UDATA walkRC = vm->walkStackFrames(currentThread, walkState);
 			UDATA framesWalked = walkState->framesWalked;


### PR DESCRIPTION
Skip the `INL` & `NullPointerException.fillInStackTrace()` frames;
Add `J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION` to `requiredClasses` list.

Related to #10296 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>