### PR TITLE
Recognize Unsafe.copyMemory0 in JDK11

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -415,6 +415,8 @@
 
    sun_misc_Unsafe_ensureClassInitialized,
 
+   jdk_internal_misc_Unsafe_copyMemory0,
+
    java_lang_reflect_Array_getLength,
    java_util_Arrays_fill,
    java_util_Arrays_equals,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3366,7 +3366,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::sun_misc_Unsafe_fullFence,     "fullFence",  "()V")},
 
       {x(TR::sun_misc_Unsafe_ensureClassInitialized,     "ensureClassInitialized", "(Ljava/lang/Class;)V")},
-
+      {x(TR::jdk_internal_misc_Unsafe_copyMemory0,   "copyMemory0", "(Ljava/lang/Object;JLjava/lang/Object;JJ)V")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -298,8 +298,8 @@ J9::Node::processJNICall(TR::TreeTop * callNodeTreeTop, TR::ResolvedMethodSymbol
       }
 #endif
 
-   if (comp->canTransformUnsafeCopyToArrayCopy() &&
-       (methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_copyMemory))
+   if (comp->canTransformUnsafeCopyToArrayCopy()
+         && self()->isUnsafeCopyMemoryIntrinsic())
       {
       return self();
       }
@@ -2209,6 +2209,27 @@ J9::Node::setDontInlinePutOrderedCall()
          _flags.set(dontInlineUnsafePutOrderedCall);
       }
 
+   }
+
+bool
+J9::Node::isUnsafeCopyMemoryIntrinsic()
+   {
+   if (self()->getOpCode().isCall() && self()->getSymbol()->isMethod())
+      {
+      TR::MethodSymbol *symbol = self()->getSymbol()->getMethodSymbol();
+      if (symbol && symbol->isNative())
+         {
+         switch (symbol->getRecognizedMethod())
+            {
+            case TR::sun_misc_Unsafe_copyMemory:
+            case TR::jdk_internal_misc_Unsafe_copyMemory0:
+               return true;
+            default:
+               break;
+            }
+         }
+      }
+   return false;
    }
 
 bool

--- a/runtime/compiler/il/J9Node.hpp
+++ b/runtime/compiler/il/J9Node.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -283,6 +283,11 @@ public:
    void setDontInlinePutOrderedCall();
    bool chkDontInlineUnsafePutOrderedCall();
    const char * printIsDontInlineUnsafePutOrderedCall();
+
+   /**
+    * Checks  and return true if the callNode is JNI Call to Unsafe.copyMemory
+    */
+   bool isUnsafeCopyMemoryIntrinsic();
 
    bool isUnsafeGetPutCASCallOnNonArray();
    void setUnsafeGetPutCASCallOnNonArray();

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -395,6 +395,7 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
+      case TR::sun_misc_Unsafe_copyMemory:
          return !calleeMethod->isNative();
       default:
          break;

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -49,6 +49,7 @@ class ValuePropagation : public OMR::ValuePropagation
  #endif
 
    virtual void constrainRecognizedMethod(TR::Node *node);
+   virtual bool transformUnsafeCopyMemoryCall(TR::Node *arrayCopyNode);
    virtual bool transformDirectLoad(TR::Node *node);
    virtual void doDelayedTransformations();
    void transformCallToNodeWithHCRGuard(TR::TreeTop *callTree, TR::Node *result);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11945,11 +11945,12 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             }
          break;
          }
-
+      case TR::jdk_internal_misc_Unsafe_copyMemory0:
       case TR::sun_misc_Unsafe_copyMemory:
-         if (comp->canTransformUnsafeCopyToArrayCopy() &&
-             performTransformation(comp,
-               "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
+         if (comp->canTransformUnsafeCopyToArrayCopy() 
+            && methodSymbol->isNative()
+            && performTransformation(comp,
+                  "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
             {
             TR::Node *src = node->getChild(1);
             TR::Node *srcOffset = node->getChild(2);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9857,11 +9857,12 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
                return true;
                }
             return false; // Call the native version of NativeThread.current()
-
+         case TR::jdk_internal_misc_Unsafe_copyMemory0:
          case TR::sun_misc_Unsafe_copyMemory:
             {
-            if (comp->canTransformUnsafeCopyToArrayCopy() &&
-                performTransformation(comp, "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
+            if (comp->canTransformUnsafeCopyToArrayCopy()
+               && methodSymbol->isNative()
+               && performTransformation(comp, "O^O Call arraycopy instead of Unsafe.copyMemory: %s\n", cg->getDebug()->getName(node)))
                {
                TR::Node *src = node->getChild(1);
                TR::Node *srcOffset = node->getChild(2);


### PR DESCRIPTION
OpenJ9 contains the optimization that recognizes the JNI call sun/misc/Unsafe.copyMemory and transforms it to System.arrayCopy calls, which is inlined and optimized on most of the platform. Due to implementation changes in JDK11 we can not apply this optimization to sun/misc/Unsafe.copyMemory method which in Java 11 acts as a java wrapper that calls the implementation of copyMemory method from jdk/internal/misc/Unsafe class. This implementation contains additional changes to check range for the source and destination (in case of illegal access throws RuntimeException) before calling the
actual JNI method jdk/internal/misc/Unsafe.copyMemory0 which can be transformed to System.arrayCopy call. Due to this behavioural changes, when compiling method that calls Unsafe.copyMemory, we need to make sure that optimizer is exposed to JNI call Unsafe.copyMemory0 and that call is recognized same way as JNI call sun/misc/Unsafe.copyMemory is recognized in Java 8 to optimize it further.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>