### PR TITLE
Not invoke Exception.printStackTrace() at early VM startup stage

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -265,7 +265,12 @@ public abstract class ClassLoader {
 			System.bootLayer = jdk.internal.module.ModuleBootstrap.boot();
 		/*[IF Java10]*/
 		} catch (Exception ex) {
-			ex.printStackTrace();
+			System.out.println(ex);
+			Throwable t = ex.getCause();
+			while (t != null) {
+				System.out.println("Caused by: " + t); //$NON-NLS-1$
+				t = t.getCause();
+			}
 			System.exit(1);
 		}
 		/*[ENDIF]*/


### PR DESCRIPTION
At early stage of `VM` startup, `vm->applicationClassLoader` is still `NULL` when `Exception.printStackTrace()` is invoked, hence causes segmentation error;
Replace it with the exception message & cause.

With this PR, the testcase exits w/ following message instead
```
java.lang.module.FindException: Unable to derive module descriptor for bug-module-openj9-1.0-SNAPSHOT.jar
Caused by: java.lang.module.InvalidModuleDescriptorException: Provider class com.fakeimpl not in module
```

closes: #10383 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>