### PR TITLE
RuntimeAssumptions: fix NULL used in arithmetic

### DIFF
--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -85,7 +85,7 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize::hashCode(char *sig, uint32_t sigLen)
 void
 TR_PatchNOPedGuardSiteOnClassPreInitialize::reclaim()
    {
-   TR_ASSERT_FATAL(_key != NULL, "Attempt to reclaim an already freed _key");
+   TR_ASSERT_FATAL(_key != 0, "Attempt to reclaim an already freed _key");
 
    jitPersistentFree((void*)_key);
    _key = 0;


### PR DESCRIPTION
ISO C11 section 7.20.1.4 only guarantees conversions to and from void pointer

not sure what's going on here exactly. _key doesn't seem to be read anywhere else, so shouldn't it be a bool?