### PR TITLE
Remove definitions/declarations of unsigned Call/Return ILopcodes

### DIFF
--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -586,10 +586,6 @@ static const char * nvvmOpCodeNames[] =
    "store",          // TR::iustorei
    "store",          // TR::lustorei
    "store",          // TR::bustorei
-   "ret",          // TR::iureturn
-   "ret",          // TR::lureturn
-   NULL,          // TR::iucall
-   NULL,          // TR::lucall
    "add",         // TR::iuadd
    "add",         // TR::luadd
    "add",         // TR::buadd
@@ -638,9 +634,7 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::contigarraylength
    NULL,          // TR::discontigarraylength
    NULL,          // TR::icalli
-   NULL,          // TR::iucalli
    NULL,          // TR::lcalli
-   NULL,          // TR::lucalli
    NULL,          // TR::fcalli
    NULL,          // TR::dcalli
    NULL,          // TR::acalli


### PR DESCRIPTION
Removed definitions, declarations, properties and all other lists/enums that define the behavior of the unsigned Call/Return IL Opcodes. The above ILOpcodes will be completely removed from OpenJ9 after this PR.

Note that this PR need to be merged simultaneously with eclipse/omr#5470

Issue:eclipse/omr#2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com