### PR TITLE
Add host class package to anon class name for 11+

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.hpp
+++ b/runtime/bcutil/ROMClassBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2019 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -122,7 +122,7 @@ private:
 	U_8 *_bufferManagerBuffer;
 	StringInternTable _stringInternTable;
 
-	BuildResult handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda);
+	BuildResult handleAnonClassName(J9CfrClassFile *classfile, bool *isLambda, U_8* hostPackageName, UDATA hostPackageLength);
 	U_32 computeExtraModifiers(ClassFileOracle *classFileOracle, ROMClassCreationContext *context);
 	U_32 computeOptionalFlags(ClassFileOracle *classFileOracle, ROMClassCreationContext *context);
 	BuildResult prepareAndLaydown( BufferManager *bufferManager, ClassFileParser *classFileParser, ROMClassCreationContext *context );

--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -52,6 +52,8 @@ public:
 		_clazz(NULL),
 		_className(NULL),
 		_classNameLength(0),
+		_hostPackageName(NULL),
+		_hostPackageLength(0),
 		_intermediateClassData(NULL),
 		_intermediateClassDataLength(0),
 		_classLoader(NULL),
@@ -89,6 +91,8 @@ public:
 		_clazz(NULL),
 		_className(NULL),
 		_classNameLength(0),
+		_hostPackageName(NULL),
+		_hostPackageLength(0),
 		_intermediateClassData(NULL),
 		_intermediateClassDataLength(0),
 		_classLoader(NULL),
@@ -115,8 +119,8 @@ public:
 
 	ROMClassCreationContext(
 			J9PortLibrary *portLibrary, J9JavaVM *javaVM, U_8 *classFileBytes, UDATA classFileSize, UDATA bctFlags, UDATA bcuFlags, UDATA findClassFlags, AllocationStrategy *allocationStrategy,
-			U_8 *className, UDATA classNameLength, U_8 *intermediateClassData, U_32 intermediateClassDataLength, J9ROMClass *romClass, J9Class *clazz, J9ClassLoader *classLoader, bool classFileBytesReplaced,
-			bool creatingIntermediateROMClass, J9TranslationLocalBuffer *localBuffer) :
+			U_8 *className, UDATA classNameLength, U_8 *hostPackageName, UDATA hostPackageLength, U_8 *intermediateClassData, U_32 intermediateClassDataLength, J9ROMClass *romClass, J9Class *clazz, 
+			J9ClassLoader *classLoader, bool classFileBytesReplaced, bool creatingIntermediateROMClass, J9TranslationLocalBuffer *localBuffer) :
 		_portLibrary(portLibrary),
 		_javaVM(javaVM),
 		_classFileBytes(classFileBytes),
@@ -129,6 +133,8 @@ public:
 		_clazz(clazz),
 		_className(className),
 		_classNameLength(classNameLength),
+		_hostPackageName(hostPackageName),
+		_hostPackageLength(hostPackageLength),
 		_intermediateClassData(intermediateClassData),
 		_intermediateClassDataLength(intermediateClassDataLength),
 		_classLoader(classLoader),
@@ -178,6 +184,8 @@ public:
 	UDATA findClassFlags() const {return _findClassFlags; }
 	U_8* className() const {return _className; }
 	UDATA classNameLength() const {return _classNameLength; }
+	U_8* hostPackageName() const {return _hostPackageName; }
+	UDATA hostPackageLength() const {return _hostPackageLength; }
 	U_32 bctFlags() const { return (U_32) _bctFlags; } /* Only use this for j9bcutil_readClassFileBytes */
 	AllocationStrategy *allocationStrategy() const { return _allocationStrategy; }
 	bool classFileBytesReplaced() const { return _classFileBytesReplaced; }
@@ -735,6 +743,8 @@ private:
 	J9Class *_clazz;
 	U_8 *_className;
 	UDATA _classNameLength;
+	U_8* _hostPackageName;
+	UDATA _hostPackageLength;
 	U_8 *_intermediateClassData;
 	U_32 _intermediateClassDataLength;
 	J9ClassLoader *_classLoader;

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -107,6 +107,14 @@ internalDefineClass(
 	loadData.freeFunction = NULL;
 	loadData.romClass = existingROMClass;
 
+	loadData.hostPackageName = NULL;
+	loadData.hostPackageLength = 0;
+	if (isAnonFlagSet && (J2SE_VERSION(vm) >= J2SE_V11)) {
+		J9ROMClass *hostROMClass = hostClass->romClass;
+		loadData.hostPackageName = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(hostROMClass));
+		loadData.hostPackageLength = packageNameLength(hostROMClass);
+	}
+
 	if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NO_CHECK_FOR_EXISTING_CLASS)) {
 		/* For non-bootstrap classes, this check is done in jcldefine.c:defineClassCommon(). */
 		if (checkForExistingClass(vmThread, &loadData) != NULL) {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -769,6 +769,8 @@ typedef struct J9LoadROMClassData {
 	j9object_t classDataObject;
 	struct J9ClassLoader* classLoader;
 	j9object_t protectionDomain;
+	U_8* hostPackageName;
+	UDATA hostPackageLength;
 	UDATA options;
 	struct J9ROMClass* romClass;
 	struct J9MemorySegment* romClassSegment;

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3531,6 +3531,13 @@ reloadROMClasses(J9VMThread * currentThread, jint class_count, const jvmtiClassD
 		loadData.protectionDomain = J9VMJAVALANGCLASS_PROTECTIONDOMAIN(currentThread, heapClass);
 		loadData.options = options;
 
+		loadData.hostPackageName = NULL;
+		loadData.hostPackageLength = 0;
+		if ((J2SE_VERSION(vm) >= J2SE_V11) && J9_ARE_ALL_BITS_SET(originalRAMClass->classFlags, J9ClassIsAnonymous)) {
+			J9ROMClass *hostROMClass = originalRAMClass->hostClass->romClass;
+			loadData.hostPackageName = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(hostROMClass));;
+			loadData.hostPackageLength = packageNameLength(hostROMClass);
+		}
 
 		loadData.freeUserData = NULL;
 		loadData.freeFunction = NULL;


### PR DESCRIPTION
Reflection fails for anonymous classes with a host class in a module which
exports only certain packages, since in OpenJ9, the anonymous class name does
not include package info. In the reference implementation, anonymous classes
do have package info in their name, so this commit changes OpenJ9 behaviour to
match that.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Part of https://github.com/eclipse/openj9/issues/7354

fyi @DanHeidinga 