### PR TITLE
JEP 360/JEP 384 Sealed classes and records DDR support

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@ import static com.ibm.j9ddr.vm29.j9.ROMHelp.J9_ROM_METHOD_FROM_RAM_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_CLASS_ANNOTATION_INFO;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_ENCLOSING_METHOD;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_GENERIC_SIGNATURE;
+import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_PERMITTEDSUBCLASSES_ATTRIBUTE;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_SIMPLE_NAME;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_SOURCE_DEBUG_EXTENSION;
 import static com.ibm.j9ddr.vm29.structure.J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_SOURCE_FILE_NAME;
@@ -234,6 +235,35 @@ public class OptInfo {
 			return J9SourceDebugExtensionPointer.cast(srpPtr.get());
 		}
 		return J9SourceDebugExtensionPointer.NULL;
+	}
+
+	private static U32Pointer getPermittedSubclassPointer(J9ROMClassPointer romClass) throws CorruptDataException {
+		SelfRelativePointer srpPtr = getSRPPtr(J9ROMClassHelper.optionalInfo(romClass), romClass.optionalFlags(),
+			J9_ROMCLASS_OPTINFO_PERMITTEDSUBCLASSES_ATTRIBUTE);
+		if (srpPtr.notNull()) {
+			return U32Pointer.cast(srpPtr.get());
+		}
+		return U32Pointer.NULL;
+	}
+
+	public static int getPermittedSubclassCount(J9ROMClassPointer romClass) throws CorruptDataException {
+		U32Pointer permittedSubclassPointer = getPermittedSubclassPointer(romClass);
+		if (permittedSubclassPointer.notNull()) {
+			return permittedSubclassPointer.at(0).intValue();
+		}
+		return 0;
+	}
+
+	public static J9UTF8Pointer getPermittedSubclassNameAtIndex(J9ROMClassPointer romClass, int index) throws CorruptDataException {
+		U32Pointer permittedSubclassPointer = getPermittedSubclassPointer(romClass);
+		if (permittedSubclassPointer.notNull()) {
+			/* extra 1 is to move past permitted subclass count. */
+			permittedSubclassPointer = permittedSubclassPointer.add(index + 1);
+
+			SelfRelativePointer nameSrp = SelfRelativePointer.cast(permittedSubclassPointer);
+			return J9UTF8Pointer.cast(nameSrp.get());
+		}
+		return J9UTF8Pointer.NULL;
 	}
 
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ROMClassHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ROMClassHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -131,5 +131,9 @@ public class J9ROMClassHelper {
 	
 	public static boolean isAnonymousClass(J9ROMClassPointer romclass) throws CorruptDataException {
 		return romclass.extraModifiers().allBitsIn(J9AccClassAnonClass);
+	}
+
+	public static boolean isSealed(J9ROMClassPointer romclass) throws CorruptDataException {
+		return romclass.extraModifiers().allBitsIn(J9AccSealed);
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -557,10 +557,10 @@ public class J9BCUtil {
 		/* dump the enclosing method */
 		dumpEnclosingMethod(out, romClass, flags);
 
-		out.append(String.format("Sun Access Flags (0x%s): ", Long.toHexString(romClass.modifiers().longValue())));
+		out.append(String.format("Basic Access Flags (0x%s): ", Long.toHexString(romClass.modifiers().longValue())));
 		dumpModifiers(out, romClass.modifiers().longValue(), MODIFIERSOURCE_CLASS, ONLY_SPEC_MODIFIERS);
 		out.append(nl);
-		out.append(String.format("J9  Access Flags (0x%s): ", Long.toHexString(romClass.extraModifiers().longValue())));
+		out.append(String.format("J9 Access Flags (0x%s): ", Long.toHexString(romClass.extraModifiers().longValue())));
 		dumpClassJ9ExtraModifiers(out, romClass.extraModifiers().longValue());
 		out.append(nl);
 
@@ -607,6 +607,17 @@ public class J9BCUtil {
 				J9UTF8Pointer innerClassName = J9UTF8Pointer.cast(innerClasses.get());
 				out.append("   " + J9UTF8Helper.stringValue(innerClassName));
 				innerClasses = innerClasses.add(1);
+			}
+		}
+
+		/* Permitted subclasses for a sealed class */
+		if (J9ROMClassHelper.isSealed(romClass)) {
+			int permittedSubclassCount = OptInfo.getPermittedSubclassCount(romClass);
+			out.format("Permitted subclasses (%d):%n", permittedSubclassCount);
+
+			for (int i = 0; i < permittedSubclassCount; i++) {
+				J9UTF8Pointer permittedSubclassName = OptInfo.getPermittedSubclassNameAtIndex(romClass, i);
+				out.format("   %s%n", J9UTF8Helper.stringValue(permittedSubclassName));
 			}
 		}
 
@@ -715,6 +726,10 @@ public class J9BCUtil {
 			out.append("(anonClass) ");
 		if ((accessFlags & J9AccClassIsUnmodifiableBit) != 0)
 			out.append("(unmodifiable) ");
+		if ((accessFlags & J9JavaAccessFlags.J9AccRecord) != 0)
+			out.append("(record) ");
+		if ((accessFlags & J9JavaAccessFlags.J9AccSealed) != 0)
+			out.append("(sealed) ");
 	}
 
 	private static void dumpEnclosingMethod(PrintStream out, J9ROMClassPointer romClass, long flags) throws CorruptDataException {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -108,6 +108,8 @@
 #define J9FieldTypeMask 0x380000
 #define J9FieldTypeShort 0x280000
 
+/* @ddr_namespace: map_to_type=J9RecordComponentFlags */
+
 /* Constants from J9RecordComponentFlags */
 #define J9RecordComponentFlagHasGenericSignature 0x1
 #define J9RecordComponentFlagHasAnnotations 0x2


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/9626
Related: https://github.com/eclipse/openj9/issues/9529

0.22 port: ~~https://github.com/eclipse/openj9/pull/10405~~ https://github.com/eclipse/openj9/pull/10443

This ended up being support for both sealed classes and records which was missed in Java 14.

- `cfdump -x <classfile>`
- `!dumpromclass <address>`
- `!dumpromclasslinear <address>`

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>