### PR TITLE
JDK15 fillInStackTrace set skipCount to 1 for non-NPE cases

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -441,6 +441,7 @@ JVM_FillInStackTrace(JNIEnv* env, jobject throwable)
 			flags |= J9_STACKWALK_HIDE_EXCEPTION_FRAMES;
 			walkState->restartException = unwrappedThrowable;
 		}
+		walkState->skipCount = 1; /* skip the INL frame -- TODO revisit this */
 #if JAVA_SPEC_VERSION >= 15
 		{
 			J9Class *receiverClass = J9OBJECT_CLAZZ(currentThread, unwrappedThrowable);
@@ -448,8 +449,6 @@ JVM_FillInStackTrace(JNIEnv* env, jobject throwable)
 				walkState->skipCount = 2;	/* skip the INL & NullPointerException.fillInStackTrace() frames */
 			}
 		}
-#else /* JAVA_SPEC_VERSION >= 15 */
-		walkState->skipCount = 1; /* skip the INL frame -- TODO revisit this */
 #endif /* JAVA_SPEC_VERSION >= 15 */
 		walkState->walkThread = currentThread;
 		walkState->flags = flags;

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2986,13 +2986,12 @@ done:
 					walkState->restartException = receiver;
 				}
 				walkState->flags = walkFlags;
+				walkState->skipCount = 1;	/* skip the INL frame */
 #if JAVA_SPEC_VERSION >= 15
 				J9Class *receiverClass = J9OBJECT_CLAZZ(_currentThread, receiver);
 				if (J9VMJAVALANGNULLPOINTEREXCEPTION_OR_NULL(_vm) == receiverClass) {
 					walkState->skipCount = 2;	/* skip the INL & NullPointerException.fillInStackTrace() frames */
 				}
-#else /* JAVA_SPEC_VERSION >= 15 */
-				walkState->skipCount = 1;	/* skip the INL frame */
 #endif /* JAVA_SPEC_VERSION >= 15 */
 				walkState->walkThread = _currentThread;
 				updateVMStruct(REGISTER_ARGS);

--- a/runtime/vm/FastJNI_java_lang_Throwable.cpp
+++ b/runtime/vm/FastJNI_java_lang_Throwable.cpp
@@ -58,13 +58,12 @@ Fast_java_lang_Throwable_fillInStackTrace(J9VMThread *currentThread, j9object_t 
 				walkState->restartException = receiver;
 			}
 			walkState->flags = walkFlags;
+			walkState->skipCount = 1;	/* skip the INL frame */
 #if JAVA_SPEC_VERSION >= 15
 			J9Class *receiverClass = J9OBJECT_CLAZZ(currentThread, receiver);
 			if (J9VMJAVALANGNULLPOINTEREXCEPTION_OR_NULL(vm) == receiverClass) {
 				walkState->skipCount = 2;	/* skip the INL & NullPointerException.fillInStackTrace() frames */
 			}
-#else /* JAVA_SPEC_VERSION >= 15 */
-			walkState->skipCount = 1;	/* skip the INL frame */
 #endif /* JAVA_SPEC_VERSION >= 15 */
 			walkState->walkThread = currentThread;
 			UDATA walkRC = vm->walkStackFrames(currentThread, walkState);


### PR DESCRIPTION
Add back `walkState->skipCount = 1` for non-NPE cases.

Run the test locally that `test_fillInStackTrace_getStackTrace` passes. (it failed before as per #10384)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>