### PR TITLE
Create Flag `-XX:[+|-]AlwaysPreTouch`

### DIFF
--- a/runtime/gc_modron_startup/mmparse.cpp
+++ b/runtime/gc_modron_startup/mmparse.cpp
@@ -1247,6 +1247,19 @@ gcParseXXArguments(J9JavaVM *vm)
 		}
 	}
 
+	{
+		IDATA alwaysPreTouchIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XX:+AlwaysPreTouch", NULL);
+		IDATA notAlwaysPreTouchIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, "-XX:-AlwaysPreTouch", NULL);
+		if (alwaysPreTouchIndex != notAlwaysPreTouchIndex) {
+			/* At least one option is set. Find the right most one. */
+			if (alwaysPreTouchIndex > notAlwaysPreTouchIndex) {
+				extensions->pretouchHeapOnExpand = true;
+			} else {
+				extensions->pretouchHeapOnExpand = false;
+			}
+		}
+	}
+
 	return 1;
 }
 


### PR DESCRIPTION
eclipse/omr#5431

Commits memory during initial heap inflation or heap expansion by writing 0s.

Default: Turned Off

Signed-off-by: Enson Guo <enson.guo@ibm.com>