### PR TITLE
Fix testSCCacheManagement failure on ibm 11 zos

### DIFF
--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,7 +165,7 @@ public class TestUtils {
 		    }
 		    else
 		    {
-		    	if (isOpenJ9()) {
+		    	if (false == isIbmJava8()) {
 		    		config.put("defaultCacheGroupAccessLocation","/tmp/");
 			    } 
 		    	config.put("defaultCacheLocation","/tmp/"); 
@@ -605,7 +605,7 @@ public class TestUtils {
 		//NOTE: use above statics to save some time when running tests ...
 		
 		String cmd = "";
-		if ( isOpenJ9() && cachename.indexOf("groupaccess") != -1 ) {
+		if ( false == isIbmJava8() && cachename.indexOf("groupaccess") != -1 ) {
 			if (persistent==true)
 			{
 				cmd = getCommand("getCacheFileNameGroupAccess",cachename);
@@ -1528,8 +1528,9 @@ public class TestUtils {
 		return RunCommand.lastCommandStderrLines;
 	}
 	
-	public static boolean isOpenJ9() {
-		return System.getProperty("java.vm.vendor").toLowerCase().contains("openj9");
+	public static boolean isIbmJava8() {
+		// ibm 11+ has the same -DOPENJ9_BUILD as openj9
+		return System.getProperty("java.vm.vendor").toLowerCase().contains("ibm") && System.getProperty("java.specification.version").contains("1.8");
 	}
 	
 	public static String removeJavaSharedResourcesDir(String dir) {

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPersistentCacheMoving01.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ public class TestPersistentCacheMoving01 extends TestUtils {
 	  }
 	  String currentCacheDir = getCacheDir();
 
-	  if ( null == currentCacheDir && isOpenJ9() ) {
+	  if ( null == currentCacheDir && false == isIbmJava8() ) {
 		  // Persistent cachefile without groupaccess are generated under HOME directory
 		  // Current directory is under /tmp. Move a file from HOME directory to /tmp may not succeed on some platforms. 
 		return;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJavaAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corp. and others
+ * Copyright (c) 2010, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			persistentList = new ArrayList<String>();
 			persistentList.add("cache1");
 			if (isWindows() == false) {
-				if (isOpenJ9()) {
+				if (false == isIbmJava8()) {
 					persistentGroupAccessList = new ArrayList<String>();
 					persistentGroupAccessList.add("cache1_groupaccess");
 				} else {
@@ -56,7 +56,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			nonpersistentList = new ArrayList<String>();
 			nonpersistentList.add("cache2");
 			if (isWindows() == false) {
-				if (isOpenJ9()) {
+				if (false == isIbmJava8()) {
 					nonpersistentGroupAccessList = new ArrayList<String>();
 					nonpersistentGroupAccessList.add("cache2_groupaccess");
 				} else {
@@ -89,7 +89,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
     	runDestroyAllCaches();
     	if (false == isWindows()) {
     		runDestroyAllSnapshots();
-        	if (isOpenJ9()) {
+        	if (false == isIbmJava8()) {
         		runDestroyAllGroupAccessCaches();
             }
     	}
@@ -110,7 +110,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 	    		oldCacheCount = cacheList.size();
 	    	}
 
-	    	if (dir == null && false == isWindows() && false == isMVS() && isOpenJ9()) {
+	    	if (dir == null && false == isWindows() && false == isMVS() && false == isIbmJava8()) {
 	    		dirGroupAccess = getCacheDir("Foo_groupaccess", false);
 	    		dirRemoveJavaSharedResources = removeJavaSharedResourcesDir(dirGroupAccess);
 	    		cacheGroupAccessList = SharedClassUtilities.getSharedCacheInfo(dirGroupAccess, SharedClassUtilities.NO_FLAGS, false);
@@ -605,7 +605,7 @@ public class TestSharedCacheJavaAPI extends TestUtils {
 			runDestroyAllCaches();
 			if (false == isWindows()) {
 				runDestroyAllSnapshots();
-				if (isOpenJ9()) {
+				if (false == isIbmJava8()) {
 					runDestroyAllGroupAccessCaches();
 				}
 			}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheJvmtiAPI.java
@@ -48,7 +48,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
         runDestroyAllCaches();
         if (false == isWindows()) {
         	runDestroyAllSnapshots();
-        	if (isOpenJ9()) {
+        	if (false == isIbmJava8()) {
         		runDestroyAllGroupAccessCaches();
         	}
         }
@@ -63,7 +63,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
 		    	fail("iterateSharedCacheFunction failed with dir " + dir);
 		    }
 	    	
-	    	if (dir == null && false == isWindows() && isOpenJ9()) {
+	    	if (dir == null && false == isWindows() && false == isIbmJava8()) {
 	    		dirGroupAccess = getCacheDir("Foo_groupaccess", false);
 	    		dirRemoveJavaSharedResources = removeJavaSharedResourcesDir(dirGroupAccess);
 	    		oldCacheGroupAccessCount = iterateSharedCache(dirGroupAccess, NO_FLAGS, false) + iterateSharedCache(dirRemoveJavaSharedResources, NO_FLAGS, false);
@@ -156,7 +156,7 @@ public class TestSharedCacheJvmtiAPI extends TestUtils {
 			runDestroyAllCaches();
 			if (false == isWindows()) {
 				runDestroyAllSnapshots();
-				if (isOpenJ9()) {
+				if (false == isIbmJava8()) {
 					runDestroyAllGroupAccessCaches();
 				}
 			}


### PR DESCRIPTION
- fix cache location change because ibm 11+ use -DOPENJ9_BUILD setting
- Related Issue:#10275
[ci skip]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>